### PR TITLE
[FLINK-28140][python][docs] Improve the documentation by adding Python examples in DataStream API Integration page

### DIFF
--- a/docs/content.zh/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content.zh/docs/dev/datastream/event-time/generating_watermarks.md
@@ -415,6 +415,11 @@ class TimeLagWatermarkGenerator extends AssignerWithPeriodicWatermarks[MyEvent] 
 }
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+目前在python中不支持该api
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 <a name="writing-a-punctuated-watermarkgenerator"></a>
@@ -460,6 +465,11 @@ class PunctuatedAssigner extends AssignerWithPunctuatedWatermarks[MyEvent] {
 }
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+目前在python中不支持该api
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 {{< hint warning >}}
@@ -497,6 +507,17 @@ kafkaSource.assignTimestampsAndWatermarks(
     .forBoundedOutOfOrderness(Duration.ofSeconds(20)))
 
 val stream: DataStream[MyType] = env.addSource(kafkaSource)
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+kafka_source = FlinkKafkaConsumer("timer-stream-source", schema, props)
+
+stream = env
+    .add_source(kafka_source)
+    .assign_timestamps_and_watermarks(
+        WatermarkStrategy
+            .for_bounded_out_of_orderness(Duration.of_seconds(20)))
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content.zh/docs/dev/datastream/execution/execution_configuration.md
+++ b/docs/content.zh/docs/dev/datastream/execution/execution_configuration.md
@@ -43,6 +43,12 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment
 var executionConfig = env.getConfig
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+execution_config = env.get_config()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 以下是可用的配置选项：（默认为粗体）

--- a/docs/content.zh/docs/dev/datastream/execution/parallel.md
+++ b/docs/content.zh/docs/dev/datastream/execution/parallel.md
@@ -73,6 +73,24 @@ wordCounts.print()
 env.execute("Word Count Example")
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+
+text = [...]
+word_counts = text
+    .flat_map(lambda x: x.split(" ")) \
+    .map(lambda i: (i, 1), output_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
+    .key_by(lambda i: i[0]) \
+    .window(TumblingEventTimeWindows.of(Time.seconds(5))) \
+    .reduce(lambda i, j: (i[0], i[1] + j[1])) \
+    .set_parallelism(5)
+word_counts.print()
+
+
+env.execute("Word Count Example")
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### 执行环境层次
@@ -106,6 +124,24 @@ val wordCounts = text
     .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1)
 wordCounts.print()
