### PR TITLE
[FLINK-28145][runtime] Let ResourceManager supports blocklist

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -61,6 +61,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /** Implementation of {@link ResourceManagerDriver} for Kubernetes deployment. */
@@ -164,7 +165,8 @@ public class KubernetesResourceManagerDriver
     public CompletableFuture<KubernetesWorkerNode> requestResource(
             TaskExecutorProcessSpec taskExecutorProcessSpec) {
         final KubernetesTaskManagerParameters parameters =
-                createKubernetesTaskManagerParameters(taskExecutorProcessSpec);
+                createKubernetesTaskManagerParameters(
+                        taskExecutorProcessSpec, getBlockedNodeRetriever().getAllBlockedNodeIds());
         final KubernetesPod taskManagerPod =
                 KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(
                         taskManagerPodTemplate, parameters);
@@ -279,7 +281,7 @@ public class KubernetesResourceManagerDriver
     }
 
     private KubernetesTaskManagerParameters createKubernetesTaskManagerParameters(
-            TaskExecutorProcessSpec taskExecutorProcessSpec) {
+            TaskExecutorProcessSpec taskExecutorProcessSpec, Set<String> blockedNodes) {
         final String podName =
                 String.format(
                         TASK_MANAGER_POD_FORMAT, clusterId, currentMaxAttemptId, ++currentMaxPodId);
@@ -302,7 +304,8 @@ public class KubernetesResourceManagerDriver
                 taskManagerParameters,
                 ExternalResourceUtils.getExternalResourceConfigurationKeys(
                         flinkConfig,
-                        KubernetesConfigOptions.EXTERNAL_RESOURCE_KUBERNETES_CONFIG_KEY_SUFFIX));
+                        KubernetesConfigOptions.EXTERNAL_RESOURCE_KUBERNETES_CONFIG_KEY_SUFFIX),
+                blockedNodes);
     }
 
     private void handlePodEventsInMainThread(List<KubernetesPod> pods) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -505,6 +505,19 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             "The user agent to be used for contacting with Kubernetes APIServer.");
 
+    /**
+     * This will only be used to support blocklist mechanism, which is experimental currently, so we
+     * do not want to expose this option in the documentation.
+     */
+    @Documentation.ExcludeFromDocumentation
+    public static final ConfigOption<String> KUBERNETES_NODE_NAME_LABEL =
+            key("kubernetes.node-name-label")
+                    .stringType()
+                    .defaultValue("kubernetes.io/hostname")
+                    .withDescription(
+                            "The node label whose value is the same as the node name. "
+                                    + "Currently, this will only be used to set the node affinity of TM pods to avoid being scheduled on blocked nodes.");
+
     private static String getDefaultFlinkImage() {
         // The default container image that ties to the exact needed versions of both Flink and
         // Scala.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -49,13 +50,16 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
     private final Map<String, String> taskManagerExternalResourceConfigKeys;
 
+    private final Set<String> blockedNodes;
+
     public KubernetesTaskManagerParameters(
             Configuration flinkConfig,
             String podName,
             String dynamicProperties,
             String jvmMemOptsEnv,
             ContaineredTaskManagerParameters containeredTaskManagerParameters,
-            Map<String, String> taskManagerExternalResourceConfigKeys) {
+            Map<String, String> taskManagerExternalResourceConfigKeys,
+            Set<String> blockedNodes) {
         super(flinkConfig);
         this.podName = checkNotNull(podName);
         this.dynamicProperties = checkNotNull(dynamicProperties);
@@ -63,6 +67,7 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
         this.containeredTaskManagerParameters = checkNotNull(containeredTaskManagerParameters);
         this.taskManagerExternalResourceConfigKeys =
                 checkNotNull(taskManagerExternalResourceConfigKeys);
+        this.blockedNodes = checkNotNull(blockedNodes);
     }
 
     @Override
@@ -177,5 +182,13 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
 
     public ContaineredTaskManagerParameters getContaineredTaskManagerParameters() {
         return containeredTaskManagerParameters;
+    }
+
+    public Set<String> getBlockedNodes() {
+        return Collections.unmodifiableSet(blockedNodes);
+    }
+
+    public String getNodeNameLabel() {
+        return checkNotNull(flinkConfig.get(KubernetesConfigOptions.KUBERNETES_NODE_NAME_LABEL));
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesTestUtils.java
@@ -63,6 +63,7 @@ public class KubernetesTestUtils {
                 "",
                 "",
                 containeredTaskManagerParameters,
-                Collections.emptyMap());
+                Collections.emptyMap(),
+                Collections.emptySet());
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -28,6 +28,10 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.externalresource.ExternalResourceUtils;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /** Base test class for the TaskManager side. */
 public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
 
@@ -47,6 +51,9 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
     protected ContaineredTaskManagerParameters containeredTaskManagerParameters;
 
     protected KubernetesTaskManagerParameters kubernetesTaskManagerParameters;
+
+    protected static final Set<String> BLOCKED_NODES =
+            new HashSet<>(Arrays.asList("blockedNode1", "blockedNode2"));
 
     @Override
     protected void setupFlinkConfig() {
@@ -87,6 +94,7 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
                         ExternalResourceUtils.getExternalResourceConfigurationKeys(
                                 flinkConfig,
                                 KubernetesConfigOptions
-                                        .EXTERNAL_RESOURCE_KUBERNETES_CONFIG_KEY_SUFFIX));
+                                        .EXTERNAL_RESOURCE_KUBERNETES_CONFIG_KEY_SUFFIX),
+                        BLOCKED_NODES);
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
@@ -99,7 +99,8 @@ class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
                         DYNAMIC_PROPERTIES,
                         JVM_MEM_OPTS_ENV,
                         containeredTaskManagerParameters,
-                        Collections.emptyMap());
+                        Collections.emptyMap(),
+                        Collections.emptySet());
     }
 
     @Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlockedNodeRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlockedNodeRetriever.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blocklist;
