### PR TITLE
[FLINK-28566][table-planner] Adds materialization support to eliminate the non determinism generated by lookup join node (plan only, without operator implementation)

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -53,6 +53,12 @@ By default no operator is disabled.</td>
             <td>Determines whether CAST will operate following the legacy behaviour or the new one that introduces various fixes and improvements.<br /><br />Possible values:<ul><li>"ENABLED": CAST will operate following the legacy behaviour.</li><li>"DISABLED": CAST will operate following the new correct behaviour.</li></ul></td>
         </tr>
         <tr>
+            <td><h5>table.exec.lookup-join.upsert-materialize</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">AUTO</td>
+            <td><p>Enum</p></td>
+            <td>In order to minimize the potential exceptions or data errors when many users use the update stream to lookup join an external table (essentially due to the non-deterministic result based on processing-time to lookup external tables). When update exists in the input stream and the lookup key does not contain the primary key of the external table, FLINK automatically adds materialization of the update by default, so that it will only lookup the external table when the insert or update_after message arrives, and when the delete or update_before message arrives, it will directly querying the latest version of the locally materialized data and sent it to downstream operator.<br />By default, the materialize operator will be added when an update stream lookup an external table without containing its primary keys(includes no primary key defined). You can also choose no materialization(NONE) or force materialization(FORCE).<br /><br />Possible values:<ul><li>"NONE"</li><li>"AUTO"</li><li>"FORCE"</li></ul></td>
+        </tr>
+        <tr>
             <td><h5>table.exec.mini-batch.allow-latency</h5><br> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">0 ms</td>
             <td>Duration</td>

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -59,7 +60,7 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
-                true,
+                ChangelogMode.insertOnly(),
                 Collections.singletonList(inputProperty),
                 outputType,
                 description);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
