### PR TITLE
[FLINK-24306][table]Group by index throw SqlValidatorException

### DIFF
--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/validate/FlinkSqlConformance.java
@@ -48,7 +48,13 @@ public enum FlinkSqlConformance implements SqlConformance {
 
     @Override
     public boolean isGroupByOrdinal() {
-        return false;
+        switch (this) {
+            case DEFAULT:
+            case HIVE:
+                return true;
+            default:
+                return false;
+        }
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -21,6 +21,7 @@ import org.apache.flink.sql.parser.ExtendedSqlNode
 import org.apache.flink.sql.parser.ddl.{SqlCompilePlan, SqlReset, SqlSet, SqlUseModules}
 import org.apache.flink.sql.parser.dml.{RichSqlInsert, SqlBeginStatementSet, SqlCompileAndExecutePlan, SqlEndStatementSet, SqlExecute, SqlExecutePlan, SqlStatementSet}
 import org.apache.flink.sql.parser.dql._
+import org.apache.flink.sql.parser.validate.FlinkSqlConformance
 import org.apache.flink.table.api.{TableException, ValidationException}
 import org.apache.flink.table.planner.parse.CalciteParser
 import org.apache.flink.table.planner.plan.FlinkCalciteCatalogReader
@@ -100,6 +101,7 @@ class FlinkPlannerImpl(
         .withIdentifierExpansion(true)
         .withDefaultNullCollation(FlinkPlannerImpl.defaultNullCollation)
         .withTypeCoercionEnabled(false)
+        .withSqlConformance(FlinkSqlConformance.DEFAULT)
     ) // Disable implicit type coercion for now.
     validator
   }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkPlannerImplTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/calcite/FlinkPlannerImplTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.calcite;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.table.api.Expressions.$;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link FlinkPlannerImpl} that require a planner. */
+public class FlinkPlannerImplTest {
+    @Test
+    public void testCreateSqlValidator() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+
+        DataStream<String> testStream =
+                env.fromCollection(Arrays.asList("beer", "disappear", "beer"));
+
+        // convert DataStream to Table
+        tEnv.createTemporaryView("test", testStream, $("user"));
+
+        // union the two tables
+        Table resultByName =
+                tEnv.sqlQuery("SELECT user, count(*) as amount FROM test group by user");
+        Table resultByPos = tEnv.sqlQuery("SELECT user, count(*) as amount FROM test group by 1");
+
+        List<Tuple2<Boolean, Row>> resultsByName =
+                CollectionUtil.iteratorToList(
+                        tEnv.toRetractStream(resultByName, Row.class).executeAndCollect());
+        List<Tuple2<Boolean, Row>> resultsByPos =
+                CollectionUtil.iteratorToList(
+                        tEnv.toRetractStream(resultByPos, Row.class).executeAndCollect());
+        assertThat(resultsByName).isEqualTo(resultsByPos);
+
+        assertThat(resultsByPos).hasSize(4);
+        assertThat(resultsByPos.get(0).f0).isEqualTo(true);
+        assertThat(resultsByPos.get(2).f0).isEqualTo(false);
+        assertThat(resultsByPos.get(1).f1.getField(1)).isEqualTo(1L);
+        assertThat(resultsByPos.get(3).f1.getField(1)).isEqualTo(2L);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*This pull request try to fix the SqlValidatorException when using group by index in Flink.*


## Brief change log

  - *Pass FlinkSqlConformance.DEFAULT to FlinkCalciteSqlValidator*
  - *Change the return value of isGroupByOrdinal() from false to true *
  - *Add unit test for these changes*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change added tests and can be verified as follows:

  - *Added test class FlinkPlannerImplTest and function testCreateSqlValidator() *

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