+
+import java.util.Set;
+
+/** This class helps to retrieve the blocked nodes. */
+public interface BlockedNodeRetriever {
+
+    /**
+     * Get all blocked node ids.
+     *
+     * @return a set containing all blocked node ids
+     */
+    Set<String> getAllBlockedNodeIds();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManagerGateway.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.blocklist.BlocklistListener;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -55,7 +56,7 @@ import java.util.concurrent.CompletableFuture;
 
 /** The {@link ResourceManager}'s RPC gateway interface. */
 public interface ResourceManagerGateway
-        extends FencedRpcGateway<ResourceManagerId>, ClusterPartitionManager {
+        extends FencedRpcGateway<ResourceManagerId>, ClusterPartitionManager, BlocklistListener {
 
     /**
      * Register a {@link JobMaster} at the resource manager.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.blocklist.BlocklistHandler;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -57,6 +58,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
             DelegationTokenManager delegationTokenManager,
             SlotManager slotManager,
             ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
+            BlocklistHandler.Factory blocklistHandlerFactory,
             JobLeaderIdService jobLeaderIdService,
             ClusterInformation clusterInformation,
             FatalErrorHandler fatalErrorHandler,
@@ -72,6 +74,7 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
                 delegationTokenManager,
                 slotManager,
                 clusterPartitionTrackerFactory,
+                blocklistHandlerFactory,
                 jobLeaderIdService,
                 clusterInformation,
                 fatalErrorHandler,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.blocklist.BlocklistUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -82,6 +83,7 @@ public final class StandaloneResourceManagerFactory extends ResourceManagerFacto
                 delegationTokenManager,
                 resourceManagerRuntimeServices.getSlotManager(),
                 ResourceManagerPartitionTrackerImpl::new,
+                BlocklistUtils.loadBlocklistHandlerFactory(configuration),
                 resourceManagerRuntimeServices.getJobLeaderIdService(),
                 clusterInformation,
                 fatalErrorHandler,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/AbstractResourceManagerDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/AbstractResourceManagerDriver.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blocklist.BlockedNodeRetriever;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -40,6 +41,7 @@ public abstract class AbstractResourceManagerDriver<WorkerType extends ResourceI
     private ResourceEventHandler<WorkerType> resourceEventHandler = null;
     private ScheduledExecutor mainThreadExecutor = null;
     private Executor ioExecutor = null;
+    private BlockedNodeRetriever blockedNodeRetriever = null;
 
     public AbstractResourceManagerDriver(
             final Configuration flinkConfig, final Configuration flinkClientConfig) {
@@ -68,15 +70,24 @@ public abstract class AbstractResourceManagerDriver<WorkerType extends ResourceI
         return ioExecutor;
     }
 
+    protected final BlockedNodeRetriever getBlockedNodeRetriever() {
+        Preconditions.checkState(
+                blockedNodeRetriever != null,
+                "Cannot get the blocked node retriever. Resource manager driver is not initialized.");
+        return blockedNodeRetriever;
+    }
+
     @Override
     public final void initialize(
             ResourceEventHandler<WorkerType> resourceEventHandler,
             ScheduledExecutor mainThreadExecutor,
-            Executor ioExecutor)
+            Executor ioExecutor,
+            BlockedNodeRetriever blockedNodeRetriever)
             throws Exception {
         this.resourceEventHandler = Preconditions.checkNotNull(resourceEventHandler);
         this.mainThreadExecutor = Preconditions.checkNotNull(mainThreadExecutor);
         this.ioExecutor = Preconditions.checkNotNull(ioExecutor);
+        this.blockedNodeRetriever = Preconditions.checkNotNull(blockedNodeRetriever);
 
         initializeInternal();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blocklist.BlocklistHandler;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
@@ -50,7 +51,6 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -113,6 +113,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
             DelegationTokenManager delegationTokenManager,
             SlotManager slotManager,
             ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
+            BlocklistHandler.Factory blocklistHandlerFactory,
             JobLeaderIdService jobLeaderIdService,
             ClusterInformation clusterInformation,
             FatalErrorHandler fatalErrorHandler,
@@ -129,6 +130,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
                 delegationTokenManager,
                 slotManager,
                 clusterPartitionTrackerFactory,
+                blocklistHandlerFactory,
                 jobLeaderIdService,
                 clusterInformation,
                 fatalErrorHandler,
@@ -157,12 +159,11 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
     @Override
     protected void initialize() throws ResourceManagerException {
         try {
-            // TODO: pass the blocked node retriever
             resourceManagerDriver.initialize(
                     this,
                     new GatewayMainThreadExecutor(),
                     ioExecutor,
-                    () -> Collections.emptySet());
+                    blocklistHandler::getAllBlockedNodeIds);
         } catch (Exception e) {
             throw new ResourceManagerException("Cannot initialize resource provider.", e);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -50,6 +50,7 @@ import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -156,7 +157,12 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
     @Override
     protected void initialize() throws ResourceManagerException {
         try {
-            resourceManagerDriver.initialize(this, new GatewayMainThreadExecutor(), ioExecutor);
+            // TODO: pass the blocked node retriever
+            resourceManagerDriver.initialize(
+                    this,
+                    new GatewayMainThreadExecutor(),
+                    ioExecutor,
+                    () -> Collections.emptySet());
         } catch (Exception e) {
             throw new ResourceManagerException("Cannot initialize resource provider.", e);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.blocklist.BlocklistUtils;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
@@ -119,6 +120,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 delegationTokenManager,
                 resourceManagerRuntimeServices.getSlotManager(),
                 ResourceManagerPartitionTrackerImpl::new,
+                BlocklistUtils.loadBlocklistHandlerFactory(configuration),
                 resourceManagerRuntimeServices.getJobLeaderIdService(),
                 clusterInformation,
                 fatalErrorHandler,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.active;
 
+import org.apache.flink.runtime.blocklist.BlockedNodeRetriever;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceIDRetrievable;
@@ -40,11 +41,13 @@ public interface ResourceManagerDriver<WorkerType extends ResourceIDRetrievable>
      * @param resourceEventHandler Handler that handles resource events.
      * @param mainThreadExecutor Rpc main thread executor.
      * @param ioExecutor IO executor.
+     * @param blockedNodeRetriever To retrieve all blocked nodes
      */
     void initialize(
             ResourceEventHandler<WorkerType> resourceEventHandler,
             ScheduledExecutor mainThreadExecutor,
-            Executor ioExecutor)
+            Executor ioExecutor,
+            BlockedNodeRetriever blockedNodeRetriever)
             throws Exception;
 
     /** Terminate the deployment specific components. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -185,6 +185,11 @@ public class DeclarativeSlotManager implements SlotManager {
         }
     }
 
+    @Override
+    public void triggerResourceRequirementsCheck() {
+        checkResourceRequirementsWithDelay();
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Component lifecycle methods
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -20,7 +20,9 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -101,6 +103,9 @@ public class DeclarativeSlotManager implements SlotManager {
     /** The future of the requirements delay check. */
     @Nullable private CompletableFuture<Void> requirementsCheckFuture;
 
+    /** Blocked task manager checker. */
+    @Nullable private BlockedTaskManagerChecker blockedTaskManagerChecker;
+
     /** True iff the component has been started. */
     private boolean started;
 
@@ -142,6 +147,7 @@ public class DeclarativeSlotManager implements SlotManager {
         resourceActions = null;
         mainThreadExecutor = null;
         taskExecutorManager = null;
+        blockedTaskManagerChecker = null;
 
         started = false;
     }
@@ -189,12 +195,14 @@ public class DeclarativeSlotManager implements SlotManager {
      * @param newResourceManagerId to use for communication with the task managers
      * @param newMainThreadExecutor to use to run code in the ResourceManager's main thread
      * @param newResourceActions to use for resource (de-)allocations
+     * @param newBlockedTaskManagerChecker to query whether a task manager is blocked
      */
     @Override
     public void start(
             ResourceManagerId newResourceManagerId,
             Executor newMainThreadExecutor,
-            ResourceActions newResourceActions) {
+            ResourceActions newResourceActions,
+            BlockedTaskManagerChecker newBlockedTaskManagerChecker) {
         LOG.debug("Starting the slot manager.");
 
         this.resourceManagerId = Preconditions.checkNotNull(newResourceManagerId);
@@ -202,6 +210,7 @@ public class DeclarativeSlotManager implements SlotManager {
         resourceActions = Preconditions.checkNotNull(newResourceActions);
         taskExecutorManager =
                 taskExecutorManagerFactory.apply(newMainThreadExecutor, newResourceActions);
+        blockedTaskManagerChecker = Preconditions.checkNotNull(newBlockedTaskManagerChecker);
 
         started = true;
 
@@ -240,6 +249,7 @@ public class DeclarativeSlotManager implements SlotManager {
         taskExecutorManager = null;
         resourceManagerId = null;
         resourceActions = null;
+        blockedTaskManagerChecker = null;
         started = false;
     }
 
@@ -551,18 +561,24 @@ public class DeclarativeSlotManager implements SlotManager {
     private int internalTryAllocateSlots(
             JobID jobId, String targetAddress, ResourceRequirement resourceRequirement) {
         final ResourceProfile requiredResource = resourceRequirement.getResourceProfile();
-        Collection<TaskManagerSlotInformation> freeSlots = slotTracker.getFreeSlots();
+        Set<TaskManagerSlotInformation> availableSlots =
+                slotTracker.getFreeSlots().stream()
+                        .filter(
+                                slotInfo ->
+                                        !isBlockedTaskManager(
+                                                slotInfo.getTaskManagerConnection()
+                                                        .getResourceID()))
+                        .collect(Collectors.toSet());
 
         int numUnfulfilled = 0;
         for (int x = 0; x < resourceRequirement.getNumberOfRequiredSlots(); x++) {
 
             final Optional<TaskManagerSlotInformation> reservedSlot =
                     slotMatchingStrategy.findMatchingSlot(
-                            requiredResource, freeSlots, this::getNumberRegisteredSlotsOf);
+                            requiredResource, availableSlots, this::getNumberRegisteredSlotsOf);
             if (reservedSlot.isPresent()) {
-                // we do not need to modify freeSlots because it is indirectly modified by the
-                // allocation
                 allocateSlot(reservedSlot.get(), jobId, targetAddress, requiredResource);
+                availableSlots.remove(reservedSlot.get());
             } else {
                 // exit loop early; we won't find a matching slot for this requirement
                 int numRemaining = resourceRequirement.getNumberOfRequiredSlots() - x;
@@ -571,6 +587,11 @@ public class DeclarativeSlotManager implements SlotManager {
             }
         }
         return numUnfulfilled;
+    }
+
+    private boolean isBlockedTaskManager(ResourceID resourceID) {
+        Preconditions.checkNotNull(blockedTaskManagerChecker);
+        return blockedTaskManagerChecker.isBlockedTaskManager(resourceID);
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -172,6 +172,11 @@ public class FineGrainedSlotManager implements SlotManager {
         }
     }
 
+    @Override
+    public void triggerResourceRequirementsCheck() {
+        checkResourceRequirementsWithDelay();
+    }
+
     // ---------------------------------------------------------------------------------------------
     // Component lifecycle methods
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
@@ -112,6 +114,9 @@ public class FineGrainedSlotManager implements SlotManager {
 
     @Nullable private CompletableFuture<Void> requirementsCheckFuture;
 
+    /** Blocked task manager checker. */
+    @Nullable private BlockedTaskManagerChecker blockedTaskManagerChecker;
+
     /** True iff the component has been started. */
     private boolean started;
 
@@ -177,12 +182,14 @@ public class FineGrainedSlotManager implements SlotManager {
      * @param newResourceManagerId to use for communication with the task managers
      * @param newMainThreadExecutor to use to run code in the ResourceManager's main thread
      * @param newResourceActions to use for resource (de-)allocations
+     * @param newBlockedTaskManagerChecker to query whether a task manager is blocked
      */
     @Override
     public void start(
             ResourceManagerId newResourceManagerId,
             Executor newMainThreadExecutor,
-            ResourceActions newResourceActions) {
+            ResourceActions newResourceActions,
+            BlockedTaskManagerChecker newBlockedTaskManagerChecker) {
         LOG.info("Starting the slot manager.");
 
         resourceManagerId = Preconditions.checkNotNull(newResourceManagerId);
@@ -190,6 +197,7 @@ public class FineGrainedSlotManager implements SlotManager {
         resourceActions = Preconditions.checkNotNull(newResourceActions);
         slotStatusSyncer.initialize(
                 taskManagerTracker, resourceTracker, resourceManagerId, mainThreadExecutor);
+        blockedTaskManagerChecker = Preconditions.checkNotNull(newBlockedTaskManagerChecker);
 
         started = true;
 
@@ -532,7 +540,7 @@ public class FineGrainedSlotManager implements SlotManager {
 
         final ResourceAllocationResult result =
                 resourceAllocationStrategy.tryFulfillRequirements(
-                        missingResources, taskManagerTracker);
+                        missingResources, taskManagerTracker, this::isBlockedTaskManager);
 
         // Allocate slots according to the result
         allocateSlotsAccordingTo(result.getAllocationsOnRegisteredResources());
@@ -768,5 +776,10 @@ public class FineGrainedSlotManager implements SlotManager {
                         .merge(taskManagerTracker.getPendingResource());
         return totalResourceAfterAdding.getCpuCores().compareTo(maxTotalCpu) > 0
                 || totalResourceAfterAdding.getTotalMemory().compareTo(maxTotalMem) > 0;
+    }
+
+    private boolean isBlockedTaskManager(ResourceID resourceID) {
+        Preconditions.checkNotNull(blockedTaskManagerChecker);
+        return blockedTaskManagerChecker.isBlockedTaskManager(resourceID);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocationStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 
 import java.util.Collection;
@@ -37,10 +38,12 @@ public interface ResourceAllocationStrategy {
      * @param missingResources resource requirements that are not yet fulfilled, indexed by jobId
      * @param taskManagerResourceInfoProvider provide the registered/pending resources of the
      *     current cluster
+     * @param blockedTaskManagerChecker blocked task manager checker
      * @return a {@link ResourceAllocationResult} based on the current status, which contains
      *     whether the requirements can be fulfilled and the actions to take
      */
     ResourceAllocationResult tryFulfillRequirements(
             Map<JobID, Collection<ResourceRequirement>> missingResources,
-            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider);
+            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider,
+            BlockedTaskManagerChecker blockedTaskManagerChecker);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
@@ -79,11 +80,13 @@ public interface SlotManager extends AutoCloseable {
      * @param newResourceManagerId to use for communication with the task managers
      * @param newMainThreadExecutor to use to run code in the ResourceManager's main thread
      * @param newResourceActions to use for resource (de-)allocations
+     * @param newBlockedTaskManagerChecker to query whether a task manager is blocked
      */
     void start(
             ResourceManagerId newResourceManagerId,
             Executor newMainThreadExecutor,
-            ResourceActions newResourceActions);
+            ResourceActions newResourceActions,
+            BlockedTaskManagerChecker newBlockedTaskManagerChecker);
 
     /** Suspends the component. This clears the internal state of the slot manager. */
     void suspend();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -152,4 +152,10 @@ public interface SlotManager extends AutoCloseable {
     void freeSlot(SlotID slotId, AllocationID allocationId);
 
     void setFailUnfulfillableRequest(boolean failUnfulfillableRequest);
+
+    /**
+     * Trigger the resource requirement check. This method will be called when some slot statuses
+     * changed.
+     */
+    void triggerResourceRequirementsCheck();
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager;
 
 import org.apache.flink.api.common.time.Time;
+import org.apache.flink.runtime.blocklist.NoOpBlocklistHandler;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.heartbeat.HeartbeatServices;
@@ -145,6 +146,7 @@ public class StandaloneResourceManagerTest extends TestLogger {
                     delegationTokenManager,
                     slotManager,
                     NoOpResourceManagerPartitionTracker::get,
+                    new NoOpBlocklistHandler.Factory(),
                     jobLeaderIdService,
                     clusterInformation,
                     fatalErrorHandler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.runtime.blocklist.BlocklistHandler;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -50,6 +51,7 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
             DelegationTokenManager delegationTokenManager,
             SlotManager slotManager,
             ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
+            BlocklistHandler.Factory blocklistHandlerFactory,
             JobLeaderIdService jobLeaderIdService,
             FatalErrorHandler fatalErrorHandler,
             ResourceManagerMetricGroup resourceManagerMetricGroup,
@@ -62,6 +64,7 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
                 delegationTokenManager,
                 slotManager,
                 clusterPartitionTrackerFactory,
+                blocklistHandlerFactory,
                 jobLeaderIdService,
                 new ClusterInformation("localhost", 1234),
                 fatalErrorHandler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
@@ -21,6 +21,8 @@ package org.apache.flink.runtime.resourcemanager;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.AkkaOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blocklist.BlocklistHandler;
+import org.apache.flink.runtime.blocklist.BlocklistUtils;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
@@ -91,6 +93,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
                 delegationTokenManager,
                 resourceManagerRuntimeServices.getSlotManager(),
                 ResourceManagerPartitionTrackerImpl::new,
+                BlocklistUtils.loadBlocklistHandlerFactory(configuration),
                 resourceManagerRuntimeServices.getJobLeaderIdService(),
                 clusterInformation,
                 fatalErrorHandler,
@@ -173,6 +176,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
                 DelegationTokenManager delegationTokenManager,
                 SlotManager slotManager,
                 ResourceManagerPartitionTrackerFactory clusterPartitionTrackerFactory,
+                BlocklistHandler.Factory blocklistHandlerFactory,
                 JobLeaderIdService jobLeaderIdService,
                 ClusterInformation clusterInformation,
                 FatalErrorHandler fatalErrorHandler,
@@ -187,6 +191,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
                     delegationTokenManager,
                     slotManager,
                     clusterPartitionTrackerFactory,
+                    blocklistHandlerFactory,
                     jobLeaderIdService,
                     clusterInformation,
                     fatalErrorHandler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager.active;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.blocklist.NoOpBlocklistHandler;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -897,6 +898,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                             rmServices.delegationTokenManager,
                             rmServices.slotManager,
                             NoOpResourceManagerPartitionTracker::get,
+                            new NoOpBlocklistHandler.Factory(),
                             rmServices.jobLeaderIdService,
                             new ClusterInformation("localhost", 1234),
                             fatalErrorHandler,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriverTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriverTestBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.active;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.blocklist.BlockedNodeRetriever;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
@@ -164,9 +165,14 @@ public abstract class ResourceManagerDriverTestBase<WorkerType extends ResourceI
 
         private ResourceManagerDriver<WorkerType> driver;
         private ScheduledExecutor mainThreadExecutor;
+        private BlockedNodeRetriever blockedNodeRetriever = () -> Collections.emptySet();
 
         protected ResourceManagerDriver<WorkerType> getDriver() {
             return driver;
+        }
+
+        public void setBlockedNodeRetriever(BlockedNodeRetriever blockedNodeRetriever) {
+            this.blockedNodeRetriever = blockedNodeRetriever;
         }
 
         protected final void runTest(RunnableWithException testMethod) throws Exception {
@@ -178,7 +184,8 @@ public abstract class ResourceManagerDriverTestBase<WorkerType extends ResourceI
             driver.initialize(
                     resourceEventHandlerBuilder.build(),
                     mainThreadExecutor,
-                    ForkJoinPool.commonPool());
+                    ForkJoinPool.commonPool(),
+                    blockedNodeRetriever);
 
             testMethod.run();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceManagerDriver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/TestingResourceManagerDriver.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager.active;
 
+import org.apache.flink.runtime.blocklist.BlockedNodeRetriever;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -69,7 +70,8 @@ public class TestingResourceManagerDriver implements ResourceManagerDriver<Resou
     public void initialize(
             ResourceEventHandler<ResourceID> resourceEventHandler,
             ScheduledExecutor mainThreadExecutor,
-            Executor ioExecutor)
+            Executor ioExecutor,
+            BlockedNodeRetriever blockedNodeRetriever)
             throws Exception {
         initializeFunction.apply(resourceEventHandler, mainThreadExecutor, ioExecutor);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AbstractFineGrainedSlotManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AbstractFineGrainedSlotManagerITCase.java
@@ -37,7 +37,7 @@ import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
 import org.apache.flink.util.function.FunctionUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,15 +47,10 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT Cases of {@link FineGrainedSlotManager}. */
-public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManagerTestBase {
+abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManagerTestBase {
 
     // ---------------------------------------------------------------------------------------------
     // Requirement declaration
@@ -65,8 +60,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
      * Tests that a requirement declaration with no free slots will trigger the resource allocation.
      */
     @Test
-    public void testRequirementDeclarationWithoutFreeSlotsTriggersWorkerAllocation()
-            throws Exception {
+    void testRequirementDeclarationWithoutFreeSlotsTriggersWorkerAllocation() throws Exception {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
 
         final CompletableFuture<WorkerResourceSpec> allocateResourceFuture =
@@ -91,7 +85,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
 
     /** Tests that resource requirements can be fulfilled with resource that are currently free. */
     @Test
-    public void testRequirementDeclarationWithFreeResource() throws Exception {
+    void testRequirementDeclarationWithFreeResource() throws Exception {
         testRequirementDeclaration(
                 RequirementDeclarationScenario
                         .TASK_EXECUTOR_REGISTRATION_BEFORE_REQUIREMENT_DECLARATION);
@@ -102,7 +96,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
      * requirement declaration.
      */
     @Test
-    public void testRequirementDeclarationWithPendingResource() throws Exception {
+    void testRequirementDeclarationWithPendingResource() throws Exception {
         testRequirementDeclaration(
                 RequirementDeclarationScenario
                         .TASK_EXECUTOR_REGISTRATION_AFTER_REQUIREMENT_DECLARATION);
@@ -185,19 +179,15 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                                                 DEFAULT_SLOT_RESOURCE_PROFILE));
                             }
 
-                            assertThat(
-                                    assertFutureCompleteAndReturn(requestFuture),
-                                    is(
-                                            equalTo(
-                                                    Tuple6.of(
-                                                            slotId,
-                                                            jobId,
-                                                            assertFutureCompleteAndReturn(
-                                                                            requestFuture)
-                                                                    .f2,
-                                                            DEFAULT_SLOT_RESOURCE_PROFILE,
-                                                            targetAddress,
-                                                            getResourceManagerId()))));
+                            assertThat(assertFutureCompleteAndReturn(requestFuture))
+                                    .isEqualTo(
+                                            Tuple6.of(
+                                                    slotId,
+                                                    jobId,
+                                                    assertFutureCompleteAndReturn(requestFuture).f2,
+                                                    DEFAULT_SLOT_RESOURCE_PROFILE,
+                                                    targetAddress,
+                                                    getResourceManagerId()));
 
                             final TaskManagerSlotInformation slot =
                                     getTaskManagerTracker()
@@ -205,10 +195,10 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                                     assertFutureCompleteAndReturn(requestFuture).f2)
                                             .get();
 
-                            assertEquals(
-                                    "The slot has not been allocated to the expected allocation id.",
-                                    assertFutureCompleteAndReturn(requestFuture).f2,
-                                    slot.getAllocationId());
+                            assertThat(assertFutureCompleteAndReturn(requestFuture).f2)
+                                    .as(
+                                            "The slot has not been allocated to the expected allocation id.")
+                                    .isEqualTo(slot.getAllocationId());
                         });
             }
         };
@@ -219,8 +209,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
      * allocated after a pending slot request has been fulfilled but not yet freed.
      */
     @Test
-    public void testDuplicateResourceRequirementDeclarationAfterSuccessfulAllocation()
-            throws Exception {
+    void testDuplicateResourceRequirementDeclarationAfterSuccessfulAllocation() throws Exception {
         final List<CompletableFuture<Void>> allocateResourceFutures = new ArrayList<>();
         allocateResourceFutures.add(new CompletableFuture<>());
         allocateResourceFutures.add(new CompletableFuture<>());
@@ -257,15 +246,13 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
     }
 
     @Test
-    public void testResourceCanBeAllocatedForDifferentJobWithDeclarationBeforeSlotFree()
-            throws Exception {
+    void testResourceCanBeAllocatedForDifferentJobWithDeclarationBeforeSlotFree() throws Exception {
         testResourceCanBeAllocatedForDifferentJobAfterFree(
                 SecondRequirementDeclarationTime.BEFORE_FREE);
     }
 
     @Test
-    public void testResourceCanBeAllocatedForDifferentJobWithDeclarationAfterSlotFree()
-            throws Exception {
+    void testResourceCanBeAllocatedForDifferentJobWithDeclarationAfterSlotFree() throws Exception {
         testResourceCanBeAllocatedForDifferentJobAfterFree(
                 SecondRequirementDeclarationTime.AFTER_FREE);
     }
@@ -328,10 +315,9 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                             .getAllocatedOrPendingSlot(allocationId1)
                                             .get();
 
-                            assertEquals(
-                                    "The slot has not been allocated to the expected job id.",
-                                    resourceRequirements1.getJobId(),
-                                    slot.getJobId());
+                            assertThat(resourceRequirements1.getJobId())
+                                    .as("The slot has not been allocated to the expected job id.")
+                                    .isEqualTo(slot.getJobId());
 
                             if (secondRequirementDeclarationTime
                                     == SecondRequirementDeclarationTime.BEFORE_FREE) {
@@ -374,17 +360,16 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                                     assertFutureCompleteAndReturn(
                                                             allocationIdFuture2))
                                             .get();
-                            assertEquals(
-                                    "The slot has not been allocated to the expected job id.",
-                                    resourceRequirements2.getJobId(),
-                                    slot.getJobId());
+                            assertThat(resourceRequirements2.getJobId())
+                                    .as("The slot has not been allocated to the expected job id.")
+                                    .isEqualTo(slot.getJobId());
                         });
             }
         };
     }
 
     @Test
-    public void testRegisterPendingResourceAfterClearingRequirement() throws Exception {
+    void testRegisterPendingResourceAfterClearingRequirement() throws Exception {
         final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
         final CompletableFuture<Void> allocateResourceFutures = new CompletableFuture<>();
         final CompletableFuture<Void> registerFuture = new CompletableFuture<>();
@@ -428,15 +413,14 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                     });
                             assertFutureCompleteAndReturn(registerFuture);
                             assertFutureNotComplete(allocationIdFuture);
-                            assertEquals(
-                                    getTaskManagerTracker().getPendingTaskManagers().size(), 0);
+                            assertThat(getTaskManagerTracker().getPendingTaskManagers()).isEmpty();
                         });
             }
         };
     }
 
     @Test
-    public void testRegisterPendingResourceAfterEmptyResourceRequirement() throws Exception {
+    void testRegisterPendingResourceAfterEmptyResourceRequirement() throws Exception {
         final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
         final CompletableFuture<Void> allocateResourceFutures = new CompletableFuture<>();
         final CompletableFuture<Void> registerFuture = new CompletableFuture<>();
@@ -483,8 +467,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                     });
                             assertFutureCompleteAndReturn(registerFuture);
                             assertFutureNotComplete(allocationIdFuture);
-                            assertEquals(
-                                    getTaskManagerTracker().getPendingTaskManagers().size(), 0);
+                            assertThat(getTaskManagerTracker().getPendingTaskManagers()).isEmpty();
                         });
             }
         };
@@ -495,7 +478,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
      * managers.
      */
     @Test
-    public void testRequestNewResources() throws Exception {
+    void testRequestNewResources() throws Exception {
         final JobID jobId = new JobID();
         final List<CompletableFuture<Void>> allocateResourceFutures = new ArrayList<>();
         allocateResourceFutures.add(new CompletableFuture<>());
@@ -548,7 +531,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
      * fails.
      */
     @Test
-    public void testSlotRequestFailure() throws Exception {
+    void testSlotRequestFailure() throws Exception {
         final JobID jobId = new JobID();
         final ResourceRequirements resourceRequirements =
                 createResourceRequirementsForSingleSlot(jobId);
@@ -591,7 +574,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                     });
 
                             final AllocationID firstAllocationId = allocationIds.take();
-                            assertThat(allocationIds, is(empty()));
+                            assertThat(allocationIds).isEmpty();
 
                             // let the first attempt fail --> this should trigger a second attempt
                             runInMainThread(
@@ -601,19 +584,19 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                                             "Test exception.")));
 
                             final AllocationID secondAllocationId = allocationIds.take();
-                            assertThat(allocationIds, is(empty()));
+                            assertThat(allocationIds).isEmpty();
 
                             final TaskManagerSlotInformation slot =
                                     getTaskManagerTracker()
                                             .getAllocatedOrPendingSlot(secondAllocationId)
                                             .get();
 
-                            assertEquals(jobId, slot.getJobId());
+                            assertThat(slot.getJobId()).isEqualTo(jobId);
 
-                            assertFalse(
-                                    getTaskManagerTracker()
-                                            .getAllocatedOrPendingSlot(firstAllocationId)
-                                            .isPresent());
+                            assertThat(
+                                            getTaskManagerTracker()
+                                                    .getAllocatedOrPendingSlot(firstAllocationId))
+                                    .isNotPresent();
                         });
             }
         };
