### PR TITLE
[hotfix] [docs] Update gradle build script in the overview.md

### DIFF
--- a/docs/content/docs/dev/configuration/overview.md
+++ b/docs/content/docs/dev/configuration/overview.md
@@ -130,7 +130,7 @@ repositories {
 configurations {
     flinkShadowJar // dependencies which go into the shadowJar
     // always exclude these (also from transitive dependencies) since they are provided by Flink
-    flinkShadowJar.exclude group: 'org.apache.flink', module: 'force-shading'
+    flinkShadowJar.exclude group: 'org.apache.flink', module: 'flink-shaded-force-shading'
     flinkShadowJar.exclude group: 'com.google.code.findbugs', module: 'jsr305'
     flinkShadowJar.exclude group: 'org.slf4j'
     flinkShadowJar.exclude group: 'org.apache.logging.log4j'


### PR DESCRIPTION
Use `flink-shaded-force-shanding` instead of `force-shading` in the excludes since at least 1.15.x use that naming.

## Brief change log

* Just an artifactId update in the `flinkShadowJar` excludes in the gradle build script example.   

## Verifying this change

This change is a trivial docs update without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): *no*
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: *no*
  - The serializers: *no*
  - The runtime per-record code paths (performance sensitive): *no*
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: *no*
  - The S3 file system connector: *no*

## Documentation

  - Does this pull request introduce a new feature? *no*
  - If yes, how is the feature documented? *not applicable*
