### PR TITLE
[FLINK-23633][FLIP-150][connector/common] HybridSource: Support dynamic stop position in FileSource

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
@@ -1,0 +1,2 @@
+package org.apache.flink.connector.base.source.hybrid;public interface DynamicHybridSourceReader {
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
@@ -18,11 +18,20 @@
 
 package org.apache.flink.connector.base.source.hybrid;
 
+import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceSplit;
 
 import java.util.List;
 
+/**
+ * Sources that implement this interface can allow dynamic initialization for the next source during
+ * sources switch when using {@link HybridSource}.
+ *
+ * @param <T> The type of the record emitted by this source reader.
+ * @param <SplitT> The type of the source splits.
+ */
+@PublicEvolving
 public interface DynamicHybridSourceReader<T, SplitT extends SourceSplit>
         extends SourceReader<T, SplitT> {
     /**
@@ -31,8 +40,8 @@ public interface DynamicHybridSourceReader<T, SplitT extends SourceSplit>
      * <p>This method is called by {@link HybridSourceReader} during checkpoint for persistent, and
      * source switch to dynamically initiate the start positions of the next source.
      *
-     * <p>The contract is that implementation should ensure the new finished splits since the last
-     * call of this method persist until the next checkpoint.
+     * <p><b>Important:</b> The contract is that implementation should ensure the new finished
+     * splits since the last call of this method persist until the next checkpoint.
      */
     List<SplitT> getFinishedSplits();
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
@@ -1,2 +1,20 @@
-package org.apache.flink.connector.base.source.hybrid;public interface DynamicHybridSourceReader {
+package org.apache.flink.connector.base.source.hybrid;
+
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import java.util.List;
+
+public interface DynamicHybridSourceReader<T, SplitT extends SourceSplit>
+        extends SourceReader<T, SplitT> {
+    /**
+     * Gets a list of finished splits for this reader.
+     *
+     * <p>This method is called by {@link HybridSourceReader} during checkpoint for persistent, and
+     * source switch to dynamically initiate the start positions of the next source.
+     *
+     * <p>The contract is that implementation should ensure the new finished splits since the last
+     * call of this method persist until the next checkpoint.
+     */
+    List<SplitT> getFinishedSplits();
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/DynamicHybridSourceReader.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.base.source.hybrid;
 
 import org.apache.flink.api.connector.source.SourceReader;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSource.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSource.java
@@ -159,8 +159,7 @@ public class HybridSource<T> implements Source<T, HybridSourceSplit, HybridSourc
      * supplied in the future.
      */
     @PublicEvolving
-    public interface SourceSwitchContext<
-            SplitT extends SourceSplit, EnumT extends SplitEnumerator<SplitT, ?>> {
+    public interface SourceSwitchContext<SplitT, EnumT> {
         EnumT getPreviousEnumerator();
 
         List<SplitT> getPreviousSplits();

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -26,6 +26,7 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -26,7 +26,6 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.util.Preconditions;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +92,13 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
             // Signal the coordinator that this reader has consumed all input and the
             // next source can potentially be activated.
             readerContext.sendSourceEventToCoordinator(
-                    new SourceReaderFinishedEvent(currentSourceIndex));
+                    // TODO: finishedSplits should also checkpoint into the state
+                    new SourceReaderFinishedEvent(
+                            currentSourceIndex,
+                            HybridSourceSplit.wrapSplits(
+                                    currentReader.getFinishedSplits(),
+                                    currentSourceIndex,
+                                    switchedSources)));
             if (!isFinalSource) {
                 // More splits may arrive for a subsequent reader.
                 // InputStatus.NOTHING_AVAILABLE suspends poll, requires completion of the

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReader.java
@@ -224,9 +224,15 @@ public class HybridSourceReader<T> implements SourceReader<T, HybridSourceSplit>
 
     private List<HybridSourceSplit> snapshotFinishedSplits() {
         Preconditions.checkNotNull(currentReader, "Current reader should not be null.");
-        currentReaderFinishedSplits.addAll(currentReader.getFinishedSplits());
-        return HybridSourceSplit.wrapSplits(
-                currentReaderFinishedSplits, currentSourceIndex, switchedSources, true);
+        if (currentReader instanceof DynamicHybridSourceReader) {
+            currentReaderFinishedSplits.addAll(
+                    ((DynamicHybridSourceReader<T, SourceSplit>) currentReader)
+                            .getFinishedSplits());
+            return HybridSourceSplit.wrapSplits(
+                    currentReaderFinishedSplits, currentSourceIndex, switchedSources, true);
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     private void setCurrentReader(int index) {

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplit.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplit.java
@@ -77,8 +77,8 @@ public class HybridSourceSplit implements SourceSplit {
         }
         HybridSourceSplit that = (HybridSourceSplit) o;
         return sourceIndex == that.sourceIndex
-            && Arrays.equals(wrappedSplitBytes, that.wrappedSplitBytes)
-            && isFinished == that.isFinished;
+                && Arrays.equals(wrappedSplitBytes, that.wrappedSplitBytes)
+                && isFinished == that.isFinished;
     }
 
     @Override
@@ -89,13 +89,13 @@ public class HybridSourceSplit implements SourceSplit {
     @Override
     public String toString() {
         return "HybridSourceSplit{"
-            + "sourceIndex="
-            + sourceIndex
-            + ", splitId="
-            + splitId
-            + ", isFinished="
-            + isFinished
-            + "}";
+                + "sourceIndex="
+                + sourceIndex
+                + ", splitId="
+                + splitId
+                + ", isFinished="
+                + isFinished
+                + "}";
     }
 
     public static List<HybridSourceSplit> wrapSplits(

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
 import org.apache.flink.util.Preconditions;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SourceReaderFinishedEvent.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SourceReaderFinishedEvent.java
@@ -19,6 +19,12 @@
 package org.apache.flink.connector.base.source.hybrid;
 
 import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * A source event sent from the HybridSourceReader to the enumerator to indicate that the current
@@ -28,6 +34,7 @@ public class SourceReaderFinishedEvent implements SourceEvent {
 
     private static final long serialVersionUID = 1L;
     private final int sourceIndex;
+    private final List<HybridSourceSplit> finishedSplits;
 
     /**
      * Constructor.
@@ -35,7 +42,16 @@ public class SourceReaderFinishedEvent implements SourceEvent {
      * @param sourceIndex
      */
     public SourceReaderFinishedEvent(int sourceIndex) {
+        this(sourceIndex, Collections.emptyList());
+    }
+
+    public SourceReaderFinishedEvent(int sourceIndex, List<HybridSourceSplit> finishedSplits) {
         this.sourceIndex = sourceIndex;
+        this.finishedSplits = finishedSplits;
+    }
+
+    public List<HybridSourceSplit> getFinishedSplits() {
+        return finishedSplits;
     }
 
     public int sourceIndex() {

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -26,18 +26,17 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.hybrid.DynamicHybridSourceReader;
 import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -66,7 +65,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @PublicEvolving
 public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitStateT>
-        implements SourceReader<T, SplitT> {
+        implements DynamicHybridSourceReader<T, SplitT> {
     private static final Logger LOG = LoggerFactory.getLogger(SourceReaderBase.class);
 
     /** A queue to buffer the elements fetched by the fetcher thread. */
@@ -195,8 +194,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
             Map<String, SplitStateT> stateOfFinishedSplits = new HashMap<>();
             for (String finishedSplitId : finishedSplits) {
                 SplitStateT splitState = splitStates.remove(finishedSplitId).state;
-                stateOfFinishedSplits.put(
-                        finishedSplitId, splitState);
+                stateOfFinishedSplits.put(finishedSplitId, splitState);
                 this.finishedSplits.add(toSplitType(finishedSplitId, splitState));
                 output.releaseOutputForSplit(finishedSplitId);
             }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -33,10 +33,12 @@ import org.apache.flink.connector.base.source.reader.synchronization.FutureCompl
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
@@ -113,7 +113,11 @@ public class HybridSourceITCase extends TestLogger {
                 HybridSource.builder(new MockBaseSource(2, 10, Boundedness.BOUNDED));
         return builder.addSource(
                         (context) -> {
-                            List<MockSourceSplit> finishedSplits = context.getPreviousSplits();
+                            List<MockSourceSplit> previousSplits = context.getPreviousSplits();
+                            assertThat(previousSplits.size()).isEqualTo(2);
+                            previousSplits.forEach(
+                                    split -> assertThat(split).isInstanceOf(MockSourceSplit.class));
+
                             // lazily create source here
                             return new MockBaseSource(2, 10, 20, Boundedness.BOUNDED);
                         },

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
+
 import org.junit.Rule;
 import org.junit.Test;
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
@@ -23,7 +23,9 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
+import org.apache.flink.connector.base.source.reader.mocks.MockSplitEnumerator;
 import org.apache.flink.runtime.highavailability.nonha.embedded.HaLeadershipControl;
 import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.minicluster.RpcServiceSharing;
@@ -34,7 +36,6 @@ import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.operators.collect.ClientAndIterator;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
-
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -108,9 +109,11 @@ public class HybridSourceITCase extends TestLogger {
     }
 
     private Source sourceWithDynamicSwitchPosition() {
-        return HybridSource.builder(new MockBaseSource(2, 10, Boundedness.BOUNDED))
-                .addSource(
-                        (enumerator) -> {
+        HybridSource.HybridSourceBuilder<Integer, MockSourceSplit, MockSplitEnumerator> builder =
+                HybridSource.builder(new MockBaseSource(2, 10, Boundedness.BOUNDED));
+        return builder.addSource(
+                        (context) -> {
+                            List<MockSourceSplit> finishedSplits = context.getPreviousSplits();
                             // lazily create source here
                             return new MockBaseSource(2, 10, 20, Boundedness.BOUNDED);
                         },

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceITCase.java
@@ -116,7 +116,11 @@ public class HybridSourceITCase extends TestLogger {
                             List<MockSourceSplit> previousSplits = context.getPreviousSplits();
                             assertThat(previousSplits.size()).isEqualTo(2);
                             previousSplits.forEach(
-                                    split -> assertThat(split).isInstanceOf(MockSourceSplit.class));
+                                    split -> {
+                                        assertThat(split).isInstanceOf(MockSourceSplit.class);
+                                        assertThat(split.isFinished()).isTrue();
+                                        assertThat(split.endIndex()).isEqualTo(10);
+                                    });
 
                             // lazily create source here
                             return new MockBaseSource(2, 10, 20, Boundedness.BOUNDED);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.mock.Whitebox;
+
 import org.junit.Test;
 import org.mockito.Mockito;
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
 import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitEnumerator;
 import org.apache.flink.mock.Whitebox;
+
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.mockito.Mockito;

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.base.source.hybrid;
 
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.mocks.MockSource;
+
 import org.junit.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
@@ -20,9 +20,12 @@ package org.apache.flink.connector.base.source.hybrid;
 
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.mocks.MockSource;
-
 import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,18 +36,52 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Tests for {@link HybridSourceSplitSerializer}. */
 public class HybridSourceSplitSerializerTest {
 
+    @ParameterizedTest(name = "isFinished = {0}")
+    @ValueSource(booleans = {true, false})
+    public void testSerialization(boolean isFinished) throws Exception {
+        HybridSourceSplit split = createSerializedSplit(isFinished);
+        HybridSourceSplitSerializer serializer = new HybridSourceSplitSerializer();
+        byte[] serialized = serializer.serialize(split);
+        HybridSourceSplit clonedSplit = serializer.deserialize(1, serialized);
+        assertThat(clonedSplit).isEqualTo(split);
+        assertThat(clonedSplit.isFinished).isEqualTo(isFinished);
+
+        assertThatThrownBy(() -> serializer.deserialize(2, serialized))
+                .isInstanceOf(IOException.class);
+    }
+
     @Test
-    public void testSerialization() throws Exception {
+    public void testBackwardCompatibility() throws Exception {
+        HybridSourceSplit split = createSerializedSplit(true);
+        byte[] serializedV0 = deserializeV0(split);
+
+        HybridSourceSplitSerializer serializer = new HybridSourceSplitSerializer();
+        HybridSourceSplit clonedSplit = serializer.deserialize(0, serializedV0);
+
+        // version 0 doesn't serialize the isFinished field, so it should get the default false.
+        HybridSourceSplit expectedSplit = createSerializedSplit(false);
+        assertThat(clonedSplit).isEqualTo(expectedSplit);
+    }
+
+    private byte[] deserializeV0(HybridSourceSplit split) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeInt(split.sourceIndex());
+            out.writeUTF(split.splitId());
+            out.writeInt(split.wrappedSplitSerializerVersion());
+            out.writeInt(split.wrappedSplitBytes().length);
+            out.write(split.wrappedSplitBytes());
+            out.writeBoolean(split.isFinished);
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    private HybridSourceSplit createSerializedSplit(boolean isFinished) {
         Map<Integer, Source> switchedSources = new HashMap<>();
         switchedSources.put(0, new MockSource(null, 0));
         byte[] splitBytes = {1, 2, 3};
-        HybridSourceSplitSerializer serializer = new HybridSourceSplitSerializer();
-        HybridSourceSplit split = new HybridSourceSplit(0, splitBytes, 0, "splitId");
-        byte[] serialized = serializer.serialize(split);
-        HybridSourceSplit clonedSplit = serializer.deserialize(0, serialized);
-        assertThat(clonedSplit).isEqualTo(split);
-
-        assertThatThrownBy(() -> serializer.deserialize(1, serialized))
-                .isInstanceOf(IOException.class);
+        HybridSourceSplit split = new HybridSourceSplit(0, splitBytes, 0, "splitId", isFinished);
+        return split;
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitEnumerator;
+
 import org.junit.Test;
 
 import java.util.List;

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
@@ -71,7 +71,10 @@ public class MockSourceReader
 
     @Override
     protected MockSourceSplit toSplitType(String splitId, MockSplitState splitState) {
-        return new MockSourceSplit(Integer.parseInt(splitId), splitState.getRecordIndex());
+        return new MockSourceSplit(
+                Integer.parseInt(splitId),
+                splitState.getRecordIndex(),
+                splitState.getEndRecordIndex());
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
@@ -25,7 +25,10 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -102,6 +105,14 @@ public interface SourceReader<T, SplitT extends SourceSplit>
      * @param splits The splits assigned by the split enumerator.
      */
     void addSplits(List<SplitT> splits);
+
+    /**
+     * Gets a list of finished splits for this reader.
+     *
+     */
+    default List<SplitT> getFinishedSplits() {
+        return Collections.emptyList();
+    }
 
     /**
      * This method is called when the reader is notified that it will not receive any further

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
@@ -25,10 +25,7 @@ import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -105,14 +102,6 @@ public interface SourceReader<T, SplitT extends SourceSplit>
      * @param splits The splits assigned by the split enumerator.
      */
     void addSplits(List<SplitT> splits);
-
-    /**
-     * Gets a list of finished splits for this reader.
-     *
-     */
-    default List<SplitT> getFinishedSplits() {
-        return Collections.emptyList();
-    }
 
     /**
      * This method is called when the reader is notified that it will not receive any further


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Support dynamic stop position in FileSource

## Brief change log

- Added a new interface `DynamicHybridSourceReader` interface to allow implementor to participate dynamic initialization
  - implementation is added for `SourceReaderBase` so most reader can participate automatically
- The high-level mechanism works as follow:
  - On each checkpoint, `HybridSourceReader` retrieve the finished states (marked with `HybridSourceSplit.isFinished = true`) from the underlying reader and checkpoint them for persistent along with the unfinished states. 
  - Upon source switch, `HybridSourceReader` will send all the finished splits in `SourceReaderFinishedEvent` to the enumerator. 
  - Enumerator will pass along those finished splits to in `SourceSwitchContext` to the next source.


## Verifying this change

- Current test cases pass
- Test split serialization backward compatibility 
- Adjust one existing test case to check `SourceSwitchContext` has the correct finished splits from the previous source
- TODO: plan to add more tests

## Does this pull request potentially affect one of the following parts:

  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes

## Documentation

  - If yes, how is the feature documented? : should add documentation after change signed off