@@ -628,7 +611,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
      * breakdown.
      */
     @Test
-    public void testAllocationUpdatesIgnoredIfTaskExecutorUnregistered() throws Exception {
+    void testAllocationUpdatesIgnoredIfTaskExecutorUnregistered() throws Exception {
         final CompletableFuture<Acknowledge> slotRequestFuture = new CompletableFuture<>();
         final CompletableFuture<Void> slotRequestCallFuture = new CompletableFuture<>();
         final TestingTaskExecutorGateway taskExecutorGateway =
@@ -679,9 +662,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                         slotRequestFuture.complete(Acknowledge.get());
                                     });
 
-                            assertThat(
-                                    trackingSecurityManager.getSystemExitFuture().isDone(),
-                                    is(false));
+                            assertThat(trackingSecurityManager.getSystemExitFuture()).isNotDone();
                         });
             }
         };
@@ -690,8 +671,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
     }
 
     @Test
-    public void testAllocationUpdatesIgnoredIfSlotMarkedAsAllocatedAfterSlotReport()
-            throws Exception {
+    void testAllocationUpdatesIgnoredIfSlotMarkedAsAllocatedAfterSlotReport() throws Exception {
         final CompletableFuture<AllocationID> allocationIdFuture = new CompletableFuture<>();
         final TestingTaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder()
@@ -743,9 +723,7 @@ public abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSl
                                                                             allocationId,
                                                                             DEFAULT_SLOT_RESOURCE_PROFILE))));
 
