### PR TITLE
[FLINK-27908][network] Introduce HsResultPartition and HsSubpartitionView

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -94,9 +94,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
     }
 
     @Override
-    public void setup() throws IOException {
-        super.setup();
-
+    protected void setupInternal() throws IOException {
         checkState(
                 bufferPool.getNumberOfRequiredMemorySegments() >= getNumberOfSubpartitions(),
                 "Bug in result partition setup logic: Buffer pool has not enough guaranteed buffers for"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartition.java
@@ -158,8 +158,12 @@ public abstract class ResultPartition implements ResultPartitionWriter {
                 "Bug in result partition setup logic: Already registered buffer pool.");
 
         this.bufferPool = checkNotNull(bufferPoolFactory.get());
+        setupInternal();
         partitionManager.registerResultPartition(this);
     }
+
+    /** Do the subclass's own setup operation. */
+    protected abstract void setupInternal() throws IOException;
 
     public String getOwningTaskName() {
         return owningTaskName;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.BufferPoolFactory;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsResultPartition;
+import org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleConfiguration;
 import org.apache.flink.runtime.shuffle.NettyShuffleUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
@@ -213,6 +215,26 @@ public class ResultPartitionFactory {
 
                 partition = blockingPartition;
             }
+        } else if (type == ResultPartitionType.HYBRID) {
+            partition =
+                    new HsResultPartition(
+                            taskNameWithSubtaskAndId,
+                            partitionIndex,
+                            id,
+                            type,
+                            subpartitions.length,
+                            maxParallelism,
+                            batchShuffleReadBufferPool,
+                            batchShuffleReadIOExecutor,
+                            partitionManager,
+                            channelManager.createChannel().getPath(),
+                            networkBufferSize,
+                            HybridShuffleConfiguration.builder(
+                                            numberOfSubpartitions,
+                                            batchShuffleReadBufferPool.getNumBuffersPerRequest())
+                                    .build(),
+                            bufferCompressor,
+                            bufferPoolFactory);
         } else {
             throw new IllegalArgumentException("Unrecognized ResultPartitionType: " + type);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -89,7 +89,7 @@ public enum ResultPartitionType {
      *
      * <p>Hybrid partitions can be consumed any time, whether fully produced or not.
      */
-    HYBRID(true, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);
+    HYBRID(false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);
 
     /** Does this partition use a limited number of (network) buffers? */
     private final boolean isBounded;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -173,7 +173,7 @@ public class SortMergeResultPartition extends ResultPartition {
     }
 
     @Override
-    public void setup() throws IOException {
+    protected void setupInternal() throws IOException {
         synchronized (lock) {
             if (isReleased()) {
                 throw new IOException("Result partition has been released.");
@@ -189,8 +189,6 @@ public class SortMergeResultPartition extends ResultPartition {
 
         // initialize the buffer pool eagerly to avoid reporting errors such as OOM too late
         readBufferPool.initialize();
-        super.setup();
-
         LOG.info("Sort-merge partition {} initialized.", getPartitionId());
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsDataView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsDataView.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+
+import java.util.Optional;
+
+/**
+ * A view for {@link HsSubpartitionView} to find out what data exists in memory or disk and polling
+ * the data.
+ */
+public interface HsDataView {
+
+    /**
+     * Try to consume next buffer.
+     *
+     * <p>Only invoked by consumer thread.
+     *
+     * @param nextBufferToConsume next buffer index to consume.
+     * @return If the target buffer does exist, return buffer and next buffer's backlog, otherwise
+     *     return {@link Optional#empty()}.
+     */
+    Optional<BufferAndBacklog> consumeBuffer(int nextBufferToConsume) throws Throwable;
+
+    /**
+     * Get dataType of next buffer to consume.
+     *
+     * @param nextBufferToConsume next buffer index to consume
+     * @return next buffer's dataType. If not found in memory, return {@link DataType#NONE}.
+     */
+    DataType peekNextToConsumeDataType(int nextBufferToConsume);
+
+    /**
+     * Get the number of buffers backlog.
+     *
+     * @return backlog of this view's corresponding subpartition.
+     */
+    int getBacklog();
+
+    /** Release this {@link HsDataView} when related subpartition view is releasing. */
+    void releaseDataView();
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -121,7 +121,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
      * #subpartitionViewOperationsMap}. It is used to obtain the consumption progress of the
      * subpartition.
      */
-    public void registerSubpartitionView(
+    public HsDataView registerSubpartitionView(
             int subpartitionId, HsSubpartitionViewInternalOperations viewOperations) {
         HsSubpartitionViewInternalOperations oldView =
                 subpartitionViewOperationsMap.put(subpartitionId, viewOperations);
@@ -130,6 +130,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
                     "subpartition : {} register subpartition view will replace old view. ",
                     subpartitionId);
         }
+        return getSubpartitionMemoryDataManager(subpartitionId);
     }
 
     /** Close this {@link HsMemoryDataManager}, it means no data can append to memory. */
@@ -316,26 +317,6 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
             return callable.get();
         } finally {
             lock.unlock();
-        }
-    }
-
-    /** Integrate the buffer and dataType of next buffer. */
-    public static class BufferAndNextDataType {
-        private final Buffer buffer;
-
-        private final Buffer.DataType nextDataType;
-
-        public BufferAndNextDataType(Buffer buffer, Buffer.DataType nextDataType) {
-            this.buffer = buffer;
-            this.nextDataType = nextDataType;
-        }
-
-        public Buffer getBuffer() {
-            return buffer;
-        }
-
-        public Buffer.DataType getNextDataType() {
-            return nextDataType;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -255,7 +255,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
         bufferPool.recycle(buffer);
     }
 
-    public <T, R extends Exception> T callWithLock(SupplierWithException<T, R> callable) throws R {
+    private <T, R extends Exception> T callWithLock(SupplierWithException<T, R> callable) throws R {
         try {
             lock.lock();
             return callable.get();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerOperation.java
@@ -49,4 +49,11 @@ public interface HsMemoryDataManagerOperation {
 
     /** This method is called when buffer is finished. */
     void onBufferFinished();
+
+    /**
+     * This method is called when subpartition data become available.
+     *
+     * @param subpartitionId the subpartition need notify data available.
+     */
+    void onDataAvailable(int subpartitionId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.network.api.EndOfData;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.StopMode;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.ResultPartition;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.util.function.SupplierWithException;
+
+import javax.annotation.Nullable;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.concurrent.Executor;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * {@link HsResultPartition} appends records and events to {@link HsMemoryDataManager}, the shuffle
+ * data maybe spilled to disk according to the {@link HsSpillingStrategy}, and the downstream can
+ * consume data from memory or disk.
+ */
+public class HsResultPartition extends ResultPartition {
+    public static final String DATA_FILE_SUFFIX = ".hybrid.data";
+
+    private final HsFileDataIndex dataIndex;
+
+    private final HsFileDataManager fileDataManager;
+
+    private final Path dataFilePath;
+
+    private final int networkBufferSize;
+
+    private final HybridShuffleConfiguration hybridShuffleConfiguration;
+
+    private boolean hasNotifiedEndOfUserRecords;
+
+    @Nullable private HsMemoryDataManager memoryDataManager;
+
+    public HsResultPartition(
+            String owningTaskName,
+            int partitionIndex,
+            ResultPartitionID partitionId,
+            ResultPartitionType partitionType,
+            int numSubpartitions,
+            int numTargetKeyGroups,
+            BatchShuffleReadBufferPool readBufferPool,
+            Executor readIOExecutor,
+            ResultPartitionManager partitionManager,
+            String dataFileBashPath,
+            int networkBufferSize,
+            HybridShuffleConfiguration hybridShuffleConfiguration,
+            @Nullable BufferCompressor bufferCompressor,
+            SupplierWithException<BufferPool, IOException> bufferPoolFactory) {
+        super(
+                owningTaskName,
+                partitionIndex,
+                partitionId,
+                partitionType,
+                numSubpartitions,
+                numTargetKeyGroups,
+                partitionManager,
+                bufferCompressor,
+                bufferPoolFactory);
+        this.networkBufferSize = networkBufferSize;
+        this.dataIndex = new HsFileDataIndexImpl(numSubpartitions);
+        this.dataFilePath = new File(dataFileBashPath + DATA_FILE_SUFFIX).toPath();
+        this.hybridShuffleConfiguration = hybridShuffleConfiguration;
+        this.fileDataManager =
+                new HsFileDataManager(
+                        readBufferPool,
+                        readIOExecutor,
+                        dataIndex,
+                        dataFilePath,
+                        HsSubpartitionFileReaderImpl.Factory.INSTANCE,
+                        hybridShuffleConfiguration);
+    }
+
+    // Called by task thread.
+    @Override
+    protected void setupInternal() throws IOException {
+        if (isReleased()) {
+            throw new IOException("Result partition has been released.");
+        }
+        this.fileDataManager.setup();
+        this.memoryDataManager =
+                new HsMemoryDataManager(
+                        numSubpartitions,
+                        networkBufferSize,
+                        bufferPool,
+                        getSpillingStrategy(hybridShuffleConfiguration),
+                        dataIndex,
+                        dataFilePath);
+    }
+
+    @Override
+    public void emitRecord(ByteBuffer record, int targetSubpartition) throws IOException {
+        emit(record, targetSubpartition, Buffer.DataType.DATA_BUFFER);
+    }
+
+    @Override
+    public void broadcastRecord(ByteBuffer record) throws IOException {
+        broadcast(record, Buffer.DataType.DATA_BUFFER);
+    }
+
+    @Override
+    public void broadcastEvent(AbstractEvent event, boolean isPriorityEvent) throws IOException {
+        Buffer buffer = EventSerializer.toBuffer(event, isPriorityEvent);
+        try {
+            ByteBuffer serializedEvent = buffer.getNioBufferReadable();
+            broadcast(serializedEvent, buffer.getDataType());
+        } finally {
+            buffer.recycleBuffer();
+        }
+    }
+
+    private void broadcast(ByteBuffer record, Buffer.DataType dataType) throws IOException {
+        for (int i = 0; i < numSubpartitions; i++) {
+            emit(record.duplicate(), i, dataType);
+        }
+    }
+
+    private void emit(ByteBuffer record, int targetSubpartition, Buffer.DataType dataType)
+            throws IOException {
+        checkInProduceState();
+        checkNotNull(memoryDataManager).append(record, targetSubpartition, dataType);
+    }
+
+    @Override
+    public ResultSubpartitionView createSubpartitionView(
+            int subpartitionId, BufferAvailabilityListener availabilityListener)
+            throws IOException {
+        checkState(!isReleased(), "ResultPartition already released.");
+        HsSubpartitionView subpartitionView = new HsSubpartitionView(availabilityListener);
+        HsDataView diskDataView =
+                fileDataManager.registerNewSubpartition(subpartitionId, subpartitionView);
+
+        HsDataView memoryDataView =
+                checkNotNull(memoryDataManager)
+                        .registerSubpartitionView(subpartitionId, subpartitionView);
+
+        subpartitionView.setDiskDataView(diskDataView);
+        subpartitionView.setMemoryDataView(memoryDataView);
+        return subpartitionView;
+    }
+
+    @Override
+    public void alignedBarrierTimeout(long checkpointId) throws IOException {
+        // Nothing to do.
+    }
+
+    @Override
+    public void abortCheckpoint(long checkpointId, CheckpointException cause) {
+        // Nothing to do.
+    }
+
+    @Override
+    public void flushAll() {
+        // Nothing to do.
+    }
+
+    @Override
+    public void flush(int subpartitionIndex) {
+        // Nothing to do.
+    }
+
+    @Override
+    public void finish() throws IOException {
+        broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
+
+        checkState(!isReleased(), "Result partition is already released.");
+
+        super.finish();
+    }
+
+    @Override
+    public void close() {
+        // close is called when task is finished or failed.
+        checkNotNull(memoryDataManager).close();
+        super.close();
+    }
+
+    @Override
+    protected void releaseInternal() {
+        // release is called when release by scheduler, later than close.
+        // mainly work :
+        // 1. release read scheduler.
+        // 2. delete shuffle file.
+        // 3. release all data in memory.
+
+        fileDataManager.release();
+
+        checkNotNull(memoryDataManager).release();
+    }
+
+    @Override
+    public int getNumberOfQueuedBuffers() {
+        // Batch shuffle does not need to provide QueuedBuffers information
+        return 0;
+    }
+
+    @Override
+    public long getSizeOfQueuedBuffersUnsafe() {
+        // Batch shuffle does not need to provide QueuedBuffers information
+        return 0;
+    }
+
+    @Override
+    public int getNumberOfQueuedBuffers(int targetSubpartition) {
+        // Batch shuffle does not need to provide QueuedBuffers information
+        return 0;
+    }
+
+    @Override
+    public void notifyEndOfData(StopMode mode) throws IOException {
+        if (!hasNotifiedEndOfUserRecords) {
+            broadcastEvent(new EndOfData(mode), false);
+            hasNotifiedEndOfUserRecords = true;
+        }
+    }
+
+    private HsSpillingStrategy getSpillingStrategy(
+            HybridShuffleConfiguration hybridShuffleConfiguration) {
+        switch (hybridShuffleConfiguration.getSpillingStrategyType()) {
+            case FULL:
+                return new HsFullSpillingStrategy(hybridShuffleConfiguration);
+            case SELECTIVE:
+                return new HsSelectiveSpillingStrategy(hybridShuffleConfiguration);
+            default:
+                throw new IllegalConfigurationException("Illegal spilling strategy.");
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
@@ -102,4 +102,24 @@ public class HsSelectiveSpillingStrategy implements HsSpillingStrategy {
                 });
         return builder.build();
     }
+
+    @Override
+    public Decision onResultPartitionClosed(HsSpillingInfoProvider spillingInfoProvider) {
+        Decision.Builder builder = Decision.builder();
+        for (int subpartitionId = 0;
+                subpartitionId < spillingInfoProvider.getNumSubpartitions();
+                subpartitionId++) {
+            builder.addBufferToSpill(
+                            subpartitionId,
+                            // get all not start spilling buffers.
+                            spillingInfoProvider.getBuffersInOrder(
+                                    subpartitionId, SpillStatus.NOT_SPILL, ConsumeStatus.ALL))
+                    .addBufferToRelease(
+                            subpartitionId,
+                            // get all not released buffers.
+                            spillingInfoProvider.getBuffersInOrder(
+                                    subpartitionId, SpillStatus.ALL, ConsumeStatus.ALL));
+        }
+        return builder.build();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
@@ -72,6 +72,15 @@ public interface HsSpillingStrategy {
     Decision decideActionWithGlobalInfo(HsSpillingInfoProvider spillingInfoProvider);
 
     /**
+     * Make a decision when result partition is closed. Because this method will directly touch the
+     * {@link HsSpillingInfoProvider}, the caller should take care of the thread safety.
+     *
+     * @param spillingInfoProvider that provides information about the current status.
+     * @return A {@link Decision} based on the global information.
+     */
+    Decision onResultPartitionClosed(HsSpillingInfoProvider spillingInfoProvider);
+
+    /**
      * This class represents the spill and release decision made by {@link HsSpillingStrategy}, in
      * other words, which data is to be spilled and which data is to be released.
      */
@@ -139,6 +148,12 @@ public interface HsSpillingStrategy {
 
             public Builder addBufferToRelease(
                     int subpartitionId, List<BufferIndexAndChannel> buffers) {
+                bufferToRelease.computeIfAbsent(subpartitionId, ArrayList::new).addAll(buffers);
+                return this;
+            }
+
+            public Builder addBufferToRelease(
+                    int subpartitionId, Deque<BufferIndexAndChannel> buffers) {
                 bufferToRelease.computeIfAbsent(subpartitionId, ArrayList::new).addAll(buffers);
                 return this;
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.Queue;
+import java.util.function.Consumer;
 
 /**
  * This component is responsible for reading data from disk for a specific subpartition.
@@ -31,7 +32,7 @@ import java.util.Queue;
  * <p>In order to access the disk as sequentially as possible {@link HsSubpartitionFileReader} need
  * to be able to compare priorities.
  */
-public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileReader> {
+public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileReader>, HsDataView {
     /** Do prep work before this {@link HsSubpartitionFileReader} is scheduled to read data. */
     void prepareForScheduling();
 
@@ -58,6 +59,7 @@ public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileR
                 FileChannel dataFileChannel,
                 HsSubpartitionViewInternalOperations operation,
                 HsFileDataIndex dataIndex,
-                int maxBuffersReadAhead);
+                int maxBuffersReadAhead,
+                Consumer<HsSubpartitionFileReader> fileReaderReleaser);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -152,7 +152,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         }
 
         if (loadedBuffers.size() <= numLoaded) {
-            operations.notifyDataAvailableFromDisk();
+            operations.notifyDataAvailable();
         }
     }
 
@@ -171,7 +171,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         }
 
         loadedBuffers.add(BufferIndexOrError.newError(failureCause));
-        operations.notifyDataAvailableFromDisk();
+        operations.notifyDataAvailable();
     }
 
     /** Refresh downstream consumption progress for another round scheduling of reading. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -23,6 +23,8 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+import org.apache.flink.util.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
@@ -34,6 +36,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.positionToNextBuffer;
 import static org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil.readFromByteChannel;
@@ -62,6 +65,8 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
     private final Deque<BufferIndexOrError> loadedBuffers = new LinkedBlockingDeque<>();
 
+    private final Consumer<HsSubpartitionFileReader> fileReaderReleaser;
+
     private volatile boolean isFailed;
 
     public HsSubpartitionFileReaderImpl(
@@ -69,12 +74,14 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
             FileChannel dataFileChannel,
             HsSubpartitionViewInternalOperations operations,
             HsFileDataIndex dataIndex,
-            int maxBufferReadAhead) {
+            int maxBufferReadAhead,
+            Consumer<HsSubpartitionFileReader> fileReaderReleaser) {
         this.subpartitionId = subpartitionId;
         this.dataFileChannel = dataFileChannel;
         this.operations = operations;
         this.bufferIndexManager = new BufferIndexManager(maxBufferReadAhead);
         this.cachedRegionManager = new CachedRegionManager(subpartitionId, dataIndex);
+        this.fileReaderReleaser = fileReaderReleaser;
     }
 
     @Override
@@ -192,9 +199,76 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         return loadedBuffers;
     }
 
+    @Override
+    public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(int nextBufferToConsume)
+            throws Throwable {
+        if (!checkAndGetFirstBufferIndexOrError(nextBufferToConsume).isPresent()) {
+            return Optional.empty();
+        }
+
+        // already ensure that peek element is not null and not throwable.
+        BufferIndexOrError current = checkNotNull(loadedBuffers.poll());
+
+        BufferIndexOrError next = loadedBuffers.peek();
+
+        Buffer.DataType nextDataType = next == null ? Buffer.DataType.NONE : next.getDataType();
+        int backlog = loadedBuffers.size();
+        int bufferIndex = current.getIndex();
+        Buffer buffer =
+                current.getBuffer()
+                        .orElseThrow(
+                                () ->
+                                        new NullPointerException(
+                                                "Get a non-throwable and non-buffer bufferIndexOrError, which is not allowed"));
+        return Optional.of(
+                ResultSubpartition.BufferAndBacklog.fromBufferAndLookahead(
+                        buffer, nextDataType, backlog, bufferIndex));
+    }
+
+    @Override
+    public Buffer.DataType peekNextToConsumeDataType(int nextBufferToConsume) {
+        Buffer.DataType dataType = Buffer.DataType.NONE;
+        try {
+            dataType =
+                    checkAndGetFirstBufferIndexOrError(nextBufferToConsume)
+                            .map(BufferIndexOrError::getDataType)
+                            .orElse(Buffer.DataType.NONE);
+        } catch (Throwable throwable) {
+            ExceptionUtils.rethrow(throwable);
+        }
+        return dataType;
+    }
+
+    @Override
+    public void releaseDataView() {
+        fileReaderReleaser.accept(this);
+    }
+
+    @Override
+    public int getBacklog() {
+        return loadedBuffers.size();
+    }
+
     // ------------------------------------------------------------------------
     //  Internal Methods
     // ------------------------------------------------------------------------
+
+    private Optional<BufferIndexOrError> checkAndGetFirstBufferIndexOrError(int expectedBufferIndex)
+            throws Throwable {
+        if (loadedBuffers.isEmpty()) {
+            return Optional.empty();
+        }
+
+        BufferIndexOrError peek = loadedBuffers.peek();
+
+        if (peek.getThrowable().isPresent()) {
+            throw peek.getThrowable().get();
+        } else if (peek.getIndex() != expectedBufferIndex) {
+            return Optional.empty();
+        }
+
+        return Optional.of(peek);
+    }
 
     private void moveFileOffsetToBuffer(int bufferIndex) throws IOException {
         Tuple2<Integer, Long> indexAndOffset =
@@ -403,9 +477,15 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
                 FileChannel dataFileChannel,
                 HsSubpartitionViewInternalOperations operation,
                 HsFileDataIndex dataIndex,
-                int maxBuffersReadAhead) {
+                int maxBuffersReadAhead,
+                Consumer<HsSubpartitionFileReader> fileReaderReleaser) {
             return new HsSubpartitionFileReaderImpl(
-                    subpartitionId, dataFileChannel, operation, dataIndex, maxBuffersReadAhead);
+                    subpartitionId,
+                    dataFileChannel,
+                    operation,
+                    dataIndex,
+                    maxBuffersReadAhead,
+                    fileReaderReleaser);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
@@ -351,11 +351,10 @@ public class HsSubpartitionMemoryDataManager {
                                     bufferContext.getBufferIndexAndChannel().getBufferIndex(),
                                     bufferContext);
                             trimHeadingReleasedBuffers(unConsumedBuffers);
-                            return unConsumedBuffers.isEmpty();
+                            return unConsumedBuffers.size() <= 1;
                         });
         if (needNotify) {
-            // TODO notify data available, the notification mechanism may need further
-            // consideration.
+            memoryDataManagerOperation.onDataAvailable(targetChannel);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatus;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.SpillStatus;
 import org.apache.flink.util.function.SupplierWithException;
@@ -54,7 +55,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * This class is responsible for managing the data in a single subpartition. One {@link
  * HsMemoryDataManager} will hold multiple {@link HsSubpartitionMemoryDataManager}.
  */
-public class HsSubpartitionMemoryDataManager {
+public class HsSubpartitionMemoryDataManager implements HsDataView {
     private final int targetChannel;
 
     private final int bufferSize;
@@ -108,22 +109,24 @@ public class HsSubpartitionMemoryDataManager {
     @SuppressWarnings("FieldAccessNotGuarded")
     // Note that: callWithLock ensure that code block guarded by resultPartitionReadLock and
     // subpartitionLock.
+    @Override
     public DataType peekNextToConsumeDataType(int nextToConsumeIndex) {
         return callWithLock(() -> peekNextToConsumeDataTypeInternal(nextToConsumeIndex));
     }
 
     /**
      * Check whether the head of {@link #unConsumedBuffers} is the buffer to be consumed. If so,
-     * return the buffer and next data type.
+     * return the buffer and backlog.
      *
      * @param toConsumeIndex index of buffer to be consumed.
      * @return If the head of {@link #unConsumedBuffers} is target, return optional of the buffer
-     *     and next data type. Otherwise, return {@link Optional#empty()}.
+     *     and backlog. Otherwise, return {@link Optional#empty()}.
      */
     @SuppressWarnings("FieldAccessNotGuarded")
     // Note that: callWithLock ensure that code block guarded by resultPartitionReadLock and
     // subpartitionLock.
-    public Optional<HsMemoryDataManager.BufferAndNextDataType> consumeBuffer(int toConsumeIndex) {
+    @Override
+    public Optional<BufferAndBacklog> consumeBuffer(int toConsumeIndex) {
         Optional<Tuple2<HsBufferContext, DataType>> bufferAndNextDataType =
                 callWithLock(
                         () -> {
@@ -145,8 +148,22 @@ public class HsSubpartitionMemoryDataManager {
                                 tuple.f0.getBufferIndexAndChannel()));
         return bufferAndNextDataType.map(
                 tuple ->
-                        new HsMemoryDataManager.BufferAndNextDataType(
-                                tuple.f0.getBuffer(), tuple.f1));
+                        new BufferAndBacklog(
+                                tuple.f0.getBuffer(), getBacklog(), tuple.f1, toConsumeIndex));
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    // Un-synchronized get unConsumedBuffers size to provide memory data backlog,this will make the
+    // result greater than or equal to the actual backlog, but obtaining an accurate backlog will
+    // bring too much extra overhead.
+    @Override
+    public int getBacklog() {
+        return unConsumedBuffers.size();
+    }
+
+    @Override
+    public void releaseDataView() {
+        // nothing to do for memory data.
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** The read view of HsResultPartition, data can be read from memory or disk. */
+public class HsSubpartitionView
+        implements ResultSubpartitionView, HsSubpartitionViewInternalOperations {
+    private final BufferAvailabilityListener availabilityListener;
+    private final Object lock = new Object();
+
+    /** Index of last consumed buffer. */
+    @GuardedBy("lock")
+    private int lastConsumedBufferIndex = -1;
+
+    @GuardedBy("lock")
+    private boolean needNotify = false;
+
+    @Nullable
+    @GuardedBy("lock")
+    private Buffer.DataType cachedNextDataType = null;
+
+    @Nullable
+    @GuardedBy("lock")
+    private Throwable failureCause = null;
+
+    @GuardedBy("lock")
+    private boolean isReleased = false;
+
+    @Nullable
+    @GuardedBy("lock")
+    // diskDataView can be null only before initialization.
+    private HsDataView diskDataView;
+
+    @Nullable
+    @GuardedBy("lock")
+    // memoryDataView can be null only before initialization.
+    private HsDataView memoryDataView;
+
+    public HsSubpartitionView(BufferAvailabilityListener availabilityListener) {
+        this.availabilityListener = availabilityListener;
+    }
+
+    @Nullable
+    @Override
+    public BufferAndBacklog getNextBuffer() {
+        synchronized (lock) {
+            try {
+                checkNotNull(diskDataView, "disk data view must be not null.");
+                checkNotNull(memoryDataView, "memory data view must be not null.");
+
+                Optional<BufferAndBacklog> bufferToConsume = tryReadFromDisk();
+                if (!bufferToConsume.isPresent()) {
+                    bufferToConsume = memoryDataView.consumeBuffer(lastConsumedBufferIndex + 1);
+                }
+                updateConsumingStatus(bufferToConsume);
+                return bufferToConsume.orElse(null);
+            } catch (Throwable cause) {
+                releaseInternal(cause);
+                return null;
+            }
+        }
+    }
+
+    @Override
+    public void notifyDataAvailable() {
+        boolean notifyDownStream = false;
+        synchronized (lock) {
+            if (isReleased) {
+                return;
+            }
+            if (needNotify) {
+                notifyDownStream = true;
+                needNotify = false;
+            }
+        }
+        // notify outside of lock to avoid deadlock
+        if (notifyDownStream) {
+            availabilityListener.notifyDataAvailable();
+        }
+    }
+
+    @Override
+    public AvailabilityWithBacklog getAvailabilityAndBacklog(int numCreditsAvailable) {
+        synchronized (lock) {
+            boolean availability = numCreditsAvailable > 0;
+            if (numCreditsAvailable <= 0
+                    && cachedNextDataType != null
+                    && cachedNextDataType == Buffer.DataType.EVENT_BUFFER) {
+                availability = true;
+            }
+            return new AvailabilityWithBacklog(availability, diskDataView.getBacklog());
+        }
+    }
+
+    @Override
+    public void releaseAllResources() throws IOException {
+        releaseInternal(null);
+    }
+
+    @Override
+    public boolean isReleased() {
+        synchronized (lock) {
+            return isReleased;
+        }
+    }
+
+    @Override
+    public int getConsumingOffset() {
+        synchronized (lock) {
+            return lastConsumedBufferIndex;
+        }
+    }
+
+    @Override
+    public Throwable getFailureCause() {
+        synchronized (lock) {
+            return failureCause;
+        }
+    }
+
+    /**
+     * Set {@link HsDataView} for this subpartition, this method only called when {@link
+     * HsSubpartitionFileReader} is creating.
+     */
+    void setDiskDataView(HsDataView diskDataView) {
+        synchronized (lock) {
+            checkState(this.diskDataView == null, "repeatedly set disk data view is not allowed.");
+            this.diskDataView = diskDataView;
+        }
+    }
+
+    /**
+     * Set {@link HsDataView} for this subpartition, this method only called when {@link
+     * HsSubpartitionFileReader} is creating.
+     */
+    void setMemoryDataView(HsDataView memoryDataView) {
+        synchronized (lock) {
+            checkState(
+                    this.memoryDataView == null, "repeatedly set memory data view is not allowed.");
+            this.memoryDataView = memoryDataView;
+        }
+    }
+
+    @Override
+    public void resumeConsumption() {
+        throw new UnsupportedOperationException("resumeConsumption should never be called.");
+    }
+
+    @Override
+    public void acknowledgeAllDataProcessed() {
+        // in case of bounded partitions there is no upstream to acknowledge, we simply ignore
+        // the ack, as there are no checkpoints
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    @Override
+    public int unsynchronizedGetNumberOfQueuedBuffers() {
+        return diskDataView.getBacklog();
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    @Override
+    public int getNumberOfQueuedBuffers() {
+        return diskDataView.getBacklog();
+    }
+
+    @Override
+    public void notifyNewBufferSize(int newBufferSize) {
+        throw new UnsupportedOperationException("Method should never be called.");
+    }
+
+    // -------------------------------
+    //       Internal Methods
+    // -------------------------------
+
+    @GuardedBy("lock")
+    private Optional<BufferAndBacklog> tryReadFromDisk() throws Throwable {
+        final int nextBufferIndexToConsume = lastConsumedBufferIndex + 1;
+        return checkNotNull(diskDataView)
+                .consumeBuffer(nextBufferIndexToConsume)
+                .map(
+                        bufferAndBacklog -> {
+                            if (bufferAndBacklog.getNextDataType() == Buffer.DataType.NONE) {
+                                return new BufferAndBacklog(
+                                        bufferAndBacklog.buffer(),
+                                        bufferAndBacklog.buffersInBacklog(),
+                                        checkNotNull(memoryDataView)
+                                                .peekNextToConsumeDataType(
+                                                        nextBufferIndexToConsume + 1),
+                                        bufferAndBacklog.getSequenceNumber());
+                            }
+                            return bufferAndBacklog;
+                        });
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @GuardedBy("lock")
+    private void updateConsumingStatus(Optional<BufferAndBacklog> bufferAndBacklog) {
+        assert Thread.holdsLock(lock);
+        // if consumed, update and check consume offset
+        if (bufferAndBacklog.isPresent()) {
+            ++lastConsumedBufferIndex;
+            checkState(bufferAndBacklog.get().getSequenceNumber() == lastConsumedBufferIndex);
+        }
+
+        // update need-notify
+        boolean dataAvailable =
+                bufferAndBacklog.map(BufferAndBacklog::isDataAvailable).orElse(false);
+        needNotify = !dataAvailable;
+        // update cached next data type
+        cachedNextDataType = bufferAndBacklog.map(BufferAndBacklog::getNextDataType).orElse(null);
+    }
+
+    private void releaseInternal(@Nullable Throwable throwable) {
+        boolean releaseSubpartitionReader = false;
+        synchronized (lock) {
+            if (isReleased) {
+                return;
+            }
+            isReleased = true;
+            failureCause = throwable;
+            if (diskDataView != null) {
+                releaseSubpartitionReader = true;
+            }
+        }
+        // release subpartition reader outside of lock to avoid deadlock.
+        if (releaseSubpartitionReader) {
+            //noinspection FieldAccessNotGuarded
+            diskDataView.releaseDataView();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewInternalOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewInternalOperations.java
@@ -24,8 +24,8 @@ package org.apache.flink.runtime.io.network.partition.hybrid;
  */
 public interface HsSubpartitionViewInternalOperations {
 
-    /** Callback for new data become available from disk. */
-    void notifyDataAvailableFromDisk();
+    /** Callback for new data become available. */
+    void notifyDataAvailable();
 
     /** Get the latest consuming offset of the subpartition. */
     int getConsumingOffset();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
@@ -36,11 +36,16 @@ public class HybridShuffleConfiguration {
 
     private static final float DEFAULT_FULL_STRATEGY_RELEASE_BUFFER_RATIO = 0.4f;
 
+    private static final SpillingStrategyType DEFAULT_SPILLING_STRATEGY_NAME =
+            SpillingStrategyType.FULL;
+
     private final int maxBuffersReadAhead;
 
     private final Duration bufferRequestTimeout;
 
     private final int maxRequestedBuffers;
+
+    private final SpillingStrategyType spillingStrategyType;
 
     // ----------------------------------------
     //        Selective Spilling Strategy
@@ -66,7 +71,8 @@ public class HybridShuffleConfiguration {
             float selectiveStrategySpillBufferRatio,
             int fullStrategyNumBuffersTriggerSpilling,
             float fullStrategyReleaseThreshold,
-            float fullStrategyReleaseBufferRatio) {
+            float fullStrategyReleaseBufferRatio,
+            SpillingStrategyType spillingStrategyType) {
         this.maxBuffersReadAhead = maxBuffersReadAhead;
         this.bufferRequestTimeout = bufferRequestTimeout;
         this.maxRequestedBuffers = maxRequestedBuffers;
@@ -75,10 +81,16 @@ public class HybridShuffleConfiguration {
         this.fullStrategyNumBuffersTriggerSpilling = fullStrategyNumBuffersTriggerSpilling;
         this.fullStrategyReleaseThreshold = fullStrategyReleaseThreshold;
         this.fullStrategyReleaseBufferRatio = fullStrategyReleaseBufferRatio;
+        this.spillingStrategyType = spillingStrategyType;
     }
 
     public static Builder builder(int numSubpartitions, int numBuffersPerRequest) {
         return new Builder(numSubpartitions, numBuffersPerRequest);
+    }
+
+    /** Get {@link SpillingStrategyType} for hybrid shuffle mode. */
+    public SpillingStrategyType getSpillingStrategyType() {
+        return spillingStrategyType;
     }
 
     public int getMaxRequestedBuffers() {
@@ -135,8 +147,14 @@ public class HybridShuffleConfiguration {
         return fullStrategyReleaseBufferRatio;
     }
 
+    /** Type of {@link HsSpillingStrategy}. */
+    public enum SpillingStrategyType {
+        FULL,
+        SELECTIVE
+    }
+
     /** Builder for {@link HybridShuffleConfiguration}. */
-    static class Builder {
+    public static class Builder {
         private int maxBuffersReadAhead = DEFAULT_MAX_BUFFERS_READ_AHEAD;
 
         private Duration bufferRequestTimeout = DEFAULT_BUFFER_REQUEST_TIMEOUT;
@@ -152,6 +170,8 @@ public class HybridShuffleConfiguration {
         private float fullStrategyReleaseThreshold = DEFAULT_FULL_STRATEGY_RELEASE_THRESHOLD;
 
         private float fullStrategyReleaseBufferRatio = DEFAULT_FULL_STRATEGY_RELEASE_BUFFER_RATIO;
+
+        private SpillingStrategyType spillingStrategyType = DEFAULT_SPILLING_STRATEGY_NAME;
 
         private final int numSubpartitions;
 
@@ -199,6 +219,11 @@ public class HybridShuffleConfiguration {
             return this;
         }
 
+        public Builder setSpillingStrategyType(SpillingStrategyType spillingStrategyType) {
+            this.spillingStrategyType = spillingStrategyType;
+            return this;
+        }
+
         public HybridShuffleConfiguration build() {
             return new HybridShuffleConfiguration(
                     maxBuffersReadAhead,
@@ -208,7 +233,8 @@ public class HybridShuffleConfiguration {
                     selectiveStrategySpillBufferRatio,
                     fullStrategyNumBuffersTriggerSpilling,
                     fullStrategyReleaseThreshold,
-                    fullStrategyReleaseBufferRatio);
+                    fullStrategyReleaseBufferRatio,
+                    spillingStrategyType);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsResultPartition;
 import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
@@ -83,6 +84,12 @@ public class ResultPartitionFactoryTest extends TestLogger {
     }
 
     @Test
+    public void testHybridResultPartitionCreated() {
+        ResultPartition resultPartition = createResultPartition(ResultPartitionType.HYBRID);
+        assertTrue(resultPartition instanceof HsResultPartition);
+    }
+
+    @Test
     public void testNoReleaseOnConsumptionForBoundedBlockingPartition() {
         final ResultPartition resultPartition = createResultPartition(ResultPartitionType.BLOCKING);
 
@@ -95,6 +102,15 @@ public class ResultPartitionFactoryTest extends TestLogger {
     public void testNoReleaseOnConsumptionForSortMergePartition() {
         final ResultPartition resultPartition =
                 createResultPartition(ResultPartitionType.BLOCKING, 1);
+
+        resultPartition.onConsumedSubpartition(0);
+
+        assertFalse(resultPartition.isReleased());
+    }
+
+    @Test
+    public void testNoReleaseOnConsumptionForHybridPartition() {
+        final ResultPartition resultPartition = createResultPartition(ResultPartitionType.HYBRID);
 
         resultPartition.onConsumedSubpartition(0);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategyTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -181,5 +182,37 @@ class HsFullSpillingStrategyTest {
                 .containsOnly(entry(subpartitionId, subpartitionBuffers.subList(0, 4)))
                 .extractingByKey(subpartitionId)
                 .satisfies((buffers) -> assertThat(buffers).hasSizeGreaterThan(numReleaseBuffer));
+    }
+
+    @Test
+    void testOnResultPartitionClosed() {
+        final int subpartition1 = 0;
+        final int subpartition2 = 1;
+
+        List<BufferIndexAndChannel> subpartitionBuffer1 =
+                createBufferIndexAndChannelsList(subpartition1, 0, 1, 2, 3);
+        List<BufferIndexAndChannel> subpartitionBuffer2 =
+                createBufferIndexAndChannelsList(subpartition2, 0, 1, 2);
+        TestingSpillingInfoProvider spillInfoProvider =
+                TestingSpillingInfoProvider.builder()
+                        .setGetNumSubpartitionsSupplier(() -> 2)
+                        .addSubpartitionBuffers(subpartition1, subpartitionBuffer1)
+                        .addSubpartitionBuffers(subpartition2, subpartitionBuffer2)
+                        .addSpillBuffers(subpartition1, Arrays.asList(2, 3))
+                        .addConsumedBuffers(subpartition1, Collections.singletonList(0))
+                        .addSpillBuffers(subpartition2, Collections.singletonList(2))
+                        .build();
+
+        Decision decision = spillStrategy.onResultPartitionClosed(spillInfoProvider);
+
+        Map<Integer, List<BufferIndexAndChannel>> expectedToSpillBuffers = new HashMap<>();
+        expectedToSpillBuffers.put(subpartition1, subpartitionBuffer1.subList(0, 2));
+        expectedToSpillBuffers.put(subpartition2, subpartitionBuffer2.subList(0, 2));
+        assertThat(decision.getBufferToSpill()).isEqualTo(expectedToSpillBuffers);
+
+        Map<Integer, List<BufferIndexAndChannel>> expectedToReleaseBuffers = new HashMap<>();
+        expectedToReleaseBuffers.put(subpartition1, subpartitionBuffer1.subList(0, 4));
+        expectedToReleaseBuffers.put(subpartition2, subpartitionBuffer2.subList(0, 3));
+        assertThat(decision.getBufferToRelease()).isEqualTo(expectedToReleaseBuffers);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
@@ -1,0 +1,476 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.core.memory.MemorySegment;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.runtime.event.AbstractEvent;
+import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
+import org.apache.flink.runtime.io.disk.FileChannelManager;
+import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
+import org.apache.flink.runtime.io.network.api.EndOfPartitionEvent;
+import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.BufferPool;
+import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
+import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.NoOpBufferAvailablityListener;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
+import org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleConfiguration.SpillingStrategyType;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Queue;
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link HsResultPartition}. */
+class HsResultPartitionTest {
+
+    private static final int bufferSize = 1024;
+
+    private static final int totalBuffers = 1000;
+
+    private static final int totalBytes = 32 * 1024 * 1024;
+
+    private static final int numThreads = 4;
+
+    private FileChannelManager fileChannelManager;
+
+    private NetworkBufferPool globalPool;
+
+    private BatchShuffleReadBufferPool readBufferPool;
+
+    private ExecutorService readIOExecutor;
+
+    @TempDir public Path tempDataPath;
+
+    @BeforeEach
+    void before() {
+        fileChannelManager =
+                new FileChannelManagerImpl(new String[] {tempDataPath.toString()}, "testing");
+        globalPool = new NetworkBufferPool(totalBuffers, bufferSize);
+        readBufferPool = new BatchShuffleReadBufferPool(totalBytes, bufferSize);
+        readIOExecutor = Executors.newFixedThreadPool(numThreads);
+    }
+
+    @AfterEach
+    void after() throws Exception {
+        fileChannelManager.close();
+        globalPool.destroy();
+        readBufferPool.destroy();
+        readIOExecutor.shutdown();
+    }
+
+    @Test
+    void testEmit() throws Exception {
+        int numBuffers = 100;
+        int numSubpartitions = 10;
+        int numRecords = 1000;
+        Random random = new Random();
+
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+
+        try (HsResultPartition partition = createHsResultPartition(numSubpartitions, bufferPool)) {
+            Queue<Tuple2<ByteBuffer, Buffer.DataType>>[] dataWritten = new Queue[numSubpartitions];
+            Queue<Buffer>[] buffersRead = new Queue[numSubpartitions];
+            for (int i = 0; i < numSubpartitions; ++i) {
+                dataWritten[i] = new ArrayDeque<>();
+                buffersRead[i] = new ArrayDeque<>();
+            }
+
+            int[] numBytesWritten = new int[numSubpartitions];
+            int[] numBytesRead = new int[numSubpartitions];
+            Arrays.fill(numBytesWritten, 0);
+            Arrays.fill(numBytesRead, 0);
+
+            for (int i = 0; i < numRecords; ++i) {
+                ByteBuffer record = generateRandomData(random.nextInt(2 * bufferSize) + 1, random);
+                boolean isBroadCast = random.nextBoolean();
+
+                if (isBroadCast) {
+                    partition.broadcastRecord(record);
+                    for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+                        recordDataWritten(
+                                record,
+                                dataWritten,
+                                subpartition,
+                                numBytesWritten,
+                                Buffer.DataType.DATA_BUFFER);
+                    }
+                } else {
+                    int subpartition = random.nextInt(numSubpartitions);
+                    partition.emitRecord(record, subpartition);
+                    recordDataWritten(
+                            record,
+                            dataWritten,
+                            subpartition,
+                            numBytesWritten,
+                            Buffer.DataType.DATA_BUFFER);
+                }
+            }
+
+            partition.finish();
+
+            for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+                ByteBuffer record = EventSerializer.toSerializedEvent(EndOfPartitionEvent.INSTANCE);
+                recordDataWritten(
+                        record,
+                        dataWritten,
+                        subpartition,
+                        numBytesWritten,
+                        Buffer.DataType.EVENT_BUFFER);
+            }
+
+            Tuple2<ResultSubpartitionView, TestingBufferAvailabilityListener>[] viewAndListeners =
+                    createSubpartitionViews(partition, numSubpartitions);
+            readData(
+                    viewAndListeners,
+                    (buffer, subpartitionId) -> {
+                        int numBytes = buffer.readableBytes();
+                        numBytesRead[subpartitionId] += numBytes;
+
+                        MemorySegment segment =
+                                MemorySegmentFactory.allocateUnpooledSegment(numBytes);
+                        segment.put(0, buffer.getNioBufferReadable(), numBytes);
+                        buffersRead[subpartitionId].add(
+                                new NetworkBuffer(
+                                        segment, (buf) -> {}, buffer.getDataType(), numBytes));
+                    });
+            checkWriteReadResult(
+                    numSubpartitions, numBytesWritten, numBytesRead, dataWritten, buffersRead);
+        }
+    }
+
+    @Test
+    void testBroadcastEvent() throws Exception {
+        final int numBuffers = 1;
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        try (HsResultPartition resultPartition = createHsResultPartition(2, bufferPool)) {
+            resultPartition.broadcastEvent(EndOfPartitionEvent.INSTANCE, false);
+            // broadcast event does not request buffer
+            assertThat(bufferPool.getNumberOfAvailableMemorySegments()).isEqualTo(1);
+
+            Tuple2[] viewAndListeners = createSubpartitionViews(resultPartition, 2);
+
+            boolean[] receivedEvent = new boolean[2];
+            readData(
+                    viewAndListeners,
+                    (buffer, subpartition) -> {
+                        assertThat(buffer.getDataType().isEvent()).isTrue();
+                        try {
+                            AbstractEvent event =
+                                    EventSerializer.fromSerializedEvent(
+                                            buffer.readOnlySlice().getNioBufferReadable(),
+                                            HsResultPartitionTest.class.getClassLoader());
+                            assertThat(event).isInstanceOf(EndOfPartitionEvent.class);
+                            receivedEvent[subpartition] = true;
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+
+            assertThat(receivedEvent).containsExactly(true, true);
+        }
+    }
+
+    @Test
+    void testClose() throws Exception {
+        final int numBuffers = 1;
+
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        HsResultPartition partition = createHsResultPartition(1, bufferPool);
+
+        partition.close();
+        // emit data to closed partition will throw exception.
+        assertThatThrownBy(() -> partition.emitRecord(ByteBuffer.allocate(bufferSize), 0));
+    }
+
+    @Test
+    @Timeout(30)
+    void testRelease() throws Exception {
+        final int numBuffers = 10;
+
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        HsResultPartition partition = createHsResultPartition(2, bufferPool);
+
+        partition.emitRecord(ByteBuffer.allocate(bufferSize * numBuffers), 1);
+        assertThat(bufferPool.bestEffortGetNumOfUsedBuffers()).isEqualTo(numBuffers);
+
+        partition.close();
+        assertThat(bufferPool.isDestroyed()).isTrue();
+
+        partition.release();
+
+        while (checkNotNull(fileChannelManager.getPaths()[0].listFiles()).length != 0) {
+            Thread.sleep(10);
+        }
+
+        assertThat(totalBuffers).isEqualTo(globalPool.getNumberOfAvailableMemorySegments());
+    }
+
+    @Test
+    void testCreateSubpartitionViewAfterRelease() throws Exception {
+        final int numBuffers = 10;
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        HsResultPartition resultPartition = createHsResultPartition(2, bufferPool);
+        resultPartition.release();
+        assertThatThrownBy(
+                        () ->
+                                resultPartition.createSubpartitionView(
+                                        0, new NoOpBufferAvailablityListener()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testAvailability() throws Exception {
+        final int numBuffers = 2;
+
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        HsResultPartition partition = createHsResultPartition(1, bufferPool);
+
+        partition.emitRecord(ByteBuffer.allocate(bufferSize * numBuffers), 0);
+        assertThat(partition.isAvailable()).isFalse();
+
+        // release partition to recycle buffer.
+        partition.close();
+        partition.release();
+
+        assertThat(partition.isAvailable()).isTrue();
+    }
+
+    private static void recordDataWritten(
+            ByteBuffer record,
+            Queue<Tuple2<ByteBuffer, Buffer.DataType>>[] dataWritten,
+            int subpartition,
+            int[] numBytesWritten,
+            Buffer.DataType dataType) {
+        record.rewind();
+        dataWritten[subpartition].add(Tuple2.of(record, dataType));
+        numBytesWritten[subpartition] += record.remaining();
+    }
+
+    private long readData(
+            Tuple2<ResultSubpartitionView, TestingBufferAvailabilityListener>[] viewAndListeners,
+            BiConsumer<Buffer, Integer> bufferProcessor)
+            throws Exception {
+        AtomicInteger dataSize = new AtomicInteger(0);
+        AtomicInteger numEndOfPartitionEvents = new AtomicInteger(0);
+        CheckedThread[] subpartitionViewThreads = new CheckedThread[viewAndListeners.length];
+        for (int i = 0; i < viewAndListeners.length; i++) {
+            // start thread for each view.
+            final int subpartition = i;
+            CheckedThread subpartitionViewThread =
+                    new CheckedThread() {
+                        @Override
+                        public void go() throws Exception {
+                            ResultSubpartitionView view = viewAndListeners[subpartition].f0;
+                            while (true) {
+                                ResultSubpartition.BufferAndBacklog bufferAndBacklog =
+                                        view.getNextBuffer();
+                                if (bufferAndBacklog == null) {
+                                    viewAndListeners[subpartition].f1.waitForData();
+                                    continue;
+                                }
+                                Buffer buffer = bufferAndBacklog.buffer();
+                                bufferProcessor.accept(buffer, subpartition);
+                                dataSize.addAndGet(buffer.readableBytes());
+                                buffer.recycleBuffer();
+
+                                if (!buffer.isBuffer()) {
+                                    numEndOfPartitionEvents.incrementAndGet();
+                                    view.releaseAllResources();
+                                    break;
+                                }
+                                if (bufferAndBacklog.getNextDataType() == Buffer.DataType.NONE) {
+                                    viewAndListeners[subpartition].f1.waitForData();
+                                }
+                            }
+                        }
+                    };
+            subpartitionViewThreads[subpartition] = subpartitionViewThread;
+            subpartitionViewThread.start();
+        }
+        for (CheckedThread thread : subpartitionViewThreads) {
+            thread.sync();
+        }
+        return dataSize.get();
+    }
+
+    private static ByteBuffer generateRandomData(int dataSize, Random random) {
+        byte[] dataWritten = new byte[dataSize];
+        random.nextBytes(dataWritten);
+        return ByteBuffer.wrap(dataWritten);
+    }
+
+    private HsResultPartition createHsResultPartition(
+            int numSubpartitions, BufferPool bufferPool, int numBuffersTriggerSpilling)
+            throws IOException {
+        HsResultPartition hsResultPartition =
+                new HsResultPartition(
+                        "HsResultPartitionTest",
+                        0,
+                        new ResultPartitionID(),
+                        ResultPartitionType.HYBRID,
+                        numSubpartitions,
+                        numSubpartitions,
+                        readBufferPool,
+                        readIOExecutor,
+                        new ResultPartitionManager(),
+                        fileChannelManager.createChannel().getPath(),
+                        bufferSize,
+                        HybridShuffleConfiguration.builder(
+                                        numSubpartitions, readBufferPool.getNumBuffersPerRequest())
+                                .setSpillingStrategyType(SpillingStrategyType.FULL)
+                                .setFullStrategyNumBuffersTriggerSpilling(numBuffersTriggerSpilling)
+                                .build(),
+                        null,
+                        () -> bufferPool);
+        hsResultPartition.setup();
+        return hsResultPartition;
+    }
+
+    private HsResultPartition createHsResultPartition(int numSubpartitions, BufferPool bufferPool)
+            throws IOException {
+        HsResultPartition hsResultPartition =
+                new HsResultPartition(
+                        "HsResultPartitionTest",
+                        0,
+                        new ResultPartitionID(),
+                        ResultPartitionType.HYBRID,
+                        numSubpartitions,
+                        numSubpartitions,
+                        readBufferPool,
+                        readIOExecutor,
+                        new ResultPartitionManager(),
+                        fileChannelManager.createChannel().getPath(),
+                        bufferSize,
+                        HybridShuffleConfiguration.builder(
+                                        numSubpartitions, readBufferPool.getNumBuffersPerRequest())
+                                .build(),
+                        null,
+                        () -> bufferPool);
+        hsResultPartition.setup();
+        return hsResultPartition;
+    }
+
+    private static void checkWriteReadResult(
+            int numSubpartitions,
+            int[] numBytesWritten,
+            int[] numBytesRead,
+            Queue<Tuple2<ByteBuffer, Buffer.DataType>>[] dataWritten,
+            Queue<Buffer>[] buffersRead) {
+        for (int subpartitionIndex = 0; subpartitionIndex < numSubpartitions; ++subpartitionIndex) {
+            assertThat(numBytesWritten[subpartitionIndex])
+                    .isEqualTo(numBytesRead[subpartitionIndex]);
+
+            List<Tuple2<ByteBuffer, Buffer.DataType>> eventsWritten = new ArrayList<>();
+            List<Buffer> eventsRead = new ArrayList<>();
+
+            ByteBuffer subpartitionDataWritten =
+                    ByteBuffer.allocate(numBytesWritten[subpartitionIndex]);
+            for (Tuple2<ByteBuffer, Buffer.DataType> bufferDataTypeTuple :
+                    dataWritten[subpartitionIndex]) {
+                subpartitionDataWritten.put(bufferDataTypeTuple.f0);
+                bufferDataTypeTuple.f0.rewind();
+                if (bufferDataTypeTuple.f1.isEvent()) {
+                    eventsWritten.add(bufferDataTypeTuple);
+                }
+            }
+
+            ByteBuffer subpartitionDataRead = ByteBuffer.allocate(numBytesRead[subpartitionIndex]);
+            for (Buffer buffer : buffersRead[subpartitionIndex]) {
+                subpartitionDataRead.put(buffer.getNioBufferReadable());
+                if (!buffer.isBuffer()) {
+                    eventsRead.add(buffer);
+                }
+            }
+
+            subpartitionDataWritten.flip();
+            subpartitionDataRead.flip();
+            assertThat(subpartitionDataWritten).isEqualTo(subpartitionDataRead);
+
+            assertThat(eventsWritten.size()).isEqualTo(eventsRead.size());
+            for (int i = 0; i < eventsWritten.size(); i++) {
+                assertThat(eventsWritten.get(i).f1).isEqualTo(eventsRead.get(i).getDataType());
+                assertThat(eventsWritten.get(i).f0)
+                        .isEqualTo(eventsRead.get(i).getNioBufferReadable());
+            }
+        }
+    }
+
+    private Tuple2<ResultSubpartitionView, TestingBufferAvailabilityListener>[]
+            createSubpartitionViews(HsResultPartition partition, int numSubpartitions)
+                    throws Exception {
+        Tuple2<ResultSubpartitionView, TestingBufferAvailabilityListener>[] viewAndListeners =
+                new Tuple2[numSubpartitions];
+        for (int subpartition = 0; subpartition < numSubpartitions; ++subpartition) {
+            TestingBufferAvailabilityListener listener = new TestingBufferAvailabilityListener();
+            viewAndListeners[subpartition] =
+                    Tuple2.of(partition.createSubpartitionView(subpartition, listener), listener);
+        }
+        return viewAndListeners;
+    }
+
+    private static final class TestingBufferAvailabilityListener
+            implements BufferAvailabilityListener {
+
+        private int numNotifications;
+
+        @Override
+        public synchronized void notifyDataAvailable() {
+            if (numNotifications == 0) {
+                notifyAll();
+            }
+            ++numNotifications;
+        }
+
+        public synchronized void waitForData() throws InterruptedException {
+            if (numNotifications == 0) {
+                wait();
+            }
+            numNotifications = 0;
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
+import org.apache.flink.runtime.io.network.partition.BufferAvailabilityListener;
+import org.apache.flink.runtime.io.network.partition.NoOpBufferAvailablityListener;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView.AvailabilityWithBacklog;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link HsSubpartitionView}. */
+class HsSubpartitionViewTest {
+    @Test
+    void testGetNextBufferFromDisk() {
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+
+        BufferAndBacklog bufferAndBacklog = createBufferAndBacklog(0, DataType.DATA_BUFFER, 0);
+        CompletableFuture<Void> consumeBufferFromMemoryFuture = new CompletableFuture<>();
+        TestingHsDataView diskDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (bufferToConsume) -> Optional.of(bufferAndBacklog))
+                        .build();
+        TestingHsDataView memoryDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (ignore) -> {
+                                    consumeBufferFromMemoryFuture.complete(null);
+                                    return Optional.empty();
+                                })
+                        .build();
+        subpartitionView.setDiskDataView(diskDataView);
+        subpartitionView.setMemoryDataView(memoryDataView);
+
+        BufferAndBacklog nextBuffer = subpartitionView.getNextBuffer();
+        assertThat(consumeBufferFromMemoryFuture).isNotCompleted();
+        assertThat(nextBuffer).isSameAs(bufferAndBacklog);
+    }
+
+    @Test
+    void testGetNextBufferFromDiskNextDataTypeIsNone() {
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+        BufferAndBacklog bufferAndBacklog = createBufferAndBacklog(0, DataType.NONE, 0);
+
+        TestingHsDataView diskDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (bufferToConsume) -> Optional.of(bufferAndBacklog))
+                        .build();
+
+        TestingHsDataView memoryDataView =
+                TestingHsDataView.builder()
+                        .setPeekNextToConsumeDataTypeFunction(
+                                (bufferToConsume) -> {
+                                    assertThat(bufferToConsume).isEqualTo(1);
+                                    return DataType.EVENT_BUFFER;
+                                })
+                        .build();
+        subpartitionView.setDiskDataView(diskDataView);
+        subpartitionView.setMemoryDataView(memoryDataView);
+
+        BufferAndBacklog nextBuffer = subpartitionView.getNextBuffer();
+        assertThat(nextBuffer).isNotNull();
+        assertThat(nextBuffer.buffer()).isSameAs(bufferAndBacklog.buffer());
+        assertThat(nextBuffer.buffersInBacklog()).isEqualTo(bufferAndBacklog.buffersInBacklog());
+        assertThat(nextBuffer.getSequenceNumber()).isEqualTo(bufferAndBacklog.getSequenceNumber());
+        assertThat(nextBuffer.getNextDataType()).isEqualTo(DataType.EVENT_BUFFER);
+    }
+
+    @Test
+    void testGetNextBufferFromMemory() {
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+
+        BufferAndBacklog bufferAndBacklog = createBufferAndBacklog(0, DataType.DATA_BUFFER, 0);
+        TestingHsDataView memoryDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (bufferToConsume) -> Optional.of(bufferAndBacklog))
+                        .build();
+        TestingHsDataView diskDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction((bufferToConsume) -> Optional.empty())
+                        .build();
+        subpartitionView.setDiskDataView(diskDataView);
+        subpartitionView.setMemoryDataView(memoryDataView);
+
+        BufferAndBacklog nextBuffer = subpartitionView.getNextBuffer();
+        assertThat(nextBuffer).isSameAs(bufferAndBacklog);
+    }
+
+    @Test
+    void testGetNextBufferThrowException() {
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+
+        TestingHsDataView diskDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (nextToConsume) -> {
+                                    throw new RuntimeException("expected exception.");
+                                })
+                        .build();
+        subpartitionView.setDiskDataView(diskDataView);
+        subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
+
+        subpartitionView.getNextBuffer();
+        assertThat(subpartitionView.getFailureCause())
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("expected exception.");
+        assertThat(subpartitionView.isReleased()).isTrue();
+    }
+
+    @Test
+    void testNotifyDataAvailableNeedNotify() {
+        CompletableFuture<Void> notifyAvailableFuture = new CompletableFuture<>();
+        HsSubpartitionView subpartitionView =
+                createSubpartitionView(() -> notifyAvailableFuture.complete(null));
+
+        TestingHsDataView memoryDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (bufferToConsume) ->
+                                        Optional.of(createBufferAndBacklog(0, DataType.NONE, 0)))
+                        .build();
+        subpartitionView.setMemoryDataView(memoryDataView);
+        subpartitionView.setDiskDataView(TestingHsDataView.NO_OP);
+
+        subpartitionView.getNextBuffer();
+        subpartitionView.notifyDataAvailable();
+        assertThat(notifyAvailableFuture).isCompleted();
+    }
+
+    @Test
+    void testNotifyDataAvailableNotNeedNotify() {
+        CompletableFuture<Void> notifyAvailableFuture = new CompletableFuture<>();
+        HsSubpartitionView subpartitionView =
+                createSubpartitionView(() -> notifyAvailableFuture.complete(null));
+
+        TestingHsDataView memoryDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (bufferToConsume) ->
+                                        Optional.of(
+                                                createBufferAndBacklog(0, DataType.DATA_BUFFER, 0)))
+                        .build();
+        subpartitionView.setMemoryDataView(memoryDataView);
+        subpartitionView.setDiskDataView(TestingHsDataView.NO_OP);
+
+        subpartitionView.getNextBuffer();
+        subpartitionView.notifyDataAvailable();
+        assertThat(notifyAvailableFuture).isNotCompleted();
+    }
+
+    @Test
+    void testGetAvailabilityAndBacklogPositiveCredit() {
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+        subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
+
+        final int backlog = 2;
+        subpartitionView.setDiskDataView(
+                TestingHsDataView.builder().setGetBacklogSupplier(() -> backlog).build());
+        AvailabilityWithBacklog availabilityAndBacklog =
+                subpartitionView.getAvailabilityAndBacklog(1);
+        assertThat(availabilityAndBacklog.getBacklog()).isEqualTo(backlog);
+        // positive credit always available.
+        assertThat(availabilityAndBacklog.isAvailable()).isTrue();
+    }
+
+    @Test
+    void testGetAvailabilityAndBacklogNonPositiveCreditNextIsData() {
+        final int backlog = 2;
+
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+        subpartitionView.setMemoryDataView(
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (nextToConsume) ->
+                                        Optional.of(
+                                                createBufferAndBacklog(
+                                                        backlog, DataType.DATA_BUFFER, 0)))
+                        .build());
+        subpartitionView.setDiskDataView(
+                TestingHsDataView.builder().setGetBacklogSupplier(() -> backlog).build());
+
+        subpartitionView.getNextBuffer();
+
+        AvailabilityWithBacklog availabilityAndBacklog =
+                subpartitionView.getAvailabilityAndBacklog(0);
+        assertThat(availabilityAndBacklog.getBacklog()).isEqualTo(backlog);
+        // if credit is non-positive, only event can be available.
+        assertThat(availabilityAndBacklog.isAvailable()).isFalse();
+    }
+
+    @Test
+    void testGetAvailabilityAndBacklogNonPositiveCreditNextIsEvent() {
+        final int backlog = 2;
+
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+        subpartitionView.setMemoryDataView(
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (nextToConsume) ->
+                                        Optional.of(
+                                                createBufferAndBacklog(
+                                                        backlog, DataType.EVENT_BUFFER, 0)))
+                        .build());
+        subpartitionView.setDiskDataView(
+                TestingHsDataView.builder().setGetBacklogSupplier(() -> backlog).build());
+
+        subpartitionView.getNextBuffer();
+
+        AvailabilityWithBacklog availabilityAndBacklog =
+                subpartitionView.getAvailabilityAndBacklog(0);
+        assertThat(availabilityAndBacklog.getBacklog()).isEqualTo(backlog);
+        // if credit is non-positive, only event can be available.
+        assertThat(availabilityAndBacklog.isAvailable()).isTrue();
+    }
+
+    @Test
+    void testRelease() throws Exception {
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+        CompletableFuture<Void> releaseDataViewFuture = new CompletableFuture<>();
+        TestingHsDataView diskDataView =
+                TestingHsDataView.builder()
+                        .setReleaseDataViewRunnable(() -> releaseDataViewFuture.complete(null))
+                        .build();
+        subpartitionView.setDiskDataView(diskDataView);
+        subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
+        subpartitionView.releaseAllResources();
+        assertThat(subpartitionView.isReleased()).isTrue();
+        assertThat(releaseDataViewFuture).isCompleted();
+    }
+
+    @Test
+    void testGetConsumingOffset() {
+        AtomicInteger nextBufferIndex = new AtomicInteger(0);
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+        TestingHsDataView diskDataView =
+                TestingHsDataView.builder()
+                        .setConsumeBufferFunction(
+                                (toConsumeBuffer) ->
+                                        Optional.of(
+                                                createBufferAndBacklog(
+                                                        0,
+                                                        DataType.DATA_BUFFER,
+                                                        nextBufferIndex.getAndIncrement())))
+                        .build();
+        subpartitionView.setDiskDataView(diskDataView);
+        subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
+
+        assertThat(subpartitionView.getConsumingOffset()).isEqualTo(-1);
+        subpartitionView.getNextBuffer();
+        assertThat(subpartitionView.getConsumingOffset()).isEqualTo(0);
+        subpartitionView.getNextBuffer();
+        assertThat(subpartitionView.getConsumingOffset()).isEqualTo(1);
+    }
+
+    @Test
+    void testSetDataViewRepeatedly() {
+        HsSubpartitionView subpartitionView = createSubpartitionView();
+
+        subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
+        assertThatThrownBy(() -> subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("repeatedly set memory data view is not allowed.");
+
+        subpartitionView.setDiskDataView(TestingHsDataView.NO_OP);
+        assertThatThrownBy(() -> subpartitionView.setDiskDataView(TestingHsDataView.NO_OP))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("repeatedly set disk data view is not allowed.");
+    }
+
+    private static HsSubpartitionView createSubpartitionView() {
+        return new HsSubpartitionView(new NoOpBufferAvailablityListener());
+    }
+
+    private static HsSubpartitionView createSubpartitionView(
+            BufferAvailabilityListener bufferAvailabilityListener) {
+        return new HsSubpartitionView(bufferAvailabilityListener);
+    }
+
+    private static BufferAndBacklog createBufferAndBacklog(
+            int buffersInBacklog, DataType nextDataType, int sequenceNumber) {
+        final int bufferSize = 8;
+        Buffer buffer = HybridShuffleTestUtils.createBuffer(bufferSize, true);
+        return new BufferAndBacklog(buffer, buffersInBacklog, nextDataType, sequenceNumber);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingHsDataView.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingHsDataView.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/** Mock {@link HsDataView} for testing. */
+public class TestingHsDataView implements HsDataView {
+    public static final TestingHsDataView NO_OP = TestingHsDataView.builder().build();
+
+    private final FunctionWithException<
+                    Integer, Optional<ResultSubpartition.BufferAndBacklog>, Throwable>
+            consumeBufferFunction;
+
+    private final Function<Integer, Buffer.DataType> peekNextToConsumeDataTypeFunction;
+
+    private final Supplier<Integer> getBacklogSupplier;
+
+    private final Runnable releaseDataViewRunnable;
+
+    private TestingHsDataView(
+            FunctionWithException<Integer, Optional<ResultSubpartition.BufferAndBacklog>, Throwable>
+                    consumeBufferFunction,
+            Function<Integer, Buffer.DataType> peekNextToConsumeDataTypeFunction,
+            Supplier<Integer> getBacklogSupplier,
+            Runnable releaseDataViewRunnable) {
+        this.consumeBufferFunction = consumeBufferFunction;
+        this.peekNextToConsumeDataTypeFunction = peekNextToConsumeDataTypeFunction;
+        this.getBacklogSupplier = getBacklogSupplier;
+        this.releaseDataViewRunnable = releaseDataViewRunnable;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    @Override
+    public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(int nextBufferToConsume)
+            throws Throwable {
+        return consumeBufferFunction.apply(nextBufferToConsume);
+    }
+
+    @Override
+    public Buffer.DataType peekNextToConsumeDataType(int nextBufferToConsume) {
+        return peekNextToConsumeDataTypeFunction.apply(nextBufferToConsume);
+    }
+
+    @Override
+    public int getBacklog() {
+        return getBacklogSupplier.get();
+    }
+
+    @Override
+    public void releaseDataView() {
+        releaseDataViewRunnable.run();
+    }
+
+    /** Builder for {@link TestingHsDataView}. */
+    public static class Builder {
+        private FunctionWithException<
+                        Integer, Optional<ResultSubpartition.BufferAndBacklog>, Throwable>
+                consumeBufferFunction = (ignore) -> Optional.empty();
+
+        private Function<Integer, Buffer.DataType> peekNextToConsumeDataTypeFunction =
+                (ignore) -> Buffer.DataType.NONE;
+
+        private Supplier<Integer> getBacklogSupplier = () -> 0;
+
+        private Runnable releaseDataViewRunnable = () -> {};
+
+        private Builder() {}
+
+        public Builder setConsumeBufferFunction(
+                FunctionWithException<
+                                Integer, Optional<ResultSubpartition.BufferAndBacklog>, Throwable>
+                        consumeBufferFunction) {
+            this.consumeBufferFunction = consumeBufferFunction;
+            return this;
+        }
+
+        public Builder setPeekNextToConsumeDataTypeFunction(
+                Function<Integer, Buffer.DataType> peekNextToConsumeDataTypeFunction) {
+            this.peekNextToConsumeDataTypeFunction = peekNextToConsumeDataTypeFunction;
+            return this;
+        }
+
+        public Builder setGetBacklogSupplier(Supplier<Integer> getBacklogSupplier) {
+            this.getBacklogSupplier = getBacklogSupplier;
+            return this;
+        }
+
+        public Builder setReleaseDataViewRunnable(Runnable releaseDataViewRunnable) {
+            this.releaseDataViewRunnable = releaseDataViewRunnable;
+            return this;
+        }
+
+        public TestingHsDataView build() {
+            return new TestingHsDataView(
+                    consumeBufferFunction,
+                    peekNextToConsumeDataTypeFunction,
+                    getBacklogSupplier,
+                    releaseDataViewRunnable);
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingMemoryDataManagerOperation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingMemoryDataManagerOperation.java
@@ -35,16 +35,20 @@ public class TestingMemoryDataManagerOperation implements HsMemoryDataManagerOpe
 
     private final Runnable onBufferFinishedRunnable;
 
+    private final Runnable onDataAvailableRunnable;
+
     private TestingMemoryDataManagerOperation(
             SupplierWithException<BufferBuilder, InterruptedException>
                     requestBufferFromPoolSupplier,
             BiConsumer<Integer, Integer> markBufferReadableConsumer,
             Consumer<BufferIndexAndChannel> onBufferConsumedConsumer,
-            Runnable onBufferFinishedRunnable) {
+            Runnable onBufferFinishedRunnable,
+            Runnable onDataAvailableRunnable) {
         this.requestBufferFromPoolSupplier = requestBufferFromPoolSupplier;
         this.markBufferReadableConsumer = markBufferReadableConsumer;
         this.onBufferConsumedConsumer = onBufferConsumedConsumer;
         this.onBufferFinishedRunnable = onBufferFinishedRunnable;
+        this.onDataAvailableRunnable = onDataAvailableRunnable;
     }
 
     @Override
@@ -67,6 +71,11 @@ public class TestingMemoryDataManagerOperation implements HsMemoryDataManagerOpe
         onBufferFinishedRunnable.run();
     }
 
+    @Override
+    public void onDataAvailable(int subpartitionId) {
+        onDataAvailableRunnable.run();
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -81,6 +90,8 @@ public class TestingMemoryDataManagerOperation implements HsMemoryDataManagerOpe
         private Consumer<BufferIndexAndChannel> onBufferConsumedConsumer = (ignore1) -> {};
 
         private Runnable onBufferFinishedRunnable = () -> {};
+
+        private Runnable onDataAvailableRunnable = () -> {};
 
         public Builder setRequestBufferFromPoolSupplier(
                 SupplierWithException<BufferBuilder, InterruptedException>
@@ -106,6 +117,11 @@ public class TestingMemoryDataManagerOperation implements HsMemoryDataManagerOpe
             return this;
         }
 
+        public Builder setOnDataAvailableRunnable(Runnable onDataAvailableRunnable) {
+            this.onDataAvailableRunnable = onDataAvailableRunnable;
+            return this;
+        }
+
         private Builder() {}
 
         public TestingMemoryDataManagerOperation build() {
@@ -113,7 +129,8 @@ public class TestingMemoryDataManagerOperation implements HsMemoryDataManagerOpe
                     requestBufferFromPoolSupplier,
                     markBufferReadableConsumer,
                     onBufferConsumedConsumer,
-                    onBufferFinishedRunnable);
+                    onBufferFinishedRunnable,
+                    onDataAvailableRunnable);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingStrategy.java
@@ -32,15 +32,19 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
 
     private final Function<HsSpillingInfoProvider, Decision> decideActionWithGlobalInfoFunction;
 
+    private final Function<HsSpillingInfoProvider, Decision> onResultPartitionClosedFunction;
+
     private TestingSpillingStrategy(
             BiFunction<Integer, Integer, Optional<Decision>> onMemoryUsageChangedFunction,
             Function<Integer, Optional<Decision>> onBufferFinishedFunction,
             Function<BufferIndexAndChannel, Optional<Decision>> onBufferConsumedFunction,
-            Function<HsSpillingInfoProvider, Decision> decideActionWithGlobalInfoFunction) {
+            Function<HsSpillingInfoProvider, Decision> decideActionWithGlobalInfoFunction,
+            Function<HsSpillingInfoProvider, Decision> onResultPartitionClosedFunction) {
         this.onMemoryUsageChangedFunction = onMemoryUsageChangedFunction;
         this.onBufferFinishedFunction = onBufferFinishedFunction;
         this.onBufferConsumedFunction = onBufferConsumedFunction;
         this.decideActionWithGlobalInfoFunction = decideActionWithGlobalInfoFunction;
+        this.onResultPartitionClosedFunction = onResultPartitionClosedFunction;
     }
 
     @Override
@@ -64,6 +68,11 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
         return decideActionWithGlobalInfoFunction.apply(spillingInfoProvider);
     }
 
+    @Override
+    public Decision onResultPartitionClosed(HsSpillingInfoProvider spillingInfoProvider) {
+        return onResultPartitionClosedFunction.apply(spillingInfoProvider);
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -80,6 +89,9 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
                 (ignore) -> Optional.of(Decision.NO_ACTION);
 
         private Function<HsSpillingInfoProvider, Decision> decideActionWithGlobalInfoFunction =
+                (ignore) -> Decision.NO_ACTION;
+
+        private Function<HsSpillingInfoProvider, Decision> onResultPartitionClosedFunction =
                 (ignore) -> Decision.NO_ACTION;
 
         private Builder() {}
@@ -108,12 +120,19 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
             return this;
         }
 
+        public Builder setOnResultPartitionClosedFunction(
+                Function<HsSpillingInfoProvider, Decision> onResultPartitionClosedFunction) {
+            this.onResultPartitionClosedFunction = onResultPartitionClosedFunction;
+            return this;
+        }
+
         public TestingSpillingStrategy build() {
             return new TestingSpillingStrategy(
                     onMemoryUsageChangedFunction,
                     onBufferFinishedFunction,
                     onBufferConsumedFunction,
-                    decideActionWithGlobalInfoFunction);
+                    decideActionWithGlobalInfoFunction,
+                    onResultPartitionClosedFunction);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionViewInternalOperation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionViewInternalOperation.java
@@ -27,7 +27,7 @@ public class TestingSubpartitionViewInternalOperation
     private Runnable notifyDataAvailableRunnable = () -> {};
 
     @Override
-    public void notifyDataAvailableFromDisk() {
+    public void notifyDataAvailable() {
         notifyDataAvailableRunnable.run();
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Introduce HsResultPartition and HsSubpartitionView, this is the last part of hybrid shuffle mode in the shuffle layer.*


## Brief change log

  - *Extends onResultPartitionClosed to HsSpillingStrategy and add lifecycle method for hybrid shuffle component.*
  - *HybridShuffleConfiguration supports set spillingStrategy name and load spillingStrategy.*
  - *Introduce HsResultPartition and HsSubpartitionView.*
  - *ResultPartitionFactory also supports HYBRID type and introduce config option for hybrid spilling strategy.*


## Verifying this change

This change added UT tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
