### PR TITLE
[FLINK-28731][conf] Log dynamic properties

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -134,11 +134,24 @@ public final class GlobalConfiguration {
 
         Configuration configuration = loadYAMLResource(yamlConfigFile);
 
+        logConfiguration("Loading", configuration);
+
         if (dynamicProperties != null) {
+            logConfiguration("Loading dynamic", dynamicProperties);
             configuration.addAll(dynamicProperties);
         }
 
         return configuration;
+    }
+
+    private static void logConfiguration(String prefix, Configuration config) {
+        config.confData.forEach(
+                (key, value) ->
+                        LOG.info(
+                                "{} configuration property: {}, {}",
+                                prefix,
+                                key,
+                                isSensitive(key) ? HIDDEN_CONTENT : value));
     }
 
     /**
@@ -210,10 +223,6 @@ public final class GlobalConfiguration {
                         continue;
                     }
 
-                    LOG.info(
-                            "Loading configuration property: {}, {}",
-                            key,
-                            isSensitive(key) ? HIDDEN_CONTENT : value);
                     config.setString(key, value);
                 }
             }


### PR DESCRIPTION
This is mostly to ease discovery; while the dynamic properties are logged as part of the program args my impression is that this isn't the place that users would look at.