### PR TITLE
[FLINK-28548][Connectors / FileSystem] Fix the exception FileNotFoundException when the commit partition base path is not created

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTempFileManager.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTempFileManager.java
@@ -24,6 +24,9 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.streaming.api.functions.sink.filesystem.OutputFileConfig;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,6 +46,7 @@ import static org.apache.flink.table.utils.PartitionPathUtils.searchPartSpecAndP
  */
 @Internal
 public class PartitionTempFileManager {
+    private static final Logger LOG = LoggerFactory.getLogger(PartitionTempFileManager.class);
 
     private static final String TASK_DIR_PREFIX = "task-";
 
@@ -101,10 +105,16 @@ public class PartitionTempFileManager {
     public static List<Path> listTaskTemporaryPaths(FileSystem fs, Path basePath) throws Exception {
         List<Path> taskTmpPaths = new ArrayList<>();
 
-        for (FileStatus taskStatus : fs.listStatus(basePath)) {
-            if (isTaskDir(taskStatus.getPath().getName())) {
-                taskTmpPaths.add(taskStatus.getPath());
+        if (fs.exists(basePath)) {
+            for (FileStatus taskStatus : fs.listStatus(basePath)) {
+                if (isTaskDir(taskStatus.getPath().getName())) {
+                    taskTmpPaths.add(taskStatus.getPath());
+                }
             }
+        } else {
+            LOG.warn(
+                    "The path {} doesn't exist. Maybe no data is generated in the path and the path is not created.",
+                    basePath);
         }
         return taskTmpPaths;
     }

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
@@ -198,6 +198,23 @@ class FileSystemCommitterTest {
         assertThat(new File(emptyPartitionFile, "f1")).exists();
     }
 
+    @Test
+    void testPartitionPathNotExist() throws Exception {
+        Files.delete(path);
+        LinkedHashMap<String, String> staticPartitions = new LinkedHashMap<String, String>();
+        FileSystemCommitter committer =
+                new FileSystemCommitter(
+                        fileSystemFactory,
+                        metaStoreFactory,
+                        true,
+                        new Path(path.toString()),
+                        1,
+                        false,
+                        staticPartitions);
+        committer.commitPartitions();
+        assertThat(outputPath.toFile().list()).isEqualTo(new String[0]);
+    }
+
     static class TestMetaStoreFactory implements TableMetaStoreFactory {
 
         private final Path outputPath;


### PR DESCRIPTION
## What is the purpose of the change

*The commit partition base path is not created when no data is sent which may cause FileNotFoundException. Just fix it.*


## Brief change log

  - *Check whether the base path exists before listStatus for the path.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test testPartitionPathNotExist in FileSystemCommitterTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
