### PR TITLE
[FLINK-28519][network] Fix the bug that SortMergeResultPartitionReadScheduler may not read data sequentially

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PartitionedFileReader.java
@@ -66,7 +66,8 @@ class PartitionedFileReader {
             PartitionedFile partitionedFile,
             int targetSubpartition,
             FileChannel dataFileChannel,
-            FileChannel indexFileChannel) {
+            FileChannel indexFileChannel)
+            throws IOException {
         checkArgument(checkNotNull(dataFileChannel).isOpen(), "Data file channel must be opened.");
         checkArgument(
                 checkNotNull(indexFileChannel).isOpen(), "Index file channel must be opened.");
@@ -78,6 +79,7 @@ class PartitionedFileReader {
 
         this.indexEntryBuf = ByteBuffer.allocateDirect(PartitionedFile.INDEX_ENTRY_SIZE);
         BufferReaderWriterUtil.configureByteBuffer(indexEntryBuf);
+        moveToNextReadableRegion();
     }
 
     private void moveToNextReadableRegion() throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -29,6 +29,7 @@ import org.apache.flink.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
@@ -101,6 +102,13 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
     @GuardedBy("lock")
     private final Set<SortMergeSubpartitionReader> allReaders = new HashSet<>();
 
+    /**
+     * All readers to be read in order. This queue sorts all readers by file offset to achieve
+     * better sequential IO.
+     */
+    @GuardedBy("lock")
+    private final Queue<SortMergeSubpartitionReader> sortedReaders = new PriorityQueue<>();
+
     /** File channel shared by all subpartitions to read data from. */
     @GuardedBy("lock")
     private FileChannel dataFileChannel;
@@ -152,12 +160,35 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
 
     @Override
     public synchronized void run() {
-        Queue<SortMergeSubpartitionReader> availableReaders = getAvailableReaders();
-
-        Queue<MemorySegment> buffers = allocateBuffers(availableReaders);
+        Set<SortMergeSubpartitionReader> finishedReaders = new HashSet<>();
+        Queue<MemorySegment> buffers;
+        try {
+            buffers = allocateBuffers();
+        } catch (Throwable throwable) {
+            // fail all pending subpartition readers immediately if any exception occurs
+            LOG.error("Failed to request buffers for data reading.", throwable);
+            failSubpartitionReaders(getAllReaders(), throwable);
+            removeFinishedAndFailedReaders(0, finishedReaders);
+            return;
+        }
         int numBuffersAllocated = buffers.size();
 
-        Set<SortMergeSubpartitionReader> finishedReaders = readData(availableReaders, buffers);
+        SortMergeSubpartitionReader subpartitionReader = addPreviousAndGetNextReader(null, true);
+        while (subpartitionReader != null && !buffers.isEmpty()) {
+            try {
+                if (!subpartitionReader.readBuffers(buffers, this)) {
+                    // there is no resource to release for finished readers currently
+                    finishedReaders.add(subpartitionReader);
+                    subpartitionReader = null;
+                }
+            } catch (Throwable throwable) {
+                failSubpartitionReaders(Collections.singletonList(subpartitionReader), throwable);
+                subpartitionReader = null;
+                LOG.error("Failed to read shuffle data.", throwable);
+            }
+            subpartitionReader =
+                    addPreviousAndGetNextReader(subpartitionReader, !buffers.isEmpty());
+        }
 
         int numBuffersRead = numBuffersAllocated - buffers.size();
         releaseBuffers(buffers);
@@ -166,33 +197,23 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
     }
 
     @VisibleForTesting
-    Queue<MemorySegment> allocateBuffers(Queue<SortMergeSubpartitionReader> availableReaders) {
-        if (availableReaders.isEmpty()) {
-            return new ArrayDeque<>();
-        }
-
-        try {
-            long timeoutTime = getBufferRequestTimeoutTime();
-            do {
-                List<MemorySegment> buffers = bufferPool.requestBuffers();
-                if (!buffers.isEmpty()) {
-                    return new ArrayDeque<>(buffers);
-                }
-                checkState(!isReleased, "Result partition has been already released.");
-            } while (System.nanoTime() < timeoutTime
-                    || System.nanoTime() < (timeoutTime = getBufferRequestTimeoutTime()));
-
-            if (numRequestedBuffers <= 0) {
-                throw new TimeoutException(
-                        String.format(
-                                "Buffer request timeout, this means there is a fierce contention of"
-                                        + " the batch shuffle read memory, please increase '%s'.",
-                                TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key()));
+    Queue<MemorySegment> allocateBuffers() throws Exception {
+        long timeoutTime = getBufferRequestTimeoutTime();
+        do {
+            List<MemorySegment> buffers = bufferPool.requestBuffers();
+            if (!buffers.isEmpty()) {
+                return new ArrayDeque<>(buffers);
             }
-        } catch (Throwable throwable) {
-            // fail all pending subpartition readers immediately if any exception occurs
-            failSubpartitionReaders(availableReaders, throwable);
-            LOG.error("Failed to request buffers for data reading.", throwable);
+            checkState(!isReleased, "Result partition has been already released.");
+        } while (System.nanoTime() < timeoutTime
+                || System.nanoTime() < (timeoutTime = getBufferRequestTimeoutTime()));
+
+        if (numRequestedBuffers <= 0) {
+            throw new TimeoutException(
+                    String.format(
+                            "Buffer request timeout, this means there is a fierce contention of"
+                                    + " the batch shuffle read memory, please increase '%s'.",
+                            TaskManagerOptions.NETWORK_BATCH_SHUFFLE_READ_MEMORY.key()));
         }
         return new ArrayDeque<>();
     }
@@ -212,25 +233,6 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
                         Thread.currentThread(), throwable);
             }
         }
-    }
-
-    private Set<SortMergeSubpartitionReader> readData(
-            Queue<SortMergeSubpartitionReader> availableReaders, Queue<MemorySegment> buffers) {
-        Set<SortMergeSubpartitionReader> finishedReaders = new HashSet<>();
-
-        while (!availableReaders.isEmpty() && !buffers.isEmpty()) {
-            SortMergeSubpartitionReader subpartitionReader = availableReaders.poll();
-            try {
-                if (!subpartitionReader.readBuffers(buffers, this)) {
-                    // there is no resource to release for finished readers currently
-                    finishedReaders.add(subpartitionReader);
-                }
-            } catch (Throwable throwable) {
-                failSubpartitionReaders(Collections.singletonList(subpartitionReader), throwable);
-                LOG.debug("Failed to read shuffle data.", throwable);
-            }
-        }
-        return finishedReaders;
     }
 
     private void failSubpartitionReaders(
@@ -266,6 +268,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             if (allReaders.isEmpty()) {
                 bufferPool.unregisterRequester(this);
                 closeFileChannels();
+                sortedReaders.clear();
             }
 
             numRequestedBuffers += numBuffersRead;
@@ -283,13 +286,30 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         }
     }
 
