### PR TITLE
[FLINK-28416][table] Add (Async)LookupFunction and providers in replace of (Async)TableFunction as the API for lookup table

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/AsyncTableFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/AsyncTableFunctionProvider.java
@@ -19,7 +19,7 @@
 package org.apache.flink.table.connector.source;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.AsyncLookupFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AsyncTableFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
@@ -38,7 +38,8 @@ import org.apache.flink.types.Row;
  * LookupTableSource} the output type can simply be a {@link Row} or {@link RowData} in which case
  * the input and output types are derived from the table's schema with default conversion.
  *
- * @deprecated Please use {@link LookupFunctionProvider} to implement asynchronous lookup table.
+ * @deprecated Please use {@link AsyncLookupFunctionProvider} to implement asynchronous lookup
+ *     table.
  */
 @PublicEvolving
 @Deprecated

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/AsyncTableFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/AsyncTableFunctionProvider.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.connector.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.AsyncTableFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
@@ -36,8 +37,11 @@ import org.apache.flink.types.Row;
  * similar to other {@link UserDefinedFunction}s. However, for convenience, in a {@link
  * LookupTableSource} the output type can simply be a {@link Row} or {@link RowData} in which case
  * the input and output types are derived from the table's schema with default conversion.
+ *
+ * @deprecated Please use {@link LookupFunctionProvider} to implement asynchronous lookup table.
  */
 @PublicEvolving
+@Deprecated
 public interface AsyncTableFunctionProvider<T> extends LookupTableSource.LookupRuntimeProvider {
 
     /** Helper method for creating a static provider. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/LookupTableSource.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/LookupTableSource.java
@@ -19,6 +19,8 @@
 package org.apache.flink.table.connector.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.lookup.AsyncLookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
 import org.apache.flink.types.RowKind;
 
 import java.io.Serializable;
@@ -56,8 +58,8 @@ public interface LookupTableSource extends DynamicTableSource {
      * <p>The given {@link LookupContext} offers utilities by the planner for creating runtime
      * implementation with minimal dependencies to internal data structures.
      *
-     * @see TableFunctionProvider
-     * @see AsyncTableFunctionProvider
+     * @see LookupFunctionProvider
+     * @see AsyncLookupFunctionProvider
      */
     LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context);
 