-                            assertThat(
-                                    trackingSecurityManager.getSystemExitFuture().isDone(),
-                                    is(false));
+                            assertThat(trackingSecurityManager.getSystemExitFuture()).isNotDone();
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.resources.CPUResource;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.ResourceManagerOptions;
+import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
@@ -181,8 +182,18 @@ public class DeclarativeSlotManagerBuilder {
             ResourceManagerId resourceManagerId,
             Executor executor,
             ResourceActions resourceManagerActions) {
+        return buildAndStart(
+                resourceManagerId, executor, resourceManagerActions, resourceID -> false);
+    }
+
+    public DeclarativeSlotManager buildAndStart(
+            ResourceManagerId resourceManagerId,
+            Executor executor,
+            ResourceActions resourceManagerActions,
+            BlockedTaskManagerChecker blockedTaskManagerChecker) {
         final DeclarativeSlotManager slotManager = build();
-        slotManager.start(resourceManagerId, executor, resourceManagerActions);
+        slotManager.start(
+                resourceManagerId, executor, resourceManagerActions, blockedTaskManagerChecker);
         return slotManager;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -46,9 +46,8 @@ import org.apache.flink.runtime.taskexecutor.exceptions.SlotAllocationException;
 import org.apache.flink.runtime.taskexecutor.exceptions.SlotOccupiedException;
 import org.apache.flink.runtime.testutils.SystemExitTrackingSecurityManager;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
@@ -58,9 +57,8 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -82,27 +80,14 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link DeclarativeSlotManager}. */
-public class DeclarativeSlotManagerTest extends TestLogger {
+class DeclarativeSlotManagerTest {
 
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     private static final FlinkException TEST_EXCEPTION = new FlinkException("Test exception");
 
@@ -116,7 +101,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
                     .build();
 
     @Test
-    public void testCloseAfterSuspendDoesNotThrowException() throws Exception {
+    void testCloseAfterSuspendDoesNotThrowException() throws Exception {
         try (DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder().buildAndStartWithDirectExec()) {
             slotManager.suspend();
@@ -125,7 +110,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
     /** Tests that we can register task manager and their slots at the slot manager. */
     @Test
-    public void testTaskManagerRegistration() throws Exception {
+    void testTaskManagerRegistration() throws Exception {
         final TaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
         final ResourceID resourceId = ResourceID.generate();
@@ -148,19 +133,18 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotManager.registerTaskManager(
                     taskManagerConnection, slotReport, ResourceProfile.ANY, ResourceProfile.ANY);
 
-            assertThat(
-                    "The number registered slots does not equal the expected number.",
-                    slotManager.getNumberRegisteredSlots(),
-                    is(2));
+            assertThat(slotManager.getNumberRegisteredSlots())
+                    .as("The number registered slots does not equal the expected number.")
+                    .isEqualTo(2);
 
-            assertNotNull(slotTracker.getSlot(slotId1));
-            assertNotNull(slotTracker.getSlot(slotId2));
+            assertThat(slotTracker.getSlot(slotId1)).isNotNull();
+            assertThat(slotTracker.getSlot(slotId2)).isNotNull();
         }
     }
 
     /** Tests that un-registration of task managers will free and remove all registered slots. */
     @Test
-    public void testTaskManagerUnregistration() throws Exception {
+    void testTaskManagerUnregistration() throws Exception {
         final TaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder()
                         .setRequestSlotFunction(tuple6 -> new CompletableFuture<>())
@@ -188,24 +172,22 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotManager.registerTaskManager(
                     taskManagerConnection, slotReport, ResourceProfile.ANY, ResourceProfile.ANY);
 
-            assertEquals(
-                    "The number registered slots does not equal the expected number.",
-                    2,
-                    slotManager.getNumberRegisteredSlots());
+            assertThat(slotManager.getNumberRegisteredSlots())
+                    .as("The number registered slots does not equal the expected number.")
+                    .isEqualTo(2);
 
             slotManager.processResourceRequirements(resourceRequirements);
 
             slotManager.unregisterTaskManager(
                     taskManagerConnection.getInstanceID(), TEST_EXCEPTION);
 
-            assertEquals(0, slotManager.getNumberRegisteredSlots());
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(0);
         }
     }
 
     /** Tests that a slot request with no free slots will trigger the resource allocation. */
     @Test
-    public void testRequirementDeclarationWithoutFreeSlotsTriggersWorkerAllocation()
-            throws Exception {
+    void testRequirementDeclarationWithoutFreeSlotsTriggersWorkerAllocation() throws Exception {
         final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
 
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
@@ -229,7 +211,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * Tests that resources continue to be considered missing if we cannot allocate more resources.
      */
     @Test
-    public void testRequirementDeclarationWithResourceAllocationFailure() throws Exception {
+    void testRequirementDeclarationWithResourceAllocationFailure() throws Exception {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
 
         ResourceActions resourceManagerActions =
@@ -248,14 +230,14 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotManager.processResourceRequirements(resourceRequirements);
 
             final JobID jobId = resourceRequirements.getJobId();
-            assertThat(
-                    getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)), is(1));
+            assertThat(getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)))
+                    .isEqualTo(1);
         }
     }
 
     /** Tests that resource requirements can be fulfilled with slots that are currently free. */
     @Test
-    public void testRequirementDeclarationWithFreeSlot() throws Exception {
+    void testRequirementDeclarationWithFreeSlot() throws Exception {
         testRequirementDeclaration(
                 RequirementDeclarationScenario
                         .TASK_EXECUTOR_REGISTRATION_BEFORE_REQUIREMENT_DECLARATION);
@@ -266,7 +248,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * requirement declaration.
      */
     @Test
-    public void testRequirementDeclarationWithPendingSlot() throws Exception {
+    void testRequirementDeclarationWithPendingSlot() throws Exception {
         testRequirementDeclaration(
                 RequirementDeclarationScenario
                         .TASK_EXECUTOR_REGISTRATION_AFTER_REQUIREMENT_DECLARATION);
@@ -350,30 +332,27 @@ public class DeclarativeSlotManagerTest extends TestLogger {
                         ResourceProfile.ANY);
             }
 
-            assertThat(
-                    requestFuture.get(),
-                    is(
-                            equalTo(
-                                    Tuple6.of(
-                                            slotId,
-                                            jobId,
-                                            requestFuture.get().f2,
-                                            resourceProfile,
-                                            targetAddress,
-                                            resourceManagerId))));
+            assertThat(requestFuture.get())
+                    .isEqualTo(
+                            Tuple6.of(
+                                    slotId,
+                                    jobId,
+                                    requestFuture.get().f2,
+                                    resourceProfile,
+                                    targetAddress,
+                                    resourceManagerId));
 
             DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
 
-            assertEquals(
-                    "The slot has not been allocated to the expected allocation id.",
-                    jobId,
-                    slot.getJobId());
+            assertThat(slot.getJobId())
+                    .as("The slot has not been allocated to the expected allocation id.")
+                    .isEqualTo(jobId);
         }
     }
 
     /** Tests that freeing a slot will correctly reset the slot and mark it as a free slot. */
     @Test
-    public void testFreeSlot() throws Exception {
+    void testFreeSlot() throws Exception {
         final TaskExecutorConnection taskExecutorConnection = createTaskExecutorConnection();
         final ResourceID resourceID = taskExecutorConnection.getResourceID();
         final SlotID slotId = new SlotID(resourceID, 0);
@@ -391,13 +370,13 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
 
-            assertSame(SlotState.ALLOCATED, slot.getState());
+            assertThat(slot.getState()).isSameAs(SlotState.ALLOCATED);
 
             slotManager.freeSlot(slotId, new AllocationID());
 
-            assertSame(SlotState.FREE, slot.getState());
+            assertThat(slot.getState()).isSameAs(SlotState.FREE);
 
-            assertEquals(1, slotManager.getNumberFreeSlots());
+            assertThat(slotManager.getNumberFreeSlots()).isEqualTo(1);
         }
     }
 
@@ -406,8 +385,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * allocated after a pending slot request has been fulfilled but not yet freed.
      */
     @Test
-    public void testDuplicateResourceRequirementDeclarationAfterSuccessfulAllocation()
-            throws Exception {
+    void testDuplicateResourceRequirementDeclarationAfterSuccessfulAllocation() throws Exception {
         final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
         final AtomicInteger allocateResourceCalls = new AtomicInteger(0);
         final ResourceActions resourceManagerActions =
@@ -441,21 +419,21 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
 
-            assertThat(slot.getState(), is(SlotState.ALLOCATED));
+            assertThat(slot.getState()).isEqualTo(SlotState.ALLOCATED);
 
             slotManager.processResourceRequirements(requirements);
         }
 
         // check that we have only called the resource allocation only for the first slot request,
         // since the second request is a duplicate
-        assertThat(allocateResourceCalls.get(), is(0));
+        assertThat(allocateResourceCalls.get()).isEqualTo(0);
     }
 
     /**
      * Tests that a slot allocated for one job can be allocated for another job after being freed.
      */
     @Test
-    public void testSlotCanBeAllocatedForDifferentJobAfterFree() throws Exception {
+    void testSlotCanBeAllocatedForDifferentJobAfterFree() throws Exception {
         testSlotCanBeAllocatedForDifferentJobAfterFree(
                 SecondRequirementDeclarationTime.BEFORE_FREE);
         testSlotCanBeAllocatedForDifferentJobAfterFree(SecondRequirementDeclarationTime.AFTER_FREE);
@@ -493,10 +471,9 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             DeclarativeTaskManagerSlot slot = slotTracker.getSlot(slotId);
 
-            assertEquals(
-                    "The slot has not been allocated to the expected job id.",
-                    resourceRequirements1.getJobId(),
-                    slot.getJobId());
+            assertThat(resourceRequirements1.getJobId())
+                    .as("The slot has not been allocated to the expected job id.")
+                    .isEqualTo(slot.getJobId());
 
             if (secondRequirementDeclarationTime == SecondRequirementDeclarationTime.BEFORE_FREE) {
                 slotManager.processResourceRequirements(resourceRequirements2);
@@ -515,10 +492,9 @@ public class DeclarativeSlotManagerTest extends TestLogger {
                 slotManager.processResourceRequirements(resourceRequirements2);
             }
 
-            assertEquals(
-                    "The slot has not been allocated to the expected job id.",
-                    resourceRequirements2.getJobId(),
-                    slot.getJobId());
+            assertThat(resourceRequirements2.getJobId())
+                    .as("The slot has not been allocated to the expected job id.")
+                    .isEqualTo(slot.getJobId());
         }
     }
 
@@ -527,7 +503,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * managers).
      */
     @Test
-    public void testReceivingUnknownSlotReport() throws Exception {
+    void testReceivingUnknownSlotReport() throws Exception {
         final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
         final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
 
@@ -538,13 +514,14 @@ public class DeclarativeSlotManagerTest extends TestLogger {
         try (SlotManager slotManager =
                 createSlotManager(resourceManagerId, resourceManagerActions)) {
             // check that we don't have any slots registered
-            assertThat(slotManager.getNumberRegisteredSlots(), is(0));
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(0);
 
             // this should not update anything since the instance id is not known to the slot
             // manager
-            assertFalse(slotManager.reportSlotStatus(unknownInstanceID, unknownSlotReport));
+            assertThat(slotManager.reportSlotStatus(unknownInstanceID, unknownSlotReport))
+                    .isFalse();
 
-            assertThat(slotManager.getNumberRegisteredSlots(), is(0));
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(0);
         }
     }
 
@@ -553,7 +530,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * slots for which a report was received are updated accordingly.
      */
     @Test
-    public void testUpdateSlotReport() throws Exception {
+    void testUpdateSlotReport() throws Exception {
         final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection();
         final ResourceID resourceId = taskManagerConnection.getResourceID();
 
@@ -576,7 +553,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
                         .buildAndStartWithDirectExec()) {
 
             // check that we don't have any slots registered
-            assertEquals(0, slotManager.getNumberRegisteredSlots());
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(0);
 
             slotManager.registerTaskManager(
                     taskManagerConnection, slotReport1, ResourceProfile.ANY, ResourceProfile.ANY);
@@ -584,29 +561,30 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             DeclarativeTaskManagerSlot slot1 = slotTracker.getSlot(slotId1);
             DeclarativeTaskManagerSlot slot2 = slotTracker.getSlot(slotId2);
 
-            assertEquals(2, slotManager.getNumberRegisteredSlots());
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(2);
 
-            assertSame(SlotState.FREE, slot1.getState());
-            assertSame(SlotState.FREE, slot2.getState());
+            assertThat(slot1.getState()).isSameAs(SlotState.FREE);
+            assertThat(slot2.getState()).isSameAs(SlotState.FREE);
 
-            assertTrue(
-                    slotManager.reportSlotStatus(
-                            taskManagerConnection.getInstanceID(), slotReport2));
+            assertThat(
+                            slotManager.reportSlotStatus(
+                                    taskManagerConnection.getInstanceID(), slotReport2))
+                    .isTrue();
 
-            assertEquals(2, slotManager.getNumberRegisteredSlots());
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(2);
 
-            assertNotNull(slotTracker.getSlot(slotId1));
-            assertNotNull(slotTracker.getSlot(slotId2));
+            assertThat(slotTracker.getSlot(slotId1)).isNotNull();
+            assertThat(slotTracker.getSlot(slotId2)).isNotNull();
 
             // slot1 should still be free, slot2 should have been allocated
-            assertSame(SlotState.FREE, slot1.getState());
-            assertEquals(jobId, slotTracker.getSlot(slotId2).getJobId());
+            assertThat(slot1.getState()).isSameAs(SlotState.FREE);
+            assertThat(jobId).isEqualTo(slotTracker.getSlot(slotId2).getJobId());
         }
     }
 
     /** Tests that if a slot allocation times out we try to allocate another slot. */
     @Test
-    public void testSlotAllocationTimeout() throws Exception {
+    void testSlotAllocationTimeout() throws Exception {
         final CompletableFuture<Void> secondSlotRequestFuture = new CompletableFuture<>();
 
         final BlockingQueue<Supplier<CompletableFuture<Acknowledge>>> responseQueue =
@@ -657,7 +635,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
     /** Tests that a slot allocation is retried if it times out on the task manager side. */
     @Test
-    public void testTaskExecutorSlotAllocationTimeoutHandling() throws Exception {
+    void testTaskExecutorSlotAllocationTimeoutHandling() throws Exception {
         final JobID jobId = new JobID();
         final ResourceRequirements resourceRequirements =
                 createResourceRequirementsForSingleSlot(jobId);
@@ -703,7 +681,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotManager.processResourceRequirements(resourceRequirements);
 
             final SlotID firstSlotId = slotIds.take();
-            assertThat(slotIds, is(empty()));
+            assertThat(slotIds).isEmpty();
 
             DeclarativeTaskManagerSlot failedSlot = slotTracker.getSlot(firstSlotId);
 
@@ -711,21 +689,22 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotRequestFuture1.completeExceptionally(
                     new SlotAllocationException("Test exception."));
 
-            assertThat(getTotalResourceCount(resourceTracker.getAcquiredResources(jobId)), is(1));
+            assertThat(getTotalResourceCount(resourceTracker.getAcquiredResources(jobId)))
+                    .isEqualTo(1);
 
             // the second attempt succeeds
             slotRequestFuture2.complete(Acknowledge.get());
 
             final SlotID secondSlotId = slotIds.take();
-            assertThat(slotIds, is(empty()));
+            assertThat(slotIds).isEmpty();
 
             DeclarativeTaskManagerSlot slot = slotTracker.getSlot(secondSlotId);
 
-            assertThat(slot.getState(), is(SlotState.ALLOCATED));
-            assertEquals(jobId, slot.getJobId());
+            assertThat(slot.getState()).isEqualTo(SlotState.ALLOCATED);
+            assertThat(jobId).isEqualTo(slot.getJobId());
 
             if (!failedSlot.getSlotId().equals(slot.getSlotId())) {
-                assertThat(failedSlot.getState(), is(SlotState.FREE));
+                assertThat(failedSlot.getState()).isEqualTo(SlotState.FREE);
             }
         }
     }
@@ -735,7 +714,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * already allocated by another job.
      */
     @Test
-    public void testSlotReportWithConflictingJobIdDuringSlotAllocation() throws Exception {
+    void testSlotReportWithConflictingJobIdDuringSlotAllocation() throws Exception {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
         final ArrayBlockingQueue<SlotID> requestedSlotIds = new ArrayBlockingQueue<>(2);
 
@@ -787,7 +766,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             final SlotID secondRequestedSlotId = requestedSlotIds.take();
 
-            assertEquals(freeSlotId, secondRequestedSlotId);
+            assertThat(freeSlotId).isEqualTo(secondRequestedSlotId);
         }
     }
 
@@ -798,7 +777,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * <p>See: FLINK-8505
      */
     @Test
-    public void testReportAllocatedSlot() throws Exception {
+    void testReportAllocatedSlot() throws Exception {
         final ResourceID taskManagerId = ResourceID.generate();
         final TestingTaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder().createTestingTaskExecutorGateway();
@@ -824,7 +803,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
                     ResourceProfile.ANY,
                     ResourceProfile.ANY);
 
-            assertThat(slotManager.getNumberRegisteredSlots(), is(equalTo(1)));
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(1);
 
             // Now report this slot as allocated
             final SlotStatus slotStatus = createAllocatedSlotStatus(slotId);
@@ -838,9 +817,9 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             slotManager.processResourceRequirements(requirements);
 
-            assertThat(slotTracker.getSlot(slotId).getJobId(), is(slotStatus.getJobID()));
-            assertThat(
-                    getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)), is(1));
+            assertThat(slotTracker.getSlot(slotId).getJobId()).isEqualTo(slotStatus.getJobID());
+            assertThat(getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)))
+                    .isEqualTo(1);
         }
     }
 
@@ -849,7 +828,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * fails.
      */
     @Test
-    public void testSlotRequestFailure() throws Exception {
+    void testSlotRequestFailure() throws Exception {
         final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
         try (final DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()
@@ -913,14 +892,14 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             final Tuple6<SlotID, JobID, AllocationID, ResourceProfile, String, ResourceManagerId>
                     secondRequest = requestSlotQueue.take();
 
-            assertThat(secondRequest.f1, equalTo(firstRequest.f1));
-            assertThat(secondRequest.f0, equalTo(firstRequest.f0));
+            assertThat(secondRequest.f1).isEqualTo(firstRequest.f1);
+            assertThat(secondRequest.f0).isEqualTo(firstRequest.f0);
 
             secondManualSlotRequestResponse.complete(Acknowledge.get());
 
             final DeclarativeTaskManagerSlot slot = slotTracker.getSlot(secondRequest.f0);
-            assertThat(slot.getState(), equalTo(SlotState.ALLOCATED));
-            assertThat(slot.getJobId(), equalTo(secondRequest.f1));
+            assertThat(slot.getState()).isEqualTo(SlotState.ALLOCATED);
+            assertThat(slot.getJobId()).isEqualTo(secondRequest.f1);
         }
     }
 
@@ -928,7 +907,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * Tests that pending request is removed if task executor reports a slot with the same job id.
      */
     @Test
-    public void testSlotRequestRemovedIfTMReportsAllocation() throws Exception {
+    void testSlotRequestRemovedIfTMReportsAllocation() throws Exception {
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
         final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
 
@@ -999,21 +978,22 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             secondManualSlotRequestResponse.completeExceptionally(
                     new SlotOccupiedException("Test exception", new AllocationID(), jobID));
 
-            assertThat(firstRequest.f1, equalTo(jobID));
-            assertThat(secondRequest.f1, equalTo(jobID));
-            assertThat(secondRequest.f0, equalTo(firstRequest.f0));
+            assertThat(firstRequest.f1).isEqualTo(jobID);
+            assertThat(secondRequest.f1).isEqualTo(jobID);
+            assertThat(secondRequest.f0).isEqualTo(firstRequest.f0);
 
             final DeclarativeTaskManagerSlot slot = slotTracker.getSlot(secondRequest.f0);
-            assertThat(slot.getState(), equalTo(SlotState.ALLOCATED));
-            assertThat(slot.getJobId(), equalTo(firstRequest.f1));
+            assertThat(slot.getState()).isEqualTo(SlotState.ALLOCATED);
+            assertThat(slot.getJobId()).isEqualTo(firstRequest.f1);
 
-            assertThat(slotManager.getNumberRegisteredSlots(), is(1));
-            assertThat(getTotalResourceCount(resourceTracker.getAcquiredResources(jobID)), is(1));
+            assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(1);
+            assertThat(getTotalResourceCount(resourceTracker.getAcquiredResources(jobID)))
+                    .isEqualTo(1);
         }
     }
 
     @Test
-    public void testTaskExecutorFailedHandling() throws Exception {
+    void testTaskExecutorFailedHandling() throws Exception {
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
 
         try (final DeclarativeSlotManager slotManager =
@@ -1037,8 +1017,8 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotManager.unregisterTaskManager(
                     taskExecutionConnection1.getInstanceID(), TEST_EXCEPTION);
 
-            assertThat(
-                    getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)), is(2));
+            assertThat(getTotalResourceCount(resourceTracker.getMissingResources().get(jobId)))
+                    .isEqualTo(2);
         }
     }
 
@@ -1047,7 +1027,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * manager slots.
      */
     @Test
-    public void testRequestNewResources() throws Exception {
+    void testRequestNewResources() throws Exception {
         final int numberSlots = 2;
         final AtomicInteger resourceRequests = new AtomicInteger(0);
         final TestingResourceActions testingResourceActions =
@@ -1068,13 +1048,13 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             // the first 2 requirements should be fulfillable with the pending slots of the first
             // allocation (2 slots per worker)
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 1));
-            assertThat(resourceRequests.get(), is(1));
+            assertThat(resourceRequests.get()).isEqualTo(1);
 
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 2));
-            assertThat(resourceRequests.get(), is(1));
+            assertThat(resourceRequests.get()).isEqualTo(1);
 
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 3));
-            assertThat(resourceRequests.get(), is(2));
+            assertThat(resourceRequests.get()).isEqualTo(2);
         }
     }
 
