### PR TITLE
[FLINK-28380][runtime] Produce one intermediate dataset for multiple consumer job vertices consuming the same data

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -32,7 +32,7 @@ public enum ResultPartitionType {
      * {@link #PIPELINED} partitions), but only released through the scheduler, when it determines
      * that the partition is no longer needed.
      */
-    BLOCKING(false, false, ConsumingConstraint.BLOCKING, ReleaseBy.SCHEDULER),
+    BLOCKING(true, false, false, ConsumingConstraint.BLOCKING, ReleaseBy.SCHEDULER),
 
     /**
      * BLOCKING_PERSISTENT partitions are similar to {@link #BLOCKING} partitions, but have a
@@ -45,7 +45,7 @@ public enum ResultPartitionType {
      * scenarios, like when the TaskManager exits or when the TaskManager loses connection to
      * JobManager / ResourceManager for too long.
      */
-    BLOCKING_PERSISTENT(false, true, ConsumingConstraint.BLOCKING, ReleaseBy.SCHEDULER),
+    BLOCKING_PERSISTENT(true, false, true, ConsumingConstraint.BLOCKING, ReleaseBy.SCHEDULER),
 
     /**
      * A pipelined streaming data exchange. This is applicable to both bounded and unbounded
@@ -57,7 +57,7 @@ public enum ResultPartitionType {
      * <p>This result partition type may keep an arbitrary amount of data in-flight, in contrast to
      * the {@link #PIPELINED_BOUNDED} variant.
      */
-    PIPELINED(false, false, ConsumingConstraint.MUST_BE_PIPELINED, ReleaseBy.UPSTREAM),
+    PIPELINED(false, false, false, ConsumingConstraint.MUST_BE_PIPELINED, ReleaseBy.UPSTREAM),
 
     /**
      * Pipelined partitions with a bounded (local) buffer pool.
@@ -70,7 +70,8 @@ public enum ResultPartitionType {
      * <p>For batch jobs, it will be best to keep this unlimited ({@link #PIPELINED}) since there
      * are no checkpoint barriers.
      */
-    PIPELINED_BOUNDED(true, false, ConsumingConstraint.MUST_BE_PIPELINED, ReleaseBy.UPSTREAM),
+    PIPELINED_BOUNDED(
+            false, true, false, ConsumingConstraint.MUST_BE_PIPELINED, ReleaseBy.UPSTREAM),
 
     /**
      * Pipelined partitions with a bounded (local) buffer pool to support downstream task to
@@ -81,7 +82,8 @@ public enum ResultPartitionType {
      * in that {@link #PIPELINED_APPROXIMATE} partition can be reconnected after down stream task
      * fails.
      */
-    PIPELINED_APPROXIMATE(true, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.UPSTREAM),
+    PIPELINED_APPROXIMATE(
+            false, true, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.UPSTREAM),
 
     /**
      * Hybrid partitions with a bounded (local) buffer pool to support downstream task to
@@ -89,7 +91,12 @@ public enum ResultPartitionType {
      *
      * <p>Hybrid partitions can be consumed any time, whether fully produced or not.
      */
-    HYBRID(false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);
+    HYBRID(false, false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);
+
+    /**
+     * Can this result partition be consumed by multiple downstream consumers for multiple times.
+     */
+    private final boolean isReconsumable;
 
     /** Does this partition use a limited number of (network) buffers? */
     private final boolean isBounded;
@@ -125,10 +132,12 @@ public enum ResultPartitionType {
 
     /** Specifies the behaviour of an intermediate result partition at runtime. */
     ResultPartitionType(
+            boolean isReconsumable,
             boolean isBounded,
             boolean isPersistent,
             ConsumingConstraint consumingConstraint,
             ReleaseBy releaseBy) {
+        this.isReconsumable = isReconsumable;
         this.isBounded = isBounded;
         this.isPersistent = isPersistent;
         this.consumingConstraint = consumingConstraint;
@@ -199,5 +208,9 @@ public enum ResultPartitionType {
 
     public boolean supportCompression() {
         return isBlockingOrBlockingPersistentResultPartition() || this == HYBRID;
+    }
+
+    public boolean isReconsumable() {
+        return isReconsumable;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/NonChainedOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/NonChainedOutput.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.graph;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.util.OutputTag;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Used by operator chain and represents a non-chained output of the corresponding stream operator.
+ */
+@Internal
+public class NonChainedOutput implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Is unaligned checkpoint supported. */
+    private final boolean supportsUnalignedCheckpoints;
+
+    /** ID of the producer {@link StreamNode}. */
+    private final int sourceNodeId;
+
+    /** Parallelism of the consumer vertex. */
+    private final int consumerParallelism;
+
+    /** Max parallelism of the consumer vertex. */
+    private final int consumerMaxParallelism;
+
+    /** Buffer flush timeout of this output. */
+    private final long bufferTimeout;
+
+    /** ID of the produced intermediate dataset. */
+    private final IntermediateDataSetID dataSetId;
+
+    /** Whether this intermediate dataset is a persistent dataset or not. */
+    private final boolean isPersistentDataSet;
+
+    /** The side-output tag (if any). */
+    private final OutputTag<?> outputTag;
+
+    /** The corresponding data partitioner. */
+    private final StreamPartitioner<?> partitioner;
+
+    /** Target {@link ResultPartitionType}. */
+    private final ResultPartitionType partitionType;
+
+    public NonChainedOutput(
+            boolean supportsUnalignedCheckpoints,
+            int sourceNodeId,
+            int consumerParallelism,
+            int consumerMaxParallelism,
+            long bufferTimeout,
+            boolean isPersistentDataSet,
+            IntermediateDataSetID dataSetId,
+            OutputTag<?> outputTag,
+            StreamPartitioner<?> partitioner,
+            ResultPartitionType partitionType) {
+        this.supportsUnalignedCheckpoints = supportsUnalignedCheckpoints;
+        this.sourceNodeId = sourceNodeId;
+        this.consumerParallelism = consumerParallelism;
+        this.consumerMaxParallelism = consumerMaxParallelism;
+        this.bufferTimeout = bufferTimeout;
+        this.isPersistentDataSet = isPersistentDataSet;
+        this.dataSetId = dataSetId;
+        this.outputTag = outputTag;
+        this.partitioner = partitioner;
+        this.partitionType = partitionType;
+    }
+
+    public boolean supportsUnalignedCheckpoints() {
+        return supportsUnalignedCheckpoints;
+    }
+
+    public int getSourceNodeId() {
+        return sourceNodeId;
+    }
+
+    public int getConsumerParallelism() {
+        return consumerParallelism;
+    }
+
+    public int getConsumerMaxParallelism() {
+        return consumerMaxParallelism;
+    }
+
+    public long getBufferTimeout() {
+        return bufferTimeout;
+    }
+
+    public IntermediateDataSetID getDataSetId() {
+        return dataSetId;
+    }
+
+    public IntermediateDataSetID getPersistentDataSetId() {
+        return isPersistentDataSet ? dataSetId : null;
+    }
+
+    public OutputTag<?> getOutputTag() {
+        return outputTag;
+    }
+
+    public StreamPartitioner<?> getPartitioner() {
+        return partitioner;
+    }
+
+    public ResultPartitionType getPartitionType() {
+        return partitionType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NonChainedOutput output = (NonChainedOutput) o;
+        return Objects.equals(dataSetId, output.dataSetId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dataSetId);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -97,9 +97,11 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -176,6 +178,8 @@ public class StreamingJobGraphGenerator {
     // Futures for the serialization of operator coordinators
     private final List<CompletableFuture<Void>> coordinatorSerializationFutures = new ArrayList<>();
 
+    private final Map<Integer, Map<StreamEdge, NonChainedOutput>> opIntermediateOutputs;
+
     private StreamingJobGraphGenerator(
             StreamGraph streamGraph, @Nullable JobID jobID, Executor serializationExecutor) {
         this.streamGraph = streamGraph;
@@ -192,6 +196,7 @@ public class StreamingJobGraphGenerator {
         this.chainedInputOutputFormats = new HashMap<>();
         this.physicalEdgesInOrder = new ArrayList<>();
         this.serializationExecutor = Preconditions.checkNotNull(serializationExecutor);
+        this.opIntermediateOutputs = new HashMap<>();
 
         jobGraph = new JobGraph(jobID, streamGraph.getJobName());
     }
@@ -677,11 +682,15 @@ public class StreamingJobGraphGenerator {
                 config.setChainIndex(chainIndex);
                 config.setOperatorName(streamGraph.getStreamNode(currentNodeId).getOperatorName());
 
+                LinkedHashSet<NonChainedOutput> transitiveOutputs = new LinkedHashSet<>();
                 for (StreamEdge edge : transitiveOutEdges) {
-                    connect(startNodeId, edge);
+                    NonChainedOutput output =
+                            opIntermediateOutputs.get(edge.getSourceId()).get(edge);
+                    transitiveOutputs.add(output);
+                    connect(startNodeId, edge, output);
                 }
 
-                config.setOutEdgesInOrder(transitiveOutEdges);
+                config.setVertexNonChainedOutputs(new ArrayList<>(transitiveOutputs));
                 config.setTransitiveChainedTaskConfigs(chainedConfigs.get(startNodeId));
 
             } else {
@@ -937,8 +946,10 @@ public class StreamingJobGraphGenerator {
 
         config.setStreamOperatorFactory(vertex.getOperatorFactory());
 
-        config.setNumberOfOutputs(nonChainableOutputs.size());
-        config.setNonChainedOutputs(nonChainableOutputs);
+        List<NonChainedOutput> deduplicatedOutputs =
+                mayReuseNonChainedOutputs(vertexID, nonChainableOutputs);
+        config.setNumberOfOutputs(deduplicatedOutputs.size());
+        config.setOperatorNonChainedOutputs(deduplicatedOutputs);
         config.setChainedOutputs(chainableOutputs);
 
         config.setTimeCharacteristic(streamGraph.getTimeCharacteristic());
@@ -973,6 +984,75 @@ public class StreamingJobGraphGenerator {
         }
 
         vertexConfigs.put(vertexID, config);
+    }
+
+    private List<NonChainedOutput> mayReuseNonChainedOutputs(
+            int vertexId, List<StreamEdge> consumerEdges) {
+        if (consumerEdges.isEmpty()) {
+            return new ArrayList<>();
+        }
+        List<NonChainedOutput> outputs = new ArrayList<>(consumerEdges.size());
+        Map<StreamEdge, NonChainedOutput> outputsConsumedByEdge =
+                opIntermediateOutputs.computeIfAbsent(vertexId, ignored -> new HashMap<>());
+        for (StreamEdge consumerEdge : consumerEdges) {
+            checkState(vertexId == consumerEdge.getSourceId(), "Vertex id must be the same.");
+            int consumerParallelism =
+                    streamGraph.getStreamNode(consumerEdge.getTargetId()).getParallelism();
+            int consumerMaxParallelism =
+                    streamGraph.getStreamNode(consumerEdge.getTargetId()).getMaxParallelism();
+            StreamPartitioner<?> partitioner = consumerEdge.getPartitioner();
+            ResultPartitionType partitionType = getResultPartitionType(consumerEdge);
+            IntermediateDataSetID dataSetId = new IntermediateDataSetID();
+
+            boolean isPersistentDataSet =
+                    isPersistentIntermediateDataset(partitionType, consumerEdge);
+            if (isPersistentDataSet) {
+                partitionType = ResultPartitionType.BLOCKING_PERSISTENT;
+                dataSetId = consumerEdge.getIntermediateDatasetIdToProduce();
+            }
+
+            NonChainedOutput output =
+                    new NonChainedOutput(
+                            consumerEdge.supportsUnalignedCheckpoints(),
+                            consumerEdge.getSourceId(),
+                            consumerParallelism,
+                            consumerMaxParallelism,
+                            consumerEdge.getBufferTimeout(),
+                            isPersistentDataSet,
+                            dataSetId,
+                            consumerEdge.getOutputTag(),
+                            partitioner,
+                            partitionType);
+            if (!partitionType.isReconsumable()) {
+                outputs.add(output);
+                outputsConsumedByEdge.put(consumerEdge, output);
+            } else {
+                NonChainedOutput reusableOutput = null;
+                for (NonChainedOutput outputCandidate : outputsConsumedByEdge.values()) {
+                    // the target output can be reused if they have the same partitioner and
+                    // consumer parallelism, reusing the same output can improve performance
+                    if (outputCandidate.getPartitionType().isReconsumable()
+                            && consumerParallelism == outputCandidate.getConsumerParallelism()
+                            && consumerMaxParallelism == outputCandidate.getConsumerMaxParallelism()
+                            && outputCandidate.getPartitionType() == partitionType
+                            && Objects.equals(
+                                    outputCandidate.getPersistentDataSetId(),
+                                    consumerEdge.getIntermediateDatasetIdToProduce())
+                            && Objects.equals(
+                                    outputCandidate.getOutputTag(), consumerEdge.getOutputTag())
+                            && Objects.equals(partitioner, outputCandidate.getPartitioner())) {
+                        reusableOutput = outputCandidate;
+                        outputsConsumedByEdge.put(consumerEdge, reusableOutput);
+                        break;
+                    }
+                }
+                if (reusableOutput == null) {
+                    outputs.add(output);
+                    outputsConsumedByEdge.put(consumerEdge, output);
+                }
+            }
+        }
+        return outputs;
     }
 
     private void tryConvertPartitionerForDynamicGraph(
@@ -1026,7 +1106,7 @@ public class StreamingJobGraphGenerator {
         }
     }
 
-    private void connect(Integer headOfChain, StreamEdge edge) {
+    private void connect(Integer headOfChain, StreamEdge edge, NonChainedOutput output) {
 
         physicalEdgesInOrder.add(edge);
 
@@ -1039,35 +1119,11 @@ public class StreamingJobGraphGenerator {
 
         downStreamConfig.setNumberOfNetworkInputs(downStreamConfig.getNumberOfNetworkInputs() + 1);
 
-        StreamPartitioner<?> partitioner = edge.getPartitioner();
-
-        ResultPartitionType resultPartitionType;
-        switch (edge.getExchangeMode()) {
-            case PIPELINED:
-                resultPartitionType = ResultPartitionType.PIPELINED_BOUNDED;
-                break;
-            case BATCH:
-                resultPartitionType = ResultPartitionType.BLOCKING;
-                break;
-            case HYBRID:
-                resultPartitionType = ResultPartitionType.HYBRID;
-                break;
-            case UNDEFINED:
-                resultPartitionType = determineResultPartitionType(partitioner);
-                break;
-            default:
-                throw new UnsupportedOperationException(
-                        "Data exchange mode " + edge.getExchangeMode() + " is not supported yet.");
-        }
+        StreamPartitioner<?> partitioner = output.getPartitioner();
+        ResultPartitionType resultPartitionType = output.getPartitionType();
 
         if (resultPartitionType == ResultPartitionType.HYBRID) {
             hasHybridResultPartition = true;
-        }
-
-        IntermediateDataSetID intermediateDataSetID = new IntermediateDataSetID();
-        if (isPersistentIntermediateDataset(resultPartitionType, edge)) {
-            resultPartitionType = ResultPartitionType.BLOCKING_PERSISTENT;
-            intermediateDataSetID = edge.getIntermediateDatasetIdToProduce();
         }
 
         checkBufferTimeout(resultPartitionType, edge);
@@ -1079,7 +1135,7 @@ public class StreamingJobGraphGenerator {
                             headVertex,
                             DistributionPattern.POINTWISE,
                             resultPartitionType,
-                            intermediateDataSetID,
+                            opIntermediateOutputs.get(edge.getSourceId()).get(edge).getDataSetId(),
                             partitioner.isBroadcast());
         } else {
             jobEdge =
@@ -1087,7 +1143,7 @@ public class StreamingJobGraphGenerator {
                             headVertex,
                             DistributionPattern.ALL_TO_ALL,
                             resultPartitionType,
-                            intermediateDataSetID,
+                            opIntermediateOutputs.get(edge.getSourceId()).get(edge).getDataSetId(),
                             partitioner.isBroadcast());
         }
 
@@ -1125,7 +1181,24 @@ public class StreamingJobGraphGenerator {
         }
     }
 
-    private ResultPartitionType determineResultPartitionType(StreamPartitioner<?> partitioner) {
+    private ResultPartitionType getResultPartitionType(StreamEdge edge) {
+        switch (edge.getExchangeMode()) {
+            case PIPELINED:
+                return ResultPartitionType.PIPELINED_BOUNDED;
+            case BATCH:
+                return ResultPartitionType.BLOCKING;
+            case HYBRID:
+                return ResultPartitionType.HYBRID;
+            case UNDEFINED:
+                return determineUndefinedResultPartitionType(edge.getPartitioner());
+            default:
+                throw new UnsupportedOperationException(
+                        "Data exchange mode " + edge.getExchangeMode() + " is not supported yet.");
+        }
+    }
+
+    private ResultPartitionType determineUndefinedResultPartitionType(
+            StreamPartitioner<?> partitioner) {
         switch (streamGraph.getGlobalStreamExchangeMode()) {
             case ALL_EDGES_BLOCKING:
                 return ResultPartitionType.BLOCKING;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/partitioner/CustomPartitionerWrapper.java
@@ -26,6 +26,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.InstantiationUtil;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Partitioner that selects the channel with a user defined partitioner function on a key.
@@ -74,6 +75,25 @@ public class CustomPartitionerWrapper<K, T> extends StreamPartitioner<T> {
         } catch (ClassNotFoundException | IOException e) {
             throw new IllegalStateException("Cannot clone custom partitioner", e);
         }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final CustomPartitionerWrapper<?, ?> that = (CustomPartitionerWrapper<?, ?>) o;
+        return numberOfChannels == that.numberOfChannels
+                && Objects.equals(partitioner, that.partitioner)
+                && Objects.equals(keySelector, that.keySelector);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), partitioner, keySelector);
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitionerTest.java
@@ -19,24 +19,22 @@ package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 /** Test for {@link ForwardForConsecutiveHashPartitioner}. */
-public class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
+class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
 
     @Test
-    public void testConvertToForwardPartitioner() {
+    void testConvertToForwardPartitioner() {
         testConvertToForwardPartitioner(StreamExchangeMode.BATCH);
         testConvertToForwardPartitioner(StreamExchangeMode.PIPELINED);
         testConvertToForwardPartitioner(StreamExchangeMode.UNDEFINED);
@@ -50,16 +48,16 @@ public class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
                         new ForwardForConsecutiveHashPartitioner<>(
                                 new KeyGroupStreamPartitioner<>(record -> 0L, 100)));
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
-        assertThat(jobVertices.size(), is(1));
+        Assertions.assertThat(jobVertices.size()).isEqualTo(1);
         JobVertex vertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 
         StreamConfig sourceConfig = new StreamConfig(vertex.getConfiguration());
         StreamEdge edge = sourceConfig.getChainedOutputs(getClass().getClassLoader()).get(0);
-        assertThat(edge.getPartitioner(), instanceOf(ForwardPartitioner.class));
+        Assertions.assertThat(edge.getPartitioner()).isInstanceOf(ForwardPartitioner.class);
     }
 
     @Test
-    public void testConvertToHashPartitioner() {
+    void testConvertToHashPartitioner() {
         testConvertToHashPartitioner(StreamExchangeMode.BATCH);
         testConvertToHashPartitioner(StreamExchangeMode.PIPELINED);
         testConvertToHashPartitioner(StreamExchangeMode.UNDEFINED);
@@ -73,11 +71,13 @@ public class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
                         new ForwardForConsecutiveHashPartitioner<>(
                                 new KeyGroupStreamPartitioner<>(record -> 0L, 100)));
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
-        assertThat(jobVertices.size(), is(2));
+        Assertions.assertThat(jobVertices.size()).isEqualTo(2);
         JobVertex sourceVertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 
         StreamConfig sourceConfig = new StreamConfig(sourceVertex.getConfiguration());
-        StreamEdge edge = sourceConfig.getNonChainedOutputs(getClass().getClassLoader()).get(0);
-        assertThat(edge.getPartitioner(), instanceOf(KeyGroupStreamPartitioner.class));
+        NonChainedOutput output =
+                sourceConfig.getOperatorNonChainedOutputs(getClass().getClassLoader()).get(0);
+        Assertions.assertThat(output.getPartitioner())
+                .isInstanceOf(KeyGroupStreamPartitioner.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitionerTest.java
@@ -19,46 +19,45 @@ package org.apache.flink.streaming.runtime.partitioner;
 
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 /** Test for {@link ForwardForUnspecifiedPartitioner}. */
-public class ForwardForUnspecifiedPartitionerTest extends TestLogger {
+class ForwardForUnspecifiedPartitionerTest extends TestLogger {
 
     @Test
-    public void testConvertToForwardPartitioner() {
+    void testConvertToForwardPartitioner() {
         JobGraph jobGraph =
                 StreamPartitionerTestUtils.createJobGraph(
                         "group1", "group1", new ForwardForUnspecifiedPartitioner<>());
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
-        assertThat(jobVertices.size(), is(1));
+        Assertions.assertThat(jobVertices.size()).isEqualTo(1);
         JobVertex vertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 
         StreamConfig sourceConfig = new StreamConfig(vertex.getConfiguration());
         StreamEdge edge = sourceConfig.getChainedOutputs(getClass().getClassLoader()).get(0);
-        assertThat(edge.getPartitioner(), instanceOf(ForwardPartitioner.class));
+        Assertions.assertThat(edge.getPartitioner()).isInstanceOf(ForwardPartitioner.class);
     }
 
     @Test
-    public void testConvertToRescalePartitioner() {
+    void testConvertToRescalePartitioner() {
         JobGraph jobGraph =
                 StreamPartitionerTestUtils.createJobGraph(
                         "group1", "group2", new ForwardForUnspecifiedPartitioner<>());
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
-        assertThat(jobVertices.size(), is(2));
+        Assertions.assertThat(jobVertices.size()).isEqualTo(2);
         JobVertex sourceVertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 
         StreamConfig sourceConfig = new StreamConfig(sourceVertex.getConfiguration());
-        StreamEdge edge = sourceConfig.getNonChainedOutputs(getClass().getClassLoader()).get(0);
-        assertThat(edge.getPartitioner(), instanceOf(RescalePartitioner.class));
+        NonChainedOutput output =
+                sourceConfig.getOperatorNonChainedOutputs(getClass().getClassLoader()).get(0);
+        Assertions.assertThat(output.getPartitioner()).isInstanceOf(RescalePartitioner.class);
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamConfigChainer.java
@@ -21,7 +21,10 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
@@ -166,36 +169,34 @@ public class StreamConfigChainer<OWNER> {
 
     public OWNER finish() {
         checkState(chainIndex > 0, "Use finishForSingletonOperatorChain");
-        List<StreamEdge> outEdgesInOrder = new LinkedList<StreamEdge>();
+        List<NonChainedOutput> outEdgesInOrder = new LinkedList<>();
 
         StreamNode sourceVertex =
                 new StreamNode(chainIndex, null, null, (StreamOperator<?>) null, null, null);
         for (int i = 0; i < numberOfNonChainedOutputs; ++i) {
-            StreamEdge streamEdge =
-                    new StreamEdge(
-                            sourceVertex,
-                            new StreamNode(
-                                    chainIndex + i,
-                                    null,
-                                    null,
-                                    (StreamOperator<?>) null,
-                                    null,
-                                    null),
-                            0,
+            NonChainedOutput streamOutput =
+                    new NonChainedOutput(
+                            true,
+                            sourceVertex.getId(),
+                            1,
+                            1,
+                            100,
+                            false,
+                            new IntermediateDataSetID(),
+                            null,
                             new BroadcastPartitioner<>(),
-                            null);
-            streamEdge.setBufferTimeout(1);
-            outEdgesInOrder.add(streamEdge);
+                            ResultPartitionType.PIPELINED_BOUNDED);
+            outEdgesInOrder.add(streamOutput);
         }
 
         tailConfig.setChainEnd();
         tailConfig.setNumberOfOutputs(numberOfNonChainedOutputs);
-        tailConfig.setOutEdgesInOrder(outEdgesInOrder);
-        tailConfig.setNonChainedOutputs(outEdgesInOrder);
+        tailConfig.setVertexNonChainedOutputs(outEdgesInOrder);
+        tailConfig.setOperatorNonChainedOutputs(outEdgesInOrder);
         chainedConfigs.values().forEach(StreamConfig::serializeAllConfigs);
 
         headConfig.setAndSerializeTransitiveChainedTaskConfigs(chainedConfigs);
-        headConfig.setOutEdgesInOrder(outEdgesInOrder);
+        headConfig.setVertexNonChainedOutputs(outEdgesInOrder);
         headConfig.serializeAllConfigs();
 
         return owner;
@@ -209,7 +210,7 @@ public class StreamConfigChainer<OWNER> {
                 new AbstractStreamOperator<OUT>() {
                     private static final long serialVersionUID = 1L;
                 };
-        List<StreamEdge> outEdgesInOrder = new LinkedList<>();
+        List<NonChainedOutput> streamOutputs = new LinkedList<>();
 
         StreamNode sourceVertexDummy =
                 new StreamNode(
@@ -220,31 +221,27 @@ public class StreamConfigChainer<OWNER> {
                         "source dummy",
                         SourceStreamTask.class);
         for (int i = 0; i < numberOfNonChainedOutputs; ++i) {
-            StreamNode targetVertexDummy =
-                    new StreamNode(
-                            MAIN_NODE_ID + 1 + i,
-                            "group",
+            streamOutputs.add(
+                    new NonChainedOutput(
+                            true,
+                            sourceVertexDummy.getId(),
+                            1,
+                            1,
+                            100,
+                            false,
+                            new IntermediateDataSetID(),
                             null,
-                            dummyOperator,
-                            "target dummy",
-                            SourceStreamTask.class);
-
-            outEdgesInOrder.add(
-                    new StreamEdge(
-                            sourceVertexDummy,
-                            targetVertexDummy,
-                            0,
                             new BroadcastPartitioner<>(),
-                            null));
+                            ResultPartitionType.PIPELINED_BOUNDED));
         }
 
         headConfig.setVertexID(0);
         headConfig.setNumberOfOutputs(1);
-        headConfig.setOutEdgesInOrder(outEdgesInOrder);
-        headConfig.setNonChainedOutputs(outEdgesInOrder);
+        headConfig.setVertexNonChainedOutputs(streamOutputs);
+        headConfig.setOperatorNonChainedOutputs(streamOutputs);
         chainedConfigs.values().forEach(StreamConfig::serializeAllConfigs);
         headConfig.setAndSerializeTransitiveChainedTaskConfigs(chainedConfigs);
-        headConfig.setOutEdgesInOrder(outEdgesInOrder);
+        headConfig.setVertexNonChainedOutputs(streamOutputs);
         headConfig.setTypeSerializerOut(outputSerializer);
         headConfig.serializeAllConfigs();
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTestHarness.java
@@ -34,7 +34,9 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
 import org.apache.flink.runtime.io.network.api.StopMode;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.consumer.StreamTestSingleInputGate;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.memory.MemoryManager;
@@ -50,8 +52,8 @@ import org.apache.flink.runtime.state.TestTaskStateManager;
 import org.apache.flink.runtime.taskmanager.TaskManagerRuntimeInfo;
 import org.apache.flink.runtime.util.TestingTaskManagerRuntimeInfo;
 import org.apache.flink.streaming.api.TimeCharacteristic;
+import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
@@ -237,24 +239,26 @@ public class StreamTaskTestHarness<OUT> {
                     private static final long serialVersionUID = 1L;
                 };
 
-        List<StreamEdge> outEdgesInOrder = new LinkedList<>();
+        List<NonChainedOutput> streamOutputs = new LinkedList<>();
         StreamNode sourceVertexDummy =
                 new StreamNode(
                         0, "group", null, dummyOperator, "source dummy", SourceStreamTask.class);
-        StreamNode targetVertexDummy =
-                new StreamNode(
-                        1, "group", null, dummyOperator, "target dummy", SourceStreamTask.class);
 
-        outEdgesInOrder.add(
-                new StreamEdge(
-                        sourceVertexDummy,
-                        targetVertexDummy,
-                        0,
+        streamOutputs.add(
+                new NonChainedOutput(
+                        true,
+                        sourceVertexDummy.getId(),
+                        1,
+                        1,
+                        100,
+                        false,
+                        new IntermediateDataSetID(),
+                        null,
                         new BroadcastPartitioner<>(),
-                        null /* output tag */));
+                        ResultPartitionType.PIPELINED_BOUNDED));
 
-        streamConfig.setOutEdgesInOrder(outEdgesInOrder);
-        streamConfig.setNonChainedOutputs(outEdgesInOrder);
+        streamConfig.setVertexNonChainedOutputs(streamOutputs);
+        streamConfig.setOperatorNonChainedOutputs(streamOutputs);
         streamConfig.serializeAllConfigs();
     }
 

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamConfig.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/MockStreamConfig.java
@@ -19,9 +19,11 @@ package org.apache.flink.streaming.util;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
-import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.graph.StreamNode;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperator;
@@ -51,21 +53,24 @@ public class MockStreamConfig extends StreamConfig {
 
         StreamNode sourceVertex =
                 new StreamNode(0, null, null, dummyOperator, "source", SourceStreamTask.class);
-        StreamNode targetVertex =
-                new StreamNode(1, null, null, dummyOperator, "target", SourceStreamTask.class);
 
-        List<StreamEdge> outEdgesInOrder = new ArrayList<>(numberOfOutputs);
+        List<NonChainedOutput> streamOutputs = new ArrayList<>(numberOfOutputs);
         for (int i = 0; i < numberOfOutputs; i++) {
-            outEdgesInOrder.add(
-                    new StreamEdge(
-                            sourceVertex,
-                            targetVertex,
-                            numberOfOutputs,
+            streamOutputs.add(
+                    new NonChainedOutput(
+                            true,
+                            sourceVertex.getId(),
+                            1,
+                            1,
+                            100,
+                            false,
+                            new IntermediateDataSetID(),
+                            null,
                             new BroadcastPartitioner<>(),
-                            null));
+                            ResultPartitionType.PIPELINED_BOUNDED));
         }
-        setOutEdgesInOrder(outEdgesInOrder);
-        setNonChainedOutputs(outEdgesInOrder);
+        setVertexNonChainedOutputs(streamOutputs);
+        setOperatorNonChainedOutputs(streamOutputs);
         serializeAllConfigs();
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/partitioner/BinaryHashPartitioner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/partitioner/BinaryHashPartitioner.java
@@ -77,6 +77,26 @@ public class BinaryHashPartitioner extends StreamPartitioner<RowData> {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final BinaryHashPartitioner that = (BinaryHashPartitioner) o;
+        return numberOfChannels == that.numberOfChannels
+                && Arrays.equals(hashFieldNames, that.hashFieldNames);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + Arrays.hashCode(hashFieldNames);
+        return result;
+    }
+
+    @Override
     public String toString() {
         return "HASH" + Arrays.toString(hashFieldNames);
     }


### PR DESCRIPTION
## What is the purpose of the change

Currently, if one output of an upstream job vertex is consumed by multiple downstream job vertices, the upstream vertex will produce multiple dataset. For blocking shuffle, it means serialize and persist the same data multiple times. This ticket aims to optimize this behavior and make the upstream job vertex produce one dataset which will be read by multiple downstream vertex.


## Brief change log

  - Produce one intermediate dataset for multiple consumer job vertices consuming the same data.


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
