### PR TITLE
[FLINK-28177][Connectors/ElasticSearch] add retry in elasticsearch ta…

### DIFF
--- a/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
+++ b/flink-connectors/flink-connector-elasticsearch6/src/test/java/org/apache/flink/streaming/connectors/elasticsearch/table/Elasticsearch6DynamicSinkITCase.java
@@ -231,8 +231,11 @@ public class Elasticsearch6DynamicSinkITCase extends TestLogger {
 
     @Test
     public void testWritingDocumentsNoPrimaryKey() throws Exception {
-        TableEnvironment tableEnvironment =
-                TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        EnvironmentSettings settings = EnvironmentSettings.inStreamingMode();
+        settings.getConfiguration().setString("restart-strategy", "fixed-delay");
+        settings.getConfiguration().setInteger("restart-strategy.fixed-delay.attempts", 3);
+        // default fixed delay is 1 seconds
+        TableEnvironment tableEnvironment = TableEnvironment.create(settings);
 
         String index = "no-primary-key";
         String myType = "MyType";


### PR DESCRIPTION
## What is the purpose of the change

  Fix FLINK-28177, this it case failed sometimes because  elasticsearch service  is temporary unavaliable. So I add fixed restart strategy to avoid this failure in a sense.


## Brief change log
- Add job restart strategy in flink table setting


## Verifying this change

None

## Does this pull request potentially affect one of the following parts:

None

## Documentation

None
