### PR TITLE
[FLINK-28198][connectors][cassandra] raise driver timeouts per session request and raise it higher than cluster side timetouts

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -464,8 +464,7 @@ public class CassandraConnectorITCase
     protected void verifyResultsIdealCircumstances(
             CassandraTupleWriteAheadSink<Tuple3<String, Integer, Integer>> sink) {
 
-        ResultSet result =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet result = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         ArrayList<Integer> list = new ArrayList<>();
         for (int x = 1; x <= 60; x++) {
             list.add(x);
@@ -483,8 +482,7 @@ public class CassandraConnectorITCase
     protected void verifyResultsDataPersistenceUponMissedNotify(
             CassandraTupleWriteAheadSink<Tuple3<String, Integer, Integer>> sink) {
 
-        ResultSet result =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet result = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         ArrayList<Integer> list = new ArrayList<>();
         for (int x = 1; x <= 60; x++) {
             list.add(x);
@@ -502,8 +500,7 @@ public class CassandraConnectorITCase
     protected void verifyResultsDataDiscardingUponRestore(
             CassandraTupleWriteAheadSink<Tuple3<String, Integer, Integer>> sink) {
 
-        ResultSet result =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet result = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         ArrayList<Integer> list = new ArrayList<>();
         for (int x = 1; x <= 20; x++) {
             list.add(x);
@@ -537,8 +534,7 @@ public class CassandraConnectorITCase
         }
 
         ArrayList<Integer> actual = new ArrayList<>();
-        ResultSet result =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet result = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
 
         for (com.datastax.driver.core.Row s : result) {
             actual.add(s.getInt(TUPLE_COUNTER_FIELD));
@@ -617,8 +613,7 @@ public class CassandraConnectorITCase
             sink.close();
         }
 
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         assertThat(rs.all()).hasSize(20);
     }
 
@@ -636,8 +631,7 @@ public class CassandraConnectorITCase
             sink.close();
         }
 
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         assertThat(rs.all()).hasSize(20);
     }
 
@@ -647,8 +641,7 @@ public class CassandraConnectorITCase
                 annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
         writePojos(annotatedPojoClass, null);
 
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         assertThat(rs.all()).hasSize(20);
     }
 
@@ -657,8 +650,7 @@ public class CassandraConnectorITCase
         final Class<? extends Pojo> annotatedPojoClass =
                 annotatePojoWithTable("", TABLE_NAME_PREFIX + tableID);
         writePojos(annotatedPojoClass, KEYSPACE);
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         assertThat(rs.all()).hasSize(20);
     }
 
@@ -699,8 +691,7 @@ public class CassandraConnectorITCase
 
         tEnv.sqlQuery("select * from testFlinkTable").executeInsert("cassandraTable").await();
 
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
 
         // validate that all input was correctly written to Cassandra
         List<Row> input = new ArrayList<>(rowCollection);
@@ -735,8 +726,7 @@ public class CassandraConnectorITCase
                 annotatePojoWithTable(KEYSPACE, TABLE_NAME_PREFIX + tableID);
 
         final List<? extends Pojo> pojos = writePojosWithOutputFormat(annotatedPojoClass);
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         assertThat(rs.all()).hasSize(20);
 
         final List<? extends Pojo> result = readPojosWithInputFormat(annotatedPojoClass);
@@ -807,8 +797,7 @@ public class CassandraConnectorITCase
             sink.close();
         }
 
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         List<com.datastax.driver.core.Row> rows = rs.all();
         assertThat(rows).hasSize(rowCollection.size());
     }
@@ -862,8 +851,7 @@ public class CassandraConnectorITCase
             sink.close();
         }
 
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         List<com.datastax.driver.core.Row> rows = rs.all();
         assertThat(rows).hasSize(scalaTupleCollection.size());
 
@@ -903,8 +891,7 @@ public class CassandraConnectorITCase
             sink.close();
         }
 
-        ResultSet rs =
-                session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
+        ResultSet rs = session.execute(requestWithTimeout(injectTableName(SELECT_DATA_QUERY)));
         List<com.datastax.driver.core.Row> rows = rs.all();
         assertThat(rows).hasSize(1);
         // Since nulls are ignored, we should be reading one complete record

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraConnectorITCase.java
@@ -144,8 +144,9 @@ public class CassandraConnectorITCase
                                 new SocketOptions()
                                         // multiply default timeout by 3
                                         .setConnectTimeoutMillis(15000)
-                                        // double default timeout
-                                        .setReadTimeoutMillis(24000))
+                                        // x3 default timeout and higher than
+                                        // raised request_timeout_in_ms at the cluster level
+                                        .setReadTimeoutMillis(36000))
                         .withoutJMXReporting()
                         .withoutMetrics()
                         .build();
@@ -280,13 +281,13 @@ public class CassandraConnectorITCase
             String patchedConfiguration =
                     configuration
                             .replaceAll(
-                                    "request_timeout_in_ms: [0-9]+", "request_timeout_in_ms: 30000")
+                                    "request_timeout_in_ms: [0-9]+", "request_timeout_in_ms: 30000") // x3
                             .replaceAll(
                                     "read_request_timeout_in_ms: [0-9]+",
-                                    "read_request_timeout_in_ms: 15000")
+                                    "read_request_timeout_in_ms: 15000") // x3
                             .replaceAll(
                                     "write_request_timeout_in_ms: [0-9]+",
-                                    "write_request_timeout_in_ms: 6000");
+                                    "write_request_timeout_in_ms: 6000"); // x3
             CASSANDRA_CONTAINER.copyFileToContainer(
                     Transferable.of(patchedConfiguration.getBytes(StandardCharsets.UTF_8)),
                     "/etc/cassandra/cassandra.yaml");


### PR DESCRIPTION

## Contribution Checklist

## What is the purpose of the change

Raise driver timeouts per session request and raise it higher than cluster side timetouts


## Brief change log

Change in the CassandraITCase

## Verifying this change


This change is already covered by existing tests, such as *CassandraITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

R: @MartijnVisser 
