### PR TITLE
[FLINK-28623][network] Optimize the use of off heap memory by blocking and hybrid shuffle reader

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -69,6 +70,17 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
      * throwing an exception.
      */
     private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMinutes(5);
+
+    /** Used to read buffer headers from file channel. */
+    private final ByteBuffer headerBuf = BufferReaderWriterUtil.allocatedHeaderBuffer();
+
+    /** Used to read index entry for file reader initializing. */
+    private final ByteBuffer indexEntryBufferInit =
+            ByteBuffer.allocateDirect(PartitionedFile.INDEX_ENTRY_SIZE);
+
+    /** Used to read index entry for file reader reading data. */
+    private final ByteBuffer indexEntryBufferRead =
+            ByteBuffer.allocateDirect(PartitionedFile.INDEX_ENTRY_SIZE);
 
     /** Lock used to synchronize multi-thread access to thread-unsafe fields. */
     private final Object lock;
@@ -144,6 +156,8 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         this.bufferPool = checkNotNull(bufferPool);
         this.ioExecutor = checkNotNull(ioExecutor);
         this.bufferRequestTimeout = checkNotNull(bufferRequestTimeout);
+        BufferReaderWriterUtil.configureByteBuffer(indexEntryBufferInit);
+        BufferReaderWriterUtil.configureByteBuffer(indexEntryBufferRead);
     }
 
     @Override
@@ -355,8 +369,16 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             if (allReaders.isEmpty()) {
                 openFileChannels(resultFile);
             }
-            return new PartitionedFileReader(
-                    resultFile, targetSubpartition, dataFileChannel, indexFileChannel);
+            PartitionedFileReader partitionedFileReader =
+                    new PartitionedFileReader(
+                            resultFile,
+                            targetSubpartition,
+                            dataFileChannel,
+                            indexFileChannel,
+                            headerBuf,
+                            indexEntryBufferRead);
+            partitionedFileReader.initRegionIndex(indexEntryBufferInit);
+            return partitionedFileReader;
         } catch (Throwable throwable) {
             if (allReaders.isEmpty()) {
                 closeFileChannels();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
@@ -22,6 +22,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Queue;
 import java.util.function.Consumer;
@@ -60,6 +61,7 @@ public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileR
                 HsSubpartitionViewInternalOperations operation,
                 HsFileDataIndex dataIndex,
                 int maxBuffersReadAhead,
-                Consumer<HsSubpartitionFileReader> fileReaderReleaser);
+                Consumer<HsSubpartitionFileReader> fileReaderReleaser,
+                ByteBuffer headerBuffer);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -51,7 +51,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
-    private final ByteBuffer headerBuf = BufferReaderWriterUtil.allocatedHeaderBuffer();
+    private final ByteBuffer headerBuf;
 
     private final int subpartitionId;
 
@@ -75,10 +75,12 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
             HsSubpartitionViewInternalOperations operations,
             HsFileDataIndex dataIndex,
             int maxBufferReadAhead,
-            Consumer<HsSubpartitionFileReader> fileReaderReleaser) {
+            Consumer<HsSubpartitionFileReader> fileReaderReleaser,
+            ByteBuffer headerBuf) {
         this.subpartitionId = subpartitionId;
         this.dataFileChannel = dataFileChannel;
         this.operations = operations;
+        this.headerBuf = headerBuf;
         this.bufferIndexManager = new BufferIndexManager(maxBufferReadAhead);
         this.cachedRegionManager = new CachedRegionManager(subpartitionId, dataIndex);
         this.fileReaderReleaser = fileReaderReleaser;
@@ -478,14 +480,16 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
                 HsSubpartitionViewInternalOperations operation,
                 HsFileDataIndex dataIndex,
                 int maxBuffersReadAhead,
-                Consumer<HsSubpartitionFileReader> fileReaderReleaser) {
+                Consumer<HsSubpartitionFileReader> fileReaderReleaser,
+                ByteBuffer headerBuffer) {
             return new HsSubpartitionFileReaderImpl(
                     subpartitionId,
                     dataFileChannel,
                     operation,
                     dataIndex,
                     maxBuffersReadAhead,
-                    fileReaderReleaser);
+                    fileReaderReleaser,
+                    headerBuffer);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -23,15 +23,12 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
-import org.apache.flink.util.TestLogger;
 
