### PR TITLE
[FLINK-28451][hive] Use UserCodeClassloader instead of the current thread's classloader to load function

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveFunctionDefinitionFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveFunctionDefinitionFactory.java
@@ -21,9 +21,11 @@ package org.apache.flink.table.catalog.hive.factories;
 import org.apache.flink.connectors.hive.HiveTableFactory;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.UserDefinedFunction;
 import org.apache.flink.table.functions.UserDefinedFunctionHelper;
 import org.apache.flink.table.functions.hive.HiveFunctionWrapper;
 import org.apache.flink.table.functions.hive.HiveGenericUDAF;
@@ -54,17 +56,39 @@ public class HiveFunctionDefinitionFactory implements FunctionDefinitionFactory 
 
     @Override
     public FunctionDefinition createFunctionDefinition(
-            String name, CatalogFunction catalogFunction) {
-        if (catalogFunction.isGeneric()) {
-            return createFunctionDefinitionFromFlinkFunction(name, catalogFunction);
+            String name, CatalogFunction catalogFunction, Context context) {
+        if (isFlinkFunction(catalogFunction, context.getClassLoader())) {
+            return createFunctionDefinitionFromFlinkFunction(name, catalogFunction, context);
         }
-        return createFunctionDefinitionFromHiveFunction(name, catalogFunction.getClassName());
+        return createFunctionDefinitionFromHiveFunction(
+                name, catalogFunction.getClassName(), context);
     }
 
     public FunctionDefinition createFunctionDefinitionFromFlinkFunction(
-            String name, CatalogFunction catalogFunction) {
+            String name, CatalogFunction catalogFunction, Context context) {
         return UserDefinedFunctionHelper.instantiateFunction(
-                Thread.currentThread().getContextClassLoader(), null, name, catalogFunction);
+                context.getClassLoader(), null, name, catalogFunction);
+    }
+
+    /**
+     * Distinguish if the function is a generic function.
+     *
+     * @return whether the function is a generic function
+     */
+    private boolean isFlinkFunction(CatalogFunction catalogFunction, ClassLoader classLoader) {
+        if (catalogFunction.getFunctionLanguage() == FunctionLanguage.PYTHON) {
+            return true;
+        }
+        try {
+            Class<?> c = Class.forName(catalogFunction.getClassName(), true, classLoader);
+            if (UserDefinedFunction.class.isAssignableFrom(c)) {
+                return true;
+            }
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(
+                    String.format("Can't resolve udf class %s", catalogFunction.getClassName()), e);
+        }
+        return false;
     }
 
     /**
@@ -72,10 +96,10 @@ public class HiveFunctionDefinitionFactory implements FunctionDefinitionFactory 
      * org.apache.flink.table.module.hive.HiveModule}.
      */
     public FunctionDefinition createFunctionDefinitionFromHiveFunction(
-            String name, String functionClassName) {
-        Class<?> clazz;
+            String name, String functionClassName, Context context) {
+        Class<?> functionClz;
         try {
-            clazz = Thread.currentThread().getContextClassLoader().loadClass(functionClassName);
+            functionClz = context.getClassLoader().loadClass(functionClassName);
 
             LOG.info("Successfully loaded Hive udf '{}' with class '{}'", name, functionClassName);
         } catch (ClassNotFoundException e) {
@@ -84,33 +108,31 @@ public class HiveFunctionDefinitionFactory implements FunctionDefinitionFactory 
                     e);
         }
 
