### PR TITLE
[FLINK-28457][runtime] Introduce JobStatusHook

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -289,6 +289,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
     private final ExecutionJobVertex.Factory executionJobVertexFactory;
 
+    private final List<JobStatusHook> jobStatusHooks;
+
     // --------------------------------------------------------------------------------------------
     //   Constructors
     // --------------------------------------------------------------------------------------------
@@ -311,7 +313,8 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
             VertexAttemptNumberStore initialAttemptCounts,
             VertexParallelismStore vertexParallelismStore,
             boolean isDynamic,
-            ExecutionJobVertex.Factory executionJobVertexFactory)
+            ExecutionJobVertex.Factory executionJobVertexFactory,
+            List<JobStatusHook> jobStatusHooks)
             throws IOException {
 
         this.executionGraphId = new ExecutionGraphID();
@@ -381,10 +384,14 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
         this.executionJobVertexFactory = checkNotNull(executionJobVertexFactory);
 
+        this.jobStatusHooks = checkNotNull(jobStatusHooks);
+
         LOG.info(
                 "Created execution graph {} for job {}.",
                 executionGraphId,
                 jobInformation.getJobId());
+        // Trigger hook onCreated
+        notifyJobStatusHooks(state, null);
     }
 
     @Override
@@ -1139,6 +1146,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
 
             stateTimestamps[newState.ordinal()] = System.currentTimeMillis();
             notifyJobStatusChange(newState);
+            notifyJobStatusHooks(newState, error);
             return true;
         } else {
             return false;
@@ -1540,6 +1548,30 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                 } catch (Throwable t) {
                     LOG.warn("Error while notifying JobStatusListener", t);
                 }