@@ -1094,7 +1074,7 @@ public class DeclarativeSlotManagerTest extends TestLogger {
      * available TaskExecutors. See FLINK-12122.
      */
     @Test
-    public void testSpreadOutSlotAllocationStrategy() throws Exception {
+    void testSpreadOutSlotAllocationStrategy() throws Exception {
         try (DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()
                         .setSlotMatchingStrategy(LeastUtilizationSlotMatchingStrategy.INSTANCE)
@@ -1121,8 +1101,8 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             final Set<JobID> jobIds =
                     new HashSet<>(
                             FutureUtils.combineAll(requestSlotFutures).get(10L, TimeUnit.SECONDS));
-            assertThat(jobIds, hasSize(1));
-            assertThat(jobIds, containsInAnyOrder(jobId));
+            assertThat(jobIds).hasSize(1);
+            assertThat(jobIds).containsExactlyInAnyOrder(jobId);
         }
     }
 
@@ -1150,12 +1130,12 @@ public class DeclarativeSlotManagerTest extends TestLogger {
     }
 
     @Test
-    public void testNotificationAboutNotEnoughResources() throws Exception {
+    void testNotificationAboutNotEnoughResources() throws Exception {
         testNotificationAboutNotEnoughResources(false);
     }
 
     @Test
-    public void testGracePeriodForNotificationAboutNotEnoughResources() throws Exception {
+    void testGracePeriodForNotificationAboutNotEnoughResources() throws Exception {
         testNotificationAboutNotEnoughResources(true);
     }
 
@@ -1204,29 +1184,28 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotManager.processResourceRequirements(resourceRequirements);
 
             if (withNotificationGracePeriod) {
-                assertThat(notEnoughResourceNotifications, empty());
+                assertThat(notEnoughResourceNotifications).isEmpty();
 
                 // re-enable notifications which should also trigger another resource check
                 slotManager.setFailUnfulfillableRequest(true);
             }
 
-            assertThat(notEnoughResourceNotifications, hasSize(1));
+            assertThat(notEnoughResourceNotifications).hasSize(1);
             Tuple2<JobID, Collection<ResourceRequirement>> notification =
                     notEnoughResourceNotifications.get(0);
-            assertThat(notification.f0, is(jobId));
-            assertThat(
-                    notification.f1,
-                    hasItem(ResourceRequirement.create(ResourceProfile.ANY, numExistingSlots)));
+            assertThat(notification.f0).isEqualTo(jobId);
+            assertThat(notification.f1)
+                    .contains(ResourceRequirement.create(ResourceProfile.ANY, numExistingSlots));
 
             // another slot report that does not indicate any changes should not trigger another
             // notification
             slotManager.reportSlotStatus(taskExecutionConnection.getInstanceID(), slotReport);
-            assertThat(notEnoughResourceNotifications, hasSize(1));
+            assertThat(notEnoughResourceNotifications).hasSize(1);
         }
     }
 
     @Test
-    public void testAllocationUpdatesIgnoredIfTaskExecutorUnregistered() throws Exception {
+    void testAllocationUpdatesIgnoredIfTaskExecutorUnregistered() throws Exception {
         final ManuallyTriggeredScheduledExecutorService executor =
                 new ManuallyTriggeredScheduledExecutorService();
 
@@ -1266,15 +1245,14 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             executor.triggerAll();
 
-            assertThat(trackingSecurityManager.getSystemExitFuture().isDone(), is(false));
+            assertThat(trackingSecurityManager.getSystemExitFuture()).isNotDone();
         } finally {
             System.setSecurityManager(null);
         }
     }
 
     @Test
-    public void testAllocationUpdatesIgnoredIfSlotMarkedAsAllocatedAfterSlotReport()
-            throws Exception {
+    void testAllocationUpdatesIgnoredIfSlotMarkedAsAllocatedAfterSlotReport() throws Exception {
         final ManuallyTriggeredScheduledExecutorService executor =
                 new ManuallyTriggeredScheduledExecutorService();
 
@@ -1316,14 +1294,14 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             executor.triggerAll();
 
-            assertThat(trackingSecurityManager.getSystemExitFuture().isDone(), is(false));
+            assertThat(trackingSecurityManager.getSystemExitFuture()).isNotDone();
         } finally {
             System.setSecurityManager(null);
         }
     }
 
     @Test
-    public void testAllocationUpdatesIgnoredIfSlotMarkedAsPendingForOtherJob() throws Exception {
+    void testAllocationUpdatesIgnoredIfSlotMarkedAsPendingForOtherJob() throws Exception {
         final DefaultSlotTracker slotTracker = new DefaultSlotTracker();
 
         final CompletableFuture<AllocationID> firstSlotAllocationIdFuture =
@@ -1383,12 +1361,12 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             firstSlotRequestAcknowledgeFuture.complete(Acknowledge.get());
 
             // sanity check that the acknowledge was really ignored
-            assertThat(slotTracker.getSlot(slotId).getJobId(), is(not(firstJobId)));
+            assertThat(slotTracker.getSlot(slotId).getJobId()).isNotEqualTo(firstJobId);
         }
     }
 
     @Test
-    public void testReclaimInactiveSlotsOnClearRequirements() throws Exception {
+    void testReclaimInactiveSlotsOnClearRequirements() throws Exception {
         final CompletableFuture<JobID> freeInactiveSlotsJobIdFuture = new CompletableFuture<>();
 
         final TestingTaskExecutorGateway taskExecutorGateway =
@@ -1415,20 +1393,20 @@ public class DeclarativeSlotManagerTest extends TestLogger {
 
             // setup initial requirements, which should not trigger slots being reclaimed
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 2));
-            assertThat(freeInactiveSlotsJobIdFuture.isDone(), is(false));
+            assertThat(freeInactiveSlotsJobIdFuture).isNotDone();
 
             // set requirements to 0, which should not trigger slots being reclaimed
             slotManager.processResourceRequirements(ResourceRequirements.empty(jobId, "foobar"));
-            assertThat(freeInactiveSlotsJobIdFuture.isDone(), is(false));
+            assertThat(freeInactiveSlotsJobIdFuture).isNotDone();
 
             // clear requirements, which should trigger slots being reclaimed
             slotManager.clearResourceRequirements(jobId);
-            assertThat(freeInactiveSlotsJobIdFuture.get(), is(jobId));
+            assertThat(freeInactiveSlotsJobIdFuture.get()).isEqualTo(jobId);
         }
     }
 
     @Test
-    public void testProcessResourceRequirementsWithDelay() throws Exception {
+    void testProcessResourceRequirementsWithDelay() throws Exception {
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
         final AtomicInteger allocatedResourceCounter = new AtomicInteger(0);
         final ManuallyTriggeredScheduledExecutor scheduledExecutor =
@@ -1449,25 +1427,23 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             final JobID jobId = new JobID();
 
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 1));
-            Assertions.assertEquals(0, allocatedResourceCounter.get());
-            Assertions.assertEquals(
-                    1, scheduledExecutor.getActiveNonPeriodicScheduledTask().size());
+            assertThat(allocatedResourceCounter.get()).isEqualTo(0);
+            assertThat(scheduledExecutor.getActiveNonPeriodicScheduledTask()).hasSize(1);
             final ScheduledFuture<?> future =
                     scheduledExecutor.getActiveNonPeriodicScheduledTask().iterator().next();
-            Assertions.assertEquals(delay.toMillis(), future.getDelay(TimeUnit.MILLISECONDS));
+            assertThat(future.getDelay(TimeUnit.MILLISECONDS)).isEqualTo(delay.toMillis());
 
             // the second request is skipped
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 1));
-            Assertions.assertEquals(
-                    1, scheduledExecutor.getActiveNonPeriodicScheduledTask().size());
+            assertThat(scheduledExecutor.getActiveNonPeriodicScheduledTask()).hasSize(1);
 
             scheduledExecutor.triggerNonPeriodicScheduledTask();
-            Assertions.assertEquals(1, allocatedResourceCounter.get());
+            assertThat(allocatedResourceCounter.get()).isEqualTo(1);
         }
     }
 
     @Test
-    public void testClearRequirementsClearsResourceTracker() throws Exception {
+    void testClearRequirementsClearsResourceTracker() throws Exception {
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
 
         final CompletableFuture<JobID> freeInactiveSlotsJobIdFuture = new CompletableFuture<>();
@@ -1498,17 +1474,17 @@ public class DeclarativeSlotManagerTest extends TestLogger {
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 2));
             slotManager.clearResourceRequirements(jobId);
 
-            assertThat(resourceTracker.getMissingResources().keySet(), empty());
+            assertThat(resourceTracker.getMissingResources().keySet()).isEmpty();
         }
     }
 
     @Test
-    public void testMetricsUnregisteredWhenSuspending() throws Exception {
+    void testMetricsUnregisteredWhenSuspending() throws Exception {
         testAccessMetricValueDuringItsUnregister(SlotManager::suspend);
     }
 
     @Test
-    public void testMetricsUnregisteredWhenClosing() throws Exception {
+    void testMetricsUnregisteredWhenClosing() throws Exception {
         testAccessMetricValueDuringItsUnregister(AutoCloseable::close);
     }
 
@@ -1528,9 +1504,9 @@ public class DeclarativeSlotManagerTest extends TestLogger {
                         .buildAndStartWithDirectExec();
 
         // sanity check to ensure metrics were actually registered
-        assertThat(registeredMetrics.get(), greaterThan(0));
+        assertThat(registeredMetrics.get()).isGreaterThan(0);
         closeFn.accept(slotManager);
-        assertThat(registeredMetrics.get(), is(0));
+        assertThat(registeredMetrics.get()).isEqualTo(0);
     }
 
     private static SlotReport createSlotReport(ResourceID taskExecutorResourceId, int numberSlots) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DefaultResourceAllocationStrategyTest.java
@@ -22,22 +22,18 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.runtime.util.ResourceCounter;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link DefaultResourceAllocationStrategy}. */
-public class DefaultResourceAllocationStrategyTest extends TestLogger {
+class DefaultResourceAllocationStrategyTest {
     private static final ResourceProfile DEFAULT_SLOT_RESOURCE =
             ResourceProfile.fromResources(1, 100);
     private static final int NUM_OF_SLOTS = 5;
@@ -46,7 +42,7 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
                     DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS), NUM_OF_SLOTS);
 
     @Test
-    public void testFulfillRequirementWithRegisteredResources() {
+    void testFulfillRequirementWithRegisteredResources() {
         final TaskManagerInfo taskManager =
                 new TestingTaskManagerInfo(
                         DEFAULT_SLOT_RESOURCE.multiply(10),
@@ -66,25 +62,25 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
                 STRATEGY.tryFulfillRequirements(
                         Collections.singletonMap(jobId, requirements),
                         taskManagerResourceInfoProvider);
-        assertThat(result.getUnfulfillableJobs(), is(empty()));
-        assertThat(result.getAllocationsOnPendingResources().keySet(), is(empty()));
-        assertThat(result.getPendingTaskManagersToAllocate(), is(empty()));
+        assertThat(result.getUnfulfillableJobs()).isEmpty();
+        assertThat(result.getAllocationsOnPendingResources()).isEmpty();
+        assertThat(result.getPendingTaskManagersToAllocate()).isEmpty();
         assertThat(
-                result.getAllocationsOnRegisteredResources()
-                        .get(jobId)
-                        .get(taskManager.getInstanceId())
-                        .getResourceCount(DEFAULT_SLOT_RESOURCE),
-                is(2));
+                        result.getAllocationsOnRegisteredResources()
+                                .get(jobId)
+                                .get(taskManager.getInstanceId())
+                                .getResourceCount(DEFAULT_SLOT_RESOURCE))
+                .isEqualTo(2);
         assertThat(
-                result.getAllocationsOnRegisteredResources()
-                        .get(jobId)
-                        .get(taskManager.getInstanceId())
-                        .getResourceCount(largeResource),
-                is(1));
+                        result.getAllocationsOnRegisteredResources()
+                                .get(jobId)
+                                .get(taskManager.getInstanceId())
+                                .getResourceCount(largeResource))
+                .isEqualTo(1);
     }
 
     @Test
-    public void testFulfillRequirementWithPendingResources() {
+    void testFulfillRequirementWithPendingResources() {
         final JobID jobId = new JobID();
         final List<ResourceRequirement> requirements = new ArrayList<>();
         final ResourceProfile largeResource = DEFAULT_SLOT_RESOURCE.multiply(3);
@@ -102,9 +98,9 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
                 STRATEGY.tryFulfillRequirements(
                         Collections.singletonMap(jobId, requirements),
                         taskManagerResourceInfoProvider);
-        assertThat(result.getUnfulfillableJobs(), is(empty()));
-        assertThat(result.getAllocationsOnRegisteredResources().keySet(), is(empty()));
-        assertThat(result.getPendingTaskManagersToAllocate().size(), is(1));
+        assertThat(result.getUnfulfillableJobs()).isEmpty();
+        assertThat(result.getAllocationsOnRegisteredResources()).isEmpty();
+        assertThat(result.getPendingTaskManagersToAllocate()).hasSize(1);
         final PendingTaskManagerId newAllocated =
                 result.getPendingTaskManagersToAllocate().get(0).getPendingTaskManagerId();
         ResourceCounter allFulfilledRequirements = ResourceCounter.empty();
@@ -127,12 +123,12 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
                             resourceWithCount.getKey(), resourceWithCount.getValue());
         }
 
-        assertThat(allFulfilledRequirements.getResourceCount(DEFAULT_SLOT_RESOURCE), is(4));
-        assertThat(allFulfilledRequirements.getResourceCount(largeResource), is(2));
+        assertThat(allFulfilledRequirements.getResourceCount(DEFAULT_SLOT_RESOURCE)).isEqualTo(4);
+        assertThat(allFulfilledRequirements.getResourceCount(largeResource)).isEqualTo(2);
     }
 
     @Test
