### PR TITLE
[FLINK-25371] Include data port as part of the host info for subtask detail panel on Web UI

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -47,7 +47,9 @@
           <th [nzSortFn]="sortAttemptFn" (nzSortOrderChange)="collapseAll()" nzWidth="100px">
             Attempt
           </th>
-          <th [nzSortFn]="sortHostFn" (nzSortOrderChange)="collapseAll()" nzWidth="200px">Host</th>
+          <th [nzSortFn]="sortHostFn" (nzSortOrderChange)="collapseAll()" nzWidth="200px">
+            Host:port
+          </th>
           <th [nzSortFn]="sortStartTimeFn" (nzSortOrderChange)="collapseAll()" nzWidth="150px">
             Start Time
           </th>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/taskmanagers/job-overview-drawer-taskmanagers.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/taskmanagers/job-overview-drawer-taskmanagers.component.html
@@ -30,7 +30,7 @@
 >
   <thead>
     <tr>
-      <th nzWidth="160px" nzLeft [nzSortFn]="sortHostFn">Host</th>
+      <th nzWidth="160px" nzLeft [nzSortFn]="sortHostFn">Host:port</th>
       <th nzWidth="150px" [nzSortFn]="sortReadBytesFn">Bytes received</th>
       <th nzWidth="150px" [nzSortFn]="sortReadRecordsFn">Records received</th>
       <th nzWidth="120px" [nzSortFn]="sortWriteBytesFn">Bytes sent</th>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -271,7 +271,7 @@ public class JobExceptionsHandler
         // '(unassigned)' being the default value is added to support backward-compatibility for the
         // deprecated fields
         return location != null
-                ? taskManagerLocationToString(location.getFQDNHostname(), location.dataPort())
+                ? location.getLocationString()
                 : "(unassigned)";
     }
 
@@ -286,7 +286,7 @@ public class JobExceptionsHandler
     @Nullable
     static String toString(@Nullable ExceptionHistoryEntry.ArchivedTaskManagerLocation location) {
         return location != null
-                ? taskManagerLocationToString(location.getFQDNHostname(), location.getPort())
+                ? location.getLocationString()
                 : null;
     }
 
