### PR TITLE
[FLINK-19589][Filesystem][S3] Support per-connector FileSystem configuration

### DIFF
--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/java/org/apache/flink/fs/s3hadoop/S3FileSystemFactory.java
@@ -25,13 +25,18 @@ import org.apache.flink.runtime.util.HadoopConfigLoader;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.s3a.S3AFileSystem;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
 import java.net.URI;
+import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /** Simple factory for the S3 file system. */
 public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
@@ -39,6 +44,8 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
     private static final Logger LOG = LoggerFactory.getLogger(S3FileSystemFactory.class);
 
     private static final String[] FLINK_CONFIG_PREFIXES = {"s3.", "s3a.", "fs.s3a."};
+
+    private static final String FS_S3A_PREFIX = "fs.s3a.";
 
     private static final String[][] MIRRORED_CONFIG_KEYS = {
         {"fs.s3a.access-key", "fs.s3a.access.key"},
@@ -87,7 +94,52 @@ public class S3FileSystemFactory extends AbstractS3FileSystemFactory {
 
         LOG.debug("Using scheme {} for s3a file system backing the S3 File System", fsUri);
 
-        return fsUri;
+        /*
+        While s3a settings can be set through flink-conf, it may be desirable to set these
+        configuration items dynamically. To support this, we can use the query parameters allowed in
+        a URI to extract these values and apply them to the Hadoop Configuration before passing
+        to Hadoop-AWS.
+
+        As an example, this can allow connectors to programmatically create an S3 URI with an
+        AssumeRoleCredentialProvider and role ARN, which will be consumed here. The URI's query
+        parameters are removed before returning.
+
+        NB: Flink maintains a FileSystem cache where the `FSKey` is made up of the scheme and
+        authority (bucket name). In a session cluster with multiple AWS accounts, a collision may
+        be possible.
+         */
+        try {
+            Map<String, String> queryParams = parseQueryParams(fsUri);
+            if (queryParams.isEmpty()) {
+                return fsUri;
+            }
+            queryParams.entrySet().stream()
+                    .filter(e -> e.getKey().startsWith(FS_S3A_PREFIX))
+                    .forEach(
+                            e -> {
+                                LOG.debug(
+                                        "Setting Hadoop config key '{}' to '{}'",
+                                        e.getKey(),
+                                        e.getValue());
+                                hadoopConfig.set(e.getKey(), e.getValue());
+                            });
+
+            // Remove the query parameters now that they've been consumed
+            URI cleanURI =
+                    new URI(fsUri.getScheme(), fsUri.getAuthority(), fsUri.getPath(), null, null);
+            LOG.debug(
+                    "Consumed and applied all 'fs.s3a' parameters from URI. Returning clean URI: {}",
+                    cleanURI);
+            return cleanURI;
+        } catch (Exception e) {
+            LOG.error("Could not parse and apply URI query params to Hadoop Configuration", e);
+            return fsUri;
+        }
+    }
+
+    protected static Map<String, String> parseQueryParams(URI fsUri) {
+        return URLEncodedUtils.parse(fsUri, Charset.forName("UTF-8")).stream()
+                .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue));
     }
 
     @Nullable


### PR DESCRIPTION
## What is the purpose of the change

Introduces dynamic filesystem configuration for S3

## Brief change log

  - *Add URI query parameter parsing and apply `fs.s3a.` entries to Hadoop Configuration for S3/S3A*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - *Added unit test that verifies URI parameters are parsed and applied to Hadoop configuration*
  - *A version of this is running in production for an S3-backed sink using an AssumedRoleProvider and dynamic role ARN*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
