### PR TITLE
[hotfix][docs-zh] Fix the formatting of Chinese documents.

### DIFF
--- a/docs/content.zh/docs/ops/upgrading.md
+++ b/docs/content.zh/docs/ops/upgrading.md
@@ -46,7 +46,8 @@ Flink DataStream 程序通常设计为长时间运行，例如数周、数月甚
 ```
 这意味着应用程序在 Savepoint 完成后立即取消，即在 Savepoint 之后不进行其他 checkpoint。
 
-给定从应用程序获取的 Savepoint ，可以从该 Savepoint 启动相同或兼容的应用程序（请参阅下面的 [应用程序状态兼容性](#application-state-compatibility) 部分）。从 Savepoint 启动应用程序意味着其算子的状态被初始化为 Savepoint 中保存的算子状态。这是通过使用 Savepoint 启动应用程序来完成的。```bash
+给定从应用程序获取的 Savepoint ，可以从该 Savepoint 启动相同或兼容的应用程序（请参阅下面的 [应用程序状态兼容性](#application-state-compatibility) 部分）。从 Savepoint 启动应用程序意味着其算子的状态被初始化为 Savepoint 中保存的算子状态。这是通过使用 Savepoint 启动应用程序来完成的。
+```bash
 > ./bin/flink run -d -s [ Savepoint 的路径] ~/application.jar
 ```
  


### PR DESCRIPTION

## What is the purpose of the change

- **In english document:**
![image](https://user-images.githubusercontent.com/95120044/179017291-709b64b8-c124-4c08-90fd-5462132594aa.png)

- **In chinese document:**

![image](https://user-images.githubusercontent.com/95120044/179017569-e28e8f92-d533-4ef6-b7d3-77dd5af260af.png)

## Brief change log

- **The modified result looks like this:**

![image](https://user-images.githubusercontent.com/95120044/179017975-055037fb-cd03-42be-8fac-0d690a36f4f5.png)


## Verifying this change

- **No need to test.**

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
