### PR TITLE
[FLINK-28140][python][docs] Improve the documentation by adding Python examples

### DIFF
--- a/docs/content/docs/dev/table/concepts/time_attributes.md
+++ b/docs/content/docs/dev/table/concepts/time_attributes.md
@@ -164,6 +164,30 @@ val table = tEnv.fromDataStream(stream, $"user_action_time".rowtime, $"user_name
 val windowedTable = table.window(Tumble over 10.minutes on $"user_action_time" as "userActionWindow")
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+
+# Option 1:
+
+# extract timestamp and assign watermarks based on knowledge of the stream
+stream = input_stream.assign_timestamps_and_watermarks(...)
+
+table = t_env.from_data_stream(stream, col('user_name'), col('data'), col('user_action_time').rowtime)
+
+# Option 2:
+
+# extract timestamp from first field, and assign watermarks based on knowledge of the stream
+stream = input_stream.assign_timestamps_and_watermarks(...)
+
+# the first field has been used for timestamp extraction, and is no longer necessary
+# replace first field with a logical event time attribute
+table = t_env.from_data_stream(stream, col("user_action_time").rowtime, col('user_name'), col('data'))
+
+# Usage:
+
+table.window(Tumble.over(lit(10).minutes).on(col("user_action_time")).alias("userActionWindow"))
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 
@@ -220,6 +244,16 @@ val stream: DataStream[(String, String)] = ...
 val table = tEnv.fromDataStream(stream, $"UserActionTimestamp", $"user_name", $"data", $"user_action_time".proctime)
 
 val windowedTable = table.window(Tumble over 10.minutes on $"user_action_time" as "userActionWindow")
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+stream = ...
+
+# declare an additional logical field as a processing time attribute
+table = t_env.from_data_stream(stream, col("UserActionTimestamp"), col("user_name"), col("data"), col("user_action_time").proctime)
+
+windowed_table = table.window(Tumble.over(lit(10).minutes).on(col("user_action_time")).alias("userActionWindow"))
 ```
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
## What is the purpose of the change

Improve the documentation by adding Python examples.

## Brief change log

  - Improve the Time Attributes of Table api documentation by adding Python examples.
 
## Verifying this change

  - This Change without andy test coverage.
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)