### PR TITLE
[FLINK-28530][table-planner] Improvement of extraction of conditions that can be pushed into join inputs

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/FlinkRexExtract.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/FlinkRexExtract.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlKind;
+
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Extracts sub-condition according AND/OR structure of condition. We must be able to extract at
+ * least one sub-condition from each of the arms of the OR, else the result will be true literal. It
+ * is assumed that condition has already been simplified (e.g. by FlinkRexUtil.simplify) in such a
+ * way that there is no NOT before AND/OR.
+ */
+@Internal
+public final class FlinkRexExtract {
+    private final RexBuilder rexBuilder;
+
+    public FlinkRexExtract(RexBuilder rexBuilder) {
+        this.rexBuilder = rexBuilder;
+    }
+
+    public RexNode extract(RexNode rex, Predicate<RexNode> extractable) {
+        return extractRecur(rex, extractable);
+    }
+
+    private RexNode extractRecur(RexNode rex, Predicate<RexNode> extractable) {
+        if (rex.isA(SqlKind.OR) || rex.isA(SqlKind.AND)) {
+            Stream<RexNode> ops = operands(rex).map(r -> extractRecur(r, extractable));
+            if (rex.isA(SqlKind.OR)) {
+                return or(ops);
+            }
+            return and(ops);
+        }
+        if (extractable.test(rex)) {
+            return rex;
+        }
+        return rexBuilder.makeLiteral(true);
+    }
+
+    private Stream<RexNode> operands(RexNode rex) {
+        return ((RexCall) rex).getOperands().stream();
+    }
+
+    private RexNode or(Stream<RexNode> rexs) {
+        return RexUtil.composeDisjunction(rexBuilder, rexs.collect(Collectors.toList()));
+    }
+
+    private RexNode and(Stream<RexNode> rexs) {
+        return RexUtil.composeConjunction(rexBuilder, rexs.collect(Collectors.toList()));
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -585,6 +585,11 @@ object FlinkRexUtil {
     }
     false
   }
+
+  /** Extracts sub-condition according AND/OR structure of condition. */
+  def extract(rexBuilder: RexBuilder, rex: RexNode, extractable: Predicate[RexNode]): RexNode = {
+    new FlinkRexExtract(rexBuilder).extract(rex, extractable)
+  }
 }
 
 /**

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/FlinkRexExtractTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/FlinkRexExtractTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.calcite.FlinkTypeSystem;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import static org.junit.Assert.assertEquals;
+
+/** Test for {@link FlinkRexExtract}. */
+public class FlinkRexExtractTest {
+    RexBuilder rexBuilder;
+    FlinkRexExtract rexExtract;
+    Predicate<RexNode> onlyA;
+    RexNode a0, a1, a2, a3;
+    RexNode b0, b1, b2;
+
+    @Before
+    public void setUp() {
+        FlinkTypeFactory typeFactory =
+                new FlinkTypeFactory(
+                        Thread.currentThread().getContextClassLoader(), FlinkTypeSystem.INSTANCE);
+        rexBuilder = new RexBuilder(typeFactory);
+        rexExtract = new FlinkRexExtract(rexBuilder);
+        a0 = atom(0);
+        a1 = atom(1);
+        a2 = atom(2);
+        a3 = atom(3);
+        b0 = atom(4);
+        b1 = atom(5);
+        b2 = atom(6);
+        onlyA = rex -> Arrays.asList(a0, a1, a2, a3).contains(rex);
+    }
+
+    @Test
+    public void testSimple() {
+        // ((a0 and b0) or a1) => (a0 or a1)
+        RexNode rex = or(and(a0, b0), a1);
+        RexNode expected = or(a0, a1);
+        assertEquals(expected, rexExtract.extract(rex, onlyA));
+    }
+
+    @Test
+    public void testDeepNested() {
+        // ((((((a0 and b0) or a1) and b1) or a2) and b2) or a3) => (a0 or a1 or a2 or a3)
+        RexNode rex = or(and(or(and(or(and(a0, b0), a1), b1), a2), b2), a3);
+        RexNode expected = or(a0, a1, a2, a3);
+        assertEquals(expected, rexExtract.extract(rex, onlyA));
+    }
+
+    RexNode atom(int ordinal) {
+        RelDataType type = rexBuilder.getTypeFactory().createSqlType(SqlTypeName.INTEGER);
+        RexNode zeroLiteral = rexBuilder.makeLiteral(0, type, false);
+        RexInputRef inputRef = rexBuilder.makeInputRef(type, ordinal);
+        return rexBuilder.makeCall(SqlStdOperatorTable.EQUALS, inputRef, zeroLiteral);
+    }
+
+    RexNode or(RexNode... rexs) {
+        return RexUtil.composeDisjunction(rexBuilder, Arrays.asList(rexs));
+    }
+
+    RexNode and(RexNode... rexs) {
+        return RexUtil.composeConjunction(rexBuilder, Arrays.asList(rexs));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/JoinDependentConditionDerivationRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/JoinDependentConditionDerivationRuleTest.xml
@@ -120,7 +120,7 @@ LogicalProject(a=[$0], d=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(a=[$0], d=[$3])
-+- LogicalJoin(condition=[AND(OR(AND(=($0, 1), =($3, 2)), AND(=($0, 2), =($3, 1))), OR(AND(=($0, 3), =($3, 4)), AND(=($0, 4), =($3, 3))), SEARCH($0, Sarg[1, 2]), SEARCH($3, Sarg[1, 2]), SEARCH($0, Sarg[3, 4]), SEARCH($3, Sarg[3, 4]))], joinType=[inner])
++- LogicalJoin(condition=[AND(OR(AND(=($0, 1), =($3, 2)), AND(=($0, 2), =($3, 1))), OR(AND(=($0, 3), =($3, 4)), AND(=($0, 4), =($3, 3))), SEARCH($0, Sarg[1, 2]), SEARCH($0, Sarg[3, 4]), SEARCH($3, Sarg[1, 2]), SEARCH($3, Sarg[3, 4]))], joinType=[inner])
    :- LogicalTableScan(table=[[default_catalog, default_database, MyTable1, source: [TestTableSource(a, b, c)]]])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable2, source: [TestTableSource(d, e, f, g, h)]]])
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/JoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/JoinTest.xml
@@ -102,6 +102,29 @@ Join(joinType=[InnerJoin], where=[(((a = 0) AND (d = 3)) OR SEARCH(a, Sarg[1]))]
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testDependentConditionDerivationInnerJoinDeepNested">
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], d=[$3], e=[$4])
++- LogicalFilter(condition=[AND(OR(AND(OR(AND(=($0, 0), =($3, 3)), =($1, 2)), =($4, 4)), =($2, _UTF-16LE'A')), =($5, _UTF-16LE'B'))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, d, e])
++- Join(joinType=[InnerJoin], where=[(((((a = 0) AND (d = 3)) OR (b = 2)) AND (e = 4)) OR (c = 'A'))], select=[a, b, c, d, e], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[single])
+   :  +- Calc(select=[a, b, c], where=[((a = 0) OR (b = 2) OR (c = 'A'))])
+   :     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[d, e], where=[(f = 'B')])
+         +- DataStreamScan(table=[[default_catalog, default_database, T2]], fields=[d, e, f])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testLeftOuterJoinEquiAndLocalPred">
     <Resource name="ast">
       <![CDATA[


### PR DESCRIPTION
## What is the purpose of the change

This PR is aimed at replacing current extraction algorithm in `JoinDependentConditionDerivationRule` with new one which covers more complex case with deep nested predicate:
for all n > 0
`((((((((a0 and b0) or a1) and b1) or a2) and b2) or a3) ... and bn-1) or an) => (a0 or a1 or ... or an)`

## Brief change log

  - Introduced new algorithm placed in `FlinkRexExtract`


## Verifying this change

This change added tests and can be verified as follows:

  - Added unit tests for extraction `FlinkRexExtractTest`
  - Added test to `JoinTest` to verify changed sql plan

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
