### PR TITLE
[FLINK-28475] [Connector/kafka] stopping offset can be 0.

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplit.java
@@ -77,7 +77,7 @@ public class KafkaPartitionSplit implements SourceSplit {
     }
 
     public Optional<Long> getStoppingOffset() {
-        return stoppingOffset > 0
+        return stoppingOffset >= 0
                         || stoppingOffset == LATEST_OFFSET
                         || stoppingOffset == COMMITTED_OFFSET
                 ? Optional.of(stoppingOffset)

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -76,6 +76,7 @@ public class KafkaPartitionSplitReaderTest {
     private static final int NUM_SUBTASKS = 3;
     private static final String TOPIC1 = "topic1";
     private static final String TOPIC2 = "topic2";
+    private static final String TOPIC3 = "topic3";
 
     private static Map<Integer, Map<String, KafkaPartitionSplit>> splitsByOwners;
     private static Map<TopicPartition, Long> earliestOffsets;
@@ -87,6 +88,7 @@ public class KafkaPartitionSplitReaderTest {
         KafkaSourceTestEnv.setup();
         KafkaSourceTestEnv.setupTopic(TOPIC1, true, true, KafkaSourceTestEnv::getRecordsForTopic);
         KafkaSourceTestEnv.setupTopic(TOPIC2, true, true, KafkaSourceTestEnv::getRecordsForTopic);
+        KafkaSourceTestEnv.createTestTopic(TOPIC3);
         splitsByOwners =
                 KafkaSourceTestEnv.getSplitsByOwners(Arrays.asList(TOPIC1, TOPIC2), NUM_SUBTASKS);
         earliestOffsets =
@@ -246,11 +248,20 @@ public class KafkaPartitionSplitReaderTest {
                         new TopicPartition(TOPIC2, 0),
                         KafkaPartitionSplit.LATEST_OFFSET,
                         KafkaPartitionSplit.LATEST_OFFSET);
-        reader.handleSplitsChanges(new SplitsAddition<>(Arrays.asList(normalSplit, emptySplit)));
+        final KafkaPartitionSplit emptySplitWithZeroStoppingOffset =
+                new KafkaPartitionSplit(new TopicPartition(TOPIC3, 0), 0, 0);
+
+        reader.handleSplitsChanges(
+                new SplitsAddition<>(
+                        Arrays.asList(normalSplit, emptySplit, emptySplitWithZeroStoppingOffset)));
 
         // Fetch and check empty splits is added to finished splits
         RecordsWithSplitIds<ConsumerRecord<byte[], byte[]>> recordsWithSplitIds = reader.fetch();
         assertTrue(recordsWithSplitIds.finishedSplits().contains(emptySplit.splitId()));
+        assertTrue(
+                recordsWithSplitIds
+                        .finishedSplits()
+                        .contains(emptySplitWithZeroStoppingOffset.splitId()));
 
         // Assign another valid split to avoid consumer.poll() blocking
         final KafkaPartitionSplit anotherNormalSplit =

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializerTest.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.source.split;
+
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link KafkaPartitionSplitSerializer}. */
+public class KafkaPartitionSplitSerializerTest {
+
+    @Test
+    public void testSerializer() throws IOException {
+        String topic = "topic";
+        Long offsetZero = 0L;
+        Long normalOffset = 1L;
+        TopicPartition topicPartition = new TopicPartition(topic, 1);
+        List<Long> stoppingOffsets =
+                Arrays.asList(
+                        KafkaPartitionSplit.COMMITTED_OFFSET,
+                        KafkaPartitionSplit.LATEST_OFFSET,
+                        offsetZero,
+                        normalOffset);
+        KafkaPartitionSplitSerializer splitSerializer = new KafkaPartitionSplitSerializer();
+        for (Long stoppingOffset : stoppingOffsets) {
+            KafkaPartitionSplit kafkaPartitionSplit =
+                    new KafkaPartitionSplit(topicPartition, 0, stoppingOffset);
+            byte[] serialize = splitSerializer.serialize(kafkaPartitionSplit);
+            KafkaPartitionSplit deserializeSplit =
+                    splitSerializer.deserialize(splitSerializer.getVersion(), serialize);
+            assertTrue(deserializeSplit.equals(kafkaPartitionSplit));
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Stopping offset can be 0.When we make a zero stopping offset empty,it would be serialized to NO_STOPPING_OFFSET, which it is not expected.
It' had been fixed in master by https://github.com/apache/flink/pull/20234, now need to merge into release-1.14.

## Brief change log
change a stopping offset conditon from '>0' to '>=0'

## Verifying this change
Can be verified by:
KafkaPartitionSplitReaderTest#testAssignEmptySplit
KafkaPartitionSplitSerializerTest


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
