### PR TITLE
[FLINK-28651] [Runtime / REST] JarRunHandler gets restore mode from configuration when it is missing in the request

### DIFF
--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -148,7 +148,7 @@ public class JarRunHandler
                         log);
         final RestoreMode restoreMode =
                 Optional.ofNullable(requestBody.getRestoreMode())
-                        .orElseGet(SavepointConfigOptions.RESTORE_MODE::defaultValue);
+                        .orElse(configuration.get(SavepointConfigOptions.RESTORE_MODE));
         final SavepointRestoreSettings savepointRestoreSettings;
         if (savepointPath != null) {
             savepointRestoreSettings =

--- a/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
+++ b/flink-runtime-web/src/main/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandler.java
@@ -125,7 +125,8 @@ public class JarRunHandler
                         });
     }
 
-    private SavepointRestoreSettings getSavepointRestoreSettings(
+    @VisibleForTesting
+    SavepointRestoreSettings getSavepointRestoreSettings(
             final @Nonnull HandlerRequest<JarRunRequestBody> request) throws RestHandlerException {
 
         final JarRunRequestBody requestBody = request.getRequestBody();

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarRunHandlerTest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.webmonitor.handlers;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.client.deployment.application.ApplicationRunner;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.RestoreMode;
+import org.apache.flink.runtime.jobgraph.SavepointConfigOptions;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.webmonitor.TestingDispatcherGateway;
+import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/** Tests for {@link JarRunHandler}. */
+class JarRunHandlerTest {
+    private static final Time TIMEOUT = Time.seconds(10);
+    private static final Map<String, String> RESPONSE_HEADERS = Collections.emptyMap();
+    private static final String SAVEPOINT_PATH = "dummy/path";
+
+    @Test
+    void testGetSavepointRestoreSettings() throws Exception {
+        assertGetSavepointRestoreSettings(new Configuration(), null, RestoreMode.NO_CLAIM);
+        assertGetSavepointRestoreSettings(
+                getConfig(RestoreMode.NO_CLAIM), null, RestoreMode.NO_CLAIM);
+        assertGetSavepointRestoreSettings(
+                new Configuration(), RestoreMode.NO_CLAIM, RestoreMode.NO_CLAIM);
+        assertGetSavepointRestoreSettings(getConfig(RestoreMode.CLAIM), null, RestoreMode.CLAIM);
+        assertGetSavepointRestoreSettings(
+                new Configuration(), RestoreMode.CLAIM, RestoreMode.CLAIM);
+        assertGetSavepointRestoreSettings(getConfig(RestoreMode.LEGACY), null, RestoreMode.LEGACY);
+        assertGetSavepointRestoreSettings(
+                new Configuration(), RestoreMode.LEGACY, RestoreMode.LEGACY);
+        assertGetSavepointRestoreSettings(
+                getConfig(RestoreMode.LEGACY), RestoreMode.CLAIM, RestoreMode.CLAIM);
+    }
+
+    private static void assertGetSavepointRestoreSettings(
+            Configuration configuration, RestoreMode request, RestoreMode expected)
+            throws Exception {
+        JarRunHandler jarRunHandler = getJarRunHandler(configuration);
+        HandlerRequest<JarRunRequestBody> handlerRequest = getHandlerRequest(request);
+        SavepointRestoreSettings savepointRestoreSettings =
+                jarRunHandler.getSavepointRestoreSettings(handlerRequest);
+        assertEquals(expected, savepointRestoreSettings.getRestoreMode());
+    }
+
+    private static Configuration getConfig(RestoreMode restoreMode) {
+        Configuration configuration = new Configuration();
+        configuration.set(SavepointConfigOptions.RESTORE_MODE, restoreMode);
+        return configuration;
+    }
+
+    private static HandlerRequest<JarRunRequestBody> getHandlerRequest(RestoreMode restoreMode) {
+        HandlerRequest<JarRunRequestBody> handlerRequest =
+                (HandlerRequest<JarRunRequestBody>) mock(HandlerRequest.class);
+        JarRunRequestBody requestBody =
+                new JarRunRequestBody(
+                        null,
+                        null,
+                        null,
+                        Integer.MAX_VALUE,
+                        new JobID(),
+                        false,
+                        SAVEPOINT_PATH,
+                        restoreMode);
+        when(handlerRequest.getRequestBody()).thenReturn(requestBody);
+        return handlerRequest;
+    }
+
+    private static JarRunHandler getJarRunHandler(Configuration configuration) {
+        return new JarRunHandler(
+                (GatewayRetriever<TestingDispatcherGateway>) mock(GatewayRetriever.class),
+                TIMEOUT,
+                RESPONSE_HEADERS,
+                JarRunHeaders.getInstance(),
+                mock(Path.class),
+                configuration,
+                mock(ScheduledExecutorService.class),
+                (Supplier<ApplicationRunner>) mock(Supplier.class));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request updates `JarRunHandler` to get the restore mode from the configuration when it is missing from the run request.

## Brief change log

- `getSavepointRestoreSettings` in `JarRunHandler` gets the restore mode from the configuration when it is not defined in the run request
- `JarRunHandlerTest` was added to test the `getSavepointRestoreSettings` method

## Verifying this change

This change added tests and can be verified as follows:

- Added test that validates that `getSavepointRestoreSettings` uses configuration to get the restore mode when it is not defined in the request

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