-        if (UDF.class.isAssignableFrom(clazz)) {
+        if (UDF.class.isAssignableFrom(functionClz)) {
             LOG.info("Transforming Hive function '{}' into a HiveSimpleUDF", name);
 
-            return new HiveSimpleUDF(new HiveFunctionWrapper<>(functionClassName), hiveShim);
-        } else if (GenericUDF.class.isAssignableFrom(clazz)) {
+            return new HiveSimpleUDF(new HiveFunctionWrapper<>(functionClz), hiveShim);
+        } else if (GenericUDF.class.isAssignableFrom(functionClz)) {
             LOG.info("Transforming Hive function '{}' into a HiveGenericUDF", name);
 
-            return new HiveGenericUDF(new HiveFunctionWrapper<>(functionClassName), hiveShim);
-        } else if (GenericUDTF.class.isAssignableFrom(clazz)) {
+            return new HiveGenericUDF(new HiveFunctionWrapper<>(functionClz), hiveShim);
+        } else if (GenericUDTF.class.isAssignableFrom(functionClz)) {
             LOG.info("Transforming Hive function '{}' into a HiveGenericUDTF", name);
-            return new HiveGenericUDTF(new HiveFunctionWrapper<>(functionClassName), hiveShim);
-        } else if (GenericUDAFResolver2.class.isAssignableFrom(clazz)
-                || UDAF.class.isAssignableFrom(clazz)) {
+            return new HiveGenericUDTF(new HiveFunctionWrapper<>(functionClz), hiveShim);
+        } else if (GenericUDAFResolver2.class.isAssignableFrom(functionClz)
+                || UDAF.class.isAssignableFrom(functionClz)) {
 
-            if (GenericUDAFResolver2.class.isAssignableFrom(clazz)) {
+            if (GenericUDAFResolver2.class.isAssignableFrom(functionClz)) {
                 LOG.info(
                         "Transforming Hive function '{}' into a HiveGenericUDAF without UDAF bridging",
                         name);
-                return new HiveGenericUDAF(
-                        new HiveFunctionWrapper<>(functionClassName), false, hiveShim);
+                return new HiveGenericUDAF(new HiveFunctionWrapper<>(functionClz), false, hiveShim);
             } else {
                 LOG.info(
                         "Transforming Hive function '{}' into a HiveGenericUDAF with UDAF bridging",
                         name);
 
-                return new HiveGenericUDAF(
-                        new HiveFunctionWrapper<>(functionClassName), true, hiveShim);
+                return new HiveGenericUDAF(new HiveFunctionWrapper<>(functionClz), true, hiveShim);
             }
         } else {
             throw new IllegalArgumentException(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveFunctionDefinitionFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/factories/HiveFunctionDefinitionFactory.java
@@ -71,9 +71,9 @@ public class HiveFunctionDefinitionFactory implements FunctionDefinitionFactory 
     }
 
     /**
-     * Distinguish if the function is a generic function.
+     * Distinguish if the function is a Flink function.
      *
-     * @return whether the function is a generic function
+     * @return whether the function is a Flink function
      */
     private boolean isFlinkFunction(CatalogFunction catalogFunction, ClassLoader classLoader) {
         if (catalogFunction.getFunctionLanguage() == FunctionLanguage.PYTHON) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveFunction.java
@@ -86,7 +86,7 @@ public interface HiveFunction<UDFType> {
                 if (throwOnFailure) {
                     throw callContext.newValidationError(
                             "Cannot find a suitable Hive function from %s for the input arguments",
-                            hiveFunction.getFunctionWrapper().getClassName());
+                            hiveFunction.getFunctionWrapper().getUDFClassName());
                 } else {
                     return Optional.empty();
                 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDAF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDAF.java
@@ -172,7 +172,7 @@ public class HiveGenericUDAF
             throw new FlinkHiveUDFException(
                     String.format(
                             "Failed to create accumulator for %s",
-                            hiveFunctionWrapper.getClassName()),
+                            hiveFunctionWrapper.getUDFClassName()),
                     e);
         }
     }
@@ -206,7 +206,8 @@ public class HiveGenericUDAF
         } catch (HiveException e) {
             throw new FlinkHiveUDFException(
                     String.format(
-                            "Failed to get final result on %s", hiveFunctionWrapper.getClassName()),
+                            "Failed to get final result on %s",
+                            hiveFunctionWrapper.getUDFClassName()),
                     e);
         }
     }
