### PR TITLE
[FLINK-28595][Connectors/kafka] KafkaSource should not read metadata of unmatched regex topics

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/KafkaSubscriberUtils.java
@@ -23,6 +23,8 @@ import org.apache.kafka.clients.admin.TopicDescription;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /** The base implementations of {@link KafkaSubscriber}. */
 class KafkaSubscriberUtils {
@@ -32,6 +34,27 @@ class KafkaSubscriberUtils {
     static Map<String, TopicDescription> getAllTopicMetadata(AdminClient adminClient) {
         try {
             Set<String> allTopicNames = adminClient.listTopics().names().get();
+            return getTopicMetadata(adminClient, allTopicNames);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to get metadata for all topics.", e);
+        }
+    }
+
+    /**
+     * The difference between this method and the getAllTopicMetadata method is that it filters out
+     * topics that meet regular matches.
+     *
+     * @param adminClient admin clients
+     * @param topicPattern Pattern
+     * @return Map containing the topic name TopicDescription key-value pairs
+     */
+    static Map<String, TopicDescription> getAllPatternTopicMetadata(
+            AdminClient adminClient, Pattern topicPattern) {
+        try {
+            Set<String> allTopicNames =
+                    adminClient.listTopics().names().get().stream()
+                            .filter(topicName -> topicPattern.matcher(topicName).matches())
+                            .collect(Collectors.toSet());
             return getTopicMetadata(adminClient, allTopicNames);
         } catch (Exception e) {
             throw new RuntimeException("Failed to get metadata for all topics.", e);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/subscriber/TopicPatternSubscriber.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getAllTopicMetadata;
+import static org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriberUtils.getAllPatternTopicMetadata;
 
 /** A subscriber to a topic pattern. */
 class TopicPatternSubscriber implements KafkaSubscriber {
@@ -45,18 +45,16 @@ class TopicPatternSubscriber implements KafkaSubscriber {
     @Override
     public Set<TopicPartition> getSubscribedTopicPartitions(AdminClient adminClient) {
         LOG.debug("Fetching descriptions for all topics on Kafka cluster");
-        final Map<String, TopicDescription> allTopicMetadata = getAllTopicMetadata(adminClient);
+        final Map<String, TopicDescription> allTopicMetadata =
+                getAllPatternTopicMetadata(adminClient, topicPattern);
 
         Set<TopicPartition> subscribedTopicPartitions = new HashSet<>();
 
         allTopicMetadata.forEach(
                 (topicName, topicDescription) -> {
-                    if (topicPattern.matcher(topicName).matches()) {
-                        for (TopicPartitionInfo partition : topicDescription.partitions()) {
-                            subscribedTopicPartitions.add(
-                                    new TopicPartition(
-                                            topicDescription.name(), partition.partition()));
-                        }
+                    for (TopicPartitionInfo partition : topicDescription.partitions()) {
+                        subscribedTopicPartitions.add(
+                                new TopicPartition(topicDescription.name(), partition.partition()));
                     }
                 });
 


### PR DESCRIPTION

## What is the purpose of the change

*KafkaSource should not read metadata of unmatched regex topics, Optimize the logic for filtering topics*


## Brief change log

*The filter logic from TopicPatternSubscriber# getSubscribedTopicPartitions method moves to KafkaSubscriberUtils# getAllTopicMetadata method*


## Verifying this change

This change is already covered by existing tests, such as *KafkaSubscriberTest#testTopicPatternSubscriber*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
