### PR TITLE
[FLINK-28559][python] Support DataStream PythonKeyedProcessOperator in Thread Mode

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -31,6 +31,6 @@ numpy>=1.14.3,<1.20; python_version < '3.7'
 fastavro>=1.1.0,<1.4.8
 grpcio>=1.29.0,<1.47
 grpcio-tools>=1.3.5,<=1.14.2
-pemja==0.2.0; python_version >= '3.7' and platform_system != 'Windows'
+pemja==0.2.2; python_version >= '3.7' and platform_system != 'Windows'
 httplib2>=0.19.0,<=0.20.4
 protobuf<3.18

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -104,7 +104,7 @@ under the License.
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>pemja</artifactId>
-			<version>0.2.0</version>
+			<version>0.2.2</version>
 		</dependency>
 
 		<!-- Protobuf dependencies -->

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -49,9 +49,8 @@ from pyflink.datastream.functions import (_get_python_env, FlatMapFunction, MapF
                                           InternalSingleValueProcessAllWindowFunction)
 from pyflink.datastream.output_tag import OutputTag
 from pyflink.datastream.slot_sharing_group import SlotSharingGroup
-from pyflink.datastream.state import ValueStateDescriptor, ValueState, ListStateDescriptor, \
-    StateDescriptor, ReducingStateDescriptor, AggregatingStateDescriptor, MapStateDescriptor, \
-    ReducingState
+from pyflink.datastream.state import (ListStateDescriptor, StateDescriptor, ReducingStateDescriptor,
+                                      AggregatingStateDescriptor, MapStateDescriptor, ReducingState)
 from pyflink.datastream.utils import convert_to_python_obj
 from pyflink.datastream.window import (CountTumblingWindowAssigner, CountSlidingWindowAssigner,
                                        CountWindowSerializer, TimeWindowSerializer, Trigger,
@@ -1201,101 +1200,60 @@ class KeyedStream(DataStream):
             j_conf.getString(
                 gateway.jvm.org.apache.flink.python.PythonOptions.PYTHON_EXECUTION_MODE))
 
-        if python_execution_mode == 'process':
-            class ReduceProcessKeyedProcessFunctionAdapter(KeyedProcessFunction):
+        class ReduceProcessKeyedProcessFunctionAdapter(KeyedProcessFunction):
 
-                def __init__(self, reduce_function):
-                    if isinstance(reduce_function, ReduceFunction):
-                        self._open_func = reduce_function.open
-                        self._close_func = reduce_function.close
-                        self._reduce_function = reduce_function.reduce
-                    else:
-                        self._open_func = None
-                        self._close_func = None
-                        self._reduce_function = reduce_function
-                    self._reduce_value_state = None  # type: ValueState
+            def __init__(self, reduce_function):
+                if isinstance(reduce_function, ReduceFunction):
+                    self._open_func = reduce_function.open
+                    self._close_func = reduce_function.close
+                    self._reduce_function = reduce_function.reduce
+                else:
+                    self._open_func = None
+                    self._close_func = None
+                    self._reduce_function = reduce_function
+                self._reduce_state = None  # type: ReducingState
+                self._in_batch_execution_mode = True
+                self._has_started_key_set = set()
 
-                def open(self, runtime_context: RuntimeContext):
-                    if self._open_func:
-                        self._open_func(runtime_context)
+            def open(self, runtime_context: RuntimeContext):
+                if self._open_func:
+                    self._open_func(runtime_context)
 
-                    self._reduce_value_state = runtime_context.get_state(
-                        ValueStateDescriptor("_reduce_state" + str(uuid.uuid4()), output_type))
+                self._reduce_state = runtime_context.get_reducing_state(
+                    ReducingStateDescriptor(
+                        "_reduce_state" + str(uuid.uuid4()),
+                        self._reduce_function,
+                        output_type))
+
+                if python_execution_mode == "process":
                     from pyflink.fn_execution.datastream.process.runtime_context import (
                         StreamingRuntimeContext)
-                    self._in_batch_execution_mode = \
-                        cast(StreamingRuntimeContext, runtime_context)._in_batch_execution_mode
-
-                def close(self):
-                    if self._close_func:
-                        self._close_func()
-
-                def process_element(self, value, ctx: 'KeyedProcessFunction.Context'):
-                    reduce_value = self._reduce_value_state.value()
-                    if reduce_value is not None:
-                        reduce_value = self._reduce_function(reduce_value, value)
-                    else:
-                        # register a timer for emitting the result at the end when this is the
-                        # first input for this key
-                        if self._in_batch_execution_mode:
-                            ctx.timer_service().register_event_time_timer(0x7fffffffffffffff)
-                        reduce_value = value
-                    self._reduce_value_state.update(reduce_value)
-                    if not self._in_batch_execution_mode:
-                        # only emitting the result when all the data for a key is received
-                        yield reduce_value
-
-                def on_timer(self, timestamp: int, ctx: 'KeyedProcessFunction.OnTimerContext'):
-                    current_value = self._reduce_value_state.value()
-                    if current_value is not None:
-                        yield current_value
-        else:
-            class ReduceProcessKeyedProcessFunctionAdapter(KeyedProcessFunction):
-
-                def __init__(self, reduce_function):
-                    if isinstance(reduce_function, ReduceFunction):
-                        self._open_func = reduce_function.open
-                        self._close_func = reduce_function.close
-                        self._reduce_function = reduce_function.reduce
-                    else:
-                        self._open_func = None
-                        self._close_func = None
-                        self._reduce_function = reduce_function
-                    self._reduce_state = None  # type: ReducingState
-                    self._in_batch_execution_mode = True
-                    self._has_started_key_set = set()
-
-                def open(self, runtime_context: RuntimeContext):
-                    if self._open_func:
-                        self._open_func(runtime_context)
-
-                    self._reduce_state = runtime_context.get_reducing_state(
-                        ReducingStateDescriptor(
-                            "_reduce_state" + str(uuid.uuid4()),
-                            self._reduce_function,
-                            output_type))
-
+                    self._in_batch_execution_mode = (
+                        cast(StreamingRuntimeContext, runtime_context)._in_batch_execution_mode)
+                else:
                     self._in_batch_execution_mode = runtime_context.get_job_parameter(
                         "inBatchExecutionMode", "false") == "true"
 
-                def close(self):
-                    if self._close_func:
-                        self._close_func()
+            def close(self):
+                if self._close_func:
+                    self._close_func()
 
-                def process_element(self, value, ctx: 'KeyedProcessFunction.Context'):
-                    self._reduce_state.add(value)
-                    if self._in_batch_execution_mode:
-                        key = ctx.get_current_key()
-                        if key not in self._has_started_key_set:
-                            ctx.timer_service().register_event_time_timer(0x7fffffffffffffff)
-                            self._has_started_key_set.add(key)
-                    else:
-                        yield self._reduce_state.get()
+            def process_element(self, value, ctx: 'KeyedProcessFunction.Context'):
+                self._reduce_state.add(value)
+                if self._in_batch_execution_mode:
+                    key = ctx.get_current_key()
+                    if isinstance(key, list):
+                        key = tuple(key)
+                    if key not in self._has_started_key_set:
+                        ctx.timer_service().register_event_time_timer(0x7fffffffffffffff)
+                        self._has_started_key_set.add(key)
+                else:
+                    yield self._reduce_state.get()
 
-                def on_timer(self, timestamp: int, ctx: 'KeyedProcessFunction.OnTimerContext'):
-                    current_value = self._reduce_state.get()
-                    if current_value is not None:
-                        yield current_value
+            def on_timer(self, timestamp: int, ctx: 'KeyedProcessFunction.OnTimerContext'):
+                current_value = self._reduce_state.get()
+                if current_value is not None:
+                    yield current_value
 
         return self.process(ReduceProcessKeyedProcessFunctionAdapter(func), output_type) \
             .name("Reduce")

