### PR TITLE
[FLINK-27188][Connector][StreamingFileSink] Mark StreamingFileSink as deprecated

### DIFF
--- a/docs/content.zh/docs/dev/datastream/overview.md
+++ b/docs/content.zh/docs/dev/datastream/overview.md
@@ -418,7 +418,7 @@ Data sinks 使用 DataStream 并将它们转发到文件、套接字、外部系
 
 注意，DataStream 的 `write*()` 方法主要用于调试目的。它们不参与 Flink 的 checkpointing，这意味着这些函数通常具有至少有一次语义。刷新到目标系统的数据取决于 OutputFormat 的实现。这意味着并非所有发送到 OutputFormat 的元素都会立即显示在目标系统中。此外，在失败的情况下，这些记录可能会丢失。
 
-为了将流可靠地、精准一次地传输到文件系统中，请使用 `StreamingFileSink`。此外，通过 `.addSink(...)` 方法调用的自定义实现也可以参与 Flink 的 checkpointing，以实现精准一次的语义。
+为了将流可靠地、精准一次地传输到文件系统中，请使用 `FileSink`。此外，通过 `.addSink(...)` 方法调用的自定义实现也可以参与 Flink 的 checkpointing，以实现精准一次的语义。
 
 {{< top >}}
 

--- a/docs/content.zh/docs/dev/datastream/testing.md
+++ b/docs/content.zh/docs/dev/datastream/testing.md
@@ -302,7 +302,6 @@ class StatefulFlatMapTest extends FlatSpec with Matchers with BeforeAndAfter {
 在 Flink 代码库里可以找到更多使用这些测试工具的示例，例如：
 
 * `org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorTest` 是测试算子和用户自定义函数（取决于处理时间和事件时间）的一个很好的例子。
-* `org.apache.flink.streaming.api.functions.sink.filesystem.LocalStreamingFileSinkTest` 展示了如何使用 `AbstractStreamOperatorTestHarness` 测试自定义 sink。具体来说，它使用 `AbstractStreamOperatorTestHarness.snapshot` 和 `AbstractStreamOperatorTestHarness.initializeState` 来测试它与 Flink checkpoint 机制的交互。
 
 <span class="label label-info">注意</span> `AbstractStreamOperatorTestHarness` 及其派生类目前不属于公共 API，可以进行更改。
 

--- a/docs/content.zh/docs/dev/python/datastream/data_types.md
+++ b/docs/content.zh/docs/dev/python/datastream/data_types.md
@@ -60,22 +60,22 @@ However, types need to be specified when:
 ### Passing Python records to Java operations
 
 Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python types to Java types for processing.
-For example, types need to be provided if you want to output data using the StreamingFileSink which is implemented in Java.
+For example, types need to be provided if you want to output data using the FileSink which is implemented in Java.
 
 ```python
 from pyflink.common.serialization import Encoder
 from pyflink.common.typeinfo import Types
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.datastream.connectors import StreamingFileSink
+from pyflink.datastream.connectors import FileSink
 
 
-def streaming_file_sink():
+def file_sink():
     env = StreamExecutionEnvironment.get_execution_environment()
     env.set_parallelism(1)
     env.from_collection(collection=[(1, 'aaa'), (2, 'bbb')]) \
         .map(lambda record: (record[0] + 1, record[1].upper()),
              output_type=Types.ROW([Types.INT(), Types.STRING()])) \
-        .add_sink(StreamingFileSink
+        .add_sink(FileSink
                   .for_row_format('/tmp/output', Encoder.simple_string_encoder())
                   .build())
 
@@ -83,7 +83,7 @@ def streaming_file_sink():
 
 
 if __name__ == '__main__':
-    streaming_file_sink()
+    file_sink()
 
 ```
 

--- a/docs/content.zh/docs/dev/python/datastream/intro_to_datastream_api.md
+++ b/docs/content.zh/docs/dev/python/datastream/intro_to_datastream_api.md
@@ -317,8 +317,8 @@ kafka_producer = FlinkKafkaProducer(
 ds.add_sink(kafka_producer)
 ```
 
-<span class="label label-info">Note</span> It currently only supports FlinkKafkaProducer,
-JdbcSink and StreamingFileSink to be used as DataStream sink connectors with method `add_sink`.
+<span class="label label-info">Note</span> It currently only supports FlinkKafkaProducer and
+JdbcSink to be used as DataStream sink connectors with method `add_sink`.
 
 <span class="label label-info">Note</span> The method `add_sink` could only be used in `streaming`
 executing mode.

--- a/docs/content.zh/docs/dev/table/data_stream_api.md
+++ b/docs/content.zh/docs/dev/table/data_stream_api.md
@@ -2892,7 +2892,7 @@ env.execute()
 ```python
 from pyflink.common import Encoder
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.datastream.connectors import StreamingFileSink
+from pyflink.datastream.connectors import FileSink
 from pyflink.table import StreamTableEnvironment, TableDescriptor, Schema, DataTypes
     
 env = StreamExecutionEnvironment.get_execution_environment()
@@ -2925,7 +2925,7 @@ statement_set.add_insert(sink_descriptor, table_from_stream)
 
 # define other DataStream API parts
 env.from_collection([4, 5, 6])
-    .add_sink(StreamingFileSink
+    .add_sink(FileSink
               .for_row_format('/tmp/output', Encoder.simple_string_encoder())
               .build())
 

--- a/docs/content.zh/docs/learn-flink/datastream_api.md
+++ b/docs/content.zh/docs/learn-flink/datastream_api.md
@@ -182,8 +182,7 @@ DataStream<String> lines = env.readTextFile("file:///path");
 
 1> 和 2> 指出输出来自哪个 sub-task（即 thread）
 
-In production, commonly used sinks include the StreamingFileSink, various databases,
-and several pub-sub systems.
+In production, commonly used sinks include various databases and several pub-sub systems.
 
 ### 调试
 

--- a/docs/content/docs/dev/datastream/overview.md
+++ b/docs/content/docs/dev/datastream/overview.md
@@ -519,7 +519,7 @@ at-least-once semantics. The data flushing to the target system depends on the i
 OutputFormat. This means that not all elements send to the OutputFormat are immediately showing up
 in the target system. Also, in failure cases, those records might be lost.
 
-For reliable, exactly-once delivery of a stream into a file system, use the `StreamingFileSink`.
+For reliable, exactly-once delivery of a stream into a file system, use the `FileSink`.
 Also, custom implementations through the `.addSink(...)` method can participate in Flink's checkpointing
 for exactly-once semantics.
 

--- a/docs/content/docs/dev/datastream/testing.md
+++ b/docs/content/docs/dev/datastream/testing.md
@@ -301,7 +301,6 @@ class StatefulFlatMapTest extends FlatSpec with Matchers with BeforeAndAfter {
 Many more examples for the usage of these test harnesses can be found in the Flink code base, e.g.:
 
 * `org.apache.flink.streaming.runtime.operators.windowing.WindowOperatorTest` is a good example for testing operators and user-defined functions, which depend on processing or event time.
-* `org.apache.flink.streaming.api.functions.sink.filesystem.LocalStreamingFileSinkTest` shows how to test a custom sink with the `AbstractStreamOperatorTestHarness`. Specifically, it uses `AbstractStreamOperatorTestHarness.snapshot` and `AbstractStreamOperatorTestHarness.initializeState` to tests its interaction with Flink's checkpointing mechanism.
 
 <span class="label label-info">Note</span> Be aware that `AbstractStreamOperatorTestHarness` and its derived classes are currently not part of the public API and can be subject to change.
 

--- a/docs/content/docs/dev/python/datastream/data_types.md
+++ b/docs/content/docs/dev/python/datastream/data_types.md
@@ -60,22 +60,22 @@ However, types need to be specified when:
 ### Passing Python records to Java operations
 
 Since Java operators or functions can not identify Python data, types need to be provided to help to convert Python types to Java types for processing.
-For example, types need to be provided if you want to output data using the StreamingFileSink which is implemented in Java.
+For example, types need to be provided if you want to output data using the FileSink which is implemented in Java.
 
 ```python
 from pyflink.common.serialization import Encoder
 from pyflink.common.typeinfo import Types
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.datastream.connectors import StreamingFileSink
+from pyflink.datastream.connectors import FileSink
 
 
-def streaming_file_sink():
+def file_sink():
     env = StreamExecutionEnvironment.get_execution_environment()
     env.set_parallelism(1)
     env.from_collection(collection=[(1, 'aaa'), (2, 'bbb')]) \
         .map(lambda record: (record[0]+1, record[1].upper()),
              output_type=Types.ROW([Types.INT(), Types.STRING()])) \
-        .add_sink(StreamingFileSink
+        .add_sink(FileSink
                   .for_row_format('/tmp/output', Encoder.simple_string_encoder())
                   .build())
 
@@ -83,7 +83,7 @@ def streaming_file_sink():
 
 
 if __name__ == '__main__':
-    streaming_file_sink()
+    file_sink()
 
 ```
 

--- a/docs/content/docs/dev/python/datastream/intro_to_datastream_api.md
+++ b/docs/content/docs/dev/python/datastream/intro_to_datastream_api.md
@@ -317,8 +317,8 @@ kafka_producer = FlinkKafkaProducer(
 ds.add_sink(kafka_producer)
 ```
 
-<span class="label label-info">Note</span> It currently only supports FlinkKafkaProducer,
-JdbcSink and StreamingFileSink to be used as DataStream sink connectors with method `add_sink`.
+<span class="label label-info">Note</span> It currently only supports FlinkKafkaProducer and
+JdbcSink to be used as DataStream sink connectors with method `add_sink`.
 
 <span class="label label-info">Note</span> The method `add_sink` could only be used in `streaming`
 executing mode.

--- a/docs/content/docs/dev/table/data_stream_api.md
+++ b/docs/content/docs/dev/table/data_stream_api.md
@@ -2890,7 +2890,7 @@ env.execute()
 ```python
 from pyflink.common import Encoder
 from pyflink.datastream import StreamExecutionEnvironment
-from pyflink.datastream.connectors import StreamingFileSink
+from pyflink.datastream.connectors import FileSink
 from pyflink.table import StreamTableEnvironment, TableDescriptor, Schema, DataTypes
     
 env = StreamExecutionEnvironment.get_execution_environment()
@@ -2923,7 +2923,7 @@ statement_set.add_insert(sink_descriptor, table_from_stream)
 
 # define other DataStream API parts
 env.from_collection([4, 5, 6])
-    .add_sink(StreamingFileSink
+    .add_sink(FileSink
               .for_row_format('/tmp/output', Encoder.simple_string_encoder())
               .build())
 

--- a/docs/content/docs/learn-flink/datastream_api.md
+++ b/docs/content/docs/learn-flink/datastream_api.md
@@ -199,7 +199,7 @@ The output looks something like this
 
 where 1> and 2> indicate which sub-task (i.e., thread) produced the output.
 
-In production, commonly used sinks include the StreamingFileSink, various databases,
+In production, commonly used sinks include the FileSink, various databases,
 and several pub-sub systems.
 
 ### Debugging

--- a/flink-python/pyflink/datastream/connectors/file_system.py
+++ b/flink-python/pyflink/datastream/connectors/file_system.py
@@ -15,6 +15,8 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+import warnings
+
 from pyflink.common import Duration, Encoder
 from pyflink.datastream.functions import SinkFunction
 from pyflink.datastream.connectors import Source, Sink
@@ -550,6 +552,7 @@ class StreamingFileSink(SinkFunction):
     """
 
     def __init__(self, j_obj):
+        warnings.warn("Deprecated in 1.15. Use FileSink instead.", DeprecationWarning)
         super(StreamingFileSink, self).__init__(j_obj)
 
     class DefaultRowFormatBuilder(object):

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/filesystem/StreamingFileSink.java
@@ -86,8 +86,10 @@ import java.io.Serializable;
  * arrived after the checkpoint from which we restore.
  *
  * @param <IN> Type of the elements emitted by this sink
+ * @deprecated Use {@link org.apache.flink.connector.file.sink.FileSink} instead.
  */
 @PublicEvolving
+@Deprecated
 public class StreamingFileSink<IN> extends RichSinkFunction<IN>
         implements CheckpointedFunction, CheckpointListener {
 


### PR DESCRIPTION
## What is the purpose of the change

* Mark StreamingFileSink as deprecated

## Brief change log

* Added `@Deprecated` annotation and included link to replacement

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