@@ -18,9 +18,12 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecLookupJoin;
@@ -64,5 +67,14 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
                 Collections.singletonList(inputProperty),
                 outputType,
                 description);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Transformation<RowData> translateToPlanInternal(
+            PlannerBase planner, ExecNodeConfig config) {
+        // There's no optimization when lookupKeyContainsPrimaryKey is true for batch, so set it to
+        // false for now. We can add it to CommonExecLookupJoin when needed.
+        return createJoinTransformation(planner, config, ChangelogMode.insertOnly(), false, false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
@@ -55,14 +55,9 @@ import java.util.Map;
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLookupJoin extends CommonExecLookupJoin implements StreamExecNode<RowData> {
 
-    public static final String FIELD_NAME_INPUT_CHANGELOG_MODE = "inputChangelogMode";
-
     public static final String FIELD_NAME_REQUIRE_UPSERT_MATERIALIZE = "requireUpsertMaterialize";
 
     public static final String FIELD_NAME_LEFT_UNIQUE_KEYS = "leftUniqueKeys";
-
-    @JsonProperty(FIELD_NAME_INPUT_CHANGELOG_MODE)
-    private final ChangelogMode inputChangelogMode;
 
     @JsonProperty(FIELD_NAME_LEFT_UNIQUE_KEYS)
     private final List<int[]> leftUniqueKeys;
@@ -79,10 +74,9 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
             @Nullable List<RexNode> projectionOnTemporalTable,
             @Nullable RexNode filterOnTemporalTable,
-            boolean inputInsertOnly,
+            ChangelogMode inputChangelogMode,
             InputProperty inputProperty,
             RowType outputType,
-            ChangelogMode inputChangelogMode,
             List<int[]> leftUniqueKeys,
             boolean upsertMaterialize,
             String description) {
@@ -96,10 +90,9 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
-                inputInsertOnly,
+                inputChangelogMode,
                 Collections.singletonList(inputProperty),
                 outputType,
-                inputChangelogMode,
                 leftUniqueKeys,
                 upsertMaterialize,
                 description);
@@ -119,10 +112,10 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                     List<RexNode> projectionOnTemporalTable,
             @JsonProperty(FIELD_NAME_FILTER_ON_TEMPORAL_TABLE) @Nullable
                     RexNode filterOnTemporalTable,
-            @JsonProperty(FIELD_NAME_INPUT_INSERT_ONLY) @Nullable Boolean inputInsertOnly,
+            @JsonProperty(FIELD_NAME_INPUT_CHANGELOG_MODE) @Nullable
+                    ChangelogMode inputChangelogMode,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
-            @JsonProperty(FIELD_NAME_INPUT_CHANGELOG_MODE) ChangelogMode inputChangelogMode,
             @JsonProperty(FIELD_NAME_LEFT_UNIQUE_KEYS) List<int[]> leftUniqueKeys,
             @JsonProperty(FIELD_NAME_REQUIRE_UPSERT_MATERIALIZE) boolean upsertMaterialize,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
@@ -136,11 +129,10 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
-                inputInsertOnly,
+                inputChangelogMode,
                 inputProperties,
                 outputType,
                 description);
-        this.inputChangelogMode = inputChangelogMode;
         this.leftUniqueKeys = leftUniqueKeys;
         this.upsertMaterialize = upsertMaterialize;
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeys.scala
@@ -17,7 +17,7 @@
  */
 package org.apache.flink.table.planner.plan.metadata
 
-import org.apache.flink.table.catalog.{CatalogTable, ResolvedCatalogBaseTable, ResolvedCatalogTable}
+import org.apache.flink.table.catalog.{CatalogTable, ResolvedCatalogBaseTable}
 import org.apache.flink.table.planner._
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.nodes.calcite.{Expand, Rank, WatermarkAssigner, WindowAggregate}
@@ -488,16 +488,36 @@ class FlinkRelMdUniqueKeys private extends MetadataHandler[BuiltInMetadata.Uniqu
       ignoreNulls: Boolean): util.Set[ImmutableBitSet] = {
     val left = join.getInput
     val leftUniqueKeys = mq.getUniqueKeys(left, ignoreNulls)
-    val leftType = left.getRowType
-    getJoinUniqueKeys(
-      join.joinType,
-      leftType,
-      leftUniqueKeys,
-      null,
-      mq.areColumnsUnique(left, join.joinInfo.leftSet, ignoreNulls),
-      // TODO get uniqueKeys from TableSchema of TableSource
+
+    if (leftUniqueKeys != null) {
+      val rightUniqueKeys = getUniqueKeysOfTemporalTable(join)
+
+      getJoinUniqueKeys(
+        join.joinType,
+        left.getRowType,
+        leftUniqueKeys,
+        rightUniqueKeys,
+        mq.areColumnsUnique(left, join.joinInfo.leftSet, ignoreNulls),
+        rightUniqueKeys != null)
+    } else {
       null
-    )
+    }
+  }
+
+  private[flink] def getUniqueKeysOfTemporalTable(
+      join: CommonPhysicalLookupJoin): JSet[ImmutableBitSet] = {
+    val outputPkIdx = join.getOutputPrimaryKeyIndexes
+    if (!outputPkIdx.isEmpty) {
+      // compare with join key pairs
+      val lookupKeys = join.joinInfo.pairs().map(_.target).toSet
+      if (outputPkIdx.forall(lookupKeys.contains)) {
+        ImmutableSet.of(ImmutableBitSet.of(outputPkIdx: _*))
+      } else {
+        null
+      }
+    } else {
+      null
+    }
   }
 
   private def getJoinUniqueKeys(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeys.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeys.scala
@@ -228,17 +228,20 @@ class FlinkRelMdUpsertKeys private extends MetadataHandler[UpsertKeys] {
       join: CommonPhysicalLookupJoin,
       mq: RelMetadataQuery): util.Set[ImmutableBitSet] = {
     val left = join.getInput
-    val leftKeys = FlinkRelMetadataQuery.reuseOrCreate(mq).getUpsertKeys(left)
     val leftType = left.getRowType
     val leftJoinKeys = join.joinInfo.leftSet
+    // differs from regular join, here we do not filterKeys because there's no shuffle on join keys
+    // by default.
+    val leftUpsertKeys = FlinkRelMetadataQuery.reuseOrCreate(mq).getUpsertKeys(left)
+    val rightUpsertKeys = FlinkRelMdUniqueKeys.INSTANCE.getUniqueKeysOfTemporalTable(join)
+
     FlinkRelMdUniqueKeys.INSTANCE.getJoinUniqueKeys(
       join.joinType,
       leftType,
-      filterKeys(leftKeys, leftJoinKeys),
-      null,
-      areColumnsUpsertKeys(leftKeys, leftJoinKeys),
-      // TODO get uniqueKeys from TableSchema of TableSource
-      null
+      leftUpsertKeys,
+      rightUpsertKeys,
+      areColumnsUpsertKeys(leftUpsertKeys, leftJoinKeys),
+      rightUpsertKeys != null
     )
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
@@ -285,7 +285,7 @@ abstract class CommonPhysicalLookupJoin(
     val outputPkIdx = getOutputPrimaryKeyIndexes
     // use allLookupKeys instead of joinInfo.rightSet because there may exists constant
     // lookup key(s) which are not included in joinInfo.rightKeys.
-    outputPkIdx.nonEmpty && outputPkIdx.forall(index => !allLookupKeys.contains(index))
+    outputPkIdx.nonEmpty && outputPkIdx.forall(index => allLookupKeys.contains(index))
   }
 
   /** Get final output pk indexes if exists, otherwise will get empty. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalLookupJoin.scala
@@ -280,6 +280,14 @@ abstract class CommonPhysicalLookupJoin(
     constantLookupKeys.toMap[Int, LookupKey] ++ fieldRefLookupKeys.toMap[Int, LookupKey]
   }
 
+  /** Check if lookup key contains primary key, include constant lookup keys. */
+  def lookupKeyContainsPrimaryKey(): Boolean = {
+    val outputPkIdx = getOutputPrimaryKeyIndexes
+    // use allLookupKeys instead of joinInfo.rightSet because there may exists constant
+    // lookup key(s) which are not included in joinInfo.rightKeys.
+    outputPkIdx.nonEmpty && outputPkIdx.forall(index => !allLookupKeys.contains(index))
+  }
+
   /** Get final output pk indexes if exists, otherwise will get empty. */
   def getOutputPrimaryKeyIndexes: Array[Int] = {
     val temporalPkIdxs = getPrimaryKeyIndexesOfTemporalTable

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLookupJoin.scala
@@ -121,10 +121,9 @@ class StreamPhysicalLookupJoin(
       allLookupKeys.map(item => (Int.box(item._1), item._2)).asJava,
       projectionOnTemporalTable,
       filterOnTemporalTable,
-      ChangelogPlanUtils.inputInsertOnly(this),
+      inputChangelogMode,
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
-      inputChangelogMode,
       getUpsertKey,
       upsertMaterialize,
       getRelDetailedDescription)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -25,14 +25,13 @@ import org.apache.flink.table.planner.plan.nodes.calcite.Sink
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink
-import org.apache.flink.table.planner.plan.utils.{ChangelogPlanUtils, RelDescriptionWriterImpl}
+import org.apache.flink.table.planner.plan.utils.ChangelogPlanUtils
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.hint.RelHint
 
-import java.io.{PrintWriter, StringWriter}
 import java.util
 
 /**
@@ -89,17 +88,12 @@ class StreamPhysicalSink(
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
       upsertMaterialize,
-      getDescriptionWithUpsert(upsertMaterialize))
+      getRelDetailedDescription)
   }
 
-  /** The inputChangelogMode can only be obtained in translateToExecNode phase. */
-  def getDescriptionWithUpsert(upsertMaterialize: Boolean): String = {
-    val sw = new StringWriter
-    val pw = new PrintWriter(sw)
-    val relWriter = new RelDescriptionWriterImpl(pw)
-    this.explainTerms(relWriter)
-    relWriter.itemIf("upsertMaterialize", "true", upsertMaterialize)
-    relWriter.done(this)
-    sw.toString
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super
+      .explainTerms(pw)
+      .itemIf("upsertMaterialize", "true", upsertMaterialize)
   }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/StreamOperatorNameTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/StreamOperatorNameTest.xml
@@ -24,7 +24,7 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
+Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b], upsertMaterialize=[true])
 +- ChangelogNormalize(key=[a, b])
    +- Exchange(distribution=[hash[a, b]])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[c, a, b], metadata=[]]], fields=[c, a, b])
