### PR TITLE
[FLINK-28586] Enable speculative execution for new sources

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsHandleExecutionAttemptSourceEvent.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsHandleExecutionAttemptSourceEvent.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * An decorative interface of {@link SplitEnumerator} which allows to handle {@link SourceEvent}
+ * sent from a specific execution attempt.
+ *
+ * <p>The split enumerator must implement this interface if it needs to deal with custom source
+ * events and is used in cases that a subtask can have multiple concurrent execution attempts, e.g.
+ * if speculative execution is enabled. Otherwise an error will be thrown when the split enumerator
+ * receives a custom source event.
+ */
+@PublicEvolving
+public interface SupportsHandleExecutionAttemptSourceEvent {
+
+    /**
+     * Handles a custom source event from the source reader. It is similar to {@link
+     * SplitEnumerator#handleSourceEvent(int, SourceEvent)} but is aware of the subtask execution
+     * attempt who sent this event.
+     *
+     * @param subtaskId the subtask id of the source reader who sent the source event.
+     * @param attemptNumber the attempt number of the source reader who sent the source event.
+     * @param sourceEvent the source event from the source reader.
+     */
+    void handleSourceEvent(int subtaskId, int attemptNumber, SourceEvent sourceEvent);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -220,8 +220,8 @@ public class ExecutionJobVertex
                 for (final SerializedValue<OperatorCoordinator.Provider> provider :
                         coordinatorProviders) {
                     coordinators.add(
-                            OperatorCoordinatorHolder.create(
-                                    provider, this, graph.getUserClassLoader(), coordinatorStore));
+                            createOperatorCoordinatorHolder(
+                                    provider, graph.getUserClassLoader(), coordinatorStore));
                 }
             } catch (Exception | LinkageError e) {
                 IOUtils.closeAllQuietly(coordinators);
@@ -276,6 +276,15 @@ public class ExecutionJobVertex
                 createTimestamp,
                 executionHistorySizeLimit,
                 initialAttemptCount);
