### PR TITLE
[FLINK-28138] Add metrics for speculative execution

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionVertex.java
@@ -44,6 +44,8 @@ public class SpeculativeExecutionVertex extends ExecutionVertex {
 
     private final Map<ExecutionAttemptID, Execution> currentExecutions;
 
+    private int originalAttemptNumber;
+
     public SpeculativeExecutionVertex(
             ExecutionJobVertex jobVertex,
             int subTaskIndex,
@@ -63,6 +65,7 @@ public class SpeculativeExecutionVertex extends ExecutionVertex {
 
         this.currentExecutions = new LinkedHashMap<>();
         this.currentExecutions.put(currentExecution.getAttemptId(), currentExecution);
+        this.originalAttemptNumber = currentExecution.getAttemptNumber();
     }
 
     public boolean containsSources() {
@@ -78,6 +81,14 @@ public class SpeculativeExecutionVertex extends ExecutionVertex {
         getExecutionGraphAccessor().registerExecution(newExecution);
         currentExecutions.put(newExecution.getAttemptId(), newExecution);
         return newExecution;
+    }
+
+    /**
+     * Returns whether the given attempt is the original execution attempt of the execution vertex,
+     * i.e. it is created along with the creation of resetting of the execution vertex.
+     */
+    public boolean isOriginalAttempt(int attemptNumber) {
+        return attemptNumber == originalAttemptNumber;
     }
 
     @Override
@@ -138,6 +149,7 @@ public class SpeculativeExecutionVertex extends ExecutionVertex {
 
         currentExecutions.clear();
         currentExecutions.put(currentExecution.getAttemptId(), currentExecution);
+        originalAttemptNumber = currentExecution.getAttemptNumber();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -109,4 +109,7 @@ public class MetricNames {
     public static final String MAILBOX_THROUGHPUT = "mailboxMailsPerSecond";
     public static final String MAILBOX_LATENCY = "mailboxLatencyMs";
     public static final String MAILBOX_SIZE = "mailboxQueueSize";
+
+    // speculative execution
+    public static final String NUM_SLOW_EXECUTION_VERTICES = "numSlowExecutionVertices";
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -112,4 +112,6 @@ public class MetricNames {
 
     // speculative execution
     public static final String NUM_SLOW_EXECUTION_VERTICES = "numSlowExecutionVertices";
+    public static final String NUM_EFFECTIVE_SPECULATIVE_EXECUTIONS =
+            "numEffectiveSpeculativeExecutions";
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -380,9 +380,11 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
     }
 
     protected void resetForNewExecutions(final Collection<ExecutionVertexID> vertices) {
-        vertices.stream()
-                .map(this::getExecutionVertex)
-                .forEach(ExecutionVertex::resetForNewExecution);
+        vertices.stream().forEach(this::resetForNewExecution);
+    }
+
+    protected void resetForNewExecution(final ExecutionVertexID executionVertexId) {
+        getExecutionVertex(executionVertexId).resetForNewExecution();
     }
 
     protected void restoreState(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -141,7 +141,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
     private final CheckpointIDCounter checkpointIdCounter;
 
-    private final JobManagerJobMetricGroup jobManagerJobMetricGroup;
+    protected final JobManagerJobMetricGroup jobManagerJobMetricGroup;
 
     protected final ExecutionVertexVersioner executionVertexVersioner;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -47,7 +47,6 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
 import org.apache.flink.runtime.scheduler.ExecutionOperations;
 import org.apache.flink.runtime.scheduler.ExecutionSlotAllocatorFactory;
 import org.apache.flink.runtime.scheduler.ExecutionVertexVersioner;
-import org.apache.flink.runtime.scheduler.SchedulerOperations;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.adaptivebatch.forwardgroup.ForwardGroup;
 import org.apache.flink.runtime.scheduler.adaptivebatch.forwardgroup.ForwardGroupComputeUtil;
@@ -71,7 +70,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * This scheduler decides the parallelism of JobVertex according to the data volume it consumes. A
  * dynamically built up ExecutionGraph is used for this purpose.
  */
-public class AdaptiveBatchScheduler extends DefaultScheduler implements SchedulerOperations {
+public class AdaptiveBatchScheduler extends DefaultScheduler {
 
     private final DefaultLogicalTopology logicalTopology;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeSchedulerTest.java
@@ -403,6 +403,42 @@ class SpeculativeSchedulerTest {
         assertThat(scheduler.getNumSlowExecutionVertices()).isZero();
     }
 
+    @Test
+    void testEffectiveSpeculativeExecutionsMetric() {
+        final SpeculativeScheduler scheduler = createSchedulerAndStartScheduling();
+        final ExecutionVertex ev = getOnlyExecutionVertex(scheduler);
+        final Execution attempt1 = ev.getCurrentExecutionAttempt();
+
+        notifySlowTask(scheduler, attempt1);
+
+        // numEffectiveSpeculativeExecutions will increase if a speculative execution attempt
+        // finishes first
+        final Execution attempt2 = getExecution(ev, 1);
+        scheduler.updateTaskExecutionState(
+                new TaskExecutionState(attempt2.getAttemptId(), ExecutionState.FINISHED));
+        assertThat(scheduler.getNumEffectiveSpeculativeExecutions()).isEqualTo(1);
+
+        // complete cancellation
+        scheduler.updateTaskExecutionState(
+                new TaskExecutionState(attempt1.getAttemptId(), ExecutionState.CANCELED));
+
+        // trigger a global failure to reset the vertex.
+        // after that, no speculative execution finishes before its original execution and the
+        // numEffectiveSpeculativeExecutions will be decreased accordingly.
+        scheduler.handleGlobalFailure(new Exception());
+        taskRestartExecutor.triggerScheduledTasks();
+        assertThat(scheduler.getNumEffectiveSpeculativeExecutions()).isZero();
+
+        final Execution attempt3 = getExecution(ev, 2);
+        notifySlowTask(scheduler, attempt3);
+
+        // numEffectiveSpeculativeExecutions will not increase if an original execution attempt
+        // finishes first
+        scheduler.updateTaskExecutionState(
+                new TaskExecutionState(attempt3.getAttemptId(), ExecutionState.FINISHED));
+        assertThat(scheduler.getNumEffectiveSpeculativeExecutions()).isZero();
+    }
+
     private static Execution getExecution(ExecutionVertex executionVertex, int attemptNumber) {
         return executionVertex.getCurrentExecutions().stream()
                 .filter(e -> e.getAttemptNumber() == attemptNumber)


### PR DESCRIPTION
## What is the purpose of the change

This PR adds two metrics to expose job problems and show the effectiveness of speculative execution:
 - numSlowExecutionVertices: Number of slow execution vertices at the moment.
 - numEffectiveSpeculativeExecutions: Number of speculative executions which finish before their corresponding original executions finish.

## Verifying this change

  - *Added unit tests in SpeculativeSchedulerTest*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
