### PR TITLE
[FLINK-28329][BP 1.14][Tests] Output the top 15 directories in terms of used disk space

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test-runner-common.sh
+++ b/flink-end-to-end-tests/test-scripts/test-runner-common.sh
@@ -109,7 +109,10 @@ function log_environment_info {
     jps
 
     echo "Disk information"
-    df -hH
+    df -h
+
+    echo "##[group]Top 15 biggest directories in terms of used disk space"
+    du -a . | sort -n -r | head -n 15
 
     if sudo -n true 2>/dev/null; then
       echo "Allocated ports"

--- a/tools/ci/controller_utils.sh
+++ b/tools/ci/controller_utils.sh
@@ -25,7 +25,7 @@ print_system_info() {
     cat /proc/meminfo
 
     echo "Disk information"
-    df -hH
+    df -h
 
     echo "Running build as"
     whoami


### PR DESCRIPTION
(cherry picked from commit a33970455712b9d5a67cc66bb049d94ad4c4b543)

Unchanged backport of https://github.com/apache/flink/pull/20114