### PR TITLE
[FLINK-28680] Revisit 'free_disk_space.sh' to free up more space

### DIFF
--- a/tools/azure-pipelines/free_disk_space.sh
+++ b/tools/azure-pipelines/free_disk_space.sh
@@ -43,6 +43,12 @@ sudo apt-get autoremove -y
 sudo apt-get clean
 df -h
 echo "Removing large directories"
-# deleting 15GB
-rm -rf /usr/share/dotnet/
+
+sudo rm -rf /usr/share/dotnet/
+sudo rm -rf /usr/local/graalvm/
+sudo rm -rf /usr/local/.ghcup/
+sudo rm -rf /usr/local/share/powershell
+sudo rm -rf /usr/local/share/chromium
+sudo rm -rf /usr/local/lib/android
+sudo rm -rf /usr/local/lib/node_modules
 df -h


### PR DESCRIPTION
## What is the purpose of the change

Tests are running out of disk space. With this PR we'll have 53 instead of 24GB available.
