### PR TITLE
[FLINK-28433][connector/jdbc]Add mariadb jdbc connection validation

### DIFF
--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -53,7 +53,8 @@ JDBC 连接器不是二进制发行版的一部分，请查阅[这里]({{< ref "
 | MySQL       |       `mysql`      | `mysql-connector-java` | [下载](https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/) |
 | Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [下载](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8)
 | PostgreSQL  |  `org.postgresql`  |      `postgresql`      | [下载](https://jdbc.postgresql.org/download.html) |
-| Derby       | `org.apache.derby` |        `derby`         | [下载](http://db.apache.org/derby/derby_downloads.html) | |
+| Derby       | `org.apache.derby` |        `derby`         | [下载](http://db.apache.org/derby/derby_downloads.html) |
+| MariaDB     | `org.mariadb.jdbc` | `mariadb-java-client`  | [下载](https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/) | |
 
 当前，JDBC 连接器和驱动不在 Flink 二进制发布包中，请参阅[这里]({{< ref "docs/dev/configuration" >}})了解在集群上执行时何连接它们。
 
@@ -327,7 +328,7 @@ lookup cache 的主要目的是用于提高时态表关联 JDBC 连接器的性�
     </thead>
     <tbody>
         <tr>
-            <td>MySQL</td>
+            <td>MySQL / MariaDB</td>
             <td>INSERT .. ON DUPLICATE KEY UPDATE ..</td>
         </tr>
         <tr>
@@ -544,7 +545,7 @@ SELECT * FROM given_database.test_table2;
 
 数据类型映射
 ----------------
-Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、Oracle、PostgreSQL、Derby 等。其中，Derby 通常是用于测试目的。下表列出了从关系数据库数据类型到 Flink SQL 数据类型的类型映射，映射表可以使得在 Flink 中定义 JDBC 表更加简单。
+Flink 支持连接到多个使用方言（dialect）的数据库，如 MySQL、Oracle、PostgreSQL、Derby、MariaDB 等。其中，Derby 通常是用于测试目的。下表列出了从关系数据库数据类型到 Flink SQL 数据类型的类型映射，映射表可以使得在 Flink 中定义 JDBC 表更加简单。
 
 <table class="table table-bordered">
     <thead>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -51,6 +51,7 @@ A driver dependency is also required to connect to a specified database. Here ar
 | Oracle      | `com.oracle.database.jdbc` |        `ojdbc8`        | [Download](https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8) |
 | PostgreSQL  |  `org.postgresql`  |      `postgresql`      | [Download](https://jdbc.postgresql.org/download.html) |
 | Derby       | `org.apache.derby` |        `derby`         | [Download](http://db.apache.org/derby/derby_downloads.html) |
+| MariaDB     | `org.mariadb.jdbc` | `mariadb-java-client`  | [Download](https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/) | |
 
 
 JDBC connector and drivers are not part of Flink's binary distribution. See how to link with them for cluster execution [here]({{< ref "docs/dev/configuration" >}}).
@@ -333,7 +334,7 @@ As there is no standard syntax for upsert, the following table describes the dat
     </thead>
     <tbody>
         <tr>
-            <td>MySQL</td>
+            <td>MySQL / MariaDB</td>
             <td>INSERT .. ON DUPLICATE KEY UPDATE ..</td>
         </tr>
         <tr>
@@ -538,7 +539,7 @@ SELECT * FROM given_database.test_table2;
 
 Data Type Mapping
 ----------------
-Flink supports connect to several databases which uses dialect like MySQL, Oracle, PostgreSQL, Derby. The Derby dialect usually used for testing purpose. The field data type mappings from relational databases data types to Flink SQL data types are listed in the following table, the mapping table can help define JDBC table in Flink easily.
+Flink supports connect to several databases which uses dialect like MySQL, Oracle, PostgreSQL, Derby, MariaDB. The Derby dialect usually used for testing purpose. The field data type mappings from relational databases data types to Flink SQL data types are listed in the following table, the mapping table can help define JDBC table in Flink easily.
 
 <table class="table table-bordered">
     <thead>

--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -165,6 +165,19 @@ under the License.
 			<scope>test</scope>
 		</dependency>
 
+		<!-- MariaDB tests -->
+		<dependency>
+			<groupId>org.mariadb.jdbc</groupId>
+			<artifactId>mariadb-java-client</artifactId>
+			<version>3.0.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mariadb</artifactId>
+			<scope>test</scope>
+		</dependency>
+
 		<!-- ArchUit test dependencies -->
 
 		<dependency>

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mariadb/MariaDBDialect.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mariadb/MariaDBDialect.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.dialect.mariadb;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.jdbc.converter.JdbcRowConverter;
+import org.apache.flink.connector.jdbc.dialect.AbstractDialect;
+import org.apache.flink.connector.jdbc.internal.converter.MariaDBRowConverter;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
+
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** JDBC dialect for MariaDB. */
+@Internal
+public class MariaDBDialect extends AbstractDialect {
+
+    private static final long serialVersionUID = 1L;
+
+    // Define MAX/MIN precision of TIMESTAMP type according to MariaDB docs:
+    // https://mariadb.com/kb/en/timestamp/#supported-values
+    private static final int MAX_TIMESTAMP_PRECISION = 6;
+    private static final int MIN_TIMESTAMP_PRECISION = 0;
+
+    // Define MAX/MIN precision of DECIMAL type according to MariaDB docs:
+    // https://mariadb.com/kb/en/decimal/#description
+    private static final int MAX_DECIMAL_PRECISION = 65;
+    private static final int MIN_DECIMAL_PRECISION = 1;
+
+    @Override
+    public JdbcRowConverter getRowConverter(RowType rowType) {
+        return new MariaDBRowConverter(rowType);
+    }
+
+    @Override
+    public String getLimitClause(long limit) {
+        return "LIMIT " + limit;
+    }
+
+    @Override
+    public Optional<String> defaultDriverName() {
+        return Optional.of("org.mariadb.jdbc.Driver");
+    }
+
+    @Override
+    public String quoteIdentifier(String identifier) {
+        return "`" + identifier + "`";
+    }
+
+    /**
+     * MariaDB upsert query use DUPLICATE KEY UPDATE.
+     *
+     * <p>NOTE: It requires MariaDB's primary key to be consistent with pkFields.
+     *
+     * <p>We don't use REPLACE INTO, if there are other fields, we can keep their previous values.
+     */
+    @Override
+    public Optional<String> getUpsertStatement(
+            String tableName, String[] fieldNames, String[] uniqueKeyFields) {
+        String updateClause =
+                Arrays.stream(fieldNames)
+                        .map(f -> quoteIdentifier(f) + "=VALUES(" + quoteIdentifier(f) + ")")
+                        .collect(Collectors.joining(", "));
+        return Optional.of(
+                getInsertIntoStatement(tableName, fieldNames)
+                        + " ON DUPLICATE KEY UPDATE "
+                        + updateClause);
+    }
+
+    @Override
+    public String dialectName() {
+        return "MariaDB";
+    }
+
+    @Override
+    public Optional<Range> decimalPrecisionRange() {
+        return Optional.of(Range.of(MIN_DECIMAL_PRECISION, MAX_DECIMAL_PRECISION));
+    }
+
+    @Override
+    public Optional<Range> timestampPrecisionRange() {
+        return Optional.of(Range.of(MIN_TIMESTAMP_PRECISION, MAX_TIMESTAMP_PRECISION));
+    }
+
+    @Override
+    public Set<LogicalTypeRoot> supportedTypes() {
+        // The data types used in MariaDB are list at:
+        // https://mariadb.com/kb/en/data-types/
+
+        // TODO: We can't convert BINARY data type to
+        //  PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO in
+        // LegacyTypeInfoDataTypeConverter.
+        return EnumSet.of(
+                LogicalTypeRoot.CHAR,
+                LogicalTypeRoot.VARCHAR,
+                LogicalTypeRoot.BOOLEAN,
+                LogicalTypeRoot.VARBINARY,
+                LogicalTypeRoot.DECIMAL,
+                LogicalTypeRoot.TINYINT,
+                LogicalTypeRoot.SMALLINT,
+                LogicalTypeRoot.INTEGER,
+                LogicalTypeRoot.BIGINT,
+                LogicalTypeRoot.FLOAT,
+                LogicalTypeRoot.DOUBLE,
+                LogicalTypeRoot.DATE,
+                LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE,
+                LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE);
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mariadb/MariaDBDialectFactory.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mariadb/MariaDBDialectFactory.java
@@ -16,22 +16,22 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.jdbc.dialect.mysql;
+package org.apache.flink.connector.jdbc.dialect.mariadb;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
 import org.apache.flink.connector.jdbc.dialect.JdbcDialectFactory;
 
-/** Factory for {@link MySqlDialect}. */
+/** Factory for {@link MariaDBDialect}. */
 @Internal
-public class MySqlDialectFactory implements JdbcDialectFactory {
+public class MariaDBDialectFactory implements JdbcDialectFactory {
     @Override
     public boolean acceptsURL(String url) {
-        return (url.startsWith("jdbc:mysql:") || url.startsWith("jdbc:mariadb:"));
+        return url.startsWith("jdbc:mariadb:");
     }
 
     @Override
     public JdbcDialect create() {
-        return new MySqlDialect();
+        return new MariaDBDialect();
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mariadb/MariaDBTypeMapper.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/dialect/mariadb/MariaDBTypeMapper.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.jdbc.dialect.mariadb;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.jdbc.dialect.JdbcDialectTypeMapper;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.CatalogException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DecimalType;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+
+/** MariaDBTypeMapper util class. */
+@Internal
+public class MariaDBTypeMapper implements JdbcDialectTypeMapper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MariaDBTypeMapper.class);
+
+    // ============================data types=====================
+
+    private static final String MARIADB_UNKNOWN = "UNKNOWN";
+    private static final String MARIADB_BIT = "BIT";
+
+    // -------------------------number----------------------------
+    private static final String MARIADB_TINYINT = "TINYINT";
+    private static final String MARIADB_TINYINT_UNSIGNED = "TINYINT UNSIGNED";
+    private static final String MARIADB_SMALLINT = "SMALLINT";
+    private static final String MARIADB_SMALLINT_UNSIGNED = "SMALLINT UNSIGNED";
+    private static final String MARIADB_MEDIUMINT = "MEDIUMINT";
+    private static final String MARIADB_MEDIUMINT_UNSIGNED = "MEDIUMINT UNSIGNED";
+    private static final String MARIADB_INT = "INT";
+    private static final String MARIADB_INT_UNSIGNED = "INT UNSIGNED";
+    private static final String MARIADB_INTEGER = "INTEGER";
+    private static final String MARIADB_INTEGER_UNSIGNED = "INTEGER UNSIGNED";
+    private static final String MARIADB_BIGINT = "BIGINT";
+    private static final String MARIADB_BIGINT_UNSIGNED = "BIGINT UNSIGNED";
+    private static final String MARIADB_DECIMAL = "DECIMAL";
+    private static final String MARIADB_DECIMAL_UNSIGNED = "DECIMAL UNSIGNED";
+    private static final String MARIADB_FLOAT = "FLOAT";
+    private static final String MARIADB_FLOAT_UNSIGNED = "FLOAT UNSIGNED";
+    private static final String MARIADB_DOUBLE = "DOUBLE";
+    private static final String MARIADB_DOUBLE_UNSIGNED = "DOUBLE UNSIGNED";
+
+    // -------------------------string----------------------------
+    private static final String MARIADB_CHAR = "CHAR";
+    private static final String MARIADB_VARCHAR = "VARCHAR";
+    private static final String MARIADB_TINYTEXT = "TINYTEXT";
+    private static final String MARIADB_MEDIUMTEXT = "MEDIUMTEXT";
+    private static final String MARIADB_TEXT = "TEXT";
+    private static final String MARIADB_LONGTEXT = "LONGTEXT";
+    private static final String MARIADB_JSON = "JSON";
+
+    // ------------------------------time-------------------------
+    private static final String MARIADB_DATE = "DATE";
+    private static final String MARIADB_DATETIME = "DATETIME";
+    private static final String MARIADB_TIME = "TIME";
+    private static final String MARIADB_TIMESTAMP = "TIMESTAMP";
+    private static final String MARIADB_YEAR = "YEAR";
+
+    // ------------------------------blob-------------------------
+    private static final String MARIADB_TINYBLOB = "TINYBLOB";
+    private static final String MARIADB_MEDIUMBLOB = "MEDIUMBLOB";
+    private static final String MARIADB_BLOB = "BLOB";
+    private static final String MARIADB_LONGBLOB = "LONGBLOB";
+    private static final String MARIADB_BINARY = "BINARY";
+    private static final String MARIADB_VARBINARY = "VARBINARY";
+    private static final String MARIADB_GEOMETRY = "GEOMETRY";
+
+    private static final int RAW_TIME_LENGTH = 10;
+    private static final int RAW_TIMESTAMP_LENGTH = 19;
+
+    private final String databaseVersion;
+    private final String driverVersion;
+
+    public MariaDBTypeMapper(String databaseVersion, String driverVersion) {
+        this.databaseVersion = databaseVersion;
+        this.driverVersion = driverVersion;
+    }
+
+    @Override
+    public DataType mapping(ObjectPath tablePath, ResultSetMetaData metadata, int colIndex)
+            throws SQLException {
+        String mariadbType = metadata.getColumnTypeName(colIndex).toUpperCase();
+        String columnName = metadata.getColumnName(colIndex);
+        int precision = metadata.getPrecision(colIndex);
+        int scale = metadata.getScale(colIndex);
+
+        switch (mariadbType) {
+            case MARIADB_BIT:
+                return DataTypes.BOOLEAN();
+            case MARIADB_TINYBLOB:
+            case MARIADB_MEDIUMBLOB:
+            case MARIADB_BLOB:
+            case MARIADB_LONGBLOB:
+            case MARIADB_VARBINARY:
+            case MARIADB_BINARY:
+                // BINARY is not supported in MariaDBDialect now.
+                // VARBINARY(n) is not supported in MariaDBDialect when 'n' is not equals to
+                // Integer.MAX_VALUE. Please see
+                // org.apache.flink.connector.jdbc.dialect.mariadb.MariaDBDialect#supportedTypes and
+                // org.apache.flink.connector.jdbc.dialect.AbstractDialect#validate for more
+                // details.
+                return DataTypes.BYTES();
+            case MARIADB_TINYINT:
+                return DataTypes.TINYINT();
+            case MARIADB_TINYINT_UNSIGNED:
+            case MARIADB_SMALLINT:
+                return DataTypes.SMALLINT();
+            case MARIADB_SMALLINT_UNSIGNED:
+            case MARIADB_MEDIUMINT:
+            case MARIADB_MEDIUMINT_UNSIGNED:
+            case MARIADB_INT:
+            case MARIADB_INTEGER:
+                return DataTypes.INT();
+            case MARIADB_INT_UNSIGNED:
+            case MARIADB_INTEGER_UNSIGNED:
+            case MARIADB_BIGINT:
+                return DataTypes.BIGINT();
+            case MARIADB_BIGINT_UNSIGNED:
+                return DataTypes.DECIMAL(20, 0);
+            case MARIADB_DECIMAL:
+                return DataTypes.DECIMAL(precision, scale);
+            case MARIADB_DECIMAL_UNSIGNED:
+                checkMaxPrecision(tablePath, columnName, precision);
+                return DataTypes.DECIMAL(precision + 1, scale);
+            case MARIADB_FLOAT:
+                return DataTypes.FLOAT();
+            case MARIADB_FLOAT_UNSIGNED:
+                LOG.warn("{} will probably cause value overflow.", MARIADB_FLOAT_UNSIGNED);
+                return DataTypes.FLOAT();
+            case MARIADB_DOUBLE:
+                return DataTypes.DOUBLE();
+            case MARIADB_DOUBLE_UNSIGNED:
+                LOG.warn("{} will probably cause value overflow.", MARIADB_DOUBLE_UNSIGNED);
+                return DataTypes.DOUBLE();
+            case MARIADB_CHAR:
+                return DataTypes.CHAR(precision);
+            case MARIADB_VARCHAR:
+            case MARIADB_TINYTEXT:
+            case MARIADB_MEDIUMTEXT:
+            case MARIADB_TEXT:
+                return DataTypes.VARCHAR(precision);
+            case MARIADB_JSON:
+                return DataTypes.STRING();
+            case MARIADB_LONGTEXT:
+                LOG.warn(
+                        "Type '{}' has a maximum precision of 4,294,967,295 or 4GB characters "
+                                + "in MariaDB. "
+                                + "Due to limitations in the Flink type system, "
+                                + "the precision will be set to 2147483647.",
+                        MARIADB_LONGTEXT);
+                return DataTypes.STRING();
+            case MARIADB_DATE:
+                return DataTypes.DATE();
+            case MARIADB_TIME:
+                return isExplicitPrecision(precision, RAW_TIME_LENGTH)
+                        ? DataTypes.TIME(precision - RAW_TIME_LENGTH - 1)
+                        : DataTypes.TIME(0);
+            case MARIADB_DATETIME:
+            case MARIADB_TIMESTAMP:
+                boolean explicitPrecision = isExplicitPrecision(precision, RAW_TIMESTAMP_LENGTH);
+                if (explicitPrecision) {
+                    int p = precision - RAW_TIMESTAMP_LENGTH - 1;
+                    if (p <= 6 && p >= 0) {
+                        return DataTypes.TIMESTAMP(p);
+                    }
+                    return p > 6 ? DataTypes.TIMESTAMP(6) : DataTypes.TIMESTAMP(0);
+                }
+                return DataTypes.TIMESTAMP(0);
+
+            case MARIADB_YEAR:
+            case MARIADB_GEOMETRY:
+            case MARIADB_UNKNOWN:
+            default:
+                final String jdbcColumnName = metadata.getColumnName(colIndex);
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Doesn't support MariaDB type '%s' on column '%s' in MariaDB version %s, driver version %s yet.",
+                                mariadbType, jdbcColumnName, databaseVersion, driverVersion));
+        }
+    }
+
+    private boolean isExplicitPrecision(int precision, int defaultPrecision) {
+
+        return precision > defaultPrecision && precision - defaultPrecision - 1 <= 9;
+    }
+
+    private void checkMaxPrecision(ObjectPath tablePath, String columnName, int precision) {
+
+        if (precision >= DecimalType.MAX_PRECISION) {
+            throw new CatalogException(
+                    String.format(
+                            "Precision %s of table %s column name %s in type %s exceeds "
+                                    + "DecimalType.MAX_PRECISION %s.",
+                            precision,
+                            tablePath.getFullName(),
+                            columnName,
+                            MARIADB_DECIMAL_UNSIGNED,
+                            DecimalType.MAX_PRECISION));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/MariaDBRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/internal/converter/MariaDBRowConverter.java
@@ -16,22 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.jdbc.dialect.mysql;
+package org.apache.flink.connector.jdbc.internal.converter;
 
-import org.apache.flink.annotation.Internal;
-import org.apache.flink.connector.jdbc.dialect.JdbcDialect;
-import org.apache.flink.connector.jdbc.dialect.JdbcDialectFactory;
+import org.apache.flink.connector.jdbc.converter.AbstractJdbcRowConverter;
+import org.apache.flink.table.types.logical.RowType;
 
-/** Factory for {@link MySqlDialect}. */
-@Internal
-public class MySqlDialectFactory implements JdbcDialectFactory {
+/**
+ * Runtime converter that responsible to convert between JDBC object and Flink internal object for
+ * MariaDB.
+ */
+public class MariaDBRowConverter extends AbstractJdbcRowConverter {
+
+    private static final long serialVersionUID = 1L;
+
     @Override
-    public boolean acceptsURL(String url) {
-        return (url.startsWith("jdbc:mysql:") || url.startsWith("jdbc:mariadb:"));
+    public String converterName() {
+        return "MariaDB";
     }
 
-    @Override
-    public JdbcDialect create() {
-        return new MySqlDialect();
+    public MariaDBRowConverter(RowType rowType) {
+        super(rowType);
     }
 }

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTypeTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/JdbcDataTypeTest.java
@@ -117,6 +117,22 @@ public class JdbcDataTypeTest {
                 createTestItem("oracle", "TIMESTAMP(3)"),
                 createTestItem("oracle", "TIMESTAMP WITHOUT TIME ZONE"),
                 createTestItem("oracle", "VARBINARY"),
+                createTestItem("mariadb", "CHAR"),
+                createTestItem("mariadb", "VARCHAR"),
+                createTestItem("mariadb", "BOOLEAN"),
+                createTestItem("mariadb", "TINYINT"),
+                createTestItem("mariadb", "SMALLINT"),
+                createTestItem("mariadb", "INTEGER"),
+                createTestItem("mariadb", "BIGINT"),
+                createTestItem("mariadb", "FLOAT"),
+                createTestItem("mariadb", "DOUBLE"),
+                createTestItem("mariadb", "DECIMAL(10, 4)"),
+                createTestItem("mariadb", "DECIMAL(38, 18)"),
+                createTestItem("mariadb", "DATE"),
+                createTestItem("mariadb", "TIME"),
+                createTestItem("mariadb", "TIMESTAMP(3)"),
+                createTestItem("mariadb", "TIMESTAMP WITHOUT TIME ZONE"),
+                createTestItem("mariadb", "VARBINARY"),
 
                 // Unsupported types throws errors.
                 createTestItem(
@@ -166,7 +182,21 @@ public class JdbcDataTypeTest {
                 createTestItem(
                         "oracle",
                         "VARBINARY(10)",
-                        "The Oracle dialect doesn't support type: VARBINARY(10)."));
+                        "The Oracle dialect doesn't support type: VARBINARY(10)."),
+                createTestItem(
+                        "mariadb", "BINARY", "The MySQL dialect doesn't support type: BINARY(1)."),
+                createTestItem(
+                        "mariadb",
+                        "VARBINARY(10)",
+                        "The MySQL dialect doesn't support type: VARBINARY(10)."),
+                createTestItem(
+                        "mariadb",
+                        "TIMESTAMP(9) WITHOUT TIME ZONE",
+                        "The precision of field 'f0' is out of the TIMESTAMP precision range [0, 6] supported by MySQL dialect."),
+                createTestItem(
+                        "mariadb",
+                        "TIMESTAMP_LTZ(3)",
+                        "The MySQL dialect doesn't support type: TIMESTAMP_LTZ(3)."));
     }
 
     private static TestItem createTestItem(Object... args) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

1. Flink Connector support the jdbc connection with Mysql series DB, such as MySQL, MariaDB,
Percona and etc. But we see the doc reference[1] shows the Mariadb Connector/J 3.0 will
accepts jdbc:mariadb: as the protocal in connection strings by default. So we need to apply
this change in our mysql jdbc connection vailidation. Mariadb Connector/J 2.X still support
both "jdbc:mysql:" and "jdbc:mariadb:".
2. Introduce MariaDB dialect implemented like Mysql.
3. Add UTs for DataTypes and a testcontainer for MariaDB in
   JdbcExactlyOnceSinkE2eTest.

[1] https://mariadb.com/kb/en/about-mariadb-connector-j/#jdbcmysql-scheme-compatibility



## Brief change log

-  Making Mysql jdbc connector validate the MariaDB type connection protocol for fit users to use Mysql jdbc connector to access MariaDB instances.
- Introduce MariaDB jdbc dialect into Flink, which is very similar with Mysql.
- Introduce UTs and E2E test for them.

## Verifying this change

Exec `mvn clean package -Dfast -Pskip-webui-build -pl flink-connectors/flink-connector-jdbc`
Or `mvn clean package -Dfast -Pskip-webui-build -pl flink-connectors/flink-connector-jdbc -Dtest="org.apache.flink.connector.jdbc.xa.JdbcExactlyOnceSinkE2eTest"` for run all tests or a single test. 
Notes that all types didn't cover, and will be on going for support.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive):  (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no) 
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
