### PR TITLE
[FLINK-28603] nextNameOffset should be capitalized and separated by an underscore.

### DIFF
--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcServiceUtils.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcServiceUtils.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /** These RPC utilities contain helper methods around RPC use. */
 public class RpcServiceUtils {
-    private static final AtomicLong nextNameOffset = new AtomicLong(0L);
+    private static final AtomicLong NEXT_NAME_OFFSET = new AtomicLong(0L);
 
     /**
      * Creates a random name of the form prefix_X, where X is an increasing number.
@@ -38,8 +38,8 @@ public class RpcServiceUtils {
 
         // obtain the next name offset by incrementing it atomically
         do {
-            nameOffset = nextNameOffset.get();
-        } while (!nextNameOffset.compareAndSet(nameOffset, nameOffset + 1L));
+            nameOffset = NEXT_NAME_OFFSET.get();
+        } while (!NEXT_NAME_OFFSET.compareAndSet(nameOffset, nameOffset + 1L));
 
         return prefix + '_' + nameOffset;
     }


### PR DESCRIPTION
## What is the purpose of the change

*
Hello, I found a code style problem in flick, which is located in RpcServiceUtils, where nextNameOffset should be capitalized and separated by an underscore.
*


## Brief change log
  - *rename  nextNameOffset to NEXT_NAME_OFFSET*


## Verifying this change

This change is already covered by existing tests, such as *AkkaRpcActorTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