@@ -99,7 +99,7 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
+Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b], upsertMaterialize=[true])
 +- ChangelogNormalize(key=[a, b])
    +- Exchange(distribution=[hash[a, b]])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[c, a, b], metadata=[]]], fields=[c, a, b])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
@@ -258,7 +258,7 @@
     },
     "projectionOnTemporalTable" : null,
     "filterOnTemporalTable" : null,
-    "inputInsertOnly" : true,
+    "inputChangelogMode" : [ "INSERT" ],
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -303,6 +303,7 @@
         "fieldType" : "INT"
       } ]
     },
+    "leftUniqueKeys" : [ ],
     "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])"
   }, {
     "id" : 5,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
@@ -303,7 +303,7 @@
         "fieldType" : "INT"
       } ]
     },
-    "leftUniqueKeys" : [ ],
+    "lookupKeyContainsPrimaryKey" : false,
     "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])"
   }, {
     "id" : 5,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
@@ -262,7 +262,7 @@
       "type" : "INT"
     } ],
     "filterOnTemporalTable" : null,
-    "inputInsertOnly" : true,
+    "inputChangelogMode" : [ "INSERT" ],
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -301,6 +301,7 @@
         "fieldType" : "INT"
       } ]
     },
+    "leftUniqueKeys" : [ ],
     "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])"
   }, {
     "id" : 5,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
@@ -301,7 +301,7 @@
         "fieldType" : "INT"
       } ]
     },
