### PR TITLE
[FLINK-28660][runtime] Simplify logs of blocklist

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlockedNodeAdditionResult.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlockedNodeAdditionResult.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.blocklist;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The result of adding new blocked nodes. */
+class BlockedNodeAdditionResult {
+
+    private final Collection<BlockedNode> newlyAddedNodes;
+
+    private final Collection<BlockedNode> mergedNodes;
+
+    BlockedNodeAdditionResult(
+            Collection<BlockedNode> newlyAddedNodes, Collection<BlockedNode> mergedNodes) {
+        this.newlyAddedNodes = checkNotNull(newlyAddedNodes);
+        this.mergedNodes = checkNotNull(mergedNodes);
+    }
+
+    public Collection<BlockedNode> getNewlyAddedNodes() {
+        return Collections.unmodifiableCollection(newlyAddedNodes);
+    }
+
+    public Collection<BlockedNode> getMergedNodes() {
+        return Collections.unmodifiableCollection(mergedNodes);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlocklistTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/blocklist/BlocklistTracker.java
@@ -29,9 +29,9 @@ public interface BlocklistTracker {
      * added one will be merged with the existing one.
      *
      * @param newNodes the new blocked node records
-     * @return the changes of blocklist after execution, which will be synchronized to other JMs/RM
+     * @return the addition result
      */
-    Collection<BlockedNode> addNewBlockedNodes(Collection<BlockedNode> newNodes);
+    BlockedNodeAdditionResult addNewBlockedNodes(Collection<BlockedNode> newNodes);
 
     /**
      * Returns whether the given node is blocked.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blocklist/DefaultBlocklistTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blocklist/DefaultBlocklistTrackerTest.java
@@ -49,11 +49,12 @@ class DefaultBlocklistTrackerTest {
         // do nothing because blockedNode6 equals to blockedNode3
         BlockedNode blockedNode6 = new BlockedNode("node3", "cause1", 1L);
 
-        Collection<BlockedNode> changes =
+        BlockedNodeAdditionResult result =
                 blocklistTracker.addNewBlockedNodes(
                         Arrays.asList(blockedNode4, blockedNode5, blockedNode6));
 
-        assertThat(changes).containsExactlyInAnyOrder(blockedNode4, blockedNode5);
+        assertThat(result.getNewlyAddedNodes()).containsExactly(blockedNode4);
+        assertThat(result.getMergedNodes()).containsExactly(blockedNode5);
         assertThat(blocklistTracker.getAllBlockedNodes())
                 .containsExactlyInAnyOrder(blockedNode1, blockedNode3, blockedNode4, blockedNode5);
 
@@ -61,9 +62,10 @@ class DefaultBlocklistTrackerTest {
         // blockedNode7.cause != blockedNode3.cause
         BlockedNode blockedNode7 = new BlockedNode("node3", "cause2", 1L);
 
-        changes = blocklistTracker.addNewBlockedNodes(Collections.singletonList(blockedNode7));
+        result = blocklistTracker.addNewBlockedNodes(Collections.singletonList(blockedNode7));
 
-        assertThat(changes).containsExactly(blockedNode7);
+        assertThat(result.getNewlyAddedNodes()).isEmpty();
+        assertThat(result.getMergedNodes()).containsExactly(blockedNode7);
         assertThat(blocklistTracker.getAllBlockedNodes())
                 .containsExactlyInAnyOrder(blockedNode1, blockedNode4, blockedNode5, blockedNode7);
     }


### PR DESCRIPTION
## What is the purpose of the change
Simplify logs of blocklist

## Verifying this change
This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