-    public void testUnfulfillableRequirement() {
+    void testUnfulfillableRequirement() {
         final TaskManagerInfo taskManager =
                 new TestingTaskManagerInfo(
                         DEFAULT_SLOT_RESOURCE.multiply(NUM_OF_SLOTS),
@@ -151,7 +147,7 @@ public class DefaultResourceAllocationStrategyTest extends TestLogger {
                 STRATEGY.tryFulfillRequirements(
                         Collections.singletonMap(jobId, requirements),
                         taskManagerResourceInfoProvider);
-        assertThat(result.getUnfulfillableJobs(), contains(jobId));
-        assertThat(result.getPendingTaskManagersToAllocate(), is(empty()));
+        assertThat(result.getUnfulfillableJobs()).containsExactly(jobId);
+        assertThat(result.getPendingTaskManagersToAllocate()).isEmpty();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * IT Cases of {@link FineGrainedSlotManager}, with the {@link DefaultResourceAllocationStrategy}.
  */
-public class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
+class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
         extends AbstractFineGrainedSlotManagerITCase {
     private static final ResourceProfile OTHER_SLOT_RESOURCE_PROFILE =
             DEFAULT_TOTAL_RESOURCE_PROFILE.multiply(2);
@@ -48,7 +47,7 @@ public class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
      * requested resource profile.
      */
     @Test
-    public void testWorkerOnlyAllocatedIfRequestedSlotCouldBeFulfilled() throws Exception {
+    void testWorkerOnlyAllocatedIfRequestedSlotCouldBeFulfilled() throws Exception {
         final AtomicInteger resourceRequests = new AtomicInteger(0);
 
         new Context() {
@@ -68,7 +67,7 @@ public class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
                                                                     new JobID(),
                                                                     1,
                                                                     OTHER_SLOT_RESOURCE_PROFILE)));
-                            assertThat(resourceRequests.get(), is(0));
+                            assertThat(resourceRequests.get()).isEqualTo(0);
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -40,7 +40,7 @@ import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.util.function.ThrowingConsumer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -52,21 +52,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /** Tests of {@link FineGrainedSlotManager}. */
-public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
+class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
     private static final ResourceProfile LARGE_SLOT_RESOURCE_PROFILE =
             DEFAULT_TOTAL_RESOURCE_PROFILE.multiply(2);
@@ -83,7 +74,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
     // ---------------------------------------------------------------------------------------------
 
     @Test
-    public void testInitializeAndClose() throws Exception {
+    void testInitializeAndClose() throws Exception {
         new Context() {
             {
                 runTest(() -> {});
@@ -97,7 +88,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
     /** Tests that we can register task manager at the slot manager. */
     @Test
-    public void testTaskManagerRegistration() throws Exception {
+    void testTaskManagerRegistration() throws Exception {
         final TaskExecutorConnection taskManagerConnection = createTaskExecutorConnection();
         new Context() {
             {
@@ -114,34 +105,31 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     new SlotReport(),
                                                                     DEFAULT_TOTAL_RESOURCE_PROFILE,
                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture))
+                                    .isTrue();
+                            assertThat(getSlotManager().getNumberRegisteredSlots())
+                                    .isEqualTo(DEFAULT_NUM_SLOTS_PER_WORKER);
+                            assertThat(getTaskManagerTracker().getRegisteredTaskManagers())
+                                    .hasSize(1);
                             assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture),
-                                    is(true));
+                                            getTaskManagerTracker()
+                                                    .getRegisteredTaskManager(
+                                                            taskManagerConnection.getInstanceID()))
+                                    .isPresent();
                             assertThat(
-                                    getSlotManager().getNumberRegisteredSlots(),
-                                    equalTo(DEFAULT_NUM_SLOTS_PER_WORKER));
+                                            getTaskManagerTracker()
+                                                    .getRegisteredTaskManager(
+                                                            taskManagerConnection.getInstanceID())
+                                                    .get()
+                                                    .getAvailableResource())
+                                    .isEqualTo(DEFAULT_TOTAL_RESOURCE_PROFILE);
                             assertThat(
-                                    getTaskManagerTracker().getRegisteredTaskManagers().size(),
-                                    equalTo(1));
-                            assertTrue(
-                                    getTaskManagerTracker()
-                                            .getRegisteredTaskManager(
-                                                    taskManagerConnection.getInstanceID())
-                                            .isPresent());
-                            assertThat(
-                                    getTaskManagerTracker()
-                                            .getRegisteredTaskManager(
-                                                    taskManagerConnection.getInstanceID())
-                                            .get()
-                                            .getAvailableResource(),
-                                    equalTo(DEFAULT_TOTAL_RESOURCE_PROFILE));
-                            assertThat(
-                                    getTaskManagerTracker()
-                                            .getRegisteredTaskManager(
-                                                    taskManagerConnection.getInstanceID())
-                                            .get()
-                                            .getTotalResource(),
-                                    equalTo(DEFAULT_TOTAL_RESOURCE_PROFILE));
+                                            getTaskManagerTracker()
+                                                    .getRegisteredTaskManager(
+                                                            taskManagerConnection.getInstanceID())
+                                                    .get()
+                                                    .getTotalResource())
+                                    .isEqualTo(DEFAULT_TOTAL_RESOURCE_PROFILE);
                         });
             }
         };
@@ -149,7 +137,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
     /** Tests that un-registration of task managers will free and remove all allocated slots. */
     @Test
-    public void testTaskManagerUnregistration() throws Exception {
+    void testTaskManagerUnregistration() throws Exception {
         final TaskExecutorGateway taskExecutorGateway =
                 new TestingTaskExecutorGatewayBuilder()
                         .setRequestSlotFunction(tuple6 -> new CompletableFuture<>())
@@ -177,16 +165,14 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     slotReport,
                                                                     DEFAULT_TOTAL_RESOURCE_PROFILE,
                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)));
-                            assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture),
-                                    is(true));
-                            assertThat(
-                                    getTaskManagerTracker().getRegisteredTaskManagers().size(),
-                                    is(1));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture))
+                                    .isTrue();
+                            assertThat(getTaskManagerTracker().getRegisteredTaskManagers())
+                                    .hasSize(1);
                             final Optional<TaskManagerSlotInformation> slot =
                                     getTaskManagerTracker().getAllocatedOrPendingSlot(allocationId);
-                            assertTrue(slot.isPresent());
-                            assertTrue(slot.get().getState() == SlotState.ALLOCATED);
+                            assertThat(slot).isPresent();
+                            assertThat(slot.get().getState()).isSameAs(SlotState.ALLOCATED);
 
                             runInMainThread(
                                     () ->
@@ -197,16 +183,14 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                             .getInstanceID(),
                                                                     TEST_EXCEPTION)));
 
+                            assertThat(assertFutureCompleteAndReturn(unRegisterTaskManagerFuture))
+                                    .isTrue();
+                            assertThat(getTaskManagerTracker().getRegisteredTaskManagers())
+                                    .isEmpty();
                             assertThat(
-                                    assertFutureCompleteAndReturn(unRegisterTaskManagerFuture),
-                                    is(true));
-                            assertThat(
-                                    getTaskManagerTracker().getRegisteredTaskManagers(),
-                                    is(empty()));
-                            assertFalse(
-                                    getTaskManagerTracker()
-                                            .getAllocatedOrPendingSlot(allocationId)
-                                            .isPresent());
+                                            getTaskManagerTracker()
+                                                    .getAllocatedOrPendingSlot(allocationId))
+                                    .isNotPresent();
                         });
             }
         };
@@ -214,7 +198,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
     /** Tests that we can matched task manager will deduct pending task manager. */
     @Test
-    public void testTaskManagerRegistrationDeductPendingTaskManager() throws Exception {
+    void testTaskManagerRegistrationDeductPendingTaskManager() throws Exception {
         final TaskExecutorConnection taskExecutionConnection1 = createTaskExecutorConnection();
         final TaskExecutorConnection taskExecutionConnection2 = createTaskExecutorConnection();
         final TaskExecutorConnection taskExecutionConnection3 = createTaskExecutorConnection();
@@ -250,11 +234,9 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                 DEFAULT_SLOT_RESOURCE_PROFILE));
                                     });
 
-                            assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture1),
-                                    is(true));
-                            assertThat(
-                                    getTaskManagerTracker().getPendingTaskManagers().size(), is(1));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture1))
+                                    .isTrue();
+                            assertThat(getTaskManagerTracker().getPendingTaskManagers()).hasSize(1);
 
                             // task manager with mismatched resource cannot deduct
                             // pending task manager
@@ -268,11 +250,9 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     LARGE_TOTAL_RESOURCE_PROFILE,
                                                                     LARGE_SLOT_RESOURCE_PROFILE)));
 
-                            assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture2),
-                                    is(true));
-                            assertThat(
-                                    getTaskManagerTracker().getPendingTaskManagers().size(), is(1));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture2))
+                                    .isTrue();
+                            assertThat(getTaskManagerTracker().getPendingTaskManagers()).hasSize(1);
 
                             runInMainThread(
                                     () ->
@@ -283,11 +263,9 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     new SlotReport(),
                                                                     DEFAULT_TOTAL_RESOURCE_PROFILE,
                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)));
-                            assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture3),
-                                    is(true));
-                            assertThat(
-                                    getTaskManagerTracker().getPendingTaskManagers().size(), is(0));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture3))
+                                    .isTrue();
+                            assertThat(getTaskManagerTracker().getPendingTaskManagers()).isEmpty();
                         });
             }
         };
@@ -298,7 +276,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
      * managers).
      */
     @Test
-    public void testReceivingUnknownSlotReport() throws Exception {
+    void testReceivingUnknownSlotReport() throws Exception {
         final InstanceID unknownInstanceID = new InstanceID();
         final SlotReport unknownSlotReport = new SlotReport();
         new Context() {
@@ -306,7 +284,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                 runTest(
                         () -> {
                             // check that we don't have any slots registered
-                            assertThat(getSlotManager().getNumberRegisteredSlots(), is(0));
+                            assertThat(getSlotManager().getNumberRegisteredSlots()).isEqualTo(0);
 
                             // this should not update anything since the instance id is not known to
                             // the slot manager
@@ -319,8 +297,8 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                             .reportSlotStatus(
                                                                     unknownInstanceID,
                                                                     unknownSlotReport)));
-                            assertFalse(assertFutureCompleteAndReturn(reportSlotFuture));
-                            assertThat(getSlotManager().getNumberRegisteredSlots(), is(0));
+                            assertThat(assertFutureCompleteAndReturn(reportSlotFuture)).isFalse();
+                            assertThat(getSlotManager().getNumberRegisteredSlots()).isEqualTo(0);
                         });
             }
         };
@@ -331,7 +309,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
     // ---------------------------------------------------------------------------------------------
 
     @Test
-    public void testSlotAllocationAccordingToStrategyResult() throws Exception {
+    void testSlotAllocationAccordingToStrategyResult() throws Exception {
         final CompletableFuture<
                         Tuple6<
                                 SlotID,
@@ -385,15 +363,15 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                             String,
                                             ResourceManagerId>
                                     requestSlot = assertFutureCompleteAndReturn(requestSlotFuture);
-                            assertEquals(jobId, requestSlot.f1);
-                            assertEquals(DEFAULT_SLOT_RESOURCE_PROFILE, requestSlot.f3);
+                            assertThat(requestSlot.f1).isEqualTo(jobId);
+                            assertThat(requestSlot.f3).isEqualTo(DEFAULT_SLOT_RESOURCE_PROFILE);
                         });
             }
         };
     }
 
     @Test
-    public void testRequestNewResourcesAccordingToStrategyResult() throws Exception {
+    void testRequestNewResourcesAccordingToStrategyResult() throws Exception {
         final JobID jobId = new JobID();
         final List<CompletableFuture<Void>> allocateResourceFutures = new ArrayList<>();
         allocateResourceFutures.add(new CompletableFuture<>());
@@ -431,7 +409,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
     }
 
     @Test
-    public void testSlotAllocationForPendingTaskManagerWillBeRespected() throws Exception {
+    void testSlotAllocationForPendingTaskManagerWillBeRespected() throws Exception {
         final JobID jobId = new JobID();
         final CompletableFuture<Void> requestResourceFuture = new CompletableFuture<>();
         final PendingTaskManager pendingTaskManager =
@@ -493,20 +471,20 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                             String,
                                             ResourceManagerId>
                                     requestSlot = assertFutureCompleteAndReturn(requestSlotFuture);
-                            assertEquals(jobId, requestSlot.f1);
-                            assertEquals(DEFAULT_SLOT_RESOURCE_PROFILE, requestSlot.f3);
+                            assertThat(requestSlot.f1).isEqualTo(jobId);
+                            assertThat(requestSlot.f3).isEqualTo(DEFAULT_SLOT_RESOURCE_PROFILE);
                         });
             }
         };
     }
 
     @Test
-    public void testNotificationAboutNotEnoughResources() throws Exception {
+    void testNotificationAboutNotEnoughResources() throws Exception {
         testNotificationAboutNotEnoughResources(false);
     }
 
     @Test
-    public void testGracePeriodForNotificationAboutNotEnoughResources() throws Exception {
+    void testGracePeriodForNotificationAboutNotEnoughResources() throws Exception {
         testNotificationAboutNotEnoughResources(true);
     }
 
@@ -548,7 +526,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
                             if (withNotificationGracePeriod) {
                                 assertFutureNotComplete(notifyNotEnoughResourceFuture);
-                                assertThat(notEnoughResourceNotifications, empty());
+                                assertThat(notEnoughResourceNotifications).isEmpty();
 
                                 // re-enable notifications which should also trigger another
                                 // resource check
@@ -557,10 +535,10 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                             }
 
                             assertFutureCompleteAndReturn(notifyNotEnoughResourceFuture);
-                            assertThat(notEnoughResourceNotifications, hasSize(1));
+                            assertThat(notEnoughResourceNotifications).hasSize(1);
                             final Tuple2<JobID, Collection<ResourceRequirement>> notification =
                                     notEnoughResourceNotifications.get(0);
-                            assertThat(notification.f0, is(jobId));
+                            assertThat(notification.f0).isEqualTo(jobId);
                         });
             }
         };
