### PR TITLE
[FLINK-25909][runtime][security] Add HBaseDelegationTokenProvider

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/HBaseDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/HBaseDelegationTokenProvider.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.util.HadoopUtils;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Delegation token provider implementation for HBase. */
+public class HBaseDelegationTokenProvider implements DelegationTokenProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HBaseDelegationTokenProvider.class);
+
+    org.apache.hadoop.conf.Configuration hbaseConf;
+
+    @Override
+    public String serviceName() {
+        return "hbase";
+    }
+
+    @Override
+    public void init(Configuration configuration) throws Exception {
+        getHBaseConfiguration(configuration);
+    }
+
+    private void getHBaseConfiguration(Configuration conf) {
+        hbaseConf = null;
+        try {
+            org.apache.hadoop.conf.Configuration hadoopConf =
+                    HadoopUtils.getHadoopConfiguration(conf);
+            // ----
+            // Intended call: HBaseConfiguration.create(conf);
+            hbaseConf =
+                    (org.apache.hadoop.conf.Configuration)
+                            Class.forName("org.apache.hadoop.hbase.HBaseConfiguration")
+                                    .getMethod("create", org.apache.hadoop.conf.Configuration.class)
+                                    .invoke(null, hadoopConf);
+            // ----
+
+        } catch (InvocationTargetException
+                 | NoSuchMethodException
+                 | IllegalAccessException
+                 | ClassNotFoundException e) {
+            LOG.info(
+                    "HBase is not available (not packaged with this application): {} : \"{}\".",
+                    e.getClass().getSimpleName(),
+                    e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean delegationTokensRequired() throws Exception {
+        try {
+            if (!HadoopUtils.isKerberosSecurityEnabled(UserGroupInformation.getCurrentUser())) {
+                return false;
+            }
+        } catch (IOException e) {
+            LOG.debug("Hadoop Kerberos is not enabled.");
+            return false;
+        }
+        return Objects.nonNull(hbaseConf)
+                && hbaseConf.get("hbase.security.authentication").equals("kerberos");
+    }
+
+    @Override
+    public Optional<Long> obtainDelegationTokens(Credentials credentials) throws Exception {
+        Token<?> token;
+        try {
+            Preconditions.checkNotNull(hbaseConf);
+            try {
+                LOG.info("Obtaining Kerberos security token for HBase");
+                // ----
+                // Intended call: Token<AuthenticationTokenIdentifier> token =
+                // TokenUtil.obtainToken(conf);
+                token =
+                        (Token<?>)
+                                Class.forName("org.apache.hadoop.hbase.security.token.TokenUtil")
+                                        .getMethod(
+                                                "obtainToken",
+                                                org.apache.hadoop.conf.Configuration.class)
+                                        .invoke(null, hbaseConf);
+            } catch (NoSuchMethodException e) {
+                // for HBase 2
+
+                // ----
+                // Intended call: ConnectionFactory connectionFactory =
+                // ConnectionFactory.createConnection(conf);
+                Closeable connectionFactory =
+                        (Closeable)
+                                Class.forName("org.apache.hadoop.hbase.client.ConnectionFactory")
+                                        .getMethod(
+                                                "createConnection",
+                                                org.apache.hadoop.conf.Configuration.class)
+                                        .invoke(null, hbaseConf);
+                // ----
+                Class<?> connectionClass =
+                        Class.forName("org.apache.hadoop.hbase.client.Connection");
+                // ----
+                // Intended call: Token<AuthenticationTokenIdentifier> token =
+                // TokenUtil.obtainToken(connectionFactory);
+                token =
+                        (Token<?>)
+                                Class.forName("org.apache.hadoop.hbase.security.token.TokenUtil")
+                                        .getMethod("obtainToken", connectionClass)
+                                        .invoke(null, connectionFactory);
+                if (null != connectionFactory) {
+                    connectionFactory.close();
+                }
+            }
+            if (token == null) {
+                LOG.error("No Kerberos security token for HBase available");
+            } else {
+                credentials.addToken(token.getService(), token);
+                LOG.info("Added HBase Kerberos security token to credentials.");
+            }
+        } catch (ClassNotFoundException
+                 | NoSuchMethodException
+                 | IllegalAccessException
+                 | InvocationTargetException
+                 | IOException e) {
+            LOG.info(
+                    "HBase is not available (failed to obtain delegation tokens): {} : \"{}\".",
+                    e.getClass().getSimpleName(),
+                    e.getMessage());
+        }
+
+        // HBase does not support to renew the delegation token currently
+        // https://cwiki.apache.org/confluence/display/HADOOP2/Hbase+HBaseTokenAuthentication
+        return Optional.empty();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/HBaseDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/HBaseDelegationTokenProvider.java
@@ -48,11 +48,11 @@ public class HBaseDelegationTokenProvider implements DelegationTokenProvider {
 
     @Override
     public void init(Configuration configuration) throws Exception {
-        getHBaseConfiguration(configuration);
+        hbaseConf = getHBaseConfiguration(configuration);
     }
 
-    private void getHBaseConfiguration(Configuration conf) {
-        hbaseConf = null;
+    private org.apache.hadoop.conf.Configuration getHBaseConfiguration(Configuration conf) {
+        org.apache.hadoop.conf.Configuration hbaseConf = null;
         try {
             org.apache.hadoop.conf.Configuration hadoopConf =
                     HadoopUtils.getHadoopConfiguration(conf);
@@ -66,14 +66,15 @@ public class HBaseDelegationTokenProvider implements DelegationTokenProvider {
             // ----
 
         } catch (InvocationTargetException
-                 | NoSuchMethodException
-                 | IllegalAccessException
-                 | ClassNotFoundException e) {
+                | NoSuchMethodException
+                | IllegalAccessException
+                | ClassNotFoundException e) {
             LOG.info(
                     "HBase is not available (not packaged with this application): {} : \"{}\".",
                     e.getClass().getSimpleName(),
                     e.getMessage());
         }
+        return hbaseConf;
     }
 
     @Override
@@ -142,10 +143,10 @@ public class HBaseDelegationTokenProvider implements DelegationTokenProvider {
                 LOG.info("Added HBase Kerberos security token to credentials.");
             }
         } catch (ClassNotFoundException
-                 | NoSuchMethodException
-                 | IllegalAccessException
-                 | InvocationTargetException
-                 | IOException e) {
+                | NoSuchMethodException
+                | IllegalAccessException
+                | InvocationTargetException
+                | IOException e) {
             LOG.info(
                     "HBase is not available (failed to obtain delegation tokens): {} : \"{}\".",
                     e.getClass().getSimpleName(),

--- a/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenProvider
+++ b/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenProvider
@@ -14,3 +14,4 @@
 # limitations under the License.
 
 org.apache.flink.runtime.security.token.HadoopFSDelegationTokenProvider
+org.apache.flink.runtime.security.token.HBaseDelegationTokenProvider

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerITCase.java
@@ -101,8 +101,9 @@ public class KerberosDelegationTokenManagerITCase {
         KerberosDelegationTokenManager delegationTokenManager =
                 new KerberosDelegationTokenManager(configuration, null, null);
 
-        assertEquals(2, delegationTokenManager.delegationTokenProviders.size());
+        assertEquals(3, delegationTokenManager.delegationTokenProviders.size());
         assertTrue(delegationTokenManager.isProviderLoaded("hadoopfs"));
+        assertTrue(delegationTokenManager.isProviderLoaded("hbase"));
         assertTrue(delegationTokenManager.isProviderLoaded("test"));
         assertTrue(ExceptionThrowingDelegationTokenProvider.constructed);
         assertFalse(delegationTokenManager.isProviderLoaded("throw"));

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -169,7 +169,10 @@ public abstract class YarnTestBase {
         // this can happen during cluster shutdown, if AMRMClient happens to be heartbeating
         Pattern.compile("Exception on heartbeat"),
         Pattern.compile("java\\.io\\.InterruptedIOException: Call interrupted"),
-        Pattern.compile("java\\.lang\\.InterruptedException")
+        Pattern.compile("java\\.lang\\.InterruptedException"),
+
+        // this can happen if the hbase delegation token provider is not available
+        Pattern.compile("ClassNotFoundException : \"org.apache.hadoop.hbase.HBaseConfiguration\"")
     };
 
     // Temp directory which is deleted after the unit test.


### PR DESCRIPTION
## What is the purpose of the change

This PR adds HBaseDelegationTokenProvider to obtain HBase Delegation tokens using the new delegation token framework.


## Brief change log

  - Add `HBaseDelegationTokenProvider`
  - Add `HBaseDelegationTokenProvider` into the `META-INFO` service registration


## Verifying this change
 - This provider functionality will be covered by some existing tests. But We don't have dedicated tests to test the HBase delegation token obtainning. I think we may need to add new end-to-end tests to cover it. 
 - Manually tests on Yarn, detailed: [Test Gist](https://gist.github.com/JackWangCS/3019355b9fc4746024fe72b3bbad839b)

 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs / not documented)