+            }
+        }
+    }
+
+    private void notifyJobStatusHooks(JobStatus newState, Throwable cause) {
+        JobID jobID = jobInformation.getJobId();
+        for (JobStatusHook hook : jobStatusHooks) {
+            try {
+                switch (newState) {
+                    case CREATED:
+                        hook.onCreated(jobID);
+                        break;
+                    case CANCELED:
+                        hook.onCanceled(jobID);
+                        break;
+                    case FAILED:
+                        hook.onFailed(jobID, cause);
+                        break;
+                    case FINISHED:
+                        hook.onFinished(jobID);
+                        break;
+                }
+            } catch (Throwable ignore) {
+                LOG.warn("Error while notifying JobStatusHook[{}]", hook.getClass(), ignore);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1552,7 +1552,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         }
     }
 
-    private void notifyJobStatusHooks(JobStatus newState, Throwable cause) {
+    private void notifyJobStatusHooks(JobStatus newState, @Nullable Throwable cause) {
         JobID jobID = jobInformation.getJobId();
         for (JobStatusHook hook : jobStatusHooks) {
             try {
@@ -1570,8 +1570,9 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
                         hook.onFinished(jobID);
                         break;
                 }
-            } catch (Throwable ignore) {
-                LOG.warn("Error while notifying JobStatusHook[{}]", hook.getClass(), ignore);
+            } catch (Throwable e) {
+                throw new RuntimeException(
+                        "Error while notifying JobStatusHook[" + hook.getClass() + "]", e);
             }
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -138,7 +138,8 @@ public class DefaultExecutionGraphBuilder {
                             vertexAttemptNumberStore,
                             vertexParallelismStore,
                             isDynamicGraph,
-                            executionJobVertexFactory);
+                            executionJobVertexFactory,
+                            jobGraph.getJobStatusHooks());
         } catch (IOException e) {
             throw new JobException("Could not create the ExecutionGraph.", e);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusHook.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
 
 import java.io.Serializable;
 
@@ -37,7 +38,7 @@ import java.io.Serializable;
 @Internal
 public interface JobStatusHook extends Serializable {
 
-    /** When Job become {@link JobStatus#CREATED} status, it would only be called one time. */
+    /** When Job becomes {@link JobStatus#CREATED} status, it would only be called one time. */
     void onCreated(JobID jobId);
 
     /** When job finished successfully. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusHook.java
@@ -23,11 +23,21 @@ import org.apache.flink.api.common.JobID;
 
 import java.io.Serializable;
 
-/** Hooks provided by users on job status changing. */
+/**
+ * Hooks provided by users on job status changing. Triggered at the initial(CREATED) and final
+ * state(FINISHED/CANCELED/FAILED) of the job.
+ *
+ * <p>Usage examples: <code>
+ *     StreamGraph streamGraph = env.getStreamGraph();
+ *     streamGraph.registerJobStatusHook(myJobStatusHook);
+ *     streamGraph.setJobName("my_flink");
+ *     env.execute(streamGraph);
+ * </code>
+ */
 @Internal
 public interface JobStatusHook extends Serializable {
 
-    /** When Job become CREATED status. It would only be called one time. */
+    /** When Job become {@link JobStatus#CREATED} status, it would only be called one time. */
     void onCreated(JobID jobId);
 
     /** When job finished successfully. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusHook.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/JobStatusHook.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
+
+import java.io.Serializable;
+
+/** Hooks provided by users on job status changing. */
+@Internal
+public interface JobStatusHook extends Serializable {
+
+    /** When Job become CREATED status. It would only be called one time. */
+    void onCreated(JobID jobId);
+
+    /** When job finished successfully. */
+    void onFinished(JobID jobId);
+
+    /** When job failed finally. */
+    void onFailed(JobID jobId, Throwable throwable);
+
+    /** When job get canceled by users. */
+    void onCanceled(JobID jobId);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -26,6 +26,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
+import org.apache.flink.runtime.executiongraph.JobStatusHook;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
 import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
@@ -117,6 +118,9 @@ public class JobGraph implements Serializable {
 
     /** List of classpaths required to run this job. */
     private List<URL> classpaths = Collections.emptyList();
+
+    /** List of user-defined job status change hooks. */
+    private final List<JobStatusHook> jobStatusHooks = new ArrayList<>();
 
     // --------------------------------------------------------------------------------------------
 
@@ -639,5 +643,14 @@ public class JobGraph implements Serializable {
         this.jobConfiguration.setBoolean(
                 StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION,
                 changelogStateBackendEnabled.getAsBoolean());
+    }
+
+    public void setJobStatusHooks(List<JobStatusHook> hooks) {
+        this.jobStatusHooks.clear();
+        this.jobStatusHooks.addAll(hooks);
+    }
+
+    public List<JobStatusHook> getJobStatusHooks() {
+        return this.jobStatusHooks;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -646,6 +646,7 @@ public class JobGraph implements Serializable {
     }
 
     public void setJobStatusHooks(List<JobStatusHook> hooks) {
+        checkNotNull(hooks, "Setting the JobStatusHook list to null is not allowed.");
         this.jobStatusHooks = hooks;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -120,7 +120,7 @@ public class JobGraph implements Serializable {
     private List<URL> classpaths = Collections.emptyList();
 
     /** List of user-defined job status change hooks. */
-    private final List<JobStatusHook> jobStatusHooks = new ArrayList<>();
+    private List<JobStatusHook> jobStatusHooks = Collections.emptyList();
 
     // --------------------------------------------------------------------------------------------
 
@@ -646,8 +646,7 @@ public class JobGraph implements Serializable {
     }
 
     public void setJobStatusHooks(List<JobStatusHook> hooks) {
-        this.jobStatusHooks.clear();
-        this.jobStatusHooks.addAll(hooks);
+        this.jobStatusHooks = hooks;
     }
 
     public List<JobStatusHook> getJobStatusHooks() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingJobStatusHook.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingJobStatusHook.java
@@ -20,35 +20,50 @@ package org.apache.flink.runtime.executiongraph;
 
 import org.apache.flink.api.common.JobID;
 
-import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 /** {@link JobStatusHook} implementation for testing purposes. */
 public class TestingJobStatusHook implements JobStatusHook {
 
-    // Record job status changes.
-    private final List<String> jobStatus;
+    private Consumer<JobID> onCreatedConsumer = (jobID) -> {};
+    private Consumer<JobID> onFinishedConsumer = (jobID) -> {};
+    private BiConsumer<JobID, Throwable> onFailedConsumer = (jobID, throwable) -> {};
+    private Consumer<JobID> onCanceledConsumer = (jobID) -> {};
 
-    public TestingJobStatusHook(List<String> jobStatus) {
-        this.jobStatus = jobStatus;
+    public void setOnCreatedConsumer(Consumer<JobID> onCreatedConsumer) {
+        this.onCreatedConsumer = onCreatedConsumer;
+    }
+
+    public void setonFinishedConsumer(Consumer<JobID> onFinishedConsumer) {
+        this.onFinishedConsumer = onFinishedConsumer;
+    }
+
+    public void setOnFailedConsumer(BiConsumer<JobID, Throwable> onFailedConsumer) {
+        this.onFailedConsumer = onFailedConsumer;
+    }
+
+    public void setOnCanceledConsumer(Consumer<JobID> onCanceledConsumer) {
+        this.onCanceledConsumer = onCanceledConsumer;
     }
 
     @Override
     public void onCreated(JobID jobId) {
-        jobStatus.add("Created");
+        onCreatedConsumer.accept(jobId);
     }
 
     @Override
     public void onFinished(JobID jobId) {
-        jobStatus.add("Finished");
+        onFinishedConsumer.accept(jobId);
     }
 
     @Override
     public void onFailed(JobID jobId, Throwable throwable) {
-        jobStatus.add("Failed");
+        onFailedConsumer.accept(jobId, throwable);
     }
 
     @Override
     public void onCanceled(JobID jobId) {
-        jobStatus.add("Canceled");
+        onCanceledConsumer.accept(jobId);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingJobStatusHook.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingJobStatusHook.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import org.apache.flink.api.common.JobID;
+
+import java.util.List;
+
+/** {@link JobStatusHook} implementation for testing purposes. */
+public class TestingJobStatusHook implements JobStatusHook {
+
+    // Record job status changes.
+    private final List<String> jobStatus;
+
+    public TestingJobStatusHook(List<String> jobStatus) {
+        this.jobStatus = jobStatus;
+    }
+
+    @Override
+    public void onCreated(JobID jobId) {
+        jobStatus.add("Created");
+    }
+
+    @Override
+    public void onFinished(JobID jobId) {
+        jobStatus.add("Finished");
+    }
+
+    @Override
+    public void onFailed(JobID jobId, Throwable throwable) {
+        jobStatus.add("Failed");
+    }
+
+    @Override
+    public void onCanceled(JobID jobId) {
+        jobStatus.add("Canceled");
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingJobStatusHook.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingJobStatusHook.java
@@ -35,7 +35,7 @@ public class TestingJobStatusHook implements JobStatusHook {
         this.onCreatedConsumer = onCreatedConsumer;
     }
 
-    public void setonFinishedConsumer(Consumer<JobID> onFinishedConsumer) {
+    public void setOnFinishedConsumer(Consumer<JobID> onFinishedConsumer) {
         this.onFinishedConsumer = onFinishedConsumer;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -36,6 +36,7 @@ import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.executiongraph.JobStatusHook;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -134,6 +135,8 @@ public class StreamGraph implements Pipeline {
     private PipelineOptions.VertexDescriptionMode descriptionMode =
             PipelineOptions.VertexDescriptionMode.TREE;
     private boolean vertexNameIncludeIndexPrefix = false;
+
+    private final List<JobStatusHook> jobStatusHooks = new ArrayList<>();
 
     public StreamGraph(
             ExecutionConfig executionConfig,
@@ -1033,5 +1036,19 @@ public class StreamGraph implements Pipeline {
 
     public boolean isVertexNameIncludeIndexPrefix() {
         return this.vertexNameIncludeIndexPrefix;
+    }
+
+    /** Registers the JobStatusHook. */
+    public void registerJobStatusHook(JobStatusHook hook) {
+        if (hook == null) {
+            throw new IllegalArgumentException();
+        }
+        if (!jobStatusHooks.contains(hook)) {
+            this.jobStatusHooks.add(hook);
+        }
+    }
+
+    public List<JobStatusHook> getJobStatusHooks() {
+        return this.jobStatusHooks;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -1040,9 +1040,7 @@ public class StreamGraph implements Pipeline {
 
     /** Registers the JobStatusHook. */
     public void registerJobStatusHook(JobStatusHook hook) {
-        if (hook == null) {
-            throw new IllegalArgumentException();
-        }
+        checkNotNull(hook, "Registering a null JobStatusHook is not allowed. ");
         if (!jobStatusHooks.contains(hook)) {
             this.jobStatusHooks.add(hook);
         }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -273,6 +273,8 @@ public class StreamingJobGraphGenerator {
             throw new FlinkRuntimeException("Error in serialization.", e);
         }
 
+        jobGraph.setJobStatusHooks(streamGraph.getJobStatusHooks());
+
         return jobGraph;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -273,7 +273,7 @@ public class StreamingJobGraphGenerator {
             throw new FlinkRuntimeException("Error in serialization.", e);
         }
 
-        if (streamGraph.getJobStatusHooks().size() > 0) {
+        if (!streamGraph.getJobStatusHooks().isEmpty()) {
             jobGraph.setJobStatusHooks(streamGraph.getJobStatusHooks());
         }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -273,7 +273,9 @@ public class StreamingJobGraphGenerator {
             throw new FlinkRuntimeException("Error in serialization.", e);
         }
 
-        jobGraph.setJobStatusHooks(streamGraph.getJobStatusHooks());
+        if (streamGraph.getJobStatusHooks().size() > 0) {
+            jobGraph.setJobStatusHooks(streamGraph.getJobStatusHooks());
+        }
 
         return jobGraph;
     }


### PR DESCRIPTION
## What is the purpose of the change

Introduce JobStatusHook
User can customize Hook to execute on JM side


## Brief change log

Introduce JobStatusHook
Users can register JobStatusHook through StreamGraph.

## Verifying this change

DefaultSchedulerTest#testJobStatusHookWithJobFailed
DefaultSchedulerTest#testJobStatusHookWithJobCanceled
DefaultSchedulerTest#testJobStatusHookWithJobFinished

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
