### PR TITLE
[FLINK-28602][state/changelog] Close stream of StateChangeFsUploader normally while enabling compression

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/StateChangeFsUploader.java
@@ -38,7 +38,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -145,9 +144,7 @@ public class StateChangeFsUploader implements StateChangeUploader {
     }
 
     private UploadTasksResult upload(Path path, Collection<UploadTask> tasks) throws IOException {
-        boolean wrappedStreamClosed = false;
-        FSDataOutputStream fsStream = fileSystem.create(path, NO_OVERWRITE);
-        try {
+        try (FSDataOutputStream fsStream = fileSystem.create(path, NO_OVERWRITE)) {
             fsStream.write(compression ? 1 : 0);
             try (OutputStreamWithPos stream = wrap(fsStream)) {
                 final Map<UploadTask, Map<StateChangeSet, Long>> tasksOffsets = new HashMap<>();
@@ -164,12 +161,6 @@ public class StateChangeFsUploader implements StateChangeUploader {
                 // WARN: streams have to be closed before returning the results
                 // otherwise JM may receive invalid handles
                 return new UploadTasksResult(tasksOffsets, handle);
-            } finally {
-                wrappedStreamClosed = true;
-            }
-        } finally {
-            if (!wrappedStreamClosed) {
-                fsStream.close();
             }
         }
     }
@@ -179,9 +170,8 @@ public class StateChangeFsUploader implements StateChangeUploader {
                 compression
                         ? SnappyStreamCompressionDecorator.INSTANCE
                         : UncompressedStreamCompressionDecorator.INSTANCE;
-        OutputStream compressed =
-                compression ? instance.decorateWithCompression(fsStream) : fsStream;
-        return new OutputStreamWithPos(new BufferedOutputStream(compressed, bufferSize));
+        return new OutputStreamWithPos(
+                new BufferedOutputStream(instance.decorateWithCompression(fsStream), bufferSize));
     }
 
     private String generateFileName() {


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request makes output stream of StateChangeFsUploader could be closed normally while enbaling compression.

## Brief change log

 - Always call close in StateChangeFsUploader#upload while enabling compression

## Verifying this change

- Added StateChangeFsUploaderTest#testCompress

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