-    "leftUniqueKeys" : [ ],
+    "lookupKeyContainsPrimaryKey" : false,
     "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])"
   }, {
     "id" : 5,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -234,7 +234,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, c, rn])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[a, c, w0$o0], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[a, c, w0$o0], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[a, c, w0$o0], changelogMode=[I,UB,UA,D])
    +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[b], orderBy=[c DESC], select=[a, b, c, w0$o0], changelogMode=[I,UB,UA,D])
       +- Exchange(distribution=[hash[b]], changelogMode=[I])
@@ -261,7 +261,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], upsertMaterialize=[true], changelogMode=[NONE])
 +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[a], orderBy=[c DESC], select=[a, b, c], changelogMode=[I,UB,UA,D])
    +- Exchange(distribution=[hash[a]], changelogMode=[I])
       +- Calc(select=[a, b, c], changelogMode=[I])
@@ -286,7 +286,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], upsertMaterialize=[true], changelogMode=[NONE])
 +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[b], orderBy=[c DESC], select=[a, b, c], changelogMode=[I,UB,UA,D])
    +- Exchange(distribution=[hash[b]], changelogMode=[I])
       +- Calc(select=[a, b, c], changelogMode=[I])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
@@ -349,7 +349,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[c, cnt])
       +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- GroupAggregate(groupBy=[c], select=[c, COUNT(*) AS cnt], changelogMode=[I,UB,UA])
    +- Exchange(distribution=[hash[c]], changelogMode=[I])
       +- Calc(select=[c], changelogMode=[I])
@@ -374,7 +374,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[c, cnt])
          +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[c, cnt], changelogMode=[I,UB,UA])
    +- GroupAggregate(groupBy=[a, c], select=[a, c, COUNT(*) AS cnt], changelogMode=[I,UB,UA])
       +- Exchange(distribution=[hash[a, c]], changelogMode=[I])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
