### PR TITLE
[FLINK-28417][table] Add interfaces for LookupCache and default implementation

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/CacheMetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/CacheMetricGroup.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.metrics.groups;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * Pre-defined metrics for cache.
+ *
+ * <p>Please note that these methods should only be invoked once. Registering a metric with same
+ * name for multiple times would lead to an undefined behavior.
+ */
+@PublicEvolving
+public interface CacheMetricGroup extends MetricGroup {
+    /** The number of cache hits. */
+    void hitCounter(Counter hitCounter);
+
+    /** The number of cache misses. */
+    void missCounter(Counter missCounter);
+
+    /** The number of times to load data into cache from external system. */
+    void loadCounter(Counter loadCounter);
+
+    /** The number of load failures. */
+    void numLoadFailuresCounter(Counter numLoadFailuresCounter);
+
+    /** The time spent for the latest load operation. */
+    void latestLoadTimeGauge(Gauge<Long> latestLoadTimeGauge);
+
+    /** The number of records in cache. */
+    void numCachedRecordsGauge(Gauge<Long> numCachedRecordsGauge);
+
+    /** The number of bytes used by cache. */
+    void numCachedBytesGauge(Gauge<Long> numCachedBytesGauge);
+}

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/UnregisteredMetricsGroup.java
@@ -108,6 +108,10 @@ public class UnregisteredMetricsGroup implements MetricGroup {
         return new UnregisteredSplitEnumeratorMetricGroup();
     }
 
