### PR TITLE
[FLINK-28612] [FLINK-28612][runtime] SpeculativeScheduler cancels pending slot allocation after canceling pending executions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
@@ -178,15 +178,29 @@ public class SpeculativeScheduler extends AdaptiveBatchScheduler
 
     private CompletableFuture<?> cancelPendingExecutions(
             final ExecutionVertexID executionVertexId) {
-        // cancel all the related pending requests to avoid that slots returned by the canceled
-        // vertices are used to fulfill these pending requests
-        // do not cancel the FINISHED execution
-        cancelAllPendingSlotRequestsForVertex(executionVertexId);
-        return FutureUtils.combineAll(
+        final List<Execution> pendingExecutions =
                 getExecutionVertex(executionVertexId).getCurrentExecutions().stream()
-                        .filter(e -> e.getState() != ExecutionState.FINISHED)
-                        .map(this::cancelExecution)
-                        .collect(Collectors.toList()));
+                        .filter(
+                                e ->
+                                        !e.getState().isTerminal()
+                                                && e.getState() != ExecutionState.CANCELING)
+                        .collect(Collectors.toList());
+        if (pendingExecutions.isEmpty()) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        log.info(
+                "Canceling {} un-finished executions of {} because one of its executions has finished.",
+                pendingExecutions.size(),
+                executionVertexId);
+
+        final CompletableFuture<?> future =
+                FutureUtils.combineAll(
+                        pendingExecutions.stream()
+                                .map(this::cancelExecution)
+                                .collect(Collectors.toList()));
+        cancelAllPendingSlotRequestsForVertex(executionVertexId);
+        return future;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
@@ -307,7 +307,15 @@ public class SpeculativeScheduler extends AdaptiveBatchScheduler
 
         return slowExecutions.stream()
                 .map(id -> getExecutionGraph().getRegisteredExecutions().get(id))
-                .map(Execution::getAssignedResourceLocation)
+                .map(
+                        e -> {
+                            checkNotNull(
+                                    e.getAssignedResource(),
+                                    "The reported slow node have not been assigned a slot. "
+                                            + "This is unexpected and indicates that there is "
+                                            + "something wrong with the slow task detector.");
+                            return e.getAssignedResourceLocation();
+                        })
                 .map(TaskManagerLocation::getNodeId)
                 .collect(Collectors.toSet());
     }


### PR DESCRIPTION
## What is the purpose of the change

Canceling pending slot allocation before canceling executions will result in execution failures and pollute the logs. It will also result in an execution to be FAILED even if the execution vertex has FINISHED, which breaks the assumption of SpeculativeScheduler#isExecutionVertexPossibleToFinish().
This PR changes SpeculativeScheduler to cancel pending slot allocation after canceling pending executions.

## Verifying this change

  - *Added units test in SpeculativeSchedulerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
