### PR TITLE
[FLINK-28713][tests] Remove unused curator-test dependency

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-elasticsearch/pom.xml
@@ -67,6 +67,11 @@ under the License.
 			<artifactId>assertj-core</artifactId>
 			<scope>compile</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<!-- This is needed because Elasticsearch bundles two different versions of this component. -->

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -441,10 +441,6 @@ under the License.
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>org.apache.curator</groupId>
 					<artifactId>curator-client</artifactId>
 				</exclusion>

--- a/flink-test-utils-parent/flink-test-utils/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils/pom.xml
@@ -106,13 +106,6 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>org.apache.curator</groupId>
-			<artifactId>curator-test</artifactId>
-			<version>${curator.version}</version>
-			<scope>compile</scope>
-		</dependency>
-
-		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-minikdc</artifactId>
 			<version>${minikdc.version}</version>


### PR DESCRIPTION
Removes an unused dependency.

`end-to-end-tests-common-elasticsearch` now has a direct compile dependency on `junit-jupiter`, which previously got pulled in by `curator-test`.
`sql-client` no longer excludes `guava` from `hadoop-common`, because `guava` was previously pulled in by `curator-test` and is still required by the annoying `KerberosDelegationTokenManager` which automatically activates when `hadoop-common` is on the classpath.

Core benefit is one less dependency being pulled into user projects (which also pulls in log4j1).