### PR TITLE
[FLINK-28640][runtime] Let BlocklistDeclarativeSlotPool accept duplicate slot offers

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPool.java
@@ -36,8 +36,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -76,8 +76,8 @@ public class BlocklistDeclarativeSlotPool extends DefaultDeclarativeSlotPool {
             return super.offerSlots(offers, taskManagerLocation, taskManagerGateway, currentTime);
         } else {
             LOG.debug(
-                    "Reject slots {} from a blocked TaskManager {}.", offers, taskManagerLocation);
-            return Collections.emptySet();
+                    "Receive slots {} from a blocked TaskManager {}.", offers, taskManagerLocation);
+            return internalOfferSlotsFromBlockedTaskManager(offers);
         }
     }
 
@@ -90,9 +90,27 @@ public class BlocklistDeclarativeSlotPool extends DefaultDeclarativeSlotPool {
         if (!isBlockedTaskManager(taskManagerLocation.getResourceID())) {
             return super.registerSlots(slots, taskManagerLocation, taskManagerGateway, currentTime);
         } else {
-            LOG.debug("Reject slots {} from a blocked TaskManager {}.", slots, taskManagerLocation);
-            return Collections.emptySet();
+            LOG.debug(
+                    "Receive slots {} from a blocked TaskManager {}.", slots, taskManagerLocation);
+            return internalOfferSlotsFromBlockedTaskManager(slots);
         }
+    }
+
+    private Collection<SlotOffer> internalOfferSlotsFromBlockedTaskManager(
+            Collection<? extends SlotOffer> offers) {
+        final Collection<SlotOffer> acceptedSlotOffers = new ArrayList<>();
+
+        // we should accept a duplicate (already accepted) slot, even if it's from a currently
+        // blocked task manager. Because the slot may already be assigned to an execution, rejecting
+        // it will cause a task failover.
+        for (SlotOffer offer : offers) {
+            if (slotPool.containsSlot(offer.getAllocationId())) {
+                // we have already accepted this offer
+                acceptedSlotOffers.add(offer);
+            }
+        }
+
+        return acceptedSlotOffers;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

BlocklistDeclarativeSlotPool should accept a duplicate (already accepted) slot, even if it's from a currently blocked task manager. Because the slot may already be assigned to an execution, rejecting it will cause a task failover.

## Verifying this change
`BlocklistDeclarativeSlotPoolTest#testOfferDuplicateSlots`
`BlocklistDeclarativeSlotPoolTest#testRegisterDuplicateSlots`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