--- a/flink-python/pyflink/datastream/state.py
+++ b/flink-python/pyflink/datastream/state.py
@@ -899,14 +899,14 @@ class StateTtlConfig(object):
             Configuration of cleanup strategy while taking the full snapshot.
             """
 
-            def __init__(self, cleanup_size: int, run_cleanup_for_every_record: int):
+            def __init__(self, cleanup_size: int, run_cleanup_for_every_record: bool):
                 self._cleanup_size = cleanup_size
                 self._run_cleanup_for_every_record = run_cleanup_for_every_record
 
             def get_cleanup_size(self) -> int:
                 return self._cleanup_size
 
-            def run_cleanup_for_every_record(self) -> int:
+            def run_cleanup_for_every_record(self) -> bool:
                 return self._run_cleanup_for_every_record
 
         class RocksdbCompactFilterCleanupStrategy(CleanupStrategy):

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -164,6 +164,310 @@ class DataStreamTests(object):
 
         self.env.execute('test_partition_custom')
 
+    def test_keyed_process_function_with_state(self):
+        self.env.get_config().set_auto_watermark_interval(2000)
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+        data_stream = self.env.from_collection([(1, 'hi', '1603708211000'),
+                                                (2, 'hello', '1603708224000'),
+                                                (3, 'hi', '1603708226000'),
+                                                (4, 'hello', '1603708289000'),
+                                                (5, 'hi', '1603708291000'),
+                                                (6, 'hello', '1603708293000')],
+                                               type_info=Types.ROW([Types.INT(), Types.STRING(),
+                                                                    Types.STRING()]))
+
+        class MyTimestampAssigner(TimestampAssigner):
+
+            def extract_timestamp(self, value, record_timestamp) -> int:
+                return int(value[2])
+
+        class MyProcessFunction(KeyedProcessFunction):
+
+            def __init__(self):
+                self.value_state = None
+                self.list_state = None
+                self.map_state = None
+
+            def open(self, runtime_context: RuntimeContext):
+                value_state_descriptor = ValueStateDescriptor('value_state', Types.INT())
+                self.value_state = runtime_context.get_state(value_state_descriptor)
+                list_state_descriptor = ListStateDescriptor('list_state', Types.INT())
+                self.list_state = runtime_context.get_list_state(list_state_descriptor)
+                map_state_descriptor = MapStateDescriptor('map_state', Types.INT(), Types.STRING())
+                state_ttl_config = StateTtlConfig \
+                    .new_builder(Time.seconds(1)) \
+                    .set_update_type(StateTtlConfig.UpdateType.OnReadAndWrite) \
+                    .set_state_visibility(
+                        StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp) \
+                    .disable_cleanup_in_background() \
+                    .build()
+                map_state_descriptor.enable_time_to_live(state_ttl_config)
+                self.map_state = runtime_context.get_map_state(map_state_descriptor)
+
+            def process_element(self, value, ctx):
+                current_value = self.value_state.value()
+                self.value_state.update(value[0])
+                current_list = [_ for _ in self.list_state.get()]
+                self.list_state.add(value[0])
+                map_entries = {k: v for k, v in self.map_state.items()}
+                keys = sorted(map_entries.keys())
+                map_entries_string = [str(k) + ': ' + str(map_entries[k]) for k in keys]
+                map_entries_string = '{' + ', '.join(map_entries_string) + '}'
+                self.map_state.put(value[0], value[1])
+                current_key = ctx.get_current_key()
+                yield "current key: {}, current value state: {}, current list state: {}, " \
+                      "current map state: {}, current value: {}".format(str(current_key),
+                                                                        str(current_value),
+                                                                        str(current_list),
+                                                                        map_entries_string,
+                                                                        str(value))
+
+            def on_timer(self, timestamp, ctx):
+                pass
+
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(MyTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[1], key_type=Types.STRING()) \
+            .process(MyProcessFunction(), output_type=Types.STRING()) \
+            .add_sink(self.test_sink)
+        self.env.execute('test time stamp assigner with keyed process function')
+        results = self.test_sink.get_results()
+        expected = ["current key: hi, current value state: None, current list state: [], "
+                    "current map state: {}, current value: Row(f0=1, f1='hi', "
+                    "f2='1603708211000')",
+                    "current key: hello, current value state: None, "
+                    "current list state: [], current map state: {}, current value: Row(f0=2,"
+                    " f1='hello', f2='1603708224000')",
+                    "current key: hi, current value state: 1, current list state: [1], "
+                    "current map state: {1: hi}, current value: Row(f0=3, f1='hi', "
+                    "f2='1603708226000')",
+                    "current key: hello, current value state: 2, current list state: [2], "
+                    "current map state: {2: hello}, current value: Row(f0=4, f1='hello', "
+                    "f2='1603708289000')",
+                    "current key: hi, current value state: 3, current list state: [1, 3], "
+                    "current map state: {1: hi, 3: hi}, current value: Row(f0=5, f1='hi', "
+                    "f2='1603708291000')",
+                    "current key: hello, current value state: 4, current list state: [2, 4],"
+                    " current map state: {2: hello, 4: hello}, current value: Row(f0=6, "
+                    "f1='hello', f2='1603708293000')"]
+        self.assert_equals_sorted(expected, results)
+
+    def test_reducing_state(self):
+        self.env.set_parallelism(2)
+        data_stream = self.env.from_collection([
+            (1, 'hi'), (2, 'hello'), (3, 'hi'), (4, 'hello'), (5, 'hi'), (6, 'hello')],
+            type_info=Types.TUPLE([Types.INT(), Types.STRING()]))
+
+        class MyProcessFunction(KeyedProcessFunction):
+
+            def __init__(self):
+                self.reducing_state = None  # type: ReducingState
+
+            def open(self, runtime_context: RuntimeContext):
+                self.reducing_state = runtime_context.get_reducing_state(
+                    ReducingStateDescriptor(
+                        'reducing_state', lambda i, i2: i + i2, Types.INT()))
+
+            def process_element(self, value, ctx):
+                self.reducing_state.add(value[0])
+                yield self.reducing_state.get(), value[1]
+
+        data_stream.key_by(lambda x: x[1], key_type=Types.STRING()) \
+            .process(MyProcessFunction(), output_type=Types.TUPLE([Types.INT(), Types.STRING()])) \
+            .add_sink(self.test_sink)
+        self.env.execute('test_reducing_state')
+        result = self.test_sink.get_results()
+        expected_result = ['(1,hi)', '(2,hello)', '(4,hi)', '(6,hello)', '(9,hi)', '(12,hello)']
+        result.sort()
+        expected_result.sort()
+        self.assertEqual(expected_result, result)
+
+    def test_aggregating_state(self):
+        self.env.set_parallelism(2)
+        data_stream = self.env.from_collection([
+            (1, 'hi'), (2, 'hello'), (3, 'hi'), (4, 'hello'), (5, 'hi'), (6, 'hello')],
+            type_info=Types.TUPLE([Types.INT(), Types.STRING()]))
+
+        class MyAggregateFunction(AggregateFunction):
+
+            def create_accumulator(self):
+                return 0
+
+            def add(self, value, accumulator):
+                return value + accumulator
+
+            def get_result(self, accumulator):
+                return accumulator
+
+            def merge(self, acc_a, acc_b):
+                return acc_a + acc_b
+
+        class MyProcessFunction(KeyedProcessFunction):
+
+            def __init__(self):
+                self.aggregating_state = None  # type: AggregatingState
+
+            def open(self, runtime_context: RuntimeContext):
+                descriptor = AggregatingStateDescriptor(
+                    'aggregating_state', MyAggregateFunction(), Types.INT())
+                state_ttl_config = StateTtlConfig \
+                    .new_builder(Time.seconds(1)) \
+                    .set_update_type(StateTtlConfig.UpdateType.OnReadAndWrite) \
+                    .disable_cleanup_in_background() \
+                    .build()
+                descriptor.enable_time_to_live(state_ttl_config)
+                self.aggregating_state = runtime_context.get_aggregating_state(descriptor)
+
+            def process_element(self, value, ctx):
+                self.aggregating_state.add(value[0])
+                yield self.aggregating_state.get(), value[1]
+
+        config = Configuration(
+            j_configuration=get_j_env_configuration(self.env._j_stream_execution_environment))
+        config.set_integer("python.fn-execution.bundle.size", 1)
+        data_stream.key_by(lambda x: x[1], key_type=Types.STRING()) \
+            .process(MyProcessFunction(), output_type=Types.TUPLE([Types.INT(), Types.STRING()])) \
+            .add_sink(self.test_sink)
+        self.env.execute('test_aggregating_state')
+        results = self.test_sink.get_results()
+        expected = ['(1,hi)', '(2,hello)', '(4,hi)', '(6,hello)', '(9,hi)', '(12,hello)']
+        self.assert_equals_sorted(expected, results)
+
+
+class DataStreamStreamingTests(DataStreamTests):
+    def test_timestamp_assigner_and_watermark_strategy(self):
+        self.env.set_parallelism(1)
+        self.env.get_config().set_auto_watermark_interval(2000)
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+        data_stream = self.env.from_collection([(1, '1603708211000'),
+                                                (2, '1603708224000'),
+                                                (3, '1603708226000'),
+                                                (4, '1603708289000')],
+                                               type_info=Types.ROW([Types.INT(), Types.STRING()]))
+
+        class MyTimestampAssigner(TimestampAssigner):
+
+            def extract_timestamp(self, value, record_timestamp) -> int:
+                return int(value[1])
+
+        class MyProcessFunction(KeyedProcessFunction):
+
+            def __init__(self):
+                self.timer_registered = False
+
+            def open(self, runtime_context: RuntimeContext):
+                self.timer_registered = False
+
+            def process_element(self, value, ctx):
+                if not self.timer_registered:
+                    ctx.timer_service().register_event_time_timer(3)
+                    self.timer_registered = True
+                current_timestamp = ctx.timestamp()
+                current_watermark = ctx.timer_service().current_watermark()
+                current_key = ctx.get_current_key()
+                yield "current key: {}, current timestamp: {}, current watermark: {}, " \
+                      "current_value: {}".format(str(current_key), str(current_timestamp),
+                                                 str(current_watermark), str(value))
+
+            def on_timer(self, timestamp, ctx):
+                yield "on timer: " + str(timestamp)
+
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(MyTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type=Types.INT()) \
+            .process(MyProcessFunction(), output_type=Types.STRING()).add_sink(self.test_sink)
+        self.env.execute('test time stamp assigner with keyed process function')
+        results = self.test_sink.get_results()
+        # Because the watermark interval is too long, no watermark was sent before processing these
+        # data. So all current watermarks are Long.MIN_VALUE.
+        expected = ["current key: 1, current timestamp: 1603708211000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=1, f1='1603708211000')",
+                    "current key: 2, current timestamp: 1603708224000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=2, f1='1603708224000')",
+                    "current key: 3, current timestamp: 1603708226000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=3, f1='1603708226000')",
+                    "current key: 4, current timestamp: 1603708289000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=4, f1='1603708289000')",
+                    "on timer: 3"]
+        self.assert_equals_sorted(expected, results)
+
+    def test_reduce_with_state(self):
+        ds = self.env.from_collection([('a', 0), ('c', 1), ('d', 1), ('b', 0), ('e', 1)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        keyed_stream = ds.key_by(MyKeySelector(), key_type=Types.INT())
+
+        with self.assertRaises(Exception):
+            keyed_stream.name("keyed stream")
+
+        keyed_stream.reduce(MyReduceFunction()).add_sink(self.test_sink)
+        self.env.execute('key_by_test')
+        results = self.test_sink.get_results(False)
+        expected = ['+I[a, 0]', '+I[ab, 0]', '+I[c, 1]', '+I[cd, 1]', '+I[cde, 1]']
+        self.assert_equals_sorted(expected, results)
+
+
+class DataStreamBatchTests(DataStreamTests):
+    def test_timestamp_assigner_and_watermark_strategy(self):
+        self.env.set_parallelism(1)
+        self.env.get_config().set_auto_watermark_interval(2000)
+        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
+        data_stream = self.env.from_collection([(1, '1603708211000'),
+                                                (2, '1603708224000'),
+                                                (3, '1603708226000'),
+                                                (4, '1603708289000')],
+                                               type_info=Types.ROW([Types.INT(), Types.STRING()]))
+
+        class MyTimestampAssigner(TimestampAssigner):
+
+            def extract_timestamp(self, value, record_timestamp) -> int:
+                return int(value[1])
+
+        class MyProcessFunction(KeyedProcessFunction):
+
+            def process_element(self, value, ctx):
+                current_timestamp = ctx.timestamp()
+                current_watermark = ctx.timer_service().current_watermark()
+                current_key = ctx.get_current_key()
+                yield "current key: {}, current timestamp: {}, current watermark: {}, " \
+                      "current_value: {}".format(str(current_key), str(current_timestamp),
+                                                 str(current_watermark), str(value))
+
+            def on_timer(self, timestamp, ctx):
+                pass
+
+        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
+            .with_timestamp_assigner(MyTimestampAssigner())
+        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
+            .key_by(lambda x: x[0], key_type=Types.INT()) \
+            .process(MyProcessFunction(), output_type=Types.STRING()).add_sink(self.test_sink)
+        self.env.execute('test time stamp assigner with keyed process function')
+        results = self.test_sink.get_results()
+        expected = ["current key: 1, current timestamp: 1603708211000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=1, f1='1603708211000')",
+                    "current key: 2, current timestamp: 1603708224000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=2, f1='1603708224000')",
+                    "current key: 3, current timestamp: 1603708226000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=3, f1='1603708226000')",
+                    "current key: 4, current timestamp: 1603708289000, current watermark: "
+                    "-9223372036854775808, current_value: Row(f0=4, f1='1603708289000')"]
+        self.assert_equals_sorted(expected, results)
+
+    def test_reduce_with_state(self):
+        ds = self.env.from_collection([('a', 0), ('c', 1), ('d', 1), ('b', 0), ('e', 1)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        keyed_stream = ds.key_by(MyKeySelector(), key_type=Types.INT())
+
+        with self.assertRaises(Exception):
+            keyed_stream.name("keyed stream")
+
+        keyed_stream.reduce(MyReduceFunction()).add_sink(self.test_sink)
+        self.env.execute('key_by_test')
+        results = self.test_sink.get_results(False)
+        expected = ['+I[ab, 0]', '+I[cde, 1]']
+        self.assert_equals_sorted(expected, results)
+
 
 class ProcessDataStreamTests(DataStreamTests):
     """
