### PR TITLE
[FLINK-28575] [connectors/hbase] support hbase connector 2.2 write to 2.4.9

### DIFF
--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseConfigurationUtil.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/util/HBaseConfigurationUtil.java
@@ -46,7 +46,12 @@ public class HBaseConfigurationUtil {
 
         // Instantiate an HBaseConfiguration to load the hbase-default.xml and hbase-site.xml from
         // the classpath.
-        Configuration result = HBaseConfiguration.create();
+
+        Configuration result = new Configuration();
+        result.setClassLoader(HBaseConfiguration.class.getClassLoader());
+        result.set("hbase.defaults.for.version.skip", "true");
+        HBaseConfiguration.addHbaseResources(result);
+
         boolean foundHBaseConfiguration = false;
 
         // We need to load both hbase-default.xml and hbase-site.xml to the hbase configuration


### PR DESCRIPTION
support hbase connector 2.2 to write to hbase 2.4.9

### What is the purpose of the change
hbase does version checks when creating configurations by default
so this prevents using connector2.2 to write to like hbase 2.4.9. however this restriction is not necessary.

### Brief change log
add the hbase configuration to skip the version check

### Verifying this change
This change can be verified as follows:
hbase-2.2 connector writes normally to hbase 2.4.9 in my local integration

### Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): no
The public API, i.e., is any changed class annotated with @Public(Evolving): no
The serializers: no
The runtime per-record code paths (performance sensitive): no
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
The S3 file system connector: no

### Documentation
Does this pull request introduce a new feature? no
If yes, how is the feature documented?


