### PR TITLE
[FLINK-28609][Connector/Pulsar] PulsarSchema didn't get properly serialized

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
@@ -27,12 +27,8 @@ import org.apache.pulsar.common.schema.KeyValueEncodingType;
 import org.apache.pulsar.common.schema.SchemaInfo;
 import org.apache.pulsar.common.schema.SchemaType;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -61,6 +57,11 @@ public final class PulsarSchema<T> implements Serializable {
     private transient Schema<T> schema;
     private transient SchemaInfo schemaInfo;
 
+    private String schemaName;
+    private byte[] schemaBytes;
+    private SchemaType schemaType;
+    private Map<String, String> schemaProperties;
+
     /** Create serializable pulsar schema for primitive types. */
     public PulsarSchema(Schema<T> schema) {
         SchemaInfo info = schema.getSchemaInfo();
@@ -77,8 +78,7 @@ public final class PulsarSchema<T> implements Serializable {
         // Primitive type information could be reflected from the schema class.
         Class<?> typeClass = getTemplateType1(schema.getClass());
 
-        this.schemaInfo = encodeClassInfo(info, typeClass);
-        this.schema = createSchema(schemaInfo);
+        setSchemaInfo(encodeClassInfo(info, typeClass));
     }
 
     /**
@@ -94,8 +94,7 @@ public final class PulsarSchema<T> implements Serializable {
                 "Key Value Schema should provide the type classes of key and value");
         validateSchemaInfo(info);
 
-        this.schemaInfo = encodeClassInfo(info, typeClass);
-        this.schema = createSchema(schemaInfo);
+        setSchemaInfo(encodeClassInfo(info, typeClass));
     }
 
     /** Create serializable pulsar schema for key value type. */
@@ -118,67 +117,37 @@ public final class PulsarSchema<T> implements Serializable {
         SchemaInfo encodedInfo =
                 encodeKeyValueSchemaInfo(info.getName(), infoKey, infoValue, encodingType);
 
-        this.schemaInfo = encodeClassInfo(encodedInfo, KeyValue.class);
-        this.schema = createSchema(this.schemaInfo);
+        setSchemaInfo(encodeClassInfo(encodedInfo, KeyValue.class));
+    }
+
+    /** Validate the schema for having the required class info. */
+    private void setSchemaInfo(SchemaInfo schemaInfo) {
+        this.schema = createSchema(schemaInfo);
+        this.schemaInfo = schemaInfo;
+
+        this.schemaName = schemaInfo.getName();
+        this.schemaBytes = schemaInfo.getSchema();
+        this.schemaType = schemaInfo.getType();
+        this.schemaProperties = schemaInfo.getProperties();
     }
 
     public Schema<T> getPulsarSchema() {
+        if (schema == null) {
+            this.schema = createSchema(getSchemaInfo());
+        }
         return schema;
     }
 
     public SchemaInfo getSchemaInfo() {
+        if (schemaInfo == null) {
+            this.schemaInfo =
+                    new SchemaInfoImpl(schemaName, schemaBytes, schemaType, schemaProperties);
+        }
         return schemaInfo;
     }
 
     public Class<T> getRecordClass() {
-        return decodeClassInfo(schemaInfo);
-    }
-
-    private void writeObject(ObjectOutputStream oos) throws IOException {
-        // Name
-        oos.writeUTF(schemaInfo.getName());
-
-        // Schema
-        byte[] schemaBytes = schemaInfo.getSchema();
-        oos.writeInt(schemaBytes.length);
-        oos.write(schemaBytes);
-
-        // Type
-        SchemaType type = schemaInfo.getType();
-        oos.writeInt(type.getValue());
-
-        // Properties
-        Map<String, String> properties = schemaInfo.getProperties();
-        oos.writeInt(properties.size());
-        for (Map.Entry<String, String> entry : properties.entrySet()) {
-            oos.writeUTF(entry.getKey());
-            oos.writeUTF(entry.getValue());
-        }
-    }
-
-    private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
-        // Name
-        String name = ois.readUTF();
-
-        // Schema
-        int byteLen = ois.readInt();
-        byte[] schemaBytes = new byte[byteLen];
-        int read = ois.read(schemaBytes);
-        checkState(read == byteLen);
-
-        // Type
-        int typeIdx = ois.readInt();
-        SchemaType type = SchemaType.valueOf(typeIdx);
-
-        // Properties
-        int propSize = ois.readInt();
-        Map<String, String> properties = new HashMap<>(propSize);
-        for (int i = 0; i < propSize; i++) {
-            properties.put(ois.readUTF(), ois.readUTF());
-        }
-
-        this.schemaInfo = new SchemaInfoImpl(name, schemaBytes, type, properties);
-        this.schema = createSchema(schemaInfo);
+        return decodeClassInfo(getSchemaInfo());
     }
 
     @Override
@@ -189,24 +158,21 @@ public final class PulsarSchema<T> implements Serializable {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        SchemaInfo that = ((PulsarSchema<?>) o).getPulsarSchema().getSchemaInfo();
+        PulsarSchema<?> that = ((PulsarSchema<?>) o);
 
-        return Objects.equals(schemaInfo.getType(), that.getType())
-                && Arrays.equals(schemaInfo.getSchema(), that.getSchema())
-                && Objects.equals(schemaInfo.getProperties(), that.getProperties());
+        return Objects.equals(schemaType, that.schemaType)
+                && Arrays.equals(schemaBytes, that.schemaBytes)
+                && Objects.equals(schemaProperties, that.schemaProperties);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(
-                schemaInfo.getType(),
-                Arrays.hashCode(schemaInfo.getSchema()),
-                schemaInfo.getProperties());
+        return Objects.hash(schemaType, Arrays.hashCode(schemaBytes), schemaProperties);
     }
 
     @Override
     public String toString() {
-        return schemaInfo.toString();
+        return getSchemaInfo().toString();
     }
 
     /**

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaTest.java
@@ -36,6 +36,8 @@ import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.common.schema.SchemaType;
 import org.junit.jupiter.api.Test;
 
+import java.io.Serializable;
+
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -117,9 +119,35 @@ class PulsarSchemaTest {
         assertPulsarSchemaIsSerializable(new PulsarSchema<>(KV, Foo.class, FA.class));
     }
 
+    @Test
+    void largeAvroSchemaSerialization() throws Exception {
+        Schema<LargeMessage> largeMessageSchema = Schema.AVRO(LargeMessage.class);
+        assertPulsarSchemaIsSerializable(
+                new PulsarSchema<>(largeMessageSchema, LargeMessage.class));
+    }
+
     private <T> void assertPulsarSchemaIsSerializable(PulsarSchema<T> schema) throws Exception {
         PulsarSchema<T> clonedSchema = InstantiationUtil.clone(schema);
         assertEquals(clonedSchema.getSchemaInfo(), schema.getSchemaInfo());
         assertEquals(clonedSchema.getRecordClass(), schema.getRecordClass());
+    }
+
+    /** A POJO Class which would generate a large schema by Avro. */
+    public static class LargeMessage implements Serializable {
+        private static final long serialVersionUID = 5364494369740402518L;
+
+        public String
+                aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+        public String
+                bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+        public String
+                cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc;
+        public String
+                dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd;
+        public String
+                eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee;
+        // the problem begins
+        public String
+                ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

PulsarSchema uses readObject and writeObject for customized serialization. But the ObjectInputStream only accepts the first 1018 bytes. We had to remove the custom logic and didn't override the default mechanism.

## Brief change log

1. Add a test for reproducing the bug (Big schema serialization issue)
2. Change the serialization logic in `PulsarSchema`

## Verifying this change

This change added tests and can be verified as follows:

- `PulsarSchemaTest.largeAvroSchemaSerialization`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
