### PR TITLE
[FLINK-28399] Refactor CheckedThread to accept runnable via constructor

### DIFF
--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/streaming/connectors/cassandra/CassandraSinkBaseTest.java
@@ -173,13 +173,12 @@ public class CassandraSinkBaseTest {
 
             final CountDownLatch latch = new CountDownLatch(1);
             Thread t =
-                    new CheckedThread("Flink-CassandraSinkBaseTest") {
-                        @Override
-                        public void go() throws Exception {
-                            testHarness.snapshot(123L, 123L);
-                            latch.countDown();
-                        }
-                    };
+                    new CheckedThread(
+                            () -> {
+                                testHarness.snapshot(123L, 123L);
+                                latch.countDown();
+                            },
+                            "Flink-CassandraSinkBaseTest");
             t.start();
             while (t.getState() != Thread.State.TIMED_WAITING) {
                 Thread.sleep(5);
@@ -207,13 +206,12 @@ public class CassandraSinkBaseTest {
 
             final CountDownLatch latch = new CountDownLatch(1);
             Thread t =
-                    new CheckedThread("Flink-CassandraSinkBaseTest") {
-                        @Override
-                        public void go() throws Exception {
-                            testHarness.close();
-                            latch.countDown();
-                        }
-                    };
+                    new CheckedThread(
+                            () -> {
+                                testHarness.close();
+                                latch.countDown();
+                            },
+                            "Flink-CassandraSinkBaseTest");
             t.start();
             while (t.getState() != Thread.State.TIMED_WAITING) {
                 Thread.sleep(5);

--- a/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
+++ b/flink-connectors/flink-connector-elasticsearch-base/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/ElasticsearchSinkBaseTest.java
@@ -180,13 +180,7 @@ public class ElasticsearchSinkBaseTest {
         testHarness.processElement(new StreamRecord<>("msg-3"));
         verify(sink.getMockBulkProcessor(), times(3)).add(any(IndexRequest.class));
 
-        CheckedThread snapshotThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        testHarness.snapshot(1L, 1000L);
-                    }
-                };
+        CheckedThread snapshotThread = new CheckedThread(() -> testHarness.snapshot(1L, 1000L));
         snapshotThread.start();
 
         // the snapshot should eventually be blocked before snapshot triggers flushing
@@ -296,14 +290,7 @@ public class ElasticsearchSinkBaseTest {
         testHarness.processElement(new StreamRecord<>("msg-2"));
         testHarness.processElement(new StreamRecord<>("msg-3"));
         verify(sink.getMockBulkProcessor(), times(3)).add(any(IndexRequest.class));
-
-        CheckedThread snapshotThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        testHarness.snapshot(1L, 1000L);
-                    }
-                };
+        CheckedThread snapshotThread = new CheckedThread(() -> testHarness.snapshot(1L, 1000L));
         snapshotThread.start();
 
         // the snapshot should eventually be blocked before snapshot triggers flushing
@@ -348,13 +335,7 @@ public class ElasticsearchSinkBaseTest {
         testHarness.processElement(new StreamRecord<>("msg"));
         verify(sink.getMockBulkProcessor(), times(1)).add(any(IndexRequest.class));
 
-        CheckedThread snapshotThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        testHarness.snapshot(1L, 1000L);
-                    }
-                };
+        CheckedThread snapshotThread = new CheckedThread(() -> testHarness.snapshot(1L, 1000L));
         snapshotThread.start();
 
         // the snapshot should eventually be blocked before snapshot triggers flushing

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/connection/SimpleJdbcConnectionProviderDriverClassConcurrentLoadingITCase.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/internal/connection/SimpleJdbcConnectionProviderDriverClassConcurrentLoadingITCase.java
@@ -74,17 +74,15 @@ public class SimpleJdbcConnectionProviderDriverClassConcurrentLoadingITCase {
         Function<JdbcConnectionOptions, CheckedThread> connectionThreadCreator =
                 options -> {
                     CheckedThread thread =
-                            new CheckedThread() {
-                                @Override
-                                public void go() throws Exception {
-                                    startLatch.await();
-                                    JdbcConnectionProvider connectionProvider =
-                                            new SimpleJdbcConnectionProvider(options);
-                                    Connection connection =
-                                            connectionProvider.getOrEstablishConnection();
-                                    connection.close();
-                                }
-                            };
+                            new CheckedThread(
+                                    () -> {
+                                        startLatch.await();
+                                        JdbcConnectionProvider connectionProvider =
+                                                new SimpleJdbcConnectionProvider(options);
+                                        Connection connection =
+                                                connectionProvider.getOrEstablishConnection();
+                                        connection.close();
+                                    });
                     thread.setName("Loading " + options.getDriverName());
                     thread.setDaemon(true);
                     return thread;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseTest.java
@@ -407,12 +407,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
         setupConsumer(consumer, false, listState, true, 0, 1);
 
         final CheckedThread runThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        consumer.run(new TestSourceContext<>());
-                    }
-                };
+                new CheckedThread(() -> consumer.run(new TestSourceContext<>()));
         runThread.start();
         fetcher.waitUntilRun();
 
@@ -520,12 +515,7 @@ public class FlinkKafkaConsumerBaseTest extends TestLogger {
         setupConsumer(consumer, false, listState, true, 0, 1);
 
         final CheckedThread runThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        consumer.run(new TestSourceContext<>());
-                    }
-                };
+                new CheckedThread(() -> consumer.run(new TestSourceContext<>()));
         runThread.start();
         fetcher.waitUntilRun();
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerBaseTest.java
@@ -245,14 +245,12 @@ public class FlinkKafkaProducerBaseTest {
         producer.getPendingCallbacks().get(0).onCompletion(null, null);
 
         CheckedThread snapshotThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        // this should block at first, since there are still two pending records
-                        // that needs to be flushed
-                        testHarness.snapshot(123L, 123L);
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            // this should block at first, since there are still two pending records
+                            // that needs to be flushed
+                            testHarness.snapshot(123L, 123L);
+                        });
         snapshotThread.start();
 
         // let the 2nd message fail with an async exception
