### PR TITLE
[FLINK-27479] [Connectors / Common] introduce availability helper to manage future for hybr…

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -24,7 +24,14 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
 import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
+import org.apache.flink.connector.base.source.reader.mocks.MockSourceReader;
+import org.apache.flink.connector.base.source.reader.mocks.MockSplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
@@ -35,6 +42,8 @@ import org.mockito.Mockito;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -121,6 +130,120 @@ public class HybridSourceReaderTest {
     }
 
     @Test
+    public void testAvailabilityFutureSwitchover() throws Exception {
+        TestingReaderContext readerContext = new TestingReaderContext();
+        TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
+        MockBaseSource source = new MockBaseSource(1, 1, Boundedness.BOUNDED);
+
+        // 2 underlying readers to exercise switch
+        MutableFutureSourceReader mockSplitReader1 =
+                MutableFutureSourceReader.createReader(readerContext);
+        MutableFutureSourceReader mockSplitReader2 =
+                MutableFutureSourceReader.createReader(readerContext);
+
+        HybridSourceReader<Integer> reader = new HybridSourceReader<>(readerContext);
+
+        assertThat(readerContext.getSentEvents()).isEmpty();
+        reader.start();
+        assertAndClearSourceReaderFinishedEvent(readerContext, -1);
+        assertThat(currentReader(reader)).isNull();
+        assertThat(reader.pollNext(readerOutput)).isEqualTo(InputStatus.NOTHING_AVAILABLE);
+        CompletableFuture<Void> hybridSourceFutureBeforeFirstReader = reader.isAvailable();
+        assertThat(hybridSourceFutureBeforeFirstReader).isNotDone();
+
+        Source source1 =
+                new MockSource(null, 0) {
+                    @Override
+                    public SourceReader<Integer, MockSourceSplit> createReader(
+                            SourceReaderContext readerContext) {
+                        return mockSplitReader1;
+                    }
+                };
+        reader.handleSourceEvents(new SwitchSourceEvent(0, source1, false));
+        assertThat(hybridSourceFutureBeforeFirstReader)
+                .isDone()
+                .as("the previous underlying future should be completed after switch event");
+
+        MockSourceSplit mockSplit = new MockSourceSplit(0, 0, 1);
+        mockSplit.addRecord(0);
+
+        SwitchedSources switchedSources = new SwitchedSources();
+        switchedSources.put(0, source);
+        HybridSourceSplit hybridSplit = HybridSourceSplit.wrapSplit(mockSplit, 0, switchedSources);
+        reader.addSplits(Collections.singletonList(hybridSplit));
+
+        // drain splits
+        CompletableFuture<Void> futureBeforeDraining = reader.isAvailable();
+        mockSplitReader1.completeFuture();
+        assertThat(futureBeforeDraining)
+                .isDone()
+                .as("underlying future is complete and hybrid source should poll");
+
+        InputStatus status = reader.pollNext(readerOutput);
+        while (readerOutput.getEmittedRecords().isEmpty() || status == InputStatus.MORE_AVAILABLE) {
+            status = reader.pollNext(readerOutput);
+            Thread.sleep(10);
+        }
+        // mock reader no more records
+        mockSplitReader1.resetFuture();
+
+        CompletableFuture<Void> futureAfterDraining = reader.isAvailable();
+        assertThat(futureBeforeDraining)
+                .isNotEqualTo(futureAfterDraining)
+                .as("Future should have been refreshed since the previous future is complete");
+        assertThat(futureAfterDraining).isNotDone().as("Future should not be complete");
+
+        assertThat(readerOutput.getEmittedRecords()).contains(0);
+        reader.pollNext(readerOutput);
+        assertThat(reader.pollNext(readerOutput))
+                .as("before notifyNoMoreSplits")
+                .isEqualTo(InputStatus.NOTHING_AVAILABLE);
+
+        reader.notifyNoMoreSplits();
+        reader.pollNext(readerOutput);
+        assertAndClearSourceReaderFinishedEvent(readerContext, 0);
+
+        assertThat(futureAfterDraining)
+                .isNotDone()
+                .as("still no more records and runtime should not poll");
+
+        assertThat(currentReader(reader))
+                .as("reader before switch source event")
+                .isEqualTo(mockSplitReader1);
+
+        Source source2 =
+                new MockSource(null, 0) {
+                    @Override
+                    public SourceReader<Integer, MockSourceSplit> createReader(
+                            SourceReaderContext readerContext) {
+                        return mockSplitReader2;
+                    }
+                };
+
+        reader.handleSourceEvents(new SwitchSourceEvent(1, source2, true));
+        assertThat(futureAfterDraining)
+                .isDone()
+                .as("switching should signal completion to poll the new reader");
+        CompletableFuture<Void> futureReader2 = reader.isAvailable();
+
+        // futures must be different
+        assertThat(futureBeforeDraining).isNotSameAs(futureReader2);
+        assertThat(currentReader(reader))
+                .as("reader after switch source event")
+                .isEqualTo(mockSplitReader2);
+
+        reader.notifyNoMoreSplits();
+        assertThat(reader.pollNext(readerOutput))
+                .as("reader 1 after notifyNoMoreSplits")
+                .isEqualTo(InputStatus.END_OF_INPUT);
+        assertThat(futureReader2)
+                .isSameAs(reader.isAvailable())
+                .as("future should not have been refreshed");
+
+        reader.close();
+    }
+
+    @Test
     public void testReaderRecovery() throws Exception {
         TestingReaderContext readerContext = new TestingReaderContext();
         TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
@@ -200,5 +323,48 @@ public class HybridSourceReaderTest {
         assertThat(((SourceReaderFinishedEvent) context.getSentEvents().get(0)).sourceIndex())
                 .isEqualTo(sourceIndex);
         context.clearSentEvents();
+    }
+
+    private static class MutableFutureSourceReader extends MockSourceReader {
+
+        private CompletableFuture<Void> availabilityFuture = new CompletableFuture<>();
+
+        public MutableFutureSourceReader(
+                FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
+                Supplier<SplitReader<int[], MockSourceSplit>> splitFetcherSupplier,
+                Configuration config,
+                SourceReaderContext context) {
+            super(elementsQueue, splitFetcherSupplier, config, context);
+        }
+
+        public static MutableFutureSourceReader createReader(SourceReaderContext readerContext) {
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue =
+                    new FutureCompletingBlockingQueue<>();
+
+            Configuration config = new Configuration();
+            config.setInteger(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 2);
+            config.setLong(SourceReaderOptions.SOURCE_READER_CLOSE_TIMEOUT, 30000L);
+            MockSplitReader.Builder builder =
+                    MockSplitReader.newBuilder()
+                            .setNumRecordsPerSplitPerFetch(2)
+                            .setBlockingFetch(true);
+            return new MutableFutureSourceReader(
+                    elementsQueue, builder::build, config, readerContext);
+        }
+
+        @Override
+        public CompletableFuture<Void> isAvailable() {
+            return availabilityFuture;
+        }
+
+        public void completeFuture() {
+            availabilityFuture.complete(null);
+        }
+
+        public void resetFuture() {
+            if (this.availabilityFuture.isDone()) {
+                availabilityFuture = new CompletableFuture<>();
+            }
+        }
     }
 }


### PR DESCRIPTION
…id source

## What is the purpose of the change

Hybrid Source gets into tight busy loop since availability future is marked completed and never refreshed.

## Brief change log

- Introduce MultipleFuturesAvailabilityHelper to help manage availability future

## Verifying this change

This change added tests and can be verified as follows:

- Added basic unit test to verify that availability future is refreshed
- Existing tests exercise that source continues to emit records properly

I verified this fix on the latest 1.14 branch.

Test setup: Hybrid Source setup (bounded read on short csv file and then switchover to unbounded read from Kafka)

Test Jobs:
1. Hybrid Source without fix
2. Hybrid Source with fix
3. Kafka Source 


I have attached the flamegraphs to the jira ticket. Additionally, I confirmed that test job 2 and test job 3 CPU usage similar running in EKS (2% CPU usage) vs test job 1 (~80%). 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no. This is not per-record but this is performance impacting
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
