### PR TITLE
[FLINK-28489][sql-parser] Introduce `ANALYZE TABLE` syntax in sql parser

### DIFF
--- a/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
+++ b/flink-table/flink-sql-parser/src/main/codegen/data/Parser.tdd
@@ -71,6 +71,7 @@
     "org.apache.flink.sql.parser.ddl.SqlUseDatabase"
     "org.apache.flink.sql.parser.ddl.SqlUseModules"
     "org.apache.flink.sql.parser.ddl.SqlWatermark"
+    "org.apache.flink.sql.parser.ddl.SqlAnalyzeTable"
     "org.apache.flink.sql.parser.dml.RichSqlInsert"
     "org.apache.flink.sql.parser.dml.RichSqlInsertKeyword"
     "org.apache.flink.sql.parser.dml.SqlBeginStatementSet"
@@ -107,6 +108,7 @@
     "org.apache.flink.sql.parser.utils.ParserResource"
     "org.apache.flink.sql.parser.validate.FlinkSqlConformance"
     "org.apache.flink.sql.parser.SqlProperty"
+    "org.apache.flink.sql.parser.SqlPair"
     "org.apache.calcite.sql.SqlAlienSystemTypeNameSpec"
     "org.apache.calcite.sql.SqlCreate"
     "org.apache.calcite.sql.SqlDrop"
@@ -159,6 +161,9 @@
     "WATERMARKS"
     "TIMESTAMP_LTZ"
     "TRY_CAST"
+    "ANALYZE"
+    "COMPUTE"
+    "STATISTICS"
   ]
 
   # List of keywords from "keywords" section that are not reserved.
@@ -501,6 +506,9 @@
     "PARTITIONS"
     "TRY_CAST"
     "VIRTUAL"
+    "ANALYZE"
+    "COMPUTE"
+    "STATISTICS"
   ]
 
   # List of non-reserved keywords to remove;
@@ -546,6 +554,7 @@
     "SqlShowJars()"
     "SqlSet()"
     "SqlReset()"
+    "SqlAnalyzeTable()"
   ]
 
   # List of methods for parsing custom literals.

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlPair.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlPair.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+import org.apache.calcite.util.NlsString;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Properties of PartitionSpec, a key-value pair with key as component identifier and value as
+ * string literal. Different from {@link SqlProperty}, {@link SqlPair} allows the value is null.
+ */
+public class SqlPair extends SqlCall {
+
+    /** Use this operator only if you don't have a better one. */
+    protected static final SqlOperator OPERATOR = new SqlSpecialOperator("Pair", SqlKind.OTHER);
+
+    private final SqlIdentifier key;
+    private final SqlNode value;
+
+    public SqlPair(SqlIdentifier key, SqlNode value, SqlParserPos pos) {
+        super(pos);
+        this.key = requireNonNull(key, "Pair key is missing");
+        this.value = value;
+    }
+
+    public SqlIdentifier getKey() {
+        return key;
+    }
+
+    public SqlNode getValue() {
+        return value;
+    }
+
+    public String getKeyString() {
+        return key.toString();
+    }
+
+    public String getValueString() {
+        return value != null ? ((NlsString) SqlLiteral.value(value)).getValue() : null;
+    }
+
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    @Override
+    public List<SqlNode> getOperandList() {
+        if (value != null) {
+            return ImmutableNullableList.of(key, value);
+        } else {
+            return ImmutableNullableList.of(key);
+        }
+    }
+
+    @Override
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        key.unparse(writer, leftPrec, rightPrec);
+        if (value != null) {
+            writer.keyword("=");
+            value.unparse(writer, leftPrec, rightPrec);
+        }
+    }
+}
+
+// End SqlPair.java

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAnalyzeTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlAnalyzeTable.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.sql.parser.ddl;
+
+import org.apache.flink.sql.parser.SqlPartitionUtils;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.ImmutableNullableList;
+
+import javax.annotation.Nonnull;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+
+/** ANALYZE TABLE to compute the statistics for a given table. */
+public class SqlAnalyzeTable extends SqlCall {
+    public static final SqlSpecialOperator OPERATOR =
+            new SqlSpecialOperator("ANALYZE TABLE", SqlKind.OTHER_DDL);
+
+    private final SqlIdentifier tableName;
+    private final SqlNodeList partitions;
+    private final SqlNodeList columns;
+    private final boolean allColumns;
+
+    public SqlAnalyzeTable(
+            SqlParserPos pos,
+            SqlIdentifier tableName,
+            SqlNodeList partitions,
+            SqlNodeList columns,
+            boolean allColumns) {
+        super(pos);
+        this.tableName = tableName;
+        this.partitions = partitions;
+        this.columns = columns;
+        this.allColumns = allColumns;
+    }
+
+    public String[] fullTableName() {
+        return tableName.names.toArray(new String[0]);
+    }
+
+    /** Get partition spec as key-value strings. */
+    public LinkedHashMap<String, String> getPartitionKVs() {
+        return SqlPartitionUtils.getPartitionKVs(partitions);
+    }
+
+    public String[] getColumnNames() {
+        if (columns == null) {
+            return new String[0];
+        }
+        return columns.getList().stream()
+                .map(col -> ((SqlIdentifier) col).getSimple())
+                .toArray(String[]::new);
+    }
+
+    public boolean isAllColumns() {
+        return allColumns;
+    }
+
+    @Nonnull
+    @Override
+    public SqlOperator getOperator() {
+        return OPERATOR;
+    }
+
+    @Nonnull
+    @Override
+    public List<SqlNode> getOperandList() {
+        return ImmutableNullableList.of(tableName, partitions, columns);
+    }
+
+    public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+        writer.keyword("ANALYZE");
+        writer.keyword("TABLE");
+        final int opLeft = getOperator().getLeftPrec();
+        final int opRight = getOperator().getRightPrec();
+        tableName.unparse(writer, opLeft, opRight);
+
+        if (partitions != null && partitions.size() > 0) {
+            writer.keyword("PARTITION");
+            partitions.unparse(writer, opLeft, opRight);
+        }
+
+        writer.keyword("COMPUTE");
+        writer.keyword("STATISTICS");
+
+        if (columns != null && columns.size() > 0) {
+            writer.keyword("FOR");
+            writer.keyword("COLUMNS");
+            columns.unparse(writer, opLeft, opRight);
+        }
+        if (allColumns) {
+            writer.keyword("FOR");
+            writer.keyword("ALL");
+            writer.keyword("COLUMNS");
+        }
+    }
+}

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -1856,6 +1856,36 @@ class FlinkSqlParserImplTest extends SqlParserTest {
                         "TRY_CAST(`A` AS ROW(`F0` INTEGER ARRAY, `F1` MAP< STRING, DECIMAL(10, 2) >, `F2` STRING NOT NULL))");
     }
 