+    }
+
+    protected OperatorCoordinatorHolder createOperatorCoordinatorHolder(
+            SerializedValue<OperatorCoordinator.Provider> provider,
+            ClassLoader classLoader,
+            CoordinatorStore coordinatorStore)
+            throws Exception {
+        return OperatorCoordinatorHolder.create(
+                provider, this, classLoader, coordinatorStore, false);
     }
 
     public boolean isInitialized() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -49,6 +49,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.runtime.execution.ExecutionState.FINISHED;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -256,6 +257,11 @@ public class ExecutionVertex
 
     public Collection<Execution> getCurrentExecutions() {
         return Collections.singleton(currentExecution);
+    }
+
+    public Execution getCurrentExecution(int attemptNumber) {
+        checkArgument(attemptNumber == currentExecution.getAttemptNumber());
+        return currentExecution;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
@@ -21,7 +21,11 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
+import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
+import org.apache.flink.util.SerializedValue;
 
 /** The ExecutionJobVertex which supports speculative execution. */
 public class SpeculativeExecutionJobVertex extends ExecutionJobVertex {
@@ -51,6 +55,16 @@ public class SpeculativeExecutionJobVertex extends ExecutionJobVertex {
                 createTimestamp,
                 executionHistorySizeLimit,
                 initialAttemptCount);
+    }
+
+    @Override
+    protected OperatorCoordinatorHolder createOperatorCoordinatorHolder(
+            SerializedValue<OperatorCoordinator.Provider> provider,
+            ClassLoader classLoader,
+            CoordinatorStore coordinatorStore)
+            throws Exception {
+        return OperatorCoordinatorHolder.create(
+                provider, this, classLoader, coordinatorStore, true);
     }
 
     /** Factory to create {@link SpeculativeExecutionJobVertex}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -256,10 +256,16 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
         ClassLoader getUserCodeClassloader();
 
         /**
-         * Get the {@link CoordinatorStore} instance for sharring information between {@link
+         * Gets the {@link CoordinatorStore} instance for sharing information between {@link
          * OperatorCoordinator}s.
          */
         CoordinatorStore getCoordinatorStore();
+
+        /**
+         * Gets that whether the coordinator supports an execution vertex to have multiple
+         * concurrent running execution attempts.
+         */
+        boolean isConcurrentExecutionAttemptsSupported();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -54,21 +54,24 @@ import java.util.concurrent.CompletableFuture;
  * In particular, the following methods are guaranteed to be called strictly in order:
  *
  * <ol>
- *   <li>{@link #subtaskReady(int, SubtaskGateway)}: Called once you can send events to the subtask.
- *       The provided gateway is bound to that specific task. This is the start of interaction with
- *       the operator subtasks.
- *   <li>{@link #subtaskFailed(int, Throwable)}: Called for each subtask as soon as the subtask
- *       execution failed or was cancelled. At this point, interaction with the subtask should stop.
+ *   <li>{@link #executionAttemptReady(int, int, SubtaskGateway)}: Called once you can send events
+ *       to the subtask execution attempt. The provided gateway is bound to that specific execution
+ *       attempt. This is the start of interaction with the operator subtask attempt.
+ *   <li>{@link #executionAttemptFailed(int, int, Throwable)}: Called for each subtask execution
+ *       attempt as soon as the attempt failed or was cancelled. At this point, interaction with the
+ *       subtask attempt should stop.
  *   <li>{@link #subtaskReset(int, long)} or {@link #resetToCheckpoint(long, byte[])}: Once the
  *       scheduler determined which checkpoint to restore, these methods notify the coordinator of
  *       that. The former method is called in case of a regional failure/recovery (affecting
  *       possible a subset of subtasks), the later method in case of a global failure/recovery. This
  *       method should be used to determine which actions to recover, because it tells you which
  *       checkpoint to fall back to. The coordinator implementation needs to recover the
- *       interactions with the relevant tasks since the checkpoint that is restored.
- *   <li>{@link #subtaskReady(int, SubtaskGateway)}: Called again, once the recovered tasks are
- *       ready to go. This is later than {@link #subtaskReset(int, long)}, because between those
- *       methods, the task are scheduled and deployed.
+ *       interactions with the relevant tasks since the checkpoint that is restored. It will be
+ *       called only after {@link #executionAttemptFailed(int, int, Throwable)} has been called on
+ *       all the attempts of the subtask.
+ *   <li>{@link #executionAttemptReady(int, int, SubtaskGateway)}: Called again, once the recovered
+ *       tasks (new attempts) are ready to go. This is later than {@link #subtaskReset(int, long)},
+ *       because between those methods, the new attempts are scheduled and deployed.
  * </ol>
  */
 @Internal
@@ -101,13 +104,14 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
     // ------------------------------------------------------------------------
 
     /**
-     * Hands an OperatorEvent coming from a parallel Operator instances (one of the parallel
+     * Hands an OperatorEvent coming from a parallel Operator instance (one attempt of the parallel
      * subtasks).
      *
      * @throws Exception Any exception thrown by this method results in a full job failure and
      *     recovery.
      */
-    void handleEventFromOperator(int subtask, OperatorEvent event) throws Exception;
+    void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event)
+            throws Exception;
 
     // ------------------------------------------------------------------------
 
@@ -195,35 +199,38 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
     // ------------------------------------------------------------------------
 
     /**
-     * Called when one of the subtasks of the task running the coordinated operator goes through a
-     * failover (failure / recovery cycle).
-     *
-     * <p>This method is called every time there is a failover of a subtasks, regardless of whether
-     * there it is a partial failover or a global failover.
-     */
-    void subtaskFailed(int subtask, @Nullable Throwable reason);
-
-    /**
-     * Called if a task is recovered as part of a <i>partial failover</i>, meaning a failover
+     * Called if a subtask is recovered as part of a <i>partial failover</i>, meaning a failover
      * handled by the scheduler's failover strategy (by default recovering a pipelined region). The
      * method is invoked for each subtask involved in that partial failover.
      *
      * <p>In contrast to this method, the {@link #resetToCheckpoint(long, byte[])} method is called
      * in the case of a global failover, which is the case when the coordinator (JobManager) is
      * recovered.
+     *
+     * <p>Note that this method will not be called if an execution attempt of a subtask failed, if
+     * the subtask is not entirely failed, i.e. if the subtask has other execution attempts that are
+     * not failed/canceled.
      */
     void subtaskReset(int subtask, long checkpointId);
 
     /**
-     * This is called when a subtask of the Operator becomes ready to receive events, both after
-     * initial startup and after task failover. The given {@code SubtaskGateway} can be used to send
-     * events to the executed subtask.
+     * Called when any subtask execution attempt of the task running the coordinated operator is
+     * failed/canceled.
+     *
+     * <p>This method is called every time an execution attempt is failed/canceled, regardless of
+     * whether there it is caused by a partial failover or a global failover.
+     */
+    void executionAttemptFailed(int subtask, int attemptNumber, @Nullable Throwable reason);
+
+    /**
+     * This is called when a subtask execution attempt of the Operator becomes ready to receive
+     * events. The given {@code SubtaskGateway} can be used to send events to the execution attempt.
      *
      * <p>The given {@code SubtaskGateway} is bound to that specific execution attempt that became
      * ready. All events sent through the gateway target that execution attempt; if the attempt is
      * no longer running by the time the event is sent, then the events are failed.
      */
-    void subtaskReady(int subtask, SubtaskGateway gateway);
+    void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway);
 
     // ------------------------------------------------------------------------
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -200,14 +200,15 @@ public class OperatorCoordinatorHolder
         context.unInitialize();
     }
 
-    public void handleEventFromOperator(int subtask, OperatorEvent event) throws Exception {
+    public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event)
+            throws Exception {
         mainThreadExecutor.assertRunningInMainThread();
-        coordinator.handleEventFromOperator(subtask, event);
+        coordinator.handleEventFromOperator(subtask, attemptNumber, event);
     }
 
-    public void subtaskFailed(int subtask, @Nullable Throwable reason) {
+    public void executionAttemptFailed(int subtask, int attemptNumber, @Nullable Throwable reason) {
         mainThreadExecutor.assertRunningInMainThread();
-        coordinator.subtaskFailed(subtask, reason);
+        coordinator.executionAttemptFailed(subtask, attemptNumber, reason);
     }
 
     @Override
@@ -409,7 +410,8 @@ public class OperatorCoordinatorHolder
 
     private void notifySubtaskReady(int subtask, OperatorCoordinator.SubtaskGateway gateway) {
         try {
-            coordinator.subtaskReady(subtask, gateway);
+            coordinator.executionAttemptReady(
+                    subtask, gateway.getExecution().getAttemptNumber(), gateway);
         } catch (Throwable t) {
             ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
             globalFailureHandler.handleGlobalFailure(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorEventGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorEventGateway.java
@@ -43,7 +43,7 @@ public interface OperatorEventGateway {
 
     /**
      * Sends the given event to the coordinator, where it will be handled by the {@link
-     * OperatorCoordinator#handleEventFromOperator(int, OperatorEvent)} method.
+     * OperatorCoordinator#handleEventFromOperator(int, int, OperatorEvent)} method.
      */
     void sendEventToCoordinator(OperatorEvent event);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorEventHandler.java
@@ -23,7 +23,7 @@ package org.apache.flink.runtime.operators.coordination;
  * an {@link OperatorCoordinator} and a runtime operator (which registers this handler).
  *
  * <p>The counterpart to this handler is the {@link OperatorCoordinator#handleEventFromOperator(int,
- * OperatorEvent)} method.
+ * int, OperatorEvent)} method.
  */
 public interface OperatorEventHandler {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -246,6 +246,11 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
             return context.getCoordinatorStore();
         }
 
+        @Override
+        public boolean isConcurrentExecutionAttemptsSupported() {
+            return context.isConcurrentExecutionAttemptsSupported();
+        }
+
         @VisibleForTesting
         synchronized void quiesce() {
             quiesced = true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -77,14 +77,18 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
-    public void handleEventFromOperator(int subtask, OperatorEvent event) throws Exception {
+    public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event)
+            throws Exception {
         coordinator.applyCall(
-                "handleEventFromOperator", c -> c.handleEventFromOperator(subtask, event));
+                "handleEventFromOperator",
+                c -> c.handleEventFromOperator(subtask, attemptNumber, event));
     }
 
     @Override
-    public void subtaskFailed(int subtask, @Nullable Throwable reason) {
-        coordinator.applyCall("subtaskFailed", c -> c.subtaskFailed(subtask, reason));
+    public void executionAttemptFailed(int subtask, int attemptNumber, @Nullable Throwable reason) {
+        coordinator.applyCall(
+                "executionAttemptFailed",
+                c -> c.executionAttemptFailed(subtask, attemptNumber, reason));
     }
 
     @Override
@@ -93,8 +97,10 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
-    public void subtaskReady(int subtask, SubtaskGateway gateway) {
-        coordinator.applyCall("subtaskReady", c -> c.subtaskReady(subtask, gateway));
+    public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {
+        coordinator.applyCall(
+                "executionAttemptReady",
+                c -> c.executionAttemptReady(subtask, attemptNumber, gateway));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/SubtaskAccess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/SubtaskAccess.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.util.SerializedValue;
 
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 
@@ -90,9 +91,15 @@ interface SubtaskAccess {
     interface SubtaskAccessFactory {
 
         /**
-         * Creates an access to the current execution attempt of the subtask with the given
+         * Creates accesses to all the current execution attempt of the subtask with the given
          * subtaskIndex.
          */
-        SubtaskAccess getAccessForSubtask(int subtaskIndex);
+        Collection<SubtaskAccess> getAccessesForSubtask(int subtaskIndex);
+
+        /**
+         * Creates an access to the execution attempt with the given attemptNumber of the subtask
+         * with the given subtaskIndex.
+         */
+        SubtaskAccess getAccessForAttempt(int subtaskIndex, int attemptNumber);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -118,7 +118,8 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
         }
 
         try {
-            coordinator.handleEventFromOperator(exec.getParallelSubtaskIndex(), evt);
+            coordinator.handleEventFromOperator(
+                    exec.getParallelSubtaskIndex(), exec.getAttemptNumber(), evt);
         } catch (Throwable t) {
             ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
             globalFailureHandler.handleGlobalFailure(t);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -283,8 +283,11 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
             final Execution execution, @Nullable final Throwable error) {
         final ExecutionJobVertex jobVertex = execution.getVertex().getJobVertex();
         final int subtaskIndex = execution.getParallelSubtaskIndex();
+        final int attemptNumber = execution.getAttemptNumber();
 
-        jobVertex.getOperatorCoordinators().forEach(c -> c.subtaskFailed(subtaskIndex, error));
+        jobVertex
+                .getOperatorCoordinators()
+                .forEach(c -> c.executionAttemptFailed(subtaskIndex, attemptNumber, error));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -219,7 +219,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     }
 
     @Override
-    public void handleEventFromOperator(int subtask, OperatorEvent event) {
+    public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event) {
         runInEventLoop(
                 () -> {
                     if (event instanceof RequestSplitEvent) {
@@ -261,7 +261,8 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     }
 
     @Override
-    public void subtaskFailed(int subtaskId, @Nullable Throwable reason) {
+    public void executionAttemptFailed(
+            int subtaskId, int attemptNumber, @Nullable Throwable reason) {
         runInEventLoop(
                 () -> {
                     LOG.info(
@@ -299,7 +300,7 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
     }
 
     @Override
-    public void subtaskReady(int subtask, SubtaskGateway gateway) {
+    public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {
         assert subtask == gateway.getSubtask();
 
         runInEventLoop(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -22,11 +22,11 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.common.eventtime.WatermarkAlignmentParams;
-import org.apache.flink.api.connector.source.ReaderInfo;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SupportsHandleExecutionAttemptSourceEvent;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.core.memory.DataInputViewStreamWrapper;
 import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
@@ -68,6 +68,7 @@ import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerde
 import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.readBytes;
 import static org.apache.flink.runtime.source.coordinator.SourceCoordinatorSerdeUtils.writeCoordinatorSerdeVersion;
 import static org.apache.flink.util.IOUtils.closeAll;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
@@ -137,6 +138,12 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         this.watermarkAlignmentParams = watermarkAlignmentParams;
 
         if (watermarkAlignmentParams.isEnabled()) {
+            if (context.isConcurrentExecutionAttemptsSupported()) {
+                throw new IllegalArgumentException(
+                        "Watermark alignment is not supported in concurrent execution attempts "
+                                + "scenario (e.g. if speculative execution is enabled)");
+            }
+
             coordinatorStore.putIfAbsent(
                     watermarkAlignmentParams.getWatermarkGroup(), new WatermarkAggregator<>());
             context.getCoordinatorExecutor()
@@ -223,30 +230,15 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         runInEventLoop(
                 () -> {
                     if (event instanceof RequestSplitEvent) {
-                        LOG.info(
-                                "Source {} received split request from parallel task {}",
-                                operatorName,
-                                subtask);
-                        enumerator.handleSplitRequest(
-                                subtask, ((RequestSplitEvent) event).hostName());
+                        handleRequestSplitEvent(subtask, attemptNumber, (RequestSplitEvent) event);
                     } else if (event instanceof SourceEventWrapper) {
-                        final SourceEvent sourceEvent =
-                                ((SourceEventWrapper) event).getSourceEvent();
-                        LOG.debug(
-                                "Source {} received custom event from parallel task {}: {}",
-                                operatorName,
+                        handleSourceEvent(
                                 subtask,
-                                sourceEvent);
-                        enumerator.handleSourceEvent(subtask, sourceEvent);
+                                attemptNumber,
+                                ((SourceEventWrapper) event).getSourceEvent());
                     } else if (event instanceof ReaderRegistrationEvent) {
-                        final ReaderRegistrationEvent registrationEvent =
-                                (ReaderRegistrationEvent) event;
-                        LOG.info(
-                                "Source {} registering reader for parallel task {} @ {}",
-                                operatorName,
-                                subtask,
-                                registrationEvent.location());
-                        handleReaderRegistrationEvent(registrationEvent);
+                        handleReaderRegistrationEvent(
+                                subtask, attemptNumber, (ReaderRegistrationEvent) event);
                     } else if (event instanceof ReportedWatermarkEvent) {
                         handleReportedWatermark(
                                 subtask,
@@ -255,9 +247,10 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                         throw new FlinkException("Unrecognized Operator Event: " + event);
                     }
                 },
-                "handling operator event %s from subtask %d",
+                "handling operator event %s from subtask %d (#%d)",
                 event,
-                subtask);
+                subtask,
+                attemptNumber);
     }
 
     @Override
@@ -266,14 +259,17 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
         runInEventLoop(
                 () -> {
                     LOG.info(
-                            "Removing registered reader after failure for subtask {} of source {}.",
+                            "Removing registered reader after failure for subtask {} (#{}) of source {}.",
                             subtaskId,
+                            attemptNumber,
                             operatorName);
-                    context.unregisterSourceReader(subtaskId);
-                    context.subtaskNotReady(subtaskId);
+
+                    context.unregisterSourceReader(subtaskId, attemptNumber);
+                    context.attemptFailed(subtaskId, attemptNumber);
                 },
-                "handling subtask %d failure",
-                subtaskId);
+                "handling subtask %d (#%d) failure",
+                subtaskId,
+                attemptNumber);
     }
 
     @Override
@@ -285,6 +281,8 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
                             subtaskId,
                             checkpointId,
                             operatorName);
+
+                    context.subtaskReset(subtaskId);
 
                     final List<SplitT> splitsToAddBack =
                             context.getAndRemoveUncheckpointedAssignment(subtaskId, checkpointId);
@@ -301,12 +299,14 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
 
     @Override
     public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {
-        assert subtask == gateway.getSubtask();
+        checkArgument(subtask == gateway.getSubtask());
+        checkArgument(attemptNumber == gateway.getExecution().getAttemptNumber());
 
         runInEventLoop(
-                () -> context.subtaskReady(gateway),
-                "making event gateway to subtask %d available",
-                subtask);
+                () -> context.attemptReady(gateway),
+                "making event gateway to subtask %d (#%d) available",
+                subtask,
+                attemptNumber);
     }
 
     @Override
@@ -493,12 +493,68 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
 
     // --------------------- private methods -------------
 
-    private void handleReaderRegistrationEvent(ReaderRegistrationEvent event) {
-        context.registerSourceReader(new ReaderInfo(event.subtaskId(), event.location()));
-        enumerator.addReader(event.subtaskId());
+    private void handleRequestSplitEvent(int subtask, int attemptNumber, RequestSplitEvent event) {
+        LOG.info(
+                "Source {} received split request from parallel task {} (#{})",
+                operatorName,
+                subtask,
+                attemptNumber);
+
+        // request splits from the enumerator only if the enumerator has un-assigned splits
+        // this helps to reduce unnecessary split requests to the enumerator
+        if (!context.hasNoMoreSplits(subtask)) {
+            enumerator.handleSplitRequest(subtask, event.hostName());
+        }
     }
 
-    private void handleReportedWatermark(int subtask, Watermark watermark) {
+    private void handleSourceEvent(int subtask, int attemptNumber, SourceEvent event) {
+        LOG.debug(
+                "Source {} received custom event from parallel task {} (#{}): {}",
+                operatorName,
+                subtask,
+                attemptNumber,
+                event);
+
+        if (context.isConcurrentExecutionAttemptsSupported()) {
+            checkState(
+                    enumerator instanceof SupportsHandleExecutionAttemptSourceEvent,
+                    "The split enumerator %s must implement SupportsHandleExecutionAttemptSourceEvent "
+                            + "to be used in concurrent execution attempts scenario (e.g. if "
+                            + "speculative execution is enabled).",
+                    enumerator.getClass().getCanonicalName());
+            ((SupportsHandleExecutionAttemptSourceEvent) enumerator)
+                    .handleSourceEvent(subtask, attemptNumber, event);
+        } else {
+            enumerator.handleSourceEvent(subtask, event);
+        }
+    }
+
+    private void handleReaderRegistrationEvent(
+            int subtask, int attemptNumber, ReaderRegistrationEvent event) {
+        checkArgument(subtask == event.subtaskId());
+
+        LOG.info(
+                "Source {} registering reader for parallel task {} (#{}) @ {}",
+                operatorName,
+                subtask,
+                attemptNumber,
+                event.location());
+
+        final boolean subtaskReaderExisted =
+                context.registeredReadersOfAttempts().containsKey(subtask);
+        context.registerSourceReader(subtask, attemptNumber, event.location());
+        if (!subtaskReaderExisted) {
+            enumerator.addReader(event.subtaskId());
+        }
+    }
+
+    private void handleReportedWatermark(int subtask, Watermark watermark) throws FlinkException {
+        if (context.isConcurrentExecutionAttemptsSupported()) {
+            throw new FlinkException(
+                    "ReportedWatermarkEvent is not supported in concurrent execution attempts "
+                            + "scenario (e.g. if speculative execution is enabled)");
+        }
+
         LOG.debug("New reported watermark={} from subTaskId={}", watermark, subtask);
 
         checkState(watermarkAlignmentParams.isEnabled());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -38,14 +38,21 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.ThrowableCatchingRunnable;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -56,6 +63,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.BiConsumer;
 
 import static org.apache.flink.runtime.operators.coordination.ComponentClosingUtils.shutdownExecutorForcefully;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * A context class for the {@link OperatorCoordinator}. Compared with {@link SplitEnumeratorContext}
@@ -88,13 +96,14 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     private final ExecutorNotifier notifier;
     private final OperatorCoordinator.Context operatorCoordinatorContext;
     private final SimpleVersionedSerializer<SplitT> splitSerializer;
-    private final ConcurrentMap<Integer, ReaderInfo> registeredReaders;
+    private final ConcurrentMap<Integer, ConcurrentMap<Integer, ReaderInfo>> registeredReaders;
     private final SplitAssignmentTracker<SplitT> assignmentTracker;
     private final SourceCoordinatorProvider.CoordinatorExecutorThreadFactory
             coordinatorThreadFactory;
-    private final OperatorCoordinator.SubtaskGateway[] subtaskGateways;
+    private final SubtaskGateways subtaskGateways;
     private final String coordinatorThreadName;
     private final boolean supportsConcurrentExecutionAttempts;
+    private final boolean[] subtaskHasNoMoreSplits;
     private volatile boolean closed;
 
     public SourceCoordinatorContext(
@@ -135,9 +144,11 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         this.assignmentTracker = splitAssignmentTracker;
         this.coordinatorThreadName = coordinatorThreadFactory.getCoordinatorThreadName();
         this.supportsConcurrentExecutionAttempts = supportsConcurrentExecutionAttempts;
-        this.subtaskGateways =
-                new OperatorCoordinator.SubtaskGateway
-                        [operatorCoordinatorContext.currentParallelism()];
+
+        final int parallelism = operatorCoordinatorContext.currentParallelism();
+        this.subtaskGateways = new SubtaskGateways(parallelism);
+        this.subtaskHasNoMoreSplits = new boolean[parallelism];
+        Arrays.fill(subtaskHasNoMoreSplits, false);
 
         final Executor errorHandlingCoordinatorExecutor =
                 (runnable) ->
@@ -159,16 +170,39 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     @Override
     public void sendEventToSourceReader(int subtaskId, SourceEvent event) {
+        checkState(
+                !supportsConcurrentExecutionAttempts,
+                "The split enumerator must invoke SplitEnumeratorContext"
+                        + "#sendEventToSourceReader(int, int, SourceEvent) instead of "
+                        + "SplitEnumeratorContext#sendEventToSourceReader(int, SourceEvent) "
+                        + "to send custom source events in concurrent execution attempts scenario "
+                        + "(e.g. if speculative execution is enabled).");
         checkSubtaskIndex(subtaskId);
 
         callInCoordinatorThread(
                 () -> {
                     final OperatorCoordinator.SubtaskGateway gateway =
-                            getGatewayAndCheckReady(subtaskId);
+                            subtaskGateways.getOnlyGatewayAndCheckReady(subtaskId);
                     gateway.sendEvent(new SourceEventWrapper(event));
                     return null;
                 },
                 String.format("Failed to send event %s to subtask %d", event, subtaskId));
+    }
+
+    @Override
+    public void sendEventToSourceReader(int subtaskId, int attemptNumber, SourceEvent event) {
+        checkSubtaskIndex(subtaskId);
+
+        callInCoordinatorThread(
+                () -> {
+                    final OperatorCoordinator.SubtaskGateway gateway =
+                            subtaskGateways.getGatewayAndCheckReady(subtaskId, attemptNumber);
+                    gateway.sendEvent(new SourceEventWrapper(event));
+                    return null;
+                },
+                String.format(
+                        "Failed to send event %s to subtask %d (#%d)",
+                        event, subtaskId, attemptNumber));
     }
 
     void sendEventToSourceOperator(int subtaskId, OperatorEvent event) {
@@ -177,7 +211,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         callInCoordinatorThread(
                 () -> {
                     final OperatorCoordinator.SubtaskGateway gateway =
-                            getGatewayAndCheckReady(subtaskId);
+                            subtaskGateways.getOnlyGatewayAndCheckReady(subtaskId);
                     gateway.sendEvent(event);
                     return null;
                 },
@@ -195,6 +229,24 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     @Override
     public Map<Integer, ReaderInfo> registeredReaders() {
+        final Map<Integer, ReaderInfo> readers = new HashMap<>();
+        for (Map.Entry<Integer, ConcurrentMap<Integer, ReaderInfo>> entry :
+                registeredReaders.entrySet()) {
+            final int subtaskIndex = entry.getKey();
+            final Map<Integer, ReaderInfo> attemptReaders = entry.getValue();
+            int earliestAttempt = Integer.MAX_VALUE;
+            for (int attemptNumber : attemptReaders.keySet()) {
+                if (attemptNumber < earliestAttempt) {
+                    earliestAttempt = attemptNumber;
+                }
+            }
+            readers.put(subtaskIndex, attemptReaders.get(earliestAttempt));
+        }
+        return Collections.unmodifiableMap(readers);
+    }
+
+    @Override
+    public Map<Integer, Map<Integer, ReaderInfo>> registeredReadersOfAttempts() {
         return Collections.unmodifiableMap(registeredReaders);
     }
 
@@ -217,24 +269,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
                                     });
 
                     assignmentTracker.recordSplitAssignment(assignment);
-                    assignment
-                            .assignment()
-                            .forEach(
-                                    (id, splits) -> {
-                                        final OperatorCoordinator.SubtaskGateway gateway =
-                                                getGatewayAndCheckReady(id);
-
-                                        final AddSplitEvent<SplitT> addSplitEvent;
-                                        try {
-                                            addSplitEvent =
-                                                    new AddSplitEvent<>(splits, splitSerializer);
-                                        } catch (IOException e) {
-                                            throw new FlinkRuntimeException(
-                                                    "Failed to serialize splits.", e);
-                                        }
-
-                                        gateway.sendEvent(addSplitEvent);
-                                    });
+                    assignSplitsToAttempts(assignment);
                     return null;
                 },
                 String.format("Failed to assign splits %s due to ", assignment));
@@ -247,9 +282,8 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         // Ensure the split assignment is done by the coordinator executor.
         callInCoordinatorThread(
                 () -> {
-                    final OperatorCoordinator.SubtaskGateway gateway =
-                            getGatewayAndCheckReady(subtask);
-                    gateway.sendEvent(new NoMoreSplitsEvent());
+                    subtaskHasNoMoreSplits[subtask] = true;
+                    signalNoMoreSplitsToAttempts(subtask);
                     return null; // void return value
                 },
                 "Failed to send 'NoMoreSplits' to reader " + subtask);
@@ -293,27 +327,28 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     // --------- Package private additional methods for the SourceCoordinator ------------
 
-    void subtaskReady(OperatorCoordinator.SubtaskGateway gateway) {
-        final int subtask = gateway.getSubtask();
-        if (subtaskGateways[subtask] == null) {
-            subtaskGateways[gateway.getSubtask()] = gateway;
-        } else {
-            throw new IllegalStateException("Already have a subtask gateway for " + subtask);
-        }
+    void attemptReady(OperatorCoordinator.SubtaskGateway gateway) {
+        checkState(coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
+
+        subtaskGateways.registerSubtaskGateway(gateway);
     }
 
-    void subtaskNotReady(int subtaskIndex) {
-        subtaskGateways[subtaskIndex] = null;
+    void attemptFailed(int subtaskIndex, int attemptNumber) {
+        checkState(coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
+
+        subtaskGateways.unregisterSubtaskGateway(subtaskIndex, attemptNumber);
     }
 
-    OperatorCoordinator.SubtaskGateway getGatewayAndCheckReady(int subtaskIndex) {
-        final OperatorCoordinator.SubtaskGateway gateway = subtaskGateways[subtaskIndex];
-        if (gateway != null) {
-            return gateway;
-        }
+    void subtaskReset(int subtaskIndex) {
+        checkState(coordinatorThreadFactory.isCurrentThreadCoordinatorThread());
 
-        throw new IllegalStateException(
-                String.format("Subtask %d is not ready yet to receive events.", subtaskIndex));
+        subtaskGateways.reset(subtaskIndex);
+        registeredReaders.remove(subtaskIndex);
+        subtaskHasNoMoreSplits[subtaskIndex] = false;
+    }
+
+    boolean hasNoMoreSplits(int subtaskIndex) {
+        return subtaskHasNoMoreSplits[subtaskIndex];
     }
 
     /**
@@ -350,24 +385,38 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
     /**
      * Register a source reader.
      *
-     * @param readerInfo the reader information of the source reader.
+     * @param subtaskId the subtask id of the source reader.
+     * @param attemptNumber the attempt number of the source reader.
+     * @param location the location of the source reader.
      */
-    void registerSourceReader(ReaderInfo readerInfo) {
-        final ReaderInfo previousReader =
-                registeredReaders.put(readerInfo.getSubtaskId(), readerInfo);
-        if (previousReader != null) {
-            throw new IllegalStateException(
-                    "Overwriting " + previousReader + " with " + readerInfo);
-        }
+    void registerSourceReader(int subtaskId, int attemptNumber, String location) {
+        final Map<Integer, ReaderInfo> attemptReaders =
+                registeredReaders.computeIfAbsent(subtaskId, k -> new ConcurrentHashMap<>());
+        checkState(
+                !attemptReaders.containsKey(attemptNumber),
+                "ReaderInfo of subtask %s (#%s) already exists.",
+                subtaskId,
+                attemptNumber);
+        attemptReaders.put(attemptNumber, new ReaderInfo(subtaskId, location));
+
+        sendCachedSplitsToNewlyRegisteredReader(subtaskId, attemptNumber);
     }
 
     /**
      * Unregister a source reader.
      *
      * @param subtaskId the subtask id of the source reader.
+     * @param attemptNumber the attempt number of the source reader.
      */
-    void unregisterSourceReader(int subtaskId) {
-        registeredReaders.remove(subtaskId);
+    void unregisterSourceReader(int subtaskId, int attemptNumber) {
+        final Map<Integer, ReaderInfo> attemptReaders = registeredReaders.get(subtaskId);
+        if (attemptReaders != null) {
+            attemptReaders.remove(attemptNumber);
+
+            if (attemptReaders.isEmpty()) {
+                registeredReaders.remove(subtaskId);
+            }
+        }
     }
 
     /**
@@ -438,6 +487,131 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
         } catch (Throwable t) {
             LOG.error("Uncaught Exception in Source Coordinator Executor", t);
             throw new FlinkRuntimeException(errorMessage, t);
+        }
+    }
+
+    private void assignSplitsToAttempts(SplitsAssignment<SplitT> assignment) {
+        assignment.assignment().forEach((index, splits) -> assignSplitsToAttempts(index, splits));
+    }
+
+    private void assignSplitsToAttempts(int subtaskIndex, List<SplitT> splits) {
+        getRegisteredAttempts(subtaskIndex)
+                .forEach(attempt -> assignSplitsToAttempt(subtaskIndex, attempt, splits));
+    }
+
+    private void assignSplitsToAttempt(int subtaskIndex, int attemptNumber, List<SplitT> splits) {
+        if (splits.isEmpty()) {
+            return;
+        }
+
+        checkAttemptReaderReady(subtaskIndex, attemptNumber);
+
+        final AddSplitEvent<SplitT> addSplitEvent;
+        try {
+            addSplitEvent = new AddSplitEvent<>(splits, splitSerializer);
+        } catch (IOException e) {
+            throw new FlinkRuntimeException("Failed to serialize splits.", e);
+        }
+
+        final OperatorCoordinator.SubtaskGateway gateway =
+                subtaskGateways.getGatewayAndCheckReady(subtaskIndex, attemptNumber);
+        gateway.sendEvent(addSplitEvent);
+    }
+
+    private void signalNoMoreSplitsToAttempts(int subtaskIndex) {
+        getRegisteredAttempts(subtaskIndex)
+                .forEach(attemptNumber -> signalNoMoreSplitsToAttempt(subtaskIndex, attemptNumber));
+    }
+
+    private void signalNoMoreSplitsToAttempt(int subtaskIndex, int attemptNumber) {
+        checkAttemptReaderReady(subtaskIndex, attemptNumber);
+
+        final OperatorCoordinator.SubtaskGateway gateway =
+                subtaskGateways.getGatewayAndCheckReady(subtaskIndex, attemptNumber);
+        gateway.sendEvent(new NoMoreSplitsEvent());
+    }
+
+    private void checkAttemptReaderReady(int subtaskIndex, int attemptNumber) {
+        checkState(registeredReaders.containsKey(subtaskIndex));
+        checkState(getRegisteredAttempts(subtaskIndex).contains(attemptNumber));
+    }
+
+    private Set<Integer> getRegisteredAttempts(int subtaskIndex) {
+        return registeredReaders.get(subtaskIndex).keySet();
+    }
+
+    private void sendCachedSplitsToNewlyRegisteredReader(int subtaskIndex, int attemptNumber) {
+        // For batch jobs, checkpoints will never happen so that the un-checkpointed assignments in
+        // assignmentTracker can be seen as cached splits. For streaming jobs,
+        // #supportsConcurrentExecutionAttempts should be false and un-checkpointed assignments
+        // should be empty when a new reader is registered (cleared when the last reader failed).
+        final LinkedHashSet<SplitT> cachedSplits =
+                assignmentTracker.uncheckpointedAssignments().get(subtaskIndex);
+
+        if (cachedSplits != null) {
+            if (supportsConcurrentExecutionAttempts) {
+                assignSplitsToAttempt(subtaskIndex, attemptNumber, new ArrayList<>(cachedSplits));
+                if (hasNoMoreSplits(subtaskIndex)) {
+                    signalNoMoreSplitsToAttempt(subtaskIndex, attemptNumber);
+                }
+            } else {
+                throw new IllegalStateException("No cached split is expected.");
+            }
+        }
+    }
+
+    /** Maintains the subtask gateways for different execution attempts of different subtasks. */
+    private static class SubtaskGateways {
+        private final Map<Integer, OperatorCoordinator.SubtaskGateway>[] gateways;
+
+        private SubtaskGateways(int parallelism) {
+            gateways = new Map[parallelism];
+            for (int i = 0; i < parallelism; i++) {
+                gateways[i] = new HashMap<>();
+            }
+        }
+
+        private void registerSubtaskGateway(OperatorCoordinator.SubtaskGateway gateway) {
+            final int subtaskIndex = gateway.getSubtask();
+            final int attemptNumber = gateway.getExecution().getAttemptNumber();
+
+            checkState(
+                    !gateways[subtaskIndex].containsKey(attemptNumber),
+                    "Already have a subtask gateway for %s (#%s).",
+                    subtaskIndex,
+                    attemptNumber);
+            gateways[subtaskIndex].put(attemptNumber, gateway);
+        }
+
+        private void unregisterSubtaskGateway(int subtaskIndex, int attemptNumber) {
+            gateways[subtaskIndex].remove(attemptNumber);
+        }
+
+        private OperatorCoordinator.SubtaskGateway getOnlyGatewayAndCheckReady(int subtaskIndex) {
+            checkState(
+                    gateways[subtaskIndex].size() > 0,
+                    "Subtask %s is not ready yet to receive events.",
+                    subtaskIndex);
+
+            return Iterables.getOnlyElement(gateways[subtaskIndex].values());
+        }
+
+        private OperatorCoordinator.SubtaskGateway getGatewayAndCheckReady(
+                int subtaskIndex, int attemptNumber) {
+            final OperatorCoordinator.SubtaskGateway gateway =
+                    gateways[subtaskIndex].get(attemptNumber);
+            if (gateway != null) {
+                return gateway;
+            }
+
+            throw new IllegalStateException(
+                    String.format(
+                            "Subtask %d (#%d) is not ready yet to receive events.",
+                            subtaskIndex, attemptNumber));
+        }
+
+        private void reset(int subtaskIndex) {
+            gateways[subtaskIndex].clear();
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProvider.java
@@ -77,7 +77,11 @@ public class SourceCoordinatorProvider<SplitT extends SourceSplit>
         SimpleVersionedSerializer<SplitT> splitSerializer = source.getSplitSerializer();
         SourceCoordinatorContext<SplitT> sourceCoordinatorContext =
                 new SourceCoordinatorContext<>(
-                        coordinatorThreadFactory, numWorkerThreads, context, splitSerializer);
+                        coordinatorThreadFactory,
+                        numWorkerThreads,
+                        context,
+                        splitSerializer,
+                        context.isConcurrentExecutionAttemptsSupported());
         return new SourceCoordinator<>(
                 operatorName,
                 source,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SplitAssignmentTracker.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitsAssignment;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -121,9 +122,8 @@ public class SplitAssignmentTracker<SplitT extends SourceSplit> {
         return assignmentsByCheckpointId.get(checkpointId);
     }
 
-    @VisibleForTesting
     Map<Integer, LinkedHashSet<SplitT>> uncheckpointedAssignments() {
-        return uncheckpointedAssignments;
+        return Collections.unmodifiableMap(uncheckpointedAssignments);
     }
 
     // -------------- private helpers ---------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinator.java
@@ -39,12 +39,12 @@ public final class MockOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
-    public void handleEventFromOperator(int subtask, OperatorEvent event) {
+    public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void subtaskFailed(int subtask, @Nullable Throwable reason) {
+    public void executionAttemptFailed(int subtask, int attemptNumber, @Nullable Throwable reason) {
         throw new UnsupportedOperationException();
     }
 
@@ -54,7 +54,7 @@ public final class MockOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
-    public void subtaskReady(int subtask, SubtaskGateway gateway) {
+    public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -78,6 +78,11 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
         return coordinatorStore;
     }
 
+    @Override
+    public boolean isConcurrentExecutionAttemptsSupported() {
+        return false;
+    }
+
     // -------------------------------
 
     public boolean isJobFailed() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -264,7 +264,8 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                 context ->
                         new TestingOperatorCoordinator(context) {
                             @Override
-                            public void handleEventFromOperator(int subtask, OperatorEvent event) {
+                            public void handleEventFromOperator(
+                                    int subtask, int attemptNumber, OperatorEvent event) {
                                 context.failJob(new RuntimeException("Artificial Exception"));
                             }
                         };
@@ -272,11 +273,11 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
         final OperatorCoordinatorHolder holder =
                 createCoordinatorHolder(tasks, coordinatorProvider);
 
-        holder.handleEventFromOperator(0, new TestOperatorEvent());
+        holder.handleEventFromOperator(0, 0, new TestOperatorEvent());
         assertNotNull(globalFailure);
         final Throwable firstGlobalFailure = globalFailure;
 
-        holder.handleEventFromOperator(1, new TestOperatorEvent());
+        holder.handleEventFromOperator(1, 0, new TestOperatorEvent());
         assertEquals(
                 "The global failure should be the same instance because the context"
                         + "should only take the first request from the coordinator to fail the job.",
@@ -284,7 +285,7 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                 globalFailure);
 
         holder.resetToCheckpoint(0L, new byte[0]);
-        holder.handleEventFromOperator(1, new TestOperatorEvent());
+        holder.handleEventFromOperator(1, 1, new TestOperatorEvent());
         assertNotEquals(
                 "The new failures should be propagated after the coordinator " + "is reset.",
                 firstGlobalFailure,
@@ -676,16 +677,17 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
         }
 
         @Override
-        public void handleEventFromOperator(int subtask, OperatorEvent event) {}
+        public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event) {}
 
         @Override
-        public void subtaskFailed(int subtask, @Nullable Throwable reason) {}
+        public void executionAttemptFailed(
+                int subtask, int attemptNumber, @Nullable Throwable reason) {}
 
         @Override
         public void subtaskReset(int subtask, long checkpointId) {}
 
         @Override
-        public void subtaskReady(int subtask, SubtaskGateway gateway) {
+        public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {
             subtaskGateways[subtask] = gateway;
 
             for (SubtaskGateway subtaskGateway : subtaskGateways) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -511,7 +511,8 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                         getClass().getClassLoader(),
                         3,
                         1775,
-                        eventTarget);
+                        eventTarget,
+                        false);
 
         holder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
         holder.start();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
@@ -149,8 +149,8 @@ public class RecreateOnResetOperatorCoordinatorTest {
         // The following method calls should be applied to the new internal
         // coordinator asynchronously because the current coordinator has not
         // been successfully closed yet.
-        coordinator.handleEventFromOperator(1, testingEvent);
-        coordinator.subtaskFailed(1, new Exception("Subtask Failure Exception."));
+        coordinator.handleEventFromOperator(1, 0, testingEvent);
+        coordinator.executionAttemptFailed(1, 0, new Exception("Subtask Failure Exception."));
         coordinator.notifyCheckpointComplete(completedCheckpointId);
 
         // The new coordinator should not have been created because the resetToCheckpoint()
@@ -198,8 +198,8 @@ public class RecreateOnResetOperatorCoordinatorTest {
         // Loop to get some interleaved method invocations on multiple instances
         // of active coordinators.
         for (int i = 0; i < numResets; i++) {
-            coordinator.handleEventFromOperator(1, new TestingEvent(i));
-            coordinator.subtaskFailed(i, new Exception());
+            coordinator.handleEventFromOperator(1, 0, new TestingEvent(i));
+            coordinator.executionAttemptFailed(i, 0, new Exception());
             CompletableFuture<byte[]> future = CompletableFuture.completedFuture(new byte[i]);
             coordinator.checkpointCoordinator(i, future);
             final int loop = i;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -88,12 +88,12 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
-    public void handleEventFromOperator(int subtask, OperatorEvent event) {
+    public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event) {
         receivedOperatorEvents.add(event);
     }
 
     @Override
-    public void subtaskFailed(int subtask, @Nullable Throwable reason) {
+    public void executionAttemptFailed(int subtask, int attemptNumber, @Nullable Throwable reason) {
         failedTasks.add(subtask);
         subtaskGateways.remove(subtask);
     }
@@ -104,7 +104,7 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
     }
 
     @Override
-    public void subtaskReady(int subtask, SubtaskGateway gateway) {
+    public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {
         subtaskGateways.put(subtask, gateway);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/CoordinatorTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/CoordinatorTestUtils.java
@@ -22,17 +22,14 @@ import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.util.function.ThrowingRunnable;
 
-import org.hamcrest.Matchers;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** A util class containing the helper methods for the coordinator tests. */
 class CoordinatorTestUtils {
@@ -58,24 +55,15 @@ class CoordinatorTestUtils {
     /** Check the actual assignment meets the expectation. */
     static void verifyAssignment(
             List<String> expectedSplitIds, Collection<MockSourceSplit> actualAssignment) {
-        assertEquals(expectedSplitIds.size(), actualAssignment.size());
+        assertThat(actualAssignment.size()).isEqualTo(expectedSplitIds.size());
         int i = 0;
         for (MockSourceSplit split : actualAssignment) {
-            assertEquals(expectedSplitIds.get(i++), split.splitId());
+            assertThat(split.splitId()).isEqualTo(expectedSplitIds.get(i++));
         }
     }
 
     static void verifyException(
             ThrowingRunnable<Throwable> runnable, String failureMessage, String errorMessage) {
-        try {
-            runnable.run();
-            fail(failureMessage);
-        } catch (Throwable t) {
-            Throwable rootCause = t;
-            while (rootCause.getCause() != null) {
-                rootCause = rootCause.getCause();
-            }
-            assertThat(rootCause.getMessage(), Matchers.startsWith(errorMessage));
-        }
+        assertThatThrownBy(runnable::run, failureMessage).hasStackTraceContaining(errorMessage);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
@@ -130,7 +130,8 @@ class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
 
     private void reportWatermarkEvent(
             SourceCoordinator<?, ?> sourceCoordinator1, int subtask, long watermark) {
-        sourceCoordinator1.handleEventFromOperator(subtask, new ReportedWatermarkEvent(watermark));
+        sourceCoordinator1.handleEventFromOperator(
+                subtask, 0, new ReportedWatermarkEvent(watermark));
         waitForCoordinatorToProcessActions();
         sourceCoordinator1.announceCombinedWatermark();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorAlignmentTest.java
@@ -24,19 +24,18 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.ReportedWatermarkEvent;
 import org.apache.flink.runtime.source.event.WatermarkAlignmentEvent;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for watermark alignment of the {@link SourceCoordinator}. */
 @SuppressWarnings("serial")
-public class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
+class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
 
     @Test
-    public void testWatermarkAlignment() throws Exception {
+    void testWatermarkAlignment() throws Exception {
         try (AutoCloseableRegistry closeableRegistry = new AutoCloseableRegistry()) {
             SourceCoordinator<?, ?> sourceCoordinator1 =
                     getAndStartNewSourceCoordinator(
@@ -59,7 +58,7 @@ public class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
     }
 
     @Test
-    public void testWatermarkAlignmentWithIdleness() throws Exception {
+    void testWatermarkAlignmentWithIdleness() throws Exception {
         try (AutoCloseableRegistry closeableRegistry = new AutoCloseableRegistry()) {
             SourceCoordinator<?, ?> sourceCoordinator1 =
                     getAndStartNewSourceCoordinator(
@@ -88,7 +87,7 @@ public class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
     }
 
     @Test
-    public void testWatermarkAlignmentWithTwoGroups() throws Exception {
+    void testWatermarkAlignmentWithTwoGroups() throws Exception {
         try (AutoCloseableRegistry closeableRegistry = new AutoCloseableRegistry()) {
             long maxDrift = 1000L;
             SourceCoordinator<?, ?> sourceCoordinator1 =
@@ -116,7 +115,7 @@ public class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
         }
     }
 
-    protected SourceCoordinator<?, ?> getAndStartNewSourceCoordinator(
+    private SourceCoordinator<?, ?> getAndStartNewSourceCoordinator(
             WatermarkAlignmentParams watermarkAlignmentParams,
             AutoCloseableRegistry closeableRegistry)
             throws Exception {
@@ -138,7 +137,8 @@ public class SourceCoordinatorAlignmentTest extends SourceCoordinatorTestBase {
 
     private void assertLatestWatermarkAlignmentEvent(int subtask, long expectedWatermark) {
         List<OperatorEvent> events = receivingTasks.getSentEventsForSubtask(subtask);
-        assertFalse(events.isEmpty());
-        assertEquals(new WatermarkAlignmentEvent(expectedWatermark), events.get(events.size() - 1));
+        assertThat(events).isNotEmpty();
+        assertThat(events.get(events.size() - 1))
+                .isEqualTo(new WatermarkAlignmentEvent(expectedWatermark));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorConcurrentAttemptsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorConcurrentAttemptsTest.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.source.coordinator;
+
+import org.apache.flink.api.common.eventtime.WatermarkAlignmentParams;
+import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SupportsHandleExecutionAttemptSourceEvent;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorCheckpointSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.source.event.NoMoreSplitsEvent;
+import org.apache.flink.runtime.source.event.RequestSplitEvent;
+import org.apache.flink.runtime.source.event.SourceEventWrapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link SourceCoordinator} when it is enabled to handle concurrent execution
+ * attempts.
+ */
+class SourceCoordinatorConcurrentAttemptsTest extends SourceCoordinatorTestBase {
+
+    private boolean enumeratorSupportsHandleExecutionAttemptSourceEvent;
+
+    @Override
+    @BeforeEach
+    void setup() {
+        supportsConcurrentExecutionAttempts = true;
+        enumeratorSupportsHandleExecutionAttemptSourceEvent = true;
+        super.setup();
+    }
+
+    @Test
+    void testCoordinatorThrowExceptionIfWatermarkAlignmentIsEnabled() {
+        enumeratorSupportsHandleExecutionAttemptSourceEvent = false;
+
+        assertThatThrownBy(
+                        () ->
+                                getNewSourceCoordinator(
+                                        new WatermarkAlignmentParams(
+                                                1000L, "group1", Long.MAX_VALUE)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testCoordinatorFailJobOnSourceEventToNonsupportingEnumerator() throws Exception {
+        enumeratorSupportsHandleExecutionAttemptSourceEvent = false;
+        sourceCoordinator = getNewSourceCoordinator();
+        context = sourceCoordinator.getContext();
+
+        sourceCoordinator.start();
+        sourceCoordinator.handleEventFromOperator(
+                0, 0, new SourceEventWrapper(new TestSourceEvent()));
+        waitForCoordinatorToProcessActions();
+        assertThat(operatorCoordinatorContext.isJobFailed()).isTrue();
+    }
+
+    @Test
+    void testContextThrowExceptionOnSourceEventToNonsupportingMethod() throws Exception {
+        enumeratorSupportsHandleExecutionAttemptSourceEvent = false;
+        sourceCoordinator = getNewSourceCoordinator();
+        context = sourceCoordinator.getContext();
+
+        sourceCoordinator.start();
+        sourceReady();
+        assertThatThrownBy(() -> context.sendEventToSourceReader(0, new TestSourceEvent()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    public void testConcurrentAttemptsRequestSplits() throws Exception {
+        sourceCoordinator.start();
+
+        final List<MockSourceSplit> splits = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            splits.add(new MockSourceSplit(i));
+        }
+        getEnumerator().addNewSplits(splits);
+
+        int attempt0 = 0;
+        setReaderTaskReady(sourceCoordinator, 0, attempt0);
+        registerReader(0, attempt0);
+        sourceCoordinator.handleEventFromOperator(0, attempt0, new RequestSplitEvent());
+        waitForSentEvents(1);
+
+        int attempt1 = 3;
+        setReaderTaskReady(sourceCoordinator, 0, attempt1);
+        registerReader(0, attempt1);
+        waitForSentEvents(2);
+
+        sourceCoordinator.handleEventFromOperator(0, attempt1, new RequestSplitEvent());
+        waitForSentEvents(4);
+
+        sourceCoordinator.handleEventFromOperator(0, attempt0, new RequestSplitEvent());
+        waitForSentEvents(6);
+
+        int attempt2 = 5;
+        setReaderTaskReady(sourceCoordinator, 0, attempt2);
+        registerReader(0, attempt2);
+        waitForSentEvents(8);
+
+        final List<OperatorEvent> events = receivingTasks.getSentEventsForSubtask(0);
+        assertAddSplitEvent(events.get(0), Collections.singletonList(splits.get(0)));
+        assertAddSplitEvent(events.get(1), Collections.singletonList(splits.get(0)));
+        assertAddSplitEvent(events.get(2), Collections.singletonList(splits.get(1)));
+        assertAddSplitEvent(events.get(3), Collections.singletonList(splits.get(1)));
+        assertAddSplitEvent(events.get(6), splits);
+
+        assertThat(events.get(4)).isInstanceOf(NoMoreSplitsEvent.class);
+        assertThat(events.get(5)).isInstanceOf(NoMoreSplitsEvent.class);
+        assertThat(events.get(7)).isInstanceOf(NoMoreSplitsEvent.class);
+    }
+
+    @Test
+    public void testReaderInfoOfConcurrentAttempts() throws Exception {
+        sourceCoordinator.start();
+        registerReader(0, 3);
+        registerReader(0, 5);
+        waitForCoordinatorToProcessActions();
+
+        assertThat(context.registeredReadersOfAttempts()).hasSize(1);
+
+        Map<Integer, ReaderInfo> attemptReaders = context.registeredReadersOfAttempts().get(0);
+        assertThat(attemptReaders).containsOnlyKeys(3, 5);
+        assertThat(attemptReaders.get(3)).isNotNull();
+        assertThat(attemptReaders.get(3).getLocation()).isEqualTo(createLocationFor(0, 3));
+        assertThat(attemptReaders.get(5)).isNotNull();
+        assertThat(attemptReaders.get(5).getLocation()).isEqualTo(createLocationFor(0, 5));
+
+        sourceCoordinator.executionAttemptFailed(0, 5, new Exception());
+        waitForCoordinatorToProcessActions();
+
+        attemptReaders = context.registeredReadersOfAttempts().get(0);
+        assertThat(attemptReaders).containsOnlyKeys(3);
+
+        sourceCoordinator.subtaskReset(0, -1);
+        waitForCoordinatorToProcessActions();
+
+        assertThat(context.registeredReadersOfAttempts()).isEmpty();
+    }
+
+    @Test
+    public void testSubtaskReaderInfoOfConcurrentAttempts() throws Exception {
+        sourceCoordinator.start();
+        registerReader(0, 3);
+        registerReader(0, 5);
+        waitForCoordinatorToProcessActions();
+
+        assertThat(context.registeredReaders()).hasSize(1);
+        assertThat(context.registeredReaders().get(0).getLocation())
+                .isEqualTo(createLocationFor(0, 3));
+
+        registerReader(0, 1);
+        waitForCoordinatorToProcessActions();
+
+        // the subtask reader info is the reader info of the attempt with the smallest attempt
+        // number
+        assertThat(context.registeredReaders().get(0).getLocation())
+                .isEqualTo(createLocationFor(0, 1));
+    }
+
+    @Test
+    public void testForwardAttemptSourceEvents() throws Exception {
+        sourceCoordinator.start();
+
+        final SourceEvent event1 = new TestSourceEvent();
+        final SourceEvent event2 = new TestSourceEvent();
+        sourceCoordinator.handleEventFromOperator(0, 3, new SourceEventWrapper(event1));
+        sourceCoordinator.handleEventFromOperator(0, 5, new SourceEventWrapper(event2));
+
+        waitForCoordinatorToProcessActions();
+
+        assertThat(getTestEnumerator().getEvent(0, 3)).isSameAs(event1);
+        assertThat(getTestEnumerator().getEvent(0, 5)).isSameAs(event2);
+    }
+
+    @Override
+    Source<Integer, MockSourceSplit, Set<MockSourceSplit>> createMockSource() {
+        if (enumeratorSupportsHandleExecutionAttemptSourceEvent) {
+            return new TestSource(
+                    new MockSourceSplitSerializer(), new MockSplitEnumeratorCheckpointSerializer());
+        } else {
+            return TestingSplitEnumerator.factorySource(
+                    new MockSourceSplitSerializer(), new MockSplitEnumeratorCheckpointSerializer());
+        }
+    }
+
+    private TestEnumerator<MockSourceSplit> getTestEnumerator() {
+        return (TestEnumerator) super.getEnumerator();
+    }
+
+    private static final class TestSource<T, SplitT extends SourceSplit>
+            extends TestingSplitEnumerator.FactorySource<T, SplitT> {
+
+        public TestSource(
+                SimpleVersionedSerializer<SplitT> splitSerializer,
+                SimpleVersionedSerializer<Set<SplitT>> checkpointSerializer) {
+            super(splitSerializer, checkpointSerializer);
+        }
+
+        @Override
+        public TestingSplitEnumerator<SplitT> createEnumerator(
+                SplitEnumeratorContext<SplitT> enumContext) {
+            return new TestEnumerator<>(enumContext);
+        }
+
+        @Override
+        public SplitEnumerator<SplitT, Set<SplitT>> restoreEnumerator(
+                SplitEnumeratorContext<SplitT> enumContext, Set<SplitT> checkpoint) {
+            return new TestEnumerator<>(enumContext, checkpoint);
+        }
+    }
+
+    private static class TestEnumerator<SplitT extends SourceSplit>
+            extends TestingSplitEnumerator<SplitT>
+            implements SupportsHandleExecutionAttemptSourceEvent {
+
+        private final Map<Integer, Map<Integer, SourceEvent>> sourceEvents;
+
+        private TestEnumerator(SplitEnumeratorContext<SplitT> context) {
+            super(context);
+            this.sourceEvents = new HashMap<>();
+        }
+
+        private TestEnumerator(
+                SplitEnumeratorContext<SplitT> context, Collection<SplitT> restoredSplits) {
+            super(context, restoredSplits);
+            this.sourceEvents = new HashMap<>();
+        }
+
+        @Override
+        public void handleSourceEvent(int subtaskId, int attemptNumber, SourceEvent sourceEvent) {
+            sourceEvents.computeIfAbsent(subtaskId, HashMap::new).put(attemptNumber, sourceEvent);
+            handleSourceEvent(subtaskId, sourceEvent);
+        }
+
+        private SourceEvent getEvent(int subtaskId, int attemptNumber) {
+            return sourceEvents.getOrDefault(subtaskId, new HashMap<>()).get(attemptNumber);
+        }
+    }
+
+    private static class TestSourceEvent implements SourceEvent, Serializable {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -75,7 +75,7 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 
     @Test
     void testUnregisterUnregisteredReader() {
-        context.unregisterSourceReader(0);
+        context.unregisterSourceReader(0, 0);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -62,7 +62,7 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         sourceReady();
         List<ReaderInfo> readerInfo = registerReaders();
 
-        sourceCoordinator.subtaskFailed(0, null);
+        sourceCoordinator.executionAttemptFailed(0, 0, null);
         waitForCoordinatorToProcessActions();
 
         assertThat(context.registeredReaders())
@@ -235,6 +235,7 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         for (ReaderInfo info : infos) {
             sourceCoordinator.handleEventFromOperator(
                     info.getSubtaskId(),
+                    0,
                     new ReaderRegistrationEvent(info.getSubtaskId(), info.getLocation()));
         }
         waitForCoordinatorToProcessActions();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -166,7 +166,8 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
                         coordinatorThreadFactory,
                         operatorCoordinatorContext,
                         new MockSourceSplitSerializer(),
-                        splitSplitAssignmentTracker);
+                        splitSplitAssignmentTracker,
+                        false);
 
         testingContext.runInCoordinatorThread(
                 () -> {
@@ -200,7 +201,8 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
                                 TEST_OPERATOR_ID.toHexString(), operatorCoordinatorContext),
                         operatorCoordinatorContext,
                         new MockSourceSplitSerializer(),
-                        splitSplitAssignmentTracker);
+                        splitSplitAssignmentTracker,
+                        false);
 
         testingContext.callAsync(
                 () -> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -27,8 +27,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
 
-import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,55 +38,53 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.getSplitsAssignment;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyAssignment;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for {@link SourceCoordinatorContext}. */
-public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
+class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
 
     @Test
-    public void testRegisterReader() throws Exception {
+    void testRegisterReader() throws Exception {
         sourceReady();
         List<ReaderInfo> readerInfo = registerReaders();
 
-        assertTrue(context.registeredReaders().containsKey(0));
-        assertTrue(context.registeredReaders().containsKey(1));
-        assertEquals(readerInfo.get(0), context.registeredReaders().get(0));
-        assertEquals(readerInfo.get(1), context.registeredReaders().get(1));
+        assertThat(context.registeredReaders()).containsKey(0);
+        assertThat(context.registeredReaders()).containsKey(1);
+        assertThat(context.registeredReaders().get(0)).isEqualTo(readerInfo.get(0));
+        assertThat(context.registeredReaders().get(1)).isEqualTo(readerInfo.get(1));
 
         final TestingSplitEnumerator<?> enumerator = getEnumerator();
-        assertThat(enumerator.getRegisteredReaders(), Matchers.containsInAnyOrder(0, 1, 2));
+        assertThat(enumerator.getRegisteredReaders()).containsExactlyInAnyOrder(0, 1, 2);
     }
 
     @Test
-    public void testTaskFailureUnregistersReader() throws Exception {
+    void testTaskFailureUnregistersReader() throws Exception {
         sourceReady();
         List<ReaderInfo> readerInfo = registerReaders();
 
         sourceCoordinator.subtaskFailed(0, null);
         waitForCoordinatorToProcessActions();
 
-        assertEquals("Only reader 2 should be registered.", 2, context.registeredReaders().size());
-        assertNull(context.registeredReaders().get(0));
-        assertEquals(readerInfo.get(1), context.registeredReaders().get(1));
-        assertEquals(readerInfo.get(2), context.registeredReaders().get(2));
+        assertThat(context.registeredReaders())
+                .as("Only reader 2 should be registered.")
+                .hasSize(2);
+        assertThat(context.registeredReaders().get(0)).isNull();
+        assertThat(context.registeredReaders().get(1)).isEqualTo(readerInfo.get(1));
+        assertThat(context.registeredReaders().get(2)).isEqualTo(readerInfo.get(2));
     }
 
     @Test
-    public void testUnregisterUnregisteredReader() {
+    void testUnregisterUnregisteredReader() {
         context.unregisterSourceReader(0);
     }
 
     @Test
-    public void testAssignSplitsFromCoordinatorExecutor() throws Exception {
+    void testAssignSplitsFromCoordinatorExecutor() throws Exception {
         testAssignSplits(true);
     }
 
     @Test
-    public void testAssignSplitsFromOtherThread() throws Exception {
+    void testAssignSplitsFromOtherThread() throws Exception {
         testAssignSplits(false);
     }
 
@@ -112,28 +109,27 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
                 Arrays.asList("1", "2"),
                 splitSplitAssignmentTracker.uncheckpointedAssignments().get(1));
         // The OperatorCoordinatorContext should have received the event sending call.
-        assertEquals(
-                "There should be two events sent to the subtasks.",
-                2,
-                receivingTasks.getNumberOfSentEvents());
+        assertThat(receivingTasks.getNumberOfSentEvents())
+                .as("There should be two events sent to the subtasks.")
+                .isEqualTo(2);
 
         // Assert the events to subtask0.
         List<OperatorEvent> eventsToSubtask0 = receivingTasks.getSentEventsForSubtask(0);
-        assertEquals(1, eventsToSubtask0.size());
+        assertThat(eventsToSubtask0).hasSize(1);
         OperatorEvent event = eventsToSubtask0.get(0);
-        assertTrue(event instanceof AddSplitEvent);
+        assertThat(event).isInstanceOf(AddSplitEvent.class);
         verifyAssignment(
                 Collections.singletonList("0"),
                 ((AddSplitEvent<MockSourceSplit>) event).splits(new MockSourceSplitSerializer()));
     }
 
     @Test
-    public void testAssignSplitToUnregisteredReaderFromCoordinatorExecutor() throws Exception {
+    void testAssignSplitToUnregisteredReaderFromCoordinatorExecutor() throws Exception {
         testAssignSplitToUnregisterdReader(true);
     }
 
     @Test
-    public void testAssignSplitToUnregisteredReaderFromOtherThread() throws Exception {
+    void testAssignSplitToUnregisteredReaderFromOtherThread() throws Exception {
         testAssignSplitToUnregisterdReader(false);
     }
 
@@ -157,8 +153,7 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
     }
 
     @Test
-    public void testExceptionInRunnableFailsTheJob()
-            throws InterruptedException, ExecutionException {
+    void testExceptionInRunnableFailsTheJob() throws InterruptedException, ExecutionException {
         ManuallyTriggeredScheduledExecutorService manualWorkerExecutor =
                 new ManuallyTriggeredScheduledExecutorService();
         // need the factory to have the exception handler set
@@ -185,11 +180,11 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         // blocks until the job is failed: wait that the uncaught exception handler calls
         // operatorCoordinatorContext#failJob() which completes the future
         operatorCoordinatorContext.getJobFailedFuture().get();
-        assertTrue(operatorCoordinatorContext.isJobFailed());
+        assertThat(operatorCoordinatorContext.isJobFailed()).isTrue();
     }
 
     @Test
-    public void testCallableInterruptedDuringShutdownDoNotFailJob() throws InterruptedException {
+    void testCallableInterruptedDuringShutdownDoNotFailJob() throws InterruptedException {
         AtomicReference<Throwable> expectedError = new AtomicReference<>(null);
 
         ManuallyTriggeredScheduledExecutorService manualWorkerExecutor =
@@ -222,8 +217,8 @@ public class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         testingContext.close();
         manualCoordinatorExecutor.triggerAll();
 
-        assertTrue(expectedError.get() instanceof InterruptedException);
-        assertFalse(operatorCoordinatorContext.isJobFailed());
+        assertThat(expectedError.get()).isInstanceOf(InterruptedException.class);
+        assertThat(operatorCoordinatorContext.isJobFailed()).isFalse();
     }
 
     // ------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorProviderTest.java
@@ -77,13 +77,13 @@ public class SourceCoordinatorProviderTest {
         // Start the coordinator.
         coordinator.start();
         // register reader 0 and take a checkpoint.
-        coordinator.handleEventFromOperator(0, new ReaderRegistrationEvent(0, "location"));
+        coordinator.handleEventFromOperator(0, 0, new ReaderRegistrationEvent(0, "location"));
         CompletableFuture<byte[]> future = new CompletableFuture<>();
         coordinator.checkpointCoordinator(0L, future);
         byte[] bytes = future.get();
 
         // Register reader 1.
-        coordinator.handleEventFromOperator(1, new ReaderRegistrationEvent(1, "location"));
+        coordinator.handleEventFromOperator(1, 0, new ReaderRegistrationEvent(1, "location"));
         // Wait until the coordinator context is updated with registration of reader 1.
         while (sourceCoordinator.getContext().registeredReaders().size() < 2) {
             Thread.sleep(1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -77,11 +77,11 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                 failureMessage,
                 "The coordinator has not started yet.");
         verifyException(
-                () -> sourceCoordinator.handleEventFromOperator(0, null),
+                () -> sourceCoordinator.handleEventFromOperator(0, 0, null),
                 failureMessage,
                 "The coordinator has not started yet.");
         verifyException(
-                () -> sourceCoordinator.subtaskFailed(0, null),
+                () -> sourceCoordinator.executionAttemptFailed(0, 0, null),
                 failureMessage,
                 "The coordinator has not started yet.");
         verifyException(
@@ -120,7 +120,7 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         sourceReady();
 
         SourceEvent sourceEvent = new SourceEvent() {};
-        sourceCoordinator.handleEventFromOperator(0, new SourceEventWrapper(sourceEvent));
+        sourceCoordinator.handleEventFromOperator(0, 0, new SourceEventWrapper(sourceEvent));
         waitForCoordinatorToProcessActions();
 
         assertThat(getEnumerator().getHandledSourceEvent()).hasSize(1);
@@ -183,7 +183,7 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                 splitSplitAssignmentTracker.assignmentsByCheckpointId(101L).get(0));
 
         // none of the checkpoints is confirmed, we fail and revert to the previous one
-        sourceCoordinator.subtaskFailed(0, null);
+        sourceCoordinator.executionAttemptFailed(0, 0, null);
         sourceCoordinator.subtaskReset(0, 99L);
         waitForCoordinatorToProcessActions();
 
@@ -216,7 +216,7 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         sourceCoordinator.checkpointCoordinator(100L, new CompletableFuture<>());
         sourceCoordinator.notifyCheckpointComplete(100L);
 
-        sourceCoordinator.subtaskFailed(0, null);
+        sourceCoordinator.executionAttemptFailed(0, 0, null);
 
         waitForCoordinatorToProcessActions();
 
@@ -298,7 +298,7 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                                 WatermarkAlignmentParams.WATERMARK_ALIGNMENT_DISABLED)) {
 
             coordinator.start();
-            coordinator.handleEventFromOperator(1, new SourceEventWrapper(new SourceEvent() {}));
+            coordinator.handleEventFromOperator(1, 0, new SourceEventWrapper(new SourceEvent() {}));
 
             waitUtil(
                     () -> operatorCoordinatorContext.isJobFailed(),
@@ -340,7 +340,7 @@ class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                                 new CoordinatorStoreImpl())) {
 
             coordinator.start();
-            coordinator.handleEventFromOperator(1, new SourceEventWrapper(new SourceEvent() {}));
+            coordinator.handleEventFromOperator(1, 0, new SourceEventWrapper(new SourceEvent() {}));
             // Wait until the coordinator executor blocks.
             latch.await();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTest.java
@@ -41,7 +41,7 @@ import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.source.event.SourceEventWrapper;
 import org.apache.flink.util.function.ThrowingRunnable;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -62,18 +62,14 @@ import java.util.function.Supplier;
 import static org.apache.flink.core.testutils.CommonTestUtils.waitUtil;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyAssignment;
 import static org.apache.flink.runtime.source.coordinator.CoordinatorTestUtils.verifyException;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link SourceCoordinator}. */
 @SuppressWarnings("serial")
-public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
+class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 
     @Test
-    public void testThrowExceptionWhenNotStarted() {
+    void testThrowExceptionWhenNotStarted() {
         // The following methods should only be invoked after the source coordinator has started.
         String failureMessage = "Call should fail when source coordinator has not started yet.";
         verifyException(
@@ -95,7 +91,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
     }
 
     @Test
-    public void testRestCheckpointAfterCoordinatorStarted() throws Exception {
+    void testRestCheckpointAfterCoordinatorStarted() throws Exception {
         // The following methods should only be invoked after the source coordinator has started.
         sourceCoordinator.start();
         verifyException(
@@ -105,34 +101,34 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
     }
 
     @Test
-    public void testStart() throws Exception {
+    void testStart() throws Exception {
         sourceCoordinator.start();
         waitForCoordinatorToProcessActions();
 
-        assertTrue(getEnumerator().isStarted());
+        assertThat(getEnumerator().isStarted()).isTrue();
     }
 
     @Test
-    public void testClosed() throws Exception {
+    void testClosed() throws Exception {
         sourceCoordinator.start();
         sourceCoordinator.close();
-        assertTrue(getEnumerator().isClosed());
+        assertThat(getEnumerator().isClosed()).isTrue();
     }
 
     @Test
-    public void testHandleSourceEvent() throws Exception {
+    void testHandleSourceEvent() throws Exception {
         sourceReady();
 
         SourceEvent sourceEvent = new SourceEvent() {};
         sourceCoordinator.handleEventFromOperator(0, new SourceEventWrapper(sourceEvent));
         waitForCoordinatorToProcessActions();
 
-        assertEquals(1, getEnumerator().getHandledSourceEvent().size());
-        assertEquals(sourceEvent, getEnumerator().getHandledSourceEvent().get(0));
+        assertThat(getEnumerator().getHandledSourceEvent()).hasSize(1);
+        assertThat(getEnumerator().getHandledSourceEvent().get(0)).isEqualTo(sourceEvent);
     }
 
     @Test
-    public void testCheckpointCoordinatorAndRestore() throws Exception {
+    void testCheckpointCoordinatorAndRestore() throws Exception {
         sourceReady();
         addTestingSplitSet(6);
 
@@ -150,19 +146,17 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         TestingSplitEnumerator<?> restoredEnumerator =
                 (TestingSplitEnumerator<?>) restoredCoordinator.getEnumerator();
         SourceCoordinatorContext<?> restoredContext = restoredCoordinator.getContext();
-        assertEquals(
-                "2 splits should have been assigned to reader 0",
-                4,
-                restoredEnumerator.getUnassignedSplits().size());
-        assertTrue(restoredEnumerator.getContext().registeredReaders().isEmpty());
-        assertEquals(
-                "Registered readers should not be recovered by restoring",
-                0,
-                restoredContext.registeredReaders().size());
+        assertThat(restoredEnumerator.getUnassignedSplits())
+                .as("2 splits should have been assigned to reader 0")
+                .hasSize(4);
+        assertThat(restoredEnumerator.getContext().registeredReaders()).isEmpty();
+        assertThat(restoredContext.registeredReaders())
+                .as("Registered readers should not be recovered by restoring")
+                .isEmpty();
     }
 
     @Test
-    public void testSubtaskFailedAndRevertUncompletedAssignments() throws Exception {
+    void testSubtaskFailedAndRevertUncompletedAssignments() throws Exception {
         sourceReady();
         addTestingSplitSet(6);
 
@@ -179,8 +173,8 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         // check the state.
         waitForCoordinatorToProcessActions();
 
-        assertEquals(4, getEnumerator().getUnassignedSplits().size());
-        assertTrue(splitSplitAssignmentTracker.uncheckpointedAssignments().isEmpty());
+        assertThat(getEnumerator().getUnassignedSplits()).hasSize(4);
+        assertThat(splitSplitAssignmentTracker.uncheckpointedAssignments()).isEmpty();
         verifyAssignment(
                 Arrays.asList("0", "1"),
                 splitSplitAssignmentTracker.assignmentsByCheckpointId().get(100L).get(0));
@@ -193,24 +187,24 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         sourceCoordinator.subtaskReset(0, 99L);
         waitForCoordinatorToProcessActions();
 
-        assertFalse(
-                "Reader 0 should have been unregistered.",
-                context.registeredReaders().containsKey(0));
+        assertThat(context.registeredReaders())
+                .as("Reader 0 should have been unregistered.")
+                .doesNotContainKey(0);
         // The tracker should have reverted all the splits assignment to reader 0.
         for (Map<Integer, ?> assignment :
                 splitSplitAssignmentTracker.assignmentsByCheckpointId().values()) {
-            assertFalse(
-                    "Assignment in uncompleted checkpoint should have been reverted.",
-                    assignment.containsKey(0));
+            assertThat(assignment)
+                    .as("Assignment in uncompleted checkpoint should have been reverted.")
+                    .doesNotContainKey(0);
         }
-        assertFalse(splitSplitAssignmentTracker.uncheckpointedAssignments().containsKey(0));
+        assertThat(splitSplitAssignmentTracker.uncheckpointedAssignments()).doesNotContainKey(0);
         // The split enumerator should now contains the splits used to b
         // assigned to reader 0.
-        assertEquals(7, getEnumerator().getUnassignedSplits().size());
+        assertThat(getEnumerator().getUnassignedSplits()).hasSize(7);
     }
 
     @Test
-    public void testFailedSubtaskDoNotRevertCompletedCheckpoint() throws Exception {
+    void testFailedSubtaskDoNotRevertCompletedCheckpoint() throws Exception {
         sourceReady();
         addTestingSplitSet(6);
 
@@ -226,15 +220,15 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 
         waitForCoordinatorToProcessActions();
 
-        assertEquals(100L, (long) getEnumerator().getSuccessfulCheckpoints().get(0));
-        assertFalse(context.registeredReaders().containsKey(0));
-        assertEquals(4, getEnumerator().getUnassignedSplits().size());
-        assertFalse(splitSplitAssignmentTracker.uncheckpointedAssignments().containsKey(0));
-        assertTrue(splitSplitAssignmentTracker.assignmentsByCheckpointId().isEmpty());
+        assertThat(getEnumerator().getSuccessfulCheckpoints().get(0)).isEqualTo(100);
+        assertThat(context.registeredReaders()).doesNotContainKey(0);
+        assertThat(getEnumerator().getUnassignedSplits()).hasSize(4);
+        assertThat(splitSplitAssignmentTracker.uncheckpointedAssignments()).doesNotContainKey(0);
+        assertThat(splitSplitAssignmentTracker.assignmentsByCheckpointId()).isEmpty();
     }
 
     @Test
-    public void testFailJobWhenExceptionThrownFromStart() throws Exception {
+    void testFailJobWhenExceptionThrownFromStart() throws Exception {
         final RuntimeException failureReason = new RuntimeException("Artificial Exception");
         try (final MockSplitEnumeratorContext<MockSourceSplit> enumeratorContext =
                         new MockSplitEnumeratorContext<>(1);
@@ -258,12 +252,12 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                     () -> operatorCoordinatorContext.isJobFailed(),
                     Duration.ofSeconds(10),
                     "The job should have failed due to the artificial exception.");
-            assertEquals(failureReason, operatorCoordinatorContext.getJobFailureReason());
+            assertThat(operatorCoordinatorContext.getJobFailureReason()).isEqualTo(failureReason);
         }
     }
 
     @Test
-    public void testFailJobWhenExceptionThrownFromEnumeratorCreation() throws Exception {
+    void testFailJobWhenExceptionThrownFromEnumeratorCreation() throws Exception {
         final RuntimeException failureReason = new RuntimeException("Artificial Exception");
 
         final SourceCoordinator<?, ?> coordinator =
@@ -279,12 +273,12 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 
         coordinator.start();
 
-        assertTrue(operatorCoordinatorContext.isJobFailed());
-        assertEquals(failureReason, operatorCoordinatorContext.getJobFailureReason());
+        assertThat(operatorCoordinatorContext.isJobFailed()).isTrue();
+        assertThat(operatorCoordinatorContext.getJobFailureReason()).isEqualTo(failureReason);
     }
 
     @Test
-    public void testErrorThrownFromSplitEnumerator() throws Exception {
+    void testErrorThrownFromSplitEnumerator() throws Exception {
         final Error error = new Error("Test Error");
         try (final MockSplitEnumeratorContext<MockSourceSplit> enumeratorContext =
                         new MockSplitEnumeratorContext<>(1);
@@ -310,12 +304,12 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
                     () -> operatorCoordinatorContext.isJobFailed(),
                     Duration.ofSeconds(10),
                     "The job should have failed due to the artificial exception.");
-            assertEquals(error, operatorCoordinatorContext.getJobFailureReason());
+            assertThat(operatorCoordinatorContext.getJobFailureReason()).isEqualTo(error);
         }
     }
 
     @Test
-    public void testBlockOnClose() throws Exception {
+    void testBlockOnClose() throws Exception {
         // It is possible that the split enumerator submits some heavy-duty work to the
         // coordinator executor which blocks the coordinator closure.
         final CountDownLatch latch = new CountDownLatch(1);
@@ -358,7 +352,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
 
             future.exceptionally(
                             e -> {
-                                assertTrue(e instanceof TimeoutException);
+                                assertThat(e).isInstanceOf(TimeoutException.class);
                                 return null;
                             })
                     .get();
@@ -371,7 +365,7 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
     }
 
     @Test
-    public void testUserClassLoaderWhenCreatingNewEnumerator() throws Exception {
+    void testUserClassLoaderWhenCreatingNewEnumerator() throws Exception {
         final ClassLoader testClassLoader = new URLClassLoader(new URL[0]);
         final OperatorCoordinator.Context context =
                 new MockOperatorCoordinatorContext(new OperatorID(), testClassLoader);
@@ -390,15 +384,15 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         coordinator.start();
 
         final ClassLoaderTestEnumerator enumerator = source.createEnumeratorFuture.get();
-        assertSame(testClassLoader, enumerator.constructorClassLoader);
-        assertSame(testClassLoader, enumerator.threadClassLoader.get());
+        assertThat(enumerator.constructorClassLoader).isSameAs(testClassLoader);
+        assertThat(enumerator.threadClassLoader.get()).isSameAs(testClassLoader);
 
         // cleanup
         coordinator.close();
     }
 
     @Test
-    public void testUserClassLoaderWhenRestoringEnumerator() throws Exception {
+    void testUserClassLoaderWhenRestoringEnumerator() throws Exception {
         final ClassLoader testClassLoader = new URLClassLoader(new URL[0]);
         final OperatorCoordinator.Context context =
                 new MockOperatorCoordinatorContext(new OperatorID(), testClassLoader);
@@ -418,15 +412,15 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         coordinator.start();
 
         final ClassLoaderTestEnumerator enumerator = source.restoreEnumeratorFuture.get();
-        assertSame(testClassLoader, enumerator.constructorClassLoader);
-        assertSame(testClassLoader, enumerator.threadClassLoader.get());
+        assertThat(enumerator.constructorClassLoader).isSameAs(testClassLoader);
+        assertThat(enumerator.threadClassLoader.get()).isSameAs(testClassLoader);
 
         // cleanup
         coordinator.close();
     }
 
     @Test
-    public void testSerdeBackwardCompatibility() throws Exception {
+    void testSerdeBackwardCompatibility() throws Exception {
         sourceReady();
         addTestingSplitSet(6);
 
@@ -445,9 +439,9 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         SourceCoordinatorContext<?> restoredContext = restoredCoordinator.getContext();
 
         // Check if enumerator is restored correctly
-        assertEquals(splits, restoredEnumerator.getUnassignedSplits());
-        assertTrue(restoredEnumerator.getHandledSourceEvent().isEmpty());
-        assertEquals(0, restoredContext.registeredReaders().size());
+        assertThat(restoredEnumerator.getUnassignedSplits()).isEqualTo(splits);
+        assertThat(restoredEnumerator.getHandledSourceEvent()).isEmpty();
+        assertThat(restoredContext.registeredReaders()).isEmpty();
     }
 
     // ------------------------------------------------------------------------
@@ -475,14 +469,6 @@ public class SourceCoordinatorTest extends SourceCoordinatorTestBase {
         serializer.writeInt(0); // Number of checkpoint in assignment tracker
 
         return serializer.getCopyOfBuffer();
-    }
-
-    private void check(Runnable runnable) {
-        try {
-            coordinatorExecutor.submit(runnable).get();
-        } catch (Exception e) {
-            fail("Test failed due to " + e);
-        }
     }
 
     private static byte[] createEmptyCheckpoint() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -115,7 +115,8 @@ abstract class SourceCoordinatorTestBase {
 
     protected void setAllReaderTasksReady(SourceCoordinator<?, ?> sourceCoordinator) {
         for (int i = 0; i < NUM_SUBTASKS; i++) {
-            sourceCoordinator.subtaskReady(i, receivingTasks.createGatewayForSubtask(i));
+            sourceCoordinator.executionAttemptReady(
+                    i, 0, receivingTasks.createGatewayForSubtask(i));
         }
     }
 
@@ -130,7 +131,7 @@ abstract class SourceCoordinatorTestBase {
 
     protected void registerReader(int subtask) {
         sourceCoordinator.handleEventFromOperator(
-                subtask, new ReaderRegistrationEvent(subtask, "location_" + subtask));
+                subtask, 0, new ReaderRegistrationEvent(subtask, "location_" + subtask));
     }
 
     protected void waitForCoordinatorToProcessActions() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -31,8 +31,8 @@ import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,10 +44,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** The test base for SourceCoordinator related tests. */
-public abstract class SourceCoordinatorTestBase {
+abstract class SourceCoordinatorTestBase {
 
     protected static final String OPERATOR_NAME = "TestOperator";
     protected static final OperatorID TEST_OPERATOR_ID = new OperatorID(1234L, 5678L);
@@ -69,8 +69,8 @@ public abstract class SourceCoordinatorTestBase {
 
     // ------------------------------------------------------------------------
 
-    @Before
-    public void setup() throws Exception {
+    @BeforeEach
+    void setup() {
         receivingTasks = EventReceivingTasks.createForRunningTasks();
         operatorCoordinatorContext =
                 new MockOperatorCoordinatorContext(TEST_OPERATOR_ID, NUM_SUBTASKS);
@@ -85,8 +85,8 @@ public abstract class SourceCoordinatorTestBase {
         context = sourceCoordinator.getContext();
     }
 
-    @After
-    public void cleanUp() throws InterruptedException, TimeoutException {
+    @AfterEach
+    void cleanUp() throws InterruptedException, TimeoutException {
         coordinatorExecutor.shutdown();
         if (!coordinatorExecutor.awaitTermination(10, TimeUnit.SECONDS)) {
             throw new TimeoutException("Failed to close the CoordinatorExecutor before timeout.");
@@ -99,7 +99,7 @@ public abstract class SourceCoordinatorTestBase {
         if (enumerator == null) {
             enumerator =
                     (TestingSplitEnumerator<MockSourceSplit>) sourceCoordinator.getEnumerator();
-            assertNotNull("source was not started", enumerator);
+            assertThat(enumerator).as("source was not started").isNotNull();
         }
         return enumerator;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -177,6 +177,7 @@ abstract class SourceCoordinatorTestBase {
                 coordinatorThreadFactory,
                 operatorCoordinatorContext,
                 new MockSourceSplitSerializer(),
-                splitSplitAssignmentTracker);
+                splitSplitAssignmentTracker,
+                false);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorTestBase.java
@@ -20,13 +20,17 @@ package org.apache.flink.runtime.source.coordinator;
 
 import org.apache.flink.api.common.eventtime.WatermarkAlignmentParams;
 import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorCheckpointSerializer;
+import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.operators.coordination.EventReceivingTasks;
 import org.apache.flink.runtime.operators.coordination.MockOperatorCoordinatorContext;
+import org.apache.flink.runtime.operators.coordination.OperatorEvent;
+import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.runtime.source.event.ReaderRegistrationEvent;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
@@ -34,6 +38,7 @@ import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -43,6 +48,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,6 +58,8 @@ abstract class SourceCoordinatorTestBase {
     protected static final String OPERATOR_NAME = "TestOperator";
     protected static final OperatorID TEST_OPERATOR_ID = new OperatorID(1234L, 5678L);
     protected static final int NUM_SUBTASKS = 3;
+
+    protected boolean supportsConcurrentExecutionAttempts = false;
 
     // ---- Mocks for the underlying Operator Coordinator Context ---
     protected EventReceivingTasks receivingTasks;
@@ -109,15 +117,18 @@ abstract class SourceCoordinatorTestBase {
         setAllReaderTasksReady(sourceCoordinator);
     }
 
-    protected void setAllReaderTasksReady() {
-        setAllReaderTasksReady(sourceCoordinator);
-    }
-
     protected void setAllReaderTasksReady(SourceCoordinator<?, ?> sourceCoordinator) {
         for (int i = 0; i < NUM_SUBTASKS; i++) {
-            sourceCoordinator.executionAttemptReady(
-                    i, 0, receivingTasks.createGatewayForSubtask(i));
+            setReaderTaskReady(sourceCoordinator, i, 0);
         }
+    }
+
+    protected void setReaderTaskReady(
+            SourceCoordinator<?, ?> sourceCoordinator, int subtask, int attemptNumber) {
+        sourceCoordinator.executionAttemptReady(
+                subtask,
+                attemptNumber,
+                receivingTasks.createGatewayForSubtask(subtask, attemptNumber));
     }
 
     protected void addTestingSplitSet(int num) {
@@ -130,8 +141,18 @@ abstract class SourceCoordinatorTestBase {
     }
 
     protected void registerReader(int subtask) {
+        registerReader(subtask, 0);
+    }
+
+    protected void registerReader(int subtask, int attemptNumber) {
         sourceCoordinator.handleEventFromOperator(
-                subtask, 0, new ReaderRegistrationEvent(subtask, "location_" + subtask));
+                subtask,
+                attemptNumber,
+                new ReaderRegistrationEvent(subtask, createLocationFor(subtask, attemptNumber)));
+    }
+
+    static String createLocationFor(int subtask, int attemptNumber) {
+        return String.format("location_%d_%d", subtask, attemptNumber);
     }
 
     protected void waitForCoordinatorToProcessActions() {
@@ -147,6 +168,26 @@ abstract class SourceCoordinatorTestBase {
         }
     }
 
+    void waitForSentEvents(int expectedEventNumber) throws Exception {
+        waitUtilNumberReached(() -> receivingTasks.getNumberOfSentEvents(), expectedEventNumber);
+    }
+
+    static void waitUtilNumberReached(Supplier<Integer> numberSupplier, int expectedNumber)
+            throws Exception {
+        CommonTestUtils.waitUtil(
+                () -> numberSupplier.get() == expectedNumber,
+                Duration.ofDays(1),
+                "Not reach expected number within timeout.");
+    }
+
+    static <SplitT extends SourceSplit> void assertAddSplitEvent(
+            OperatorEvent event, List<SplitT> expectedSplits) throws Exception {
+        assertThat(event).isInstanceOf(AddSplitEvent.class);
+
+        final List<SplitT> splits = ((AddSplitEvent) event).splits(new MockSourceSplitSerializer());
+        assertThat(splits).isEqualTo(expectedSplits);
+    }
+
     // ------------------------------------------------------------------------
 
     protected SourceCoordinator<MockSourceSplit, Set<MockSourceSplit>> getNewSourceCoordinator() {
@@ -156,9 +197,7 @@ abstract class SourceCoordinatorTestBase {
     protected SourceCoordinator<MockSourceSplit, Set<MockSourceSplit>> getNewSourceCoordinator(
             WatermarkAlignmentParams watermarkAlignmentParams) {
         final Source<Integer, MockSourceSplit, Set<MockSourceSplit>> mockSource =
-                TestingSplitEnumerator.factorySource(
-                        new MockSourceSplitSerializer(),
-                        new MockSplitEnumeratorCheckpointSerializer());
+                createMockSource();
 
         return new SourceCoordinator<>(
                 OPERATOR_NAME,
@@ -166,6 +205,11 @@ abstract class SourceCoordinatorTestBase {
                 getNewSourceCoordinatorContext(),
                 new CoordinatorStoreImpl(),
                 watermarkAlignmentParams);
+    }
+
+    Source<Integer, MockSourceSplit, Set<MockSourceSplit>> createMockSource() {
+        return TestingSplitEnumerator.factorySource(
+                new MockSourceSplitSerializer(), new MockSplitEnumeratorCheckpointSerializer());
     }
 
     protected SourceCoordinatorContext<MockSourceSplit> getNewSourceCoordinatorContext() {
@@ -179,6 +223,6 @@ abstract class SourceCoordinatorTestBase {
                 operatorCoordinatorContext,
                 new MockSourceSplitSerializer(),
                 splitSplitAssignmentTracker,
-                false);
+                supportsConcurrentExecutionAttempts);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinator.java
@@ -84,7 +84,8 @@ public class CollectSinkOperatorCoordinator
     }
 
     @Override
-    public void handleEventFromOperator(int subtask, OperatorEvent event) throws Exception {
+    public void handleEventFromOperator(int subtask, int attemptNumber, OperatorEvent event)
+            throws Exception {
         Preconditions.checkArgument(
                 event instanceof CollectSinkAddressEvent,
                 "Operator event must be a CollectSinkAddressEvent");
@@ -183,8 +184,8 @@ public class CollectSinkOperatorCoordinator
     }
 
     @Override
-    public void subtaskFailed(int subtask, @Nullable Throwable reason) {
-        // subtask failed, the socket server does not exist anymore
+    public void executionAttemptFailed(int subtask, int attemptNumber, @Nullable Throwable reason) {
+        // attempt failed, the socket server does not exist anymore
         address = null;
     }
 
@@ -194,7 +195,7 @@ public class CollectSinkOperatorCoordinator
     }
 
     @Override
-    public void subtaskReady(int subtask, SubtaskGateway gateway) {
+    public void executionAttemptReady(int subtask, int attemptNumber, SubtaskGateway gateway) {
         // nothing to do here, connections are re-created lazily
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/CollectSinkOperatorCoordinatorTest.java
@@ -78,7 +78,7 @@ public class CollectSinkOperatorCoordinatorTest {
         ServerThread server = new ServerThread(expected, 3);
         server.start();
         coordinator.handleEventFromOperator(
-                0, new CollectSinkAddressEvent(server.getServerAddress()));
+                0, 0, new CollectSinkAddressEvent(server.getServerAddress()));
 
         // a normal response
         CollectCoordinationRequest request = new CollectCoordinationRequest("version1", 123);
@@ -96,14 +96,14 @@ public class CollectSinkOperatorCoordinatorTest {
         request = new CollectCoordinationRequest("version3", 789);
         CompletableFuture<CoordinationResponse> responseFuture =
                 coordinator.handleCoordinationRequest(request);
-        coordinator.subtaskFailed(0, null);
+        coordinator.executionAttemptFailed(0, 0, null);
 
         // new server comes
         expected = Collections.singletonList(Arrays.asList(Row.of(6, "fff"), Row.of(7, "ggg")));
         server = new ServerThread(expected, 2);
         server.start();
         coordinator.handleEventFromOperator(
-                0, new CollectSinkAddressEvent(server.getServerAddress()));
+                0, 0, new CollectSinkAddressEvent(server.getServerAddress()));
 
         // check failed request
         response = (CollectCoordinationResponse) responseFuture.get();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/CollectSinkFunctionTestWrapper.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/collect/utils/CollectSinkFunctionTestWrapper.java
@@ -100,7 +100,7 @@ public class CollectSinkFunctionTestWrapper<IN> {
         function.setRuntimeContext(runtimeContext);
         function.setOperatorEventGateway(gateway);
         function.open(new Configuration());
-        coordinator.handleEventFromOperator(0, gateway.getNextEvent());
+        coordinator.handleEventFromOperator(0, 0, gateway.getNextEvent());
     }
 
     public void openFunctionWithState() throws Exception {
@@ -110,7 +110,7 @@ public class CollectSinkFunctionTestWrapper<IN> {
         function.setOperatorEventGateway(gateway);
         function.initializeState(functionInitializationContext);
         function.open(new Configuration());
-        coordinator.handleEventFromOperator(0, gateway.getNextEvent());
+        coordinator.handleEventFromOperator(0, 0, gateway.getNextEvent());
     }
 
     public void invoke(IN record) throws Exception {
@@ -136,7 +136,7 @@ public class CollectSinkFunctionTestWrapper<IN> {
     public void closeFunctionAbnormally() throws Exception {
         // this is an exceptional shutdown
         function.close();
-        coordinator.subtaskFailed(0, null);
+        coordinator.executionAttemptFailed(0, 0, null);
     }
 
     public CollectCoordinationResponse sendRequestAndGetResponse(String version, long offset)

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSplitEnumeratorContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/source/reader/TestingSplitEnumeratorContext.java
@@ -104,6 +104,11 @@ public class TestingSplitEnumeratorContext<SplitT extends SourceSplit>
     }
 
     @Override
+    public void sendEventToSourceReader(int subtaskId, int attemptNumber, SourceEvent event) {
+        sendEventToSourceReader(subtaskId, event);
+    }
+
+    @Override
     public int currentParallelism() {
         return parallelism;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2171,6 +2171,8 @@ under the License.
 								<exclude>org.apache.flink.metrics.Meter#getMetricType()</exclude>
 								<exclude>org.apache.flink.metrics.Gauge#getMetricType()</exclude>
 								<exclude>org.apache.flink.metrics.Histogram#getMetricType()</exclude>
+								<exclude>org.apache.flink.api.connector.source.SplitEnumeratorContext#sendEventToSourceReader(int,int,org.apache.flink.api.connector.source.SourceEvent)</exclude>
+								<exclude>org.apache.flink.api.connector.source.SplitEnumeratorContext#registeredReadersOfAttempts()</exclude>
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>


### PR DESCRIPTION
## What is the purpose of the change

This PR enables new sources(FLIP-27) for speculative execution.
It mainly improved the SourceCoordinator and SourceCoordinatorContext to deal with attempt level split requests and source events.


## Verifying this change

  - *Added unit tests SourceCoordinatorConcurrentAttemptsTest*
  - *Added test cases in SourceCoordinatorTest*
  - *Covered by existing tests of SourceCoordinator and SourceCoordinatorContext*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
