### PR TITLE
[FLINK-28512][network] Select HashBasedDataBuffer and SortBasedDataBuffer dynamically based on the number of network buffers that can be allocated for SortMergeResultPartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataBuffer.java
@@ -58,9 +58,6 @@ public interface DataBuffer {
     /** Returns true if not all data appended to this {@link DataBuffer} is consumed. */
     boolean hasRemaining();
 
-    /** Resets this {@link DataBuffer} to be reused for data appending. */
-    void reset();
-
     /** Finishes this {@link DataBuffer} which means no record can be appended any more. */
     void finish();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/HashBasedDataBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/HashBasedDataBuffer.java
@@ -23,7 +23,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
-import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
+import java.util.LinkedList;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -47,14 +48,20 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class HashBasedDataBuffer implements DataBuffer {
 
-    /** A buffer pool to request memory segments from. */
-    private final BufferPool bufferPool;
+    /** A list of {@link MemorySegment}s used to store data in memory. */
+    private final LinkedList<MemorySegment> freeSegments;
+
+    /** {@link BufferRecycler} used to recycle {@link #freeSegments}. */
+    private final BufferRecycler bufferRecycler;
 
     /** Number of guaranteed buffers can be allocated from the buffer pool for data sort. */
     private final int numGuaranteedBuffers;
 
     /** Buffers containing data for all subpartitions. */
     private final ArrayDeque<BufferConsumer>[] buffers;
+
+    /** Size of buffers requested from buffer pool. All buffers must be of the same size. */
+    private final int bufferSize;
 
     // ---------------------------------------------------------------------------------------------
     // Statistics and states
@@ -65,9 +72,6 @@ public class HashBasedDataBuffer implements DataBuffer {
 
     /** Total number of records already appended to this sort buffer. */
     private long numTotalRecords;
-
-    /** Whether this sort buffer is full and ready to read data from. */
-    private boolean isFull;
 
     /** Whether this sort buffer is finished. One can only read a finished sort buffer. */
     private boolean isFinished;
@@ -99,14 +103,19 @@ public class HashBasedDataBuffer implements DataBuffer {
     private long numTotalBytesRead;
 
     public HashBasedDataBuffer(
-            BufferPool bufferPool,
+            LinkedList<MemorySegment> freeSegments,
+            BufferRecycler bufferRecycler,
             int numSubpartitions,
+            int bufferSize,
             int numGuaranteedBuffers,
             @Nullable int[] customReadOrder) {
         checkArgument(numGuaranteedBuffers > 0, "No guaranteed buffers for sort.");
 
-        this.bufferPool = checkNotNull(bufferPool);
+        this.freeSegments = checkNotNull(freeSegments);
+        this.bufferRecycler = checkNotNull(bufferRecycler);
+        this.bufferSize = bufferSize;
         this.numGuaranteedBuffers = numGuaranteedBuffers;
+        checkState(numGuaranteedBuffers <= freeSegments.size(), "Wrong number of free segments.");
 
         this.builders = new BufferBuilder[numSubpartitions];
         this.buffers = new ArrayDeque[numSubpartitions];
@@ -134,7 +143,6 @@ public class HashBasedDataBuffer implements DataBuffer {
     public boolean append(ByteBuffer source, int targetChannel, Buffer.DataType dataType)
             throws IOException {
         checkArgument(source.hasRemaining(), "Cannot append empty data.");
-        checkState(!isFull, "Sort buffer is already full.");
         checkState(!isFinished, "Sort buffer is already finished.");
         checkState(!isReleased, "Sort buffer is already released.");
 
@@ -145,19 +153,18 @@ public class HashBasedDataBuffer implements DataBuffer {
             writeEvent(source, targetChannel, dataType);
         }
 
-        isFull = source.hasRemaining();
-        if (!isFull) {
-            ++numTotalRecords;
+        if (source.hasRemaining()) {
+            return true;
         }
+        ++numTotalRecords;
         numTotalBytes += totalBytes - source.remaining();
-        return isFull;
+        return false;
     }
 
     private void writeEvent(ByteBuffer source, int targetChannel, Buffer.DataType dataType) {
         BufferBuilder builder = builders[targetChannel];
         if (builder != null) {
             builder.finish();
-            buffers[targetChannel].add(builder.createBufferConsumerFromBeginning());
             builder.close();
             builders[targetChannel] = null;
         }
@@ -172,14 +179,19 @@ public class HashBasedDataBuffer implements DataBuffer {
         buffers[targetChannel].add(consumer);
     }
 
-    private void writeRecord(ByteBuffer source, int targetChannel) throws IOException {
+    private void writeRecord(ByteBuffer source, int targetChannel) {
+        BufferBuilder builder = builders[targetChannel];
+        int availableBytes = builder != null ? builder.getWritableBytes() : 0;
+        if (source.remaining()
+                > availableBytes
+                        + (numGuaranteedBuffers - numBuffersOccupied) * (long) bufferSize) {
+            return;
+        }
+
         do {
-            BufferBuilder builder = builders[targetChannel];
             if (builder == null) {
-                builder = requestBufferFromPool();
-                if (builder == null) {
-                    break;
-                }
+                builder = new BufferBuilder(freeSegments.poll(), bufferRecycler);
+                buffers[targetChannel].add(builder.createBufferConsumer());
                 ++numBuffersOccupied;
                 builders[targetChannel] = builder;
             }
@@ -187,29 +199,16 @@ public class HashBasedDataBuffer implements DataBuffer {
             builder.append(source);
             if (builder.isFull()) {
                 builder.finish();
-                buffers[targetChannel].add(builder.createBufferConsumerFromBeginning());
                 builder.close();
                 builders[targetChannel] = null;
+                builder = null;
             }
         } while (source.hasRemaining());
     }
 
-    private BufferBuilder requestBufferFromPool() throws IOException {
-        try {
-            // blocking request buffers if there is still guaranteed memory
-            if (numBuffersOccupied < numGuaranteedBuffers) {
-                return bufferPool.requestBufferBuilderBlocking();
-            }
-        } catch (InterruptedException e) {
-            throw new IOException("Interrupted while requesting buffer.", e);
-        }
-
-        return bufferPool.requestBufferBuilder();
-    }
-
     @Override
     public BufferWithChannel getNextBuffer(MemorySegment transitBuffer) {
-        checkState(isFull, "Sort buffer is not ready to be read.");
+        checkState(isFinished, "Sort buffer is not ready to be read.");
         checkState(!isReleased, "Sort buffer is already released.");
 
         BufferWithChannel buffer = null;
@@ -251,26 +250,14 @@ public class HashBasedDataBuffer implements DataBuffer {
     }
 
     @Override
-    public void reset() {
-        checkState(!isFinished, "Sort buffer has been finished.");
-        checkState(!isReleased, "Sort buffer has been released.");
-
-        isFull = false;
-        readOrderIndex = 0;
-    }
-
-    @Override
     public void finish() {
-        checkState(!isFull, "DataBuffer must not be full.");
         checkState(!isFinished, "DataBuffer is already finished.");
 
-        isFull = true;
         isFinished = true;
         for (int channel = 0; channel < builders.length; ++channel) {
             BufferBuilder builder = builders[channel];
             if (builder != null) {
                 builder.finish();
-                buffers[channel].add(builder.createBufferConsumerFromBeginning());
                 builder.close();
                 builders[channel] = null;
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortBasedDataBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortBasedDataBuffer.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.io.network.partition;
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 
 import javax.annotation.Nullable;
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedList;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -58,8 +59,11 @@ public class SortBasedDataBuffer implements DataBuffer {
      */
     private static final int INDEX_ENTRY_SIZE = 4 + 4 + 8;
 
-    /** A buffer pool to request memory segments from. */
-    private final BufferPool bufferPool;
+    /** A list of {@link MemorySegment}s used to store data in memory. */
+    private final LinkedList<MemorySegment> freeSegments;
+
+    /** {@link BufferRecycler} used to recycle {@link #freeSegments}. */
+    private final BufferRecycler bufferRecycler;
 
     /** A segment list as a joint buffer which stores all records and index entries. */
     private final ArrayList<MemorySegment> segments = new ArrayList<>();
@@ -88,9 +92,6 @@ public class SortBasedDataBuffer implements DataBuffer {
 
     /** Total number of bytes already read from this sort buffer. */
     private long numTotalBytesRead;
-
-    /** Whether this sort buffer is full and ready to read data from. */
-    private boolean isFull;
 
     /** Whether this sort buffer is finished. One can only read a finished sort buffer. */
     private boolean isFinished;
@@ -125,7 +126,8 @@ public class SortBasedDataBuffer implements DataBuffer {
     private int readOrderIndex = -1;
 
     public SortBasedDataBuffer(
-            BufferPool bufferPool,
+            LinkedList<MemorySegment> freeSegments,
+            BufferRecycler bufferRecycler,
             int numSubpartitions,
             int bufferSize,
             int numGuaranteedBuffers,
@@ -133,9 +135,11 @@ public class SortBasedDataBuffer implements DataBuffer {
         checkArgument(bufferSize > INDEX_ENTRY_SIZE, "Buffer size is too small.");
         checkArgument(numGuaranteedBuffers > 0, "No guaranteed buffers for sort.");
 
-        this.bufferPool = checkNotNull(bufferPool);
+        this.freeSegments = checkNotNull(freeSegments);
+        this.bufferRecycler = checkNotNull(bufferRecycler);
         this.bufferSize = bufferSize;
         this.numGuaranteedBuffers = numGuaranteedBuffers;
+        checkState(numGuaranteedBuffers <= freeSegments.size(), "Wrong number of free segments.");
         this.firstIndexEntryAddresses = new long[numSubpartitions];
         this.lastIndexEntryAddresses = new long[numSubpartitions];
 
@@ -162,7 +166,6 @@ public class SortBasedDataBuffer implements DataBuffer {
     public boolean append(ByteBuffer source, int targetChannel, DataType dataType)
             throws IOException {
         checkArgument(source.hasRemaining(), "Cannot append empty data.");
-        checkState(!isFull, "Sort buffer is already full.");
         checkState(!isFinished, "Sort buffer is already finished.");
         checkState(!isReleased, "Sort buffer is already released.");
 
@@ -170,11 +173,6 @@ public class SortBasedDataBuffer implements DataBuffer {
 
         // return true directly if it can not allocate enough buffers for the given record
         if (!allocateBuffersForRecord(totalBytes)) {
-            isFull = true;
-            if (hasRemaining()) {
-                // prepare for reading
-                updateReadChannelAndIndexEntryAddress();
-            }
             return true;
         }
 
@@ -224,7 +222,7 @@ public class SortBasedDataBuffer implements DataBuffer {
         }
     }
 
-    private boolean allocateBuffersForRecord(int numRecordBytes) throws IOException {
+    private boolean allocateBuffersForRecord(int numRecordBytes) {
         int numBytesRequired = INDEX_ENTRY_SIZE + numRecordBytes;
         int availableBytes =
                 writeSegmentIndex == segments.size() ? 0 : bufferSize - writeSegmentOffset;
@@ -240,16 +238,16 @@ public class SortBasedDataBuffer implements DataBuffer {
             availableBytes = 0;
         }
 
+        if (availableBytes + (numGuaranteedBuffers - segments.size()) * (long) bufferSize
+                < numBytesRequired) {
+            return false;
+        }
+
         // allocate exactly enough buffers for the appended record
         do {
-            MemorySegment segment = requestBufferFromPool();
-            if (segment == null) {
-                // return false if we can not allocate enough buffers for the appended record
-                return false;
-            }
-
+            MemorySegment segment = freeSegments.poll();
             availableBytes += bufferSize;
-            addBuffer(segment);
+            addBuffer(checkNotNull(segment));
         } while (availableBytes < numBytesRequired);
 
         return true;
@@ -257,29 +255,16 @@ public class SortBasedDataBuffer implements DataBuffer {
 
     private void addBuffer(MemorySegment segment) {
         if (segment.size() != bufferSize) {
-            bufferPool.recycle(segment);
+            bufferRecycler.recycle(segment);
             throw new IllegalStateException("Illegal memory segment size.");
         }
 
         if (isReleased) {
-            bufferPool.recycle(segment);
+            bufferRecycler.recycle(segment);
             throw new IllegalStateException("Sort buffer is already released.");
         }
 
         segments.add(segment);
-    }
-
-    private MemorySegment requestBufferFromPool() throws IOException {
-        try {
-            // blocking request buffers if there is still guaranteed memory
-            if (segments.size() < numGuaranteedBuffers) {
-                return bufferPool.requestMemorySegmentBlocking();
-            }
-        } catch (InterruptedException e) {
-            throw new IOException("Interrupted while requesting buffer.");
-        }
-
-        return bufferPool.requestMemorySegment();
     }
 
     private void updateWriteSegmentIndexAndOffset(int numBytes) {
@@ -294,7 +279,7 @@ public class SortBasedDataBuffer implements DataBuffer {
 
     @Override
     public BufferWithChannel getNextBuffer(MemorySegment transitBuffer) {
-        checkState(isFull, "Sort buffer is not ready to be read.");
+        checkState(isFinished, "Sort buffer is not ready to be read.");
         checkState(!isReleased, "Sort buffer is already released.");
 
         if (!hasRemaining()) {
@@ -427,37 +412,12 @@ public class SortBasedDataBuffer implements DataBuffer {
     }
 
     @Override
-    public void reset() {
-        checkState(!isFinished, "Sort buffer has been finished.");
-        checkState(!isReleased, "Sort buffer has been released.");
-        checkState(!hasRemaining(), "Still has remaining data.");
-
-        for (MemorySegment segment : segments) {
-            bufferPool.recycle(segment);
-        }
-        segments.clear();
-
-        // initialized with -1 means the corresponding channel has no data
-        Arrays.fill(firstIndexEntryAddresses, -1L);
-        Arrays.fill(lastIndexEntryAddresses, -1L);
-
-        isFull = false;
-        writeSegmentIndex = 0;
-        writeSegmentOffset = 0;
-        readIndexEntryAddress = 0;
-        recordRemainingBytes = 0;
-        readOrderIndex = -1;
-    }
-
-    @Override
     public void finish() {
-        checkState(!isFull, "DataBuffer must not be full.");
         checkState(!isFinished, "DataBuffer is already finished.");
 
         isFinished = true;
 
         // prepare for reading
-        isFull = true;
         updateReadChannelAndIndexEntryAddress();
     }
 
@@ -474,7 +434,7 @@ public class SortBasedDataBuffer implements DataBuffer {
         isReleased = true;
 
         for (MemorySegment segment : segments) {
-            bufferPool.recycle(segment);
+            bufferRecycler.recycle(segment);
         }
         segments.clear();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
@@ -84,9 +85,6 @@ public class SortMergeResultPartition extends ResultPartition {
     @GuardedBy("lock")
     private PartitionedFile resultFile;
 
-    /** Buffers cut from the network buffer pool for data writing. */
-    private final List<MemorySegment> writeSegments = new ArrayList<>();
-
     private boolean hasNotifiedEndOfUserRecords;
 
     /** Size of network buffer and write buffer. */
@@ -114,6 +112,9 @@ public class SortMergeResultPartition extends ResultPartition {
      * Data read scheduler for this result partition which schedules data read of all subpartitions.
      */
     private final SortMergeResultPartitionReadScheduler readScheduler;
+
+    /** All available network buffers can be used by this result partition for a data region. */
+    private final LinkedList<MemorySegment> freeSegments = new LinkedList<>();
 
     /**
      * Number of guaranteed network buffers can be used by {@link #unicastDataBuffer} and {@link
@@ -190,42 +191,7 @@ public class SortMergeResultPartition extends ResultPartition {
         readBufferPool.initialize();
         super.setup();
 
-        int numRequiredBuffer = bufferPool.getNumberOfRequiredMemorySegments();
-        if (numRequiredBuffer < 2) {
-            throw new IOException(
-                    String.format(
-                            "Too few sort buffers, please increase %s.",
-                            NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS));
-        }
-
-        int expectedWriteBuffers = 0;
-        if (numRequiredBuffer >= 2 * numSubpartitions) {
-            useHashBuffer = true;
-        } else if (networkBufferSize >= NUM_WRITE_BUFFER_BYTES) {
-            expectedWriteBuffers = 1;
-        } else {
-            expectedWriteBuffers =
-                    Math.min(EXPECTED_WRITE_BATCH_SIZE, NUM_WRITE_BUFFER_BYTES / networkBufferSize);
-        }
-
-        int numBuffersForWrite = Math.min(numRequiredBuffer / 2, expectedWriteBuffers);
-        numBuffersForSort = numRequiredBuffer - numBuffersForWrite;
-
-        try {
-            for (int i = 0; i < numBuffersForWrite; ++i) {
-                MemorySegment segment = bufferPool.requestMemorySegmentBlocking();
-                writeSegments.add(segment);
-            }
-        } catch (InterruptedException exception) {
-            // the setup method does not allow InterruptedException
-            throw new IOException(exception);
-        }
-
-        LOG.info(
-                "Sort-merge partition {} initialized, num sort buffers: {}, num write buffers: {}.",
-                getPartitionId(),
-                numBuffersForSort,
-                numBuffersForWrite);
+        LOG.info("Sort-merge partition {} initialized.", getPartitionId());
     }
 
     @Override
@@ -296,13 +262,13 @@ public class SortMergeResultPartition extends ResultPartition {
         }
 
         if (!dataBuffer.hasRemaining()) {
-            dataBuffer.reset();
+            dataBuffer.release();
             writeLargeRecord(record, targetSubpartition, dataType, isBroadcast);
             return;
         }
 
         flushDataBuffer(dataBuffer, isBroadcast);
-        dataBuffer.reset();
+        dataBuffer.release();
         if (record.hasRemaining()) {
             emit(record, targetSubpartition, dataType, isBroadcast);
         }
@@ -317,7 +283,9 @@ public class SortMergeResultPartition extends ResultPartition {
     private DataBuffer getUnicastDataBuffer() throws IOException {
         flushBroadcastDataBuffer();
 
-        if (unicastDataBuffer != null && !unicastDataBuffer.isFinished()) {
+        if (unicastDataBuffer != null
+                && !unicastDataBuffer.isFinished()
+                && !unicastDataBuffer.isReleased()) {
             return unicastDataBuffer;
         }
 
@@ -328,7 +296,9 @@ public class SortMergeResultPartition extends ResultPartition {
     private DataBuffer getBroadcastDataBuffer() throws IOException {
         flushUnicastDataBuffer();
 
-        if (broadcastDataBuffer != null && !broadcastDataBuffer.isFinished()) {
+        if (broadcastDataBuffer != null
+                && !broadcastDataBuffer.isFinished()
+                && !broadcastDataBuffer.isReleased()) {
             return broadcastDataBuffer;
         }
 
@@ -336,12 +306,20 @@ public class SortMergeResultPartition extends ResultPartition {
         return broadcastDataBuffer;
     }
 
-    private DataBuffer createNewDataBuffer() {
+    private DataBuffer createNewDataBuffer() throws IOException {
+        requestNetworkBuffers();
+
         if (useHashBuffer) {
             return new HashBasedDataBuffer(
-                    bufferPool, numSubpartitions, numBuffersForSort, subpartitionOrder);
+                    freeSegments,
+                    bufferPool,
+                    numSubpartitions,
+                    networkBufferSize,
+                    numBuffersForSort,
+                    subpartitionOrder);
         } else {
             return new SortBasedDataBuffer(
+                    freeSegments,
                     bufferPool,
                     numSubpartitions,
                     networkBufferSize,
@@ -350,12 +328,53 @@ public class SortMergeResultPartition extends ResultPartition {
         }
     }
 
+    private void requestNetworkBuffers() throws IOException {
+        int numRequiredBuffer = bufferPool.getNumberOfRequiredMemorySegments();
+        if (numRequiredBuffer < 2) {
+            throw new IOException(
+                    String.format(
+                            "Too few sort buffers, please increase %s.",
+                            NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS));
+        }
+
+        try {
+            while (freeSegments.size() < numRequiredBuffer) {
+                freeSegments.add(checkNotNull(bufferPool.requestMemorySegmentBlocking()));
+            }
+        } catch (InterruptedException exception) {
+            throw new IOException("Failed to allocate buffers for result partition.", exception);
+        }
+
+        // avoid taking too many buffers in one result partition
+        while (freeSegments.size() < bufferPool.getMaxNumberOfMemorySegments()) {
+            MemorySegment segment = bufferPool.requestMemorySegment();
+            if (segment == null) {
+                break;
+            }
+            freeSegments.add(segment);
+        }
+
+        useHashBuffer = false;
+        int numWriteBuffers = 0;
+        if (freeSegments.size() >= 2 * numSubpartitions) {
+            useHashBuffer = true;
+        } else if (networkBufferSize >= NUM_WRITE_BUFFER_BYTES) {
+            numWriteBuffers = 1;
+        } else {
+            numWriteBuffers =
+                    Math.min(EXPECTED_WRITE_BATCH_SIZE, NUM_WRITE_BUFFER_BYTES / networkBufferSize);
+        }
+        numWriteBuffers = Math.min(freeSegments.size() / 2, numWriteBuffers);
+        numBuffersForSort = freeSegments.size() - numWriteBuffers;
+    }
+
     private void flushDataBuffer(DataBuffer dataBuffer, boolean isBroadcast) throws IOException {
         if (dataBuffer == null || dataBuffer.isReleased() || !dataBuffer.hasRemaining()) {
             return;
         }
+        dataBuffer.finish();
 
-        Queue<MemorySegment> segments = new ArrayDeque<>(writeSegments);
+        Queue<MemorySegment> segments = new ArrayDeque<>(freeSegments);
         int numBuffersToWrite =
                 useHashBuffer
                         ? EXPECTED_WRITE_BATCH_SIZE
@@ -366,7 +385,7 @@ public class SortMergeResultPartition extends ResultPartition {
         do {
             if (toWrite.size() >= numBuffersToWrite) {
                 writeBuffers(toWrite);
-                segments = new ArrayDeque<>(writeSegments);
+                segments = new ArrayDeque<>(freeSegments);
             }
 
             BufferWithChannel bufferWithChannel = dataBuffer.getNextBuffer(segments.poll());
@@ -378,11 +397,12 @@ public class SortMergeResultPartition extends ResultPartition {
             updateStatistics(bufferWithChannel.getBuffer(), isBroadcast);
             toWrite.add(compressBufferIfPossible(bufferWithChannel));
         } while (true);
+
+        releaseFreeBuffers();
     }
 
     private void flushBroadcastDataBuffer() throws IOException {
         if (broadcastDataBuffer != null) {
-            broadcastDataBuffer.finish();
             flushDataBuffer(broadcastDataBuffer, true);
             broadcastDataBuffer.release();
             broadcastDataBuffer = null;
@@ -391,7 +411,6 @@ public class SortMergeResultPartition extends ResultPartition {
 
     private void flushUnicastDataBuffer() throws IOException {
         if (unicastDataBuffer != null) {
-            unicastDataBuffer.finish();
             flushDataBuffer(unicastDataBuffer, false);
             unicastDataBuffer.release();
             unicastDataBuffer = null;
@@ -421,19 +440,17 @@ public class SortMergeResultPartition extends ResultPartition {
     private void writeLargeRecord(
             ByteBuffer record, int targetSubpartition, DataType dataType, boolean isBroadcast)
             throws IOException {
-        // for the hash-based data buffer implementation, a large record will be appended to the
-        // data buffer directly and spilled to multiple data regions
-        checkState(!useHashBuffer, "No buffers available for writing.");
+        // a large record will be spilled to a separated data region
         fileWriter.startNewRegion(isBroadcast);
 
         List<BufferWithChannel> toWrite = new ArrayList<>();
-        Queue<MemorySegment> segments = new ArrayDeque<>(writeSegments);
+        Queue<MemorySegment> segments = new ArrayDeque<>(freeSegments);
 
         while (record.hasRemaining()) {
             if (segments.isEmpty()) {
                 fileWriter.writeBuffers(toWrite);
                 toWrite.clear();
-                segments = new ArrayDeque<>(writeSegments);
+                segments = new ArrayDeque<>(freeSegments);
             }
 
             int toCopy = Math.min(record.remaining(), networkBufferSize);
@@ -447,6 +464,7 @@ public class SortMergeResultPartition extends ResultPartition {
         }
 
         fileWriter.writeBuffers(toWrite);
+        releaseFreeBuffers();
     }
 
     private void writeBuffers(List<BufferWithChannel> buffers) throws IOException {
@@ -480,18 +498,16 @@ public class SortMergeResultPartition extends ResultPartition {
         }
     }
 
-    private void releaseWriteBuffers() {
+    private void releaseFreeBuffers() {
         if (bufferPool != null) {
-            for (MemorySegment segment : writeSegments) {
-                bufferPool.recycle(segment);
-            }
-            writeSegments.clear();
+            freeSegments.forEach(buffer -> bufferPool.recycle(buffer));
+            freeSegments.clear();
         }
     }
 
     @Override
     public void close() {
-        releaseWriteBuffers();
+        releaseFreeBuffers();
         // the close method will be always called by the task thread, so there is need to make
         // the sort buffer fields volatile and visible to the cancel thread intermediately
         releaseDataBuffer(unicastDataBuffer);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the SortMergeResultPartition selects to use HashBasedDataBuffer and SortBasedDataBuffer based on the number of required buffers per result partition decided by `taskmanager.network.sort-shuffle.min-buffers`. If the configured value is large enough, HashBasedDataBuffer will be used, otherwise, SortBasedDataBuffer will be used. Usually, the HashBasedDataBuffer has better performance. However, it is not easy to tune this value, because if a user tries to increase it for better performance, he/she is easy to encounter the 'Insufficient number of network buffers' error. 

This patch improves this case by selecting HashBasedDataBuffer and SortBasedDataBuffer dynamically based on the number of network buffers that can be allocated. More specifically, if there are enough buffers at runtime, HashBasedDataBuffer will be used, otherwise, SortBasedDataBuffer will be used. To achieve better performance, the user only needs to increase the total amount of network memory per task manager.


## Brief change log

  - *Select HashBasedDataBuffer and SortBasedDataBuffer dynamically based on the number of network buffers that can be allocated for SortMergeResultPartition*

## Verifying this change

This change is already covered by existing tests, such as *SortMergeResultPartitionTest, DataBufferTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
