### PR TITLE
[FLINK-26621][tests] Close delegate keyed state backend

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendTestUtils.java
@@ -179,11 +179,13 @@ public class StateBackendTestUtils {
 
                 @Override
                 public void dispose() {
+                    super.dispose();
                     delegatedKeyedStateBackend.dispose();
                 }
 
                 @Override
                 public void close() throws IOException {
+                    super.close();
                     delegatedKeyedStateBackend.close();
                 }
             };


### PR DESCRIPTION
Fixes an issue where we are wrapping a keyed state backend, without overriding&forwarding `close()`/`dispose()`.