@@ -571,7 +549,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
      * function calls.
      */
     @Test
-    public void testRequirementCheckOnlyTriggeredOnce() throws Exception {
+    void testRequirementCheckOnlyTriggeredOnce() throws Exception {
         new Context() {
             {
                 final List<CompletableFuture<Void>> checkRequirementFutures = new ArrayList<>();
@@ -618,9 +596,10 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
 
                             assertFutureCompleteAndReturn(registrationFuture);
                             final long registrationTime = (System.nanoTime() - start) / 1_000_000;
-                            assumeTrue(
-                                    "The time of process requirement and register task manager must not take longer than the requirement check delay. If it does, then this indicates a very slow machine.",
-                                    registrationTime < requirementCheckDelay.toMillis());
+                            assumeThat(registrationTime < requirementCheckDelay.toMillis())
+                                    .as(
+                                            "The time of process requirement and register task manager must not take longer than the requirement check delay. If it does, then this indicates a very slow machine.")
+                                    .isTrue();
 
                             assertFutureCompleteAndReturn(checkRequirementFutures.get(0));
                             assertFutureNotComplete(checkRequirementFutures.get(1));
@@ -650,7 +629,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
      * Tests that formerly used task managers can timeout after all of their slots have been freed.
      */
     @Test
-    public void testTimeoutForUnusedTaskManager() throws Exception {
+    void testTimeoutForUnusedTaskManager() throws Exception {
         final Time taskManagerTimeout = Time.milliseconds(50L);
 
         final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
@@ -678,12 +657,10 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)),
                                                                     DEFAULT_TOTAL_RESOURCE_PROFILE,
                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)));
-                            assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture),
-                                    is(true));
-                            assertEquals(
-                                    getSlotManager().getTaskManagerIdleSince(instanceId),
-                                    Long.MAX_VALUE);
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture))
+                                    .isTrue();
+                            assertThat(getSlotManager().getTaskManagerIdleSince(instanceId))
+                                    .isEqualTo(Long.MAX_VALUE);
 
                             final CompletableFuture<Long> idleSinceFuture =
                                     new CompletableFuture<>();
@@ -701,18 +678,15 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                         .getTaskManagerIdleSince(instanceId));
                                     });
 
-                            assertThat(
-                                    assertFutureCompleteAndReturn(idleSinceFuture),
-                                    not(equalTo(Long.MAX_VALUE)));
-                            assertThat(
-                                    assertFutureCompleteAndReturn(releaseResourceFuture),
-                                    is(equalTo(instanceId)));
+                            assertThat(assertFutureCompleteAndReturn(idleSinceFuture))
+                                    .isNotEqualTo(Long.MAX_VALUE);
+                            assertThat(assertFutureCompleteAndReturn(releaseResourceFuture))
+                                    .isEqualTo(instanceId);
                             // A task manager timeout does not remove the slots from the
                             // SlotManager. The receiver of the callback can then decide what to do
                             // with the TaskManager.
-                            assertEquals(
-                                    DEFAULT_NUM_SLOTS_PER_WORKER,
-                                    getSlotManager().getNumberRegisteredSlots());
+                            assertThat(getSlotManager().getNumberRegisteredSlots())
+                                    .isEqualTo(DEFAULT_NUM_SLOTS_PER_WORKER);
 
                             final CompletableFuture<Boolean> unregisterTaskManagerFuture =
                                     new CompletableFuture<>();
@@ -724,17 +698,16 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     taskExecutionConnection
                                                                             .getInstanceID(),
                                                                     TEST_EXCEPTION)));
-                            assertThat(
-                                    assertFutureCompleteAndReturn(unregisterTaskManagerFuture),
-                                    is(true));
-                            assertEquals(0, getSlotManager().getNumberRegisteredSlots());
+                            assertThat(assertFutureCompleteAndReturn(unregisterTaskManagerFuture))
+                                    .isTrue();
+                            assertThat(getSlotManager().getNumberRegisteredSlots()).isEqualTo(0);
                         });
             }
         };
     }
 
     @Test
-    public void testMaxTotalResourceCpuExceeded() throws Exception {
+    void testMaxTotalResourceCpuExceeded() throws Exception {
         Consumer<SlotManagerConfigurationBuilder> maxTotalResourceSetter =
                 (smConfigBuilder) ->
                         smConfigBuilder.setMaxTotalCpu(
@@ -747,7 +720,7 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
     }
 
     @Test
-    public void testGetResourceOverview() throws Exception {
+    void testGetResourceOverview() throws Exception {
         final TaskExecutorConnection taskExecutorConnection1 = createTaskExecutorConnection();
         final TaskExecutorConnection taskExecutorConnection2 = createTaskExecutorConnection();
         final ResourceID resourceId1 = ResourceID.generate();
@@ -789,45 +762,46 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                 resourceProfile2.multiply(2),
                                                                 resourceProfile2));
                                     });
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture1))
+                                    .isTrue();
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture2))
+                                    .isTrue();
+                            assertThat(getSlotManager().getFreeResource())
+                                    .isEqualTo(resourceProfile1.merge(resourceProfile2));
                             assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture1),
-                                    is(true));
+                                            getSlotManager()
+                                                    .getFreeResourceOf(
+                                                            taskExecutorConnection1
+                                                                    .getInstanceID()))
+                                    .isEqualTo(resourceProfile1);
                             assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture2),
-                                    is(true));
+                                            getSlotManager()
+                                                    .getFreeResourceOf(
+                                                            taskExecutorConnection2
+                                                                    .getInstanceID()))
+                                    .isEqualTo(resourceProfile2);
+                            assertThat(getSlotManager().getRegisteredResource())
+                                    .isEqualTo(
+                                            resourceProfile1.merge(resourceProfile2).multiply(2));
                             assertThat(
-                                    getSlotManager().getFreeResource(),
-                                    equalTo(resourceProfile1.merge(resourceProfile2)));
+                                            getSlotManager()
+                                                    .getRegisteredResourceOf(
+                                                            taskExecutorConnection1
+                                                                    .getInstanceID()))
+                                    .isEqualTo(resourceProfile1.multiply(2));
                             assertThat(
-                                    getSlotManager()
-                                            .getFreeResourceOf(
-                                                    taskExecutorConnection1.getInstanceID()),
-                                    equalTo(resourceProfile1));
-                            assertThat(
-                                    getSlotManager()
-                                            .getFreeResourceOf(
-                                                    taskExecutorConnection2.getInstanceID()),
-                                    equalTo(resourceProfile2));
-                            assertThat(
-                                    getSlotManager().getRegisteredResource(),
-                                    equalTo(resourceProfile1.merge(resourceProfile2).multiply(2)));
-                            assertThat(
-                                    getSlotManager()
-                                            .getRegisteredResourceOf(
-                                                    taskExecutorConnection1.getInstanceID()),
-                                    equalTo(resourceProfile1.multiply(2)));
-                            assertThat(
-                                    getSlotManager()
-                                            .getRegisteredResourceOf(
-                                                    taskExecutorConnection2.getInstanceID()),
-                                    equalTo(resourceProfile2.multiply(2)));
+                                            getSlotManager()
+                                                    .getRegisteredResourceOf(
+                                                            taskExecutorConnection2
+                                                                    .getInstanceID()))
+                                    .isEqualTo(resourceProfile2.multiply(2));
                         });
             }
         };
     }
 
     @Test
-    public void testMaxTotalResourceMemoryExceeded() throws Exception {
+    void testMaxTotalResourceMemoryExceeded() throws Exception {
         Consumer<SlotManagerConfigurationBuilder> maxTotalResourceSetter =
                 (smConfigBuilder) ->
                         smConfigBuilder.setMaxTotalMem(
@@ -916,18 +890,16 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     new SlotReport(),
                                                                     DEFAULT_TOTAL_RESOURCE_PROFILE,
                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)));
-                            assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture1),
-                                    is(true));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture1))
+                                    .isTrue();
                             assertFutureNotComplete(releaseResourceFuture);
+                            assertThat(getTaskManagerTracker().getRegisteredTaskManagers())
+                                    .hasSize(1);
                             assertThat(
-                                    getTaskManagerTracker().getRegisteredTaskManagers().size(),
-                                    equalTo(1));
-                            assertTrue(
-                                    getTaskManagerTracker()
-                                            .getRegisteredTaskManager(
-                                                    taskManagerConnection1.getInstanceID())
-                                            .isPresent());
+                                            getTaskManagerTracker()
+                                                    .getRegisteredTaskManager(
+                                                            taskManagerConnection1.getInstanceID()))
+                                    .isPresent();
 
                             runInMainThread(
                                     () ->
@@ -938,32 +910,29 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                                     new SlotReport(),
                                                                     DEFAULT_TOTAL_RESOURCE_PROFILE,
                                                                     DEFAULT_SLOT_RESOURCE_PROFILE)));
+                            assertThat(assertFutureCompleteAndReturn(registerTaskManagerFuture2))
+                                    .isFalse();
+                            assertThat(releaseResourceFuture.get())
+                                    .isEqualTo(taskManagerConnection2.getInstanceID());
+                            assertThat(getTaskManagerTracker().getRegisteredTaskManagers())
+                                    .hasSize(1);
                             assertThat(
-                                    assertFutureCompleteAndReturn(registerTaskManagerFuture2),
-                                    is(false));
-                            assertThat(
-                                    releaseResourceFuture.get(),
-                                    is(taskManagerConnection2.getInstanceID()));
-                            assertThat(
-                                    getTaskManagerTracker().getRegisteredTaskManagers().size(),
-                                    equalTo(1));
-                            assertFalse(
-                                    getTaskManagerTracker()
-                                            .getRegisteredTaskManager(
-                                                    taskManagerConnection2.getInstanceID())
-                                            .isPresent());
+                                            getTaskManagerTracker()
+                                                    .getRegisteredTaskManager(
+                                                            taskManagerConnection2.getInstanceID()))
+                                    .isNotPresent();
                         });
             }
         };
     }
 
     @Test
