### PR TITLE
[FLINK-28697][table] MapDataSerializer doesn't declare a serialVersionUID

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/MapDataSerializer.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 @Internal
 public class MapDataSerializer extends TypeSerializer<MapData> {
 
+    private static final long serialVersionUID = 1L;
     private final LogicalType keyType;
     private final LogicalType valueType;
 


### PR DESCRIPTION
## What is the purpose of the change

*MapDataSerializer doesn't declare a serialVersionUID, which can manifest as a InvalidClassException when attempting to serialize with different JREs for compilation / runtime.*


## Brief change log

  - * Set it to serialVersionUID to 1L as with the other TypeSerializers*

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

 - *Verified manually that this solves the serialization mismatch*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: don't know
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