-    private Queue<SortMergeSubpartitionReader> getAvailableReaders() {
+    private Queue<SortMergeSubpartitionReader> getAllReaders() {
         synchronized (lock) {
             if (isReleased) {
                 return new ArrayDeque<>();
             }
+            return new ArrayDeque<>(allReaders);
+        }
+    }
 
-            return new PriorityQueue<>(allReaders);
+    @Nullable
+    private SortMergeSubpartitionReader addPreviousAndGetNextReader(
+            SortMergeSubpartitionReader previousReader, boolean pollNext) {
+        synchronized (lock) {
+            if (previousReader != null) {
+                sortedReaders.add(previousReader);
+            }
+            if (!pollNext) {
+                return null;
+            }
+            SortMergeSubpartitionReader subpartitionReader = sortedReaders.poll();
+            while (subpartitionReader != null && failedReaders.contains(subpartitionReader)) {
+                subpartitionReader = sortedReaders.poll();
+            }
+            return subpartitionReader;
         }
     }
 
@@ -308,6 +328,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
                 bufferPool.registerRequester(this);
             }
             allReaders.add(subpartitionReader);
+            sortedReaders.add(subpartitionReader);
             subpartitionReader
                     .getReleaseFuture()
                     .thenRun(() -> releaseSubpartitionReader(subpartitionReader));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the SortMergeResultPartitionReadScheduler always gets all active subpartition readers and read at most one data region for them. It is common that some subpartitions are requested before others and their region indexes are ahead of others. 

If all region data of a subpartition can be read in one round, some subpartition readers will always be ahead of others which will cause random IO. 

This patch fixes this case by polling one subpartition reader at a time.


## Brief change log
  - *Fix the bug that SortMergeResultPartitionReadScheduler may not read data sequentially.*


## Verifying this change

This change is already covered by existing tests, such as *SortMergeResultPartitionReadSchedulerTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
