### PR TITLE
[FLINK-28446][runtime] Expose more information in PartitionDescriptor to support more optimized Shuffle Service

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/PartitionDescriptor.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
 import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 
@@ -53,6 +54,15 @@ public class PartitionDescriptor implements Serializable {
     /** Connection index to identify this partition of intermediate result. */
     private final int connectionIndex;
 
+    /** Whether the intermediate result is a broadcast result. */
+    private final boolean isBroadcast;
+
+    /**
+     * Whether the distribution pattern of the intermediate result is {@link
+     * DistributionPattern.ALL_TO_ALL}.
+     */
+    private final boolean isAllToAllDistribution;
+
     @VisibleForTesting
     public PartitionDescriptor(
             IntermediateDataSetID resultId,
@@ -60,7 +70,9 @@ public class PartitionDescriptor implements Serializable {
             IntermediateResultPartitionID partitionId,
             ResultPartitionType partitionType,
             int numberOfSubpartitions,
-            int connectionIndex) {
+            int connectionIndex,
+            boolean isBroadcast,
+            boolean isAllToAllDistribution) {
         this.resultId = checkNotNull(resultId);
         checkArgument(totalNumberOfPartitions >= 1);
         this.totalNumberOfPartitions = totalNumberOfPartitions;
@@ -69,6 +81,8 @@ public class PartitionDescriptor implements Serializable {
         checkArgument(numberOfSubpartitions >= 1);
         this.numberOfSubpartitions = numberOfSubpartitions;
         this.connectionIndex = connectionIndex;
+        this.isBroadcast = isBroadcast;
+        this.isAllToAllDistribution = isAllToAllDistribution;
     }
 
     public IntermediateDataSetID getResultId() {
@@ -95,12 +109,27 @@ public class PartitionDescriptor implements Serializable {
         return connectionIndex;
     }
 
+    public boolean isBroadcast() {
+        return isBroadcast;
+    }
+
+    public boolean isAllToAllDistribution() {
+        return isAllToAllDistribution;
+    }
+
     @Override
     public String toString() {
         return String.format(
                 "PartitionDescriptor [result id: %s, partition id: %s, partition type: %s, "
-                        + "subpartitions: %d, connection index: %d]",
-                resultId, partitionId, partitionType, numberOfSubpartitions, connectionIndex);
+                        + "subpartitions: %d, connection index: %d, is broadcast: %s, "
+                        + "is all-to-all distribution: %s]",
+                resultId,
+                partitionId,
+                partitionType,
+                numberOfSubpartitions,
+                connectionIndex,
+                isBroadcast,
+                isAllToAllDistribution);
     }
 
     public static PartitionDescriptor from(IntermediateResultPartition partition) {
@@ -113,6 +142,8 @@ public class PartitionDescriptor implements Serializable {
                 partition.getPartitionId(),
                 result.getResultType(),
                 partition.getNumberOfSubpartitions(),
-                result.getConnectionIndex());
+                result.getConnectionIndex(),
+                result.isBroadcast(),
+                result.getConsumingDistributionPattern() == DistributionPattern.ALL_TO_ALL);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -55,6 +55,8 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
     private static final ResultPartitionType partitionType = ResultPartitionType.PIPELINED;
     private static final int numberOfSubpartitions = 24;
     private static final int connectionIndex = 10;
+    private static final boolean isBroadcast = false;
+    private static final boolean isAllToAllDistribution = true;
 
     private static final PartitionDescriptor partitionDescriptor =
             new PartitionDescriptor(
@@ -63,7 +65,9 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
                     partitionId,
                     partitionType,
                     numberOfSubpartitions,
-                    connectionIndex);
+                    connectionIndex,
+                    isBroadcast,
+                    isAllToAllDistribution);
 
     private static final ResultPartitionID resultPartitionID =
             new ResultPartitionID(partitionId, producerExecutionId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
@@ -174,7 +174,9 @@ public class NettyShuffleUtilsTest extends TestLogger {
                         shuffleDescriptor.getResultPartitionID().getPartitionId(),
                         resultPartitionType,
                         numSubpartitions,
-                        0);
+                        0,
+                        false,
+                        true);
         ResultPartitionDeploymentDescriptor resultPartitionDeploymentDescriptor =
                 new ResultPartitionDeploymentDescriptor(partitionDescriptor, shuffleDescriptor, 1);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
@@ -55,7 +55,9 @@ public class PartitionDescriptorBuilder {
                 partitionId,
                 partitionType,
                 1,
-                0);
+                0,
+                false,
+                true);
     }
 
     public static PartitionDescriptorBuilder newBuilder() {


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

To improve shuffle performance, more detailed fields should be added to `PartitionDescriptor`, for example, whether the partition is a broadcast partition or the distribution pattern of the intermediate result.

After the detailed information is added, the Shuffle Service can use different Shuffle strategies in different situations, which may lead to better shuffle performance.

In addition, we only add fields to `PartitionDescriptor`, which is compatible with the previous version, and the added fields are insensitive to earlier users.


## Brief change log
  - *Add fields of `isBroadcast` and `distributionPattern` to `PartitionDescriptor`.*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as *NettyShuffleUtilsTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes /  **no**)
  - The serializers: (yes /  **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes /  **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes /  **no** / don't know)
  - The S3 file system connector: (yes /  **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes /  **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
