### PR TITLE
[FLINK-28504][streaming] Update watermarks across multiple oneinputstreams.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/metrics/WatermarkGauge.java
@@ -26,7 +26,9 @@ public class WatermarkGauge implements Gauge<Long> {
     private volatile long currentWatermark = Long.MIN_VALUE;
 
     public void setCurrentWatermark(long watermark) {
-        currentWatermark = watermark;
+        if (watermark > currentWatermark) {
+            currentWatermark = watermark;
+        }
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -184,7 +184,7 @@ public class OneInputStreamTaskTest extends TestLogger {
         streamConfig2.setOperatorID(new OperatorID());
 
         testHarness2.invoke();
-        testHarness.waitForTaskRunning();
+        testHarness2.waitForTaskRunning();
 
         long initialTime = 0L;
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In local-global streaming tasks, the` LOCAL` phase is classified as `POINTWISE` by default in some versions. And in the case of data skew, the following phenomena will occur.

![image](https://user-images.githubusercontent.com/10743150/180346883-5bf24a42-feb8-43e4-8f8f-788ed5815c02.png)

When `table.exec.source-idle-timeout` is set, the watermark is not aligned in the local phase and then pushes downstream.The UI is confusing,While the `idleness` effect is achieved, But the underlying logic doesn't seem to make sense.

In the `ALL-TO-ALL` case, as shown in down picture, each Input stream task contains all channels, and all Netty Input channels share a watermark value in main memory.Watermark Value or Watermark Status is updated in different input stream tasks. Other input stream tasks are clearly visible. (volatile)

![OLWY%(4WEI 08W_}WK(YS4](https://user-images.githubusercontent.com/10743150/180347084-67a0de1a-a0b2-4d86-ab43-5ff217b1f3c8.png)

In the case of `POINTWISE`, an input stream task contains only part of the Netty input channels, and each of its channels has its own independent watermark. So its watermark value, and the Posting and updating of the watermark status are only in its own part. That's what caused this. One or a portion of independent channels will advance the watermark to downstream without updating other channels.



In order to avoid this situation, I made the following changes.
However, because the streams task&channels are independent from each other, if the watermark in a certain channel is not aligned, it will not affect the watermark to advance the down stream.



It doesn't matter how many input streams and channels there are, or how they are connected, as long as  update the watermark value across the input stream with in the same Vertex.

updated effect
![image](https://user-images.githubusercontent.com/10743150/180348902-9534980b-f643-4fa0-bf0f-a12a8925c15d.png)

## Brief change log

  - *When creating a stream input task, collect all dataoutputs of the same vertex. When it is necessary to update the watermark, update all outputs together.*
 


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test case verifies that across multiple OneInputStreams update watermark.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
