### PR TITLE
[hotfix][docs-zh] Add missing the working_directory.md file to the standalone part.

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/working_directory.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/working_directory.md
@@ -1,0 +1,75 @@
+---
+title: Working Directory
+weight: 3
+type: docs
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Working Directory
+
+Flink supports to configure a working directory ([FLIP-198](https://cwiki.apache.org/confluence/x/ZZiqCw)) for Flink processes (JobManager and TaskManager).
+The working directory is used by the processes to store information that can be recovered upon a process restart.
+The requirement for this to work is that the process is started with the same identity and has access to the volume on which the working directory is stored.
+
+## Configuring the Working Directory
+
+The working directories for the Flink processes are: 
+
+* JobManager working directory: `<WORKING_DIR_BASE>/jm_<JM_RESOURCE_ID>` 
+* TaskManager working directory: `<WORKING_DIR_BASE>/tm_<TM_RESOURCE_ID>`
+
+with `<WORKING_DIR_BASE>` being the working directory base, `<JM_RESOURCE_ID>` being the resource id of the JobManager process and `<TM_RESOURCE_ID>` being the resource id of the TaskManager process.
+
+The `<WORKING_DIR_BASE>` can be configured by `process.working-dir`.
+It needs to point to a local directory.
+If not explicitly configured, then it defaults to a randomly picked directory from `io.tmp.dirs`.
+
+It is also possible to configure a JobManager and TaskManager specific `<WORKING_DIR_BASE>` via `process.jobmanager.working-dir` and `process.taskmanager.working-dir` respectively.
+
+The JobManager resource id can be configured via `jobmanager.resource-id`.
+If not explicitly configured, then it will be a random UUID.
+
+Similarly, the TaskManager resource id can be configured via `taskmanager.resource-id`.
+If not explicitly configured, then it will be a random value containing the host and port of the running process. 
+
+## Artifacts Stored in the Working Directory
+
+Flink processes will use the working directory to store the following artifacts:
+
+* Blobs stored by the `BlobServer` and `BlobCache`
+* Local state if `state.backend.local-recovery` is enabled
+* RocksDB's working directory
+
+## Local Recovery Across Process Restarts
+
+The working directory can be used to enable local recovery across process restarts ([FLIP-201](https://cwiki.apache.org/confluence/x/wJuqCw)).
+This means that Flink does not have to recover state information from remote storage. 
+
+In order to use this feature, local recovery has to be enabled via `state.backend.local-recovery`.
+Moreover, the TaskManager processes need to get a deterministic resource id assigned via `taskmanager.resource-id`.
+Last but not least, a failed TaskManager process needs to be restarted with the same working directory.
+
+```bash
+process.working-dir: /path/to/working/dir/base
+state.backend.local-recovery: true
+taskmanager.resource-id: TaskManager_1 # important: Change for every TaskManager process
+```
+
+{{< top >}}


### PR DESCRIPTION
## What is the purpose of the change

- **This is the English document：**

![image](https://user-images.githubusercontent.com/95120044/178500312-07ff8795-4375-434b-8326-d014f4b36d67.png)

- **This is the Chinese document：**

![image](https://user-images.githubusercontent.com/95120044/178500669-1c121092-a84b-48d4-bdfe-194e32f903a2.png)

- **According to the above two figures, it can be seen that the  working_directory.md file  is missing in the  standalone  Chinese document.**

## Brief change log

-  **Add missing the working_directory.md file to the standalone part.**


## Verifying this change

- **This change is a trivial rework / code cleanup without any test coverage.**


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