@@ -305,15 +303,13 @@ public class FlinkKafkaProducerBaseTest {
 
         // start a thread to perform checkpointing
         CheckedThread snapshotThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        // this should block until all records are flushed;
-                        // if the snapshot implementation returns before pending records are
-                        // flushed,
-                        testHarness.snapshot(123L, 123L);
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            // this should block until all records are flushed;
+                            // if the snapshot implementation returns before pending records are
+                            // flushed,
+                            testHarness.snapshot(123L, 123L);
+                        });
         snapshotThread.start();
 
         // before proceeding, make sure that flushing has started and that the snapshot is still

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcherTest.java
@@ -153,13 +153,8 @@ public class AbstractFetcherTest {
 
         // ----- run the fetcher -----
 
-        final CheckedThread checkedThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        fetcher.runFetchLoop();
-                    }
-                };
+        final CheckedThread checkedThread = new CheckedThread(() -> fetcher.runFetchLoop());
+
         checkedThread.start();
 
         // wait until state iteration begins before adding discovered partitions

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcherTest.java
@@ -129,12 +129,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                 new DummyFlinkKinesisConsumer<>(TestUtils.getStandardProperties(), fetcher, 1, 0);
 
         CheckedThread consumerThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        consumer.run(new TestSourceContext<>());
-                    }
-                };
+                new CheckedThread(() -> consumer.run(new TestSourceContext<>()));
         consumerThread.start();
 
         // wait for the second discovery to be triggered, that has a high probability to be inside
@@ -183,12 +178,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                 new DummyFlinkKinesisConsumer<>(TestUtils.getStandardProperties(), fetcher, 1, 0);
 
         CheckedThread consumerThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        consumer.run(new TestSourceContext<>());
-                    }
-                };
+                new CheckedThread(() -> consumer.run(new TestSourceContext<>()));
         consumerThread.start();
 
         fetcher.waitUntilRun();
@@ -252,12 +242,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                 new DummyFlinkKinesisConsumer<>(TestUtils.getStandardProperties(), fetcher, 1, 0);
 
         CheckedThread consumerThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        consumer.run(new TestSourceContext<>());
-                    }
-                };
+                new CheckedThread(() -> consumer.run(new TestSourceContext<>()));
         consumerThread.start();
 
         fetcher.waitUntilRun();
@@ -353,13 +338,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                             new SequenceNumber(restoredState.getValue())));
         }
 
-        CheckedThread runFetcherThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        fetcher.runFetcher();
-                    }
-                };
+        CheckedThread runFetcherThread = new CheckedThread(() -> fetcher.runFetcher());
         runFetcherThread.start();
 
         fetcher.waitUntilInitialDiscovery();
