### PR TITLE
[FLINK-28634][json] Add simple JsonSerDeSchema 

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/formats/json.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/json.md
@@ -1,0 +1,77 @@
+---
+title:  "JSON"
+weight: 4
+type: docs
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Json format
+
+To use the JSON format you need to add the Flink JSON dependency to your project:
+
+```xml
+<dependency>
+	<groupId>org.apache.flink</groupId>
+	<artifactId>flink-json</artifactId>
+	<version>{{< version >}}</version>
+	<scope>provided</scope>
+</dependency>
+```
+
+Flink supports reading/writing JSON records via the `JsonSerializationSchema/JsonDeserializationSchema`.
+These utilize the [Jackson](https://github.com/FasterXML/jackson) library, and support any type that is supported by Jackson, including, but not limited to, `POJO`s and `ObjectNode`.
+
+The `JsonDeserializationSchema` can be used with any connector that supports the `DeserializationSchema`.
+
+For example, this is how you use it with a `KafkaSource` to deserialize a `POJO`:
+
+```java
+JsonDeserializationSchema<SomePojo> jsonFormat = new JsonDeserializationSchema<>(SomePojo.class);
+KafkaSource<SomePojo> source =
+    KafkaSource.<SomePojo>builder()
+        .setValueOnlyDeserializer(jsonFormat)
+        ...
+```
+
+The `JsonSerializationSchema` can be used with any connector that supports the `SerializationSchema`.
+
+For example, this is how you use it with a `KafkaSink` to serialize a `POJO`:
+
+```java
+JsonSerializationSchema<SomePojo> jsonFormat = new JsonSerializationSchema<>();
+KafkaSink<SomePojo> source =
+    KafkaSink.<SomePojo>builder()
+        .setRecordSerializer(
+            new KafkaRecordSerializationSchemaBuilder<>()
+                .setValueSerializationSchema(jsonFormat)
+                ...
+```
+
+## Custom Mapper
+
+Both schemas have constructors that accept a `SerializableSupplier<ObjectMapper>`, acting a factory for object mappers.
+With this factory you gain full control over the created mapper, and can enable/disable various Jackson features or register modules to extend the set of supported types or add additional functionality.
+
+```java
+JsonSerializationSchema<SomeClass> jsonFormat = new JsonSerializationSchema<>(
+    () -> new ObjectMapper()
+        .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS))
+        .registerModule(new ParameterNamesModule());
+```

--- a/docs/content/docs/connectors/datastream/formats/json.md
+++ b/docs/content/docs/connectors/datastream/formats/json.md
@@ -1,0 +1,77 @@
+---
+title:  "JSON"
+weight: 4
+type: docs
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Json format
+
+To use the JSON format you need to add the Flink JSON dependency to your project:
+
+```xml
+<dependency>
+	<groupId>org.apache.flink</groupId>
+	<artifactId>flink-json</artifactId>
+	<version>{{< version >}}</version>
+	<scope>provided</scope>
+</dependency>
+```
+
+Flink supports reading/writing JSON records via the `JsonSerializationSchema/JsonDeserializationSchema`.
+These utilize the [Jackson](https://github.com/FasterXML/jackson) library, and support any type that is supported by Jackson, including, but not limited to, `POJO`s and `ObjectNode`.
+
+The `JsonDeserializationSchema` can be used with any connector that supports the `DeserializationSchema`.
+
+For example, this is how you use it with a `KafkaSource` to deserialize a `POJO`:
+
+```java
+JsonDeserializationSchema<SomePojo> jsonFormat=new JsonDeserializationSchema<>(SomePojo.class);
+KafkaSource<SomePojo> source=
+    KafkaSource.<SomePojo>builder()
+        .setValueOnlyDeserializer(jsonFormat)
+        ...
+```
+
+The `JsonSerializationSchema` can be used with any connector that supports the `SerializationSchema`.
+
+For example, this is how you use it with a `KafkaSink` to serialize a `POJO`:
+
+```java
+JsonSerializationSchema<SomePojo> jsonFormat=new JsonSerializationSchema<>();
+KafkaSink<SomePojo> source  = 
+    KafkaSink.<SomePojo>builder()
+        .setRecordSerializer(
+            new KafkaRecordSerializationSchemaBuilder<>()
+                .setValueSerializationSchema(jsonFormat)
+                ...
+```
+
+## Custom Mapper
+
+Both schemas have constructors that accept a `SerializableSupplier<ObjectMapper>`, acting a factory for object mappers.
+With this factory you gain full control over the created mapper, and can enable/disable various Jackson features or register modules to extend the set of supported types or add additional functionality.
+
+```java
+JsonSerializationSchema<SomeClass> jsonFormat=new JsonSerializationSchema<>(
+    () -> new ObjectMapper()
+        .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS))
+        .registerModule(new ParameterNamesModule());
+```

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/deserializer/KafkaRecordDeserializationSchemaTest.java
@@ -18,8 +18,9 @@
 
 package org.apache.flink.connector.kafka.source.reader.deserializer;
 
+import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
 import org.apache.flink.connector.testutils.source.deserialization.TestingDeserializationContext;
-import org.apache.flink.formats.json.JsonNodeDeserializationSchema;
+import org.apache.flink.formats.json.JsonDeserializationSchema;
 import org.apache.flink.streaming.util.serialization.JSONKeyValueDeserializationSchema;
 import org.apache.flink.util.Collector;
 
@@ -35,7 +36,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,10 +58,11 @@ public class KafkaRecordDeserializationSchemaTest {
     }
 
     @Test
-    public void testKafkaDeserializationSchemaWrapper() throws IOException {
+    public void testKafkaDeserializationSchemaWrapper() throws Exception {
         final ConsumerRecord<byte[], byte[]> consumerRecord = getConsumerRecord();
         KafkaRecordDeserializationSchema<ObjectNode> schema =
                 KafkaRecordDeserializationSchema.of(new JSONKeyValueDeserializationSchema(true));
+        schema.open(new DummyInitializationContext());
         SimpleCollector<ObjectNode> collector = new SimpleCollector<>();
         schema.deserialize(consumerRecord, collector);
 
@@ -76,10 +77,12 @@ public class KafkaRecordDeserializationSchemaTest {
     }
 
     @Test
-    public void testKafkaValueDeserializationSchemaWrapper() throws IOException {
+    public void testKafkaValueDeserializationSchemaWrapper() throws Exception {
         final ConsumerRecord<byte[], byte[]> consumerRecord = getConsumerRecord();
         KafkaRecordDeserializationSchema<ObjectNode> schema =
-                KafkaRecordDeserializationSchema.valueOnly(new JsonNodeDeserializationSchema());
+                KafkaRecordDeserializationSchema.valueOnly(
+                        new JsonDeserializationSchema<>(ObjectNode.class));
+        schema.open(new DummyInitializationContext());
         SimpleCollector<ObjectNode> collector = new SimpleCollector<>();
         schema.deserialize(consumerRecord, collector);
 

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -111,6 +111,12 @@ under the License.
 		<!-- test utils dependency -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonDeserializationSchema.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.util.function.SerializableSupplier;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/** DeserializationSchema that deserializes a JSON String. */
+@PublicEvolving
+public class JsonDeserializationSchema<T> extends AbstractDeserializationSchema<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Class<T> clazz;
+    private final SerializableSupplier<ObjectMapper> mapperFactory;
+    protected transient ObjectMapper mapper;
+
+    public JsonDeserializationSchema(Class<T> clazz) {
+        this(clazz, () -> new ObjectMapper());
+    }
+
+    public JsonDeserializationSchema(TypeInformation<T> typeInformation) {
+        this(typeInformation, () -> new ObjectMapper());
+    }
+
+    public JsonDeserializationSchema(
+            Class<T> clazz, SerializableSupplier<ObjectMapper> mapperFactory) {
+        super(clazz);
+        this.clazz = clazz;
+        this.mapperFactory = mapperFactory;
+    }
+
+    public JsonDeserializationSchema(
+            TypeInformation<T> typeInformation, SerializableSupplier<ObjectMapper> mapperFactory) {
+        super(typeInformation);
+        this.clazz = typeInformation.getTypeClass();
+        this.mapperFactory = mapperFactory;
+    }
+
+    @Override
+    public void open(InitializationContext context) {
+        mapper = mapperFactory.get();
+    }
+
+    @Override
+    public T deserialize(byte[] message) throws IOException {
+        return mapper.readValue(message, clazz);
+    }
+}

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonNodeDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonNodeDeserializationSchema.java
@@ -23,8 +23,10 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Obje
  * DeserializationSchema that deserializes a JSON String into an ObjectNode.
  *
  * <p>Fields can be accessed by calling objectNode.get(&lt;name>).as(&lt;type>)
+ *
+ * @deprecated Use {@code new JsonDeserializationSchema(ObjectNode.class)} instead
  */
-@PublicEvolving
+@Deprecated
 public class JsonNodeDeserializationSchema extends JsonDeserializationSchema<ObjectNode> {
 
     private static final long serialVersionUID = 2L;

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonNodeDeserializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonNodeDeserializationSchema.java
@@ -17,13 +17,7 @@
 
 package org.apache.flink.formats.json;
 
-import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.api.common.serialization.AbstractDeserializationSchema;
-
-import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
-
-import java.io.IOException;
 
 /**
  * DeserializationSchema that deserializes a JSON String into an ObjectNode.
@@ -31,14 +25,11 @@ import java.io.IOException;
  * <p>Fields can be accessed by calling objectNode.get(&lt;name>).as(&lt;type>)
  */
 @PublicEvolving
-public class JsonNodeDeserializationSchema extends AbstractDeserializationSchema<ObjectNode> {
+public class JsonNodeDeserializationSchema extends JsonDeserializationSchema<ObjectNode> {
 
-    private static final long serialVersionUID = -1699854177598621044L;
+    private static final long serialVersionUID = 2L;
 
-    private final ObjectMapper mapper = new ObjectMapper();
-
-    @Override
-    public ObjectNode deserialize(byte[] message) throws IOException {
-        return mapper.readValue(message, ObjectNode.class);
+    public JsonNodeDeserializationSchema() {
+        super(ObjectNode.class);
     }
 }

--- a/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonSerializationSchema.java
+++ b/flink-formats/flink-json/src/main/java/org/apache/flink/formats/json/JsonSerializationSchema.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.util.function.SerializableSupplier;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+
+/** SerializationSchema that serializes an object to a JSON String. */
+@PublicEvolving
+public class JsonSerializationSchema<T> implements SerializationSchema<T> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final SerializableSupplier<ObjectMapper> mapperFactory;
+
+    protected transient ObjectMapper mapper;
+
+    public JsonSerializationSchema() {
+        this(() -> new ObjectMapper());
+    }
+
+    public JsonSerializationSchema(SerializableSupplier<ObjectMapper> mapperFactory) {
+        this.mapperFactory = mapperFactory;
+    }
+
+    @Override
+    public void open(InitializationContext context) {
+        mapper = mapperFactory.get();
+    }
+
+    @Override
+    public byte[] serialize(T element) {
+        try {
+            return mapper.writeValueAsBytes(element);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(
+                    String.format("Could not serialize value '%s'.", element), e);
+        }
+    }
+}

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link JsonNodeDeserializationSchema}. */
+@SuppressWarnings("deprecation")
 class JsonNodeDeserializationSchemaTest {
 
     @Test

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonNodeDeserializationSchemaTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.formats.json;
 
+import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
+
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.ObjectNode;
 
@@ -37,6 +39,7 @@ class JsonNodeDeserializationSchemaTest {
         byte[] serializedValue = mapper.writeValueAsBytes(initialValue);
 
         JsonNodeDeserializationSchema schema = new JsonNodeDeserializationSchema();
+        schema.open(new DummyInitializationContext());
         ObjectNode deserializedValue = schema.deserialize(serializedValue);
 
         assertThat(deserializedValue.get("key").asInt()).isEqualTo(4);

--- a/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonSerDeSchemaTest.java
+++ b/flink-formats/flink-json/src/test/java/org/apache/flink/formats/json/JsonSerDeSchemaTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.json;
+
+import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JsonSerDeSchemaTest {
+    private static final JsonSerializationSchema<Event> SERIALIZATION_SCHEMA;
+    private static final JsonDeserializationSchema<Event> DESERIALIZATION_SCHEMA;
+    private static final String JSON = "{\"x\":34,\"y\":\"hello\"}";
+
+    static {
+        SERIALIZATION_SCHEMA = new JsonSerializationSchema<>();
+        SERIALIZATION_SCHEMA.open(new DummyInitializationContext());
+        DESERIALIZATION_SCHEMA = new JsonDeserializationSchema<>(Event.class);
+        DESERIALIZATION_SCHEMA.open(new DummyInitializationContext());
+    }
+
+    @Test
+    void testSrialization() throws IOException {
+        final byte[] serialized = SERIALIZATION_SCHEMA.serialize(new Event(34, "hello"));
+        assertThat(serialized).isEqualTo(JSON.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void testDeserialization() throws IOException {
+        final Event deserialized =
+                DESERIALIZATION_SCHEMA.deserialize(JSON.getBytes(StandardCharsets.UTF_8));
+        assertThat(deserialized).isEqualTo(new Event(34, "hello"));
+    }
+
+    @Test
+    void testRoundTrip() throws IOException {
+        final Event original = new Event(34, "hello");
+
+        final byte[] serialized = SERIALIZATION_SCHEMA.serialize(original);
+
+        final Event deserialized = DESERIALIZATION_SCHEMA.deserialize(serialized);
+
+        assertThat(deserialized).isEqualTo(original);
+    }
+
+    private static class Event {
+
+        private int x;
+        private String y = null;
+
+        public Event() {}
+
+        public Event(int x, String y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        public int getX() {
+            return x;
+        }
+
+        public void setX(int x) {
+            this.x = x;
+        }
+
+        public String getY() {
+            return y;
+        }
+
+        public void setY(String y) {
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Event event = (Event) o;
+            return x == event.x && Objects.equals(y, event.y);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(x, y);
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/formats/DummyInitializationContext.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testutils/formats/DummyInitializationContext.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testutils.formats;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.util.SimpleUserCodeClassLoader;
+import org.apache.flink.util.UserCodeClassLoader;
+
+/** A dummy context for serialization schemas. */
+public class DummyInitializationContext
+        implements SerializationSchema.InitializationContext,
+                DeserializationSchema.InitializationContext {
+
+    @Override
+    public MetricGroup getMetricGroup() {
+        return new UnregisteredMetricsGroup();
+    }
+
+    @Override
+    public UserCodeClassLoader getUserCodeClassLoader() {
+        return SimpleUserCodeClassLoader.create(DummyInitializationContext.class.getClassLoader());
+    }
+}


### PR DESCRIPTION
Add a basic JSON (de)serialization scheme for reading/writing any jackson-supported type.

Also deprecates the `JsonNodeDeserializationSchema` because it's now kinda redundant.