+
+env.execute("Word Count Example")
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_parallelism(3)
+
+text = [...]
+word_counts = text
+    .flat_map(lambda x: x.split(" ")) \
+    .map(lambda i: (i, 1), output_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
+    .key_by(lambda i: i[0]) \
+    .window(TumblingEventTimeWindows.of(Time.seconds(5))) \
+    .reduce(lambda i, j: (i[0], i[1] + j[1]))
+word_counts.print()
+
 
 env.execute("Word Count Example")
 ```
@@ -158,6 +194,11 @@ try {
 } catch {
     case e: Exception => e.printStackTrace
 }
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+目前在python中不支持该api
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content.zh/docs/dev/table/tableApi.md
+++ b/docs/content.zh/docs/dev/table/tableApi.md
@@ -1180,11 +1180,13 @@ val right = tableEnv.from("orders2")
 left.union(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
 left.union(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1213,11 +1215,13 @@ val right = tableEnv.from("orders2")
 left.unionAll(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
-left.unionAll(right)
+left.union_all(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1244,11 +1248,13 @@ val right = tableEnv.from("orders2")
 left.intersect(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
 left.intersect(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1275,11 +1281,13 @@ val right = tableEnv.from("orders2")
 left.intersectAll(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
-left.intersectAll(right)
+left.intersect_all(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1306,11 +1314,13 @@ val right = tableEnv.from("orders2")
 left.minus(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
 left.minus(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1336,11 +1346,13 @@ val right = tableEnv.from("orders2")
 left.minusAll(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
-left.minusAll(right)
+left.minus_all(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/docs/content.zh/docs/dev/table/timezone.md
+++ b/docs/content.zh/docs/dev/table/timezone.md
@@ -115,6 +115,21 @@ tEnv.getConfig.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 tEnv.getConfig.setLocalTimeZone(ZoneId.of("America/Los_Angeles"))
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env_setting = EnvironmentSettings.in_streaming_mode()
+t_env = TableEnvironment.create(env_setting)
+
+# set to UTC time zone
+t_env.get_config().set_local_timezone("UTC")
+
+# set to Shanghai time zone
+t_env.get_config().set_local_timezone("Asia/Shanghai")
+
+# set to Los_Angeles time zone
+t_env.get_config().set_local_timezone("America/Los_Angeles")
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 session（会话）的时区设置在 Flink SQL 中非常有用， 它的主要用法如下:

--- a/docs/content.zh/docs/ops/state/state_backends.md
+++ b/docs/content.zh/docs/ops/state/state_backends.md
@@ -136,6 +136,12 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment()
 env.setStateBackend(new HashMapStateBackend())
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(HashMapStateBackend())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 如果你想在 IDE 中使用 `EmbeddedRocksDBStateBackend`，或者需要在作业中通过编程方式动态配置它，必须添加以下依赖到 Flink 项目中。
@@ -292,6 +298,8 @@ RocksDB State Backend 会将 [这里定义]({{< ref "docs/deployment/config" >}}
 
 下面是自定义 `ConfigurableRocksDBOptionsFactory` 的一个示例 (开发完成后，请将您的实现类全名设置到 `state.backend.rocksdb.options-factory`).
 
+{{< tabs "6e6f1fd6-fcc6-4af4-929f-97dc7d639ef9" >}}
+{{< tab "Java" >}}
 ```java
 public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
     public static final ConfigOption<Integer> BLOCK_RESTART_INTERVAL = ConfigOptions
@@ -326,7 +334,13 @@ public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
     }
 }
 ```
-
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+目前在python中不支持该api
+```
+{{< /tab >}}
+{{< /tabs >}}
 {{< top >}}
 
 <a name="enabling-changelog"></a>
@@ -496,6 +510,13 @@ env.setStateBackend(new HashMapStateBackend)
 env.getCheckpointConfig().setCheckpointStorage(new JobManagerCheckpointStorage)
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(HashMapStateBackend())
+env.get_checkpoint_config().set_checkpoint_storage(JobManagerCheckpointStorage())
+```
+{{< /tab >}}
 {{< /tabs>}}
 
 ### FsStateBackend 
@@ -538,6 +559,18 @@ env.getCheckpointConfig().setCheckpointStorage("file:///checkpoint-dir")
 // Advanced FsStateBackend configurations, such as write buffer size
 // can be set by using manually instantiating a FileSystemCheckpointStorage object.
 env.getCheckpointConfig().setCheckpointStorage(new FileSystemCheckpointStorage("file:///checkpoint-dir"))
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(HashMapStateBackend())
+env.get_checkpoint_config().set_checkpoint_storage_dir("file:///checkpoint-dir")
+
+
+# Advanced FsStateBackend configurations, such as write buffer size
+# can be set by manually instantiating a FileSystemCheckpointStorage object.
+env.get_checkpoint_config().set_checkpoint_storage(FileSystemCheckpointStorage("file:///checkpoint-dir"))
 ```
 {{< /tab >}}
 {{< /tabs>}}
