### PR TITLE
[FLINK-28698][runtime-web] fix order of aggregate durations to follow task state transitions

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-vertex.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-vertex.ts
@@ -44,12 +44,20 @@ export interface AggregatedStatistics {
   p95: number;
 }
 
+export enum JobVertexStatus {
+  CREATED = 'CREATED',
+  SCHEDULED = 'SCHEDULED',
+  DEPLOYING = 'DEPLOYING',
+  INITIALIZING = 'INITIALIZING',
+  RUNNING = 'RUNNING'
+}
+
 export interface JobVertexStatusDuration<T> {
-  CREATED: T;
-  INITIALIZING: T;
-  RUNNING: T;
-  SCHEDULED: T;
-  DEPLOYING: T;
+  [JobVertexStatus.CREATED]: T;
+  [JobVertexStatus.INITIALIZING]: T;
+  [JobVertexStatus.RUNNING]: T;
+  [JobVertexStatus.SCHEDULED]: T;
+  [JobVertexStatus.DEPLOYING]: T;
 }
 
 export interface JobVertexAggregated {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.html
@@ -97,7 +97,7 @@
                 <ng-template #badges>
                   <flink-dynamic-host
                     *ngFor="let duration of convertStatusDuration(subtask['status-duration'])"
-                    [data]="{ state: duration.key, duration: duration.value }"
+                    [data]="duration"
                     [component]="durationBadgeComponent"
                   ></flink-dynamic-host>
                 </ng-template>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/subtasks/job-overview-drawer-subtasks.component.ts
@@ -20,7 +20,12 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnDestro
 import { of, Subject } from 'rxjs';
 import { catchError, mergeMap, takeUntil } from 'rxjs/operators';
 
-import { JobVertexAggregated, JobVertexStatusDuration, JobVertexSubTask } from '@flink-runtime-web/interfaces';
+import {
+  JobVertexAggregated,
+  JobVertexStatus,
+  JobVertexStatusDuration,
+  JobVertexSubTask
+} from '@flink-runtime-web/interfaces';
 import {
   JOB_OVERVIEW_MODULE_CONFIG,
   JOB_OVERVIEW_MODULE_DEFAULT_CONFIG,
@@ -106,10 +111,15 @@ export class JobOverviewDrawerSubtasksComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  convertStatusDuration(duration: JobVertexStatusDuration<number>): Array<{ key: string; value: number }> {
-    return Object.keys(duration || {}).map(key => ({
-      key,
-      value: duration[key as keyof JobVertexStatusDuration<number>]
-    }));
+  convertStatusDuration(statusDuration: JobVertexStatusDuration<number>): Array<{ state: string; duration: number }> {
+    const orderedKeys = [
+      JobVertexStatus.CREATED,
+      JobVertexStatus.SCHEDULED,
+      JobVertexStatus.DEPLOYING,
+      JobVertexStatus.INITIALIZING,
+      JobVertexStatus.RUNNING
+    ];
+
+    return orderedKeys.map(key => ({ state: key, duration: statusDuration[key] }));
   }
 }

--- a/flink-runtime-web/web-dashboard/src/app/share/common/table-aggregated-metrics/table-aggregated-metrics.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/share/common/table-aggregated-metrics/table-aggregated-metrics.component.html
@@ -40,17 +40,6 @@
   </thead>
   <tbody>
     <tr>
-      <td nzLeft>INITIALIZING Duration</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.min | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.max | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.avg | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.sum | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.median | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.p25 | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.p75 | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].INITIALIZING.p95 | humanizeDuration }}</td>
-    </tr>
-    <tr>
       <td nzLeft>CREATED Duration</td>
       <td>{{ aggregated?.['status-duration'].CREATED.min | humanizeDuration }}</td>
       <td>{{ aggregated?.['status-duration'].CREATED.max | humanizeDuration }}</td>
@@ -71,17 +60,6 @@
       <td>{{ aggregated?.['status-duration'].SCHEDULED.p25 | humanizeDuration }}</td>
       <td>{{ aggregated?.['status-duration'].SCHEDULED.p75 | humanizeDuration }}</td>
       <td>{{ aggregated?.['status-duration'].SCHEDULED.p95 | humanizeDuration }}</td>
-    </tr>
-    <tr>
-      <td nzLeft>RUNNING Duration</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.min | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.max | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.avg | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.sum | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.median | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.p25 | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.p75 | humanizeDuration }}</td>
-      <td>{{ aggregated?.['status-duration'].RUNNING.p95 | humanizeDuration }}</td>
     </tr>
     <tr>
       <td nzLeft>DEPLOYING Duration</td>
@@ -109,6 +87,28 @@
       <td>
         {{ aggregated?.['status-duration'].DEPLOYING.p95 | humanizeDuration }}
       </td>
+    </tr>
+    <tr>
+      <td nzLeft>INITIALIZING Duration</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.min | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.max | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.avg | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.sum | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.median | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.p25 | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.p75 | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].INITIALIZING.p95 | humanizeDuration }}</td>
+    </tr>
+    <tr>
+      <td nzLeft>RUNNING Duration</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.min | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.max | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.avg | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.sum | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.median | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.p25 | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.p75 | humanizeDuration }}</td>
+      <td>{{ aggregated?.['status-duration'].RUNNING.p95 | humanizeDuration }}</td>
     </tr>
     <tr>
       <td nzLeft>Read Records</td>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR closes FLINK-28698, which it fix the order of aggregated metrics status durations in order to follow the natural task state transitions: CREATED, SCHEDULED, DEPLOYING, INITIALIZING, RUNNING


## Brief change log

Change the table row order to CREATED, SCHEDULED, DEPLOYING, INITIALIZING, RUNNING.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable