### PR TITLE
[FLINK-28413][python][format] Support ParquetColumnarRowInputFormat

### DIFF
--- a/docs/content/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content/docs/connectors/datastream/formats/parquet.md
@@ -117,25 +117,47 @@ Flink will read records in batches of 500 records. The first boolean parameter s
 The second boolean instructs the application that the projected Parquet fields names are case-sensitive.
 There is no watermark strategy defined as records do not contain event timestamps.
 
+{{< tabs "RowData" >}}
+{{< tab "Java" >}}
 ```java
 final LogicalType[] fieldTypes =
-  new LogicalType[] {
-  new DoubleType(), new IntType(), new VarCharType()
-  };
+        new LogicalType[] {
+                new DoubleType(), new IntType(), new VarCharType()};
+final RowType rowType = RowType.of(fieldTypes, new String[] {"f7", "f4", "f99"});
 
 final ParquetColumnarRowInputFormat<FileSourceSplit> format =
-  new ParquetColumnarRowInputFormat<>(
-  new Configuration(),
-  RowType.of(fieldTypes, new String[] {"f7", "f4", "f99"}),
-  500,
-  false,
-  true);
+        new ParquetColumnarRowInputFormat<>(
+                new Configuration(),
+                rowType,
+                InternalTypeInfo.of(rowType),
+                500,
+                false,
+                true);
 final FileSource<RowData> source =
-  FileSource.forBulkFileFormat(format,  /* Flink Path */)
-  .build();
+        FileSource.forBulkFileFormat(format,  /* Flink Path */)
+                .build();
 final DataStream<RowData> stream =
-  env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
+        env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+row_type = DataTypes.ROW([
+    DataTypes.FIELD('f7', DataTypes.DOUBLE()),
+    DataTypes.FIELD('f4', DataTypes.INT()),
+    DataTypes.FIELD('f99', DataTypes.VARCHAR()),
+])
+source = FileSource.for_bulk_file_format(ParquetColumnarRowInputFormat(
+    hadoop_config=Configuration(),
+    row_type=row_type,
+    batch_size=500,
+    is_utc_timestamp=False,
+    is_case_sensitive=True,
+), PARQUET_FILE_PATH).build()
+ds = env.from_source(source, WatermarkStrategy.no_watermarks(), "file-source")
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## Avro Records
 

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetColumnarRowInputFormat.java
@@ -52,7 +52,7 @@ public class ParquetColumnarRowInputFormat<SplitT extends FileSourceSplit>
     private final TypeInformation<RowData> producedTypeInfo;
 
     /** Constructor to create parquet format without extra fields. */
-    ParquetColumnarRowInputFormat(
+    public ParquetColumnarRowInputFormat(
             Configuration hadoopConfig,
             RowType projectedType,
             TypeInformation<RowData> producedTypeInfo,

--- a/flink-python/pyflink/datastream/connectors/file_system.py
+++ b/flink-python/pyflink/datastream/connectors/file_system.py
@@ -119,6 +119,12 @@ class StreamFormat(object):
         return StreamFormat(j_stream_format)
 
 
+class BulkFormat(object):
+
+    def __init__(self, j_bulk_format):
+        self._j_bulk_format = j_bulk_format
+
+
 class FileSourceBuilder(object):
     """
     The builder for the :class:`~pyflink.datastream.connectors.FileSource`, to configure the
@@ -264,6 +270,14 @@ class FileSource(Source):
         j_paths = to_jarray(JPath, [JPath(p) for p in paths])
         return FileSourceBuilder(
             JFileSource.forRecordStreamFormat(stream_format._j_stream_format, j_paths))
+
+    @staticmethod
+    def for_bulk_file_format(bulk_format: BulkFormat, *paths: str) -> FileSourceBuilder:
+        JPath = get_gateway().jvm.org.apache.flink.core.fs.Path
+        JFileSource = get_gateway().jvm.org.apache.flink.connector.file.src.FileSource
+        j_paths = to_jarray(JPath, [JPath(p) for p in paths])
+        return FileSourceBuilder(
+            JFileSource.forBulkFileFormat(bulk_format._j_bulk_format, j_paths))
 
 
 # ---- FileSink ----

--- a/flink-python/pyflink/datastream/connectors/file_system.py
+++ b/flink-python/pyflink/datastream/connectors/file_system.py
@@ -120,6 +120,20 @@ class StreamFormat(object):
 
 
 class BulkFormat(object):
+    """
+    The BulkFormat reads and decodes batches of records at a time. Examples of bulk formats are
+    formats like ORC or Parquet.
+
+    Internally in the file source, the readers pass batches of records from the reading threads
+    (that perform the typically blocking I/O operations) to the async mailbox threads that do the
+    streaming and batch data processing. Passing records in batches (rather than one-at-a-time) much
+    reduce the thread-to-thread handover overhead.
+
+    For the BulkFormat, one batch (as returned by ``BulkFormat.Reader#readBatch()``) is handed over
+    as one.
+
+    .. versionadded:: 1.16.0
+    """
 
     def __init__(self, j_bulk_format):
         self._j_bulk_format = j_bulk_format

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -48,7 +48,7 @@ class AvroParquetReaders(object):
             >>> schema = AvroSchema.parse_string(JSON_SCHEMA)
             >>> source = FileSource.for_record_stream_format(
             ...     AvroParquetReaders.for_generic_record(schema),
-            ...     FILE_PATH
+            ...     PARQUET_FILE_PATH
             ... ).build()
             >>> ds = env.from_source(source, WatermarkStrategy.no_watermarks(), "parquet-source")
 
@@ -61,6 +61,29 @@ class AvroParquetReaders(object):
 
 
 class ParquetColumnarRowInputFormat(BulkFormat):
+    """
+    A ParquetVectorizedInputFormat to provide :class:`RowData` iterator. Using ColumnarRowData to
+    provide a row view of column batch. Only **primitive** types are supported for a column,
+    composite types such as array, map are not supported.
+
+    Example:
+    ::
+
+        >>> row_type = DataTypes.ROW([
+        ...     DataTypes.FIELD('a', DataTypes.INT()),
+        ...     DataTypes.FIELD('b', DataTypes.STRING()),
+        ... ])
+        >>> source = FileSource.for_bulk_file_format(ParquetColumnarRowInputFormat(
+        ...     hadoop_config=Configuration(),
+        ...     row_type=row_type,
+        ...     batch_size=500,
+        ...     is_utc_timestamp=True,
+        ...     is_case_sensitive=True,
+        ... ), PARQUET_FILE_PATH).build()
+        >>> ds = env.from_source(source, WatermarkStrategy.no_watermarks(), "parquet-source")
+
+    .. versionadded:: 1.16.0
+    """
 
     def __init__(self, hadoop_config: Configuration, row_type: RowType, batch_size: int,
                  is_utc_timestamp: bool, is_case_sensitive: bool):

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -15,9 +15,11 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from pyflink.datastream.connectors.file_system import StreamFormat
+from pyflink.common import Configuration
+from pyflink.datastream.connectors.file_system import StreamFormat, BulkFormat
 from pyflink.datastream.formats.avro import AvroSchema
 from pyflink.java_gateway import get_gateway
+from pyflink.table.types import RowType, _to_java_data_type
 
 
 class AvroParquetReaders(object):
@@ -56,3 +58,26 @@ class AvroParquetReaders(object):
         jvm = get_gateway().jvm
         JAvroParquetReaders = jvm.org.apache.flink.formats.parquet.avro.AvroParquetReaders
         return StreamFormat(JAvroParquetReaders.forGenericRecord(schema._j_schema))
+
+
+class ParquetColumnarRowInputFormat(BulkFormat):
+
+    def __init__(self, hadoop_config: Configuration, row_type: RowType, batch_size: int,
+                 is_utc_timestamp: bool, is_case_sensitive: bool):
+        jvm = get_gateway().jvm
+        j_row_type = _to_java_data_type(row_type)
+        produced_type = jvm.org.apache.flink.table.runtime.typeutils. \
+            InternalTypeInfo.of(j_row_type.getLogicalType())
+        j_parquet_columnar_format = jvm.org.apache.flink.formats.parquet. \
+            ParquetColumnarRowInputFormat(self._create_hadoop_configuration(hadoop_config),
+                                          j_row_type.getLogicalType(), produced_type, batch_size,
+                                          is_utc_timestamp, is_case_sensitive)
+        super().__init__(j_parquet_columnar_format)
+
+    @staticmethod
+    def _create_hadoop_configuration(config: Configuration):
+        jvm = get_gateway().jvm
+        hadoop_config = jvm.org.apache.hadoop.conf.Configuration()
+        for k, v in config.to_dict().items():
+            hadoop_config.set(k, v)
+        return hadoop_config

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -834,8 +834,7 @@ class StreamExecutionEnvironment(object):
 
         return StreamExecutionEnvironment(j_stream_exection_environment)
 
-    def create_input(self, input_format: 'InputFormat',
-                     type_info: Optional[TypeInformation] = None):
+    def create_input(self, input_format, type_info: Optional[TypeInformation] = None):
         """
         Create an input data stream with InputFormat.
 

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -34,7 +34,6 @@ from pyflink.datastream.checkpointing_mode import CheckpointingMode
 from pyflink.datastream.connectors import Source
 from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.execution_mode import RuntimeExecutionMode
-from pyflink.datastream.formats.base import InputFormat
 from pyflink.datastream.functions import SourceFunction
 from pyflink.datastream.state_backend import _from_j_state_backend, StateBackend
 from pyflink.datastream.time_characteristic import TimeCharacteristic
@@ -835,7 +834,8 @@ class StreamExecutionEnvironment(object):
 
         return StreamExecutionEnvironment(j_stream_exection_environment)
 
-    def create_input(self, input_format: InputFormat, type_info: Optional[TypeInformation] = None):
+    def create_input(self, input_format: 'InputFormat',
+                     type_info: Optional[TypeInformation] = None):
         """
         Create an input data stream with InputFormat.
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -63,12 +63,16 @@ import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
 import org.apache.flink.table.runtime.typeutils.ExternalTypeInfo;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.serializers.python.BigDecSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.DateSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.StringSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.table.typeutils.TimeIntervalTypeInfo;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
@@ -211,6 +215,14 @@ public class PythonTypeUtils {
                         userClassLoader);
             }
 
+            if (typeInformation instanceof InternalTypeInfo) {
+                LogicalTypeRoot logicalTypeRoot =
+                        ((InternalTypeInfo<?>) typeInformation).toLogicalType().getTypeRoot();
+                if (logicalTypeRoot.equals(LogicalTypeRoot.ROW)) {
+                    return buildRowDataTypeProto((InternalTypeInfo<?>) typeInformation);
+                }
+            }
+
             if (typeInformation
                     .getClass()
                     .getCanonicalName()
@@ -317,6 +329,33 @@ public class PythonTypeUtils {
 
             return FlinkFnApi.TypeInfo.newBuilder()
                     .setTypeName(getTypeName(rowTypeInfo))
+                    .setRowTypeInfo(rowTypeInfoBuilder.build())
+                    .build();
+        }
+
+        private static FlinkFnApi.TypeInfo buildRowDataTypeProto(
+                InternalTypeInfo<?> internalTypeInfo) {
+            RowType rowType = internalTypeInfo.toRowType();
+            FlinkFnApi.TypeInfo.RowTypeInfo.Builder rowTypeInfoBuilder =
+                    FlinkFnApi.TypeInfo.RowTypeInfo.newBuilder();
+
+            int arity = rowType.getFieldCount();
+            for (int index = 0; index < arity; index++) {
+                rowTypeInfoBuilder.addFields(
+                        FlinkFnApi.TypeInfo.RowTypeInfo.Field.newBuilder()
+                                .setFieldName(rowType.getFieldNames().get(index))
+                                .setFieldType(
+                                        toTypeInfoProto(
+                                                ExternalTypeInfo.of(
+                                                        TypeConversions.fromLogicalToDataType(
+                                                                rowType.getFields()
+                                                                        .get(index)
+                                                                        .getType()))))
+                                .build());
+            }
+
+            return FlinkFnApi.TypeInfo.newBuilder()
+                    .setTypeName(FlinkFnApi.TypeInfo.TypeName.ROW)
                     .setRowTypeInfo(rowTypeInfoBuilder.build())
                     .build();
         }
@@ -624,6 +663,19 @@ public class PythonTypeUtils {
                             typeInfoSerializerConverter(
                                     LegacyTypeInfoDataTypeConverter.toLegacyTypeInfo(
                                             ((ExternalTypeInfo<?>) typeInformation).getDataType()));
+                }
+
+                if (typeInformation instanceof InternalTypeInfo) {
+                    LogicalTypeRoot logicalTypeRoot =
+                            ((InternalTypeInfo<?>) typeInformation)
+                                    .getDataType()
+                                    .getLogicalType()
+                                    .getTypeRoot();
+                    if (logicalTypeRoot.equals(LogicalTypeRoot.ROW)) {
+                        return org.apache.flink.table.runtime.typeutils.PythonTypeUtils
+                                .toInternalSerializer(
+                                        ((InternalTypeInfo<?>) typeInformation).toRowType());
+                    }
                 }
 
                 if (typeInformation

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -219,7 +219,8 @@ public class PythonTypeUtils {
                 LogicalTypeRoot logicalTypeRoot =
                         ((InternalTypeInfo<?>) typeInformation).toLogicalType().getTypeRoot();
                 if (logicalTypeRoot.equals(LogicalTypeRoot.ROW)) {
-                    return buildRowDataTypeProto((InternalTypeInfo<?>) typeInformation);
+                    return buildRowDataTypeProto(
+                            (InternalTypeInfo<?>) typeInformation, userClassLoader);
                 }
             }
 
@@ -334,7 +335,7 @@ public class PythonTypeUtils {
         }
 
         private static FlinkFnApi.TypeInfo buildRowDataTypeProto(
-                InternalTypeInfo<?> internalTypeInfo) {
+                InternalTypeInfo<?> internalTypeInfo, ClassLoader userClassLoader) {
             RowType rowType = internalTypeInfo.toRowType();
             FlinkFnApi.TypeInfo.RowTypeInfo.Builder rowTypeInfoBuilder =
                     FlinkFnApi.TypeInfo.RowTypeInfo.newBuilder();
@@ -350,7 +351,8 @@ public class PythonTypeUtils {
                                                         TypeConversions.fromLogicalToDataType(
                                                                 rowType.getFields()
                                                                         .get(index)
-                                                                        .getType()))))
+                                                                        .getType())),
+                                                userClassLoader))
                                 .build());
             }
 


### PR DESCRIPTION

## What is the purpose of the change

This PR supports reading parquet columnar format in PyFlink.


## Brief change log

- introduce ParquetColumnarRowInputFormat class in Python API
- wrap RowType with InternalTypeInfo and add handling logic in PythonTypeUtils

## Verifying this change

This change added tests and can be verified as follows:

- integration test `FileSourceParquetColumnarFormatTests` in test_file_system.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs & Python Sphinx doc)