@@ -584,6 +617,19 @@ env.getCheckpointConfig().setCheckpointStorage("file:///checkpoint-dir")
 // to specify advanced checkpointing configurations such as write buffer size,
 // you can achieve the same results by using manually instantiating a FileSystemCheckpointStorage object.
 env.getCheckpointConfig().setCheckpointStorage(new FileSystemCheckpointStorage("file:///checkpoint-dir"))
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(EmbeddedRocksDBStateBackend())
+env.get_checkpoint_config().set_checkpoint_storage_dir("file:///checkpoint-dir")
+
+
+# If you manually passed FsStateBackend into the RocksDBStateBackend constructor
+# to specify advanced checkpointing configurations such as write buffer size,
+# you can achieve the same results by using manually instantiating a FileSystemCheckpointStorage object.
+env.get_checkpoint_config().set_checkpoint_storage(FileSystemCheckpointStorage("file:///checkpoint-dir"))
 ```
 {{< /tab >}}
 {{< /tabs>}}

--- a/docs/content.zh/docs/ops/state/task_failure_recovery.md
+++ b/docs/content.zh/docs/ops/state/task_failure_recovery.md
@@ -74,6 +74,15 @@ env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
 ))
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.fixed_delay_restart(
+    3,  # 尝试重启的次数
+    10000  # 延时(毫秒)
+))
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 
@@ -119,6 +128,15 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment()
 env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
   3, // 尝试重启的次数
   Time.of(10, TimeUnit.SECONDS) // 延时
+))
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.fixed_delay_restart(
+    3,  # 尝试重启的次数
+    10000  # 延时(毫秒)
 ))
 ```
 {{< /tab >}}
@@ -169,6 +187,16 @@ env.setRestartStrategy(RestartStrategies.failureRateRestart(
 ))
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.failure_rate_restart(
+    3,  # 每个时间间隔的最大故障次数
+    300000,  # 测量故障率的时间间隔
+    10000  # 延时(毫秒)
+))
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 
@@ -193,6 +221,12 @@ env.setRestartStrategy(RestartStrategies.noRestart());
 ```scala
 val env = StreamExecutionEnvironment.getExecutionEnvironment()
 env.setRestartStrategy(RestartStrategies.noRestart())
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.no_restart())
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
+++ b/docs/content/docs/dev/datastream/event-time/generating_watermarks.md
@@ -471,6 +471,11 @@ class TimeLagWatermarkGenerator extends WatermarkGenerator[MyEvent] {
 }
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+Currently not supported in Python API.
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Writing a Punctuated WatermarkGenerator
@@ -515,6 +520,11 @@ class PunctuatedAssigner extends WatermarkGenerator[MyEvent] {
         // don't need to do anything because we emit in reaction to events above
     }
 }
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+Currently not supported in Python API.
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -570,6 +580,17 @@ kafkaSource.assignTimestampsAndWatermarks(
     .forBoundedOutOfOrderness(Duration.ofSeconds(20)))
 
 val stream: DataStream[MyType] = env.addSource(kafkaSource)
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+kafka_source = FlinkKafkaConsumer("timer-stream-source", schema, props)
+
+stream = env
+    .add_source(kafka_source)
+    .assign_timestamps_and_watermarks(
+        WatermarkStrategy
+            .for_bounded_out_of_orderness(Duration.of_seconds(20)))
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/datastream/execution/execution_configuration.md
+++ b/docs/content/docs/dev/datastream/execution/execution_configuration.md
@@ -43,6 +43,12 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment
 var executionConfig = env.getConfig
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+execution_config = env.get_config()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 The following configuration options are available: (the default is bold)

--- a/docs/content/docs/dev/datastream/execution/parallel.md
+++ b/docs/content/docs/dev/datastream/execution/parallel.md
@@ -79,6 +79,24 @@ wordCounts.print()
 env.execute("Word Count Example")
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+
+text = [...]
+word_counts = text 
+    .flat_map(lambda x: x.split(" ")) \
+    .map(lambda i: (i, 1), output_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
+    .key_by(lambda i: i[0]) \
+    .window(TumblingEventTimeWindows.of(Time.seconds(5))) \
+    .reduce(lambda i, j: (i[0], i[1] + j[1])) \
+    .set_parallelism(5)
+word_counts.print()
+
+
+env.execute("Word Count Example")
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Execution Environment Level
@@ -118,6 +136,24 @@ val wordCounts = text
     .window(TumblingEventTimeWindows.of(Time.seconds(5)))
     .sum(1)
 wordCounts.print()
+
+env.execute("Word Count Example")
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_parallelism(3)
+
+text = [...]
+word_counts = text
+    .flat_map(lambda x: x.split(" ")) \
+    .map(lambda i: (i, 1), output_type=Types.TUPLE([Types.STRING(), Types.INT()])) \
+    .key_by(lambda i: i[0]) \
+    .window(TumblingEventTimeWindows.of(Time.seconds(5))) \
+    .reduce(lambda i, j: (i[0], i[1] + j[1]))
+word_counts.print()
+
 
 env.execute("Word Count Example")
 ```
