### PR TITLE
[FLINK-28411] - Error Handling for OperatorCoordinatorHolder which may fail Session Cluster

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -191,7 +191,14 @@ public class OperatorCoordinatorHolder
     public void start() throws Exception {
         mainThreadExecutor.assertRunningInMainThread();
         checkState(context.isInitialized(), "Coordinator Context is not yet initialized");
-        coordinator.start();
+
+        try{
+            coordinator.start();
+        } catch (Throwable t){
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+            LOG.error("Failed to start operatorCoordinator ID: {}", operatorId, t);
+            context.failJob(t);
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -192,9 +192,9 @@ public class OperatorCoordinatorHolder
         mainThreadExecutor.assertRunningInMainThread();
         checkState(context.isInitialized(), "Coordinator Context is not yet initialized");
 
-        try{
+        try {
             coordinator.start();
-        } catch (Throwable t){
+        } catch (Throwable t) {
             ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
             LOG.error("Failed to start operatorCoordinator ID: {}", operatorId, t);
             context.failJob(t);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.coordination.EventReceivingTasks.EventWithSubtask;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.util.ExceptionUtils;
-import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -37,7 +36,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
-import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.Queue;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.operators.coordination.EventReceivingTasks.EventWithSubtask;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.After;
@@ -458,6 +459,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                 createCoordinatorHolder(tasks, coordinatorProvider);
 
         assertNotNull(globalFailure);
+        assertTrue(globalFailure instanceof FlinkException);
         globalFailure = null;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -461,7 +461,6 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
         globalFailure = null;
     }
 
-
     // ------------------------------------------------------------------------
     //   test actions
     // ------------------------------------------------------------------------

--- a/mvnvm.properties
+++ b/mvnvm.properties
@@ -1,0 +1,1 @@
+mvn_version=3.2.5

--- a/mvnvm.properties
+++ b/mvnvm.properties
@@ -1,1 +1,0 @@
-mvn_version=3.2.5


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request adds error handling around OperatorCoordinatorHolder.start method, addressing problem raised in [FLINK-28411]. Previously, exception from this method (I.e from starting OperatorCoordinator) bubbles up to Dispatcher to trigger a fatal error which brings down the entire cluster. With this new change, OperatorCoordinatorHolder will instead trigger a globalFailure which is handled by the Scheduler. 


## Brief change log

OperatorCoordinatorHolder.start now handles exception thrown from OperatorCoordinator.start. It rethrows the error if it's a JVM/OOM fatal error. Else, it triggers a globalFailure which is handled by Scheduler to attempt to restart the Job.


## Verifying this change

Added Unit Test to validate:
- Exception is caught and not bubbled up above OperatorCoordinatorHolder.
- GlobalFailure is successfully triggered.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
