### PR TITLE
[FLINK-28696][runtime] Fix the bug that the blocklist listeners will not be notified when there are no newly added nodes (only merge nodes)

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/BlocklistDeclarativeSlotPool.java
@@ -31,9 +31,6 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
@@ -50,8 +47,6 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * blocked nodes.
  */
 public class BlocklistDeclarativeSlotPool extends DefaultDeclarativeSlotPool {
-
-    private static final Logger LOG = LoggerFactory.getLogger(BlocklistDeclarativeSlotPool.class);
 
     private final BlockedTaskManagerChecker blockedTaskManagerChecker;
 
@@ -109,7 +104,7 @@ public class BlocklistDeclarativeSlotPool extends DefaultDeclarativeSlotPool {
             }
         }
 
-        LOG.debug(
+        log.debug(
                 "Received {} slots from a blocked TaskManager {}, {} was accepted before: {}, {} was rejected: {}.",
                 offers.size(),
                 taskManagerLocation,
@@ -134,7 +129,7 @@ public class BlocklistDeclarativeSlotPool extends DefaultDeclarativeSlotPool {
         if (!isBlockedTaskManager(taskManagerId)) {
             return super.freeReservedSlot(allocationId, cause, currentTime);
         } else {
-            LOG.debug("Free reserved slot {}.", allocationId);
+            log.debug("Free reserved slot {}.", allocationId);
             return releaseSlot(
                     allocationId,
                     new FlinkRuntimeException(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/slotpool/DefaultDeclarativeSlotPool.java
@@ -84,7 +84,7 @@ import java.util.stream.Collectors;
  */
 public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DefaultDeclarativeSlotPool.class);
+    protected final Logger log = LoggerFactory.getLogger(getClass());
 
     private final Consumer<? super Collection<ResourceRequirement>> notifyNewResourceRequirements;
 
@@ -151,7 +151,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
     private void declareResourceRequirements() {
         final Collection<ResourceRequirement> resourceRequirements = getResourceRequirements();
 
-        LOG.debug(
+        log.debug(
                 "Declare new resource requirements for job {}.{}\trequired resources: {}{}\tacquired resources: {}",
                 jobId,
                 System.lineSeparator(),
@@ -182,7 +182,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
             TaskManagerGateway taskManagerGateway,
             long currentTime) {
 
-        LOG.debug("Received {} slot offers from TaskExecutor {}.", offers, taskManagerLocation);
+        log.debug("Received {} slot offers from TaskExecutor {}.", offers, taskManagerLocation);
 
         return internalOfferSlots(
                 offers,
@@ -213,7 +213,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
                     acceptedSlotOffers.add(offer);
                     acceptedSlots.add(acceptedSlot.get());
                 } else {
-                    LOG.debug(
+                    log.debug(
                             "Could not match offer {} to any outstanding requirement.",
                             offer.getAllocationId());
                 }
@@ -223,7 +223,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
         slotPool.addSlots(acceptedSlots, currentTime);
 
         if (!acceptedSlots.isEmpty()) {
-            LOG.debug(
+            log.debug(
                     "Acquired new resources; new total acquired resources: {}",
                     fulfilledResourceRequirements);
             newSlotsListener.notifyNewSlotsAreAvailable(acceptedSlots);
@@ -246,7 +246,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
         // While this approach does have the downside of somewhat hiding this special case, it
         // does allow the slot timeouts or releases to work as if the case didn't exist at all.
 
-        LOG.debug("Register slots {} from TaskManager {}.", slots, taskManagerLocation);
+        log.debug("Register slots {} from TaskManager {}.", slots, taskManagerLocation);
         internalOfferSlots(
                 slots,
                 taskManagerLocation,
@@ -279,7 +279,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
         if (match.isPresent()) {
             final ResourceProfile matchedRequirement = match.get();
-            LOG.debug(
+            log.debug(
                     "Matched slot offer {} to requirement {}.",
                     slotOffer.getAllocationId(),
                     matchedRequirement);
@@ -356,7 +356,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
             // computed when the slot was offered, so we have to update the mapping
             updateSlotToRequirementProfileMapping(allocationId, requiredSlotProfile);
             if (previouslyMatchedResourceProfile == ResourceProfile.ANY) {
-                LOG.debug(
+                log.debug(
                         "Re-matched slot offer {} to requirement {}.",
                         allocationId,
                         requiredSlotProfile);
@@ -366,7 +366,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
                 // If the previous profile was ANY, then the slot was accepted without
                 // being matched against a resource requirement; thus no update is needed.
 
-                LOG.debug(
+                log.debug(
                         "Adjusting requirements because a slot was reserved for a different requirement than initially assumed. Slot={} assumedRequirement={} actualRequirement={}",
                         allocationId,
                         previouslyMatchedResourceProfile,
@@ -381,7 +381,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
     @Override
     public ResourceCounter freeReservedSlot(
             AllocationID allocationId, @Nullable Throwable cause, long currentTime) {
-        LOG.debug("Free reserved slot {}.", allocationId);
+        log.debug("Free reserved slot {}.", allocationId);
 
         final Optional<AllocatedSlot> freedSlot =
                 slotPool.freeReservedSlot(allocationId, currentTime);
@@ -523,7 +523,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
 
         releaseSlots(
                 slotsToReturnToOwner, new FlinkException("Returning idle slots to their owners."));
-        LOG.debug(
+        log.debug(
                 "Idle slots have been returned; new total acquired resources: {}",
                 fulfilledResourceRequirements);
     }
@@ -532,10 +532,10 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
         for (AllocatedSlot slotToReturn : slotsToReturnToOwner) {
             Preconditions.checkState(!slotToReturn.isUsed(), "Free slot must not be used.");
 
-            if (LOG.isDebugEnabled()) {
-                LOG.info("Releasing slot [{}].", slotToReturn.getAllocationId(), cause);
+            if (log.isDebugEnabled()) {
+                log.info("Releasing slot [{}].", slotToReturn.getAllocationId(), cause);
             } else {
-                LOG.info("Releasing slot [{}].", slotToReturn.getAllocationId());
+                log.info("Releasing slot [{}].", slotToReturn.getAllocationId());
             }
 
             final ResourceProfile matchingResourceProfile =
@@ -553,7 +553,7 @@ public class DefaultDeclarativeSlotPool implements DeclarativeSlotPool {
                     (Acknowledge ignored, Throwable throwable) -> {
                         if (throwable != null) {
                             // The slot status will be synced to task manager in next heartbeat.
-                            LOG.debug(
+                            log.debug(
                                     "Releasing slot [{}] of registered TaskExecutor {} failed. Discarding slot.",
                                     slotToReturn.getAllocationId(),
                                     slotToReturn.getTaskManagerId(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blocklist/DefaultBlocklistHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blocklist/DefaultBlocklistHandlerTest.java
@@ -56,38 +56,50 @@ class DefaultBlocklistHandlerTest {
 
     @Test
     void testAddNewBlockedNodes() throws Exception {
-        BlockedNode node1 = new BlockedNode("node1", "cause", Long.MAX_VALUE);
-        BlockedNode node2 = new BlockedNode("node2", "cause", Long.MAX_VALUE);
+        BlockedNode node1 = new BlockedNode("node1", "cause", 1L);
+        BlockedNode node2 = new BlockedNode("node2", "cause", 1L);
+        BlockedNode node2Update = new BlockedNode("node2", "cause", 2L);
 
-        Collection<BlockedNode> allBlockedNodes = new ArrayList<>();
+        List<List<BlockedNode>> contextReceivedNodes = new ArrayList<>();
+
         TestBlocklistContext context =
                 TestBlocklistContext.newBuilder()
-                        .setBlockResourcesConsumer(allBlockedNodes::addAll)
+                        .setBlockResourcesConsumer(
+                                blockedNodes ->
+                                        contextReceivedNodes.add(new ArrayList<>(blockedNodes)))
                         .build();
         TestBlocklistListener listener = new TestBlocklistListener();
 
         try (DefaultBlocklistHandler handler = createDefaultBlocklistHandler(context)) {
             handler.registerBlocklistListener(listener);
-            assertThat(listener.notifiedTimes).isEqualTo(0);
-            assertThat(listener.notifiedNodes).isEmpty();
-            assertThat(allBlockedNodes).isEmpty();
+            assertThat(listener.listenerReceivedNodes).isEmpty();
+            assertThat(contextReceivedNodes).isEmpty();
 
             // add node1, node2
             handler.addNewBlockedNodes(Arrays.asList(node1, node2));
             // check listener and context
-            assertThat(listener.notifiedTimes).isEqualTo(1);
-            assertThat(listener.notifiedNodes).containsExactlyInAnyOrder(node1, node2);
-            assertThat(allBlockedNodes).containsExactlyInAnyOrder(node1, node2);
+            assertThat(listener.listenerReceivedNodes).hasSize(1);
+            assertThat(listener.listenerReceivedNodes.get(0))
+                    .containsExactlyInAnyOrder(node1, node2);
+            assertThat(contextReceivedNodes).hasSize(1);
+            assertThat(contextReceivedNodes.get(0)).containsExactlyInAnyOrder(node1, node2);
 
-            // add node1, node2 again, should not notify listener
-            handler.addNewBlockedNodes(Arrays.asList(node1, node2));
-            assertThat(listener.notifiedTimes).isEqualTo(1);
+            // add node1, node2 again, should not notify context and listener
+            assertThat(contextReceivedNodes).hasSize(1);
+            assertThat(listener.listenerReceivedNodes).hasSize(1);
+
+            // update node2, should notify listener, not notify context
+            handler.addNewBlockedNodes(Collections.singleton(node2Update));
+            assertThat(listener.listenerReceivedNodes).hasSize(2);
+            assertThat(listener.listenerReceivedNodes.get(1)).containsExactly(node2Update);
+            assertThat(contextReceivedNodes).hasSize(1);
 
             // register a new listener, will notify all items
             TestBlocklistListener listener2 = new TestBlocklistListener();
             handler.registerBlocklistListener(listener2);
-            assertThat(listener2.notifiedTimes).isEqualTo(1);
-            assertThat(listener2.notifiedNodes).containsExactlyInAnyOrder(node1, node2);
+            assertThat(listener2.listenerReceivedNodes).hasSize(1);
+            assertThat(listener2.listenerReceivedNodes.get(0))
+                    .containsExactlyInAnyOrder(node1, node2Update);
         }
     }
 
@@ -187,15 +199,12 @@ class DefaultBlocklistHandlerTest {
 
     private static class TestBlocklistListener implements BlocklistListener {
 
-        private int notifiedTimes = 0;
-
-        private final List<BlockedNode> notifiedNodes = new ArrayList<>();
+        private final List<List<BlockedNode>> listenerReceivedNodes = new ArrayList<>();
 
         @Override
         public CompletableFuture<Acknowledge> notifyNewBlockedNodes(
                 Collection<BlockedNode> newNodes) {
-            notifiedTimes++;
-            notifiedNodes.addAll(newNodes);
+            listenerReceivedNodes.add(new ArrayList<>(newNodes));
             return CompletableFuture.completedFuture(Acknowledge.get());
         }
     }


### PR DESCRIPTION
## What is the purpose of the change
[FLINK-28696][runtime] Fix the bug that the blocklist listeners will not be notified when there are no newly added nodes (only merge nodes)


## Verifying this change
`DefaultBlocklistHandlerTest#testAddNewBlockedNodes`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
