### PR TITLE
[FLINK-28074][table-planner] show statistics details for DESCRIBE EXTENDED

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
@@ -1684,7 +1684,7 @@ public class HiveParserDDLSemanticAnalyzer {
         }
 
         ObjectIdentifier tableIdentifier = parseObjectIdentifier(tableName);
-        return new DescribeTableOperation(tableIdentifier, isExt || isFormatted);
+        return new DescribeTableOperation(tableIdentifier, isExt || isFormatted, null, null);
     }
 
     public static HashMap<String, String> getPartSpec(HiveParserASTNode partspec) {

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlDescribeHiveTable.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/SqlDescribeHiveTable.java
@@ -35,7 +35,7 @@ public class SqlDescribeHiveTable extends SqlRichDescribeTable {
             SqlIdentifier tableNameIdentifier,
             boolean extended,
             boolean formatted) {
-        super(pos, tableNameIdentifier, extended || formatted);
+        super(pos, tableNameIdentifier, extended || formatted, null, null);
         this.extended = extended;
         this.formatted = formatted;
     }

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -567,7 +567,7 @@ SqlShowCreate SqlShowCreate() :
 }
 
 /**
- * DESCRIBE | DESC [ EXTENDED] [[catalogName.] dataBasesName].tableName sql call.
+ * DESCRIBE | DESC [ EXTENDED] [[catalogName.] dataBasesName].tableName [PARTITION partitionSpec] [columnName] sql call.
  * Here we add Rich in className to distinguish from calcite's original SqlDescribeTable.
  */
 SqlRichDescribeTable SqlRichDescribeTable() :
@@ -575,13 +575,21 @@ SqlRichDescribeTable SqlRichDescribeTable() :
     SqlIdentifier tableName;
     SqlParserPos pos;
     boolean isExtended = false;
+    SqlNodeList partitionSpec = null;
+    SqlIdentifier columnName = null;
 }
 {
     ( <DESCRIBE> | <DESC> ) { pos = getPos();}
     [ <EXTENDED> { isExtended = true;} ]
     tableName = CompoundIdentifier()
+    [ <PARTITION> {
+          partitionSpec = new SqlNodeList(getPos());
+          ExtendedPartitionSpecCommaList(partitionSpec);
+          }
+    ]
+    [ columnName = SimpleIdentifier() ]
     {
-        return new SqlRichDescribeTable(pos, tableName, isExtended);
+        return new SqlRichDescribeTable(pos, tableName, isExtended, partitionSpec, columnName);
     }
 }
 

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/dql/SqlRichDescribeTable.java
@@ -18,34 +18,51 @@
 
 package org.apache.flink.sql.parser.dql;
 
+import org.apache.flink.sql.parser.SqlPartitionSpecProperty;
+
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlSpecialOperator;
 import org.apache.calcite.sql.SqlWriter;
 import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.util.NlsString;
+
+import javax.annotation.Nullable;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 
 /**
- * DESCRIBE [ EXTENDED] [[catalogName.] dataBasesName].sqlIdentifier sql call. Here we add Rich in
- * className to distinguish from calcite's original SqlDescribeTable.
+ * DESCRIBE [ EXTENDED] [[catalogName.] dataBasesName].tableNameIdentifier
+ * [PARTITION(partitionSpec)] [columnName] sql call. Here we add Rich in className to distinguish
+ * from calcite's original SqlDescribeTable.
  */
 public class SqlRichDescribeTable extends SqlCall {
 
     public static final SqlSpecialOperator OPERATOR =
             new SqlSpecialOperator("DESCRIBE TABLE", SqlKind.DESCRIBE_TABLE);
     protected final SqlIdentifier tableNameIdentifier;
-    private boolean isExtended = false;
+    private final boolean isExtended;
+    protected SqlNodeList partitions;
+    protected final SqlIdentifier columnName;
 
     public SqlRichDescribeTable(
-            SqlParserPos pos, SqlIdentifier tableNameIdentifier, boolean isExtended) {
+            SqlParserPos pos,
+            SqlIdentifier tableNameIdentifier,
+            boolean isExtended,
+            @Nullable SqlNodeList partitions,
+            @Nullable SqlIdentifier columnName) {
         super(pos);
         this.tableNameIdentifier = tableNameIdentifier;
         this.isExtended = isExtended;
+        this.partitions = partitions;
+        this.columnName = columnName;
     }
 
     @Override
@@ -66,6 +83,41 @@ public class SqlRichDescribeTable extends SqlCall {
         return tableNameIdentifier.names.toArray(new String[0]);
     }
 
+    public String getColumnName() {
+        if (columnName != null) {
+            return columnName.getSimple();
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Get partition spec as key-value strings, if only partition key is given, the corresponding
+     * value is null.
+     */
+    public LinkedHashMap<String, String> getPartitions() {
+        LinkedHashMap<String, String> ret = new LinkedHashMap<>();
+        if (partitions == null) {
+            return ret;
+        }
+        for (SqlNode node : partitions.getList()) {
+            SqlPartitionSpecProperty property = (SqlPartitionSpecProperty) node;
+            final String value;
+            if (property.getValue() == null) {
+                value = null;
+            } else {
+                Comparable<?> comparable = SqlLiteral.value(property.getValue());
+                value =
+                        comparable instanceof NlsString
+                                ? ((NlsString) comparable).getValue()
+                                : comparable.toString();
+            }
+
+            ret.put(property.getKey().getSimple(), value);
+        }
+        return ret;
+    }
+
     @Override
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
         writer.keyword("DESCRIBE");
@@ -73,5 +125,14 @@ public class SqlRichDescribeTable extends SqlCall {
             writer.keyword("EXTENDED");
         }
         tableNameIdentifier.unparse(writer, leftPrec, rightPrec);
+
+        if (partitions != null && partitions.size() > 0) {
+            writer.keyword("PARTITION");
+            partitions.unparse(writer, leftPrec, rightPrec);
+        }
+
+        if (columnName != null) {
+            columnName.unparse(writer, leftPrec, rightPrec);
+        }
     }
 }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -249,6 +249,32 @@ class FlinkSqlParserImplTest extends SqlParserTest {
         sql("desc tbl").ok("DESCRIBE `TBL`");
         sql("desc catalog1.db1.tbl").ok("DESCRIBE `CATALOG1`.`DB1`.`TBL`");
         sql("desc extended db1").ok("DESCRIBE EXTENDED `DB1`");
+
+        sql("desc tbl col1").ok("DESCRIBE `TBL` `COL1`");
+        sql("desc catalog1.db1.tbl col1").ok("DESCRIBE `CATALOG1`.`DB1`.`TBL` `COL1`");
+        sql("desc extended db1 col1").ok("DESCRIBE EXTENDED `DB1` `COL1`");
+
+        sql("desc tbl partition(a=1)").ok("DESCRIBE `TBL` PARTITION `A` = 1");
+        sql("desc catalog1.db1.tbl partition(a=1)")
+                .ok("DESCRIBE `CATALOG1`.`DB1`.`TBL` PARTITION `A` = 1");
+        sql("desc extended tbl partition(a=1)").ok("DESCRIBE EXTENDED `TBL` PARTITION `A` = 1");
+
+        sql("desc tbl partition(a)").ok("DESCRIBE `TBL` PARTITION `A`");
+        sql("desc catalog1.db1.tbl partition(a)")
+                .ok("DESCRIBE `CATALOG1`.`DB1`.`TBL` PARTITION `A`");
+        sql("desc extended tbl partition(a)").ok("DESCRIBE EXTENDED `TBL` PARTITION `A`");
+
+        sql("desc tbl partition(a=1) col1").ok("DESCRIBE `TBL` PARTITION `A` = 1 `COL1`");
+        sql("desc catalog1.db1.tbl partition(a=1) col1")
+                .ok("DESCRIBE `CATALOG1`.`DB1`.`TBL` PARTITION `A` = 1 `COL1`");
+        sql("desc extended tbl partition(a=1) col1")
+                .ok("DESCRIBE EXTENDED `TBL` PARTITION `A` = 1 `COL1`");
+
+        sql("desc tbl partition(a) col1").ok("DESCRIBE `TBL` PARTITION `A` `COL1`");
+        sql("desc tbl partition(a=1, b=2) col1")
+                .ok("DESCRIBE `TBL` PARTITION `A` = 1, `B` = 2 `COL1`");
+        sql("desc extended tbl partition(a=1, b=2) col1")
+                .ok("DESCRIBE EXTENDED `TBL` PARTITION `A` = 1, `B` = 2 `COL1`");
     }
 
     @Test

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StaticResultProvider.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/StaticResultProvider.java
@@ -31,6 +31,7 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 
 /** Create result provider from a static set of data using external types. */
@@ -103,14 +104,17 @@ public class StaticResultProvider implements ResultProvider {
         Object[] values = new Object[row.getArity()];
         for (int i = 0; i < row.getArity(); i++) {
             Object value = row.getField(i);
-            if (value == null) {
+            if (value == null || (value instanceof Optional && !((Optional) value).isPresent())) {
                 values[i] = null;
             } else if (value instanceof String) {
                 values[i] = StringData.fromString((String) value);
             } else if (value instanceof Boolean
                     || value instanceof Long
-                    || value instanceof Integer) {
+                    || value instanceof Integer
+                    || value instanceof Double) {
                 values[i] = value;
+            } else if (value instanceof Optional && ((Optional) value).isPresent()) {
+                values[i] = ((Optional) value).get();
             } else {
                 throw new TableException("Cannot convert row type");
             }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/FilterUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/FilterUtils.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.utils;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.util.Preconditions;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.LOWER;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.UPPER;
+
+/** Utils for catalog and source to filter partition or row. */
+public class FilterUtils {
+
+    public static boolean shouldPushDown(ResolvedExpression expr, Set<String> filterableFields) {
+        if (expr instanceof CallExpression && expr.getChildren().size() == 2) {
+            return shouldPushDownUnaryExpression(
+                            expr.getResolvedChildren().get(0), filterableFields)
+                    && shouldPushDownUnaryExpression(
+                            expr.getResolvedChildren().get(1), filterableFields);
+        }
+        return false;
+    }
+
+    public static boolean isRetainedAfterApplyingFilterPredicates(
+            List<ResolvedExpression> predicates, Function<String, Comparable<?>> getter)
+            throws RuntimeException {
+        for (ResolvedExpression predicate : predicates) {
+            if (predicate instanceof CallExpression) {
+                FunctionDefinition definition =
+                        ((CallExpression) predicate).getFunctionDefinition();
+                boolean result = false;
+                if (definition.equals(BuiltInFunctionDefinitions.OR)) {
+                    // nested filter, such as (key1 > 2 or key2 > 3)
+                    for (Expression expr : predicate.getChildren()) {
+                        if (!(expr instanceof CallExpression && expr.getChildren().size() == 2)) {
+                            throw new TableException(expr + " not supported!");
+                        }
+                        result = binaryFilterApplies((CallExpression) expr, getter);
+                        if (result) {
+                            break;
+                        }
+                    }
+                } else if (predicate.getChildren().size() == 2) {
+                    result = binaryFilterApplies((CallExpression) predicate, getter);
+                } else {
+                    throw new UnsupportedOperationException(
+                            String.format("Unsupported expr: %s.", predicate));
+                }
+                if (!result) {
+                    return false;
+                }
+            } else {
+                throw new UnsupportedOperationException(
+                        String.format("Unsupported expr: %s.", predicate));
+            }
+        }
+        return true;
+    }
+
+    private static boolean shouldPushDownUnaryExpression(
+            ResolvedExpression expr, Set<String> filterableFields) {
+        // validate that type is comparable
+        if (!isComparable(expr.getOutputDataType().getConversionClass())) {
+            return false;
+        }
+        if (expr instanceof FieldReferenceExpression) {
+            if (filterableFields.contains(((FieldReferenceExpression) expr).getName())) {
+                return true;
+            }
+        }
+
+        if (expr instanceof ValueLiteralExpression) {
+            return true;
+        }
+
+        if (expr instanceof CallExpression && expr.getChildren().size() == 1) {
+            if (((CallExpression) expr).getFunctionDefinition().equals(UPPER)
+                    || ((CallExpression) expr).getFunctionDefinition().equals(LOWER)) {
+                return shouldPushDownUnaryExpression(
+                        expr.getResolvedChildren().get(0), filterableFields);
+            }
+        }
+        // other resolved expressions return false
+        return false;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static boolean binaryFilterApplies(
+            CallExpression binExpr, Function<String, Comparable<?>> getter)
+            throws RuntimeException {
+        List<Expression> children = binExpr.getChildren();
+        Preconditions.checkArgument(children.size() == 2);
+
+        Comparable lhsValue = getValue(children.get(0), getter);
+        Comparable rhsValue = getValue(children.get(1), getter);
+        FunctionDefinition functionDefinition = binExpr.getFunctionDefinition();
+        if (BuiltInFunctionDefinitions.GREATER_THAN.equals(functionDefinition)) {
+            return lhsValue.compareTo(rhsValue) > 0;
+        } else if (BuiltInFunctionDefinitions.LESS_THAN.equals(functionDefinition)) {
+            return lhsValue.compareTo(rhsValue) < 0;
+        } else if (BuiltInFunctionDefinitions.GREATER_THAN_OR_EQUAL.equals(functionDefinition)) {
+            return lhsValue.compareTo(rhsValue) >= 0;
+        } else if (BuiltInFunctionDefinitions.LESS_THAN_OR_EQUAL.equals(functionDefinition)) {
+            return lhsValue.compareTo(rhsValue) <= 0;
+        } else if (BuiltInFunctionDefinitions.EQUALS.equals(functionDefinition)) {
+            return lhsValue.compareTo(rhsValue) == 0;
+        } else if (BuiltInFunctionDefinitions.NOT_EQUALS.equals(functionDefinition)) {
+            return lhsValue.compareTo(rhsValue) != 0;
+        } else {
+            throw new UnsupportedOperationException("Unsupported operator: " + functionDefinition);
+        }
+    }
+
+    private static boolean isComparable(Class<?> clazz) {
+        return Comparable.class.isAssignableFrom(clazz);
+    }
+
+    private static Comparable<?> getValue(Expression expr, Function<String, Comparable<?>> getter) {
+        if (expr instanceof ValueLiteralExpression) {
+            Optional<?> value =
+                    ((ValueLiteralExpression) expr)
+                            .getValueAs(
+                                    ((ValueLiteralExpression) expr)
+                                            .getOutputDataType()
+                                            .getConversionClass());
+            return (Comparable<?>) value.orElse(null);
+        }
+
+        if (expr instanceof FieldReferenceExpression) {
+            return getter.apply(((FieldReferenceExpression) expr).getName());
+        }
+
+        if (expr instanceof CallExpression && expr.getChildren().size() == 1) {
+            Object child = getValue(expr.getChildren().get(0), getter);
+            FunctionDefinition functionDefinition = ((CallExpression) expr).getFunctionDefinition();
+            if (functionDefinition.equals(UPPER)) {
+                return child.toString().toUpperCase();
+            } else if (functionDefinition.equals(LOWER)) {
+                return child.toString().toLowerCase();
+            } else {
+                throw new UnsupportedOperationException(
+                        String.format("Unrecognized function definition: %s.", functionDefinition));
+            }
+        }
+        throw new UnsupportedOperationException(expr + " not supported!");
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/print/PrintStyle.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/print/PrintStyle.java
@@ -68,7 +68,8 @@ public interface PrintStyle {
                         schema.getColumns(), maxColumnWidth, printNullAsEmpty, printRowKind),
                 maxColumnWidth,
                 printNullAsEmpty,
-                printRowKind);
+                printRowKind,
+                false);
     }
 
     /**
@@ -86,7 +87,18 @@ public interface PrintStyle {
             boolean printRowKind) {
         Preconditions.checkArgument(maxColumnWidth > 0, "maxColumnWidth should be greater than 0");
         return new TableauStyle(
-                schema, converter, null, maxColumnWidth, printNullAsEmpty, printRowKind);
+                schema, converter, null, maxColumnWidth, printNullAsEmpty, printRowKind, false);
+    }
+
+    static TableauStyle tableauWithDataInferredColumnWidthsAndContentLeftAlign(
+            ResolvedSchema schema,
+            RowDataToStringConverter converter,
+            int maxColumnWidth,
+            boolean printNullAsEmpty,
+            boolean printRowKind) {
+        Preconditions.checkArgument(maxColumnWidth > 0, "maxColumnWidth should be greater than 0");
+        return new TableauStyle(
+                schema, converter, null, maxColumnWidth, printNullAsEmpty, printRowKind, true);
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/print/TableauStyle.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/utils/print/TableauStyle.java
@@ -82,6 +82,9 @@ public final class TableauStyle implements PrintStyle {
     /** A flag to indicate whether print row kind info. */
     private final boolean printRowKind;
 
+    /** Content is left-aligned, default is false. */
+    private boolean leftAligned = false;
+
     private int[] columnWidths;
 
     private String[] columnNames;
@@ -92,12 +95,14 @@ public final class TableauStyle implements PrintStyle {
             int[] columnWidths,
             int maxColumnWidth,
             boolean printNullAsEmpty,
-            boolean printRowKind) {
+            boolean printRowKind,
+            boolean leftAligned) {
         this.converter = converter;
         this.columnWidths = columnWidths;
         this.maxColumnWidth = maxColumnWidth;
         this.printNullAsEmpty = printNullAsEmpty;
         this.printRowKind = printRowKind;
+        this.leftAligned = leftAligned;
 
         if (printRowKind) {
             this.columnNames =
@@ -198,8 +203,13 @@ public final class TableauStyle implements PrintStyle {
             sb.append(" ");
             int displayWidth = getStringDisplayWidth(col);
             if (displayWidth <= columnWidths[idx]) {
-                sb.append(EncodingUtils.repeat(' ', columnWidths[idx] - displayWidth));
-                sb.append(col);
+                if (leftAligned) {
+                    sb.append(col);
+                    sb.append(EncodingUtils.repeat(' ', columnWidths[idx] - displayWidth));
+                } else {
+                    sb.append(EncodingUtils.repeat(' ', columnWidths[idx] - displayWidth));
+                    sb.append(col);
+                }
             } else {
                 sb.append(truncateString(col, columnWidths[idx] - COLUMN_TRUNCATED_FLAG.length()));
                 sb.append(COLUMN_TRUNCATED_FLAG);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/DatabaseCalciteSchema.java
@@ -41,7 +41,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static java.lang.String.format;
-import static org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter.convertToTableStats;
+import static org.apache.flink.table.utils.stats.CatalogTableStatisticsConverter.convertToTableStats;
 
 /**
  * A mapping between Flink catalog's database and Calcite's schema. Tables are registered as tables

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
@@ -47,15 +47,14 @@ import org.apache.calcite.rel.logical.LogicalTableScan;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.config.OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED;
-import static org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter.convertToAccumulatedTableStates;
+import static org.apache.flink.table.utils.stats.CatalogTableStatisticsConverter.convertToAccumulatedTableStates;
+import static org.apache.flink.table.utils.stats.CatalogTableStatisticsConverter.getPartitionKeys;
 
 /**
  * A FlinkOptimizeProgram that recompute statistics after partition pruning and filter push down.
@@ -214,15 +213,6 @@ public class FlinkRecomputeStatisticsProgram implements FlinkOptimizeProgram<Bat
         } catch (PartitionNotExistException e) {
             return Optional.empty();
         }
-    }
-
-    private static Set<String> getPartitionKeys(List<CatalogPartitionSpec> catalogPartitionSpecs) {
-        Set<String> partitionKeys = new HashSet<>();
-        for (CatalogPartitionSpec catalogPartitionSpec : catalogPartitionSpecs) {
-            Map<String, String> partitionSpec = catalogPartitionSpec.getPartitionSpec();
-            partitionKeys.addAll(partitionSpec.keySet());
-        }
-        return partitionKeys;
     }
 
     @SuppressWarnings({"unchecked", "raw"})

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
@@ -26,10 +26,11 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.schema.LegacyTableSourceTable
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic
 import org.apache.flink.table.planner.plan.utils.{FlinkRelOptUtil, PartitionPruner, RexNodeExtractor, RexNodeToExpressionConverter}
-import org.apache.flink.table.planner.utils.{CatalogTableStatisticsConverter, TableConfigUtils}
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapContext
+import org.apache.flink.table.planner.utils.TableConfigUtils
 import org.apache.flink.table.sources.PartitionableTableSource
+import org.apache.flink.table.utils.stats.CatalogTableStatisticsConverter
 
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.plan.RelOptRule.{none, operand}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
@@ -30,8 +30,8 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.plan.stats.ColumnStats;
 import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
-import org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter;
 import org.apache.flink.table.planner.utils.StatisticsReportTestBase;
+import org.apache.flink.table.utils.stats.CatalogTableStatisticsConverter;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverterTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.utils;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
 import org.apache.flink.table.plan.stats.ColumnStats;
+import org.apache.flink.table.utils.stats.CatalogTableStatisticsConverter;
 
 import org.junit.Test;
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

At first, this PR only wanted to support syntax `DESCRIBE EXTENDED` to print table statistics. But now, this PR is aims to realize syntax `DESCRIBE/DESC [EXTENDED]  [catalog_name.][database_name.]table_name [PARTITION(partition_spec)] [col_name]`.  Syntax implementation, get statistics from catalog and printing are mainly completed in this PR


## Brief change log

- Re implemented method `SqlRichDescribeTable` in `parserImpls.ftl`
- In `TableEnvironmentImpl`,  realize `buildDescribeResult` to build desc result.
- realize `listPartitionsByFilter` method in `GenericInMemoryCatalog` to support get partial partitions for genericInMemoryCatalog.
- Adding UT test in 'TableEnvironmentTest' to cover `desc [extended]` for none-partitioned table and partitioned table.


## Verifying this change

- Adding UT test in 'TableEnvironmentTest' to cover `desc [extended]` for none-partitioned table and partitioned table.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no 
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature?  yes 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
now there is no docs about this feature. will be adding