### PR TITLE
[FLINK-27703][core] Extend timeout and add logs for FileChannelManagerImplTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/disk/FileChannelManagerImplTest.java
@@ -124,7 +124,7 @@ public class FileChannelManagerImplTest extends TestLogger {
 
             // Waits till the process has created temporary files and registered the corresponding
             // shutdown hooks.
-            TestJvmProcess.waitForMarkerFile(signalFile, TEST_TIMEOUT.toMillis());
+            TestJvmProcess.waitForMarkerFile(signalFile, 3 * TEST_TIMEOUT.toMillis());
 
             Process kill =
                     Runtime.getRuntime()
@@ -196,6 +196,8 @@ public class FileChannelManagerImplTest extends TestLogger {
             String tmpDirectory = args[1];
             String signalFilePath = args[2];
 
+            LOG.info("The FileChannelManagerCleanupRunner process has started");
+
             FileChannelManager manager =
                     new FileChannelManagerImpl(new String[] {tmpDirectory}, DIR_NAME_PREFIX);
 
@@ -205,8 +207,12 @@ public class FileChannelManagerImplTest extends TestLogger {
                 ShutdownHookUtil.addShutdownHook(() -> manager.close(), "Caller", LOG);
             }
 
+            LOG.info("The FileChannelManagerCleanupRunner is going to create the new file");
+
             // Signals the main process to execute the kill action.
             new File(signalFilePath).createNewFile();
+
+            LOG.info("The FileChannelManagerCleanupRunner has created the new file");
 
             // Blocks the process to wait to be killed.
             Thread.sleep(3 * TEST_TIMEOUT.toMillis());


### PR DESCRIPTION
## What is the purpose of the change

This PR extends the timeout and add some logs to help debugging the reason that file creation is delayed.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
