### PR TITLE
[FLINK-28376][network] Restrict the number of threads for sort-shuffle data read

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -38,7 +38,6 @@ import org.apache.flink.runtime.shuffle.ShuffleEnvironmentContext;
 import org.apache.flink.runtime.shuffle.ShuffleMasterContext;
 import org.apache.flink.runtime.shuffle.ShuffleServiceFactory;
 import org.apache.flink.runtime.taskmanager.NettyShuffleEnvironmentConfiguration;
-import org.apache.flink.runtime.util.Hardware;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.slf4j.Logger;
@@ -81,7 +80,9 @@ public class NettyShuffleServiceFactory
                 shuffleEnvironmentContext.getTaskExecutorResourceId(),
                 shuffleEnvironmentContext.getEventPublisher(),
                 shuffleEnvironmentContext.getParentMetricGroup(),
-                shuffleEnvironmentContext.getIoExecutor());
+                shuffleEnvironmentContext.getIoExecutor(),
+                shuffleEnvironmentContext.getNumberOfSlots(),
+                shuffleEnvironmentContext.getTmpDirPaths());
     }
 
     @VisibleForTesting
@@ -90,14 +91,18 @@ public class NettyShuffleServiceFactory
             ResourceID taskExecutorResourceId,
             TaskEventPublisher taskEventPublisher,
             MetricGroup metricGroup,
-            Executor ioExecutor) {
+            Executor ioExecutor,
+            int numberOfSlots,
+            String[] tmpDirPaths) {
         return createNettyShuffleEnvironment(
                 config,
                 taskExecutorResourceId,
                 taskEventPublisher,
                 new ResultPartitionManager(),
                 metricGroup,
-                ioExecutor);
+                ioExecutor,
+                numberOfSlots,
+                tmpDirPaths);
     }
 
     @VisibleForTesting
@@ -107,7 +112,9 @@ public class NettyShuffleServiceFactory
             TaskEventPublisher taskEventPublisher,
             ResultPartitionManager resultPartitionManager,
             MetricGroup metricGroup,
-            Executor ioExecutor) {
+            Executor ioExecutor,
+            int numberOfSlots,
+            String[] tmpDirPaths) {
         NettyConfig nettyConfig = config.nettyConfig();
         ConnectionManager connectionManager =
                 nettyConfig != null
@@ -125,7 +132,9 @@ public class NettyShuffleServiceFactory
                 resultPartitionManager,
                 connectionManager,
                 metricGroup,
-                ioExecutor);
+                ioExecutor,
+                numberOfSlots,
+                tmpDirPaths);
     }
 
     @VisibleForTesting
@@ -136,7 +145,9 @@ public class NettyShuffleServiceFactory
             ResultPartitionManager resultPartitionManager,
             ConnectionManager connectionManager,
             MetricGroup metricGroup,
-            Executor ioExecutor) {
+            Executor ioExecutor,
+            int numberOfSlots,
+            String[] tmpDirPaths) {
         checkNotNull(config);
         checkNotNull(taskExecutorResourceId);
         checkNotNull(taskEventPublisher);
@@ -177,7 +188,7 @@ public class NettyShuffleServiceFactory
                                 1,
                                 Math.min(
                                         batchShuffleReadBufferPool.getMaxConcurrentRequests(),
-                                        4 * Hardware.getNumberCPUCores())),
+                                        Math.max(numberOfSlots, tmpDirPaths.length))),
                         new ExecutorThreadFactory("blocking-shuffle-io"));
 
         registerShuffleMetrics(metricGroup, networkBufferPool);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/ShuffleEnvironmentContext.java
@@ -38,6 +38,8 @@ public class ShuffleEnvironmentContext {
     private final InetAddress hostAddress;
     private final TaskEventPublisher eventPublisher;
     private final MetricGroup parentMetricGroup;
+    private final int numberOfSlots;
+    private final String[] tmpDirPaths;
 
     private final Executor ioExecutor;
 
@@ -47,6 +49,8 @@ public class ShuffleEnvironmentContext {
             MemorySize networkMemorySize,
             boolean localCommunicationOnly,
             InetAddress hostAddress,
+            int numberOfSlots,
+            String[] tmpDirPaths,
             TaskEventPublisher eventPublisher,
             MetricGroup parentMetricGroup,
             Executor ioExecutor) {
@@ -58,6 +62,8 @@ public class ShuffleEnvironmentContext {
         this.eventPublisher = checkNotNull(eventPublisher);
         this.parentMetricGroup = checkNotNull(parentMetricGroup);
         this.ioExecutor = ioExecutor;
+        this.numberOfSlots = numberOfSlots;
+        this.tmpDirPaths = checkNotNull(tmpDirPaths);
     }
 
     public Configuration getConfiguration() {
@@ -90,5 +96,13 @@ public class ShuffleEnvironmentContext {
 
     public Executor getIoExecutor() {
         return ioExecutor;
+    }
+
+    public int getNumberOfSlots() {
+        return numberOfSlots;
+    }
+
+    public String[] getTmpDirPaths() {
+        return tmpDirPaths;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerServices.java
@@ -414,6 +414,8 @@ public class TaskManagerServices {
                         taskManagerServicesConfiguration.getNetworkMemorySize(),
                         taskManagerServicesConfiguration.isLocalCommunicationOnly(),
                         taskManagerServicesConfiguration.getBindAddress(),
+                        taskManagerServicesConfiguration.getNumberOfSlots(),
+                        taskManagerServicesConfiguration.getTmpDirPaths(),
                         taskEventDispatcher,
                         taskManagerMetricGroup,
                         ioExecutor);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executor;
 /** Builder for the {@link NettyShuffleEnvironment}. */
 public class NettyShuffleEnvironmentBuilder {
 
+    private static final int DEFAULT_NUM_SLOTS = 1;
     private static final int DEFAULT_NETWORK_BUFFER_SIZE = 32 << 10;
     private static final int DEFAULT_NUM_NETWORK_BUFFERS = 1024;
 
@@ -231,6 +232,8 @@ public class NettyShuffleEnvironmentBuilder {
                 new TaskEventDispatcher(),
                 resultPartitionManager,
                 metricGroup,
-                ioExecutor);
+                ioExecutor,
+                DEFAULT_NUM_SLOTS,
+                DEFAULT_TEMP_DIRS);
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SharedPoolNettyShuffleServiceFactory.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/SharedPoolNettyShuffleServiceFactory.java
@@ -99,6 +99,8 @@ public final class SharedPoolNettyShuffleServiceFactory
                 resultPartitionManager,
                 connectionManager,
                 shuffleEnvironmentContext.getParentMetricGroup(),
-                shuffleEnvironmentContext.getIoExecutor());
+                shuffleEnvironmentContext.getIoExecutor(),
+                shuffleEnvironmentContext.getNumberOfSlots(),
+                shuffleEnvironmentContext.getTmpDirPaths());
     }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*Currently, the number of IO threads for shuffle data reading is relevant to the size of reading memory and the number of CPU cores. We should also consider the number of slots and the number of disks.*


## Brief change log

  - *Restrict the number of threads for sort-shuffle data read*


## Verifying this change

This change is already covered by existing tests, such as *SharedPoolNettyShuffleServiceFactory*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
