### PR TITLE
[FLINK-28003][Table SQL / Client] Disable SqlCompleter when using -f {file}

### DIFF
--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.environment.TestingJobClient;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.ResultKind;
+import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -82,6 +83,9 @@ public class CliClientTest extends TestLogger {
             "INSERT INTO MyTable SELECT * FROM MyOtherTable";
     private static final String INSERT_OVERWRITE_STATEMENT =
             "INSERT OVERWRITE MyTable SELECT * FROM MyOtherTable";
+    private static final String ORIGIN_HIVE_SQL = "SELECT pos\t FROM source_table;\n";
+    private static final String HIVE_SQL_WITHOUT_COMPLETER = "SELECT pos FROM source_table;";
+    private static final String HIVE_SQL_WITH_COMPLETER = "SELECT POSITION  FROM source_table;";
 
     @Test
     public void testUpdateSubmission() throws Exception {
@@ -106,6 +110,29 @@ public class CliClientTest extends TestLogger {
                         Arrays.asList(
                                 INSERT_INTO_STATEMENT, "", INSERT_OVERWRITE_STATEMENT, "\n")));
         assertThat(executor.receivedStatement).contains(INSERT_OVERWRITE_STATEMENT);
+    }
+
+    @Test
+    public void testExecuteSqlFileWithoutSqlCompleter() throws Exception {
+        MockExecutor executor = new MockExecutor(new SqlParserHelper(SqlDialect.HIVE));
+        executeSqlFromContent(executor, ORIGIN_HIVE_SQL);
+        assertThat(executor.receivedStatement).contains(HIVE_SQL_WITHOUT_COMPLETER);
+    }
+
+    @Test
+    public void testExecuteSqlInteractiveWithSqlCompleter() throws Exception {
+        final MockExecutor mockExecutor = new MockExecutor(new SqlParserHelper(SqlDialect.HIVE));
+        String sessionId = mockExecutor.openSession("test-session");
+
+        InputStream inputStream = new ByteArrayInputStream(ORIGIN_HIVE_SQL.getBytes());
+        OutputStream outputStream = new ByteArrayOutputStream(256);
+        try (Terminal terminal = new DumbTerminal(inputStream, outputStream);
+                CliClient client =
+                        new CliClient(
+                                () -> terminal, sessionId, mockExecutor, historyTempFile(), null)) {
+            client.executeInInteractiveMode();
+            assertThat(mockExecutor.receivedStatement).contains(HIVE_SQL_WITH_COMPLETER);
+        }
     }
 
     @Test
@@ -403,7 +430,15 @@ public class CliClientTest extends TestLogger {
         public String receivedStatement;
         public int receivedPosition;
         private final Map<String, SessionContext> sessionMap = new HashMap<>();
-        private final SqlParserHelper helper = new SqlParserHelper();
+        private final SqlParserHelper helper;
+
+        public MockExecutor() {
+            this.helper = new SqlParserHelper();
+        }
+
+        public MockExecutor(SqlParserHelper helper) {
+            this.helper = helper;
+        }
 
         @Override
         public void start() throws SqlExecutionException {}

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/utils/SqlParserHelper.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.delegation.Parser;
 public class SqlParserHelper {
     // return the sql parser instance hold by this table evn.
     private TableEnvironment tableEnv;
+    private boolean useHiveCatalog;
 
     public SqlParserHelper() {
         tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
@@ -37,8 +38,10 @@ public class SqlParserHelper {
 
     public SqlParserHelper(SqlDialect sqlDialect) {
         if (sqlDialect == null || SqlDialect.DEFAULT == sqlDialect) {
+            useHiveCatalog = false;
             tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
         } else if (SqlDialect.HIVE == sqlDialect) {
+            useHiveCatalog = true;
             HiveCatalog hiveCatalog = HiveTestUtils.createHiveCatalog();
             tableEnv = TableEnvironment.create(EnvironmentSettings.newInstance().build());
             tableEnv.getConfig().setSqlDialect(sqlDialect);
@@ -49,15 +52,17 @@ public class SqlParserHelper {
 
     /** prepare some tables for testing. */
     public void registerTables() {
-        registerTable(
-                "create table MyTable (a int, b bigint, c varchar(32)) "
-                        + "with ('connector' = 'filesystem', 'path' = '/non', 'format' = 'csv')");
-        registerTable(
-                "create table MyOtherTable (a int, b bigint) "
-                        + "with ('connector' = 'filesystem', 'path' = '/non', 'format' = 'csv')");
-        registerTable(
-                "create table MySink (a int, c varchar(32)) with ('connector' = 'COLLECTION' )");
-        registerTable("create view MyView as select * from MyTable");
+        if (!useHiveCatalog) {
+            registerTable(
+                    "create table MyTable (a int, b bigint, c varchar(32)) "
+                            + "with ('connector' = 'filesystem', 'path' = '/non', 'format' = 'csv')");
+            registerTable(
+                    "create table MyOtherTable (a int, b bigint) "
+                            + "with ('connector' = 'filesystem', 'path' = '/non', 'format' = 'csv')");
+            registerTable(
+                    "create table MySink (a int, c varchar(32)) with ('connector' = 'COLLECTION' )");
+            registerTable("create view MyView as select * from MyTable");
+        }
     }
 
     public void registerTable(String createTableStmt) {


### PR DESCRIPTION
## What is the purpose of the change

*When starting job using hive sql file in SQL client, the sql may be modified by SqlCompleter, for example, 'pos' field is changed to 'POSITION'. So it is better to disable SqlCompleter when using -f {file} in SQL client.*


## Brief change log

*(for example:)*
  - *Disable SqlCompleter when using sql file.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Add test testExecuteSqlFileWithoutSqlCompleter and testExecuteSqlInteractiveWithSqlCompleter in class CliClientTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)