@@ -247,7 +248,7 @@ public class HiveGenericUDAF
             throw new FlinkHiveUDFException(
                     String.format(
                             "Failed to get Hive result type from %s",
-                            hiveFunctionWrapper.getClassName()),
+                            hiveFunctionWrapper.getUDFClassName()),
                     e);
         }
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDF.java
@@ -47,13 +47,13 @@ public class HiveGenericUDF extends HiveScalarFunction<GenericUDF> {
     public HiveGenericUDF(HiveFunctionWrapper<GenericUDF> hiveFunctionWrapper, HiveShim hiveShim) {
         super(hiveFunctionWrapper);
         this.hiveShim = hiveShim;
-        LOG.info("Creating HiveGenericUDF from '{}'", hiveFunctionWrapper.getClassName());
+        LOG.info("Creating HiveGenericUDF from '{}'", hiveFunctionWrapper.getUDFClassName());
     }
 
     @Override
     public void openInternal() {
 
-        LOG.info("Open HiveGenericUDF as {}", hiveFunctionWrapper.getClassName());
+        LOG.info("Open HiveGenericUDF as {}", hiveFunctionWrapper.getUDFClassName());
 
         function = createFunction();
 
@@ -96,7 +96,7 @@ public class HiveGenericUDF extends HiveScalarFunction<GenericUDF> {
     public DataType inferReturnType() throws UDFArgumentException {
         LOG.info(
                 "Getting result type of HiveGenericUDF from {}",
-                hiveFunctionWrapper.getClassName());
+                hiveFunctionWrapper.getUDFClassName());
         ObjectInspector[] argumentInspectors = HiveInspectors.getArgInspectors(hiveShim, arguments);
 
         ObjectInspector resultObjectInspector =

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveGenericUDTF.java
@@ -145,7 +145,7 @@ public class HiveGenericUDTF extends TableFunction<Row> implements HiveFunction<
     public DataType inferReturnType() throws UDFArgumentException {
         LOG.info(
                 "Getting result type of HiveGenericUDTF with {}",
-                hiveFunctionWrapper.getClassName());
+                hiveFunctionWrapper.getUDFClassName());
         ObjectInspector[] argumentInspectors = HiveInspectors.getArgInspectors(hiveShim, arguments);
         return HiveTypeUtil.toFlinkType(
                 hiveFunctionWrapper.createFunction().initialize(argumentInspectors));

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveScalarFunction.java
@@ -52,16 +52,12 @@ public abstract class HiveScalarFunction<UDFType> extends ScalarFunction
 
     @Override
     public boolean isDeterministic() {
-        try {
-            org.apache.hadoop.hive.ql.udf.UDFType udfType =
-                    hiveFunctionWrapper
-                            .getUDFClass()
-                            .getAnnotation(org.apache.hadoop.hive.ql.udf.UDFType.class);
+        org.apache.hadoop.hive.ql.udf.UDFType udfType =
+                hiveFunctionWrapper
+                        .getUDFClass()
+                        .getAnnotation(org.apache.hadoop.hive.ql.udf.UDFType.class);
 
-            return udfType != null && udfType.deterministic() && !udfType.stateful();
-        } catch (ClassNotFoundException e) {
-            throw new FlinkHiveUDFException(e);
-        }
+        return udfType != null && udfType.deterministic() && !udfType.stateful();
     }
 
     @Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveSimpleUDF.java
@@ -61,12 +61,12 @@ public class HiveSimpleUDF extends HiveScalarFunction<UDF> {
     public HiveSimpleUDF(HiveFunctionWrapper<UDF> hiveFunctionWrapper, HiveShim hiveShim) {
         super(hiveFunctionWrapper);
         this.hiveShim = hiveShim;
-        LOG.info("Creating HiveSimpleUDF from '{}'", this.hiveFunctionWrapper.getClassName());
+        LOG.info("Creating HiveSimpleUDF from '{}'", this.hiveFunctionWrapper.getUDFClassName());
     }
 
     @Override
     public void openInternal() {
-        LOG.info("Opening HiveSimpleUDF as '{}'", hiveFunctionWrapper.getClassName());
+        LOG.info("Opening HiveSimpleUDF as '{}'", hiveFunctionWrapper.getUDFClassName());
 
         function = hiveFunctionWrapper.createFunction();
 
@@ -105,7 +105,7 @@ public class HiveSimpleUDF extends HiveScalarFunction<UDF> {
             throw new FlinkHiveUDFException(
                     String.format(
                             "Failed to open HiveSimpleUDF from %s",
-                            hiveFunctionWrapper.getClassName()),
+                            hiveFunctionWrapper.getUDFClassName()),
                     e);
         }
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.factories.HiveFunctionDefinitionFactory;
+import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
 import org.apache.flink.table.module.Module;
 import org.apache.flink.table.module.hive.udf.generic.GenericUDFLegacyGroupingID;
@@ -82,12 +83,17 @@ public class HiveModule implements Module {
     private final String hiveVersion;
     private final HiveShim hiveShim;
     private Set<String> functionNames;
+    private final ClassLoader classLoader;
 
     public HiveModule() {
-        this(HiveShimLoader.getHiveVersion());
+        this(HiveShimLoader.getHiveVersion(), Thread.currentThread().getContextClassLoader());
     }
 
     public HiveModule(String hiveVersion) {
+        this(hiveVersion, Thread.currentThread().getContextClassLoader());
+    }
+
+    public HiveModule(String hiveVersion, ClassLoader classLoader) {
         checkArgument(
                 !StringUtils.isNullOrWhitespaceOnly(hiveVersion), "hiveVersion cannot be null");
 
@@ -95,6 +101,7 @@ public class HiveModule implements Module {
         this.hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
         this.factory = new HiveFunctionDefinitionFactory(hiveShim);
         this.functionNames = new HashSet<>();
+        this.classLoader = classLoader;
     }
 
     @Override
@@ -114,18 +121,19 @@ public class HiveModule implements Module {
         if (BUILT_IN_FUNC_BLACKLIST.contains(name)) {
             return Optional.empty();
         }
+        FunctionDefinitionFactory.Context context = () -> classLoader;
         // We override Hive's grouping function. Refer to the implementation for more details.
         if (name.equalsIgnoreCase("grouping")) {
             return Optional.of(
                     factory.createFunctionDefinitionFromHiveFunction(
-                            name, HiveGenericUDFGrouping.class.getName()));
+                            name, HiveGenericUDFGrouping.class.getName(), context));
         }
 
         // this function is used to generate legacy GROUPING__ID value for old hive versions
         if (name.equalsIgnoreCase(GenericUDFLegacyGroupingID.NAME)) {
             return Optional.of(
                     factory.createFunctionDefinitionFromHiveFunction(
-                            name, GenericUDFLegacyGroupingID.class.getName()));
+                            name, GenericUDFLegacyGroupingID.class.getName(), context));
         }
 
         // We override Hive's internal_interval. Refer to the implementation for more details
@@ -140,7 +148,7 @@ public class HiveModule implements Module {
         return info.map(
                 functionInfo ->
                         factory.createFunctionDefinitionFromHiveFunction(
-                                name, functionInfo.getFunctionClass().getName()));
+                                name, functionInfo.getFunctionClass().getName(), context));
     }
 
     public String getHiveVersion() {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -140,7 +140,7 @@ public class HiveModule implements Module {
         if (name.equalsIgnoreCase("internal_interval")) {
             return Optional.of(
                     factory.createFunctionDefinitionFromHiveFunction(
-                            name, HiveGenericUDFInternalInterval.class.getName()));
+                            name, HiveGenericUDFInternalInterval.class.getName(), context));
         }
 
         Optional<FunctionInfo> info = hiveShim.getBuiltInFunctionInfo(name);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModuleFactory.java
@@ -63,6 +63,6 @@ public class HiveModuleFactory implements ModuleFactory {
                         .getOptional(HIVE_VERSION)
                         .orElseGet(HiveShimLoader::getHiveVersion);
 
-        return new HiveModule(hiveVersion);
+        return new HiveModule(hiveVersion, context.getClassLoader());
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -226,7 +226,8 @@ public class HiveParser extends ParserImpl {
                                 context,
                                 dmlHelper,
                                 frameworkConfig,
-                                plannerContext.getCluster());
+                                plannerContext.getCluster(),
+                                plannerContext.getFlinkContext().getClassLoader());
                 operation = ddlAnalyzer.convertToOperation(node);
                 return Collections.singletonList(operation);
             } else {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveFunctionWrapperTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveFunctionWrapperTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.functions.ScalarFunction;
+import org.apache.flink.util.FlinkUserCodeClassLoaders;
+import org.apache.flink.util.UserClassLoaderJarTestUtils;
+
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMacro;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link HiveFunctionWrapper}. */
+public class HiveFunctionWrapperTest {
+
+    @TempDir private static File tempFolder;
+
+    private static final Random random = new Random();
+    private static String udfClassName;
+    private static File udfJar;
+
+    @BeforeAll
+    static void before() throws Exception {
+        udfClassName = "MyToLower" + random.nextInt(50);
+        String udfCode =
+                "public class "
+                        + "%s"
+                        + " extends org.apache.flink.table.functions.ScalarFunction {\n"
+                        + "  public String eval(String str) {\n"
+                        + "    return str.toLowerCase();\n"
+                        + "  }\n"
+                        + "}\n";
+        udfJar =
+                UserClassLoaderJarTestUtils.createJarFile(
+                        tempFolder,
+                        "test-classloader-udf.jar",
+                        udfClassName,
+                        String.format(udfCode, udfClassName));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testDeserializeUDF() throws Exception {
+        // test deserialize udf
+        GenericUDFMacro udfMacro = new GenericUDFMacro();
+        HiveFunctionWrapper<GenericUDFMacro> functionWrapper =
+                new HiveFunctionWrapper<>(GenericUDFMacro.class, udfMacro);
+        GenericUDFMacro deserializeUdfMacro = functionWrapper.createFunction();
+        assertThat(deserializeUdfMacro.getClass().getName())
+                .isEqualTo(GenericUDFMacro.class.getName());
+
+        // test deserialize udf loaded by user code class loader instead of current thread class
+        // loader
+        ClassLoader userClassLoader =
+                FlinkUserCodeClassLoaders.create(
+                        new URL[] {udfJar.toURI().toURL()},
+                        getClass().getClassLoader(),
+                        new Configuration());
+        Class<ScalarFunction> udfClass =
+                (Class<ScalarFunction>) userClassLoader.loadClass(udfClassName);
+        ScalarFunction udf = udfClass.newInstance();
+        HiveFunctionWrapper<ScalarFunction> functionWrapper1 =
+                new HiveFunctionWrapper<>(udfClass, udf);
+        ScalarFunction deserializedUdf = functionWrapper1.createFunction();
+        assertThat(deserializedUdf.getClass().getName()).isEqualTo(udfClassName);
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDAFTest.java
@@ -116,8 +116,7 @@ public class HiveGenericUDAFTest {
 
     private static HiveGenericUDAF init(
             Class<?> hiveUdfClass, Object[] constantArgs, DataType[] argTypes) throws Exception {
-        HiveFunctionWrapper<GenericUDAFResolver> wrapper =
-                new HiveFunctionWrapper<>(hiveUdfClass.getName());
+        HiveFunctionWrapper<GenericUDAFResolver> wrapper = new HiveFunctionWrapper<>(hiveUdfClass);
 
         CallContextMock callContext = new CallContextMock();
         callContext.argumentDataTypes = Arrays.asList(argTypes);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDFTest.java
@@ -334,9 +334,8 @@ public class HiveGenericUDFTest {
     }
 
     private static HiveGenericUDF init(
-            Class hiveUdfClass, Object[] constantArgs, DataType[] argTypes) {
-        HiveGenericUDF udf =
-                new HiveGenericUDF(new HiveFunctionWrapper(hiveUdfClass.getName()), hiveShim);
+            Class<?> hiveUdfClass, Object[] constantArgs, DataType[] argTypes) {
+        HiveGenericUDF udf = new HiveGenericUDF(new HiveFunctionWrapper<>(hiveUdfClass), hiveShim);
 
         CallContextMock callContext = new CallContextMock();
         callContext.argumentDataTypes = Arrays.asList(argTypes);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveGenericUDTFTest.java
@@ -148,8 +148,8 @@ public class HiveGenericUDTFTest {
     }
 
     private static HiveGenericUDTF init(
-            Class hiveUdfClass, Object[] constantArgs, DataType[] argTypes) throws Exception {
-        HiveFunctionWrapper<GenericUDTF> wrapper = new HiveFunctionWrapper(hiveUdfClass.getName());
+            Class<?> hiveUdfClass, Object[] constantArgs, DataType[] argTypes) throws Exception {
+        HiveFunctionWrapper<GenericUDTF> wrapper = new HiveFunctionWrapper<>(hiveUdfClass);
 
         CallContextMock callContext = new CallContextMock();
         callContext.argumentDataTypes = Arrays.asList(argTypes);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/functions/hive/HiveSimpleUDFTest.java
@@ -214,9 +214,8 @@ public class HiveSimpleUDFTest {
         assertThat(udf.eval(5, testInputs, testInputs)).isEqualTo(11);
     }
 
-    protected static HiveSimpleUDF init(Class hiveUdfClass, DataType[] argTypes) {
-        HiveSimpleUDF udf =
-                new HiveSimpleUDF(new HiveFunctionWrapper(hiveUdfClass.getName()), hiveShim);
+    protected static HiveSimpleUDF init(Class<?> hiveUdfClass, DataType[] argTypes) {
+        HiveSimpleUDF udf = new HiveSimpleUDF(new HiveFunctionWrapper<>(hiveUdfClass), hiveShim);
 
         // Hive UDF won't have literal args
         CallContextMock callContext = new CallContextMock();

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/ExecutionContext.java
@@ -36,10 +36,8 @@ import org.apache.flink.table.factories.PlannerFactoryUtil;
 import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.resource.ResourceManager;
 import org.apache.flink.util.MutableURLClassLoader;
-import org.apache.flink.util.TemporaryClassLoaderContext;
 
 import java.lang.reflect.Method;
-import java.util.function.Supplier;
 
 import static org.apache.flink.table.client.gateway.context.SessionContext.SessionState;
 

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/ExecutionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/ExecutionContext.java
@@ -82,15 +82,6 @@ public class ExecutionContext {
         this.tableEnv = createTableEnvironment();
     }
 
-    /**
-     * Executes the given supplier using the execution context's classloader as thread classloader.
-     */
-    public <R> R wrapClassLoader(Supplier<R> supplier) {
-        try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(classLoader)) {
-            return supplier.get();
-        }
-    }
-
     public StreamTableEnvironment getTableEnvironment() {
         return tableEnv;
     }

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/LocalExecutor.java
@@ -169,7 +169,7 @@ public class LocalExecutor implements Executor {
 
         List<Operation> operations;
         try {
-            operations = context.wrapClassLoader(() -> parser.parse(statement));
+            operations = parser.parse(statement);
         } catch (Throwable t) {
             throw new SqlExecutionException("Failed to parse statement: " + statement, t);
         }
@@ -186,10 +186,7 @@ public class LocalExecutor implements Executor {
                 (TableEnvironmentInternal) context.getTableEnvironment();
 
         try {
-            return context.wrapClassLoader(
-                    () ->
-                            Arrays.asList(
-                                    tableEnv.getParser().getCompletionHints(statement, position)));
+            return Arrays.asList(tableEnv.getParser().getCompletionHints(statement, position));
         } catch (Throwable t) {
             // catch everything such that the query does not crash the executor
             if (LOG.isDebugEnabled()) {
@@ -206,7 +203,7 @@ public class LocalExecutor implements Executor {
         final TableEnvironmentInternal tEnv =
                 (TableEnvironmentInternal) context.getTableEnvironment();
         try {
-            return context.wrapClassLoader(() -> tEnv.executeInternal(operation));
+            return tEnv.executeInternal(operation);
         } catch (Throwable t) {
             throw new SqlExecutionException(MESSAGE_SQL_EXECUTION_ERROR, t);
         }
@@ -219,7 +216,7 @@ public class LocalExecutor implements Executor {
         final TableEnvironmentInternal tEnv =
                 (TableEnvironmentInternal) context.getTableEnvironment();
         try {
-            return context.wrapClassLoader(() -> tEnv.executeInternal(operations));
+            return tEnv.executeInternal(operations);
         } catch (Throwable t) {
             throw new SqlExecutionException(MESSAGE_SQL_EXECUTION_ERROR, t);
         }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/FunctionCatalog.java
@@ -578,10 +578,15 @@ public final class FunctionCatalog {
                 FunctionDefinition fd;
                 if (catalog.getFunctionDefinitionFactory().isPresent()
                         && catalogFunction.getFunctionLanguage() != FunctionLanguage.PYTHON) {
+                    registerFunctionJarResources(
+                            oi.asSummaryString(), catalogFunction.getFunctionResources());
                     fd =
                             catalog.getFunctionDefinitionFactory()
                                     .get()
-                                    .createFunctionDefinition(oi.getObjectName(), catalogFunction);
+                                    .createFunctionDefinition(
+                                            oi.getObjectName(),
+                                            catalogFunction,
+                                            resourceManager::getUserClassLoader);
                 } else {
                     fd = getFunctionDefinition(oi.asSummaryString(), catalogFunction);
                 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FunctionDefinitionFactory.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FunctionDefinitionFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.factories;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.util.TemporaryClassLoaderContext;
 
 /** A factory to create {@link FunctionDefinition}. */
 @PublicEvolving
@@ -32,6 +33,41 @@ public interface FunctionDefinitionFactory {
      * @param name name of the {@link CatalogFunction}
      * @param catalogFunction the catalog function
      * @return a {@link FunctionDefinition}
+     * @deprecated Please implement {@link #createFunctionDefinition(String, CatalogFunction,
+     *     Context)} instead.
      */
-    FunctionDefinition createFunctionDefinition(String name, CatalogFunction catalogFunction);
+    @Deprecated
+    default FunctionDefinition createFunctionDefinition(
+            String name, CatalogFunction catalogFunction) {
+        throw new RuntimeException(
+                "Please implement FunctionDefinitionFactory#createFunctionDefinition(String, CatalogFunction, Context) instead.");
+    }
+
+    /**
+     * Creates a {@link FunctionDefinition} from given {@link CatalogFunction} with the given {@link
+     * Context} containing the class loader of the current session, which is useful when it's needed
+     * to load class from class name.
+     *
+     * <p>The default implementation will call {@link #createFunctionDefinition(String,
+     * CatalogFunction)} directly.
+     *
+     * @param name name of the {@link CatalogFunction}
+     * @param catalogFunction the catalog function
+     * @param context the {@link Context} for creating function definition
+     * @return a {@link FunctionDefinition}
+     */
+    default FunctionDefinition createFunctionDefinition(
+            String name, CatalogFunction catalogFunction, Context context) {
+        try (TemporaryClassLoaderContext ignored =
+                TemporaryClassLoaderContext.of(context.getClassLoader())) {
+            return createFunctionDefinition(name, catalogFunction);
+        }
+    }
+
+    /** Context provided when a function definition is created. */
+    @PublicEvolving
+    interface Context {
+        /** Returns the class loader of the current session. */
+        ClassLoader getClassLoader();
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestFunctionDefinitionFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestFunctionDefinitionFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.factories;
+
+import org.apache.flink.table.catalog.CatalogFunction;
+import org.apache.flink.table.factories.FunctionDefinitionFactory;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.UserDefinedFunctionHelper;
+
+/**
+ * Use TestFunctionDefinitionFactory to test loading function to ensure the function can be loaded
+ * correctly if only implement legacy interface {@link
+ * FunctionDefinitionFactory#createFunctionDefinition(String, CatalogFunction)}.
+ */
+public class TestFunctionDefinitionFactory implements FunctionDefinitionFactory {
+
+    public FunctionDefinition createFunctionDefinition(
+            String name, CatalogFunction catalogFunction) {
+        return UserDefinedFunctionHelper.instantiateFunction(
+                Thread.currentThread().getContextClassLoader(), null, name, catalogFunction);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesCatalog.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestValuesCatalog.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.planner.utils.FilterUtils;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BooleanType;
@@ -44,7 +45,7 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-/** Use TestValuesCatalog to test partition push down. */
+/** Use TestValuesCatalog to test partition push down and create function definition. */
 public class TestValuesCatalog extends GenericInMemoryCatalog {
     private final boolean supportListPartitionByFilter;
 
@@ -93,6 +94,11 @@ public class TestValuesCatalog extends GenericInMemoryCatalog {
                                     resolvedExpressions, getter);
                         })
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<FunctionDefinitionFactory> getFunctionDefinitionFactory() {
+        return Optional.of(new TestFunctionDefinitionFactory());
     }
 
     private Function<String, Comparable<?>> getValueGetter(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To use usercode class loader to load function instead of current thread's class loader to avoid class not found exception.


## Brief change log
  - Pass a context with classloader to create function defination in [FunctionDefinitionFactory.java](https://github.com/apache/flink/pull/20211/files#diff-2064a179df5cb66b3df874e6961948c0108bb2bdea480c06f3e57beaf4b7bd54)
  -  Use the passed classloader to load the class of the function in [HiveFunctionDefinitionFactory.java](https://github.com/apache/flink/pull/20211/files#diff-ec7f9823d637e6fea8eadeb09825930a4431e7e09dd04d4f67ea9f62b83b923f)


## Verifying this change
This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? N/A
