### PR TITLE
[hotfix][API/Core] Modify spelling error in SplitEnumerator's annotation

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SplitEnumerator.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.util.List;
 
 /**
- * A interface of a split enumerator responsible for the followings: 1. discover the splits for the
+ * An interface of a split enumerator responsible for the followings: 1. discover the splits for the
  * {@link SourceReader} to read. 2. assign the splits to the source reader.
  */
 @Public


### PR DESCRIPTION
## What is the purpose of the change

*Fix the word error in SplitEnumerator's annotation*


## Brief change log

  - *Change the word 'A' to 'An'*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
