### PR TITLE
[FLINK-28466][Tests] Bump assertj to 3.23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@ under the License.
 		<mockito.version>3.4.6</mockito.version>
 		<powermock.version>2.0.9</powermock.version>
 		<hamcrest.version>1.3</hamcrest.version>
-		<assertj.version>3.21.0</assertj.version>
+		<assertj.version>3.23.1</assertj.version>
 		<py4j.version>0.10.9.3</py4j.version>
 		<beam.version>2.38.0</beam.version>
 		<protoc.version>3.21.2</protoc.version>


### PR DESCRIPTION

## What is the purpose of the change

This is a trivial PR updating version of assertj to 3.23.1

## Brief change log

assertj version in pom

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