@@ -552,7 +552,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[city_name, cu
       +- LogicalTableScan(table=[[default_catalog, default_database, source_city]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[city_name, customer_cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[city_name, customer_cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[city_name, customer_cnt], changelogMode=[I,UB,UA,D])
    +- Join(joinType=[InnerJoin], where=[=(city_id, id)], select=[city_id, customer_cnt, id, city_name], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], changelogMode=[I,UB,UA,D])
       :- Exchange(distribution=[hash[city_id]], changelogMode=[I,UB,UA,D])
@@ -642,7 +642,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[city_id, city
       +- LogicalTableScan(table=[[default_catalog, default_database, source_city]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[city_id, city_name, customer_cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[city_id, city_name, customer_cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[city_id, city_name, customer_cnt], changelogMode=[I,UB,UA,D])
    +- Join(joinType=[InnerJoin], where=[=(city_id, id)], select=[city_id, customer_cnt, id, city_name], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], changelogMode=[I,UB,UA,D])
       :- Exchange(distribution=[hash[city_id]], changelogMode=[I,UB,UA,D])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.xml
@@ -16,6 +16,138 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
+  <TestCase name="testAppendSourceJoinTemporalTableJoinKeyContainsPk[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=a], where=[(age = 33)], select=[a, b, c, proctime, rowtime, id, name])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendSourceJoinTemporalTableJoinKeyContainsPk[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=a], where=[(age = 33)], select=[a, b, c, proctime, rowtime, id, name])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendSourceJoinTemporalTableJoinKeyContainsPkOnly[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendSourceJoinTemporalTableJoinKeyContainsPkOnly[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendSourceJoinTemporalTableJoinKeyNotContainsPk[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.b = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CAST($1):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=b], where=[(age = 33)], select=[a, b, c, proctime, rowtime, id, name, CAST(name AS VARCHAR(2147483647)) AS name0])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendSourceJoinTemporalTableJoinKeyNotContainsPk[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.b = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CAST($1):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=b], where=[(age = 33)], select=[a, b, c, proctime, rowtime, id, name, CAST(name AS VARCHAR(2147483647)) AS name0])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testAvoidAggregatePushDown[LegacyTableSource=false]">
     <Resource name="sql">
       <![CDATA[
@@ -52,39 +184,11 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
 GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c) AS EXPR$2, SUM_RETRACT(d) AS EXPR$3])
 +- Exchange(distribution=[hash[b]])
    +- Calc(select=[b, a, c, d])
-      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id], upsertMaterialize=[true])
          +- Calc(select=[b, a, c, d])
             +- GroupAggregate(groupBy=[a, b], select=[a, b, SUM(c) AS c, SUM(d) AS d])
                +- Exchange(distribution=[hash[a, b]])
                   +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=true]">
-    <Resource name="sql">
-      <![CDATA[
-SELECT * FROM MyTable AS T
-JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
-ON T.a = D.id AND D.age = 10
-WHERE cast(D.name as bigint) > 1000
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
-+- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
-   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
-      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
-         +- LogicalSnapshot(period=[$cor0.proctime])
-            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
   </TestCase>
@@ -124,11 +228,261 @@ LogicalAggregate(group=[{0}], EXPR$1=[COUNT($1)], EXPR$2=[SUM($2)], EXPR$3=[SUM(
 GroupAggregate(groupBy=[b], select=[b, COUNT_RETRACT(a) AS EXPR$1, SUM_RETRACT(c) AS EXPR$2, SUM_RETRACT(d) AS EXPR$3])
 +- Exchange(distribution=[hash[b]])
    +- Calc(select=[b, a, c, d])
-      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id])
+      +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], where=[(age > 10)], select=[b, a, c, d, id], upsertMaterialize=[true])
          +- Calc(select=[b, a, c, d])
             +- GroupAggregate(groupBy=[a, b], select=[a, b, SUM(c) AS c, SUM(d) AS d])
                +- Exchange(distribution=[hash[a, b]])
                   +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinContainsPkForceUpsertMaterialize[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.id, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=id], where=[(age = 33)], select=[id, name, age, proctime, id, name], upsertMaterialize=[true])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinContainsPkForceUpsertMaterialize[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.id, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=id], where=[(age = 33)], select=[id, name, age, proctime, id, name], upsertMaterialize=[true])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinNotContainsPkDisableUpsertMaterialize[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.name = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.name, $1), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=name], where=[(age = 33)], select=[id, name, age, proctime, id, name])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinNotContainsPkDisableUpsertMaterialize[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.name = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.name, $1), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=name], where=[(age = 33)], select=[id, name, age, proctime, id, name])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinTemporalTableJoinKeyContainsPk[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.id, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=id], where=[(age = 33)], select=[id, name, age, proctime, id, name])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinTemporalTableJoinKeyContainsPk[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.id, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=id], where=[(age = 33)], select=[id, name, age, proctime, id, name])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinTemporalTableJoinKeyContainsPkOnly[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[=($cor0.id, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[id=id], select=[id, name, age, proctime, id0, name0, age0])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinTemporalTableJoinKeyContainsPkOnly[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[=($cor0.id, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[id=id], select=[id, name, age, proctime, id0, name0, age0])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinTemporalTableJoinKeyNotContainsPk[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.name = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.name, $1), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=name], where=[(age = 33)], select=[id, name, age, proctime, id, name], upsertMaterialize=[true])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcSourceJoinTemporalTableJoinKeyNotContainsPk[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM cdc AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.name = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[$3], id0=[$4], name0=[$5], age0=[$6])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalProject(id=[$0], name=[$1], age=[$2], proctime=[PROCTIME()])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalFilter(condition=[AND(=($cor0.name, $1), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[id, name, age, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name0, CAST(33 AS INTEGER) AS age0])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=name], where=[(age = 33)], select=[id, name, age, proctime, id, name], upsertMaterialize=[true])
+   +- Calc(select=[id, name, age, PROCTIME() AS proctime])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[id, name, age])
 ]]>
     </Resource>
   </TestCase>
