### PR TITLE
[FLINK-28448][test] fix bug in BoundedDataTestBase when enable compression

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/BufferBuilderTestUtils.java
@@ -27,7 +27,7 @@ import java.nio.ByteOrder;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.junit.Assert.assertEquals;
 
-/** Utility class for create not-pooled {@link BufferBuilder}. */
+/** Utility class for create {@link BufferBuilder}, {@link BufferConsumer} and {@link Buffer}. */
 public class BufferBuilderTestUtils {
     public static final int BUFFER_SIZE = 32 * 1024;
 
@@ -121,6 +121,26 @@ public class BufferBuilderTestUtils {
 
         for (int i = 0; i < numInts; i++) {
             assertEquals(nextValue++, bb.getInt());
+        }
+    }
+
+    public static Buffer buildBufferWithAscendingLongs(
+            int bufferSize, int numLongs, long nextValue) {
+        final MemorySegment seg = MemorySegmentFactory.allocateUnpooledSegment(bufferSize);
+        for (int i = 0; i < numLongs; i++) {
+            seg.putLongLittleEndian(8 * i, nextValue++);
+        }
+
+        return new NetworkBuffer(
+                seg, MemorySegment::free, Buffer.DataType.DATA_BUFFER, 8 * numLongs);
+    }
+
+    public static void validateBufferWithAscendingLongs(
+            Buffer buffer, int numLongs, long nextValue) {
+        final ByteBuffer bb = buffer.getNioBufferReadable().order(ByteOrder.LITTLE_ENDIAN);
+
+        for (int i = 0; i < numLongs; i++) {
+            assertEquals(nextValue++, bb.getLong());
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedDataTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedDataTestBase.java
@@ -110,11 +110,11 @@ public abstract class BoundedDataTestBase {
     }
 
     private void testWriteAndReadData(BoundedData bd) throws Exception {
-        final int numInts = 10_000_000;
-        final int numBuffers = writeInts(bd, numInts);
+        final int numLongs = 10_000_000;
+        final int numBuffers = writeLongs(bd, numLongs);
         bd.finishWrite();
 
-        readInts(bd.createReader(), numBuffers, numInts);
+        readLongs(bd.createReader(), numBuffers, numLongs);
     }
 
     @Test
@@ -181,14 +181,14 @@ public abstract class BoundedDataTestBase {
     //  utils
     // ------------------------------------------------------------------------
 
-    private static int writeInts(BoundedData bd, int numInts) throws IOException {
-        final int numIntsInBuffer = BUFFER_SIZE / 4;
+    private static int writeLongs(BoundedData bd, int numLongs) throws IOException {
+        final int numLongsInBuffer = BUFFER_SIZE / Long.BYTES;
         int numBuffers = 0;
 
-        for (int nextValue = 0; nextValue < numInts; nextValue += numIntsInBuffer) {
+        for (long nextValue = 0; nextValue < numLongs; nextValue += numLongsInBuffer) {
             Buffer buffer =
-                    BufferBuilderTestUtils.buildBufferWithAscendingInts(
-                            BUFFER_SIZE, numIntsInBuffer, nextValue);
+                    BufferBuilderTestUtils.buildBufferWithAscendingLongs(
+                            BUFFER_SIZE, numLongsInBuffer, nextValue);
             if (compressionEnabled) {
                 Buffer compressedBuffer = COMPRESSOR.compressToIntermediateBuffer(buffer);
                 bd.writeBuffer(compressedBuffer);
@@ -206,34 +206,34 @@ public abstract class BoundedDataTestBase {
         return numBuffers;
     }
 
-    private static void readInts(BoundedData.Reader reader, int numBuffersExpected, int numInts)
+    private static void readLongs(BoundedData.Reader reader, int numBuffersExpected, int numLongs)
             throws IOException {
         Buffer b;
-        int nextValue = 0;
+        long nextValue = 0;
         int numBuffers = 0;
 
-        int numIntsInBuffer;
+        int numLongsInBuffer;
         while ((b = reader.nextBuffer()) != null) {
             if (compressionEnabled && b.isCompressed()) {
                 Buffer decompressedBuffer = DECOMPRESSOR.decompressToIntermediateBuffer(b);
-                numIntsInBuffer = decompressedBuffer.getSize() / 4;
-                BufferBuilderTestUtils.validateBufferWithAscendingInts(
-                        decompressedBuffer, numIntsInBuffer, nextValue);
+                numLongsInBuffer = decompressedBuffer.getSize() / Long.BYTES;
+                BufferBuilderTestUtils.validateBufferWithAscendingLongs(
+                        decompressedBuffer, numLongsInBuffer, nextValue);
                 // recycle intermediate buffer.
                 decompressedBuffer.recycleBuffer();
             } else {
-                numIntsInBuffer = b.getSize() / 4;
-                BufferBuilderTestUtils.validateBufferWithAscendingInts(
-                        b, numIntsInBuffer, nextValue);
+                numLongsInBuffer = b.getSize() / Long.BYTES;
+                BufferBuilderTestUtils.validateBufferWithAscendingLongs(
+                        b, numLongsInBuffer, nextValue);
             }
-            nextValue += numIntsInBuffer;
+            nextValue += numLongsInBuffer;
             numBuffers++;
 
             b.recycleBuffer();
         }
 
         assertEquals(numBuffersExpected, numBuffers);
-        assertThat(nextValue, Matchers.greaterThanOrEqualTo(numInts));
+        assertThat(nextValue, Matchers.greaterThanOrEqualTo((long) numLongs));
     }
 
     private static Path createTempPath() throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

*fix bug in BoundedDataTestBase when enable compression.*


## Brief change log

  - *Migrate BoundedDataTestBase and it's subclass to JUnit5 and AssertJ.*
  - *Fix bug in BoundedDataTestBase when enable compression.*
  - *BoundedDataTestBase write and read long instead of integer value, makes it easier to compress data for default lz4 compressor.*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
