### PR TITLE
[FLINK-28459][table-planner] Supports non-atomic CREATE TABLE AS SELECT

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -40,6 +40,7 @@ import org.apache.flink.sql.parser.ddl.SqlCreateCatalog;
 import org.apache.flink.sql.parser.ddl.SqlCreateDatabase;
 import org.apache.flink.sql.parser.ddl.SqlCreateFunction;
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.ddl.SqlCreateTableAs;
 import org.apache.flink.sql.parser.ddl.SqlCreateView;
 import org.apache.flink.sql.parser.ddl.SqlDropCatalog;
 import org.apache.flink.sql.parser.ddl.SqlDropDatabase;
@@ -280,6 +281,11 @@ public class SqlToOperationConverter {
         } else if (validated instanceof SqlUseDatabase) {
             return Optional.of(converter.convertUseDatabase((SqlUseDatabase) validated));
         } else if (validated instanceof SqlCreateTable) {
+            if (validated instanceof SqlCreateTableAs) {
+                return Optional.of(
+                        converter.createTableConverter.convertCreateTableAS(
+                                flinkPlanner, (SqlCreateTableAs) validated));
+            }
             return Optional.of(
                     converter.createTableConverter.convertCreateTable((SqlCreateTable) validated));
         } else if (validated instanceof SqlDropTable) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSinkTest.scala
@@ -28,6 +28,7 @@ import org.apache.flink.table.data.RowData
 import org.apache.flink.table.factories.{DynamicTableFactory, DynamicTableSourceFactory}
 import org.apache.flink.table.planner.utils.{TableTestBase, TestingTableEnvironment}
 
+import org.assertj.core.api.Assertions
 import org.junit.Test
 
 import java.util
@@ -796,6 +797,17 @@ class TableSinkTest extends TableTestBase {
     val stmtSet = util.tableEnv.createStatementSet()
     stmtSet.addInsertSql("INSERT INTO zm_test(`a`) SELECT `a` FROM MyTable")
     util.verifyRelPlan(stmtSet, ExplainDetail.CHANGELOG_MODE)
+  }
+
+  @Test
+  def testCreateTableAsSelect(): Unit = {
+    // TODO: support explain CreateTableASOperation
+    // Flink does not support explain CreateTableASOperation yet, we will fix it in FLINK-28770.
+    Assertions
+      .assertThatThrownBy(
+        () => util.tableEnv.explainSql("CREATE TABLE zm_ctas_test AS SELECT * FROM MyTable"))
+      .hasMessage(
+        "Unsupported operation: org.apache.flink.table.operations.ddl.CreateTableASOperation")
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -219,4 +219,15 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
     )
     Assertions.assertThat(actual.sorted).isEqualTo(expected.sorted)
   }
+
+  @Test
+  def testCreateTableAsSelectWithoutOptions(): Unit = {
+    // TODO CTAS supports ManagedTable
+    Assertions
+      .assertThatThrownBy(
+        () => tEnv.executeSql("CREATE TABLE MyCtasTable AS SELECT `person`, `votes` FROM src"))
+      .hasMessage("You should enable the checkpointing for sinking to managed table " +
+        "'default_catalog.default_database.MyCtasTable'," +
+        " managed table relies on checkpoint to commit and the data is visible only after commit.")
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -222,7 +222,10 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testCreateTableAsSelectWithoutOptions(): Unit = {
-    // TODO CTAS supports ManagedTable
+    // TODO: CTAS supports ManagedTable
+    // If the connector option is not specified, Flink will creates a Managed table.
+    // Managed table requires two layers of log storage and file storage
+    // and depends on the flink table store, CTAS will support Managed Table in the future.
     Assertions
       .assertThatThrownBy(
         () => tEnv.executeSql("CREATE TABLE MyCtasTable AS SELECT `person`, `votes` FROM src"))


### PR DESCRIPTION
## What is the purpose of the change

* Supports non-atomic CREATE TABLE AS SELECT


## Brief change log

Modify the SqlCreateTableConverter and SqlToOperationConverter to support non-atomic CREATE TABLE AS SELECT


## Verifying this change

add ITCase
* org.apache.flink.table.planner.runtime.batch.sql.TableSinkITCase#testCreateTableAsSelect
* org.apache.flink.table.planner.runtime.stream.sql.TableSinkITCase#testCreateTableAsSelect

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