-import org.assertj.core.api.Assertions;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -46,13 +43,13 @@ import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link SortMergeResultPartitionReadScheduler}. */
-public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
+class SortMergeResultPartitionReadSchedulerTest {
 
     private static final int bufferSize = 1024;
 
@@ -80,17 +77,13 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
 
     private SortMergeResultPartitionReadScheduler readScheduler;
 
-    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
-    @Rule public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
-
-    @Before
-    public void before() throws Exception {
+    @BeforeEach
+    void before(@TempDir Path basePath) throws Exception {
         Random random = new Random();
         random.nextBytes(dataBytes);
         partitionedFile =
                 PartitionTestUtils.createPartitionedFile(
-                        temporaryFolder.newFile().getAbsolutePath(),
+                        basePath.toString(),
                         numSubpartitions,
                         numBuffersPerSubpartition,
                         bufferSize,
@@ -105,8 +98,8 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                 new SortMergeResultPartitionReadScheduler(bufferPool, executor, new Object());
     }
 
-    @After
-    public void after() throws Exception {
+    @AfterEach
+    void after() throws Exception {
         dataFileChannel.close();
         indexFileChannel.close();
         partitionedFile.deleteQuietly();
@@ -115,7 +108,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testCreateSubpartitionReader() throws Exception {
+    void testCreateSubpartitionReader() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
@@ -141,7 +134,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testOnSubpartitionReaderError() throws Exception {
+    void testOnSubpartitionReaderError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
@@ -152,7 +145,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testReleaseWhileReading() throws Exception {
+    void testReleaseWhileReading() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
@@ -169,20 +162,20 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         assertAllResourcesReleased();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testCreateSubpartitionReaderAfterReleased() throws Exception {
+    @Test
+    void testCreateSubpartitionReaderAfterReleased() throws Exception {
         bufferPool.initialize();
         readScheduler.release();
-        try {
-            readScheduler.createSubpartitionReader(
-                    new NoOpBufferAvailablityListener(), 0, partitionedFile);
-        } finally {
-            assertAllResourcesReleased();
-        }
+        assertThatThrownBy(
+                        () ->
+                                readScheduler.createSubpartitionReader(
+                                        new NoOpBufferAvailablityListener(), 0, partitionedFile))
+                .isInstanceOf(IllegalStateException.class);
+        assertAllResourcesReleased();
     }
 
     @Test
-    public void testOnDataReadError() throws Exception {
+    void testOnDataReadError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
@@ -205,7 +198,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testOnReadBufferRequestError() throws Exception {
+    void testOnReadBufferRequestError() throws Exception {
         SortMergeSubpartitionReader subpartitionReader =
                 readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
@@ -219,8 +212,9 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         assertAllResourcesReleased();
     }
 
-    @Test(timeout = 60000)
-    public void testNoDeadlockWhenReadAndReleaseBuffers() throws Exception {
+    @Test
+    @Timeout(60)
+    void testNoDeadlockWhenReadAndReleaseBuffers() throws Exception {
         bufferPool.initialize();
         SortMergeSubpartitionReader subpartitionReader =
                 new SortMergeSubpartitionReader(new NoOpBufferAvailablityListener(), fileReader);
@@ -248,7 +242,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testRequestBufferTimeout() throws Exception {
+    void testRequestBufferTimeout() throws Exception {
         Duration bufferRequestTimeout = Duration.ofSeconds(3);
         List<MemorySegment> buffers = bufferPool.requestBuffers();
         SortMergeResultPartitionReadScheduler readScheduler =
@@ -256,8 +250,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                         bufferPool, executor, this, bufferRequestTimeout);
 
         long startTimestamp = System.nanoTime();
-        Assertions.assertThatThrownBy(readScheduler::allocateBuffers)
-                .isInstanceOf(TimeoutException.class);
+        assertThatThrownBy(readScheduler::allocateBuffers).isInstanceOf(TimeoutException.class);
         long requestDuration = System.nanoTime() - startTimestamp;
         assertThat(requestDuration > bufferRequestTimeout.toNanos()).isTrue();
 
@@ -266,7 +259,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
     }
 
     @Test
-    public void testRequestTimeoutIsRefreshedAndSuccess() throws Exception {
+    void testRequestTimeoutIsRefreshedAndSuccess() throws Exception {
         Duration bufferRequestTimeout = Duration.ofSeconds(3);
         FakeBatchShuffleReadBufferPool bufferPool =
                 new FakeBatchShuffleReadBufferPool(bufferSize * 3, bufferSize);
@@ -280,8 +273,8 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         Queue<MemorySegment> allocatedBuffers = readScheduler.allocateBuffers();
         long requestDuration = System.nanoTime() - startTimestamp;
 
-        assertThat(allocatedBuffers.size()).isEqualTo(3);
-        assertThat(requestDuration > bufferRequestTimeout.toNanos() * 2).isTrue();
+        assertThat(allocatedBuffers).hasSize(3);
+        assertThat(requestDuration).isGreaterThan(bufferRequestTimeout.toNanos() * 2);
         assertThat(subpartitionReader.getFailureCause()).isNull();
 
         bufferPool.recycle(allocatedBuffers);
@@ -319,7 +312,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         assertThat(readScheduler.getDataFileChannel()).isNull();
         assertThat(readScheduler.getIndexFileChannel()).isNull();
         assertThat(readScheduler.isRunning()).isFalse();
-        assertThat(readScheduler.getNumPendingReaders()).isEqualTo(0);
+        assertThat(readScheduler.getNumPendingReaders()).isZero();
 
         if (!bufferPool.isDestroyed()) {
             assertThat(bufferPool.getNumTotalBuffers()).isEqualTo(bufferPool.getAvailableBuffers());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.flink.runtime.io.network.partition.PartitionedFileWriteReadTest.createAndConfigIndexEntryBuffer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -91,7 +92,13 @@ class SortMergeResultPartitionReadSchedulerTest {
         dataFileChannel = openFileChannel(partitionedFile.getDataFilePath());
         indexFileChannel = openFileChannel(partitionedFile.getIndexFilePath());
         fileReader =
-                new PartitionedFileReader(partitionedFile, 0, dataFileChannel, indexFileChannel);
+                new PartitionedFileReader(
+                        partitionedFile,
+                        0,
+                        dataFileChannel,
+                        indexFileChannel,
+                        BufferReaderWriterUtil.allocatedHeaderBuffer(),
+                        createAndConfigIndexEntryBuffer());
         bufferPool = new BatchShuffleReadBufferPool(totalBytes, bufferSize);
         executor = Executors.newFixedThreadPool(numThreads);
         readScheduler =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReaderTest.java
@@ -39,6 +39,7 @@ import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.Random;
 
+import static org.apache.flink.runtime.io.network.partition.PartitionedFileWriteReadTest.createAndConfigIndexEntryBuffer;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -236,7 +237,13 @@ class SortMergeSubpartitionReaderTest {
     private SortMergeSubpartitionReader createSortMergeSubpartitionReader(
             BufferAvailabilityListener listener) throws Exception {
         PartitionedFileReader fileReader =
-                new PartitionedFileReader(partitionedFile, 0, dataFileChannel, indexFileChannel);
+                new PartitionedFileReader(
+                        partitionedFile,
+                        0,
+                        dataFileChannel,
+                        indexFileChannel,
+                        BufferReaderWriterUtil.allocatedHeaderBuffer(),
+                        createAndConfigIndexEntryBuffer());
         assertThat(fileReader.hasRemaining()).isTrue();
         return new SortMergeSubpartitionReader(listener, fileReader);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -431,7 +432,8 @@ class HsFileDataManagerTest {
                     HsSubpartitionViewInternalOperations operation,
                     HsFileDataIndex dataIndex,
                     int maxBuffersReadAhead,
-                    Consumer<HsSubpartitionFileReader> fileReaderReleaser) {
+                    Consumer<HsSubpartitionFileReader> fileReaderReleaser,
+                    ByteBuffer headerBuffer) {
                 return checkNotNull(allReaders.poll());
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
@@ -501,7 +501,8 @@ class HsSubpartitionFileReaderImplTest {
                 operations,
                 diskIndex,
                 MAX_BUFFERS_READ_AHEAD,
-                (ignore) -> {});
+                (ignore) -> {},
+                BufferReaderWriterUtil.allocatedHeaderBuffer());
     }
 
     private static FileChannel openFileChannel(Path path) throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

*Currently, each FileReader(PartitionFileReader or HsSubpartitionFileReaderImpl) will internally allocate a headerbuffer with the size of 8B. Beside, PartitionFileReader also has a 12B indexEntryBuf. Because FileReader is of subpartition granularity, If the parallelism becomes very big, and there are many slots on each TM, the memory occupation will even reach the MB level. In fact, all FileReader of the same ResultPartition read data in a single thread, so we only need to allocate a headerbuffer to a ResultPartition to optimize this phenomenon.*


## Brief change log

  - *Move `headerBuffer` and `indexEntryBuffer` from `PartitionedFileReader` to `SortMergeResultPartitionReadScheduler`*
  - *Move `headerBuffer` from `HsSubpartitionFileReaderImpl` to `HsFileDataManager`.*


## Verifying this change


This change is already covered by existing tests.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