+    @Test
+    void testAnalyzeTable() {
+        sql("analyze table emp^s^").fails("(?s).*Encountered \"<EOF>\" at line 1, column 18.\n.*");
+        sql("analyze table emps compute statistics").ok("ANALYZE TABLE `EMPS` COMPUTE STATISTICS");
+        sql("analyze table emps partition(^)^ compute statistics")
+                .fails("(?s).*Encountered \"\\)\" at line 1, column 30.\n.*");
+        sql("analyze table emps partition(x='ab') compute statistics")
+                .ok("ANALYZE TABLE `EMPS` PARTITION (`X` = 'ab') COMPUTE STATISTICS");
+        sql("analyze table emps partition(x='ab', y='bc') compute statistics")
+                .ok("ANALYZE TABLE `EMPS` PARTITION (`X` = 'ab', `Y` = 'bc') COMPUTE STATISTICS");
+        sql("analyze table emps compute statistics for columns (^)^")
+                .fails("(?s).*Encountered \"\\)\" at line 1, column 52.\n.*");
+        sql("analyze table emps compute statistics for columns (a)")
+                .ok("ANALYZE TABLE `EMPS` COMPUTE STATISTICS FOR COLUMNS (`A`)");
+        sql("analyze table emps compute statistics for columns (a, b)")
+                .ok("ANALYZE TABLE `EMPS` COMPUTE STATISTICS FOR COLUMNS (`A`, `B`)");
+        sql("analyze table emps compute statistics for all columns")
+                .ok("ANALYZE TABLE `EMPS` COMPUTE STATISTICS FOR ALL COLUMNS");
+        sql("analyze table emps partition(x, y) compute statistics for all columns")
+                .ok("ANALYZE TABLE `EMPS` PARTITION (`X`, `Y`) COMPUTE STATISTICS FOR ALL COLUMNS");
+        sql("analyze table emps partition(x='ab', y) compute statistics for all columns")
+                .ok(
+                        "ANALYZE TABLE `EMPS` PARTITION (`X` = 'ab', `Y`) COMPUTE STATISTICS FOR ALL COLUMNS");
+        sql("analyze table emps partition(x, y='cd') compute statistics for all columns")
+                .ok(
+                        "ANALYZE TABLE `EMPS` PARTITION (`X`, `Y` = 'cd') COMPUTE STATISTICS FOR ALL COLUMNS");
+        sql("analyze table emps partition(x=^,^ y) compute statistics for all columns")
+                .fails("(?s).*Encountered \"\\,\" at line 1, column 32.\n.*");
+    }
+
     public static BaseMatcher<SqlNode> validated(String validatedSql) {
         return new TypeSafeDiagnosingMatcher<SqlNode>() {
             @Override


### PR DESCRIPTION

## What is the purpose of the change

*Introduce `ANALYZE TABLE` syntax in sql parser, see for detail from https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=217386481*


## Brief change log

  - *Introduce `ANALYZE TABLE` syntax in sql parser*


## Verifying this change



This change added tests and can be verified as follows:

  - *Extended FlinkSqlParserImplTest to verify different ANALYZE TABLE statements*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented)**