@@ -460,13 +439,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                             new SequenceNumber(restoredState.getValue())));
         }
 
-        CheckedThread runFetcherThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        fetcher.runFetcher();
-                    }
-                };
+        CheckedThread runFetcherThread = new CheckedThread(() -> fetcher.runFetcher());
         runFetcherThread.start();
 
         fetcher.waitUntilInitialDiscovery();
@@ -567,13 +540,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                             new SequenceNumber(restoredState.getValue())));
         }
 
-        CheckedThread runFetcherThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        fetcher.runFetcher();
-                    }
-                };
+        CheckedThread runFetcherThread = new CheckedThread(() -> fetcher.runFetcher());
         runFetcherThread.start();
 
         fetcher.waitUntilInitialDiscovery();
@@ -677,13 +644,7 @@ public class KinesisDataFetcherTest extends TestLogger {
                             new SequenceNumber(restoredState.getValue())));
         }
 
-        CheckedThread runFetcherThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        fetcher.runFetcher();
-                    }
-                };
+        CheckedThread runFetcherThread = new CheckedThread(() -> fetcher.runFetcher());
         runFetcherThread.start();
 
         fetcher.waitUntilInitialDiscovery();
@@ -982,12 +943,8 @@ public class KinesisDataFetcherTest extends TestLogger {
                 new DummyFlinkKinesisConsumer<>(TestUtils.getStandardProperties(), fetcher, 1, 0);
 
         CheckedThread consumerThread =
-                new CheckedThread("FlinkKinesisConsumer") {
-                    @Override
-                    public void go() throws Exception {
-                        consumer.run(new TestSourceContext<>());
-                    }
-                };
+                new CheckedThread(
+                        () -> consumer.run(new TestSourceContext<>()), "FlinkKinesisConsumer");
         consumerThread.start();
         fetcher.waitUntilRun();
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/io/OutputFormatBaseTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/io/OutputFormatBaseTest.java
@@ -106,12 +106,7 @@ class OutputFormatBaseTest {
             assertThat(testOutputFormat.getAcquiredPermits()).isEqualTo(1);
 
             CheckedThread checkedThread =
-                    new CheckedThread("Flink-OutputFormatBaseTest") {
-                        @Override
-                        public void go() throws Exception {
-                            testOutputFormat.close();
-                        }
-                    };
+                    new CheckedThread(() -> testOutputFormat.close(), "Flink-OutputFormatBaseTest");
             checkedThread.start();
             while (checkedThread.getState() != Thread.State.TIMED_WAITING) {
                 Thread.sleep(5);

--- a/flink-core/src/test/java/org/apache/flink/api/common/state/StateDescriptorTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/state/StateDescriptorTest.java
@@ -233,14 +233,12 @@ public class StateDescriptorTest {
                 new ConcurrentHashMap<>();
         for (int i = 0; i < threadNumber; i++) {
             threads.add(
-                    new CheckedThread() {
-                        @Override
-                        public void go() {
-                            desc.initializeSerializerUnlessSet(executionConfig);
-                            TypeSerializer<String> serializer = desc.getOriginalSerializer();
-                            serializers.put(System.identityHashCode(serializer), serializer);
-                        }
-                    });
+                    new CheckedThread(
+                            () -> {
+                                desc.initializeSerializerUnlessSet(executionConfig);
+                                TypeSerializer<String> serializer = desc.getOriginalSerializer();
+                                serializers.put(System.identityHashCode(serializer), serializer);
+                            }));
         }
         threads.forEach(Thread::start);
         for (CheckedThread t : threads) {

--- a/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/dag/TransformationTest.java
@@ -60,18 +60,16 @@ public class TransformationTest extends TestLogger {
         final List<List<Integer>> idLists = Collections.synchronizedList(new ArrayList<>());
         for (int x = 0; x < numThreads; x++) {
             threads.add(
-                    new CheckedThread() {
-                        @Override
-                        public void go() throws Exception {
-                            startLatch.await();
+                    new CheckedThread(
+                            () -> {
+                                startLatch.await();
 
-                            final List<Integer> ids = new ArrayList<>();
-                            for (int c = 0; c < numIdsPerThread; c++) {
-                                ids.add(Transformation.getNewNodeId());
-                            }
-                            idLists.add(ids);
-                        }
-                    });
+                                final List<Integer> ids = new ArrayList<>();
+                                for (int c = 0; c < numIdsPerThread; c++) {
+                                    ids.add(Transformation.getNewNodeId());
+                                }
+                                idLists.add(ids);
+                            }));
         }
         threads.forEach(Thread::start);
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerConcurrencyTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerConcurrencyTest.java
@@ -102,12 +102,7 @@ public class KryoSerializerConcurrencyTest {
 
         // this thread serializes and gets stuck there
         final CheckedThread thread =
-                new CheckedThread("serializer") {
-                    @Override
-                    public void go() throws Exception {
-                        serializer.serialize("a value", lockingOut);
-                    }
-                };
+                new CheckedThread(() -> serializer.serialize("a value", lockingOut), "serializer");
 
         thread.start();
         sync.awaitBlocker();

--- a/flink-core/src/test/java/org/apache/flink/core/fs/InitOutputPathTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/fs/InitOutputPathTest.java
@@ -183,21 +183,14 @@ public class InitOutputPathTest {
     // ------------------------------------------------------------------------
 
     private static class FileCreator extends CheckedThread {
-
-        private final FileSystem fs;
-        private final Path path;
-
         FileCreator(FileSystem fs, Path path) {
-            this.fs = fs;
-            this.path = path;
-        }
-
-        @Override
-        public void go() throws Exception {
-            fs.initOutPathLocalFS(path.getParent(), WriteMode.OVERWRITE, true);
-            try (FSDataOutputStream out = fs.create(path, WriteMode.OVERWRITE)) {
-                out.write(11);
-            }
+            super(
+                    () -> {
+                        fs.initOutPathLocalFS(path.getParent(), WriteMode.OVERWRITE, true);
+                        try (FSDataOutputStream out = fs.create(path, WriteMode.OVERWRITE)) {
+                            out.write(11);
+                        }
+                    });
         }
     }
 

--- a/flink-core/src/test/java/org/apache/flink/core/security/FlinkSecurityManagerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/core/security/FlinkSecurityManagerTest.java
@@ -122,18 +122,16 @@ public class FlinkSecurityManagerTest extends TestLogger {
         } catch (UserSystemExitException ignored) {
         }
         CheckedThread thread =
-                new CheckedThread() {
-                    @Override
-                    public void go() {
-                        try {
-                            flinkSecurityManager.checkExit(TEST_EXIT_CODE);
-                            fail();
-                        } catch (UserSystemExitException ignored) {
-                        } catch (Throwable t) {
-                            fail();
-                        }
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            try {
+                                flinkSecurityManager.checkExit(TEST_EXIT_CODE);
+                                fail();
+                            } catch (UserSystemExitException ignored) {
+                            } catch (Throwable t) {
+                                fail();
+                            }
+                        });
         thread.start();
         thread.sync();
     }

--- a/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
+++ b/flink-core/src/test/java/org/apache/flink/util/FileUtilsTest.java
@@ -515,15 +515,8 @@ public class FileUtilsTest extends TestLogger {
 
     private static class Deleter extends CheckedThread {
 
-        private final File target;
-
         Deleter(File target) {
-            this.target = target;
-        }
-
-        @Override
-        public void go() throws Exception {
-            FileUtils.deleteDirectory(target);
+            super(() -> FileUtils.deleteDirectory(target));
         }
     }
 }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerConcurrencyTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerConcurrencyTest.java
@@ -49,12 +49,7 @@ class AvroSerializerConcurrencyTest {
 
         // this thread serializes and gets stuck there
         final CheckedThread thread =
-                new CheckedThread("serializer") {
-                    @Override
-                    public void go() throws Exception {
-                        serializer.serialize("a value", lockingOut);
-                    }
-                };
+                new CheckedThread(() -> serializer.serialize("a value", lockingOut), "serializer");
 
         thread.start();
         sync.awaitBlocker();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobCachePutTest.java
@@ -91,38 +91,16 @@ public class BlobCachePutTest extends TestLogger {
 
     /** Checked thread that calls {@link TransientBlobCache#getStorageLocation(JobID, BlobKey)}. */
     public static class TransientBlobCacheGetStorageLocation extends CheckedThread {
-        private final TransientBlobCache cache;
-        private final JobID jobId;
-        private final BlobKey key;
-
         TransientBlobCacheGetStorageLocation(
                 TransientBlobCache cache, @Nullable JobID jobId, BlobKey key) {
-            this.cache = cache;
-            this.jobId = jobId;
-            this.key = key;
-        }
-
-        @Override
-        public void go() throws Exception {
-            cache.getStorageLocation(jobId, key);
+            super(() -> cache.getStorageLocation(jobId, key));
         }
     }
 
     /** Checked thread that calls {@link PermanentBlobCache#getStorageLocation(JobID, BlobKey)}. */
     public static class PermanentBlobCacheGetStorageLocation extends CheckedThread {
-        private final PermanentBlobCache cache;
-        private final JobID jobId;
-        private final BlobKey key;
-
         PermanentBlobCacheGetStorageLocation(PermanentBlobCache cache, JobID jobId, BlobKey key) {
-            this.cache = cache;
-            this.jobId = jobId;
-            this.key = key;
-        }
-
-        @Override
-        public void go() throws Exception {
-            cache.getStorageLocation(jobId, key);
+            super(() -> cache.getStorageLocation(jobId, key));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerPutTest.java
@@ -88,20 +88,9 @@ public class BlobServerPutTest extends TestLogger {
 
     /** Checked thread that calls {@link BlobServer#getStorageLocation(JobID, BlobKey)}. */
     public static class ContentAddressableGetStorageLocation extends CheckedThread {
-        private final BlobServer server;
-        private final JobID jobId;
-        private final BlobKey key;
-
         ContentAddressableGetStorageLocation(
                 BlobServer server, @Nullable JobID jobId, BlobKey key) {
-            this.server = server;
-            this.jobId = jobId;
-            this.key = key;
-        }
-
-        @Override
-        public void go() throws Exception {
-            server.getStorageLocation(jobId, key);
+            super(() -> server.getStorageLocation(jobId, key));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/NetworkBufferPoolTest.java
@@ -486,13 +486,11 @@ public class NetworkBufferPoolTest extends TestLogger {
 
         final OneShotLatch isRunning = new OneShotLatch();
         CheckedThread asyncRequest =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws IOException {
-                        isRunning.trigger();
-                        globalPool.requestUnpooledMemorySegments(10);
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            isRunning.trigger();
+                            globalPool.requestUnpooledMemorySegments(10);
+                        });
         asyncRequest.start();
 
         // We want the destroy call inside the blocking part of the
@@ -526,13 +524,11 @@ public class NetworkBufferPoolTest extends TestLogger {
 
         final OneShotLatch isRunning = new OneShotLatch();
         CheckedThread asyncRequest =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws IOException {
-                        isRunning.trigger();
-                        globalPool.requestUnpooledMemorySegments(10);
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            isRunning.trigger();
+                            globalPool.requestUnpooledMemorySegments(10);
+                        });
         asyncRequest.start();
 
         // We want the destroy call inside the blocking part of the
@@ -578,12 +574,8 @@ public class NetworkBufferPoolTest extends TestLogger {
         assertEquals(0, globalPool.getNumberOfAvailableMemorySegments());
 
         CheckedThread asyncRequest =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        globalPool.requestUnpooledMemorySegments(numberOfSegmentsToRequest);
-                    }
-                };
+                new CheckedThread(
+                        () -> globalPool.requestUnpooledMemorySegments(numberOfSegmentsToRequest));
 
         asyncRequest.start();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/BoundedBlockingSubpartitionWriteReadTest.java
@@ -294,32 +294,26 @@ public class BoundedBlockingSubpartitionWriteReadTest {
     }
 
     private static final class LongReader extends CheckedThread {
-
-        private final ResultSubpartitionView reader;
-
-        private final long numLongs;
-
-        private final int numBuffers;
-
-        private final boolean compressionEnabled;
-
-        private final BufferDecompressor decompressor;
-
         LongReader(
                 ResultSubpartitionView reader,
                 long numLongs,
                 int numBuffers,
-                boolean compressionEnabled) {
-            this.reader = reader;
-            this.numLongs = numLongs;
-            this.numBuffers = numBuffers;
-            this.compressionEnabled = compressionEnabled;
-            this.decompressor = new BufferDecompressor(BUFFER_SIZE, COMPRESSION_CODEC);
+                boolean compressionEnabled,
+                BufferDecompressor decompressor) {
+            super(() -> readLongs(reader, numLongs, numBuffers, compressionEnabled, decompressor));
         }
 
-        @Override
-        public void go() throws Exception {
-            readLongs(reader, numLongs, numBuffers, compressionEnabled, decompressor);
+        public LongReader(
+                ResultSubpartitionView reader,
+                long numLongs,
+                int numBuffers,
+                boolean compressionEnabled) {
+            this(
+                    reader,
+                    numLongs,
+                    numBuffers,
+                    compressionEnabled,
+                    new BufferDecompressor(BUFFER_SIZE, COMPRESSION_CODEC));
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionReadSchedulerTest.java
@@ -297,14 +297,12 @@ class HsResultPartitionReadSchedulerTest {
         factory.allReaders.add(reader);
 
         CheckedThread releaseThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        readBufferStart.get();
-                        readScheduler.release();
-                        schedulerReleasedFinish.complete(null);
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            readBufferStart.get();
+                            readScheduler.release();
+                            schedulerReleasedFinish.complete(null);
+                        });
         releaseThread.start();
 
         readScheduler.registerNewSubpartition(0, subpartitionViewOperation);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
@@ -237,22 +237,20 @@ class HsSubpartitionFileReaderImplTest {
         writeDataToFile(targetChannel, 0, numBuffers);
         subpartitionFileReader.prepareForScheduling();
         CheckedThread checkedThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        int numConsumedBuffer = 0;
-                        while (numConsumedBuffer < numBuffers) {
-                            BufferIndexOrError bufferIndexOrError = loadedBuffers.poll();
-                            if (bufferIndexOrError != null) {
-                                assertThat(bufferIndexOrError.getBuffer()).isPresent();
-                                numConsumedBuffer++;
-                            } else {
-                                notifyLatch.await();
-                                notifyLatch.reset();
+                new CheckedThread(
+                        () -> {
+                            int numConsumedBuffer = 0;
+                            while (numConsumedBuffer < numBuffers) {
+                                BufferIndexOrError bufferIndexOrError = loadedBuffers.poll();
+                                if (bufferIndexOrError != null) {
+                                    assertThat(bufferIndexOrError.getBuffer()).isPresent();
+                                    numConsumedBuffer++;
+                                } else {
+                                    notifyLatch.await();
+                                    notifyLatch.reset();
+                                }
                             }
-                        }
-                    }
-                };
+                        });
         checkedThread.start();
 
         // read data from disk then add it to buffer queue.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionServiceTest.java
@@ -282,12 +282,7 @@ public class DefaultLeaderElectionServiceTest extends TestLogger {
                         testingLeaderElectionDriverFactory.getCurrentLeaderDriver());
 
         final CheckedThread isLeaderThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() {
-                        currentLeaderDriver.isLeader();
-                    }
-                };
+                new CheckedThread(() -> currentLeaderDriver.isLeader());
         isLeaderThread.start();
 
         leaderElectionService.stop();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestBase.java
@@ -1637,34 +1637,32 @@ public abstract class StateBackendTestBase<B extends AbstractStateBackend> exten
                             namespaceSerializer,
                             valueSerializer));
             state.update("1");
-
             final CheckedThread getter =
-                    new CheckedThread("State getter") {
-                        @Override
-                        public void go() throws Exception {
-                            while (!isInterrupted()) {
-                                assertEquals("1", state.value());
-                            }
-                        }
-                    };
+                    new CheckedThread(
+                            () -> {
+                                while (!Thread.currentThread().isInterrupted()) {
+                                    assertEquals("1", state.value());
+                                }
+                            },
+                            "State getter");
 
             final CheckedThread serializedGetter =
-                    new CheckedThread("Serialized state getter") {
-                        @Override
-                        public void go() throws Exception {
-                            while (!isInterrupted() && getter.isAlive()) {
-                                final String serializedValue =
-                                        getSerializedValue(
-                                                kvState,
-                                                key2,
-                                                keySerializer,
-                                                namespace,
-                                                namespaceSerializer,
-                                                valueSerializer);
-                                assertEquals("1", serializedValue);
-                            }
-                        }
-                    };
+                    new CheckedThread(
+                            () -> {
+                                while (!Thread.currentThread().isInterrupted()
+                                        && getter.isAlive()) {
+                                    final String serializedValue =
+                                            getSerializedValue(
+                                                    kvState,
+                                                    key2,
+                                                    keySerializer,
+                                                    namespace,
+                                                    namespaceSerializer,
+                                                    valueSerializer);
+                                    assertEquals("1", serializedValue);
+                                }
+                            },
+                            "Serialized state getter");
 
             getter.start();
             serializedGetter.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/CheckpointStateOutputStreamTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/filesystem/CheckpointStateOutputStreamTest.java
@@ -206,15 +206,12 @@ public class CheckpointStateOutputStreamTest extends TestLogger {
         final OneShotLatch sync = new OneShotLatch();
 
         final CheckedThread thread =
-                new CheckedThread() {
-
-                    @Override
-                    public void go() throws Exception {
-                        sync.trigger();
-                        // that call should now block, because it accesses the position
-                        closeAndGetResult(checkpointStream);
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            sync.trigger();
+                            // that call should now block, because it accesses the position
+                            closeAndGetResult(checkpointStream);
+                        });
         thread.start();
 
         sync.await();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/DefaultJobLeaderServiceTest.java
@@ -91,17 +91,15 @@ public class DefaultJobLeaderServiceTest extends TestLogger {
                 "foobar", rpcServiceResource.getTestingRpcService(), haServices, jobLeaderListener);
 
         final CheckedThread addJobAction =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        for (int i = 0; i < numberOperations; i++) {
-                            final JobID jobId = JobID.generate();
-                            jobLeaderService.addJob(jobId, "foobar");
-                            Thread.yield();
-                            jobLeaderService.removeJob(jobId);
-                        }
-                    }
-                };
+                new CheckedThread(
+                        () -> {
+                            for (int i = 0; i < numberOperations; i++) {
+                                final JobID jobId = JobID.generate();
+                                jobLeaderService.addJob(jobId, "foobar");
+                                Thread.yield();
+                                jobLeaderService.removeJob(jobId);
+                            }
+                        });
         addJobAction.start();
 
         for (int i = 0; i < numberOperations; i++) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -168,7 +168,7 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
         InputGate receiverGate = createInputGate(senderLocation);
 
         SerializingLongReceiver receiver =
-                new SerializingLongReceiver(receiverGate, channels * partitionIds.length);
+                SerializingLongReceiver.create(receiverGate, channels * partitionIds.length);
 
         receiver.start();
         return receiver;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkThroughputBenchmark.java
@@ -120,7 +120,7 @@ public class StreamNetworkThroughputBenchmark {
                     new RecordWriterBuilder().setTimeout(flushTimeout);
             setChannelSelector(recordWriterBuilder, broadcastMode);
             writerThreads[writer] =
-                    new LongRecordWriterThread(
+                    LongRecordWriterThread.create(
                             recordWriterBuilder.build(resultPartitionWriter), broadcastMode);
             writerThreads[writer].start();
         }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/CheckpointedInputGateTest.java
@@ -248,13 +248,12 @@ public class CheckpointedInputGateTest {
                 // triggered or closing came first in which case we expect a CancelTaskException
                 CountDownLatch beforeLatch = new CountDownLatch(2);
                 final CheckedThread canceler =
-                        new CheckedThread("Canceler") {
-                            @Override
-                            public void go() throws IOException {
-                                beforeLatch.countDown();
-                                singleInputGate.close();
-                            }
-                        };
+                        new CheckedThread(
+                                () -> {
+                                    beforeLatch.countDown();
+                                    singleInputGate.close();
+                                },
+                                "Canceler");
                 canceler.start();
                 beforeLatch.countDown();
                 try {

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ThrowingRunnable.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/ThrowingRunnable.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.testutils;
+
+/**
+ * Similar to a {@link Runnable}, this interface is used to capture a block of code to be executed.
+ * In contrast to {@code Runnable}, this interface allows throwing checked exceptions.
+ *
+ * <p>This class is copied from org.apache.flink.util.function.ThrowingRunnable.
+ */
+@FunctionalInterface
+public interface ThrowingRunnable<E extends Throwable> {
+    /**
+     * The work method.
+     *
+     * @throws E Exceptions may be thrown.
+     */
+    void run() throws E;
+
+    /**
+     * Converts a {@link ThrowingRunnable} into a {@link Runnable} which throws all checked
+     * exceptions as unchecked.
+     *
+     * @param throwingRunnable to convert into a {@link Runnable}
+     * @return {@link Runnable} which throws all checked exceptions as unchecked.
+     */
+    static Runnable unchecked(ThrowingRunnable<?> throwingRunnable) {
+        return () -> {
+            try {
+                throwingRunnable.run();
+            } catch (Throwable t) {
+                if (t instanceof Error) {
+                    throw (Error) t;
+                } else if (t instanceof RuntimeException) {
+                    throw (RuntimeException) t;
+                } else {
+                    throw new RuntimeException(t);
+                }
+            }
+        };
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CheckedThreadTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/core/testutils/CheckedThreadTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.testutils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Testing for {@link CheckedThread}. */
+class CheckedThreadTest {
+
+    @Test
+    void testRunnableThrowException() {
+        CheckedThread checkedThread =
+                new CheckedThread(
+                        () -> {
+                            throw new IOException("excepted exception.");
+                        });
+        checkedThread.start();
+
+        assertThatThrownBy(checkedThread::sync)
+                .isInstanceOf(IOException.class)
+                .hasMessage("excepted exception.");
+    }
+
+    @Test
+    void testNullRunnableIsPassed() {
+        assertThatThrownBy(() -> new CheckedThread(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new CheckedThread(null, "null runnable thread"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    @Timeout(10)
+    void testSync() {
+        CheckedThread checkedThread = new CheckedThread(() -> Thread.sleep(500));
+
+        checkedThread.start();
+
+        assertThatNoException().isThrownBy(checkedThread::sync);
+    }
+
+    @Test
+    void testSyncWithTimeout() {
+        CompletableFuture<Void> blockFuture = new CompletableFuture<>();
+        // this thread will be blocked forever.
+        CheckedThread checkedThread = new CheckedThread(blockFuture::get);
+
+        checkedThread.start();
+
+        assertThatThrownBy(() -> checkedThread.sync(500)).isInstanceOf(TimeoutException.class);
+        assertThat(blockFuture).isNotDone();
+    }
+
+    @Test
+    void testTrySync() {
+        CompletableFuture<Void> blockFuture = new CompletableFuture<>();
+        // this thread will be blocked forever.
+        CheckedThread checkedThread = new CheckedThread(blockFuture::get);
+
+        checkedThread.start();
+
+        assertThatNoException()
+                .isThrownBy(
+                        () -> {
+                            checkedThread.trySync(500);
+                            assertThat(blockFuture).isNotDone();
+                        });
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/accumulators/AccumulatorLiveITCase.java
@@ -148,12 +148,10 @@ public class AccumulatorLiveITCase extends TestLogger {
         final ClusterClient<?> client = MINI_CLUSTER_RESOURCE.getClusterClient();
 
         final CheckedThread submissionThread =
-                new CheckedThread() {
-                    @Override
-                    public void go() throws Exception {
-                        submitJobAndWaitForResult(client, jobGraph, getClass().getClassLoader());
-                    }
-                };
+                new CheckedThread(
+                        () ->
+                                submitJobAndWaitForResult(
+                                        client, jobGraph, CheckedThread.class.getClassLoader()));
 
         submissionThread.start();
 

--- a/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/example/client/JobRetrievalITCase.java
@@ -94,12 +94,9 @@ public class JobRetrievalITCase extends TestLogger {
         client.submitJob(jobGraph).get();
 
         final CheckedThread resumingThread =
-                new CheckedThread("Flink-Job-Retriever") {
-                    @Override
-                    public void go() throws Exception {
-                        assertNotNull(client.requestJobResult(jobId).get());
-                    }
-                };
+                new CheckedThread(
+                        () -> assertNotNull(client.requestJobResult(jobId).get()),
+                        "Flink-Job-Retriever");
 
         // wait until the job is running
         while (client.listJobs().get().isEmpty()) {


### PR DESCRIPTION
## What is the purpose of the change

Let `CheckedThread` supports pass a `RunnableWithException` to constructor, this will make it behave more like a thread.
After this pr, we can use `CheckedThread` as the same way of using `Thread` like: `new Thread(Runnable runnable)` or
`new Thread()` and then override `Thread.run()` method. Just change it to `CheckedThread(RunnableWithException runnableWithException)` or `new CheckedThread()` and then override `CheckedThread.go()` method.


## Brief change log

  - *Let `CheckedThread` supports pass a `RunnableWithException` to constructor*
  - *All anonymous inner class based on it are replaced by lambda expressions constructor*
  - *Add test for CheckedThread*


## Verifying this change

This change added tests and can be verified by `CheckedThreadTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