@@ -194,6 +548,63 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
       +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
          +- LogicalSnapshot(period=[$cor0.proctime])
             +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(10 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=10, id=a], where=[((age = 10) AND (CAST(name AS BIGINT) > 1000))], select=[a, b, c, proctime, rowtime, id, name])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateStreamJoinTemporalTableJoinKeyNotContainsPk[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM update_view1 AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.b = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], id=[$1], proctime=[$2], id0=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(b=[$0], id=[$1], proctime=[PROCTIME()])
+   :  +- LogicalAggregate(group=[{0}], id=[MAX($1)])
+   :     +- LogicalProject(b=[$1], a=[$0])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CAST($1):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, id, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=b], where=[(age = 33)], select=[b, id, proctime, id, name, CAST(name AS VARCHAR(2147483647)) AS name0], upsertMaterialize=[true])
+   +- Calc(select=[b, id, PROCTIME() AS proctime])
+      +- GroupAggregate(groupBy=[b], select=[b, MAX(a) AS id])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b, a])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithCalcPushDown[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id AND D.age = 10
+WHERE cast(D.name as bigint) > 1000
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalFilter(condition=[>(CAST($6):BIGINT, 1000)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), =($2, 10))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -400,57 +811,6 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
    +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
       +- LogicalSnapshot(period=[$cor0.proctime])
          +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CONCAT(name, '!') AS $f3])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true]">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM (SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
