### PR TITLE
[FLINK-28523][tests] Increase Zookeeper session timeouts

### DIFF
--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.queryablestate.client.QueryableStateClient;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.apache.curator.test.TestingServer;
@@ -62,7 +63,7 @@ public class HAQueryableStateFsBackendITCase extends AbstractQueryableStateTestB
 
     @BeforeClass
     public static void setup() throws Exception {
-        zkServer = new TestingServer();
+        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
 
         // we have to manage this manually because we have to create the ZooKeeper server
         // ahead of this

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateFsBackendITCase.java
@@ -63,7 +63,7 @@ public class HAQueryableStateFsBackendITCase extends AbstractQueryableStateTestB
 
     @BeforeClass
     public static void setup() throws Exception {
-        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+        zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
 
         // we have to manage this manually because we have to create the ZooKeeper server
         // ahead of this
@@ -88,7 +88,6 @@ public class HAQueryableStateFsBackendITCase extends AbstractQueryableStateTestB
 
         client.shutdownAndWait();
 
-        zkServer.stop();
         zkServer.close();
     }
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
@@ -63,7 +63,7 @@ public class HAQueryableStateRocksDBBackendITCase extends AbstractQueryableState
 
     @BeforeClass
     public static void setup() throws Exception {
-        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+        zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
 
         // we have to manage this manually because we have to create the ZooKeeper server
         // ahead of this
@@ -88,7 +88,6 @@ public class HAQueryableStateRocksDBBackendITCase extends AbstractQueryableState
 
         client.shutdownAndWait();
 
-        zkServer.stop();
         zkServer.close();
     }
 

--- a/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
+++ b/flink-queryable-state/flink-queryable-state-runtime/src/test/java/org/apache/flink/queryablestate/itcases/HAQueryableStateRocksDBBackendITCase.java
@@ -29,6 +29,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBStateBackend;
 import org.apache.flink.queryablestate.client.QueryableStateClient;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 
 import org.apache.curator.test.TestingServer;
@@ -62,7 +63,7 @@ public class HAQueryableStateRocksDBBackendITCase extends AbstractQueryableState
 
     @BeforeClass
     public static void setup() throws Exception {
-        zkServer = new TestingServer();
+        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
 
         // we have to manage this manually because we have to create the ZooKeeper server
         // ahead of this

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -186,7 +186,7 @@ public class LeaderElectionTest extends TestLogger {
         @Override
         public void setup(FatalErrorHandler fatalErrorHandler) throws Exception {
             try {
-                testingServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+                testingServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
             } catch (Exception e) {
                 throw new RuntimeException("Could not start ZooKeeper testing cluster.", e);
             }
@@ -209,7 +209,7 @@ public class LeaderElectionTest extends TestLogger {
             }
 
             if (testingServer != null) {
-                testingServer.stop();
+                testingServer.close();
                 testingServer = null;
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/LeaderElectionTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.highavailability.nonha.embedded.EmbeddedLeaderService;
 import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.testutils.TestingUtils;
@@ -185,7 +186,7 @@ public class LeaderElectionTest extends TestLogger {
         @Override
         public void setup(FatalErrorHandler fatalErrorHandler) throws Exception {
             try {
-                testingServer = new TestingServer();
+                testingServer = ZooKeeperTestUtils.createZookeeperTestingServer();
             } catch (Exception e) {
                 throw new RuntimeException("Could not start ZooKeeper testing cluster.", e);
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -114,7 +114,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
     @Before
     public void before() {
         try {
-            testingServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+            testingServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
         } catch (Exception e) {
             throw new RuntimeException("Could not start ZooKeeper testing cluster.", e);
         }
@@ -138,7 +138,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
         }
 
         if (testingServer != null) {
-            testingServer.stop();
+            testingServer.close();
             testingServer = null;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.leaderretrieval.TestingLeaderRetrievalEventHandl
 import org.apache.flink.runtime.leaderretrieval.ZooKeeperLeaderRetrievalDriver;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandler;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
@@ -113,7 +114,7 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
     @Before
     public void before() {
         try {
-            testingServer = new TestingServer();
+            testingServer = ZooKeeperTestUtils.createZookeeperTestingServer();
         } catch (Exception e) {
             throw new RuntimeException("Could not start ZooKeeper testing cluster.", e);
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -76,7 +76,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger {
 
     @Before
     public void before() throws Exception {
-        testingServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+        testingServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
 
         config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
@@ -102,7 +102,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger {
         }
 
         if (testingServer != null) {
-            testingServer.stop();
+            testingServer.close();
 
             testingServer = null;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderelection.TestingContender;
 import org.apache.flink.runtime.rpc.AddressResolution;
 import org.apache.flink.runtime.rpc.RpcSystem;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.runtime.util.LeaderRetrievalUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
@@ -75,7 +76,7 @@ public class ZooKeeperLeaderRetrievalTest extends TestLogger {
 
     @Before
     public void before() throws Exception {
-        testingServer = new TestingServer();
+        testingServer = ZooKeeperTestUtils.createZookeeperTestingServer();
 
         config = new Configuration();
         config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -45,22 +45,25 @@ public class ZooKeeperTestUtils {
      * Creates a new {@link TestingServer}, setting additional configuration properties for
      * stability purposes.
      */
-    public static TestingServer createZookeeperTestingServer() throws Exception {
+    public static TestingServer createAndStartZookeeperTestingServer() throws Exception {
         return new TestingServer(getZookeeperInstanceSpecWithIncreasedSessionTimeout(), true);
     }
 
     private static InstanceSpec getZookeeperInstanceSpecWithIncreasedSessionTimeout() {
+        // this gives us the default settings
         final InstanceSpec instanceSpec = InstanceSpec.newInstanceSpec();
 
         final Map<String, Object> properties = new HashMap<>();
         properties.put("maxSessionTimeout", 60_000);
+
+        final boolean deleteDataDirectoryOnClose = true;
 
         return new InstanceSpec(
                 instanceSpec.getDataDirectory(),
                 instanceSpec.getPort(),
                 instanceSpec.getElectionPort(),
                 instanceSpec.getQuorumPort(),
-                instanceSpec.deleteDataDirectoryOnClose(),
+                deleteDataDirectoryOnClose,
                 instanceSpec.getServerId(),
                 instanceSpec.getTickTime(),
                 instanceSpec.getMaxClientCnxns(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/ZooKeeperTestUtils.java
@@ -25,10 +25,14 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.configuration.StateBackendOptions;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 
+import org.apache.curator.test.InstanceSpec;
+import org.apache.curator.test.TestingServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -36,6 +40,33 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public class ZooKeeperTestUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperTestUtils.class);
+
+    /**
+     * Creates a new {@link TestingServer}, setting additional configuration properties for
+     * stability purposes.
+     */
+    public static TestingServer createZookeeperTestingServer() throws Exception {
+        return new TestingServer(getZookeeperInstanceSpecWithIncreasedSessionTimeout(), true);
+    }
+
+    private static InstanceSpec getZookeeperInstanceSpecWithIncreasedSessionTimeout() {
+        final InstanceSpec instanceSpec = InstanceSpec.newInstanceSpec();
+
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put("maxSessionTimeout", 60_000);
+
+        return new InstanceSpec(
+                instanceSpec.getDataDirectory(),
+                instanceSpec.getPort(),
+                instanceSpec.getElectionPort(),
+                instanceSpec.getQuorumPort(),
+                instanceSpec.deleteDataDirectoryOnClose(),
+                instanceSpec.getServerId(),
+                instanceSpec.getTickTime(),
+                instanceSpec.getMaxClientCnxns(),
+                properties,
+                instanceSpec.getHostname());
+    }
 
     /**
      * Creates a configuration to operate in {@link HighAvailabilityMode#ZOOKEEPER}.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.testutils.FlinkMatchers;
 import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
@@ -61,7 +62,8 @@ public class ZooKeeperUtilsTreeCacheTest extends TestLogger {
     @Before
     public void setUp() throws Exception {
         closer = Closer.create();
-        final TestingServer testingServer = closer.register(new TestingServer());
+        final TestingServer testingServer =
+                closer.register(ZooKeeperTestUtils.createZookeeperTestingServer());
 
         Configuration configuration = new Configuration();
         configuration.set(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/ZooKeeperUtilsTreeCacheTest.java
@@ -63,7 +63,7 @@ public class ZooKeeperUtilsTreeCacheTest extends TestLogger {
     public void setUp() throws Exception {
         closer = Closer.create();
         final TestingServer testingServer =
-                closer.register(ZooKeeperTestUtils.createZookeeperTestingServer());
+                closer.register(ZooKeeperTestUtils.createAndStartZookeeperTestingServer());
 
         Configuration configuration = new Configuration();
         configuration.set(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.core.testutils.CustomExtension;
 import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.Preconditions;
 
@@ -52,7 +53,7 @@ public class ZooKeeperExtension implements CustomExtension {
     @Override
     public void before(ExtensionContext context) throws Exception {
         close();
-        zooKeeperServer = new TestingServer(true);
+        zooKeeperServer = ZooKeeperTestUtils.createZookeeperTestingServer();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperExtension.java
@@ -53,7 +53,7 @@ public class ZooKeeperExtension implements CustomExtension {
     @Override
     public void before(ExtensionContext context) throws Exception {
         close();
-        zooKeeperServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+        zooKeeperServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
@@ -54,7 +54,7 @@ public class ZooKeeperResource extends ExternalResource {
 
     private void terminateZooKeeperServer() throws IOException {
         if (zooKeeperServer != null) {
-            zooKeeperServer.stop();
+            zooKeeperServer.close();
             zooKeeperServer = null;
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
@@ -49,7 +49,7 @@ public class ZooKeeperResource extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         terminateZooKeeperServer();
-        zooKeeperServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+        zooKeeperServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
     }
 
     private void terminateZooKeeperServer() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperResource.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.zookeeper;
 
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.curator.test.TestingServer;
@@ -48,7 +49,7 @@ public class ZooKeeperResource extends ExternalResource {
     @Override
     protected void before() throws Throwable {
         terminateZooKeeperServer();
-        zooKeeperServer = new TestingServer(true);
+        zooKeeperServer = ZooKeeperTestUtils.createZookeeperTestingServer();
     }
 
     private void terminateZooKeeperServer() throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.zookeeper;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.HighAvailabilityOptions;
 import org.apache.flink.runtime.highavailability.zookeeper.CuratorFrameworkWithUnhandledErrorListener;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.runtime.util.ExitJVMFatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 
@@ -61,7 +62,7 @@ public class ZooKeeperTestEnvironment {
 
         try {
             if (numberOfZooKeeperQuorumPeers == 1) {
-                zooKeeperServer = new TestingServer(true);
+                zooKeeperServer = ZooKeeperTestUtils.createZookeeperTestingServer();
                 zooKeeperCluster = null;
 
                 conf.setString(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/zookeeper/ZooKeeperTestEnvironment.java
@@ -62,7 +62,7 @@ public class ZooKeeperTestEnvironment {
 
         try {
             if (numberOfZooKeeperQuorumPeers == 1) {
-                zooKeeperServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+                zooKeeperServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
                 zooKeeperCluster = null;
 
                 conf.setString(

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -40,6 +40,7 @@ import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.api.functions.windowing.RichWindowFunction;
@@ -162,8 +163,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
         // Testing HA Scenario / ZKCompletedCheckpointStore with incremental checkpoints
         StateBackendEnum stateBackendEnum = getStateBackend();
         if (ROCKSDB_INCREMENTAL_ZK.equals(stateBackendEnum)) {
-            zkServer = new TestingServer();
-            zkServer.start();
+            zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
         }
 
         Configuration config = createClusterConfig();

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/EventTimeWindowCheckpointingITCase.java
@@ -163,7 +163,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
         // Testing HA Scenario / ZKCompletedCheckpointStore with incremental checkpoints
         StateBackendEnum stateBackendEnum = getStateBackend();
         if (ROCKSDB_INCREMENTAL_ZK.equals(stateBackendEnum)) {
-            zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+            zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
         }
 
         Configuration config = createClusterConfig();
@@ -261,7 +261,7 @@ public class EventTimeWindowCheckpointingITCase extends TestLogger {
         }
 
         if (zkServer != null) {
-            zkServer.stop();
+            zkServer.close();
             zkServer = null;
         }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -153,7 +153,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
     @Test
     public void testExternalizedIncrementalRocksDBCheckpointsZookeeper() throws Exception {
-        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -166,7 +166,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
     @Test
     public void testExternalizedFullRocksDBCheckpointsZookeeper() throws Exception {
-        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -180,7 +180,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
     @Test
     public void testExternalizedIncrementalRocksDBCheckpointsWithLocalRecoveryZookeeper()
             throws Exception {
-        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -194,7 +194,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
     @Test
     public void testExternalizedFullRocksDBCheckpointsWithLocalRecoveryZookeeper()
             throws Exception {
-        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -207,7 +207,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
     @Test
     public void testExternalizedFSCheckpointsZookeeper() throws Exception {
-        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -220,7 +220,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
     @Test
     public void testExternalizedFSCheckpointsWithLocalRecoveryZookeeper() throws Exception {
-        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ResumeCheckpointManuallyITCase.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.filesystem.FsStateBackend;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -152,9 +153,7 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
 
     @Test
     public void testExternalizedIncrementalRocksDBCheckpointsZookeeper() throws Exception {
-        TestingServer zkServer = new TestingServer();
-        zkServer.start();
-        try {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -162,16 +161,12 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                     createRocksDBStateBackend(checkpointDir, true),
                     false,
                     restoreMode);
-        } finally {
-            zkServer.stop();
         }
     }
 
     @Test
     public void testExternalizedFullRocksDBCheckpointsZookeeper() throws Exception {
-        TestingServer zkServer = new TestingServer();
-        zkServer.start();
-        try {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -179,17 +174,13 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                     createRocksDBStateBackend(checkpointDir, false),
                     false,
                     restoreMode);
-        } finally {
-            zkServer.stop();
         }
     }
 
     @Test
     public void testExternalizedIncrementalRocksDBCheckpointsWithLocalRecoveryZookeeper()
             throws Exception {
-        TestingServer zkServer = new TestingServer();
-        zkServer.start();
-        try {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -197,17 +188,13 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                     createRocksDBStateBackend(checkpointDir, true),
                     true,
                     restoreMode);
-        } finally {
-            zkServer.stop();
         }
     }
 
     @Test
     public void testExternalizedFullRocksDBCheckpointsWithLocalRecoveryZookeeper()
             throws Exception {
-        TestingServer zkServer = new TestingServer();
-        zkServer.start();
-        try {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -215,16 +202,12 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                     createRocksDBStateBackend(checkpointDir, false),
                     true,
                     restoreMode);
-        } finally {
-            zkServer.stop();
         }
     }
 
     @Test
     public void testExternalizedFSCheckpointsZookeeper() throws Exception {
-        TestingServer zkServer = new TestingServer();
-        zkServer.start();
-        try {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -232,16 +215,12 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                     createFsStateBackend(checkpointDir),
                     false,
                     restoreMode);
-        } finally {
-            zkServer.stop();
         }
     }
 
     @Test
     public void testExternalizedFSCheckpointsWithLocalRecoveryZookeeper() throws Exception {
-        TestingServer zkServer = new TestingServer();
-        zkServer.start();
-        try {
+        try (TestingServer zkServer = ZooKeeperTestUtils.createZookeeperTestingServer()) {
             final File checkpointDir = temporaryFolder.newFolder();
             testExternalizedCheckpoints(
                     checkpointDir,
@@ -249,8 +228,6 @@ public class ResumeCheckpointManuallyITCase extends TestLogger {
                     createFsStateBackend(checkpointDir),
                     true,
                     restoreMode);
-        } finally {
-            zkServer.stop();
         }
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -70,7 +70,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 
     @BeforeClass
     public static void setup() throws Exception {
-        zkServer = new TestingServer(true);
+        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
     }
 
     @AfterClass

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/leaderelection/ZooKeeperLeaderElectionITCase.java
@@ -70,7 +70,7 @@ public class ZooKeeperLeaderElectionITCase extends TestLogger {
 
     @BeforeClass
     public static void setup() throws Exception {
-        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+        zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
     }
 
     @AfterClass

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.runtime.rest.messages.job.metrics.JobMetricsHeaders;
 import org.apache.flink.runtime.rest.messages.job.metrics.JobMetricsMessageParameters;
 import org.apache.flink.runtime.rest.messages.job.metrics.Metric;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
+import org.apache.flink.runtime.testutils.ZooKeeperTestUtils;
 import org.apache.flink.util.OperatingSystem;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 import org.apache.flink.yarn.entrypoint.YarnSessionClusterEntrypoint;
@@ -110,7 +111,7 @@ class YARNHighAvailabilityITCase extends YarnTestBase {
 
     @BeforeAll
     static void setup(@TempDir File tempDir) throws Exception {
-        zkServer = new TestingServer();
+        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
 
         storageDir = tempDir.getAbsolutePath();
 

--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YARNHighAvailabilityITCase.java
@@ -111,7 +111,7 @@ class YARNHighAvailabilityITCase extends YarnTestBase {
 
     @BeforeAll
     static void setup(@TempDir File tempDir) throws Exception {
-        zkServer = ZooKeeperTestUtils.createZookeeperTestingServer();
+        zkServer = ZooKeeperTestUtils.createAndStartZookeeperTestingServer();
 
         storageDir = tempDir.getAbsolutePath();
 
@@ -129,7 +129,7 @@ class YARNHighAvailabilityITCase extends YarnTestBase {
             YarnTestBase.teardown();
         } finally {
             if (zkServer != null) {
-                zkServer.stop();
+                zkServer.close();
                 zkServer = null;
             }
         }


### PR DESCRIPTION
Resolves a class of test instabilities where ZK is unavailable for longer than the default session timeout (which seemingly gets reduced to 13-20 seconds) allows. Examples are GC pauses or writes to disk (which may be impaired by other tests running on the machine)

All usages of the curator `TestingServer` were migrated to a new utility factory method that increases the server-side max session timeout to 60 seconds.