### PR TITLE
[FLINK-28402] Create FailureHandlingResultSnapshot with the truly failed execution

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/FailureHandlingResult.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.runtime.executiongraph.failover.flip1;
 
-import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 import javax.annotation.Nonnull;
@@ -47,10 +47,10 @@ public class FailureHandlingResult {
     private final long restartDelayMS;
 
     /**
-     * The {@link ExecutionVertexID} refering to the {@link ExecutionVertex} the failure is
-     * originating from or {@code null} if it's a global failure.
+     * The {@link Execution} that the failure is originating from or {@code null} if it's a global
+     * failure.
      */
-    @Nullable private final ExecutionVertexID failingExecutionVertexId;
+    @Nullable private final Execution failedExecution;
 
     /** Failure reason. {@code @Nullable} because of FLINK-21376. */
     @Nullable private final Throwable error;
@@ -64,9 +64,8 @@ public class FailureHandlingResult {
     /**
      * Creates a result of a set of tasks to restart to recover from the failure.
      *
-     * @param failingExecutionVertexId the {@link ExecutionVertexID} referring to the {@link
-     *     ExecutionVertex} the failure is originating from. Passing {@code null} as a value
-     *     indicates that the failure was issued by Flink itself.
+     * @param failedExecution the {@link Execution} that the failure is originating from. Passing
+     *     {@code null} as a value indicates that the failure was issued by Flink itself.
      * @param cause the exception that caused this failure.
      * @param timestamp the time the failure was handled.
      * @param verticesToRestart containing task vertices to restart to recover from the failure.
@@ -74,7 +73,7 @@ public class FailureHandlingResult {
      * @param restartDelayMS indicate a delay before conducting the restart
      */
     private FailureHandlingResult(
-            @Nullable ExecutionVertexID failingExecutionVertexId,
+            @Nullable Execution failedExecution,
             @Nullable Throwable cause,
             long timestamp,
             @Nullable Set<ExecutionVertexID> verticesToRestart,
@@ -84,7 +83,7 @@ public class FailureHandlingResult {
 
         this.verticesToRestart = Collections.unmodifiableSet(checkNotNull(verticesToRestart));
         this.restartDelayMS = restartDelayMS;
-        this.failingExecutionVertexId = failingExecutionVertexId;
+        this.failedExecution = failedExecution;
         this.error = cause;
         this.timestamp = timestamp;
         this.globalFailure = globalFailure;
@@ -93,20 +92,19 @@ public class FailureHandlingResult {
     /**
      * Creates a result that the failure is not recoverable and no restarting should be conducted.
      *
-     * @param failingExecutionVertexId the {@link ExecutionVertexID} referring to the {@link
-     *     ExecutionVertex} the failure is originating from. Passing {@code null} as a value
-     *     indicates that the failure was issued by Flink itself.
+     * @param failedExecution the {@link Execution} that the failure is originating from. Passing
+     *     {@code null} as a value indicates that the failure was issued by Flink itself.
      * @param error reason why the failure is not recoverable
      * @param timestamp the time the failure was handled.
      */
     private FailureHandlingResult(
-            @Nullable ExecutionVertexID failingExecutionVertexId,
+            @Nullable Execution failedExecution,
             @Nonnull Throwable error,
             long timestamp,
             boolean globalFailure) {
         this.verticesToRestart = null;
         this.restartDelayMS = -1;
-        this.failingExecutionVertexId = failingExecutionVertexId;
+        this.failedExecution = failedExecution;
         this.error = checkNotNull(error);
         this.timestamp = timestamp;
         this.globalFailure = globalFailure;
@@ -141,14 +139,14 @@ public class FailureHandlingResult {
     }
 
     /**
-     * Returns an {@code Optional} with the {@link ExecutionVertexID} of the task causing this
-     * failure or an empty {@code Optional} if it's a global failure.
+     * Returns an {@code Optional} with the {@link Execution} causing this failure or an empty
+     * {@code Optional} if it's a global failure.
      *
-     * @return The {@code ExecutionVertexID} of the causing task or an empty {@code Optional} if
-     *     it's a global failure.
+     * @return The {@code Optional} with the failed {@code Execution} or an empty {@code Optional}
+     *     if it's a global failure.
      */
-    public Optional<ExecutionVertexID> getExecutionVertexIdOfFailedTask() {
-        return Optional.ofNullable(failingExecutionVertexId);
+    public Optional<Execution> getFailedExecution() {
+        return Optional.ofNullable(failedExecution);
     }
 
     /**
@@ -193,9 +191,8 @@ public class FailureHandlingResult {
      * <p>The result can be flagged to be from a global failure triggered by the scheduler, rather
      * than from the failure of an individual task.
      *
-     * @param failingExecutionVertexId the {@link ExecutionVertexID} refering to the {@link
-     *     ExecutionVertex} the failure is originating from. Passing {@code null} as a value
-     *     indicates that the failure was issued by Flink itself.
+     * @param failedExecution the {@link Execution} that the failure is originating from. Passing
+     *     {@code null} as a value indicates that the failure was issued by Flink itself.
      * @param cause The reason of the failure.
      * @param timestamp The time of the failure.
      * @param verticesToRestart containing task vertices to restart to recover from the failure.
@@ -204,14 +201,14 @@ public class FailureHandlingResult {
      * @return result of a set of tasks to restart to recover from the failure
      */
     public static FailureHandlingResult restartable(
-            @Nullable ExecutionVertexID failingExecutionVertexId,
+            @Nullable Execution failedExecution,
             @Nullable Throwable cause,
             long timestamp,
             @Nullable Set<ExecutionVertexID> verticesToRestart,
             long restartDelayMS,
             boolean globalFailure) {
         return new FailureHandlingResult(
-                failingExecutionVertexId,
+                failedExecution,
                 cause,
                 timestamp,
                 verticesToRestart,
@@ -225,18 +222,17 @@ public class FailureHandlingResult {
      * <p>The result can be flagged to be from a global failure triggered by the scheduler, rather
      * than from the failure of an individual task.
      *
-     * @param failingExecutionVertexId the {@link ExecutionVertexID} refering to the {@link
-     *     ExecutionVertex} the failure is originating from. Passing {@code null} as a value
-     *     indicates that the failure was issued by Flink itself.
+     * @param failedExecution the {@link Execution} that the failure is originating from. Passing
+     *     {@code null} as a value indicates that the failure was issued by Flink itself.
      * @param error reason why the failure is not recoverable
      * @param timestamp The time of the failure.
      * @return result indicating the failure is not recoverable
      */
     public static FailureHandlingResult unrecoverable(
-            @Nullable ExecutionVertexID failingExecutionVertexId,
+            @Nullable Execution failedExecution,
             @Nonnull Throwable error,
             long timestamp,
             boolean globalFailure) {
-        return new FailureHandlingResult(failingExecutionVertexId, error, timestamp, globalFailure);
+        return new FailureHandlingResult(failedExecution, error, timestamp, globalFailure);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/failover/flip1/ExecutionFailureHandlerTest.java
@@ -25,26 +25,19 @@ import org.apache.flink.runtime.scheduler.strategy.SchedulingExecutionVertex;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
 import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingTopology;
 import org.apache.flink.util.IterableUtils;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.core.testutils.FlinkMatchers.containsCause;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link ExecutionFailureHandler}. */
-public class ExecutionFailureHandlerTest extends TestLogger {
+class ExecutionFailureHandlerTest {
 
     private static final long RESTART_DELAY_MS = 1234L;
 
@@ -56,8 +49,8 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 
     private ExecutionFailureHandler executionFailureHandler;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         TestingSchedulingTopology topology = new TestingSchedulingTopology();
         topology.newExecutionVertex();
         schedulingTopology = topology;
@@ -71,7 +64,7 @@ public class ExecutionFailureHandlerTest extends TestLogger {
 
     /** Tests the case that task restarting is accepted. */
     @Test
-    public void testNormalFailureHandling() {
+    void testNormalFailureHandling() {
         final Set<ExecutionVertexID> tasksToRestart =
                 Collections.singleton(new ExecutionVertexID(new JobVertexID(), 0));
         failoverStrategy.setTasksToRestart(tasksToRestart);
@@ -84,17 +77,17 @@ public class ExecutionFailureHandlerTest extends TestLogger {
                         new ExecutionVertexID(new JobVertexID(), 0), cause, timestamp);
 
         // verify results
-        assertTrue(result.canRestart());
-        assertEquals(RESTART_DELAY_MS, result.getRestartDelayMS());
-        assertEquals(tasksToRestart, result.getVerticesToRestart());
-        assertThat(result.getError(), is(cause));
-        assertThat(result.getTimestamp(), is(timestamp));
-        assertEquals(1, executionFailureHandler.getNumberOfRestarts());
+        assertThat(result.canRestart()).isTrue();
+        assertThat(result.getRestartDelayMS()).isEqualTo(RESTART_DELAY_MS);
+        assertThat(result.getVerticesToRestart()).isEqualTo(tasksToRestart);
+        assertThat(result.getError()).isSameAs(cause);
+        assertThat(result.getTimestamp()).isEqualTo(timestamp);
+        assertThat(executionFailureHandler.getNumberOfRestarts()).isEqualTo(1);
     }
 
     /** Tests the case that task restarting is suppressed. */
     @Test
-    public void testRestartingSuppressedFailureHandlingResult() {
+    void testRestartingSuppressedFailureHandlingResult() {
         // restart strategy suppresses restarting
         backoffTimeStrategy.setCanRestart(false);
 
@@ -106,28 +99,25 @@ public class ExecutionFailureHandlerTest extends TestLogger {
                         new ExecutionVertexID(new JobVertexID(), 0), error, timestamp);
 
         // verify results
-        assertFalse(result.canRestart());
-        assertThat(result.getError(), containsCause(error));
-        assertThat(result.getTimestamp(), is(timestamp));
-        assertFalse(ExecutionFailureHandler.isUnrecoverableError(result.getError()));
-        try {
-            result.getVerticesToRestart();
-            fail("get tasks to restart is not allowed when restarting is suppressed");
-        } catch (IllegalStateException ex) {
-            // expected
-        }
-        try {
-            result.getRestartDelayMS();
-            fail("get restart delay is not allowed when restarting is suppressed");
-        } catch (IllegalStateException ex) {
-            // expected
-        }
-        assertEquals(0, executionFailureHandler.getNumberOfRestarts());
+        assertThat(result.canRestart()).isFalse();
+        assertThat(result.getError()).hasCause(error);
+        assertThat(result.getTimestamp()).isEqualTo(timestamp);
+        assertThat(ExecutionFailureHandler.isUnrecoverableError(result.getError())).isFalse();
+
+        assertThatThrownBy(result::getVerticesToRestart)
+                .as("getVerticesToRestart is not allowed when restarting is suppressed")
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(result::getRestartDelayMS)
+                .as("getRestartDelayMS is not allowed when restarting is suppressed")
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThat(executionFailureHandler.getNumberOfRestarts()).isZero();
     }
 
     /** Tests the case that the failure is non-recoverable type. */
     @Test
-    public void testNonRecoverableFailureHandlingResult() {
+    void testNonRecoverableFailureHandlingResult() {
         // trigger an unrecoverable task failure
         final Throwable error =
                 new Exception(new SuppressRestartsException(new Exception("test failure")));
@@ -137,56 +127,55 @@ public class ExecutionFailureHandlerTest extends TestLogger {
                         new ExecutionVertexID(new JobVertexID(), 0), error, timestamp);
 
         // verify results
-        assertFalse(result.canRestart());
-        assertNotNull(result.getError());
-        assertTrue(ExecutionFailureHandler.isUnrecoverableError(result.getError()));
-        assertThat(result.getTimestamp(), is(timestamp));
-        try {
-            result.getVerticesToRestart();
-            fail("get tasks to restart is not allowed when restarting is suppressed");
-        } catch (IllegalStateException ex) {
-            // expected
-        }
-        try {
-            result.getRestartDelayMS();
-            fail("get restart delay is not allowed when restarting is suppressed");
-        } catch (IllegalStateException ex) {
-            // expected
-        }
-        assertEquals(0, executionFailureHandler.getNumberOfRestarts());
+        assertThat(result.canRestart()).isFalse();
+        assertThat(result.getError()).isNotNull();
+        assertThat(ExecutionFailureHandler.isUnrecoverableError(result.getError())).isTrue();
+        assertThat(result.getTimestamp()).isEqualTo(timestamp);
+
+        assertThatThrownBy(result::getVerticesToRestart)
+                .as("getVerticesToRestart is not allowed when restarting is suppressed")
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(result::getRestartDelayMS)
+                .as("getRestartDelayMS is not allowed when restarting is suppressed")
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThat(executionFailureHandler.getNumberOfRestarts()).isZero();
     }
 
     /** Tests the check for unrecoverable error. */
     @Test
-    public void testUnrecoverableErrorCheck() {
+    void testUnrecoverableErrorCheck() {
         // normal error
-        assertFalse(ExecutionFailureHandler.isUnrecoverableError(new Exception()));
+        assertThat(ExecutionFailureHandler.isUnrecoverableError(new Exception())).isFalse();
 
         // direct unrecoverable error
-        assertTrue(
-                ExecutionFailureHandler.isUnrecoverableError(
-                        new SuppressRestartsException(new Exception())));
+        assertThat(
+                        ExecutionFailureHandler.isUnrecoverableError(
+                                new SuppressRestartsException(new Exception())))
+                .isTrue();
 
         // nested unrecoverable error
-        assertTrue(
-                ExecutionFailureHandler.isUnrecoverableError(
-                        new Exception(new SuppressRestartsException(new Exception()))));
+        assertThat(
+                        ExecutionFailureHandler.isUnrecoverableError(
+                                new Exception(new SuppressRestartsException(new Exception()))))
+                .isTrue();
     }
 
     @Test
-    public void testGlobalFailureHandling() {
+    void testGlobalFailureHandling() {
         final Throwable error = new Exception("Expected test failure");
         final long timestamp = System.currentTimeMillis();
         final FailureHandlingResult result =
                 executionFailureHandler.getGlobalFailureHandlingResult(error, timestamp);
 
-        assertEquals(
-                IterableUtils.toStream(schedulingTopology.getVertices())
-                        .map(SchedulingExecutionVertex::getId)
-                        .collect(Collectors.toSet()),
-                result.getVerticesToRestart());
-        assertThat(result.getError(), is(error));
-        assertThat(result.getTimestamp(), is(timestamp));
+        assertThat(result.getVerticesToRestart())
+                .isEqualTo(
+                        IterableUtils.toStream(schedulingTopology.getVertices())
+                                .map(SchedulingExecutionVertex::getId)
+                                .collect(Collectors.toSet()));
+        assertThat(result.getError()).isSameAs(error);
+        assertThat(result.getTimestamp()).isEqualTo(timestamp);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshotTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/exceptionhistory/FailureHandlingResultSnapshotTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler.exceptionhistory;
 
-import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.client.JobExecutionException;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
@@ -36,41 +35,38 @@ import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.SerializedThrowable;
-import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
-import org.hamcrest.collection.IsIterableContainingInAnyOrder;
-import org.hamcrest.collection.IsIterableContainingInOrder;
-import org.hamcrest.core.IsInstanceOf;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * {@code FailureHandlingResultSnapshotTest} tests the creation of {@link
  * FailureHandlingResultSnapshot}.
  */
-public class FailureHandlingResultSnapshotTest extends TestLogger {
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+class FailureHandlingResultSnapshotTest {
+
+    @RegisterExtension
+    private static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     private ExecutionGraph executionGraph;
 
-    @Before
-    public void setup() throws JobException, JobExecutionException {
+    @BeforeEach
+    void setup() throws JobException, JobExecutionException {
         final JobGraph jobGraph = JobGraphTestUtils.singleNoOpJobGraph();
         jobGraph.getVertices().forEach(v -> v.setParallelism(3));
 
@@ -81,8 +77,8 @@ public class FailureHandlingResultSnapshotTest extends TestLogger {
         executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testRootCauseVertexNotFailed() {
+    @Test
+    void testRootCauseVertexNotFailed() {
         final ExecutionVertex rootCauseExecutionVertex = extractExecutionVertex(0);
         final FailureHandlingResult failureHandlingResult =
                 FailureHandlingResult.restartable(
@@ -97,11 +93,15 @@ public class FailureHandlingResultSnapshotTest extends TestLogger {
                         0L,
                         false);
 
-        FailureHandlingResultSnapshot.create(failureHandlingResult, this::getLatestExecution);
+        assertThatThrownBy(
+                        () ->
+                                FailureHandlingResultSnapshot.create(
+                                        failureHandlingResult, this::getLatestExecution))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test // see FLINK-22060/FLINK-21376
-    public void testMissingThrowableHandling() {
+    void testMissingThrowableHandling() {
         final ExecutionVertex rootCauseExecutionVertex = extractExecutionVertex(0);
 
         final long rootCauseTimestamp = triggerFailure(rootCauseExecutionVertex, null);
@@ -126,19 +126,18 @@ public class FailureHandlingResultSnapshotTest extends TestLogger {
         final Throwable actualException =
                 new SerializedThrowable(testInstance.getRootCause())
                         .deserializeError(ClassLoader.getSystemClassLoader());
-        assertThat(actualException, IsInstanceOf.instanceOf(FlinkException.class));
-        assertThat(
-                actualException,
-                FlinkMatchers.containsMessage(ErrorInfo.handleMissingThrowable(null).getMessage()));
-        assertThat(testInstance.getTimestamp(), is(rootCauseTimestamp));
-        assertThat(testInstance.getRootCauseExecution().isPresent(), is(true));
-        assertThat(
-                testInstance.getRootCauseExecution().get(),
-                is(rootCauseExecutionVertex.getCurrentExecutionAttempt()));
+
+        assertThat(actualException).isInstanceOf(FlinkException.class);
+        assertThat(actualException)
+                .hasMessageContaining(ErrorInfo.handleMissingThrowable(null).getMessage());
+        assertThat(testInstance.getTimestamp()).isEqualTo(rootCauseTimestamp);
+        assertThat(testInstance.getRootCauseExecution()).isPresent();
+        assertThat(testInstance.getRootCauseExecution().get())
+                .isSameAs(rootCauseExecutionVertex.getCurrentExecutionAttempt());
     }
 
     @Test
-    public void testLocalFailureHandlingResultSnapshotCreation() {
+    void testLocalFailureHandlingResultSnapshotCreation() {
         final ExecutionVertex rootCauseExecutionVertex = extractExecutionVertex(0);
         final Throwable rootCause = new RuntimeException("Expected exception: root cause");
         final ExecutionVertex otherFailedExecutionVertex = extractExecutionVertex(1);
@@ -165,31 +164,31 @@ public class FailureHandlingResultSnapshotTest extends TestLogger {
                 FailureHandlingResultSnapshot.create(
                         failureHandlingResult, this::getLatestExecution);
 
-        assertThat(testInstance.getRootCause(), is(rootCause));
-        assertThat(testInstance.getTimestamp(), is(rootCauseTimestamp));
-        assertThat(testInstance.getRootCauseExecution().isPresent(), is(true));
-        assertThat(
-                testInstance.getRootCauseExecution().get(),
-                is(rootCauseExecutionVertex.getCurrentExecutionAttempt()));
-
-        assertThat(
-                testInstance.getConcurrentlyFailedExecution(),
-                IsIterableContainingInOrder.contains(
-                        otherFailedExecutionVertex.getCurrentExecutionAttempt()));
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testFailureHandlingWithRootCauseExecutionBeingPartOfConcurrentlyFailedExecutions() {
-        final Execution rootCauseExecution = extractExecutionVertex(0).getCurrentExecutionAttempt();
-        new FailureHandlingResultSnapshot(
-                rootCauseExecution,
-                new RuntimeException("Expected exception"),
-                System.currentTimeMillis(),
-                Collections.singleton(rootCauseExecution));
+        assertThat(testInstance.getRootCause()).isSameAs(rootCause);
+        assertThat(testInstance.getTimestamp()).isEqualTo(rootCauseTimestamp);
+        assertThat(testInstance.getRootCauseExecution()).isPresent();
+        assertThat(testInstance.getRootCauseExecution().get())
+                .isSameAs(rootCauseExecutionVertex.getCurrentExecutionAttempt());
+        assertThat(testInstance.getConcurrentlyFailedExecution())
+                .containsExactly(otherFailedExecutionVertex.getCurrentExecutionAttempt());
     }
 
     @Test
-    public void testGlobalFailureHandlingResultSnapshotCreation() {
+    void testFailureHandlingWithRootCauseExecutionBeingPartOfConcurrentlyFailedExecutions() {
+        final Execution rootCauseExecution = extractExecutionVertex(0).getCurrentExecutionAttempt();
+
+        assertThatThrownBy(
+                        () ->
+                                new FailureHandlingResultSnapshot(
+                                        rootCauseExecution,
+                                        new RuntimeException("Expected exception"),
+                                        System.currentTimeMillis(),
+                                        Collections.singleton(rootCauseExecution)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testGlobalFailureHandlingResultSnapshotCreation() {
         final Throwable rootCause = new FlinkException("Expected exception: root cause");
         final long timestamp = System.currentTimeMillis();
 
@@ -218,15 +217,13 @@ public class FailureHandlingResultSnapshotTest extends TestLogger {
                 FailureHandlingResultSnapshot.create(
                         failureHandlingResult, this::getLatestExecution);
 
-        assertThat(testInstance.getRootCause(), is(rootCause));
-        assertThat(testInstance.getTimestamp(), is(timestamp));
-        assertThat(testInstance.getRootCauseExecution().isPresent(), is(false));
-
-        assertThat(
-                testInstance.getConcurrentlyFailedExecution(),
-                IsIterableContainingInAnyOrder.containsInAnyOrder(
+        assertThat(testInstance.getRootCause()).isSameAs(rootCause);
+        assertThat(testInstance.getTimestamp()).isEqualTo(timestamp);
+        assertThat(testInstance.getRootCauseExecution()).isNotPresent();
+        assertThat(testInstance.getConcurrentlyFailedExecution())
+                .containsExactlyInAnyOrder(
                         failedExecutionVertex0.getCurrentExecutionAttempt(),
-                        failedExecutionVertex1.getCurrentExecutionAttempt()));
+                        failedExecutionVertex1.getCurrentExecutionAttempt());
     }
 
     private Execution getLatestExecution(ExecutionVertexID executionVertexId) {


### PR DESCRIPTION
## What is the purpose of the change

Previously, FailureHandlingResultSnapshot was always created to treat the only current attempt of an execution vertex as the failed execution. This is no longer right in speculative execution cases, in which an execution vertex can have multiple current executions, and any of them may fail.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
