### PR TITLE
[FLINK-24713][Runtime/Coordination] Postpone resourceManager serving

### DIFF
--- a/docs/layouts/shortcodes/generated/resource_manager_configuration.html
+++ b/docs/layouts/shortcodes/generated/resource_manager_configuration.html
@@ -15,6 +15,12 @@
             <td>Timeout for jobs which don't have a job manager as leader assigned.</td>
         </tr>
         <tr>
+            <td><h5>resourcemanager.previous-worker.recovery.timeout</h5></td>
+            <td style="word-wrap: break-word;">0 ms</td>
+            <td>Duration</td>
+            <td>Timeout for resource manager to recover all the previous attempts workers. If exceeded, resource manager will handle new resource requests by requesting new workers. If you would like to reuse the previous workers as much as possible, you should configure a longer timeout time to wait for previous workers to register.</td>
+        </tr>
+        <tr>
             <td><h5>resourcemanager.rpc.port</h5></td>
             <td style="word-wrap: break-word;">0</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -261,6 +261,17 @@ public class ResourceManagerOptions {
                                     + TaskManagerOptions.REGISTRATION_TIMEOUT.key()
                                     + "'.");
 
+    /** Timeout for ResourceManager to recover all the previous attempts workers. */
+    public static final ConfigOption<Duration> RESOURCE_MANAGER_PREVIOUS_WORKER_RECOVERY_TIMEOUT =
+            ConfigOptions.key("resourcemanager.previous-worker.recovery.timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(0))
+                    .withDescription(
+                            "Timeout for resource manager to recover all the previous attempts workers. If exceeded,"
+                                    + " resource manager will handle new resource requests by requesting new workers."
+                                    + " If you would like to reuse the previous workers as much as possible, you should"
+                                    + " configure a longer timeout time to wait for previous workers to register.");
+
     // ---------------------------------------------------------------------------------------------
 
     /** Not intended to be instantiated. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -36,6 +36,7 @@ import org.apache.flink.util.Preconditions;
 import javax.annotation.Nullable;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
@@ -125,5 +126,10 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
                     startupPeriodMillis,
                     TimeUnit.MILLISECONDS);
         }
+    }
+
+    @Override
+    public CompletableFuture<Void> getReadyToServeFuture() {
+        return CompletableFuture.completedFuture(null);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerFactory.java
@@ -109,6 +109,10 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
         final Duration workerRegistrationTimeout =
                 configuration.get(ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT);
+        final Duration previousWorkerRecoverTimeout =
+                configuration.get(
+                        ResourceManagerOptions.RESOURCE_MANAGER_PREVIOUS_WORKER_RECOVERY_TIMEOUT);
+
         return new ActiveResourceManager<>(
                 createResourceManagerDriver(
                         configuration, webInterfaceUrl, rpcService.getAddress()),
@@ -128,6 +132,7 @@ public abstract class ActiveResourceManagerFactory<WorkerType extends ResourceID
                 failureRater,
                 retryInterval,
                 workerRegistrationTimeout,
+                previousWorkerRecoverTimeout,
                 ioExecutor);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.resourcemanager;
 
+import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.blocklist.BlocklistHandler;
 import org.apache.flink.runtime.clusterframework.ApplicationStatus;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
@@ -31,10 +32,13 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
+import org.apache.flink.util.TimeUtils;
 
 import javax.annotation.Nullable;
 
 import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.function.Function;
 
@@ -42,6 +46,7 @@ import java.util.function.Function;
 public class TestingResourceManager extends ResourceManager<ResourceID> {
 
     private final Function<ResourceID, Boolean> stopWorkerFunction;
+    private final CompletableFuture<Void> readyToServeFuture;
 
     public TestingResourceManager(
             RpcService rpcService,
@@ -55,7 +60,8 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
             JobLeaderIdService jobLeaderIdService,
             FatalErrorHandler fatalErrorHandler,
             ResourceManagerMetricGroup resourceManagerMetricGroup,
-            Function<ResourceID, Boolean> stopWorkerFunction) {
+            Function<ResourceID, Boolean> stopWorkerFunction,
+            CompletableFuture<Void> readyToServeFuture) {
         super(
                 rpcService,
                 leaderSessionId,
@@ -73,6 +79,7 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
                 ForkJoinPool.commonPool());
 
         this.stopWorkerFunction = stopWorkerFunction;
+        this.readyToServeFuture = readyToServeFuture;
     }
 
     @Override
@@ -105,5 +112,14 @@ public class TestingResourceManager extends ResourceManager<ResourceID> {
     @Override
     public boolean stopWorker(ResourceID worker) {
         return stopWorkerFunction.apply(worker);
+    }
+
+    @Override
+    public CompletableFuture<Void> getReadyToServeFuture() {
+        return readyToServeFuture;
+    }
+
+    public <T> CompletableFuture<T> runInMainThread(Callable<T> callable, Time timeout) {
+        return callAsync(callable, TimeUtils.toDuration(timeout));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
@@ -238,5 +238,10 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
             return getTerminationFutureFunction.apply(
                     MockResourceManager.this, super.getTerminationFuture());
         }
+
+        @Override
+        public CompletableFuture<Void> getReadyToServeFuture() {
+            return CompletableFuture.completedFuture(null);
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -47,6 +47,8 @@ import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.function.RunnableWithException;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -67,6 +69,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
@@ -841,6 +844,71 @@ public class ActiveResourceManagerTest extends TestLogger {
         };
     }
 
+    @Test
+    public void testResourceManagerRecoveredAfterAllTMRegistered() throws Exception {
+        new Context() {
+            {
+                final ResourceID tmResourceId1 = ResourceID.generate();
+                final ResourceID tmResourceId2 = ResourceID.generate();
+
+                runTest(
+                        () -> {
+                            // workers recovered
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .onPreviousAttemptWorkersRecovered(
+                                                            ImmutableSet.of(
+                                                                    tmResourceId1, tmResourceId2)));
+
+                            runInMainThread(
+                                    () -> getResourceManager().onWorkerRegistered(tmResourceId1));
+                            runInMainThread(
+                                    () -> getResourceManager().onWorkerRegistered(tmResourceId2));
+                            runInMainThread(
+                                            () ->
+                                                    assertTrue(
+                                                            getResourceManager()
+                                                                    .getReadyToServeFuture()
+                                                                    .isDone()))
+                                    .get(TIMEOUT_SEC, TimeUnit.SECONDS);
+                        });
+            }
+        };
+    }
+
+    @Test
+    public void testResourceManagerRecoveredAfterReconcileTimeout() throws Exception {
+        new Context() {
+            {
+                final ResourceID tmResourceId1 = ResourceID.generate();
+                final ResourceID tmResourceId2 = ResourceID.generate();
+
+                flinkConfig.set(
+                        ResourceManagerOptions.RESOURCE_MANAGER_PREVIOUS_WORKER_RECOVERY_TIMEOUT,
+                        Duration.ofMillis(TESTING_START_WORKER_TIMEOUT_MS));
+
+                runTest(
+                        () -> {
+                            // workers recovered
+                            runInMainThread(
+                                    () -> {
+                                        getResourceManager()
+                                                .onPreviousAttemptWorkersRecovered(
+                                                        ImmutableSet.of(
+                                                                tmResourceId1, tmResourceId2));
+                                    });
+
+                            runInMainThread(
+                                    () -> getResourceManager().onWorkerRegistered(tmResourceId1));
+                            getResourceManager()
+                                    .getReadyToServeFuture()
+                                    .get(TIMEOUT_SEC, TimeUnit.SECONDS);
+                        });
+            }
+        };
+    }
+
     private static class Context {
 
         final Configuration flinkConfig = new Configuration();
@@ -886,6 +954,10 @@ public class ActiveResourceManagerTest extends TestLogger {
                     configuration.get(ResourceManagerOptions.START_WORKER_RETRY_INTERVAL);
             final Duration workerRegistrationTimeout =
                     configuration.get(ResourceManagerOptions.TASK_MANAGER_REGISTRATION_TIMEOUT);
+            final Duration previousWorkerRecoverTimeout =
+                    configuration.get(
+                            ResourceManagerOptions
+                                    .RESOURCE_MANAGER_PREVIOUS_WORKER_RECOVERY_TIMEOUT);
 
             final ActiveResourceManager<ResourceID> activeResourceManager =
                     new ActiveResourceManager<>(
@@ -907,6 +979,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     configuration),
                             retryInterval,
                             workerRegistrationTimeout,
+                            previousWorkerRecoverTimeout,
                             ForkJoinPool.commonPool());
 
             activeResourceManager.start();
@@ -917,8 +990,8 @@ public class ActiveResourceManagerTest extends TestLogger {
             return activeResourceManager;
         }
 
-        void runInMainThread(Runnable runnable) {
-            resourceManager.runInMainThread(
+        CompletableFuture<Void> runInMainThread(Runnable runnable) {
+            return resourceManager.runInMainThread(
                     () -> {
                         runnable.run();
                         return null;


### PR DESCRIPTION
…after the recovery phase has finished

## What is the purpose of the change

This PR is meant to solve the problem of request the extra worker after JobManager failover. Related issue:

https://issues.apache.org/jira/browse/FLINK-24713
https://issues.apache.org/jira/browse/FLINK-27576

Based on https://github.com/apache/flink/pull/19786

## Brief change log

  -  Add the getRecoveryFuture interface in `resourceManager` to let the subclass to tell whether it is ready to serve.
  -  Postpone the process resource until the recovery future is ready.

## Verifying this change

Two tests are added to verify the change.

