### PR TITLE
[hotfix][table-runtime] Avoid NPE for SliceAssigner and improve error message

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/slicing/SliceAssigners.java
@@ -553,6 +553,11 @@ public final class SliceAssigners {
         public final long assignSliceEnd(RowData element, ClockService clock) {
             final long timestamp;
             if (rowtimeIndex >= 0) {
+                if (element.isNullAt(rowtimeIndex)) {
+                    throw new RuntimeException(
+                            "RowTime field should not be null,"
+                                    + " please convert it to a non-null long value.");
+                }
                 // Precision for row timestamp is always 3
                 TimestampData rowTime = element.getTimestamp(rowtimeIndex, 3);
                 timestamp = toUtcTimestampMills(rowTime.getMillisecond(), shiftTimeZone);


### PR DESCRIPTION
## What is the purpose of the change
NPE may occurs at LocalSlicingWindowAggOperator.processElement when an input row with null timestamp column, it would be better to avoid a NPE and improve the error message (just like WatermarkAssignerOperator does)

## Brief change log
Add null check for AbstractSliceAssigner

## Verifying this change
existing tests

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)


## Documentation
  - Does this pull request introduce a new feature? (no)