+    public static CacheMetricGroup createCacheMetricGroup() {
+        return new UnregisteredCacheMetricGroup();
+    }
+
     private static class UnregisteredOperatorMetricGroup extends UnregisteredMetricsGroup
             implements OperatorMetricGroup {
         @Override
@@ -177,5 +181,29 @@ public class UnregisteredMetricsGroup implements MetricGroup {
         public <G extends Gauge<Long>> G setUnassignedSplitsGauge(G unassignedSplitsGauge) {
             return null;
         }
+    }
+
+    private static class UnregisteredCacheMetricGroup extends UnregisteredMetricsGroup
+            implements CacheMetricGroup {
+        @Override
+        public void hitCounter(Counter hitCounter) {}
+
+        @Override
+        public void missCounter(Counter missCounter) {}
+
+        @Override
+        public void loadCounter(Counter loadCounter) {}
+
+        @Override
+        public void numLoadFailuresCounter(Counter numLoadFailuresCounter) {}
+
+        @Override
+        public void latestLoadTimeGauge(Gauge<Long> latestLoadTimeGauge) {}
+
+        @Override
+        public void numCachedRecordsGauge(Gauge<Long> numCachedRecordsGauge) {}
+
+        @Override
+        public void numCachedBytesGauge(Gauge<Long> numCachedBytesGauge) {}
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -114,4 +114,13 @@ public class MetricNames {
     public static final String NUM_SLOW_EXECUTION_VERTICES = "numSlowExecutionVertices";
     public static final String NUM_EFFECTIVE_SPECULATIVE_EXECUTIONS =
             "numEffectiveSpeculativeExecutions";
+
+    // FLIP-221 for caches
+    public static final String HIT_COUNT = "hitCount";
+    public static final String MISS_COUNT = "missCount";
+    public static final String LOAD_COUNT = "loadCount";
+    public static final String NUM_LOAD_FAILURES = "numLoadFailures";
+    public static final String LATEST_LOAD_TIME = "latestLoadTime";
+    public static final String NUM_CACHED_RECORDS = "numCachedRecords";
+    public static final String NUM_CACHED_BYTES = "numCachedBytes";
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalCacheMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalCacheMetricGroup.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.CacheMetricGroup;
+
+import static org.apache.flink.runtime.metrics.MetricNames.HIT_COUNT;
+import static org.apache.flink.runtime.metrics.MetricNames.LATEST_LOAD_TIME;
+import static org.apache.flink.runtime.metrics.MetricNames.LOAD_COUNT;
+import static org.apache.flink.runtime.metrics.MetricNames.MISS_COUNT;
+import static org.apache.flink.runtime.metrics.MetricNames.NUM_CACHED_BYTES;
+import static org.apache.flink.runtime.metrics.MetricNames.NUM_CACHED_RECORDS;
+import static org.apache.flink.runtime.metrics.MetricNames.NUM_LOAD_FAILURES;
+
+/**
+ * A {@link CacheMetricGroup} which register all cache related metrics under a subgroup of the
+ * parent metric group.
+ */
+@Internal
+public class InternalCacheMetricGroup extends ProxyMetricGroup<MetricGroup>
+        implements CacheMetricGroup {
+
+    /**
+     * Creates a subgroup with the specified subgroup name under the parent group. Metrics will be
+     * registered under the new created subgroup.
+     *
+     * <p>For example the hit counter will be registered as "root.cache.hitCount", with {@code
+     * parentMetricGroup = root} and {@code subGroupName = "cache"}.
+     *
+     * @param parentMetricGroup parent metric group of the subgroup
+     * @param subGroupName name of the subgroup
+     */
+    public InternalCacheMetricGroup(MetricGroup parentMetricGroup, String subGroupName) {
+        super(parentMetricGroup.addGroup(subGroupName));
+    }
+
+    @Override
+    public void hitCounter(Counter hitCounter) {
+        counter(HIT_COUNT, hitCounter);
+    }
+
+    @Override
+    public void missCounter(Counter missCounter) {
+        counter(MISS_COUNT, missCounter);
+    }
+
+    @Override
+    public void loadCounter(Counter loadCounter) {
+        counter(LOAD_COUNT, loadCounter);
+    }
+
+    @Override
+    public void numLoadFailuresCounter(Counter numLoadFailuresCounter) {
+        counter(NUM_LOAD_FAILURES, numLoadFailuresCounter);
+    }
+
+    @Override
+    public void latestLoadTimeGauge(Gauge<Long> latestLoadTimeGauge) {
+        gauge(LATEST_LOAD_TIME, latestLoadTimeGauge);
+    }
+
+    @Override
+    public void numCachedRecordsGauge(Gauge<Long> numCachedRecordsGauge) {
+        gauge(NUM_CACHED_RECORDS, numCachedRecordsGauge);
+    }
+
+    @Override
+    public void numCachedBytesGauge(Gauge<Long> numCachedBytesGauge) {
+        gauge(NUM_CACHED_BYTES, numCachedBytesGauge);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupOptions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupOptions.java
@@ -20,8 +20,11 @@ package org.apache.flink.table.connector.source.lookup;
 
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.description.Description;
 
 import java.time.Duration;
+
+import static org.apache.flink.configuration.description.TextElement.code;
 
 /** Predefined options for lookup cache. */
 public class LookupOptions {
@@ -29,7 +32,14 @@ public class LookupOptions {
             ConfigOptions.key("lookup.cache")
                     .enumType(LookupCacheType.class)
                     .defaultValue(LookupCacheType.NONE)
-                    .withDescription("The caching strategy for this lookup table");
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "The caching strategy for this lookup table, including %s, %s and %s",
+                                            code(LookupCacheType.NONE.toString()),
+                                            code(LookupCacheType.PARTIAL.toString()),
+                                            code(LookupCacheType.FULL.toString()))
+                                    .build());
 
     public static final ConfigOption<Integer> MAX_RETRIES =
             ConfigOptions.key("lookup.max-retries")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupOptions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupOptions.java
@@ -26,7 +26,7 @@ import java.time.Duration;
 
 import static org.apache.flink.configuration.description.TextElement.code;
 
-/** Predefined options for lookup cache. */
+/** Predefined options for lookup table. */
 public class LookupOptions {
     public static final ConfigOption<LookupCacheType> CACHE_TYPE =
             ConfigOptions.key("lookup.cache")
@@ -44,7 +44,7 @@ public class LookupOptions {
     public static final ConfigOption<Integer> MAX_RETRIES =
             ConfigOptions.key("lookup.max-retries")
                     .intType()
-                    .defaultValue(0)
+                    .defaultValue(3)
                     .withDescription("The maximum allowed retries if a lookup operation fails");
 
     public static final ConfigOption<Duration> PARTIAL_CACHE_EXPIRE_AFTER_ACCESS =

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupOptions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/LookupOptions.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+import java.time.Duration;
+
+/** Predefined options for lookup cache. */
+public class LookupOptions {
+    public static final ConfigOption<LookupCacheType> CACHE_TYPE =
+            ConfigOptions.key("lookup.cache")
+                    .enumType(LookupCacheType.class)
+                    .defaultValue(LookupCacheType.NONE)
+                    .withDescription("The caching strategy for this lookup table");
+
+    public static final ConfigOption<Integer> MAX_RETRIES =
+            ConfigOptions.key("lookup.max-retries")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription("The maximum allowed retries if a lookup operation fails");
+
+    public static final ConfigOption<Duration> PARTIAL_CACHE_EXPIRE_AFTER_ACCESS =
+            ConfigOptions.key("lookup.partial-cache.expire-after-access")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription("Duration to expire an entry in the cache after accessing");
+
+    public static final ConfigOption<Duration> PARTIAL_CACHE_EXPIRE_AFTER_WRITE =
+            ConfigOptions.key("lookup.partial-cache.expire-after-write")
+                    .durationType()
+                    .noDefaultValue()
+                    .withDescription("Duration to expire an entry in the cache after writing");
+
+    public static final ConfigOption<Boolean> PARTIAL_CACHE_CACHE_MISSING_KEY =
+            ConfigOptions.key("lookup.partial-cache.cache-missing-key")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to store an empty value into the cache if the lookup key doesn't match any rows in the table");
+
+    public static final ConfigOption<Long> PARTIAL_CACHE_MAX_ROWS =
+            ConfigOptions.key("lookup.partial-cache.max-rows")
+                    .longType()
+                    .noDefaultValue()
+                    .withDescription("The maximum number of rows to store in the cache");
+
+    /** Types of the lookup cache. */
+    public enum LookupCacheType {
+        NONE,
+        PARTIAL,
+        FULL
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/DefaultLookupCache.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/DefaultLookupCache.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup.cache;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.ThreadSafeSimpleCounter;
+import org.apache.flink.metrics.groups.CacheMetricGroup;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.clock.Clock;
+
+import org.apache.flink.shaded.guava30.com.google.common.base.Ticker;
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
+
+import javax.annotation.Nullable;
+
+import java.time.Duration;
+import java.util.Collection;
+
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.CACHE_TYPE;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.LookupCacheType.PARTIAL;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_CACHE_MISSING_KEY;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_ACCESS;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_WRITE;
+import static org.apache.flink.table.connector.source.lookup.LookupOptions.PARTIAL_CACHE_MAX_ROWS;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** Default implementation of {@link LookupCache}. */
+@PublicEvolving
+public class DefaultLookupCache implements LookupCache {
+    private static final long serialVersionUID = 6839408984141411172L;
+
+    // Configurations of the cache
+    private final Duration expireAfterAccessDuration;
+    private final Duration expireAfterWriteDuration;
+    private final Long maximumSize;
+    private final boolean cacheMissingKey;
+
+    // The underlying Guava cache implementation
+    private transient Cache<RowData, Collection<RowData>> guavaCache;
+
+    // Guava Ticker for testing expiration
+    private Ticker ticker;
+
+    // For tracking cache metrics
+    private Counter hitCounter;
+    private Counter missCounter;
+
+    private DefaultLookupCache(
+            Duration expireAfterAccessDuration,
+            Duration expireAfterWriteDuration,
+            Long maximumSize,
+            boolean cacheMissingKey) {
+        this.expireAfterAccessDuration = expireAfterAccessDuration;
+        this.expireAfterWriteDuration = expireAfterWriteDuration;
+        this.maximumSize = maximumSize;
+        this.cacheMissingKey = cacheMissingKey;
+    }
+
+    /** Creates a builder for the cache. */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static DefaultLookupCache fromConfig(ReadableConfig config) {
+        checkArgument(
+                config.get(CACHE_TYPE).equals(PARTIAL),
+                "'%s' should be '%s' in order to build a default lookup cache",
+                CACHE_TYPE.key(),
+                PARTIAL);
+        return new DefaultLookupCache(
+                config.get(PARTIAL_CACHE_EXPIRE_AFTER_ACCESS),
+                config.get(PARTIAL_CACHE_EXPIRE_AFTER_WRITE),
+                config.get(PARTIAL_CACHE_MAX_ROWS),
+                config.get(PARTIAL_CACHE_CACHE_MISSING_KEY));
+    }
+
+    @Override
+    public void open(CacheMetricGroup metricGroup) {
+        // Initialize Guava cache
+        CacheBuilder<Object, Object> guavaCacheBuilder = CacheBuilder.newBuilder();
+        if (expireAfterAccessDuration != null) {
+            guavaCacheBuilder.expireAfterAccess(expireAfterAccessDuration);
+        }
+        if (expireAfterWriteDuration != null) {
+            guavaCacheBuilder.expireAfterWrite(expireAfterWriteDuration);
+        }
+        if (maximumSize != null) {
+            guavaCacheBuilder.maximumSize(maximumSize);
+        }
+        if (ticker != null) {
+            guavaCacheBuilder.ticker(ticker);
+        }
+        guavaCache = guavaCacheBuilder.build();
+
+        // Initialize and register metrics
+        // Here we can't reuse Guava cache statistics because guavaCache#getIfPresent is not counted
+        // in the stat
+        hitCounter = new ThreadSafeSimpleCounter();
+        missCounter = new ThreadSafeSimpleCounter();
+        metricGroup.hitCounter(hitCounter);
+        metricGroup.missCounter(missCounter);
+        metricGroup.numCachedRecordsGauge(() -> guavaCache.size());
+    }
+
+    @Nullable
+    @Override
+    public Collection<RowData> getIfPresent(RowData key) {
+        Collection<RowData> value = guavaCache.getIfPresent(key);
+        if (value != null) {
+            hitCounter.inc();
+        } else {
+            missCounter.inc();
+        }
+        return value;
+    }
+
+    @Override
+    public Collection<RowData> put(RowData key, Collection<RowData> value) {
+        checkNotNull(key, "Cannot put an entry with null key into the cache");
+        checkNotNull(value, "Cannot put an entry with null value into the cache");
+        if (!value.isEmpty()) {
+            guavaCache.put(key, value);
+        } else {
+            if (cacheMissingKey) {
+                guavaCache.put(key, value);
+            }
+        }
+        return value;
+    }
+
+    @Override
+    public void invalidate(RowData key) {
+        guavaCache.invalidate(key);
+    }
+
+    @Override
+    public long size() {
+        return guavaCache.size();
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (guavaCache != null) {
+            guavaCache.invalidateAll();
+            guavaCache.cleanUp();
+        }
+    }
+
+    @VisibleForTesting
+    void withClock(Clock clock) {
+        ticker =
+                new Ticker() {
+                    @Override
+                    public long read() {
+                        return clock.relativeTimeNanos();
+                    }
+                };
+    }
+
+    /** Builder for {@link DefaultLookupCache}. */
+    @PublicEvolving
+    public static class Builder {
+        private Duration expireAfterAccessDuration;
+        private Duration expireAfterWriteDuration;
+        private Long maximumSize;
+        private boolean cacheMissingKey = true;
+
+        /**
+         * Specifies the duration after an entry is last accessed that it should be automatically
+         * removed.
+         */
+        public Builder expireAfterAccess(Duration duration) {
+            expireAfterAccessDuration = duration;
+            return this;
+        }
+
+        /**
+         * Specifies the duration after an entry is created that it should be automatically removed.
+         */
+        public Builder expireAfterWrite(Duration duration) {
+            expireAfterWriteDuration = duration;
+            return this;
+        }
+
+        /** Specifies the maximum number of entries of the cache. */
+        public Builder maximumSize(long maximumSize) {
+            this.maximumSize = maximumSize;
+            return this;
+        }
+
+        /**
+         * Specifies whether to cache empty value into the cache.
+         *
+         * <p>Please note that "empty" means a collection without any rows in it instead of null.
+         * The cache will not accept any null key or value.
+         */
+        public Builder cacheMissingKey(boolean cacheMissingKey) {
+            this.cacheMissingKey = cacheMissingKey;
+            return this;
+        }
+
+        /** Creates the cache. */
+        public DefaultLookupCache build() {
+            return new DefaultLookupCache(
+                    expireAfterAccessDuration,
+                    expireAfterWriteDuration,
+                    maximumSize,
+                    cacheMissingKey);
+        }
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/LookupCache.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/LookupCache.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup.cache;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.metrics.groups.CacheMetricGroup;
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Collection;
+
+/**
+ * A semi-persistent mapping from keys to values for storing entries of lookup table.
+ *
+ * <p>The type of the caching key is a {@link RowData} with lookup key fields packed inside. The
+ * type of value is a {@link Collection} of {@link RowData}, which are rows matching lookup key
+ * fields.
+ *
+ * <p>Cache entries are manually added using {@link #put}, and are stored in the cache until either
+ * evicted or manually invalidated.
+ *
+ * <p>Implementations of this interface are expected to be thread-safe, and can be safely accessed
+ * by multiple concurrent threads.
+ */
+@PublicEvolving
+public interface LookupCache extends AutoCloseable, Serializable {
+
+    /**
+     * Initialize the cache.
+     *
+     * @param metricGroup the metric group to register cache related metrics.
+     */
+    void open(CacheMetricGroup metricGroup);
+
+    /**
+     * Returns the value associated with key in this cache, or null if there is no cached value for
+     * key.
+     */
+    @Nullable
+    Collection<RowData> getIfPresent(RowData key);
+
+    /**
+     * Associates the specified value rows with the specified key row in the cache. If the cache
+     * previously contained value associated with the key, the old value is replaced by the
+     * specified value.
+     *
+     * @return the previous value rows associated with key, or null if there was no mapping for key.
+     * @param key - key row with which the specified value is to be associated
+     * @param value – value rows to be associated with the specified key
+     */
+    Collection<RowData> put(RowData key, Collection<RowData> value);
+
+    /** Discards any cached value for the specified key. */
+    void invalidate(RowData key);
+
+    /** Returns the number of key-value mappings in the cache. */
+    long size();
+}

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/connector/source/lookup/cache/DefaultLookupCacheTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/connector/source/lookup/cache/DefaultLookupCacheTest.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup.cache;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.groups.CacheMetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.util.clock.Clock;
+import org.apache.flink.util.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Unit test for {@link DefaultLookupCache}. */
+class DefaultLookupCacheTest {
+
+    private static final RowData KEY = GenericRowData.of("foo", "lookup", "key");
+    private static final RowData NON_EXIST_KEY = GenericRowData.of("non-exist");
+    private static final Collection<RowData> VALUE =
+            Arrays.asList(
+                    GenericRowData.of("bar", "lookup", "value", 0),
+                    GenericRowData.of("bar", "lookup", "value", 1),
+                    GenericRowData.of("bar", "lookup", "value", 2),
+                    GenericRowData.of("bar", "lookup", "value", 3));
+
+    @Test
+    void testBasicReadWriteInCache() throws Exception {
+        try (DefaultLookupCache cache = createCache(DefaultLookupCache.newBuilder())) {
+            cache.put(KEY, VALUE);
+            assertThat(cache.getIfPresent(NON_EXIST_KEY)).isNull();
+            assertThat(cache.getIfPresent(KEY)).containsExactlyElementsOf(VALUE);
+        }
+    }
+
+    @Test
+    void testExpireAfterAccess() throws Exception {
+        Duration expireDuration = Duration.ofSeconds(15213L);
+        Duration margin = Duration.ofSeconds(10);
+        ManualClock clock = new ManualClock();
+        try (DefaultLookupCache cache =
+                createCache(
+                        DefaultLookupCache.newBuilder().expireAfterAccess(expireDuration), clock)) {
+            cache.put(KEY, VALUE);
+            // Advance the clock with (expireDuration - margin) and the key should not expire
+            clock.advanceTime(expireDuration.minus(margin));
+            // This access should succeed, also renews the entry
+            assertThat(cache.getIfPresent(KEY)).containsExactlyElementsOf(VALUE);
+
+            // Advance the clock with (expireDuration - margin) again to validate that the key is
+            // not evicted because of the access above
+            clock.advanceTime(expireDuration.minus(margin));
+            assertThat(cache.getIfPresent(KEY)).containsExactlyElementsOf(VALUE);
+
+            // Advance the clock with expireDuration + margins to expire the key
+            clock.advanceTime(expireDuration.plus(margin));
+            assertThat(cache.getIfPresent(KEY)).isNull();
+        }
+    }
+
+    @Test
+    void testExpireAfterWrite() throws Exception {
+        Duration expireDuration = Duration.ofSeconds(15213L);
+        Duration margin = Duration.ofSeconds(10);
+        ManualClock clock = new ManualClock();
+        try (DefaultLookupCache cache =
+                createCache(
+                        DefaultLookupCache.newBuilder().expireAfterWrite(expireDuration), clock)) {
+            cache.put(KEY, VALUE);
+            assertThat(cache.getIfPresent(KEY)).containsAll(VALUE);
+            // Advance the clock to expire the key
+            clock.advanceTime(expireDuration.plus(margin));
+            assertThat(cache.getIfPresent(KEY)).isNull();
+        }
+    }
+
+    @Test
+    void testSizeBasedEviction() throws Exception {
+        int cacheSize = 10;
+        try (DefaultLookupCache cache =
+                createCache(DefaultLookupCache.newBuilder().maximumSize(cacheSize))) {
+            for (int i = 0; i < cacheSize; i++) {
+                cache.put(GenericRowData.of("lookup", "key", i), VALUE);
+            }
+            // Put one more entry into the cache, and the first one should be evicted
+            cache.put(GenericRowData.of("lookup", "key", cacheSize), VALUE);
+            assertThat(cache.getIfPresent(GenericRowData.of("lookup", "key", 0))).isNull();
+            // Other entries and the newly put one should stay in the cache
+            for (int i = 1; i < cacheSize + 1; i++) {
+                assertThat(cache.getIfPresent(GenericRowData.of("lookup", "key", i))).isNotNull();
+            }
+        }
+    }
+
+    @Test
+    void testCacheMissingKey() throws Exception {
+        try (DefaultLookupCache cache = createCache(DefaultLookupCache.newBuilder())) {
+            // Caching null key and value is not allowed
+            assertThatThrownBy(() -> cache.put(null, VALUE))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("Cannot put an entry with null key into the cache");
+            assertThatThrownBy(() -> cache.put(KEY, null))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessage("Cannot put an entry with null value into the cache");
+            // The default behaviour should be caching missing key
+            cache.put(KEY, Collections.emptyList());
+            assertThat(cache.getIfPresent(KEY)).isNotNull().isEmpty();
+        }
+
+        // Explicitly disable caching missing key
+        try (DefaultLookupCache cache =
+                createCache(DefaultLookupCache.newBuilder().cacheMissingKey(false))) {
+            cache.put(KEY, Collections.emptyList());
+            assertThat(cache.getIfPresent(KEY)).isNull();
+        }
+    }
+
+    @Test
+    void testCacheMetrics() throws Exception {
+        InterceptingCacheMetricGroup metricGroup = new InterceptingCacheMetricGroup();
+        try (DefaultLookupCache cache =
+                createCache(DefaultLookupCache.newBuilder(), null, metricGroup)) {
+            // These metrics are registered
+            assertThat(metricGroup.hitCounter).isNotNull();
+            assertThat(metricGroup.hitCounter.getCount()).isEqualTo(0);
+            assertThat(metricGroup.missCounter).isNotNull();
+            assertThat(metricGroup.missCounter.getCount()).isEqualTo(0);
+            assertThat(metricGroup.numCachedRecordsGauge).isNotNull();
+            assertThat(metricGroup.numCachedRecordsGauge.getValue()).isEqualTo(0);
+
+            // These metrics are left blank
+            assertThat(metricGroup.loadCounter).isNull();
+            assertThat(metricGroup.numLoadFailuresCounter).isNull();
+            assertThat(metricGroup.latestLoadTimeGauge).isNull();
+            assertThat(metricGroup.numCachedBytesGauge).isNull();
+
+            cache.put(KEY, VALUE);
+            assertThat(metricGroup.numCachedRecordsGauge.getValue()).isEqualTo(1);
+            cache.getIfPresent(KEY);
+            assertThat(metricGroup.hitCounter.getCount()).isEqualTo(1);
+            cache.getIfPresent(NON_EXIST_KEY);
+            assertThat(metricGroup.missCounter.getCount()).isEqualTo(1);
+        }
+    }
+
+    // ----------------------- Helper functions ----------------------
+
+    private DefaultLookupCache createCache(DefaultLookupCache.Builder builder) {
+        return createCache(builder, null, null);
+    }
+
+    private DefaultLookupCache createCache(DefaultLookupCache.Builder builder, Clock clock) {
+        return createCache(builder, clock, null);
+    }
+
+    private DefaultLookupCache createCache(
+            DefaultLookupCache.Builder builder, Clock clock, CacheMetricGroup metricGroup) {
+        DefaultLookupCache cache = builder.build();
+        if (clock != null) {
+            cache.withClock(clock);
+        }
+        if (metricGroup == null) {
+            cache.open(UnregisteredMetricsGroup.createCacheMetricGroup());
+        } else {
+            cache.open(metricGroup);
+        }
+        return cache;
+    }
+
+    // -------------------------- Helper classes ------------------------
+    private static class InterceptingCacheMetricGroup extends UnregisteredMetricsGroup
+            implements CacheMetricGroup {
+        private Counter hitCounter;
+        private Counter missCounter;
+        private Counter loadCounter;
+        private Counter numLoadFailuresCounter;
+        private Gauge<Long> latestLoadTimeGauge;
+        private Gauge<Long> numCachedRecordsGauge;
+        private Gauge<Long> numCachedBytesGauge;
+
+        @Override
+        public void hitCounter(Counter hitCounter) {
+            this.hitCounter = hitCounter;
+        }
+
+        @Override
+        public void missCounter(Counter missCounter) {
+            this.missCounter = missCounter;
+        }
+
+        @Override
+        public void loadCounter(Counter loadCounter) {
+            this.loadCounter = loadCounter;
+        }
+
+        @Override
+        public void numLoadFailuresCounter(Counter numLoadFailuresCounter) {
+            this.numLoadFailuresCounter = numLoadFailuresCounter;
+        }
+
+        @Override
+        public void latestLoadTimeGauge(Gauge<Long> latestLoadTimeGauge) {
+            this.latestLoadTimeGauge = latestLoadTimeGauge;
+        }
+
+        @Override
+        public void numCachedRecordsGauge(Gauge<Long> numCachedRecordsGauge) {
+            this.numCachedRecordsGauge = numCachedRecordsGauge;
+        }
+
+        @Override
+        public void numCachedBytesGauge(Gauge<Long> numCachedBytesGauge) {
+            this.numCachedBytesGauge = numCachedBytesGauge;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces interfaces for LookupCache and CacheMetricGroup, also a default implementation of LookupCache.


## Brief change log

- Add new interfaces `LookupCache` and `CacheMetricGroup`
- Add default implementation for `LookupCache` as `DefaultLookupCache`
- Add an internal implementation for `CacheMetricGroup` as `InternalCacheMetricGroup`


## Verifying this change

This change added unit tests for the newly added `DefaultLookupCache` and `InternalCacheMetricGroup`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