@@ -640,176 +944,6 @@ class ProcessDataStreamTests(DataStreamTests):
                     "-9223372036854775808, current_value: Row(f0=4, f1='1603708289000')"]
         self.assert_equals_sorted(expected, results)
 
-    def test_keyed_process_function_with_state(self):
-        self.env.get_config().set_auto_watermark_interval(2000)
-        self.env.set_stream_time_characteristic(TimeCharacteristic.EventTime)
-        data_stream = self.env.from_collection([(1, 'hi', '1603708211000'),
-                                                (2, 'hello', '1603708224000'),
-                                                (3, 'hi', '1603708226000'),
-                                                (4, 'hello', '1603708289000'),
-                                                (5, 'hi', '1603708291000'),
-                                                (6, 'hello', '1603708293000')],
-                                               type_info=Types.ROW([Types.INT(), Types.STRING(),
-                                                                    Types.STRING()]))
-
-        class MyTimestampAssigner(TimestampAssigner):
-
-            def extract_timestamp(self, value, record_timestamp) -> int:
-                return int(value[2])
-
-        class MyProcessFunction(KeyedProcessFunction):
-
-            def __init__(self):
-                self.value_state = None
-                self.list_state = None
-                self.map_state = None
-
-            def open(self, runtime_context: RuntimeContext):
-                value_state_descriptor = ValueStateDescriptor('value_state', Types.INT())
-                self.value_state = runtime_context.get_state(value_state_descriptor)
-                list_state_descriptor = ListStateDescriptor('list_state', Types.INT())
-                self.list_state = runtime_context.get_list_state(list_state_descriptor)
-                map_state_descriptor = MapStateDescriptor('map_state', Types.INT(), Types.STRING())
-                state_ttl_config = StateTtlConfig \
-                    .new_builder(Time.seconds(1)) \
-                    .set_update_type(StateTtlConfig.UpdateType.OnReadAndWrite) \
-                    .set_state_visibility(
-                        StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp) \
-                    .disable_cleanup_in_background() \
-                    .build()
-                map_state_descriptor.enable_time_to_live(state_ttl_config)
-                self.map_state = runtime_context.get_map_state(map_state_descriptor)
-
-            def process_element(self, value, ctx):
-                current_value = self.value_state.value()
-                self.value_state.update(value[0])
-                current_list = [_ for _ in self.list_state.get()]
-                self.list_state.add(value[0])
-                map_entries = {k: v for k, v in self.map_state.items()}
-                keys = sorted(map_entries.keys())
-                map_entries_string = [str(k) + ': ' + str(map_entries[k]) for k in keys]
-                map_entries_string = '{' + ', '.join(map_entries_string) + '}'
-                self.map_state.put(value[0], value[1])
-                current_key = ctx.get_current_key()
-                yield "current key: {}, current value state: {}, current list state: {}, " \
-                      "current map state: {}, current value: {}".format(str(current_key),
-                                                                        str(current_value),
-                                                                        str(current_list),
-                                                                        map_entries_string,
-                                                                        str(value))
-
-            def on_timer(self, timestamp, ctx):
-                pass
-
-        watermark_strategy = WatermarkStrategy.for_monotonous_timestamps() \
-            .with_timestamp_assigner(MyTimestampAssigner())
-        data_stream.assign_timestamps_and_watermarks(watermark_strategy) \
-            .key_by(lambda x: x[1], key_type=Types.STRING()) \
-            .process(MyProcessFunction(), output_type=Types.STRING()) \
-            .add_sink(self.test_sink)
-        self.env.execute('test time stamp assigner with keyed process function')
-        results = self.test_sink.get_results()
-        expected = ["current key: hi, current value state: None, current list state: [], "
-                    "current map state: {}, current value: Row(f0=1, f1='hi', "
-                    "f2='1603708211000')",
-                    "current key: hello, current value state: None, "
-                    "current list state: [], current map state: {}, current value: Row(f0=2,"
-                    " f1='hello', f2='1603708224000')",
-                    "current key: hi, current value state: 1, current list state: [1], "
-                    "current map state: {1: hi}, current value: Row(f0=3, f1='hi', "
-                    "f2='1603708226000')",
-                    "current key: hello, current value state: 2, current list state: [2], "
-                    "current map state: {2: hello}, current value: Row(f0=4, f1='hello', "
-                    "f2='1603708289000')",
-                    "current key: hi, current value state: 3, current list state: [1, 3], "
-                    "current map state: {1: hi, 3: hi}, current value: Row(f0=5, f1='hi', "
-                    "f2='1603708291000')",
-                    "current key: hello, current value state: 4, current list state: [2, 4],"
-                    " current map state: {2: hello, 4: hello}, current value: Row(f0=6, "
-                    "f1='hello', f2='1603708293000')"]
-        self.assert_equals_sorted(expected, results)
-
-    def test_reducing_state(self):
-        self.env.set_parallelism(2)
-        data_stream = self.env.from_collection([
-            (1, 'hi'), (2, 'hello'), (3, 'hi'), (4, 'hello'), (5, 'hi'), (6, 'hello')],
-            type_info=Types.TUPLE([Types.INT(), Types.STRING()]))
-
-        class MyProcessFunction(KeyedProcessFunction):
-
-            def __init__(self):
-                self.reducing_state = None  # type: ReducingState
-
-            def open(self, runtime_context: RuntimeContext):
-                self.reducing_state = runtime_context.get_reducing_state(
-                    ReducingStateDescriptor(
-                        'reducing_state', lambda i, i2: i + i2, Types.INT()))
-
-            def process_element(self, value, ctx):
-                self.reducing_state.add(value[0])
-                yield self.reducing_state.get(), value[1]
-
-        data_stream.key_by(lambda x: x[1], key_type=Types.STRING()) \
-            .process(MyProcessFunction(), output_type=Types.TUPLE([Types.INT(), Types.STRING()])) \
-            .add_sink(self.test_sink)
-        self.env.execute('test_reducing_state')
-        result = self.test_sink.get_results()
-        expected_result = ['(1,hi)', '(2,hello)', '(4,hi)', '(6,hello)', '(9,hi)', '(12,hello)']
-        result.sort()
-        expected_result.sort()
-        self.assertEqual(expected_result, result)
-
-    def test_aggregating_state(self):
-        self.env.set_parallelism(2)
-        data_stream = self.env.from_collection([
-            (1, 'hi'), (2, 'hello'), (3, 'hi'), (4, 'hello'), (5, 'hi'), (6, 'hello')],
-            type_info=Types.TUPLE([Types.INT(), Types.STRING()]))
-
-        class MyAggregateFunction(AggregateFunction):
-
-            def create_accumulator(self):
-                return 0
-
-            def add(self, value, accumulator):
-                return value + accumulator
-
-            def get_result(self, accumulator):
-                return accumulator
-
-            def merge(self, acc_a, acc_b):
-                return acc_a + acc_b
-
-        class MyProcessFunction(KeyedProcessFunction):
-
-            def __init__(self):
-                self.aggregating_state = None  # type: AggregatingState
-
-            def open(self, runtime_context: RuntimeContext):
-                descriptor = AggregatingStateDescriptor(
-                    'aggregating_state', MyAggregateFunction(), Types.INT())
-                state_ttl_config = StateTtlConfig \
-                    .new_builder(Time.seconds(1)) \
-                    .set_update_type(StateTtlConfig.UpdateType.OnReadAndWrite) \
-                    .disable_cleanup_in_background() \
-                    .build()
-                descriptor.enable_time_to_live(state_ttl_config)
-                self.aggregating_state = runtime_context.get_aggregating_state(descriptor)
-
-            def process_element(self, value, ctx):
-                self.aggregating_state.add(value[0])
-                yield self.aggregating_state.get(), value[1]
-
-        config = Configuration(
-            j_configuration=get_j_env_configuration(self.env._j_stream_execution_environment))
-        config.set_integer("python.fn-execution.bundle.size", 1)
-        data_stream.key_by(lambda x: x[1], key_type=Types.STRING()) \
-            .process(MyProcessFunction(), output_type=Types.TUPLE([Types.INT(), Types.STRING()])) \
-            .add_sink(self.test_sink)
-        self.env.execute('test_aggregating_state')
-        results = self.test_sink.get_results()
-        expected = ['(1,hi)', '(2,hello)', '(4,hi)', '(6,hello)', '(9,hi)', '(12,hello)']
-        self.assert_equals_sorted(expected, results)
-
     def test_process_side_output(self):
         tag = OutputTag("side", Types.INT())
 