@@ -294,9 +294,5 @@ public class JobExceptionsHandler
     static String toTaskManagerId(
             @Nullable ExceptionHistoryEntry.ArchivedTaskManagerLocation location) {
         return location != null ? String.format("%s", location.getResourceID()) : null;
-    }
-
-    private static String taskManagerLocationToString(String fqdnHostname, int port) {
-        return String.format("%s:%d", fqdnHostname, port);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -270,9 +270,7 @@ public class JobExceptionsHandler
     static String toString(@Nullable TaskManagerLocation location) {
         // '(unassigned)' being the default value is added to support backward-compatibility for the
         // deprecated fields
-        return location != null
-                ? location.getLocationString()
-                : "(unassigned)";
+        return location != null ? location.getLocationString() : "(unassigned)";
     }
 
     @VisibleForTesting
@@ -285,9 +283,7 @@ public class JobExceptionsHandler
     @VisibleForTesting
     @Nullable
     static String toString(@Nullable ExceptionHistoryEntry.ArchivedTaskManagerLocation location) {
-        return location != null
-                ? location.getLocationString()
-                : null;
+        return location != null ? location.getLocationString() : null;
     }
 
     @VisibleForTesting

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexTaskManagersHandler.java
@@ -142,9 +142,7 @@ public class JobVertexTaskManagersHandler
             for (AccessExecution execution : vertex.getCurrentExecutions()) {
                 TaskManagerLocation location = execution.getAssignedResourceLocation();
                 String taskManagerHost =
-                        location == null
-                                ? "(unassigned)"
-                                : location.getHostname() + ':' + location.dataPort();
+                        location == null ? "(unassigned)" : location.getLocationString();
                 String taskmanagerId =
                         location == null ? "(unassigned)" : location.getResourceID().toString();
                 taskManagerId2Host.put(taskmanagerId, taskManagerHost);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksAllAccumulatorsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksAllAccumulatorsHandler.java
@@ -78,7 +78,8 @@ public class SubtasksAllAccumulatorsHandler
         for (AccessExecutionVertex vertex : jobVertex.getTaskVertices()) {
             for (AccessExecution execution : vertex.getCurrentExecutions()) {
                 TaskManagerLocation location = execution.getAssignedResourceLocation();
-                String locationString = location == null ? "(unassigned)" : location.getHostname();
+                String locationString =
+                        location == null ? "(unassigned)" : location.getLocationString();
 
                 StringifiedAccumulatorResult[] accs = execution.getUserAccumulatorsStringified();
                 List<UserAccumulator> userAccumulators = new ArrayList<>(accs.length);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/SubtasksTimesHandler.java
@@ -113,7 +113,8 @@ public class SubtasksTimesHandler
             long duration = start >= 0 ? end - start : -1L;
 
             TaskManagerLocation location = vertex.getCurrentAssignedResourceLocation();
-            String locationString = location == null ? "(unassigned)" : location.getHostname();
+            String locationString =
+                    location == null ? "(unassigned)" : location.getLocationString();
 
             Map<ExecutionState, Long> timestampMap =
                     CollectionUtil.newHashMapWithExpectedSize(ExecutionState.values().length);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -203,7 +203,10 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
         final long now = System.currentTimeMillis();
 
         final TaskManagerLocation location = execution.getAssignedResourceLocation();
-        final String locationString = location == null ? "(unassigned)" : location.getHostname();
+        final String locationString =
+                location == null
+                        ? "(unassigned)"
+                        : location.getHostname() + ":" + location.dataPort();
         String taskmanagerId =
                 location == null ? "(unassigned)" : location.getResourceID().toString();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/job/SubtaskExecutionAttemptDetailsInfo.java
@@ -204,9 +204,7 @@ public class SubtaskExecutionAttemptDetailsInfo implements ResponseBody {
 
         final TaskManagerLocation location = execution.getAssignedResourceLocation();
         final String locationString =
-                location == null
-                        ? "(unassigned)"
-                        : location.getHostname() + ":" + location.dataPort();
+                location == null ? "(unassigned)" : location.getLocationString();
         String taskmanagerId =
                 location == null ? "(unassigned)" : location.getResourceID().toString();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/exceptionhistory/ExceptionHistoryEntry.java
@@ -237,6 +237,10 @@ public class ExceptionHistoryEntry extends ErrorInfo {
             return fqdnHostname;
         }
 
+        public String getLocationString() {
+            return String.format("%s:%d", fqdnHostname, port);
+        }
+
         @Override
         public String toString() {
             return new StringJoiner(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/TaskManagerLocation.java
@@ -275,6 +275,15 @@ public class TaskManagerLocation implements Comparable<TaskManagerLocation>, jav
         return hostName;
     }
 
+    /**
+     * Gets the location string of the TaskManager in the format of "$HOST:$PORT".
+     *
+     * @return The location string of the TaskManager.
+     */
+    public String getLocationString() {
+        return String.format("%s:%d", getFQDNHostname(), dataPort);
+    }
+
     @Override
     public String toString() {
         if (stringRepresentation == null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandlerTest.java
@@ -356,11 +356,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
         final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
         assertThat(
                 JobExceptionsHandler.toString(taskManagerLocation),
-                is(
-                        String.format(
-                                "%s:%s",
-                                taskManagerLocation.getFQDNHostname(),
-                                taskManagerLocation.dataPort())));
+                is(taskManagerLocation.getLocationString()));
     }
 
     @Test
@@ -376,11 +372,7 @@ public class JobExceptionsHandlerTest extends TestLogger {
         final TaskManagerLocation taskManagerLocation = new LocalTaskManagerLocation();
         assertThat(
                 JobExceptionsHandler.toString(taskManagerLocation),
-                is(
-                        String.format(
-                                "%s:%s",
-                                taskManagerLocation.getFQDNHostname(),
-                                taskManagerLocation.dataPort())));
+                is(taskManagerLocation.getLocationString()));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -186,7 +186,9 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
                         subtaskIndex,
                         expectedState,
                         attempt,
-                        assignedResourceLocation.getHostname(),
+                        assignedResourceLocation.getHostname()
+                                + ":"
+                                + assignedResourceLocation.dataPort(),
                         deployingTs,
                         finishedTs,
                         finishedTs - deployingTs,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/SubtaskCurrentAttemptDetailsHandlerTest.java
@@ -186,9 +186,7 @@ public class SubtaskCurrentAttemptDetailsHandlerTest extends TestLogger {
                         subtaskIndex,
                         expectedState,
                         attempt,
-                        assignedResourceLocation.getHostname()
-                                + ":"
-                                + assignedResourceLocation.dataPort(),
+                        assignedResourceLocation.getLocationString(),
                         deployingTs,
                         finishedTs,
                         finishedTs - deployingTs,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Help user locate the container where a task is running on from Web UI by including port in the host info on Web UI.

## Brief change log

1. Include port as part of the host info in `SubtaskExecutionAttemptDetailsInfo`.
2. Introduce a new method `toLocationString` in `TaskManagerLocation` to align the behavior of pretty printing taskmanager location in REST handlers.
3. Rename column name from "Host" to "Host:port" on Web UI to reflect the change of adding port info.

## Verifying this change

This change is already covered by existing tests, such as `SubtaskCurrentAttemptDetailsHandlerTest.testHandleRequest()`.

Also manually verified the change by running a cluster.

![image](https://github.com/apache/flink/assets/22020529/08767324-b8d9-4800-8133-538385fe284d)

![image](https://github.com/apache/flink/assets/22020529/08a1106c-c96c-4035-8372-f9cbda02fab2)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not documented