-   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
-   :  +- LogicalFilter(condition=[>($2, 1000)])
-   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalFilter(condition=[=($cor0.a, $0)])
-      +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
-   +- Calc(select=[a, b, proctime], where=[(c > 1000)])
-      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=true]">
-    <Resource name="sql">
-      <![CDATA[
-SELECT * FROM MyTable AS T
-JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
-ON T.b = concat(D.name, '!') AND D.age = 11
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
-      +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -698,6 +1058,57 @@ Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinTemporalTableWithNestedQuery[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM (SELECT a, b, proctime FROM MyTable WHERE c > 1000) AS T JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], proctime=[$2], id=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(a=[$0], b=[$1], proctime=[$3])
+   :  +- LogicalFilter(condition=[>($2, 1000)])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, proctime, id, name, age])
+   +- Calc(select=[a, b, proctime], where=[(c > 1000)])
+      +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithFunctionAndConstantCondition[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.b = concat(D.name, '!') AND D.age = 11
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CONCAT($1, _UTF-16LE'!')), =($2, 11))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, CAST(11 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[age=11], where=[(age = 11)], joinCondition=[(b = $f3)], select=[a, b, c, proctime, rowtime, id, name, CONCAT(name, '!') AS $f3])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=false]">
     <Resource name="sql">
       <![CDATA[
@@ -715,55 +1126,6 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
    +- LogicalFilter(condition=[=($cor0.a, $0)])
       +- LogicalSnapshot(period=[$cor0.proctime])
          +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true]">
-    <Resource name="sql">
-      <![CDATA[SELECT * FROM MyTable AS T LEFT JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalFilter(condition=[=($cor0.a, $0)])
-      +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
-]]>
-    </Resource>
-    <Resource name="optimized exec plan">
-      <![CDATA[
-Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
-+- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
-   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true]">
-    <Resource name="sql">
-      <![CDATA[
-SELECT T.*, D.id
-FROM MyTable AS T
-JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
-ON T.a = D.id
-      ]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
-+- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
-   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
-   +- LogicalFilter(condition=[=($cor0.a, $0)])
-      +- LogicalSnapshot(period=[$cor0.proctime])
-         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -853,6 +1215,200 @@ LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], nam
 Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
 +- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
    +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLeftJoinTemporalTable[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM MyTable AS T LEFT JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5], name=[$6], age=[$7])
++- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id, name, age])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[LeftOuterJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinTemporalTableWithProjectionPushDown[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[
+SELECT T.*, D.id
+FROM MyTable AS T
+JOIN LookupTable FOR SYSTEM_TIME AS OF T.proctime AS D
+ON T.a = D.id
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], proctime=[$3], rowtime=[$4], id=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.a, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, LookupTable, source: [TestTemporalTable(id, name, age)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, c, PROCTIME_MATERIALIZE(proctime) AS proctime, rowtime, id])
++- LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])
+   +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateStreamJoinTemporalTableJoinKeyContainsPk[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM update_view1 AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], id=[$1], proctime=[$2], id0=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 2}])
+   :- LogicalProject(b=[$0], id=[$1], proctime=[PROCTIME()])
+   :  +- LogicalAggregate(group=[{0}], id=[MAX($1)])
+   :     +- LogicalProject(b=[$1], a=[$0])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.id, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, id, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=id], where=[(age = 33)], select=[b, id, proctime, id, name])
+   +- Calc(select=[b, id, PROCTIME() AS proctime])
+      +- GroupAggregate(groupBy=[b], select=[b, MAX(a) AS id])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b, a])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateStreamJoinTemporalTableJoinKeyContainsPkOnly[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM update_view1 AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], id=[$1], proctime=[$2], id0=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 2}])
+   :- LogicalProject(b=[$0], id=[$1], proctime=[PROCTIME()])
+   :  +- LogicalAggregate(group=[{0}], id=[MAX($1)])
+   :     +- LogicalProject(b=[$1], a=[$0])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.id, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, id, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name, age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[id=id], select=[b, id, proctime, id0, name, age])
+   +- Calc(select=[b, id, PROCTIME() AS proctime])
+      +- GroupAggregate(groupBy=[b], select=[b, MAX(a) AS id])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b, a])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateStreamJoinTemporalTableJoinKeyContainsPkOnly[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM update_view1 AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], id=[$1], proctime=[$2], id0=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 2}])
+   :- LogicalProject(b=[$0], id=[$1], proctime=[PROCTIME()])
+   :  +- LogicalAggregate(group=[{0}], id=[MAX($1)])
+   :     +- LogicalProject(b=[$1], a=[$0])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[=($cor0.id, $0)])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, id, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name, age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[id=id], select=[b, id, proctime, id0, name, age])
+   +- Calc(select=[b, id, PROCTIME() AS proctime])
+      +- GroupAggregate(groupBy=[b], select=[b, MAX(a) AS id])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b, a])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateStreamJoinTemporalTableJoinKeyContainsPk[LegacyTableSource=true]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM update_view1 AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.id = D.id AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], id=[$1], proctime=[$2], id0=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 2}])
+   :- LogicalProject(b=[$0], id=[$1], proctime=[PROCTIME()])
+   :  +- LogicalAggregate(group=[{0}], id=[MAX($1)])
+   :     +- LogicalProject(b=[$1], a=[$0])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.id, $0), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, id, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, id=id], where=[(age = 33)], select=[b, id, proctime, id, name])
+   +- Calc(select=[b, id, PROCTIME() AS proctime])
+      +- GroupAggregate(groupBy=[b], select=[b, MAX(a) AS id])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b, a])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateStreamJoinTemporalTableJoinKeyNotContainsPk[LegacyTableSource=false]">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM update_view1 AS T JOIN dimWithPk FOR SYSTEM_TIME AS OF T.proctime AS D ON T.b = D.name AND D.age = 33]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b=[$0], id=[$1], proctime=[$2], id0=[$3], name=[$4], age=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2}])
+   :- LogicalProject(b=[$0], id=[$1], proctime=[PROCTIME()])
+   :  +- LogicalAggregate(group=[{0}], id=[MAX($1)])
+   :     +- LogicalProject(b=[$1], a=[$0])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+   +- LogicalFilter(condition=[AND(=($cor0.b, CAST($1):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), =($2, 33))])
+      +- LogicalSnapshot(period=[$cor0.proctime])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dimWithPk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[b, id, PROCTIME_MATERIALIZE(proctime) AS proctime, id0, name, CAST(33 AS INTEGER) AS age])
++- LookupJoin(table=[default_catalog.default_database.dimWithPk], joinType=[InnerJoin], async=[false], lookup=[age=33, name=b], where=[(age = 33)], select=[b, id, proctime, id, name, CAST(name AS VARCHAR(2147483647)) AS name0], upsertMaterialize=[true])
+   +- Calc(select=[b, id, PROCTIME() AS proctime])
+      +- GroupAggregate(groupBy=[b], select=[b, MAX(a) AS id])
+         +- Exchange(distribution=[hash[b]])
+            +- Calc(select=[b, a])
+               +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c, proctime, rowtime])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -162,7 +162,7 @@ LogicalSink(table=[default_catalog.default_database.rowtime_default_sink], field
                +- LogicalTableScan(table=[[default_catalog, default_database, versioned_currency_with_multi_key]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.rowtime_default_sink], fields=[order_id, currency, amount, order_time, rate, currency_time], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.rowtime_default_sink], fields=[order_id, currency, amount, order_time, rate, currency_time], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[order_id, currency, amount, order_time, rate, CAST(currency_time AS TIMESTAMP(3)) AS currency_time], changelogMode=[I,UB,UA,D])
    +- TemporalJoin(joinType=[InnerJoin], where=[AND(=(currency_no, currency_no0), =(currency, currency0), __TEMPORAL_JOIN_CONDITION(order_time, currency_time, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0, currency_no0), __TEMPORAL_JOIN_LEFT_KEY(currency_no, currency), __TEMPORAL_JOIN_RIGHT_KEY(currency_no0, currency0)))], select=[order_id, currency, currency_no, amount, order_time, currency0, currency_no0, rate, currency_time], changelogMode=[I,UB,UA,D])
       :- Exchange(distribution=[hash[currency_no, currency]], changelogMode=[I,UB,UA,D])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -252,6 +252,11 @@ class AsyncLookupJoinITCase(
 
   @Test
   def testAggAndAsyncLeftJoinTemporalTable(): Unit = {
+    // TODO remove this config after FLINK-28568 done
+    tEnv.getConfig.getConfiguration.set(
+      ExecutionConfigOptions.TABLE_EXEC_LOOKUP_JOIN_UPSERT_MATERIALIZE,
+      ExecutionConfigOptions.UpsertMaterialize.NONE)
+
     val sql1 = "SELECT max(id) as id, PROCTIME() as proctime FROM src AS T group by len"
 
     val table1 = tEnv.sqlQuery(sql1)


### PR DESCRIPTION
## What is the purpose of the change
In order to minimize the potential exceptions or data errors when many users use the update stream to lookup join an external table (essentially due to the non-deterministic result based on processing-time to lookup external tables). 
When update exists in the input stream and the lookup key does not contain the primary key of the external table,
FLINK automatically adds materialization of the update by default, so that it will only lookup the external table when the insert or update_after message arrives, and when the delete or update_before message arrives, it will directly querying the latest version of the locally materialized data and sent it to downstream operator.

To do so，we introduce a new option 'table.exec.lookup-join.upsert-materialize' and resue the `UpsertMaterialize`. By default, the materialize operator will be added when an update stream lookup an external table without containing its primary keys(includes no primary key defined). You can also choose no materialization(NONE) or force materialization(FORCE) which will always enable materialization except input is insert only.

## Brief change log
* add 'table.exec.lookup-join.upsert-materialize' to ExecutionConfigOptions
* add metadata (unique key & upsert key) inference for lookup join
* add analyzeUpsertMaterializeStrategy for lookup join node in FlinkChangelogModeInferenceProgram
* update tests ensure upsertMaterialize modes is covered

## Verifying this change
LookupJoinTest and LookupJoinJsonPlanTest

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)