@@ -97,8 +99,8 @@ public interface LookupTableSource extends DynamicTableSource {
      * <p>There exist different interfaces for runtime implementation which is why {@link
      * LookupRuntimeProvider} serves as the base interface.
      *
-     * @see TableFunctionProvider
-     * @see AsyncTableFunctionProvider
+     * @see LookupFunctionProvider
+     * @see AsyncLookupFunctionProvider
      */
     @PublicEvolving
     interface LookupRuntimeProvider {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/TableFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/TableFunctionProvider.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.connector.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.functions.UserDefinedFunction;
@@ -36,8 +37,11 @@ import org.apache.flink.types.Row;
  * similar to other {@link UserDefinedFunction}s. However, for convenience, in a {@link
  * LookupTableSource} the output type can simply be a {@link Row} or {@link RowData} in which case
  * the input and output types are derived from the table's schema with default conversion.
+ *
+ * @deprecated Please use {@link LookupFunctionProvider} to implement synchronous lookup table.
  */
 @PublicEvolving
+@Deprecated
 public interface TableFunctionProvider<T> extends LookupTableSource.LookupRuntimeProvider {
 
     /** Helper method for creating a static provider. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/AsyncLookupFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/AsyncLookupFunctionProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.functions.AsyncLookupFunction;
+
+/** A provider for creating {@link AsyncLookupFunction}. */
+@PublicEvolving
+public interface AsyncLookupFunctionProvider extends LookupTableSource.LookupRuntimeProvider {
+
+    static AsyncLookupFunctionProvider of(AsyncLookupFunction asyncLookupFunction) {
+        return () -> asyncLookupFunction;
+    }
+
+    AsyncLookupFunction createAsyncLookupFunction();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/AsyncLookupFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/AsyncLookupFunctionProvider.java
@@ -26,9 +26,11 @@ import org.apache.flink.table.functions.AsyncLookupFunction;
 @PublicEvolving
 public interface AsyncLookupFunctionProvider extends LookupTableSource.LookupRuntimeProvider {
 
+    /** Helper function for creating a static provider. */
     static AsyncLookupFunctionProvider of(AsyncLookupFunction asyncLookupFunction) {
         return () -> asyncLookupFunction;
     }
 
+    /** Creates an {@link AsyncLookupFunction} instance. */
     AsyncLookupFunction createAsyncLookupFunction();
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupFunctionProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.functions.LookupFunction;
+
+/** A provider for creating {@link LookupFunction}. */
+@PublicEvolving
+public interface LookupFunctionProvider extends LookupTableSource.LookupRuntimeProvider {
+
+    static LookupFunctionProvider of(LookupFunction lookupFunction) {
+        return () -> lookupFunction;
+    }
+
+    LookupFunction createLookupFunction();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupFunctionProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupFunctionProvider.java
@@ -26,9 +26,11 @@ import org.apache.flink.table.functions.LookupFunction;
 @PublicEvolving
 public interface LookupFunctionProvider extends LookupTableSource.LookupRuntimeProvider {
 
+    /** Helper function for creating a static provider. */
     static LookupFunctionProvider of(LookupFunction lookupFunction) {
         return () -> lookupFunction;
     }
 
+    /** Creates an {@link LookupFunction} instance. */
     LookupFunction createLookupFunction();
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncLookupFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncLookupFunction.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A wrapper class of {@link AsyncTableFunction} for asynchronously lookup rows matching the lookup
+ * keys from external system.
+ *
+ * <p>The output type of this table function is fixed as {@link RowData}.
+ */
+@PublicEvolving
+public abstract class AsyncLookupFunction extends AsyncTableFunction<RowData> {
+
+    /**
+     * Asynchronously lookup rows matching the lookup keys.
+     *
+     * @param keyRow - A {@link RowData} that wraps keys to lookup.
+     * @return A collection of all matching rows in the lookup table.
+     */
+    public abstract CompletableFuture<Collection<RowData>> asyncLookup(RowData keyRow);
+
+    /** Invokes {@link #asyncLookup} and chains futures. */
+    public final void eval(CompletableFuture<Collection<RowData>> future, Object... keys) {
+        asyncLookup(GenericRowData.of(keys))
+                .whenCompleteAsync(
+                        (result, exception) -> {
+                            if (exception != null) {
+                                future.completeExceptionally(exception);
+                                return;
+                            }
+                            future.complete(result);
+                        });
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/LookupFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/LookupFunction.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+
+import java.io.IOException;
+import java.util.Collection;
+
+/**
+ * A wrapper class of {@link TableFunction} for synchronously lookup rows matching the lookup keys
+ * from external system.
+ *
+ * <p>The output type of this table function is fixed as {@link RowData}.
+ */
+@PublicEvolving
+public abstract class LookupFunction extends TableFunction<RowData> {
+
+    /**
+     * Synchronously lookup rows matching the lookup keys.
+     *
+     * @param keyRow - A {@link RowData} that wraps keys to lookup.
+     * @return A collection of all matching rows in the lookup table.
+     */
+    public abstract Collection<RowData> lookup(RowData keyRow) throws IOException;
+
+    /** Invoke {@link #lookup} and handle exceptions. */
+    public final void eval(Object... keys) {
+        try {
+            lookup(GenericRowData.of(keys)).forEach(this::collect);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to lookup values with given key", e);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces new interfaces in replace of the original TableFunction and its provider for lookup table, including:
- `LookupFunction`
- `AsyncLookupFunction`
- `LookupFunctionProvider`
- `AsyncLookupFunctionProvider`

Also mark `TableFunctionProvider` and `AsyncTableFunctionProvider` as deprecated.

## Brief change log

- Add (Async)LookupFunction interface and provider interfaces
- Mark (Async)TableFunctionProvider as deprecated


## Verifying this change

This PR only creates new and marks deprecated interfaces, which does not require test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