@@ -1122,7 +1256,8 @@ class ProcessDataStreamTests(DataStreamTests):
         self.assert_equals_sorted(expected, self.test_sink.get_results())
 
 
-class StreamingModeDataStreamTests(ProcessDataStreamTests, PyFlinkStreamingTestCase):
+class ProcessDataStreamStreamingTests(DataStreamStreamingTests, ProcessDataStreamTests,
+                                      PyFlinkStreamingTestCase):
     def test_data_stream_name(self):
         ds = self.env.from_collection([(1, 'Hi', 'Hello'), (2, 'Hello', 'Hi')])
         test_name = 'test_name'
@@ -1401,20 +1536,6 @@ class StreamingModeDataStreamTests(ProcessDataStreamTests, PyFlinkStreamingTestC
         expected = ["+I[1, a]", "+I[3, a]", "+I[6, a]", "+I[4, b]"]
         self.assert_equals_sorted(expected, results)
 
-    def test_reduce_with_state(self):
-        ds = self.env.from_collection([('a', 0), ('b', 0), ('c', 1), ('d', 1), ('e', 1)],
-                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
-        keyed_stream = ds.key_by(MyKeySelector(), key_type=Types.INT())
-
-        with self.assertRaises(Exception):
-            keyed_stream.name("keyed stream")
-
-        keyed_stream.reduce(MyReduceFunction()).add_sink(self.test_sink)
-        self.env.execute('key_by_test')
-        results = self.test_sink.get_results(False)
-        expected = ['+I[a, 0]', '+I[ab, 0]', '+I[c, 1]', '+I[cd, 1]', '+I[cde, 1]']
-        self.assert_equals_sorted(expected, results)
-
     def test_keyed_sum(self):
         self.env.set_parallelism(1)
         ds = self.env.from_collection(
@@ -1529,7 +1650,8 @@ class StreamingModeDataStreamTests(ProcessDataStreamTests, PyFlinkStreamingTestC
         self.assert_equals_sorted(expected, results)
 
 
-class BatchModeDataStreamTests(ProcessDataStreamTests, PyFlinkBatchTestCase):
+class ProcessDataStreamBatchTests(DataStreamBatchTests, ProcessDataStreamTests,
+                                  PyFlinkBatchTestCase):
 
     def test_timestamp_assigner_and_watermark_strategy(self):
         self.env.set_parallelism(1)
@@ -1585,20 +1707,6 @@ class BatchModeDataStreamTests(ProcessDataStreamTests, PyFlinkBatchTestCase):
         self.env.execute('reduce_function_test')
         results = self.test_sink.get_results()
         expected = ["+I[6, a]", "+I[7, b]"]
-        self.assert_equals_sorted(expected, results)
-
-    def test_reduce_with_state(self):
-        ds = self.env.from_collection([('a', 0), ('c', 1), ('d', 1), ('b', 0), ('e', 1)],
-                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
-        keyed_stream = ds.key_by(MyKeySelector(), key_type=Types.INT())
-
-        with self.assertRaises(Exception):
-            keyed_stream.name("keyed stream")
-
-        keyed_stream.reduce(MyReduceFunction()).add_sink(self.test_sink)
-        self.env.execute('key_by_test')
-        results = self.test_sink.get_results(False)
-        expected = ['+I[ab, 0]', '+I[cde, 1]']
         self.assert_equals_sorted(expected, results)
 
     def test_keyed_sum(self):
@@ -1704,9 +1812,17 @@ class BatchModeDataStreamTests(ProcessDataStreamTests, PyFlinkBatchTestCase):
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")
-class EmbeddedDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
+class EmbeddedDataStreamStreamTests(DataStreamStreamingTests, PyFlinkStreamingTestCase):
     def setUp(self):
-        super(EmbeddedDataStreamTests, self).setUp()
+        super(EmbeddedDataStreamStreamTests, self).setUp()
+        config = get_j_env_configuration(self.env._j_stream_execution_environment)
+        config.setString("python.execution-mode", "thread")
+
+
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")
+class EmbeddedDataStreamBatchTests(DataStreamBatchTests, PyFlinkBatchTestCase):
+    def setUp(self):
+        super(EmbeddedDataStreamBatchTests, self).setUp()
         config = get_j_env_configuration(self.env._j_stream_execution_environment)
         config.setString("python.execution-mode", "thread")
 

--- a/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
@@ -18,7 +18,9 @@
 
 from pyflink.fn_execution import pickle
 from pyflink.fn_execution.datastream import operations
-from pyflink.fn_execution.datastream.embedded.process_function import InternalProcessFunctionContext
+from pyflink.fn_execution.datastream.embedded.process_function import (
+    InternalProcessFunctionContext, InternalKeyedProcessFunctionContext,
+    InternalKeyedProcessFunctionOnTimerContext)
 from pyflink.fn_execution.datastream.embedded.runtime_context import StreamingRuntimeContext
 from pyflink.fn_execution.datastream.operations import DATA_STREAM_STATELESS_FUNCTION_URN
 
@@ -29,15 +31,18 @@ class OneInputOperation(operations.OneInputOperation):
                  serialized_fn,
                  runtime_context,
                  function_context,
+                 timer_context,
                  job_parameters):
         (self.open_func,
          self.close_func,
-         self.process_element_func
+         self.process_element_func,
+         self.on_timer_func
          ) = extract_one_input_process_function(
             function_urn=function_urn,
             user_defined_function_proto=serialized_fn,
             runtime_context=StreamingRuntimeContext.of(runtime_context, job_parameters),
-            function_context=function_context)
+            function_context=function_context,
+            timer_context=timer_context)
 
     def open(self) -> None:
         self.open_func()
@@ -48,9 +53,13 @@ class OneInputOperation(operations.OneInputOperation):
     def process_element(self, value):
         return self.process_element_func(value)
 
+    def on_timer(self, timestamp):
+        return self.on_timer_func(timestamp)
+
 
 def extract_one_input_process_function(
-        function_urn, user_defined_function_proto, runtime_context, function_context):
+        function_urn, user_defined_function_proto, runtime_context, function_context,
+        timer_context):
     user_defined_func = pickle.loads(user_defined_function_proto.payload)
 
     def open_func():
@@ -61,12 +70,28 @@ def extract_one_input_process_function(
         if hasattr(user_defined_func, "close"):
             user_defined_func.close()
 
-    process_element = user_defined_func.process_element
-
     if function_urn == DATA_STREAM_STATELESS_FUNCTION_URN:
-        context = InternalProcessFunctionContext(function_context)
+        function_context = InternalProcessFunctionContext(function_context)
+
+        process_element = user_defined_func.process_element
+
+        def on_timer_func(timestamp):
+            raise Exception("This method should not be called.")
+    else:
+
+        function_context = InternalKeyedProcessFunctionContext(function_context)
+
+        timer_context = InternalKeyedProcessFunctionOnTimerContext(timer_context)
+
+        on_timer = user_defined_func.on_timer
+
+        def process_element(value, context):
+            return user_defined_func.process_element(value[1], context)
+
+        def on_timer_func(timestamp):
+            yield from on_timer(timestamp, timer_context)
 
     def process_element_func(value):
-        yield from process_element(value, context)
+        yield from process_element(value, function_context)
 
-    return open_func, close_func, process_element_func
+    return open_func, close_func, process_element_func, on_timer_func

--- a/flink-python/pyflink/fn_execution/datastream/embedded/runtime_context.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/runtime_context.py
@@ -16,9 +16,15 @@
 # limitations under the License.
 ################################################################################
 from pyflink.datastream import RuntimeContext
-from pyflink.datastream.state import AggregatingStateDescriptor, AggregatingState, \
-    ReducingStateDescriptor, ReducingState, MapStateDescriptor, MapState, ListStateDescriptor, \
-    ListState, ValueStateDescriptor, ValueState
+from pyflink.datastream.state import (AggregatingStateDescriptor, AggregatingState,
+                                      ReducingStateDescriptor, ReducingState, MapStateDescriptor,
+                                      MapState, ListStateDescriptor, ListState,
+                                      ValueStateDescriptor, ValueState)
+from pyflink.fn_execution.datastream.embedded.state_impl import (ValueStateImpl, ListStateImpl,
+                                                                 MapStateImpl, ReducingStateImpl,
+                                                                 AggregatingStateImpl)
+from pyflink.fn_execution.embedded.converters import from_type_info
+from pyflink.fn_execution.embedded.java_utils import to_java_state_descriptor
 
 
 class StreamingRuntimeContext(RuntimeContext):
@@ -76,20 +82,32 @@ class StreamingRuntimeContext(RuntimeContext):
         return self._runtime_context.getMetricGroup()
 
     def get_state(self, state_descriptor: ValueStateDescriptor) -> ValueState:
-        pass
+        return ValueStateImpl(
+            self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
+            from_type_info(state_descriptor.type_info))
 
     def get_list_state(self, state_descriptor: ListStateDescriptor) -> ListState:
-        pass
+        return ListStateImpl(
+            self._runtime_context.getListState(to_java_state_descriptor(state_descriptor)),
+            from_type_info(state_descriptor.type_info))
 
     def get_map_state(self, state_descriptor: MapStateDescriptor) -> MapState:
-        pass
+        return MapStateImpl(
+            self._runtime_context.getMapState(to_java_state_descriptor(state_descriptor)),
+            from_type_info(state_descriptor.type_info))
 
     def get_reducing_state(self, state_descriptor: ReducingStateDescriptor) -> ReducingState:
-        pass
+        return ReducingStateImpl(
+            self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
+            from_type_info(state_descriptor.type_info),
+            state_descriptor.get_reduce_function())
 
     def get_aggregating_state(self,
                               state_descriptor: AggregatingStateDescriptor) -> AggregatingState:
-        pass
+        return AggregatingStateImpl(
+            self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
+            from_type_info(state_descriptor.type_info),
+            state_descriptor.get_agg_function())
 
     @staticmethod
     def of(runtime_context, job_parameters):

--- a/flink-python/pyflink/fn_execution/datastream/embedded/state_impl.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/state_impl.py
@@ -1,0 +1,158 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from typing import List, Iterable, Tuple, Dict
+
+from pyflink.datastream import ReduceFunction, AggregateFunction
+from pyflink.datastream.state import (ValueState, T, State, ListState, IN, OUT, ReducingState,
+                                      AggregatingState, MapState, V, K)
+from pyflink.fn_execution.embedded.converters import (DataConverter, DictDataConverter,
+                                                      ListDataConverter)
+
+
+class StateImpl(State):
+    def __init__(self, state, value_converter: DataConverter):
+        self._state = state
+        self._value_converter = value_converter
+
+    def clear(self):
+        self._state.clear()
+
+
+class ValueStateImpl(StateImpl, ValueState):
+    def __init__(self, value_state, value_converter: DataConverter):
+        super(ValueStateImpl, self).__init__(value_state, value_converter)
+
+    def value(self) -> T:
+        return self._value_converter.to_internal(self._state.value())
+
+    def update(self, value: T) -> None:
+        self._state.update(self._value_converter.to_external(value))
+
+
+class ListStateImpl(StateImpl, ListState):
+
+    def __init__(self, list_state, value_converter: ListDataConverter):
+        super(ListStateImpl, self).__init__(list_state, value_converter)
+        self._element_converter = value_converter._field_converter
+
+    def update(self, values: List[T]) -> None:
+        self._state.update(self._value_converter.to_external(values))
+
+    def add_all(self, values: List[T]) -> None:
+        self._state.addAll(self._value_converter.to_external(values))
+
+    def get(self) -> OUT:
+        return self._value_converter.to_internal(self._state.get())
+
+    def add(self, value: IN) -> None:
+        self._state.add(self._element_converter.to_external(value))
+
+
+class ReducingStateImpl(StateImpl, ReducingState):
+
+    def __init__(self,
+                 value_state,
+                 value_converter: DataConverter,
+                 reduce_function: ReduceFunction):
+        super(ReducingStateImpl, self).__init__(value_state, value_converter)
+        self._reduce_function = reduce_function
+
+    def get(self) -> OUT:
+        return self._value_converter.to_internal(self._state.value())
+
+    def add(self, value: IN) -> None:
+        if value is None:
+            self.clear()
+        else:
+            current_value = self.get()
+
+            if current_value is None:
+                reduce_value = value
+            else:
+                reduce_value = self._reduce_function.reduce(current_value, value)
+
+            self._state.update(self._value_converter.to_external(reduce_value))
+
+
+class AggregatingStateImpl(StateImpl, AggregatingState):
+    def __init__(self,
+                 value_state,
+                 value_converter,
+                 agg_function: AggregateFunction):
+        super(AggregatingStateImpl, self).__init__(value_state, value_converter)
+        self._agg_function = agg_function
+
+    def get(self) -> OUT:
+        accumulator = self._value_converter.to_internal(self._state.value())
+
+        if accumulator is None:
+            return None
+        else:
+            return self._agg_function.get_result(accumulator)
+
+    def add(self, value: IN) -> None:
+        if value is None:
+            self.clear()
+        else:
+            accumulator = self._value_converter.to_internal(self._state.value())
+
+            if accumulator is None:
+                accumulator = self._agg_function.create_accumulator()
+
+            accumulator = self._agg_function.add(value, accumulator)
+            self._state.update(self._value_converter.to_external(accumulator))
+
+
+class MapStateImpl(StateImpl, MapState):
+    def __init__(self, map_state, map_converter: DictDataConverter):
+        super(MapStateImpl, self).__init__(map_state, map_converter)
+        self._k_converter = map_converter._key_converter
+        self._v_converter = map_converter._value_converter
+
+    def get(self, key: K) -> V:
+        return self._value_converter.to_internal(
+            self._state.get(self._k_converter.to_external(key)))
+
+    def put(self, key: K, value: V) -> None:
+        self._state.put(self._k_converter.to_external(key), self._v_converter.to_external(value))
+
+    def put_all(self, dict_value: Dict[K, V]) -> None:
+        self._state.putAll(self._value_converter.to_external(dict_value))
+
+    def remove(self, key: K) -> None:
+        self._state.remove(self._k_converter.to_external(key))
+
+    def contains(self, key: K) -> bool:
+        return self._state.contains(self._k_converter.to_external(key))
+
+    def items(self) -> Iterable[Tuple[K, V]]:
+        entries = self._state.entries()
+        for entry in entries:
+            yield (self._k_converter.to_internal(entry.getKey()),
+                   self._v_converter.to_internal(entry.getValue()))
+
+    def keys(self) -> Iterable[K]:
+        for k in self._state.keys():
+            yield self._k_converter.to_internal(k)
+
+    def values(self) -> Iterable[V]:
+        for v in self._state.values():
+            yield self._v_converter.to_internal(v)
+
+    def is_empty(self) -> bool:
+        return self._state.isEmpty()

--- a/flink-python/pyflink/fn_execution/datastream/embedded/timerservice_impl.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/timerservice_impl.py
@@ -1,0 +1,41 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pyflink.datastream import TimerService
+
+
+class TimerServiceImpl(TimerService):
+    def __init__(self, timer_service):
+        self._timer_service = timer_service
+
+    def current_processing_time(self):
+        return self._timer_service.currentProcessingTime()
+
+    def current_watermark(self):
+        return self._timer_service.currentWatermark()
+
+    def register_processing_time_timer(self, timestamp: int):
+        self._timer_service.registerProcessingTimeTimer(timestamp)
+
+    def register_event_time_timer(self, timestamp: int):
+        self._timer_service.registerEventTimeTimer(timestamp)
+
+    def delete_processing_time_timer(self, timestamp: int):
+        self._timer_service.deleteProcessingTimeTimer(timestamp)
+
+    def delete_event_time_timer(self, timestamp: int):
+        self._timer_service.deleteEventTimeTimer(timestamp)

--- a/flink-python/pyflink/fn_execution/embedded/java_utils.py
+++ b/flink-python/pyflink/fn_execution/embedded/java_utils.py
@@ -1,0 +1,204 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from pemja import findClass
+
+from pyflink.common.typeinfo import (TypeInformation, Types, BasicTypeInfo, BasicType,
+                                     PrimitiveArrayTypeInfo, BasicArrayTypeInfo,
+                                     ObjectArrayTypeInfo, MapTypeInfo)
+from pyflink.datastream.state import (StateDescriptor, ValueStateDescriptor,
+                                      ReducingStateDescriptor,
+                                      AggregatingStateDescriptor, ListStateDescriptor,
+                                      MapStateDescriptor, StateTtlConfig)
+
+# Java Types Class
+JTypes = findClass('org.apache.flink.api.common.typeinfo.Types')
+JPrimitiveArrayTypeInfo = findClass('org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo')
+JBasicArrayTypeInfo = findClass('org.apache.flink.api.common.typeinfo.BasicArrayTypeInfo')
+JPickledByteArrayTypeInfo = findClass('org.apache.flink.streaming.api.typeinfo.python.'
+                                      'PickledByteArrayTypeInfo')
+JMapTypeInfo = findClass('org.apache.flink.api.java.typeutils.MapTypeInfo')
+
+# Java State Descriptor Class
+JValueStateDescriptor = findClass('org.apache.flink.api.common.state.ValueStateDescriptor')
+JListStateDescriptor = findClass('org.apache.flink.api.common.state.ListStateDescriptor')
+JMapStateDescriptor = findClass('org.apache.flink.api.common.state.MapStateDescriptor')
+
+# Java StateTtlConfig
+JStateTtlConfig = findClass('org.apache.flink.api.common.state.StateTtlConfig')
+JTime = findClass('org.apache.flink.api.common.time.Time')
+JUpdateType = findClass('org.apache.flink.api.common.state.StateTtlConfig$UpdateType')
+JStateVisibility = findClass('org.apache.flink.api.common.state.StateTtlConfig$StateVisibility')
+
+
+def to_java_typeinfo(type_info: TypeInformation):
+    if isinstance(type_info, BasicTypeInfo):
+        basic_type = type_info._basic_type
+
+        if basic_type == BasicType.STRING:
+            j_typeinfo = JTypes.STRING
+        elif basic_type == BasicType.BYTE:
+            j_typeinfo = JTypes.LONG
+        elif basic_type == BasicType.BOOLEAN:
+            j_typeinfo = JTypes.BOOLEAN
+        elif basic_type == BasicType.SHORT:
+            j_typeinfo = JTypes.LONG
+        elif basic_type == BasicType.INT:
+            j_typeinfo = JTypes.LONG
+        elif basic_type == BasicType.LONG:
+            j_typeinfo = JTypes.LONG
+        elif basic_type == BasicType.FLOAT:
+            j_typeinfo = JTypes.DOUBLE
+        elif basic_type == BasicType.DOUBLE:
+            j_typeinfo = JTypes.DOUBLE
+        elif basic_type == BasicType.CHAR:
+            j_typeinfo = JTypes.STRING
+        elif basic_type == BasicType.BIG_INT:
+            j_typeinfo = JTypes.BIG_INT
+        elif basic_type == BasicType.BIG_DEC:
+            j_typeinfo = JTypes.BIG_DEC
+        elif basic_type == BasicType.INSTANT:
+            j_typeinfo = JTypes.INSTANT
+        else:
+            raise TypeError("Invalid BasicType %s." % basic_type)
+
+    elif isinstance(type_info, PrimitiveArrayTypeInfo):
+        element_type = type_info._element_type
+
+        if element_type == Types.BOOLEAN():
+            j_typeinfo = JPrimitiveArrayTypeInfo.BOOLEAN_PRIMITIVE_ARRAY_TYPE_INFO
+        elif element_type == Types.BYTE():
+            j_typeinfo = JPrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO
+        elif element_type == Types.SHORT():
+            j_typeinfo = JPrimitiveArrayTypeInfo.SHORT_PRIMITIVE_ARRAY_TYPE_INFO
+        elif element_type == Types.INT():
+            j_typeinfo = JPrimitiveArrayTypeInfo.INT_PRIMITIVE_ARRAY_TYPE_INFO
+        elif element_type == Types.LONG():
+            j_typeinfo = JPrimitiveArrayTypeInfo.LONG_PRIMITIVE_ARRAY_TYPE_INFO
+        elif element_type == Types.FLOAT():
+            j_typeinfo = JPrimitiveArrayTypeInfo.FLOAT_PRIMITIVE_ARRAY_TYPE_INFO
+        elif element_type == Types.DOUBLE():
+            j_typeinfo = JPrimitiveArrayTypeInfo.DOUBLE_PRIMITIVE_ARRAY_TYPE_INFO
+        elif element_type == Types.CHAR():
+            j_typeinfo = JPrimitiveArrayTypeInfo.CHAR_PRIMITIVE_ARRAY_TYPE_INFO
+        else:
+            raise TypeError("Invalid element type for a primitive array.")
+
+    elif isinstance(type_info, BasicArrayTypeInfo):
+        element_type = type_info._element_type
+
+        if element_type == Types.BOOLEAN():
+            j_typeinfo = JBasicArrayTypeInfo.BOOLEAN_ARRAY_TYPE_INFO
+        elif element_type == Types.BYTE():
+            j_typeinfo = JBasicArrayTypeInfo.BYTE_ARRAY_TYPE_INFO
+        elif element_type == Types.SHORT():
+            j_typeinfo = JBasicArrayTypeInfo.SHORT_ARRAY_TYPE_INFO
+        elif element_type == Types.INT():
+            j_typeinfo = JBasicArrayTypeInfo.INT_ARRAY_TYPE_INFO
+        elif element_type == Types.LONG():
+            j_typeinfo = JBasicArrayTypeInfo.LONG_ARRAY_TYPE_INFO
+        elif element_type == Types.FLOAT():
+            j_typeinfo = JBasicArrayTypeInfo.FLOAT_ARRAY_TYPE_INFO
+        elif element_type == Types.DOUBLE():
+            j_typeinfo = JBasicArrayTypeInfo.DOUBLE_ARRAY_TYPE_INFO
+        elif element_type == Types.CHAR():
+            j_typeinfo = JBasicArrayTypeInfo.CHAR_ARRAY_TYPE_INFO
+        elif element_type == Types.STRING():
+            j_typeinfo = JBasicArrayTypeInfo.STRING_ARRAY_TYPE_INFO
+        else:
+            raise TypeError("Invalid element type for a basic array.")
+
+    elif isinstance(type_info, ObjectArrayTypeInfo):
+        element_type = type_info._element_type
+
+        j_typeinfo = JTypes.OBJECT_ARRAY(to_java_typeinfo(element_type))
+
+    elif isinstance(type_info, MapTypeInfo):
+        j_key_typeinfo = to_java_typeinfo(type_info._key_type_info)
+        j_value_typeinfo = to_java_typeinfo(type_info._value_type_info)
+
+        j_typeinfo = JMapTypeInfo(j_key_typeinfo, j_value_typeinfo)
+    else:
+        j_typeinfo = JPickledByteArrayTypeInfo.PICKLED_BYTE_ARRAY_TYPE_INFO
+
+    return j_typeinfo
+
+
+def to_java_state_ttl_config(ttl_config: StateTtlConfig):
+    j_ttl_config_builder = JStateTtlConfig.newBuilder(
+        JTime.milliseconds(ttl_config.get_ttl().to_milliseconds()))
+
+    update_type = ttl_config.get_update_type()
+    if update_type == StateTtlConfig.UpdateType.Disabled:
+        j_ttl_config_builder.setUpdateType(JUpdateType.Disabled)
+    elif update_type == StateTtlConfig.UpdateType.OnCreateAndWrite:
+        j_ttl_config_builder.setUpdateType(JUpdateType.OnCreateAndWrite)
+    elif update_type == StateTtlConfig.UpdateType.OnReadAndWrite:
+        j_ttl_config_builder.setUpdateType(JUpdateType.OnReadAndWrite)
+
+    state_visibility = ttl_config.get_state_visibility()
+    if state_visibility == StateTtlConfig.StateVisibility.ReturnExpiredIfNotCleanedUp:
+        j_ttl_config_builder.setStateVisibility(JStateVisibility.ReturnExpiredIfNotCleanedUp)
+    elif state_visibility == StateTtlConfig.StateVisibility.NeverReturnExpired:
+        j_ttl_config_builder.setStateVisibility(JStateVisibility.NeverReturnExpired)
+
+    cleanup_strategies = ttl_config.get_cleanup_strategies()
+    if not cleanup_strategies.is_cleanup_in_background():
+        j_ttl_config_builder.disableCleanupInBackground()
+
+    if cleanup_strategies.in_full_snapshot():
+        j_ttl_config_builder.cleanupFullSnapshot()
+
+    incremental_cleanup_strategy = cleanup_strategies.get_incremental_cleanup_strategy()
+    if incremental_cleanup_strategy:
+        j_ttl_config_builder.cleanupIncrementally(
+            incremental_cleanup_strategy.get_cleanup_size(),
+            incremental_cleanup_strategy.run_cleanup_for_every_record())
+
+    rocksdb_compact_filter_cleanup_strategy = \
+        cleanup_strategies.get_rocksdb_compact_filter_cleanup_strategy()
+
+    if rocksdb_compact_filter_cleanup_strategy:
+        j_ttl_config_builder.cleanupInRocksdbCompactFilter(
+            rocksdb_compact_filter_cleanup_strategy.get_query_time_after_num_entries())
+
+    return j_ttl_config_builder.build()
+
+
+def to_java_state_descriptor(state_descriptor: StateDescriptor):
+    if isinstance(state_descriptor,
+                  (ValueStateDescriptor, ReducingStateDescriptor, AggregatingStateDescriptor)):
+        value_type_info = to_java_typeinfo(state_descriptor.type_info)
+        j_state_descriptor = JValueStateDescriptor(state_descriptor.name, value_type_info)
+
+    elif isinstance(state_descriptor, ListStateDescriptor):
+        element_type_info = to_java_typeinfo(state_descriptor.type_info.elem_type)
+        j_state_descriptor = JListStateDescriptor(state_descriptor.name, element_type_info)
+
+    elif isinstance(state_descriptor, MapStateDescriptor):
+        key_type_info = to_java_typeinfo(state_descriptor.type_info._key_type_info)
+        value_type_info = to_java_typeinfo(state_descriptor.type_info._value_type_info)
+        j_state_descriptor = JMapStateDescriptor(
+            state_descriptor.name, key_type_info, value_type_info)
+    else:
+        raise Exception("Unknown supported state_descriptor {0}".format(state_descriptor))
+
+    if state_descriptor._ttl_config:
+        j_state_ttl_config = to_java_state_ttl_config(state_descriptor._ttl_config)
+        j_state_descriptor.enableTimeToLive(j_state_ttl_config)
+
+    return j_state_descriptor

--- a/flink-python/pyflink/fn_execution/embedded/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/embedded/operation_utils.py
@@ -101,7 +101,7 @@ def create_table_operation_from_proto(proto, input_coder_info, output_coder_into
 
 
 def create_one_input_user_defined_data_stream_function_from_protos(
-        function_urn, function_infos, input_coder_info, output_coder_info, runtime_context,
+        function_infos, input_coder_info, output_coder_info, runtime_context,
         function_context, timer_context, job_parameters):
     serialized_fns = [pare_user_defined_data_stream_function_proto(proto)
                       for proto in function_infos]
@@ -111,7 +111,6 @@ def create_one_input_user_defined_data_stream_function_from_protos(
         from_type_info_proto(parse_coder_proto(output_coder_info).raw_type.type_info))
 
     function_operation = OneInputFunctionOperation(
-        function_urn,
         serialized_fns,
         input_data_converter,
         output_data_converter,

--- a/flink-python/pyflink/fn_execution/embedded/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/embedded/operation_utils.py
@@ -102,7 +102,7 @@ def create_table_operation_from_proto(proto, input_coder_info, output_coder_into
 
 def create_one_input_user_defined_data_stream_function_from_protos(
         function_urn, function_infos, input_coder_info, output_coder_info, runtime_context,
-        function_context, job_parameters):
+        function_context, timer_context, job_parameters):
     serialized_fns = [pare_user_defined_data_stream_function_proto(proto)
                       for proto in function_infos]
     input_data_converter = (
@@ -117,6 +117,7 @@ def create_one_input_user_defined_data_stream_function_from_protos(
         output_data_converter,
         runtime_context,
         function_context,
+        timer_context,
         job_parameters)
 
     return function_operation

--- a/flink-python/pyflink/fn_execution/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/embedded/operations.py
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from pyflink.fn_execution.datastream.embedded.operations import OneInputOperation
+from pyflink.fn_execution.datastream.embedded.operations import extract_process_function
 from pyflink.fn_execution.embedded.converters import DataConverter
 
 
@@ -44,7 +44,6 @@ class FunctionOperation(object):
 
 class OneInputFunctionOperation(FunctionOperation):
     def __init__(self,
-                 function_urn,
                  serialized_fns,
                  input_data_converter: DataConverter,
                  output_data_converter: DataConverter,
@@ -53,8 +52,7 @@ class OneInputFunctionOperation(FunctionOperation):
                  timer_context,
                  job_parameters):
         operations = (
-            [OneInputOperation(
-                function_urn,
+            [extract_process_function(
                 serialized_fn,
                 runtime_context,
                 function_context,

--- a/flink-python/pyflink/fn_execution/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/embedded/operations.py
@@ -36,6 +36,11 @@ class FunctionOperation(object):
         for operation in self._operations:
             operation.close()
 
+    def on_timer(self, timestamp):
+        for operation in self._operations:
+            for item in operation.on_timer(timestamp):
+                yield self._output_data_converter.to_external(item)
+
 
 class OneInputFunctionOperation(FunctionOperation):
     def __init__(self,
@@ -45,6 +50,7 @@ class OneInputFunctionOperation(FunctionOperation):
                  output_data_converter: DataConverter,
                  runtime_context,
                  function_context,
+                 timer_context,
                  job_parameters):
         operations = (
             [OneInputOperation(
@@ -52,6 +58,7 @@ class OneInputFunctionOperation(FunctionOperation):
                 serialized_fn,
                 runtime_context,
                 function_context,
+                timer_context,
                 job_parameters)
                 for serialized_fn in serialized_fns])
         super(OneInputFunctionOperation, self).__init__(

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -309,7 +309,7 @@ try:
                         'cloudpickle==2.1.0', 'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
                         'pytz>=2018.3', 'fastavro>=1.1.0,<1.4.8', 'requests>=2.26.0',
                         'protobuf<3.18',
-                        'pemja==0.2.0;'
+                        'pemja==0.2.2;'
                         'python_full_version >= "3.7" and platform_system != "Windows"',
                         'httplib2>=0.19.0,<=0.20.4', apache_flink_libraries_dependency]
 

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -33,6 +33,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.AbstractEmbeddedDataStreamPythonFunctionOperator;
+import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonKeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonProcessOperator;
 import org.apache.flink.streaming.api.operators.python.process.AbstractExternalDataStreamPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.process.ExternalPythonCoProcessOperator;
@@ -423,7 +424,8 @@ public class PythonOperatorChainingOptimizer {
                                 || upOperator instanceof ExternalPythonProcessOperator
                                 || upOperator instanceof ExternalPythonCoProcessOperator))
                 || (downOperator instanceof EmbeddedPythonProcessOperator
-                        && upOperator instanceof EmbeddedPythonProcessOperator);
+                        && (upOperator instanceof EmbeddedPythonProcessOperator
+                                || upOperator instanceof EmbeddedPythonKeyedProcessOperator));
     }
 
     private static boolean arePythonOperatorsInSameExecutionEnvironment(

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractEmbeddedDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractEmbeddedDataStreamPythonFunctionOperator.java
@@ -29,8 +29,6 @@ import org.apache.flink.util.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.apache.flink.python.Constants.STATEFUL_FUNCTION_URN;
-import static org.apache.flink.python.Constants.STATELESS_FUNCTION_URN;
 import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchExecutionMode;
 
 /** Base class for all Python DataStream operators executed in embedded Python environment. */
@@ -49,23 +47,14 @@ public abstract class AbstractEmbeddedDataStreamPythonFunctionOperator<OUT>
     /** The TypeInformation of output data. */
     protected final TypeInformation<OUT> outputTypeInfo;
 
-    /** The function urn. */
-    final String functionUrn;
-
     /** The number of partitions for the partition custom function. */
     private Integer numPartitions;
 
     public AbstractEmbeddedDataStreamPythonFunctionOperator(
-            String functionUrn,
             Configuration config,
             DataStreamPythonFunctionInfo pythonFunctionInfo,
             TypeInformation<OUT> outputTypeInfo) {
         super(config);
-        Preconditions.checkArgument(
-                STATELESS_FUNCTION_URN.equals(functionUrn)
-                        || STATEFUL_FUNCTION_URN.equals(functionUrn),
-                "The function urn should be `STATELESS_FUNCTION_URN` or `STATEFUL_FUNCTION_URN`.");
-        this.functionUrn = functionUrn;
         this.pythonFunctionInfo = Preconditions.checkNotNull(pythonFunctionInfo);
         this.outputTypeInfo = Preconditions.checkNotNull(outputTypeInfo);
     }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractEmbeddedDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractEmbeddedDataStreamPythonFunctionOperator.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.api.operators.python.embedded;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
 import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
 import org.apache.flink.util.Preconditions;
@@ -30,6 +31,7 @@ import java.util.Map;
 
 import static org.apache.flink.python.Constants.STATEFUL_FUNCTION_URN;
 import static org.apache.flink.python.Constants.STATELESS_FUNCTION_URN;
+import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchExecutionMode;
 
 /** Base class for all Python DataStream operators executed in embedded Python environment. */
 @Internal
@@ -87,6 +89,13 @@ public abstract class AbstractEmbeddedDataStreamPythonFunctionOperator<OUT>
         Map<String, String> jobParameters = new HashMap<>();
         if (numPartitions != null) {
             jobParameters.put(NUM_PARTITIONS, String.valueOf(numPartitions));
+        }
+
+        KeyedStateBackend<Object> keyedStateBackend = getKeyedStateBackend();
+        if (keyedStateBackend != null) {
+            jobParameters.put(
+                    "inBatchExecutionMode",
+                    String.valueOf(inBatchExecutionMode(keyedStateBackend)));
         }
         return jobParameters;
     }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractOneInputEmbeddedPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractOneInputEmbeddedPythonFunctionOperator.java
@@ -60,12 +60,11 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
     protected transient long timestamp;
 
     public AbstractOneInputEmbeddedPythonFunctionOperator(
-            String functionUrn,
             Configuration config,
             DataStreamPythonFunctionInfo pythonFunctionInfo,
             TypeInformation<IN> inputTypeInfo,
             TypeInformation<OUT> outputTypeInfo) {
-        super(functionUrn, config, pythonFunctionInfo, outputTypeInfo);
+        super(config, pythonFunctionInfo, outputTypeInfo);
         this.inputTypeInfo = Preconditions.checkNotNull(inputTypeInfo);
     }
 
@@ -84,7 +83,6 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
 
     @Override
     public void openPythonInterpreter() {
-        // function_urn = ...
         // function_protos = ...
         // input_coder_info = ...
         // output_coder_info = ...
@@ -95,12 +93,10 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
         // from pyflink.fn_execution.embedded.operation_utils import
         // create_one_input_user_defined_data_stream_function_from_protos
         //
-        // operation = create_one_input_user_defined_data_stream_function_from_protos(function_urn,
+        // operation = create_one_input_user_defined_data_stream_function_from_protos(
         //     function_protos, input_coder_info, output_coder_info, runtime_context,
         //     function_context, job_parameters)
         // operation.open()
-
-        interpreter.set("function_urn", functionUrn);
 
         interpreter.set(
                 "function_protos",
@@ -135,7 +131,6 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
 
         interpreter.exec(
                 "operation = create_one_input_user_defined_data_stream_function_from_protos("
-                        + "function_urn,"
                         + "function_protos,"
                         + "input_coder_info,"
                         + "output_coder_info,"

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonKeyedProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonKeyedProcessOperator.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.python.embedded;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.fnexecution.v1.FlinkFnApi;
+import org.apache.flink.python.util.ProtoUtils;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
+import org.apache.flink.streaming.api.SimpleTimerService;
+import org.apache.flink.streaming.api.TimeDomain;
+import org.apache.flink.streaming.api.TimerService;
+import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.types.Row;
+
+import pemja.core.object.PyIterator;
+
+import java.util.List;
+
+import static org.apache.flink.python.Constants.STATEFUL_FUNCTION_URN;
+import static org.apache.flink.python.PythonOptions.MAP_STATE_READ_CACHE_SIZE;
+import static org.apache.flink.python.PythonOptions.MAP_STATE_WRITE_CACHE_SIZE;
+import static org.apache.flink.python.PythonOptions.PYTHON_METRIC_ENABLED;
+import static org.apache.flink.python.PythonOptions.PYTHON_PROFILE_ENABLED;
+import static org.apache.flink.python.PythonOptions.STATE_CACHE_SIZE;
+import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchExecutionMode;
+
+/**
+ * {@link EmbeddedPythonKeyedProcessOperator} is responsible for executing user defined python
+ * KeyedProcessFunction in embedded Python environment. It is also able to handle the timer and
+ * state request from the python stateful user defined function.
+ */
+@Internal
+public class EmbeddedPythonKeyedProcessOperator<K, IN, OUT>
+        extends AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
+        implements Triggerable<K, VoidNamespace> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The TypeInformation of the key. */
+    private transient TypeInformation<Row> keyTypeInfo;
+
+    private transient ContextImpl context;
+
+    private transient OnTimerContextImpl onTimerContext;
+
+    public EmbeddedPythonKeyedProcessOperator(
+            Configuration config,
+            DataStreamPythonFunctionInfo pythonFunctionInfo,
+            TypeInformation<IN> inputTypeInfo,
+            TypeInformation<OUT> outputTypeInfo) {
+        super(STATEFUL_FUNCTION_URN, config, pythonFunctionInfo, inputTypeInfo, outputTypeInfo);
+    }
+
+    @Override
+    public void open() throws Exception {
+        keyTypeInfo = ((RowTypeInfo) this.getInputTypeInfo()).getTypeAt(0);
+
+        InternalTimerService<VoidNamespace> internalTimerService =
+                getInternalTimerService("user-timers", VoidNamespaceSerializer.INSTANCE, this);
+
+        TimerService timerService = new SimpleTimerService(internalTimerService);
+
+        context = new ContextImpl(timerService);
+
+        onTimerContext = new OnTimerContextImpl(timerService);
+
+        super.open();
+    }
+
+    @Override
+    public List<FlinkFnApi.UserDefinedDataStreamFunction> createUserDefinedFunctionsProto() {
+        return ProtoUtils.createUserDefinedDataStreamStatefulFunctionProtos(
+                getPythonFunctionInfo(),
+                getRuntimeContext(),
+                getJobParameters(),
+                keyTypeInfo,
+                inBatchExecutionMode(getKeyedStateBackend()),
+                config.get(PYTHON_METRIC_ENABLED),
+                config.get(PYTHON_PROFILE_ENABLED),
+                false,
+                config.get(STATE_CACHE_SIZE),
+                config.get(MAP_STATE_READ_CACHE_SIZE),
+                config.get(MAP_STATE_WRITE_CACHE_SIZE));
+    }
+
+    @Override
+    public void onEventTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+        collector.setAbsoluteTimestamp(timer.getTimestamp());
+        invokeUserFunction(TimeDomain.EVENT_TIME, timer);
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<K, VoidNamespace> timer) throws Exception {
+        collector.eraseTimestamp();
+        invokeUserFunction(TimeDomain.PROCESSING_TIME, timer);
+    }
+
+    @Override
+    public Object getFunctionContext() {
+        return context;
+    }
+
+    @Override
+    public Object getTimerContext() {
+        return onTimerContext;
+    }
+
+    @Override
+    public <T> AbstractEmbeddedDataStreamPythonFunctionOperator<T> copy(
+            DataStreamPythonFunctionInfo pythonFunctionInfo, TypeInformation<T> outputTypeInfo) {
+        return new EmbeddedPythonKeyedProcessOperator<>(
+                config, pythonFunctionInfo, getInputTypeInfo(), outputTypeInfo);
+    }
+
+    private void invokeUserFunction(TimeDomain timeDomain, InternalTimer<K, VoidNamespace> timer)
+            throws Exception {
+        onTimerContext.timeDomain = timeDomain;
+        onTimerContext.timer = timer;
+        PyIterator results =
+                (PyIterator)
+                        interpreter.invokeMethod("operation", "on_timer", timer.getTimestamp());
+
+        while (results.hasNext()) {
+            OUT result = outputDataConverter.toInternal(results.next());
+            collector.collect(result);
+        }
+        results.close();
+
+        onTimerContext.timeDomain = null;
+        onTimerContext.timer = null;
+    }
+
+    private class ContextImpl {
+
+        private final TimerService timerService;
+
+        ContextImpl(TimerService timerService) {
+            this.timerService = timerService;
+        }
+
+        public long timestamp() {
+            return timestamp;
+        }
+
+        public TimerService timerService() {
+            return timerService;
+        }
+
+        @SuppressWarnings("unchecked")
+        public K getCurrentKey() {
+            return (K) ((Row) EmbeddedPythonKeyedProcessOperator.this.getCurrentKey()).getField(0);
+        }
+    }
+
+    private class OnTimerContextImpl {
+
+        private final TimerService timerService;
+
+        private TimeDomain timeDomain;
+
+        private InternalTimer<K, VoidNamespace> timer;
+
+        OnTimerContextImpl(TimerService timerService) {
+            this.timerService = timerService;
+        }
+
+        public long timestamp() {
+            return timer.getTimestamp();
+        }
+
+        public TimerService timerService() {
+            return timerService;
+        }
+
+        public int timeDomain() {
+            return timeDomain.ordinal();
+        }
+
+        @SuppressWarnings("unchecked")
+        public K getCurrentKey() {
+            return (K) ((Row) timer.getKey()).getField(0);
+        }
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonProcessOperator.java
@@ -31,7 +31,6 @@ import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import java.util.HashMap;
 import java.util.List;
 
-import static org.apache.flink.python.Constants.STATELESS_FUNCTION_URN;
 import static org.apache.flink.python.PythonOptions.MAP_STATE_READ_CACHE_SIZE;
 import static org.apache.flink.python.PythonOptions.MAP_STATE_WRITE_CACHE_SIZE;
 import static org.apache.flink.python.PythonOptions.PYTHON_METRIC_ENABLED;
@@ -57,7 +56,7 @@ public class EmbeddedPythonProcessOperator<IN, OUT>
             DataStreamPythonFunctionInfo pythonFunctionInfo,
             TypeInformation<IN> inputTypeInfo,
             TypeInformation<OUT> outputTypeInfo) {
-        super(STATELESS_FUNCTION_URN, config, pythonFunctionInfo, inputTypeInfo, outputTypeInfo);
+        super(config, pythonFunctionInfo, inputTypeInfo, outputTypeInfo);
     }
 
     @Override

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonProcessOperator.java
@@ -88,6 +88,11 @@ public class EmbeddedPythonProcessOperator<IN, OUT>
     }
 
     @Override
+    public Object getTimerContext() {
+        return null;
+    }
+
+    @Override
     public <T> AbstractEmbeddedDataStreamPythonFunctionOperator<T> copy(
             DataStreamPythonFunctionInfo pythonFunctionInfo, TypeInformation<T> outputTypeInfo) {
         return new EmbeddedPythonProcessOperator<>(

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/EmbeddedPythonTableFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/operators/python/table/EmbeddedPythonTableFunctionOperator.java
@@ -138,7 +138,7 @@ public class EmbeddedPythonTableFunctionOperator extends AbstractEmbeddedStatele
 
     @SuppressWarnings("unchecked")
     @Override
-    public void processElement(StreamRecord<RowData> element) {
+    public void processElement(StreamRecord<RowData> element) throws Exception {
         RowData value = element.getValue();
 
         for (int i = 0; i < userDefinedFunctionInputArgs.length; i++) {
@@ -165,5 +165,6 @@ public class EmbeddedPythonTableFunctionOperator extends AbstractEmbeddedStatele
         } else if (joinType == FlinkJoinType.LEFT) {
             rowDataWrapper.collect(reuseJoinedRow.replace(value, reuseNullResultRowData));
         }
+        udtfResults.close();
     }
 }

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -28,7 +28,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.beam:beam-vendor-sdks-java-extensions-protobuf:2.38.0
 - org.apache.beam:beam-vendor-guava-26_0-jre:0.1
 - org.apache.beam:beam-vendor-grpc-1_43_2:0.1
-- com.alibaba:pemja:0.2.0
+- com.alibaba:pemja:0.2.2
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support DataStream PythonKeyedProcessOperator in Thread Mode*


## Brief change log

  - *Support DataStream PythonKeyedProcessOperator in Thread Mode*

## Verifying this change

This change added tests and can be verified as follows:

  - *`test_datastream.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
