### PR TITLE
[FLINK-26412][hive] Hive dialect supports "create function using jar"

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -51,6 +51,7 @@ import org.apache.flink.table.utils.CatalogManagerMocks;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FileUtils;
+import org.apache.flink.util.UserClassLoaderJarTestUtils;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
@@ -73,7 +74,9 @@ import org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe;
 import org.junit.After;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.net.URI;
@@ -88,6 +91,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test Hive syntax when Hive dialect is used. */
 public class HiveDialectITCase {
+
+    @ClassRule public static TemporaryFolder tempFolder = new TemporaryFolder();
 
     private TableEnvironment tableEnv;
     private HiveCatalog hiveCatalog;
@@ -784,6 +789,44 @@ public class HiveDialectITCase {
         tableEnv.executeSql("drop temporary function temp_split_struct_obj_inspector");
         functions = tableEnv.listUserDefinedFunctions();
         assertThat(functions.length).isEqualTo(0);
+    }
+
+    @Test
+    public void testCreateFunctionUsingJar() throws Exception {
+        tableEnv.executeSql("create table src(x int)");
+        tableEnv.executeSql("insert into src values (1), (2)").await();
+        String udfClass = "addOne";
+        String udfCode =
+                "public class "
+                        + udfClass
+                        + " extends org.apache.hadoop.hive.ql.exec.UDF {\n"
+                        + " public int evaluate(int content) {\n"
+                        + "    return content + 1;\n"
+                        + " }"
+                        + "}\n";
+        File jarFile =
+                UserClassLoaderJarTestUtils.createJarFile(
+                        tempFolder.newFolder("test-jar"), "test-udf.jar", udfClass, udfCode);
+        // test create function using jar
+        tableEnv.executeSql(
+                String.format(
+                        "create function add_one as 'addOne' using jar '%s'", jarFile.getPath()));
+        assertThat(
+                        CollectionUtil.iteratorToList(
+                                        tableEnv.executeSql("select add_one(x) from src").collect())
+                                .toString())
+                .isEqualTo("[+I[2], +I[3]]");
+        // test create temporary function using jar
+        tableEnv.executeSql(
+                String.format(
+                        "create temporary function t_add_one as 'addOne' using jar '%s'",
+                        jarFile.getPath()));
+        assertThat(
+                        CollectionUtil.iteratorToList(
+                                        tableEnv.executeSql("select t_add_one(x) from src")
+                                                .collect())
+                                .toString())
+                .isEqualTo("[+I[2], +I[3]]");
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To make Hive dialect support `create function using jar`


## Brief change log
  -  Get the function resource list to set them to `CatalogFunction` in parse phase
  -  When create function for HiveCatalog , set the function's resources so that we can persist the resources info to HMS.

## Verifying this change
The [test](https://github.com/apache/flink/pull/20251/files#diff-b9f5b4d8498dfe849cb01747b77c3b7c081e5262f850e845e88f807e6c3e9b11R293) to make sure HiveCatalog can persist function to HMS normally.
The [test](https://github.com/apache/flink/pull/20251/files#diff-748a9fa63f15b3bd3ea5426a5b42179cadee77ecf3359c83f846aedb27d96871R723) is to make sure Hive dialect can using "create [temporary] function using jar".

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? N/A
