### PR TITLE
[FLINK-27660][table] add table api for registering function with resource

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -521,10 +521,11 @@ public interface TableEnvironment {
      * Registers a {@link UserDefinedFunction} class as a catalog function in the given path by the
      * specific class name and user defined resource uri.
      *
-     * <p>Compared to {@link #createFunction(String, Class)}, this method allow registering a user
-     * defined function by only provide a full path class name and and available resource list in
-     * which each url may be local or remote. User doesn't need to initialize the function instance
-     * in advance.
+     * <p>Compared to {@link #createFunction(String, Class)}, this method allows registering a user
+     * defined function by only providing a full path class name and a list of resources that
+     * contain the implementation of the function along with its dependencies. Users don't need to
+     * initialize the function instance in advance. The resource file can be a local or remote JAR
+     * file.
      *
      * <p>Compared to system functions with a globally defined name, catalog functions are always
      * (implicitly or explicitly) identified by a catalog and database.
@@ -543,10 +544,11 @@ public interface TableEnvironment {
      * Registers a {@link UserDefinedFunction} class as a catalog function in the given path by the
      * specific class name and user defined resource uri.
      *
-     * <p>Compared to {@link #createFunction(String, Class)}, this method allow registering a user
-     * defined function by only provide a full path class name and an available resource list in
-     * which each url may be local or remote. User doesn't need to initialize the function instance
-     * in advance.
+     * <p>Compared to {@link #createFunction(String, Class)}, this method allows registering a user
+     * defined function by only providing a full path class name and a list of resources that
+     * contain the implementation of the function along with its dependencies. Users don't need to
+     * initialize the function instance in advance. The resource file can be a local or remote JAR
+     * file.
      *
      * <p>Compared to system functions with a globally defined name, catalog functions are always
      * (implicitly or explicitly) identified by a catalog and database.
@@ -607,10 +609,11 @@ public interface TableEnvironment {
      * Registers a {@link UserDefinedFunction} class as a temporary catalog function in the given
      * path by the specific class name and user defined resource uri.
      *
-     * <p>Compared to {@link #createTemporaryFunction(String, Class)}, this method allow registering
-     * a user defined function by only provide a full path class name and an available resource list
-     * in which each url may be local or remote. User doesn't need to initialize the function
-     * instance in advance.
+     * <p>Compared to {@link #createTemporaryFunction(String, Class)}, this method allows
+     * registering a user defined function by only providing a full path class name and a list of
+     * resources that contain the implementation of the function along with its dependencies. Users
+     * don't need to initialize the function instance in advance. The resource file can be a local
+     * or remote JAR file.
      *
      * <p>Compared to {@link #createTemporarySystemFunction(String, String, List)} with a globally
      * defined name, catalog functions are always (implicitly or explicitly) identified by a catalog
@@ -631,10 +634,11 @@ public interface TableEnvironment {
      * Registers a {@link UserDefinedFunction} class as a temporary system function by the specific
      * class name and user defined resource uri.
      *
-     * <p>Compared to {@link #createTemporarySystemFunction(String, Class)}, this method allow
-     * registering a user defined function by only provide a full path class name and an available
-     * resource list in which each url may be local or remote. User doesn't need to initialize the
-     * function instance in advance.
+     * <p>Compared to {@link #createTemporaryFunction(String, Class)}, this method allows
+     * registering a user defined function by only providing a full path class name and a list of
+     * resources that contain the implementation of the function along with its dependencies. Users
+     * don't need to initialize the function instance in advance. The resource file can be a local
+     * or remote JAR file.
      *
      * <p>Temporary functions can shadow permanent ones. If a permanent function under a given name
      * exists, it will be inaccessible in the current session. To make the permanent function

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/TableEnvironment.java
@@ -30,10 +30,12 @@ import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.module.Module;
 import org.apache.flink.table.module.ModuleEntry;
+import org.apache.flink.table.resource.ResourceUri;
 import org.apache.flink.table.types.AbstractDataType;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -516,13 +518,51 @@ public interface TableEnvironment {
             boolean ignoreIfExists);
 
     /**
-     * Drops a catalog function registered in the given path.
+     * Registers a {@link UserDefinedFunction} class as a catalog function in the given path by the
+     * specific class name and user defined resource uri.
      *
-     * @param path The path under which the function has been registered. See also the {@link
+     * <p>Compared to {@link #createFunction(String, Class)}, this method allow registering a user
+     * defined function by only provide a full path class name and and available resource list in
+     * which each url may be local or remote. User doesn't need to initialize the function instance
+     * in advance.
+     *
+     * <p>Compared to system functions with a globally defined name, catalog functions are always
+     * (implicitly or explicitly) identified by a catalog and database.
+     *
+     * <p>There must not be another function (temporary or permanent) registered under the same
+     * path.
+     *
+     * @param path The path under which the function will be registered. See also the {@link
      *     TableEnvironment} class description for the format of the path.
-     * @return true if a function existed in the given path and was removed
+     * @param className The class name of UDF to be registered.
+     * @param resourceUris The list of udf resource uris in local or remote.
      */
-    boolean dropFunction(String path);
+    void createFunction(String path, String className, List<ResourceUri> resourceUris);
+
+    /**
+     * Registers a {@link UserDefinedFunction} class as a catalog function in the given path by the
+     * specific class name and user defined resource uri.
+     *
+     * <p>Compared to {@link #createFunction(String, Class)}, this method allow registering a user
+     * defined function by only provide a full path class name and an available resource list in
+     * which each url may be local or remote. User doesn't need to initialize the function instance
+     * in advance.
+     *
+     * <p>Compared to system functions with a globally defined name, catalog functions are always
+     * (implicitly or explicitly) identified by a catalog and database.
+     *
+     * <p>There must not be another function (temporary or permanent) registered under the same
+     * path.
+     *
+     * @param path The path under which the function will be registered. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
+     * @param className The class name of UDF to be registered.
+     * @param resourceUris The list of udf resource uris in local or remote.
+     * @param ignoreIfExists If a function exists under the given path and this flag is set, no
+     *     operation is executed. An exception is thrown otherwise.
+     */
+    void createFunction(
+            String path, String className, List<ResourceUri> resourceUris, boolean ignoreIfExists);
 
     /**
      * Registers a {@link UserDefinedFunction} class as a temporary catalog function.
@@ -562,6 +602,59 @@ public interface TableEnvironment {
      *     implementation.
      */
     void createTemporaryFunction(String path, UserDefinedFunction functionInstance);
+
+    /**
+     * Registers a {@link UserDefinedFunction} class as a temporary catalog function in the given
+     * path by the specific class name and user defined resource uri.
+     *
+     * <p>Compared to {@link #createTemporaryFunction(String, Class)}, this method allow registering
+     * a user defined function by only provide a full path class name and an available resource list
+     * in which each url may be local or remote. User doesn't need to initialize the function
+     * instance in advance.
+     *
+     * <p>Compared to {@link #createTemporarySystemFunction(String, String, List)} with a globally
+     * defined name, catalog functions are always (implicitly or explicitly) identified by a catalog
+     * and database.
+     *
+     * <p>Temporary functions can shadow permanent ones. If a permanent function under a given name
+     * exists, it will be inaccessible in the current session. To make the permanent function
+     * available again one can drop the corresponding temporary function.
+     *
+     * @param path The path under which the function will be registered. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
+     * @param className The class name of UDF to be registered.
+     * @param resourceUris The list udf resource uri in local or remote.
+     */
+    void createTemporaryFunction(String path, String className, List<ResourceUri> resourceUris);
+
+    /**
+     * Registers a {@link UserDefinedFunction} class as a temporary system function by the specific
+     * class name and user defined resource uri.
+     *
+     * <p>Compared to {@link #createTemporarySystemFunction(String, Class)}, this method allow
+     * registering a user defined function by only provide a full path class name and an available
+     * resource list in which each url may be local or remote. User doesn't need to initialize the
+     * function instance in advance.
+     *
+     * <p>Temporary functions can shadow permanent ones. If a permanent function under a given name
+     * exists, it will be inaccessible in the current session. To make the permanent function
+     * available again one can drop the corresponding temporary system function.
+     *
+     * @param name The name under which the function will be registered globally.
+     * @param className The class name of UDF to be registered.
+     * @param resourceUris The list of udf resource uris in local or remote.
+     */
+    void createTemporarySystemFunction(
+            String name, String className, List<ResourceUri> resourceUris);
+
+    /**
+     * Drops a catalog function registered in the given path.
+     *
+     * @param path The path under which the function has been registered. See also the {@link
+     *     TableEnvironment} class description for the format of the path.
+     * @return true if a function existed in the given path and was removed
+     */
+    boolean dropFunction(String path);
 
     /**
      * Drops a temporary catalog function registered in the given path.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -44,6 +44,7 @@ import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.CatalogBaseTable;
 import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogManager;
 import org.apache.flink.table.catalog.CatalogPartition;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
@@ -53,6 +54,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ConnectorCatalogTable;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.catalog.FunctionCatalog;
+import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -204,6 +206,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     protected final FunctionCatalog functionCatalog;
     protected final Planner planner;
     private final boolean isStreamingMode;
+
     private static final String UNSUPPORTED_QUERY_IN_EXECUTE_SQL_MSG =
             "Unsupported SQL query! executeSql() only accepts a single SQL statement of type "
                     + "CREATE TABLE, DROP TABLE, ALTER TABLE, CREATE DATABASE, DROP DATABASE, ALTER DATABASE, "
@@ -260,7 +263,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                         },
                         getParser()::parseSqlExpression,
                         isStreamingMode);
-
         catalogManager.initSchemaResolver(
                 isStreamingMode, operationTreeBuilder.getResolverBuilder());
     }
@@ -418,6 +420,12 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     }
 
     @Override
+    public void createTemporarySystemFunction(
+            String name, String className, List<ResourceUri> resourceUris) {
+        functionCatalog.registerTemporarySystemFunction(name, className, resourceUris);
+    }
+
+    @Override
     public boolean dropTemporarySystemFunction(String name) {
         return functionCatalog.dropTemporarySystemFunction(name, true);
     }
@@ -435,6 +443,19 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         final UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         functionCatalog.registerCatalogFunction(
                 unresolvedIdentifier, functionClass, ignoreIfExists);
+    }
+
+    @Override
+    public void createFunction(String path, String className, List<ResourceUri> resourceUris) {
+        createFunction(path, className, resourceUris, false);
+    }
+
+    @Override
+    public void createFunction(
+            String path, String className, List<ResourceUri> resourceUris, boolean ignoreIfExists) {
+        final UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
+        functionCatalog.registerCatalogFunction(
+                unresolvedIdentifier, className, resourceUris, ignoreIfExists);
     }
 
     @Override
@@ -456,6 +477,16 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         final UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
         functionCatalog.registerTemporaryCatalogFunction(
                 unresolvedIdentifier, functionInstance, false);
+    }
+
+    @Override
+    public void createTemporaryFunction(
+            String path, String className, List<ResourceUri> resourceUris) {
+        final UnresolvedIdentifier unresolvedIdentifier = getParser().parseIdentifier(path);
+        final CatalogFunction catalogFunction =
+                new CatalogFunctionImpl(className, FunctionLanguage.JAVA, resourceUris);
+        functionCatalog.registerTemporaryCatalogFunction(
+                unresolvedIdentifier, catalogFunction, false);
     }
 
     @Override
@@ -1896,6 +1927,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
     private TableResultInternal createSystemFunction(CreateTempSystemFunctionOperation operation) {
         String exMsg = getDDLOpExecuteErrorMsg(operation.asSummaryString());
+
         try {
             functionCatalog.registerTemporarySystemFunction(
                     operation.getFunctionName(),

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -111,6 +111,15 @@ public final class FunctionCatalog {
                 name, new CatalogFunctionImpl(fullyQualifiedName, language), ignoreIfExists);
     }
 
+    /** Registers a temporary system function from resource uris. */
+    public void registerTemporarySystemFunction(
+            String name, String className, List<ResourceUri> resourceUris) {
+        registerTemporarySystemFunction(
+                name,
+                new CatalogFunctionImpl(className, FunctionLanguage.JAVA, resourceUris),
+                false);
+    }
+
     /** Drops a temporary system function. Returns true if a function was dropped. */
     public boolean dropTemporarySystemFunction(String name, boolean ignoreIfNotExist) {
         final String normalizedName = FunctionIdentifier.normalizeName(name);
@@ -184,8 +193,8 @@ public final class FunctionCatalog {
             Class<? extends UserDefinedFunction> functionClass,
             boolean ignoreIfExists) {
         final ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
-        final ObjectIdentifier normalizedIdentifier =
-                FunctionIdentifier.normalizeObjectIdentifier(identifier);
+        final CatalogFunction catalogFunction =
+                new CatalogFunctionImpl(functionClass.getName(), FunctionLanguage.JAVA);
 
         try {
             UserDefinedFunctionHelper.validateClass(functionClass);
@@ -197,45 +206,20 @@ public final class FunctionCatalog {
                     t);
         }
 
-        final Catalog catalog =
-                catalogManager
-                        .getCatalog(normalizedIdentifier.getCatalogName())
-                        .orElseThrow(IllegalStateException::new);
-        final ObjectPath path = identifier.toObjectPath();
+        registerCatalogFunction(identifier, catalogFunction, ignoreIfExists);
+    }
 
-        // we force users to deal with temporary catalog functions first
-        if (tempCatalogFunctions.containsKey(normalizedIdentifier)) {
-            if (ignoreIfExists) {
-                return;
-            }
-            throw new ValidationException(
-                    String.format(
-                            "Could not register catalog function. A temporary function '%s' does already exist. "
-                                    + "Please drop the temporary function first.",
-                            identifier.asSummaryString()));
-        }
+    public void registerCatalogFunction(
+            UnresolvedIdentifier unresolvedIdentifier,
+            String className,
+            List<ResourceUri> resourceUris,
+            boolean ignoreIfExists) {
 
-        if (catalog.functionExists(path)) {
-            if (ignoreIfExists) {
-                return;
-            }
-            throw new ValidationException(
-                    String.format(
-                            "Could not register catalog function. A function '%s' does already exist.",
-                            identifier.asSummaryString()));
-        }
-
+        final ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
         final CatalogFunction catalogFunction =
-                new CatalogFunctionImpl(functionClass.getName(), FunctionLanguage.JAVA);
-        try {
-            catalog.createFunction(path, catalogFunction, ignoreIfExists);
-        } catch (Throwable t) {
-            throw new TableException(
-                    String.format(
-                            "Could not register catalog function '%s'.",
-                            identifier.asSummaryString()),
-                    t);
-        }
+                new CatalogFunctionImpl(className, FunctionLanguage.JAVA, resourceUris);
+
+        registerCatalogFunction(identifier, catalogFunction, ignoreIfExists);
     }
 
     /**
@@ -711,6 +695,56 @@ public final class FunctionCatalog {
                             "Failed to register jar resource '%s' of function '%s'.",
                             resourceUris, functionName),
                     e);
+        }
+    }
+
+    private void registerCatalogFunction(
+            ObjectIdentifier identifier, CatalogFunction catalogFunction, boolean ignoreIfExists) {
+        final ObjectIdentifier normalizedIdentifier =
+                FunctionIdentifier.normalizeObjectIdentifier(identifier);
+
+        final Catalog catalog =
+                catalogManager
+                        .getCatalog(normalizedIdentifier.getCatalogName())
+                        .orElseThrow(
+                                () ->
+                                        new ValidationException(
+                                                String.format(
+                                                        "Catalog %s not exists.",
+                                                        normalizedIdentifier.getCatalogName())));
+
+        final ObjectPath path = identifier.toObjectPath();
+
+        // we force users to deal with temporary catalog functions first
+        if (tempCatalogFunctions.containsKey(normalizedIdentifier)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new ValidationException(
+                    String.format(
+                            "Could not register catalog function. A temporary function '%s' does already exist. "
+                                    + "Please drop the temporary function first.",
+                            identifier.asSummaryString()));
+        }
+
+        if (catalog.functionExists(path)) {
+            if (ignoreIfExists) {
+                return;
+            }
+            throw new ValidationException(
+                    String.format(
+                            "Could not register catalog function. A function '%s' does already exist.",
+                            identifier.asSummaryString()));
+        }
+
+        try {
+            catalog.createFunction(path, catalogFunction, ignoreIfExists);
+        } catch (Throwable t) {
+            throw new TableException(
+                    String.format(
+                            "Could not register catalog function '%s'.",
+                            identifier.asSummaryString()),
+                    t);
         }
     }
 

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableEnvironmentMock.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/utils/TableEnvironmentMock.java
@@ -81,7 +81,6 @@ public class TableEnvironmentMock extends TableEnvironmentImpl {
                         new URL[0],
                         Thread.currentThread().getContextClassLoader(),
                         tableConfig.getConfiguration());
-
         return new TableEnvironmentMock(
                 catalogManager,
                 moduleManager,


### PR DESCRIPTION
## What is the purpose of the change
Add table api for registering function with remote resource, so that we the advance function creation can be supported in DDL.


## Brief change log
1. Change on Table API with new create function with resources
2. Add test case in TableEnvironmentImplTest


## Verifying this change

The PR is tested in the new test function in TableEnvironmentImplTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
