### PR TITLE
[FLINK-28647] Remove separate error handling and adjust documentation for CLAIM mode + RocksDB native savepoint

### DIFF
--- a/docs/content/docs/ops/state/savepoints.md
+++ b/docs/content/docs/ops/state/savepoints.md
@@ -255,10 +255,8 @@ of the old job will not be deleted by Flink
 
 2. [Native](#savepoint-format) format supports incremental RocksDB savepoints. For those savepoints Flink puts all
 SST files inside the savepoints directory. This means such savepoints are self-contained and relocatable.
-However, when restored in CLAIM mode, subsequent checkpoints might reuse some SST files, which
-in turn might block deleting the savepoints directory at the time the savepoint is subsumed. Later
-on Flink will delete the reused shared SST files, but it won't retry deleting the savepoints directory.
-Therefore, it is possible Flink leaves an empty savepoints directory if it was restored in CLAIM mode.    
+Please note that, when restored in CLAIM mode, subsequent checkpoints might reuse some SST files, which
+might delay the deletion the savepoints directory.
 {{< /hint >}}
 
 **LEGACY**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1799,8 +1799,7 @@ public class CheckpointCoordinator {
                         checkpointLocation,
                         userClassLoader,
                         allowNonRestored,
-                        checkpointProperties,
-                        restoreSettings.getRestoreMode());
+                        checkpointProperties);
 
         // register shared state - even before adding the checkpoint to the store
         // because the latter might trigger subsumption so the ref counts must be up-to-date

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/Checkpoints.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.checkpoint.metadata.MetadataV4Serializer;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.CheckpointStorageLoader;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
@@ -132,8 +131,7 @@ public class Checkpoints {
             CompletedCheckpointStorageLocation location,
             ClassLoader classLoader,
             boolean allowNonRestoredState,
-            CheckpointProperties checkpointProperties,
-            RestoreMode restoreMode)
+            CheckpointProperties checkpointProperties)
             throws IOException {
 
         checkNotNull(jobId, "jobId");
@@ -221,9 +219,7 @@ public class Checkpoints {
                 operatorStates,
                 checkpointMetadata.getMasterStates(),
                 checkpointProperties,
-                restoreMode == RestoreMode.CLAIM
-                        ? new ClaimModeCompletedStorageLocation(location)
-                        : location,
+                location,
                 null,
                 checkpointMetadata.getCheckpointProperties());
     }
@@ -383,37 +379,4 @@ public class Checkpoints {
 
     /** This class contains only static utility methods and is not meant to be instantiated. */
     private Checkpoints() {}
-
-    private static class ClaimModeCompletedStorageLocation
-            implements CompletedCheckpointStorageLocation {
-
-        private final CompletedCheckpointStorageLocation wrapped;
-
-        private ClaimModeCompletedStorageLocation(CompletedCheckpointStorageLocation location) {
-            wrapped = location;
-        }
-
-        @Override
-        public String getExternalPointer() {
-            return wrapped.getExternalPointer();
-        }
-
-        @Override
-        public StreamStateHandle getMetadataHandle() {
-            return wrapped.getMetadataHandle();
-        }
-
-        @Override
-        public void disposeStorageLocation() throws IOException {
-            try {
-                wrapped.disposeStorageLocation();
-            } catch (Exception ex) {
-                LOG.debug(
-                        "We could not delete the storage location: {} in CLAIM restore mode. It is"
-                                + " most probably because of shared files still being used by newer"
-                                + " checkpoints",
-                        wrapped);
-            }
-        }
-    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointMetadataLoadingTest.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.OperatorStreamStateHandle;
 import org.apache.flink.runtime.state.StreamStateHandle;
@@ -79,8 +78,7 @@ public class CheckpointMetadataLoadingTest {
                         testSavepoint,
                         cl,
                         false,
-                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
-                        RestoreMode.NO_CLAIM);
+                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
 
         assertEquals(jobId, loaded.getJobId());
         assertEquals(checkpointId, loaded.getCheckpointID());
@@ -104,8 +102,7 @@ public class CheckpointMetadataLoadingTest {
                     testSavepoint,
                     cl,
                     false,
-                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
-                    RestoreMode.NO_CLAIM);
+                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("Max parallelism mismatch"));
@@ -131,8 +128,7 @@ public class CheckpointMetadataLoadingTest {
                     testSavepoint,
                     cl,
                     false,
-                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
-                    RestoreMode.NO_CLAIM);
+                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));
@@ -158,8 +154,7 @@ public class CheckpointMetadataLoadingTest {
                         testSavepoint,
                         cl,
                         true,
-                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
-                        RestoreMode.NO_CLAIM);
+                        CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
 
         assertTrue(loaded.getOperatorStates().isEmpty());
     }
@@ -188,8 +183,7 @@ public class CheckpointMetadataLoadingTest {
                     testSavepoint,
                     cl,
                     false,
-                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL),
-                    RestoreMode.NO_CLAIM);
+                    CheckpointProperties.forSavepoint(false, SavepointFormatType.CANONICAL));
             fail("Did not throw expected Exception");
         } catch (IllegalStateException expected) {
             assertTrue(expected.getMessage().contains("allowNonRestoredState"));


### PR DESCRIPTION
## What is the purpose of the change

Please see ticket description (FLINK-28647).

## Brief changelog

- update the docs (checkpoint folder **is** deleted but with a delay)
- remove additional error handling (just fail in case of folder deletion failure)

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
