### PR TITLE
[FLINK-28392][runtime] DefaultExecutionDeployer avoid retrieving executions from ExecutionGraph#currentExecutions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -189,7 +189,6 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
                         executionOperations,
                         executionVertexVersioner,
                         rpcTimeout,
-                        id -> getExecutionGraph().getRegisteredExecutions().get(id),
                         this::startReserveAllocation,
                         mainThreadExecutor);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionDeployer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/ExecutionDeployer.java
@@ -23,7 +23,6 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.Execution;
-import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 import org.slf4j.Logger;
@@ -31,7 +30,6 @@ import org.slf4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
-import java.util.function.Function;
 
 /** This deployer is responsible for deploying executions. */
 interface ExecutionDeployer {
@@ -63,7 +61,6 @@ interface ExecutionDeployer {
          * @param executionVertexVersioner the versioner which records the versions of execution
          *     vertices.
          * @param partitionRegistrationTimeout timeout of partition registration
-         * @param executionRetriever retriever to get executions
          * @param allocationReservationFunc function to reserve allocations for local recovery
          * @param mainThreadExecutor the main thread executor
          * @return an instantiated {@link ExecutionDeployer}
@@ -74,7 +71,6 @@ interface ExecutionDeployer {
                 final ExecutionOperations executionOperations,
                 final ExecutionVertexVersioner executionVertexVersioner,
                 final Time partitionRegistrationTimeout,
-                final Function<ExecutionAttemptID, Execution> executionRetriever,
                 final BiConsumer<ExecutionVertexID, AllocationID> allocationReservationFunc,
                 final ComponentMainThreadExecutor mainThreadExecutor);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionDeployerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultExecutionDeployerTest.java
@@ -108,7 +108,7 @@ class DefaultExecutionDeployerTest {
     void testDeployTasks() throws Exception {
         final JobGraph jobGraph = singleNonParallelJobVertexJobGraph();
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
 
         deployTasks(executionDeployer, executionGraph);
 
@@ -120,7 +120,7 @@ class DefaultExecutionDeployerTest {
     void testDeployTasksOnlyIfAllSlotRequestsAreFulfilled() throws Exception {
         final JobGraph jobGraph = singleJobVertexJobGraph(4);
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
 
         testExecutionSlotAllocator.disableAutoCompletePendingRequests();
 
@@ -143,7 +143,7 @@ class DefaultExecutionDeployerTest {
         testExecutionOperations.enableFailDeploy();
 
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
         deployTasks(executionDeployer, executionGraph);
 
         assertThat(testExecutionOperations.getFailedExecutions())
@@ -157,7 +157,7 @@ class DefaultExecutionDeployerTest {
         testExecutionSlotAllocator.disableAutoCompletePendingRequests();
 
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
         deployTasks(executionDeployer, executionGraph);
 
         assertThat(testExecutionSlotAllocator.getPendingRequests()).hasSize(2);
@@ -175,7 +175,7 @@ class DefaultExecutionDeployerTest {
         testExecutionSlotAllocator.disableAutoCompletePendingRequests();
 
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
         deployTasks(executionDeployer, executionGraph);
 
         final ExecutionAttemptID attemptId = getAnyExecution(executionGraph).getAttemptId();
@@ -193,7 +193,7 @@ class DefaultExecutionDeployerTest {
         testExecutionSlotAllocator.disableAutoCompletePendingRequests();
 
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
         deployTasks(executionDeployer, executionGraph);
 
         final ExecutionAttemptID attemptId = getAnyExecution(executionGraph).getAttemptId();
@@ -208,7 +208,7 @@ class DefaultExecutionDeployerTest {
     void testDeployOnlyIfVertexIsCreated() throws Exception {
         final JobGraph jobGraph = singleNonParallelJobVertexJobGraph();
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
 
         // deploy once to transition the tasks out from CREATED state
         deployTasks(executionDeployer, executionGraph);
@@ -233,7 +233,7 @@ class DefaultExecutionDeployerTest {
 
         final JobGraph jobGraph = nonParallelSourceSinkJobGraph();
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
 
         deployTasks(executionDeployer, executionGraph);
 
@@ -251,7 +251,7 @@ class DefaultExecutionDeployerTest {
 
         final JobGraph jobGraph = nonParallelSourceSinkJobGraph();
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
 
         deployTasks(executionDeployer, executionGraph);
 
@@ -267,7 +267,7 @@ class DefaultExecutionDeployerTest {
 
         final JobGraph jobGraph = nonParallelSourceSinkJobGraph();
         final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-        final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+        final ExecutionDeployer executionDeployer = createExecutionDeployer();
 
         deployTasks(executionDeployer, executionGraph);
 
@@ -289,7 +289,7 @@ class DefaultExecutionDeployerTest {
 
             final JobGraph jobGraph = nonParallelSourceSinkJobGraph();
             final ExecutionGraph executionGraph = createExecutionGraph(jobGraph);
-            final ExecutionDeployer executionDeployer = createExecutionDeployer(executionGraph);
+            final ExecutionDeployer executionDeployer = createExecutionDeployer();
 
             deployTasks(executionDeployer, executionGraph);
 
@@ -339,7 +339,7 @@ class DefaultExecutionDeployerTest {
         return executionGraph;
     }
 
-    private ExecutionDeployer createExecutionDeployer(ExecutionGraph executionGraph) {
+    private ExecutionDeployer createExecutionDeployer() {
         return new DefaultExecutionDeployer.Factory()
                 .createInstance(
                         LoggerFactory.getLogger(DefaultExecutionDeployer.class),
@@ -347,7 +347,6 @@ class DefaultExecutionDeployerTest {
                         testExecutionOperations,
                         executionVertexVersioner,
                         partitionRegistrationTimeout,
-                        id -> executionGraph.getRegisteredExecutions().get(id),
                         (ignored1, ignored2) -> {},
                         mainThreadExecutor);
     }


### PR DESCRIPTION
## What is the purpose of the change

This PR changes the ExecutionDeployer to not retrieve executions via ExecutionGraph#currentExecutions, to mitigate the problem reported in FLINK-28392.

## Verifying this change

This change is already covered by existing tests, i.e. DefaultExecutionDeployerTest and DefaultSchedulerTest.
This change is also verified manually with the patch that can stably reproducing the problem reported in FLINK-28392.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