-    public void testMetricsUnregisteredWhenSuspending() throws Exception {
+    void testMetricsUnregisteredWhenSuspending() throws Exception {
         testAccessMetricValueDuringItsUnregister(SlotManager::suspend);
     }
 
     @Test
-    public void testMetricsUnregisteredWhenClosing() throws Exception {
+    void testMetricsUnregisteredWhenClosing() throws Exception {
         testAccessMetricValueDuringItsUnregister(AutoCloseable::close);
     }
 
@@ -983,16 +952,13 @@ public class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         context.runTest(
                 () -> {
                     // sanity check to ensure metrics were actually registered
-                    assertThat(registeredMetrics.get(), greaterThan(0));
+                    assertThat(registeredMetrics.get()).isGreaterThan(0);
                     context.runInMainThreadAndWait(
                             () -> {
-                                try {
-                                    closeFn.accept(context.getSlotManager());
-                                } catch (Exception e) {
-                                    fail("Error when closing slot manager.");
-                                }
+                                assertThatNoException()
+                                        .isThrownBy(() -> closeFn.accept(context.getSlotManager()));
                             });
-                    assertThat(registeredMetrics.get(), is(0));
+                    assertThat(registeredMetrics.get()).isEqualTo(0);
                 });
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -34,15 +34,14 @@ import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGatewayBuilder;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.FlinkException;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 import org.apache.flink.util.function.RunnableWithException;
 
-import org.junit.ClassRule;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.Collection;
@@ -54,13 +53,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Base class for the tests of {@link FineGrainedSlotManager}. */
-public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+abstract class FineGrainedSlotManagerTestBase {
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     private static final long FUTURE_TIMEOUT_SECOND = 5;
     private static final long FUTURE_EXPECT_TIMEOUT_MS = 50;
@@ -130,12 +129,12 @@ public abstract class FineGrainedSlotManagerTestBase extends TestLogger {
     }
 
     static void assertFutureNotComplete(CompletableFuture<?> completableFuture) throws Exception {
-        try {
-            completableFuture.get(FUTURE_EXPECT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
-            fail("Expected to fail with a timeout.");
-        } catch (TimeoutException e) {
-            // expected
-        }
+        assertThatThrownBy(
+                        () ->
+                                completableFuture.get(
+                                        FUTURE_EXPECT_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+                        "Expected to fail with a timeout.")
+                .isInstanceOf(TimeoutException.class);
     }
 
     /** This class provides a self-contained context for each test case. */

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocationStrategy.java
@@ -18,6 +18,7 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 import org.apache.flink.util.Preconditions;
 
@@ -46,7 +47,8 @@ public class TestingResourceAllocationStrategy implements ResourceAllocationStra
     @Override
     public ResourceAllocationResult tryFulfillRequirements(
             Map<JobID, Collection<ResourceRequirement>> missingResources,
-            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider) {
+            TaskManagerResourceInfoProvider taskManagerResourceInfoProvider,
+            BlockedTaskManagerChecker blockedTaskManagerChecker) {
         return tryFulfillRequirementsFunction.apply(
                 missingResources, taskManagerResourceInfoProvider);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -45,16 +45,19 @@ public class TestingSlotManager implements SlotManager {
     private final Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier;
     private final Consumer<ResourceRequirements> processRequirementsConsumer;
     private final Consumer<JobID> clearRequirementsConsumer;
+    private final Consumer<Void> triggerRequirementsCheckConsumer;
 
     TestingSlotManager(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer,
             Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier,
             Consumer<ResourceRequirements> processRequirementsConsumer,
-            Consumer<JobID> clearRequirementsConsumer) {
+            Consumer<JobID> clearRequirementsConsumer,
+            Consumer<Void> triggerRequirementsCheckConsumer) {
         this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
         this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
         this.processRequirementsConsumer = processRequirementsConsumer;
         this.clearRequirementsConsumer = clearRequirementsConsumer;
+        this.triggerRequirementsCheckConsumer = triggerRequirementsCheckConsumer;
     }
 
     @Override
@@ -152,6 +155,11 @@ public class TestingSlotManager implements SlotManager {
     @Override
     public void setFailUnfulfillableRequest(boolean failUnfulfillableRequest) {
         setFailUnfulfillableRequestConsumer.accept(failUnfulfillableRequest);
+    }
+
+    @Override
+    public void triggerResourceRequirementsCheck() {
+        triggerRequirementsCheckConsumer.accept(null);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.blocklist.BlockedTaskManagerChecker;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
@@ -110,7 +111,8 @@ public class TestingSlotManager implements SlotManager {
     public void start(
             ResourceManagerId newResourceManagerId,
             Executor newMainThreadExecutor,
-            ResourceActions newResourceActions) {}
+            ResourceActions newResourceActions,
+            BlockedTaskManagerChecker newBlockedTaskManagerChecker) {}
 
     @Override
     public void suspend() {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
@@ -35,6 +35,7 @@ public class TestingSlotManagerBuilder {
             () -> Collections.emptyMap();
     private Consumer<ResourceRequirements> processRequirementsConsumer = ignored -> {};
     private Consumer<JobID> clearRequirementsConsumer = ignored -> {};
+    private Consumer<Void> triggerRequirementsCheckConsumer = ignored -> {};
 
     public TestingSlotManagerBuilder setSetFailUnfulfillableRequestConsumer(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
@@ -60,11 +61,18 @@ public class TestingSlotManagerBuilder {
         return this;
     }
 
+    public TestingSlotManagerBuilder setTriggerRequirementsCheckConsumer(
+            Consumer<Void> triggerRequirementsCheckConsumer) {
+        this.triggerRequirementsCheckConsumer = triggerRequirementsCheckConsumer;
+        return this;
+    }
+
     public TestingSlotManager createSlotManager() {
         return new TestingSlotManager(
                 setFailUnfulfillableRequestConsumer,
                 getRequiredResourcesSupplier,
                 processRequirementsConsumer,
-                clearRequirementsConsumer);
+                clearRequirementsConsumer,
+                triggerRequirementsCheckConsumer);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/utils/TestingResourceManagerGateway.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.common.time.Time;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.runtime.blob.TransientBlobKey;
+import org.apache.flink.runtime.blocklist.BlockedNode;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -506,5 +507,10 @@ public class TestingResourceManagerGateway implements ResourceManagerGateway {
     public CompletableFuture<List<ShuffleDescriptor>> getClusterPartitionsShuffleDescriptors(
             IntermediateDataSetID intermediateDataSetID) {
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public CompletableFuture<Acknowledge> notifyNewBlockedNodes(Collection<BlockedNode> newNodes) {
+        return CompletableFuture.completedFuture(Acknowledge.get());
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/recovery/TaskManagerDisconnectOnShutdownITCase.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.HeartbeatManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.blocklist.BlocklistUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.entrypoint.SessionClusterEntrypoint;
@@ -195,6 +196,7 @@ public class TaskManagerDisconnectOnShutdownITCase {
                     delegationTokenManager,
                     resourceManagerRuntimeServices.getSlotManager(),
                     ResourceManagerPartitionTrackerImpl::new,
+                    BlocklistUtils.loadBlocklistHandlerFactory(configuration),
                     resourceManagerRuntimeServices.getJobLeaderIdService(),
                     clusterInformation,
                     fatalErrorHandler,

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/AMRMClientAsyncReflector.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/AMRMClientAsyncReflector.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.yarn;
+
+import org.apache.hadoop.yarn.client.api.AMRMClient;
+import org.apache.hadoop.yarn.client.api.async.AMRMClientAsync;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Use reflection to determine whether the {@link AMRMClientAsync} supports the updateBlacklist
+ * method. If not, we will try to call updateBlacklist of {@link AMRMClientAsync#client}. If both
+ * fail, do nothing.
+ */
+class AMRMClientAsyncReflector {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AMRMClientAsyncReflector.class);
+
+    static final AMRMClientAsyncReflector INSTANCE = new AMRMClientAsyncReflector();
+
+    private static final String UPDATE_BLOCKLIST_METHOD = "updateBlacklist";
+
+    private static final String SYNC_CLIENT = "client";
+
+    private final Optional<Method> asyncClientUpdateBlocklistMethod;
+
+    private final Optional<Method> syncClientUpdateBlocklistMethod;
+
+    private final Optional<Field> syncClientField;
+
+    private AMRMClientAsyncReflector() {
+        this.asyncClientUpdateBlocklistMethod =
+                tryGetMethod(
+                        AMRMClientAsync.class, UPDATE_BLOCKLIST_METHOD, List.class, List.class);
+        this.syncClientUpdateBlocklistMethod =
+                tryGetMethod(AMRMClient.class, UPDATE_BLOCKLIST_METHOD, List.class, List.class);
+        this.syncClientField = tryGetField(AMRMClientAsync.class, SYNC_CLIENT);
+    }
+
+    private static <T> Optional<Method> tryGetMethod(
+            Class<T> clazz, String methodName, Class<?>... parameterTypes) {
+        try {
+            return Optional.of(clazz.getMethod(methodName, parameterTypes));
+        } catch (NoSuchMethodException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "{} does not support method {} in this YARN version.",
+                        clazz.getCanonicalName(),
+                        methodName);
+            }
+            return Optional.empty();
+        }
+    }
+
+    private static <T> Optional<Field> tryGetField(Class<T> clazz, String fieldName) {
+        try {
+            Field field = clazz.getDeclaredField(fieldName);
+            field.setAccessible(true);
+            return Optional.of(field);
+        } catch (NoSuchFieldException e) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                        "{} does not have field {} in this YARN version.",
+                        clazz.getCanonicalName(),
+                        fieldName);
+            }
+            return Optional.empty();
+        }
+    }
+
+    public void tryUpdateBlockList(
+            AMRMClientAsync<AMRMClient.ContainerRequest> asyncClient,
+            List<String> blocklistAdditions,
+            List<String> blocklistRemovals) {
+        try {
+            if (asyncClientUpdateBlocklistMethod.isPresent()) {
+                asyncClientUpdateBlocklistMethod
+                        .get()
+                        .invoke(asyncClient, blocklistAdditions, blocklistRemovals);
+            } else if (syncClientUpdateBlocklistMethod.isPresent() && syncClientField.isPresent()) {
+                Object syncClient = syncClientField.get().get(asyncClient);
+                syncClientUpdateBlocklistMethod
+                        .get()
+                        .invoke(syncClient, blocklistAdditions, blocklistRemovals);
+            } else {
+                throw new UnsupportedOperationException(
+                        String.format(
+                                "Neither %s nor %s support method %s",
+                                asyncClient.getClass().getCanonicalName(),
+                                syncClientField.isPresent()
+                                        ? syncClientField
+                                                .get()
+                                                .get(asyncClient)
+                                                .getClass()
+                                                .getCanonicalName()
+                                        : null,
+                                UPDATE_BLOCKLIST_METHOD));
+            }
+        } catch (Throwable throwable) {
+            LOG.warn(
+                    "Failed to update blocklist, blocklistAdditions "
+                            + blocklistAdditions
+                            + ", blocklistRemovals "
+                            + blocklistRemovals,
+                    throwable);
+        }
+    }
+}

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnResourceManagerDriver.java
@@ -65,12 +65,14 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Phaser;
 import java.util.stream.Collectors;
@@ -121,6 +123,8 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
     private String taskManagerNodeLabel;
 
     private final Phaser trackerOfReleasedResources;
+
+    private final Set<String> lastBlockedNodes = new HashSet<>();
 
     public YarnResourceManagerDriver(
             Configuration flinkConfig,
@@ -272,9 +276,7 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
         } else {
             final Priority priority = priorityAndResourceOpt.get().getPriority();
             final Resource resource = priorityAndResourceOpt.get().getResource();
-            resourceManagerClient.addContainerRequest(
-                    ContainerRequestReflector.INSTANCE.getContainerRequest(
-                            resource, priority, taskManagerNodeLabel));
+            addContainerRequest(resource, priority);
 
             // make sure we transmit the request fast and receive fast news of granted allocations
             resourceManagerClient.setHeartbeatInterval(containerRequestHeartbeatIntervalMillis);
@@ -290,6 +292,24 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
         }
 
         return requestResourceFuture;
+    }
+
+    private void tryUpdateApplicationBlockList() {
+        Set<String> currentBlockedNodes = getBlockedNodeRetriever().getAllBlockedNodeIds();
+        if (!currentBlockedNodes.equals(lastBlockedNodes)) {
+            AMRMClientAsyncReflector.INSTANCE.tryUpdateBlockList(
+                    resourceManagerClient,
+                    new ArrayList<>(getDifference(currentBlockedNodes, lastBlockedNodes)),
+                    new ArrayList<>(getDifference(lastBlockedNodes, currentBlockedNodes)));
+            this.lastBlockedNodes.clear();
+            this.lastBlockedNodes.addAll(currentBlockedNodes);
+        }
+    }
+
+    private static Set<String> getDifference(Set<String> setA, Set<String> setB) {
+        Set<String> difference = new HashSet<>(setA);
+        difference.removeAll(setB);
+        return difference;
     }
 
     @Override
@@ -376,6 +396,15 @@ public class YarnResourceManagerDriver extends AbstractResourceManagerDriver<Yar
 
     private int getNumRequestedNotAllocatedWorkers() {
         return requestResourceFutures.values().stream().mapToInt(Queue::size).sum();
+    }
+
+    private void addContainerRequest(Resource resource, Priority priority) {
+        // update blocklist
+        tryUpdateApplicationBlockList();
+        AMRMClient.ContainerRequest containerRequest =
+                ContainerRequestReflector.INSTANCE.getContainerRequest(
+                        resource, priority, taskManagerNodeLabel);
+        resourceManagerClient.addContainerRequest(containerRequest);
     }
 
     private void removeContainerRequest(AMRMClient.ContainerRequest pendingContainerRequest) {

--- a/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnAMRMClientAsync.java
+++ b/flink-yarn/src/test/java/org/apache/flink/yarn/TestingYarnAMRMClientAsync.java
@@ -57,6 +57,7 @@ public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.C
             registerApplicationMasterFunction;
     private final TriConsumer<FinalApplicationStatus, String, String>
             unregisterApplicationMasterConsumer;
+    private final BiConsumer<List<String>, List<String>> updateBlocklistConsumer;
     private final Runnable clientInitRunnable;
     private final Runnable clientStartRunnable;
     private final Runnable clientStopRunnable;
@@ -74,6 +75,7 @@ public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.C
             TriFunction<String, Integer, String, RegisterApplicationMasterResponse>
                     registerApplicationMasterFunction,
             TriConsumer<FinalApplicationStatus, String, String> unregisterApplicationMasterConsumer,
+            BiConsumer<List<String>, List<String>> updateBlocklistConsumer,
             Runnable clientInitRunnable,
             Runnable clientStartRunnable,
             Runnable clientStopRunnable) {
@@ -90,6 +92,7 @@ public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.C
         this.getMatchingRequestsFunction = Preconditions.checkNotNull(getMatchingRequestsFunction);
         this.unregisterApplicationMasterConsumer =
                 Preconditions.checkNotNull(unregisterApplicationMasterConsumer);
+        this.updateBlocklistConsumer = Preconditions.checkNotNull(updateBlocklistConsumer);
         this.clientInitRunnable = Preconditions.checkNotNull(clientInitRunnable);
         this.clientStartRunnable = Preconditions.checkNotNull(clientStartRunnable);
         this.clientStopRunnable = Preconditions.checkNotNull(clientStopRunnable);
@@ -132,6 +135,11 @@ public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.C
     public void unregisterApplicationMaster(
             FinalApplicationStatus appStatus, String appMessage, String appTrackingUrl) {
         unregisterApplicationMasterConsumer.accept(appStatus, appMessage, appTrackingUrl);
+    }
+
+    @Override
+    public void updateBlacklist(List<String> blocklistAdditions, List<String> blocklistRemovals) {
+        updateBlocklistConsumer.accept(blocklistAdditions, blocklistRemovals);
     }
 
     static Builder builder() {
@@ -177,6 +185,8 @@ public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.C
                                         Collections::emptyList);
         private TriConsumer<FinalApplicationStatus, String, String>
                 unregisterApplicationMasterConsumer = (ignored1, ignored2, ignored3) -> {};
+        private BiConsumer<List<String>, List<String>> updateBlocklistConsumer =
+                (ignored1, ignored2) -> {};
         private Runnable clientInitRunnable = () -> {};
         private Runnable clientStartRunnable = () -> {};
         private Runnable clientStopRunnable = () -> {};
@@ -231,6 +241,12 @@ public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.C
             return this;
         }
 
+        Builder setUpdateBlocklistConsumer(
+                BiConsumer<List<String>, List<String>> updateBlocklistConsumer) {
+            this.updateBlocklistConsumer = updateBlocklistConsumer;
+            return this;
+        }
+
         Builder setClientInitRunnable(Runnable clientInitRunnable) {
             this.clientInitRunnable = clientInitRunnable;
             return this;
@@ -256,6 +272,7 @@ public class TestingYarnAMRMClientAsync extends AMRMClientAsyncImpl<AMRMClient.C
                     setHeartbeatIntervalConsumer,
                     registerApplicationMasterFunction,
                     unregisterApplicationMasterConsumer,
+                    updateBlocklistConsumer,
                     clientInitRunnable,
                     clientStartRunnable,
                     clientStopRunnable);


### PR DESCRIPTION
## What is the purpose of the change
Let ResourceManager support blocklist mechanism:
1. SlotManager should filter out blocked resources when allocating registered resources.
2. ResourceManagerDriver should avoid allocating task managers from blocked nodes.

## Verifying this change
`DeclarativeSlotManagerTest#testRequirementDeclarationWithBlockedSlotsTriggersWorkerAllocation`
`AbstractFineGrainedSlotManagerITCase#testRequirementDeclarationWithBlockedSlotsTriggersWorkerAllocation`
`DefaultResourceAllocationStrategyTest#testBlockedTaskManagerCannotFulfillRequirements`
`InitTaskManagerDecoratorTest#testNodeAffinity`
`YarnResourceManagerDriverTest#testUpdateBlocklist`
`ResourceManagerTest#testUnblockResourcesWillTriggerResourceRequirementsCheck`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