@@ -173,6 +209,11 @@ try {
 } catch {
     case e: Exception => e.printStackTrace
 }
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+Currently not supported in Python API.
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/dev/table/tableApi.md
+++ b/docs/content/docs/dev/table/tableApi.md
@@ -1179,11 +1179,13 @@ val right = tableEnv.from("orders2")
 left.union(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
 left.union(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1212,11 +1214,13 @@ val right = tableEnv.from("orders2")
 left.unionAll(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
-left.unionAll(right)
+left.union_all(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1243,11 +1247,13 @@ val right = tableEnv.from("orders2")
 left.intersect(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
 left.intersect(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1274,11 +1280,13 @@ val right = tableEnv.from("orders2")
 left.intersectAll(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
-left.intersectAll(right)
+left.intersect_all(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1305,11 +1313,13 @@ val right = tableEnv.from("orders2")
 left.minus(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
 left.minus(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 
@@ -1335,11 +1345,13 @@ val right = tableEnv.from("orders2")
 left.minusAll(right)
 ```
 {{< /tab >}}
-{{< tab >}}
-left = tableEnv.from_path("orders1")
-right = tableEnv.from_path("orders2")
+{{< tab "Python" >}}
+```python
+left = t_env.from_path("orders1")
+right = t_env.from_path("orders2")
 
-left.minusAll(right)
+left.minus_all(right)
+```
 {{< /tab >}}
 {{< /tabs >}}
 

--- a/docs/content/docs/dev/table/timezone.md
+++ b/docs/content/docs/dev/table/timezone.md
@@ -115,6 +115,21 @@ tEnv.getConfig.setLocalTimeZone(ZoneId.of("Asia/Shanghai"))
 tEnv.getConfig.setLocalTimeZone(ZoneId.of("America/Los_Angeles"))
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env_setting = EnvironmentSettings.in_streaming_mode()
+t_env = TableEnvironment.create(env_setting)
+
+# set to UTC time zone
+t_env.get_config().set_local_timezone("UTC")
+
+# set to Shanghai time zone
+t_env.get_config().set_local_timezone("Asia/Shanghai")
+
+# set to Los_Angeles time zone
+t_env.get_config().set_local_timezone("America/Los_Angeles")
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 The session time zone is useful in Flink SQL, the main usages are:

--- a/docs/content/docs/ops/state/state_backends.md
+++ b/docs/content/docs/ops/state/state_backends.md
@@ -129,6 +129,12 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment()
 env.setStateBackend(new HashMapStateBackend())
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(HashMapStateBackend())
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 If you want to use the `EmbeddedRocksDBStateBackend` in your IDE or configure it programmatically in your Flink job, you will have to add the following dependency to your Flink project.
@@ -290,6 +296,8 @@ allocating more memory than configured.
 
 Below is an example how to define a custom ConfigurableOptionsFactory (set class name under `state.backend.rocksdb.options-factory`).
 
+{{< tabs "6e6f1fd6-fcc6-4af4-929f-97dc7d639eg8" >}}
+{{< tab "Java" >}}
 ```java
 public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
     public static final ConfigOption<Integer> BLOCK_RESTART_INTERVAL = ConfigOptions
@@ -324,6 +332,13 @@ public class MyOptionsFactory implements ConfigurableRocksDBOptionsFactory {
     }
 }
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+Currently not supported in Python API.
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 {{< top >}}
 
@@ -487,6 +502,13 @@ env.setStateBackend(new HashMapStateBackend)
 env.getCheckpointConfig().setCheckpointStorage(new JobManagerCheckpointStorage)
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(HashMapStateBackend())
+env.get_checkpoint_config().set_checkpoint_storage(JobManagerCheckpointStorage())
+```
+{{< /tab >}}
 {{< /tabs>}}
 
 ### FsStateBackend 
@@ -529,6 +551,18 @@ env.getCheckpointConfig().setCheckpointStorage("file:///checkpoint-dir")
 // Advanced FsStateBackend configurations, such as write buffer size
 // can be set by using manually instantiating a FileSystemCheckpointStorage object.
 env.getCheckpointConfig().setCheckpointStorage(new FileSystemCheckpointStorage("file:///checkpoint-dir"))
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(HashMapStateBackend())
+env.get_checkpoint_config().set_checkpoint_storage_dir("file:///checkpoint-dir")
+
+
+# Advanced FsStateBackend configurations, such as write buffer size
+# can be set by manually instantiating a FileSystemCheckpointStorage object.
+env.get_checkpoint_config().set_checkpoint_storage(FileSystemCheckpointStorage("file:///checkpoint-dir"))
 ```
 {{< /tab >}}
 {{< /tabs>}}
@@ -575,6 +609,19 @@ env.getCheckpointConfig().setCheckpointStorage("file:///checkpoint-dir")
 // to specify advanced checkpointing configurations such as write buffer size,
 // you can achieve the same results by using manually instantiating a FileSystemCheckpointStorage object.
 env.getCheckpointConfig().setCheckpointStorage(new FileSystemCheckpointStorage("file:///checkpoint-dir"))
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_state_backend(EmbeddedRocksDBStateBackend())
+env.get_checkpoint_config().set_checkpoint_storage_dir("file:///checkpoint-dir")
+
+
+# If you manually passed FsStateBackend into the RocksDBStateBackend constructor
+# to specify advanced checkpointing configurations such as write buffer size,
+# you can achieve the same results by using manually instantiating a FileSystemCheckpointStorage object.
+env.get_checkpoint_config().set_checkpoint_storage(FileSystemCheckpointStorage("file:///checkpoint-dir"))
 ```
 {{< /tab >}}
 {{< /tabs>}}

--- a/docs/content/docs/ops/state/task_failure_recovery.md
+++ b/docs/content/docs/ops/state/task_failure_recovery.md
@@ -77,6 +77,15 @@ env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
 ))
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.fixed_delay_restart(
+    3,  # number of restart attempts
+    10000  # delay(millisecond)
+))
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 
@@ -121,6 +130,15 @@ val env = StreamExecutionEnvironment.getExecutionEnvironment()
 env.setRestartStrategy(RestartStrategies.fixedDelayRestart(
   3, // number of restart attempts
   Time.of(10, TimeUnit.SECONDS) // delay
+))
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.fixed_delay_restart(
+    3,  # number of restart attempts
+    10000  # delay(millisecond)
 ))
 ```
 {{< /tab >}}
@@ -179,6 +197,11 @@ env.setRestartStrategy(RestartStrategies.exponentialDelayRestart(
 ))
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+Currently not supported in Python API.
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Failure Rate Restart Strategy
@@ -223,6 +246,16 @@ env.setRestartStrategy(RestartStrategies.failureRateRestart(
 ))
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.failure_rate_restart(
+    3,  # max failures per interval
+    300000,  # interval for measuring failure rate (millisecond)
+    10000  # dela(millisecond)
+))
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 
@@ -247,6 +280,12 @@ env.setRestartStrategy(RestartStrategies.noRestart());
 ```scala
 val env = StreamExecutionEnvironment.getExecutionEnvironment()
 env.setRestartStrategy(RestartStrategies.noRestart())
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+env = StreamExecutionEnvironment.get_execution_environment()
+env.set_restart_strategy(RestartStrategies.no_restart())
 ```
 {{< /tab >}}
 {{< /tabs >}}


### PR DESCRIPTION
## What is the purpose of the change

Improve the documentation by adding Python examples.

## Brief change log

  - Improve the timezone api documentation by adding Python examples.
   - Improve the table api documentation by adding Python examples.
  - Improve the generating watermarks api documentation by adding Python examples.
  - Improve the parallel configuration api documentation by adding Python examples.
  - Improve the timezone api documentation by adding Python examples.
  - Improve the state_backends api documentation by adding Python examples.
  - Improve the task_failure_recovery api documentation by adding Python examples.

## Verifying this change

  - This Change without andy test coverage.
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)