### PR TITLE
[FLINK-28570][table-planner]  Introduces a StreamNonDeterministicPlanResolver to validate and try to solve (lookup join only) the non-deterministic updates problem which may cause wrong result or error

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -30,6 +30,12 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>Tells the optimizer whether to split distinct aggregation (e.g. COUNT(DISTINCT col), SUM(DISTINCT col)) into two level. The first aggregation is shuffled by an additional key which is calculated using the hashcode of distinct_key and number of buckets. This optimization is very useful when there is data skew in distinct aggregation and gives the ability to scale-up the job. Default is false.</td>
         </tr>
         <tr>
+            <td><h5>table.optimizer.dynamic-filtering.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>When it is true, the optimizer will try to push dynamic filtering into scan table source, the irrelevant partitions or input data will be filtered to reduce scan I/O in runtime.</td>
+        </tr>
+        <tr>
             <td><h5>table.optimizer.join-reorder-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -46,6 +52,12 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>When it is true, the optimizer will merge the operators with pipelined shuffling into a multiple input operator to reduce shuffling and improve performance. Default value is true.</td>
+        </tr>
+        <tr>
+            <td><h5>table.optimizer.non-deterministic-update.strategy</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">IGNORE</td>
+            <td><p>Enum</p></td>
+            <td>When it is `TRY_RESOLVE`, the optimizer tries to resolve the correctness issue caused by 'Non-Deterministic Updates' (NDU) in a changelog pipeline. Changelog may contain kinds of message types: Insert (I), Delete (D), Update_Before (UB), Update_After (UA). There's no NDU problem in an insert only changelog pipeline. For updates, there are  three main NDU problems:<br />1. Non-deterministic functions, include scalar, table, aggregate functions, both builtin and custom ones.<br />2. LookupJoin on an evolving source<br />3. Cdc-source carries metadata fields which are system columns, not belongs to the entity data itself.<br /><br />For the first step, the optimizer automatically enables the materialization for No.2(LookupJoin) if needed, and gives the detailed error message for No.1(Non-deterministic functions) and No.3(Cdc-source with metadata) which is relatively easier to solve by changing the SQL.<br />Default value is `IGNORE`, the optimizer does no changes.<br /><br />Possible values:<ul><li>"TRY_RESOLVE"</li><li>"IGNORE"</li></ul></td>
         </tr>
         <tr>
             <td><h5>table.optimizer.reuse-source-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
@@ -76,12 +88,6 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>When it is true, the optimizer will collect and use the statistics from source connectors if the source extends from SupportsStatisticReport and the statistics from catalog is UNKNOWN.Default value is true.</td>
-        </tr>
-        <tr>
-            <td><h5>table.optimizer.dynamic-filtering.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>When it is true, the optimizer will try to push dynamic filtering into scan table source, the irrelevant partitions or input data will be filtered to reduce scan I/O in runtime.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/config/OptimizerConfigOptions.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.api.config;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.description.Description;
 
 import static org.apache.flink.configuration.ConfigOptions.key;
 
@@ -151,4 +152,53 @@ public class OptimizerConfigOptions {
                     .withDescription(
                             "When it is true, the optimizer will try to push dynamic filtering into scan table source,"
                                     + " the irrelevant partitions or input data will be filtered to reduce scan I/O in runtime.");
+
+    @Documentation.TableOption(execMode = Documentation.ExecMode.STREAMING)
+    public static final ConfigOption<NonDeterministicUpdateStrategy>
+            TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY =
+                    key("table.optimizer.non-deterministic-update.strategy")
+                            .enumType(NonDeterministicUpdateStrategy.class)
+                            .defaultValue(NonDeterministicUpdateStrategy.IGNORE)
+                            .withDescription(
+                                    Description.builder()
+                                            .text(
+                                                    "When it is `TRY_RESOLVE`, the optimizer tries to resolve the correctness issue caused by "
+                                                            + "'Non-Deterministic Updates' (NDU) in a changelog pipeline. Changelog may contain kinds"
+                                                            + " of message types: Insert (I), Delete (D), Update_Before (UB), Update_After (UA)."
+                                                            + " There's no NDU problem in an insert only changelog pipeline. For updates, there are"
+                                                            + "  three main NDU problems:")
+                                            .linebreak()
+                                            .text(
+                                                    "1. Non-deterministic functions, include scalar, table, aggregate functions, both builtin and custom ones.")
+                                            .linebreak()
+                                            .text("2. LookupJoin on an evolving source")
+                                            .linebreak()
+                                            .text(
+                                                    "3. Cdc-source carries metadata fields which are system columns, not belongs to the entity data itself.")
+                                            .linebreak()
+                                            .linebreak()
+                                            .text(
+                                                    "For the first step, the optimizer automatically enables the materialization for No.2(LookupJoin) if needed,"
+                                                            + " and gives the detailed error message for No.1(Non-deterministic functions) and"
+                                                            + " No.3(Cdc-source with metadata) which is relatively easier to solve by changing the SQL.")
+                                            .linebreak()
+                                            .text(
+                                                    "Default value is `IGNORE`, the optimizer does no changes.")
+                                            .build());
+
+    /** Strategy for handling non-deterministic updates. */
+    @PublicEvolving
+    public enum NonDeterministicUpdateStrategy {
+
+        /**
+         * Try to resolve by planner automatically if exists non-deterministic updates, will raise
+         * an error when cannot resolve.
+         */
+        TRY_RESOLVE,
+
+        /**
+         * Do nothing if exists non-deterministic updates, the risk of wrong result still exists.
+         */
+        IGNORE
+    }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ConnectorCatalogTable.java
@@ -136,6 +136,10 @@ public class ConnectorCatalogTable<T1, T2> extends AbstractCatalogTable {
         if (source instanceof DefinedProctimeAttribute) {
             updateProctimeIndicator((DefinedProctimeAttribute) source, fieldNames, types);
         }
+        if (tableSchema.getPrimaryKey().isPresent()) {
+            String[] pkCols = tableSchema.getPrimaryKey().get().getColumns().toArray(new String[0]);
+            return TableSchema.builder().fields(fieldNames, types).primaryKey(pkCols).build();
+        }
         return TableSchema.builder().fields(fieldNames, types).build();
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLookupJoin.java
@@ -18,8 +18,12 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.common.CommonExecLookupJoin;
@@ -59,9 +63,18 @@ public class BatchExecLookupJoin extends CommonExecLookupJoin implements BatchEx
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
-                true,
+                ChangelogMode.insertOnly(),
                 Collections.singletonList(inputProperty),
                 outputType,
                 description);
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Transformation<RowData> translateToPlanInternal(
+            PlannerBase planner, ExecNodeConfig config) {
+        // There's no optimization when lookupKeyContainsPrimaryKey is true for batch, so set it to
+        // false for now. We can add it to CommonExecLookupJoin when needed.
+        return createJoinTransformation(planner, config, false, false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLookupJoin.java
@@ -19,8 +19,12 @@
 package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.FlinkVersion;
+import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeMetadata;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
@@ -31,6 +35,7 @@ import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
 import org.apache.flink.table.types.logical.RowType;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonInclude;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.apache.calcite.rex.RexNode;
@@ -49,6 +54,18 @@ import java.util.Map;
         minPlanVersion = FlinkVersion.v1_15,
         minStateVersion = FlinkVersion.v1_15)
 public class StreamExecLookupJoin extends CommonExecLookupJoin implements StreamExecNode<RowData> {
+    public static final String FIELD_NAME_REQUIRE_UPSERT_MATERIALIZE = "requireUpsertMaterialize";
+
+    public static final String FIELD_NAME_LOOKUP_KEY_CONTAINS_PRIMARY_KEY =
+            "lookupKeyContainsPrimaryKey";
+
+    @JsonProperty(FIELD_NAME_LOOKUP_KEY_CONTAINS_PRIMARY_KEY)
+    private final boolean lookupKeyContainsPrimaryKey;
+
+    @JsonProperty(FIELD_NAME_REQUIRE_UPSERT_MATERIALIZE)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private final boolean upsertMaterialize;
+
     public StreamExecLookupJoin(
             ReadableConfig tableConfig,
             FlinkJoinType joinType,
@@ -57,9 +74,11 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
             Map<Integer, LookupJoinUtil.LookupKey> lookupKeys,
             @Nullable List<RexNode> projectionOnTemporalTable,
             @Nullable RexNode filterOnTemporalTable,
-            boolean inputInsertOnly,
+            ChangelogMode inputChangelogMode,
             InputProperty inputProperty,
             RowType outputType,
+            boolean lookupKeyContainsPrimaryKey,
+            boolean upsertMaterialize,
             String description) {
         this(
                 ExecNodeContext.newNodeId(),
@@ -71,9 +90,11 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
-                inputInsertOnly,
+                inputChangelogMode,
                 Collections.singletonList(inputProperty),
                 outputType,
+                lookupKeyContainsPrimaryKey,
+                upsertMaterialize,
                 description);
     }
 
@@ -91,9 +112,13 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                     List<RexNode> projectionOnTemporalTable,
             @JsonProperty(FIELD_NAME_FILTER_ON_TEMPORAL_TABLE) @Nullable
                     RexNode filterOnTemporalTable,
-            @JsonProperty(FIELD_NAME_INPUT_INSERT_ONLY) @Nullable Boolean inputInsertOnly,
+            @JsonProperty(FIELD_NAME_INPUT_CHANGELOG_MODE) @Nullable
+                    ChangelogMode inputChangelogMode,
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) RowType outputType,
+            @JsonProperty(FIELD_NAME_LOOKUP_KEY_CONTAINS_PRIMARY_KEY)
+                    boolean lookupKeyContainsPrimaryKey,
+            @JsonProperty(FIELD_NAME_REQUIRE_UPSERT_MATERIALIZE) boolean upsertMaterialize,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
                 id,
@@ -105,9 +130,19 @@ public class StreamExecLookupJoin extends CommonExecLookupJoin implements Stream
                 lookupKeys,
                 projectionOnTemporalTable,
                 filterOnTemporalTable,
-                inputInsertOnly,
+                inputChangelogMode,
                 inputProperties,
                 outputType,
                 description);
+        this.lookupKeyContainsPrimaryKey = lookupKeyContainsPrimaryKey;
+        this.upsertMaterialize = upsertMaterialize;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Transformation<RowData> translateToPlanInternal(
+            PlannerBase planner, ExecNodeConfig config) {
+        return createJoinTransformation(
+                planner, config, upsertMaterialize, lookupKeyContainsPrimaryKey);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicPhysicalPlanResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicPhysicalPlanResolver.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.optimize;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.OptimizerConfigOptions;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.calcite.rel.RelNode;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The {@link StreamNonDeterministicPhysicalPlanResolver} tries to resolve the correctness issue
+ * caused by 'Non-Deterministic Updates' (NDU) in a changelog pipeline. Changelog may contain kinds
+ * of message types: Insert (I), Delete (D), Update_Before (UB), Update_After (UA).
+ *
+ * <p>There's no NDU problem in an insert-only changelog pipeline.
+ *
+ * <p>For the updates, there are two cases, with and without upsertKey(a metadata from {@link
+ * org.apache.flink.table.planner.plan.metadata.FlinkRelMdUpsertKeys} , consider it as the primary
+ * key of the changelog). The upsertKey can be always treated as deterministic, so if all the
+ * pipeline operators can transmit upsertKey normally (include working with sink's primary key),
+ * everything goes well.
+ *
+ * <p>The key issue is upsertKey can be easily lost in a pipeline or does not exist from the source
+ * or at the sink. All stateful operators can only process an update (D/UB/UA) message by comparing
+ * the complete row (retract by row) if without a key identifier, also include a sink without
+ * primary key definition that works as retractSink. So under the 'retract by row' mode, a stateful
+ * operator requires no non-deterministic column disturb the original changelog row. There are three
+ * killers:
+ *
+ * <p>1. Non-deterministic functions(include scalar, table, aggregate functions, builtin or custom
+ * ones)
+ *
+ * <p>2. LookupJoin on an evolving source
+ *
+ * <p>3. Cdc-source carries metadata fields(system columns, not belongs to the entity row itself)
+ *
+ * <p>For the first step, this resolver automatically enables the materialization for
+ * No.2(LookupJoin) if needed, and gives the detail error message for No.1 (Non-deterministic
+ * functions) and No.3(Cdc-source with metadata) which we think it is relatively easy to change the
+ * SQL(add materialization is not a good idea for now, it has very high cost and will bring too much
+ * complexity to the operators).
+ *
+ * <p>Why not do this validation and rewriting in physical-rewrite phase, like {@link
+ * org.apache.flink.table.planner.plan.optimize.program.FlinkChangelogModeInferenceProgram} does?
+ * Because the physical plan may be changed a lot after physical-rewrite being done, we should check
+ * the 'final' plan instead.
+ *
+ * <p>Some specific plan patterns:
+ *
+ * <p>1. Non-deterministic scalar function calls
+ *
+ * <pre>{@code
+ * Sink
+ *   |
+ * Project1{select col1,col2,now(),...}
+ *   |
+ * Scan1
+ * }</pre>
+ *
+ * <p>2. Non-deterministic table function calls
+ *
+ * <pre>{@code
+ *      Sink
+ *        |
+ *     Correlate
+ *     /      \
+ * Project1  TableFunctionScan1
+ *    |
+ *  Scan1
+ * }</pre>
+ *
+ * <p>3. lookup join: lookup a source which data may change over time
+ *
+ * <pre>{@code
+ *      Sink
+ *        |
+ *     LookupJoin
+ *     /      \
+ * Filter1  Source2
+ *    |
+ * Project1
+ *    |
+ *  Scan1
+ * }</pre>
+ *
+ * <p>3.1 lookup join: an inner project with non-deterministic function calls or remaining join
+ * condition is non-deterministic
+ *
+ * <pre>{@code
+ *      Sink
+ *        |
+ *     LookupJoin
+ *     /      \
+ * Filter1  Project2
+ *    |        |
+ * Project1   Source2
+ *    |
+ *  Scan1
+ * }</pre>
+ *
+ * <p>4. cdc source with metadata
+ *
+ * <pre>{@code
+ *     Sink
+ *       | no upsertKey can be inferred
+ *   Correlate
+ *     /      \
+ *   /       TableFunctionScan1(deterministic)
+ * Project1 {select id,name,attr1,op_time}
+ *   |
+ * Scan {cdc source <id,name,attr1,op_type,op_time> }
+ * }</pre>
+ *
+ * <p>4.1 cdc source with metadata
+ *
+ * <pre>{@code
+ *     Sink
+ *       | no upsertKey can be inferred
+ *   LookupJoin {lookup key not contains the lookup source's pk}
+ *     /      \
+ *   /       Source2
+ * Project1 {select id,name,attr1,op_time}
+ *   |
+ * Scan {cdc source <id,name,attr1,op_type,op_time> }
+ * }</pre>
+ *
+ * <p>CDC source with metadata is another form of non-deterministic update.
+ *
+ * <p>5. grouping keys with non-deterministic column
+ *
+ * <pre>{@code
+ * Sink{pk=(c3,day)}
+ *   | upsertKey=(c3,day)
+ *  GroupAgg{group by c3, day}
+ *   |
+ * Project{select c1,c2,DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') day,...}
+ *   |
+ * Deduplicate{keep last row, dedup on c1,c2}
+ *   |
+ *  Scan
+ * }</pre>
+ */
+public class StreamNonDeterministicPhysicalPlanResolver {
+
+    /**
+     * Try to resolve the NDU problem if configured {@link
+     * OptimizerConfigOptions#TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY} is in `TRY_RESOLVE`
+     * mode. Will raise an error if the NDU issues in the given plan can not be completely solved.
+     */
+    public static List<RelNode> resolvePhysicalPlan(
+            List<RelNode> expanded, TableConfig tableConfig) {
+        OptimizerConfigOptions.NonDeterministicUpdateStrategy handling =
+                tableConfig
+                        .getConfiguration()
+                        .get(
+                                OptimizerConfigOptions
+                                        .TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY);
+        if (handling == OptimizerConfigOptions.NonDeterministicUpdateStrategy.TRY_RESOLVE) {
+            Preconditions.checkArgument(
+                    expanded.stream().allMatch(rel -> rel instanceof StreamPhysicalRel));
+            StreamNonDeterministicUpdatePlanVisitor planResolver =
+                    new StreamNonDeterministicUpdatePlanVisitor();
+
+            return expanded.stream()
+                    .map(rel -> (StreamPhysicalRel) rel)
+                    .map(planResolver::visit)
+                    .collect(Collectors.toList());
+        }
+        // do nothing, return original relNodes
+        return expanded;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -1,0 +1,978 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.optimize;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.constraints.UniqueConstraint;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
+import org.apache.flink.table.planner.connectors.DynamicSourceUtils;
+import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery;
+import org.apache.flink.table.planner.plan.nodes.exec.spec.OverSpec;
+import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalJoin;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCalcBase;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalChangelogNormalize;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalCorrelateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDataStreamScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDeduplicate;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalDropUpdateBefore;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalExchange;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalExpand;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalGroupAggregateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLegacySink;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLegacyTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLimit;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalLookupJoin;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalMatch;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalMiniBatchAssigner;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalOverAggregateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRank;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalRel;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSink;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSort;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalSortLimit;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalTemporalSort;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalUnion;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalValues;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWatermarkAssigner;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowAggregateBase;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowDeduplicate;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowRank;
+import org.apache.flink.table.planner.plan.nodes.physical.stream.StreamPhysicalWindowTableFunction;
+import org.apache.flink.table.planner.plan.schema.TableSourceTable;
+import org.apache.flink.table.planner.plan.utils.ChangelogPlanUtils;
+import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
+import org.apache.flink.table.planner.plan.utils.JoinUtil;
+import org.apache.flink.table.planner.plan.utils.OverAggregateUtil;
+import org.apache.flink.table.planner.plan.utils.RankProcessStrategy;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
+import org.apache.flink.table.runtime.operators.join.stream.state.JoinInputSideSpec;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.types.RowKind;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexProgram;
+import org.apache.calcite.sql.SqlExplainLevel;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.util.ImmutableBitSet;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * An inner visitor to validate if there's any NDU problems which may cause wrong result and try to
+ * rewrite lookup join node with materialization (to eliminate the non-deterministic result
+ * generated by lookup join node only).
+ *
+ * <p>The visitor will try to satisfy the required determinism(represent by ImmutableBitSet) from
+ * root. The transmission rule of required determinism:
+ *
+ * <p>0. all required determinism is under the precondition: input has updates, that is say no
+ * update determinism will be passed to an insert only stream
+ *
+ * <p>1. the initial required determinism to the root node(e.g., sink node) was none
+ *
+ * <p>2. for a relNode, it will process on two aspects: - can satisfy non-empty required determinism
+ * - actively requires determinism from input by self requirements(e.g., stateful node works on
+ * retract by row mode)
+ *
+ * <pre>{@code
+ * Rel3
+ *  | require input
+ *  v
+ * Rel2 {1. satisfy Rel3's requirement 2. append new requirement to input Rel1}
+ *  | require input
+ *  v
+ * Rel1
+ * }</pre>
+ *
+ * <p>the requiredDeterminism passed to input will exclude columns which were in upsertKey, e.g.,
+ *
+ * <pre>{@code
+ * Sink {pk=(c3)} requiredDeterminism=(c3)
+ *   | passed requiredDeterminism={}
+ *  GroupAgg{group by c3, day} append requiredDeterminism=(c3, day)
+ *   | passed requiredDeterminism=(c3, day)
+ * Project{select c1,c2,DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') day,...} [x] can not satisfy
+ *   |
+ * Deduplicate{keep last row, dedup on c1,c2}
+ *   |
+ *  Scan
+ * }</pre>
+ *
+ * <p>3. for a sink node, it will require key columns' determinism when primary key is defined or
+ * require all columns' determinism when no primary key is defined
+ *
+ * <p>4. for a cdc source node(which will generate updates), the metadata columns are treated as
+ * non-deterministic.
+ */
+public class StreamNonDeterministicUpdatePlanVisitor {
+    private static final ImmutableBitSet NO_REQUIRED_DETERMINISM = ImmutableBitSet.of();
+
+    private static final String NON_DETERMINISTIC_CONDITION_ERROR_MSG_TEMPLATE =
+            "There exists non deterministic function: '%s' in condition: '%s' which may cause wrong result in update pipeline.";
+
+    public StreamPhysicalRel visit(final StreamPhysicalRel rel) {
+        return visit(rel, NO_REQUIRED_DETERMINISM);
+    }
+
+    public StreamPhysicalRel visit(
+            final StreamPhysicalRel rel, final ImmutableBitSet requireDeterminism) {
+        if (rel instanceof StreamPhysicalSink) {
+            if (inputInsertOnly(rel)) {
+                // for append stream, not care about NDU
+                return transmitDeterminismRequirement(rel, NO_REQUIRED_DETERMINISM);
+            } else {
+                // for update streaming, when
+                // 1. sink with pk:
+                // upsert sink, update by pk, ideally pk == input.upsertKey,
+                // (otherwise upsertMaterialize will handle it)
+
+                // 1.1 input.upsertKey nonEmpty -> not care about NDU
+                // 1.2 input.upsertKey isEmpty -> retract by complete row, must not contain NDU
+
+                // once sink's requirement on pk was satisfied, no further request will be transited
+                // only when new requirement generated at stateful node which input has update
+                // (e.g., grouping keys)
+
+                // 2. sink without pk:
+                // retract sink, retract by complete row (all input columns should be deterministic)
+                // whether input.upsertKey is empty or not, must not contain NDU
+                StreamPhysicalSink sink = (StreamPhysicalSink) rel;
+                int[] primaryKey =
+                        sink.contextResolvedTable().getResolvedSchema().getPrimaryKeyIndexes();
+                ImmutableBitSet requireInputDeterminism;
+                if (sink.upsertMaterialize() || null == primaryKey || primaryKey.length == 0) {
+                    // SinkUpsertMaterializer only support no upsertKey mode, it says all input
+                    // columns should be deterministic (same as no primary key defined on sink)
+                    // TODO should optimize it after SinkUpsertMaterializer support upsertKey
+                    // FLINK-28569.
+                    requireInputDeterminism =
+                            ImmutableBitSet.range(sink.getInput().getRowType().getFieldCount());
+                } else {
+                    requireInputDeterminism = ImmutableBitSet.of(primaryKey);
+                }
+                return transmitDeterminismRequirement(sink, requireInputDeterminism);
+            }
+        } else if (rel instanceof StreamPhysicalLegacySink<?>) {
+            if (inputInsertOnly(rel)) {
+                // for append stream, not care about NDU
+                return transmitDeterminismRequirement(rel, NO_REQUIRED_DETERMINISM);
+            } else {
+                StreamPhysicalLegacySink<?> sink = (StreamPhysicalLegacySink<?>) rel;
+                TableSchema tableSchema = sink.sink().getTableSchema();
+                Optional<UniqueConstraint> primaryKey = tableSchema.getPrimaryKey();
+                List<String> columns = Arrays.asList(tableSchema.getFieldNames());
+                // SinkUpsertMaterializer does not support legacy sink
+                ImmutableBitSet requireInputDeterminism;
+                if (primaryKey.isPresent()) {
+                    requireInputDeterminism =
+                            ImmutableBitSet.of(
+                                    primaryKey.get().getColumns().stream()
+                                            .map(columns::indexOf)
+                                            .collect(Collectors.toList()));
+                } else {
+                    requireInputDeterminism = ImmutableBitSet.range(columns.size());
+                }
+                return transmitDeterminismRequirement(rel, requireInputDeterminism);
+            }
+        } else if (rel instanceof StreamPhysicalCalcBase) {
+            if (inputInsertOnly(rel) || requireDeterminism.isEmpty()) {
+                // for append stream, not care about NDU
+                return transmitDeterminismRequirement(rel, NO_REQUIRED_DETERMINISM);
+            } else {
+                // if input has updates, any non-deterministic conditions are not acceptable, also
+                // requireDeterminism should be satisfied.
+                StreamPhysicalCalcBase calc = (StreamPhysicalCalcBase) rel;
+                checkNonDeterministicRexProgram(requireDeterminism, calc.getProgram(), calc);
+
+                // evaluate required determinism from input
+                List<RexNode> projects =
+                        calc.getProgram().getProjectList().stream()
+                                .map(expr -> calc.getProgram().expandLocalRef(expr))
+                                .collect(Collectors.toList());
+                Map<Integer, Integer> outFromSourcePos = extractSourceMapping(projects);
+                List<Integer> conv2Inputs =
+                        requireDeterminism.toList().stream()
+                                .map(
+                                        out ->
+                                                Optional.ofNullable(outFromSourcePos.get(out))
+                                                        .orElseThrow(
+                                                                () ->
+                                                                        new TableException(
+                                                                                String.format(
+                                                                                        "Invalid pos:%d over projection:%s",
+                                                                                        out,
+                                                                                        calc
+                                                                                                .getProgram()))))
+                                .filter(index -> index != -1)
+                                .collect(Collectors.toList());
+
+                return transmitDeterminismRequirement(calc, ImmutableBitSet.of(conv2Inputs));
+            }
+        } else if (rel instanceof StreamPhysicalCorrelateBase) {
+            if (inputInsertOnly(rel) || requireDeterminism.isEmpty()) {
+                return transmitDeterminismRequirement(rel, NO_REQUIRED_DETERMINISM);
+            } else {
+                // check if non-deterministic condition (may exist after FLINK-7865 was fixed).
+                StreamPhysicalCorrelateBase correlate = (StreamPhysicalCorrelateBase) rel;
+                if (correlate.condition().isDefined()) {
+                    RexNode rexNode = correlate.condition().get();
+                    checkNonDeterministicCondition(rexNode, correlate);
+                }
+                // check if it is a non-deterministic function
+                int leftFieldCnt = correlate.inputRel().getRowType().getFieldCount();
+                Optional<String> ndCall =
+                        FlinkRexUtil.getNonDeterministicCallNameInStreaming(
+                                correlate.scan().getCall());
+                if (ndCall.isPresent()) {
+                    // all columns from table function scan cannot satisfy the required determinism
+                    List<Integer> unsatisfiedColumns =
+                            requireDeterminism.toList().stream()
+                                    .filter(index -> index >= leftFieldCnt)
+                                    .collect(Collectors.toList());
+                    if (!unsatisfiedColumns.isEmpty()) {
+                        throwNonDeterministicColumnsError(
+                                unsatisfiedColumns,
+                                correlate.getRowType(),
+                                correlate,
+                                null,
+                                ndCall);
+                    }
+                }
+                // evaluate required determinism from input
+                List<Integer> fromLeft =
+                        requireDeterminism.toList().stream()
+                                .filter(index -> index < leftFieldCnt)
+                                .collect(Collectors.toList());
+                if (fromLeft.isEmpty()) {
+                    return transmitDeterminismRequirement(correlate, NO_REQUIRED_DETERMINISM);
+                }
+                return transmitDeterminismRequirement(correlate, ImmutableBitSet.of(fromLeft));
+            }
+
+        } else if (rel instanceof StreamPhysicalLookupJoin) {
+            if (inputInsertOnly(rel) || requireDeterminism.isEmpty()) {
+                return transmitDeterminismRequirement(rel, NO_REQUIRED_DETERMINISM);
+            } else {
+                /**
+                 * if input has updates, the lookup join may produce non-deterministic result itself
+                 * due to backed lookup source which data may change over time, we can try to
+                 * eliminate this non-determinism by adding materialization to the join operator,
+                 * but still exists non-determinism we cannot solve: 1. join condition 2. the inner
+                 * calc in lookJoin.
+                 */
+                StreamPhysicalLookupJoin lookupJoin = (StreamPhysicalLookupJoin) rel;
+
+                // required determinism cannot be satisfied even upsert materialize was enabled if:
+                // 1. remaining join condition contains non-deterministic call
+                JavaScalaConversionUtil.toJava(lookupJoin.remainingCondition())
+                        .ifPresent(condi -> checkNonDeterministicCondition(condi, lookupJoin));
+
+                // 2. inner calc in lookJoin contains either non-deterministic condition or calls
+                JavaScalaConversionUtil.toJava(lookupJoin.calcOnTemporalTable())
+                        .ifPresent(
+                                calc ->
+                                        checkNonDeterministicRexProgram(
+                                                requireDeterminism, calc, lookupJoin));
+
+                // Try to resolve non-determinism by adding materialization which can eliminate
+                // non-determinism produced by lookup join via an evolving source.
+                int leftFieldCnt = lookupJoin.getInput().getRowType().getFieldCount();
+                List<Integer> requireRight =
+                        requireDeterminism.toList().stream()
+                                .filter(index -> index >= leftFieldCnt)
+                                .collect(Collectors.toList());
+                boolean omitUpsertMaterialize = false;
+                // two optimizations: 1. no fields from lookup source was required 2. lookup key
+                // contains pk and no requirement on other fields we can omit materialization,
+                // otherwise upsert materialize can not be omitted.
+                if (requireRight.isEmpty()) {
+                    omitUpsertMaterialize = true;
+                } else {
+                    int[] outputPkIdx = lookupJoin.getOutputIndexesOfTemporalTablePrimaryKey();
+                    ImmutableBitSet outputPkBitSet = ImmutableBitSet.of(outputPkIdx);
+                    // outputPkIdx need to used so not using #lookupKeyContainsPrimaryKey directly.
+                    omitUpsertMaterialize =
+                            Arrays.stream(outputPkIdx)
+                                            .allMatch(
+                                                    index ->
+                                                            lookupJoin
+                                                                    .allLookupKeys()
+                                                                    .contains(index))
+                                    && requireRight.stream().allMatch(outputPkBitSet::get);
+                }
+                List<Integer> requireLeft =
+                        requireDeterminism.toList().stream()
+                                .filter(index -> index < leftFieldCnt)
+                                .collect(Collectors.toList());
+
+                if (omitUpsertMaterialize) {
+                    return transmitDeterminismRequirement(
+                            lookupJoin, ImmutableBitSet.of(requireLeft));
+                } else {
+                    // enable materialize for lookup join
+                    return transmitDeterminismRequirement(
+                            lookupJoin.copy(true), ImmutableBitSet.of(requireLeft));
+                }
+            }
+        } else if (rel instanceof StreamPhysicalTableSourceScan) {
+            // tableScan has no input, so only check metadata from cdc source
+            if (!requireDeterminism.isEmpty()) {
+                StreamPhysicalTableSourceScan tableScan = (StreamPhysicalTableSourceScan) rel;
+                boolean insertOnly =
+                        tableScan.tableSource().getChangelogMode().containsOnly(RowKind.INSERT);
+                boolean supportsReadingMetadata =
+                        tableScan.tableSource() instanceof SupportsReadingMetadata;
+                if (!insertOnly && supportsReadingMetadata) {
+                    TableSourceTable sourceTable =
+                            tableScan.getTable().unwrap(TableSourceTable.class);
+                    // check if requireDeterminism contains metadata column
+                    List<Column.MetadataColumn> metadataColumns =
+                            DynamicSourceUtils.extractMetadataColumns(
+                                    sourceTable.contextResolvedTable().getResolvedSchema());
+                    Set<String> metaColumnSet =
+                            metadataColumns.stream()
+                                    .map(Column::getName)
+                                    .collect(Collectors.toSet());
+                    List<String> columns = tableScan.getRowType().getFieldNames();
+                    List<String> metadataCauseErr = new ArrayList<>();
+                    for (int index = 0; index < columns.size(); index++) {
+                        String column = columns.get(index);
+                        if (metaColumnSet.contains(column) && requireDeterminism.get(index)) {
+                            metadataCauseErr.add(column);
+                        }
+                    }
+                    if (!metadataCauseErr.isEmpty()) {
+                        StringBuilder errorMsg = new StringBuilder();
+                        errorMsg.append("The metadata column(s): '")
+                                .append(String.join(", ", metadataCauseErr.toArray(new String[0])))
+                                .append("' in cdc source may cause wrong result or error on")
+                                .append(" downstream operators, please consider removing these")
+                                .append(" columns or use a non-cdc source that only has insert")
+                                .append(" messages.\nsource node:\n")
+                                .append(
+                                        FlinkRelOptUtil.toString(
+                                                tableScan,
+                                                SqlExplainLevel.DIGEST_ATTRIBUTES,
+                                                false,
+                                                true,
+                                                false,
+                                                true));
+                        throw new TableException(errorMsg.toString());
+                    }
+                }
+            }
+            return rel;
+        } else if (rel instanceof StreamPhysicalLegacyTableSourceScan
+                || rel instanceof StreamPhysicalDataStreamScan
+                || rel instanceof StreamPhysicalValues) {
+            // not cdc source, end visit
+            return rel;
+        } else if (rel instanceof StreamPhysicalGroupAggregateBase) {
+            // output row type = grouping keys + aggCalls
+            StreamPhysicalGroupAggregateBase groupAgg = (StreamPhysicalGroupAggregateBase) rel;
+            if (inputInsertOnly(groupAgg)) {
+                // no further requirement to input, only check if it can satisfy the
+                // requiredDeterminism
+                if (!requireDeterminism.isEmpty()) {
+                    checkUnsatisfiedDeterminism(
+                            requireDeterminism,
+                            groupAgg.grouping().length,
+                            // TODO remove this conversion when scala-free was total done.
+                            scala.collection.JavaConverters.seqAsJavaList(groupAgg.aggCalls()),
+                            groupAgg.getRowType(),
+                            groupAgg);
+                }
+                return transmitDeterminismRequirement(groupAgg, NO_REQUIRED_DETERMINISM);
+            } else {
+                // agg works under retract mode if input is not insert only, and requires all input
+                // columns be deterministic
+                return transmitDeterminismRequirement(
+                        groupAgg,
+                        ImmutableBitSet.range(groupAgg.getInput().getRowType().getFieldCount()));
+            }
+        } else if (rel instanceof StreamPhysicalWindowAggregateBase) {
+            // output row type = grouping keys + aggCalls + windowProperties
+            // same logic with 'groupAgg' but they have no common parent
+            StreamPhysicalWindowAggregateBase windowAgg = (StreamPhysicalWindowAggregateBase) rel;
+            if (inputInsertOnly(windowAgg)) {
+                // no further requirement to input, only check if it can satisfy the
+                // requiredDeterminism
+                if (!requireDeterminism.isEmpty()) {
+                    checkUnsatisfiedDeterminism(
+                            requireDeterminism,
+                            windowAgg.grouping().length,
+                            // TODO remove this conversion when scala-free was total done.
+                            scala.collection.JavaConverters.seqAsJavaList(windowAgg.aggCalls()),
+                            windowAgg.getRowType(),
+                            windowAgg);
+                }
+                return transmitDeterminismRequirement(windowAgg, NO_REQUIRED_DETERMINISM);
+            } else {
+                // agg works under retract mode if input is not insert only, and requires all input
+                // columns be deterministic
+                return transmitDeterminismRequirement(
+                        windowAgg,
+                        ImmutableBitSet.range(windowAgg.getInput().getRowType().getFieldCount()));
+            }
+        } else if (rel instanceof StreamPhysicalExpand) {
+            // Expand is an internal operator only for plan rewriting currently, so only remove the
+            // expandIdIndex from requireDeterminism. We also skip checking if input has updates due
+            // to this is a non-stateful node which never changes the changelog mode.
+            StreamPhysicalExpand expand = (StreamPhysicalExpand) rel;
+            return transmitDeterminismRequirement(
+                    expand, requireDeterminism.except(ImmutableBitSet.of(expand.expandIdIndex())));
+        } else if (rel instanceof CommonPhysicalJoin) {
+            // output row type = left row type + right row type
+            CommonPhysicalJoin join = (CommonPhysicalJoin) rel;
+            StreamPhysicalRel leftRel = (StreamPhysicalRel) join.getLeft();
+            StreamPhysicalRel rightRel = (StreamPhysicalRel) join.getRight();
+            boolean leftInputHasUpdate = !inputInsertOnly(leftRel);
+            boolean rightInputHasUpdate = !inputInsertOnly(rightRel);
+            boolean innerOrSemi =
+                    join.joinSpec().getJoinType() == FlinkJoinType.INNER
+                            || join.joinSpec().getJoinType() == FlinkJoinType.SEMI;
+            /**
+             * we do not distinguish the time attribute condition in interval/temporal join from
+             * regular/window join here because: rowtime field always from source, proctime is not
+             * limited (from source), when proctime appended to an update row without upsertKey then
+             * result may goes wrong, in such a case proctime( was materialized as
+             * PROCTIME_MATERIALIZE(PROCTIME())) is equal to a normal dynamic temporal function and
+             * will be validated in calc node.
+             */
+            Optional<String> ndCall =
+                    FlinkRexUtil.getNonDeterministicCallNameInStreaming(join.getCondition());
+            if ((leftInputHasUpdate || rightInputHasUpdate || !innerOrSemi) && ndCall.isPresent()) {
+                // when output has update, the join condition cannot be non-deterministic:
+                // 1. input has update -> output has update
+                // 2. input insert only and is not innerOrSemi join -> output has update
+                throwNonDeterministicConditionError(
+                        ndCall.get(), join.getCondition(), (StreamPhysicalRel) join);
+            }
+            int leftFieldCnt = leftRel.getRowType().getFieldCount();
+            StreamPhysicalRel newLeft =
+                    visitJoinChild(
+                            requireDeterminism,
+                            leftRel,
+                            leftInputHasUpdate,
+                            leftFieldCnt,
+                            true,
+                            join.joinSpec().getLeftKeys(),
+                            // TODO remove this conversion when scala-free was total done.
+                            scala.collection.JavaConverters.seqAsJavaList(
+                                    join.getUniqueKeys(leftRel, join.joinSpec().getLeftKeys())));
+            StreamPhysicalRel newRight =
+                    visitJoinChild(
+                            requireDeterminism,
+                            rightRel,
+                            rightInputHasUpdate,
+                            leftFieldCnt,
+                            false,
+                            join.joinSpec().getRightKeys(),
+                            // TODO remove this conversion when scala-free was total done.
+                            scala.collection.JavaConverters.seqAsJavaList(
+                                    join.getUniqueKeys(rightRel, join.joinSpec().getRightKeys())));
+
+            return (StreamPhysicalRel)
+                    join.copy(
+                            join.getTraitSet(),
+                            join.getCondition(),
+                            newLeft,
+                            newRight,
+                            join.getJoinType(),
+                            join.isSemiJoin());
+
+        } else if (rel instanceof StreamPhysicalOverAggregateBase) {
+            // output row type = input row type + overAgg outputs
+            StreamPhysicalOverAggregateBase overAgg = ((StreamPhysicalOverAggregateBase) rel);
+            if (inputInsertOnly(overAgg)) {
+                // no further requirement to input, only check if the agg outputs can satisfy the
+                // requiredDeterminism
+                if (!requireDeterminism.isEmpty()) {
+                    int inputFieldCnt = overAgg.getInput().getRowType().getFieldCount();
+                    OverSpec overSpec = OverAggregateUtil.createOverSpec(overAgg.logicWindow());
+                    // add aggCall's input
+                    int aggOutputIndex = inputFieldCnt;
+                    for (OverSpec.GroupSpec groupSpec : overSpec.getGroups()) {
+                        checkUnsatisfiedDeterminism(
+                                requireDeterminism,
+                                aggOutputIndex,
+                                groupSpec.getAggCalls(),
+                                overAgg.getRowType(),
+                                overAgg);
+                        aggOutputIndex += groupSpec.getAggCalls().size();
+                    }
+                }
+                return transmitDeterminismRequirement(overAgg, NO_REQUIRED_DETERMINISM);
+            } else {
+                // OverAgg does not support input with updates currently, so this branch will not be
+                // reached for now.
+
+                // We should append partition keys and order key to requireDeterminism
+                return transmitDeterminismRequirement(
+                        overAgg, mappingRequireDeterminismToInput(requireDeterminism, overAgg));
+            }
+        } else if (rel instanceof StreamPhysicalRank) {
+            // if outputRankNumber:  output row type = input row type + rank number type
+            // else keeps the same as input
+            StreamPhysicalRank rank = (StreamPhysicalRank) rel;
+            if (inputInsertOnly(rank)) {
+                // rank output is deterministic when input is insert only, so required determinism
+                // always be satisfied here.
+                return transmitDeterminismRequirement(rank, NO_REQUIRED_DETERMINISM);
+            } else {
+                int inputFieldCnt = rank.getInput().getRowType().getFieldCount();
+                if (rank.rankStrategy() instanceof RankProcessStrategy.UpdateFastStrategy) {
+                    // in update fast mode, pass required determinism excludes partition keys and
+                    // order key
+                    ImmutableBitSet.Builder bitSetBuilder = ImmutableBitSet.builder();
+                    rank.partitionKey().toList().forEach(bitSetBuilder::set);
+                    rank.orderKey().getKeys().toIntegerList().forEach(bitSetBuilder::set);
+                    if (rank.outputRankNumber()) {
+                        // exclude last column
+                        bitSetBuilder.set(inputFieldCnt);
+                    }
+                    return transmitDeterminismRequirement(
+                            rank, requireDeterminism.except(bitSetBuilder.build()));
+                } else if (rank.rankStrategy() instanceof RankProcessStrategy.RetractStrategy) {
+                    // in retract mode then require all input columns be deterministic
+                    return transmitDeterminismRequirement(
+                            rank, ImmutableBitSet.range(inputFieldCnt));
+                } else {
+                    // AppendFastStrategy only applicable for insert only input, so the undefined
+                    // strategy is not as expected here.
+                    throw new TableException(
+                            String.format(
+                                    "Can not infer the determinism for unsupported rank strategy: %s, this is a bug, please file an issue.",
+                                    rank.rankStrategy()));
+                }
+            }
+        } else if (rel instanceof StreamPhysicalDeduplicate) {
+            // output row type same as input and does not change output columns' order
+            StreamPhysicalDeduplicate dedup = (StreamPhysicalDeduplicate) rel;
+            if (inputInsertOnly(dedup)) {
+                // similar to rank, output is deterministic when input is insert only, so required
+                // determinism always be satisfied here.
+                return transmitDeterminismRequirement(dedup, NO_REQUIRED_DETERMINISM);
+            } else {
+                // Deduplicate always has unique key currently(exec node has null check and inner
+                // state only support data with keys), so only pass the left columns of required
+                // determinism to input.
+                return transmitDeterminismRequirement(
+                        dedup,
+                        requireDeterminism.except(ImmutableBitSet.of(dedup.getUniqueKeys())));
+            }
+        } else if (rel instanceof StreamPhysicalWindowDeduplicate) {
+            // output row type same as input and does not change output columns' order
+            StreamPhysicalWindowDeduplicate winDedup = (StreamPhysicalWindowDeduplicate) rel;
+            if (inputInsertOnly(winDedup)) {
+                // similar to rank, output is deterministic when input is insert only, so required
+                // determinism always be satisfied here.
+                return transmitDeterminismRequirement(winDedup, NO_REQUIRED_DETERMINISM);
+            } else {
+                // WindowDeduplicate does not support input with updates currently, so this branch
+                // will not be reached for now.
+
+                // only append partition keys, no need to process order key because it always comes
+                // from window
+                return transmitDeterminismRequirement(
+                        winDedup,
+                        requireDeterminism
+                                .clear(winDedup.orderKey())
+                                .union(ImmutableBitSet.of(winDedup.partitionKeys())));
+            }
+        } else if (rel instanceof StreamPhysicalWindowRank) {
+            StreamPhysicalWindowRank winRank = (StreamPhysicalWindowRank) rel;
+            if (inputInsertOnly(winRank)) {
+                // similar to rank, output is deterministic when input is insert only, so required
+                // determinism always be satisfied here.
+                return transmitDeterminismRequirement(winRank, NO_REQUIRED_DETERMINISM);
+            } else {
+                // WindowRank does not support input with updates currently, so this branch will not
+                // be reached for now.
+
+                // only append partition keys, no need to process order key because it always comes
+                // from window
+                int inputFieldCnt = winRank.getInput().getRowType().getFieldCount();
+                return transmitDeterminismRequirement(
+                        winRank,
+                        requireDeterminism
+                                .intersect(ImmutableBitSet.range(inputFieldCnt))
+                                .union(winRank.partitionKey()));
+            }
+        } else if (rel instanceof StreamPhysicalWindowTableFunction) {
+            // output row type = input row type + window attributes
+            StreamPhysicalWindowTableFunction winTVF = (StreamPhysicalWindowTableFunction) rel;
+            if (inputInsertOnly(winTVF)) {
+                return transmitDeterminismRequirement(winTVF, NO_REQUIRED_DETERMINISM);
+            } else {
+                // pass the left columns of required determinism to input exclude window attributes
+                return transmitDeterminismRequirement(
+                        winTVF,
+                        requireDeterminism.intersect(
+                                ImmutableBitSet.range(
+                                        winTVF.getInput().getRowType().getFieldCount())));
+            }
+        } else if (rel instanceof StreamPhysicalChangelogNormalize
+                || rel instanceof StreamPhysicalDropUpdateBefore
+                || rel instanceof StreamPhysicalMiniBatchAssigner
+                || rel instanceof StreamPhysicalUnion
+                || rel instanceof StreamPhysicalSort
+                || rel instanceof StreamPhysicalLimit
+                || rel instanceof StreamPhysicalSortLimit
+                || rel instanceof StreamPhysicalTemporalSort
+                || rel instanceof StreamPhysicalWatermarkAssigner
+                || rel instanceof StreamPhysicalExchange) {
+            // transit requireDeterminism transparently
+            return transmitDeterminismRequirement(rel, requireDeterminism);
+        } else if (rel instanceof StreamPhysicalMatch) {
+            // TODO to be supported in FLINK-28743
+            throw new TableException(
+                    "Unsupported to resolve non-deterministic issue in match-recognize.");
+        } else {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "Unsupported to visit node %s, please add the visit implementation if it is a newly added stream physical node.",
+                            rel.getClass().getSimpleName()));
+        }
+    }
+
+    // helper methods
+    private boolean inputInsertOnly(final StreamPhysicalRel rel) {
+        return ChangelogPlanUtils.inputInsertOnly(rel);
+    }
+
+    private StreamPhysicalRel transmitDeterminismRequirement(
+            final StreamPhysicalRel parent, final ImmutableBitSet requireDeterminism) {
+        List<RelNode> newChildren = visitInputs(parent, requireDeterminism);
+        return (StreamPhysicalRel) parent.copy(parent.getTraitSet(), newChildren);
+    }
+
+    private List<RelNode> visitInputs(
+            final StreamPhysicalRel parent, final ImmutableBitSet requireDeterminism) {
+        List<RelNode> newChildren = new ArrayList<>();
+        for (int index = 0; index < parent.getInputs().size(); index++) {
+            StreamPhysicalRel input = (StreamPhysicalRel) parent.getInput(index);
+            // unified processing on input upsertKey
+            newChildren.add(
+                    visit(input, requireDeterminismExcludeUpsertKey(input, requireDeterminism)));
+        }
+        return newChildren;
+    }
+
+    private StreamPhysicalRel visitJoinChild(
+            final ImmutableBitSet requireDeterminism,
+            final StreamPhysicalRel rel,
+            final boolean inputHasUpdate,
+            final int leftFieldCnt,
+            final boolean isLeft,
+            final int[] joinKeys,
+            final List<int[]> inputUniqueKeys) {
+        JoinInputSideSpec joinInputSideSpec =
+                JoinUtil.analyzeJoinInput(
+                        ShortcutUtils.unwrapClassLoader(rel),
+                        InternalTypeInfo.of(FlinkTypeFactory.toLogicalRowType(rel.getRowType())),
+                        joinKeys,
+                        inputUniqueKeys);
+        ImmutableBitSet inputRequireDeterminism;
+        if (inputHasUpdate) {
+            if (joinInputSideSpec.hasUniqueKey() || joinInputSideSpec.joinKeyContainsUniqueKey()) {
+                // join hasUniqueKey or joinKeyContainsUniqueKey, then transmit corresponding
+                // requirement to input
+                if (isLeft) {
+                    inputRequireDeterminism =
+                            ImmutableBitSet.of(
+                                    requireDeterminism.toList().stream()
+                                            .filter(index -> index < leftFieldCnt)
+                                            .collect(Collectors.toList()));
+                } else {
+                    inputRequireDeterminism =
+                            ImmutableBitSet.of(
+                                    requireDeterminism.toList().stream()
+                                            .filter(index -> index >= leftFieldCnt)
+                                            .map(index -> index - leftFieldCnt)
+                                            .collect(Collectors.toList()));
+                }
+            } else {
+                // join need to retract by whole input row
+                inputRequireDeterminism = ImmutableBitSet.range(rel.getRowType().getFieldCount());
+            }
+        } else {
+            inputRequireDeterminism = NO_REQUIRED_DETERMINISM;
+        }
+        return transmitDeterminismRequirement(rel, inputRequireDeterminism);
+    }
+
+    /** Extracts the out from source field index mapping of the given projects. */
+    private Map<Integer, Integer> extractSourceMapping(final List<RexNode> projects) {
+        Map<Integer, Integer> mapOutFromInPos = new HashMap<>();
+
+        for (int index = 0; index < projects.size(); index++) {
+            RexNode expr = projects.get(index);
+            if (expr instanceof RexInputRef) {
+                mapOutFromInPos.put(index, ((RexInputRef) expr).getIndex());
+            } else if (expr instanceof RexCall) {
+                // rename or cast call
+                RexCall call = (RexCall) expr;
+                if ((call.getKind().equals(SqlKind.AS) || call.getKind().equals(SqlKind.CAST))
+                        && (call.getOperands().get(0) instanceof RexInputRef)) {
+                    RexInputRef ref = (RexInputRef) call.getOperands().get(0);
+                    mapOutFromInPos.put(index, ref.getIndex());
+                }
+            } else if (expr instanceof RexLiteral) {
+                mapOutFromInPos.put(index, -1);
+            }
+            // else ignore
+        }
+
+        return mapOutFromInPos;
+    }
+
+    private void checkNonDeterministicRexProgram(
+            final ImmutableBitSet requireDeterminism,
+            final RexProgram program,
+            final StreamPhysicalRel relatedRel) {
+        if (null != program.getCondition()) {
+            // firstly check if exists non-deterministic condition
+            RexNode rexNode = program.expandLocalRef(program.getCondition());
+            checkNonDeterministicCondition(rexNode, relatedRel);
+        }
+        // extract all non-deterministic output columns first and check if any of them were
+        // required be deterministic.
+        List<RexNode> projects =
+                program.getProjectList().stream()
+                        .map(expr -> program.expandLocalRef(expr))
+                        .collect(Collectors.toList());
+        Map<Integer, String> nonDeterministicCols = new HashMap<>();
+        for (int index = 0; index < projects.size(); index++) {
+            Optional<String> ndCall =
+                    FlinkRexUtil.getNonDeterministicCallNameInStreaming(projects.get(index));
+            if (ndCall.isPresent()) {
+                nonDeterministicCols.put(index, ndCall.get());
+            } // else ignore
+        }
+        List<Integer> unsatisfiedColumns =
+                requireDeterminism.toList().stream()
+                        .filter(index -> nonDeterministicCols.containsKey(index))
+                        .collect(Collectors.toList());
+        if (!unsatisfiedColumns.isEmpty()) {
+            throwNonDeterministicColumnsError(
+                    unsatisfiedColumns,
+                    relatedRel.getRowType(),
+                    relatedRel,
+                    nonDeterministicCols,
+                    Optional.empty());
+        }
+    }
+
+    private void checkNonDeterministicCondition(
+            final RexNode condition, final StreamPhysicalRel relatedRel) {
+        Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallNameInStreaming(condition);
+        if (ndCall.isPresent()) {
+            throwNonDeterministicConditionError(ndCall.get(), condition, relatedRel);
+        }
+    }
+
+    private void checkUnsatisfiedDeterminism(
+            final ImmutableBitSet requireDeterminism,
+            final int aggStartIndex,
+            final List<AggregateCall> aggCalls,
+            final RelDataType rowType,
+            final StreamPhysicalRel relatedRel) {
+        Map<Integer, String> nonDeterministicOutput = new HashMap<>();
+        // skip checking non-deterministic columns in grouping keys or filter args in agg call
+        // because they were pushed down to input project which processes input only message
+        int aggOutputIndex = aggStartIndex;
+        for (AggregateCall aggCall : aggCalls) {
+            if (!aggCall.getAggregation().isDeterministic()
+                    || aggCall.getAggregation().isDynamicFunction()) {
+                nonDeterministicOutput.put(aggOutputIndex, aggCall.getAggregation().getName());
+            }
+            aggOutputIndex++;
+        }
+        // check if exist non-deterministic aggCalls which were in requireDeterminism
+        List<Integer> unsatisfiedColumns =
+                requireDeterminism.toList().stream()
+                        .filter(nonDeterministicOutput::containsKey)
+                        .collect(Collectors.toList());
+        if (!unsatisfiedColumns.isEmpty()) {
+            throwNonDeterministicColumnsError(
+                    unsatisfiedColumns,
+                    rowType,
+                    relatedRel,
+                    nonDeterministicOutput,
+                    Optional.empty());
+        }
+    }
+
+    private void throwNonDeterministicConditionError(
+            final String ndCall, final RexNode condition, final StreamPhysicalRel relatedRel)
+            throws TableException {
+        StringBuilder errorMsg = new StringBuilder();
+        errorMsg.append(
+                String.format(NON_DETERMINISTIC_CONDITION_ERROR_MSG_TEMPLATE, ndCall, condition));
+        errorMsg.append("\nrelated rel plan:\n")
+                .append(
+                        FlinkRelOptUtil.toString(
+                                relatedRel,
+                                SqlExplainLevel.DIGEST_ATTRIBUTES,
+                                false,
+                                true,
+                                false,
+                                true));
+
+        throw new TableException(errorMsg.toString());
+    }
+
+    private void throwNonDeterministicColumnsError(
+            final List<Integer> indexes,
+            final RelDataType rowType,
+            final StreamPhysicalRel relatedRel,
+            final Map<Integer, String> ndCallMap,
+            final Optional<String> ndCallName)
+            throws TableException {
+        StringBuilder errorMsg = new StringBuilder();
+        errorMsg.append("The column(s): ");
+        int index = 0;
+        for (String column : rowType.getFieldNames()) {
+            if (indexes.contains(index)) {
+                errorMsg.append(column).append("(generated by non-deterministic function: ");
+                if (ndCallName.isPresent()) {
+                    errorMsg.append(ndCallName.get());
+                } else {
+                    errorMsg.append(ndCallMap.get(index));
+                }
+                errorMsg.append(" ) ");
+            }
+            index++;
+        }
+        errorMsg.append(
+                "can not satisfy the determinism requirement for correctly processing update message("
+                        + "'UB'/'UA'/'D' in changelogMode, not 'I' only), this usually happens when input node has"
+                        + " no upsertKey(upsertKeys=[{}]) or current node outputs non-deterministic update "
+                        + "messages. Please consider removing these non-deterministic columns or making them "
+                        + "deterministic by using deterministic functions.\n");
+        errorMsg.append("\nrelated rel plan:\n")
+                .append(
+                        FlinkRelOptUtil.toString(
+                                relatedRel,
+                                SqlExplainLevel.DIGEST_ATTRIBUTES,
+                                false,
+                                true,
+                                false,
+                                true));
+
+        throw new TableException(errorMsg.toString());
+    }
+
+    private ImmutableBitSet mappingRequireDeterminismToInput(
+            final ImmutableBitSet requireDeterminism,
+            final StreamPhysicalOverAggregateBase overAgg) {
+        int inputFieldCnt = overAgg.getInput().getRowType().getFieldCount();
+        List<Integer> requireInputIndexes =
+                requireDeterminism.toList().stream()
+                        .filter(index -> index < inputFieldCnt)
+                        .collect(Collectors.toList());
+        if (requireInputIndexes.size() == inputFieldCnt) {
+            return ImmutableBitSet.range(inputFieldCnt);
+        } else {
+            Set<Integer> allRequiredInputSet = new HashSet<>(requireInputIndexes);
+
+            OverSpec overSpec = OverAggregateUtil.createOverSpec(overAgg.logicWindow());
+            // add partitionKeys
+            Arrays.stream(overSpec.getPartition().getFieldIndices())
+                    .forEach(allRequiredInputSet::add);
+            // add aggCall's input
+            overSpec.getGroups().forEach(OverSpec.GroupSpec::getAggCalls);
+            int aggOutputIndex = inputFieldCnt;
+            for (OverSpec.GroupSpec groupSpec : overSpec.getGroups()) {
+                for (AggregateCall aggCall : groupSpec.getAggCalls()) {
+                    if (requireDeterminism.get(aggOutputIndex)) {
+                        requiredSourceInput(aggCall, allRequiredInputSet);
+                    }
+                    aggOutputIndex++;
+                }
+            }
+            assert allRequiredInputSet.size() <= inputFieldCnt;
+            return ImmutableBitSet.of(new ArrayList<>(allRequiredInputSet));
+        }
+    }
+
+    private void requiredSourceInput(
+            final AggregateCall aggCall, final Set<Integer> requiredInputSet) {
+        // add agg args first
+        requiredInputSet.addAll(aggCall.getArgList());
+        // add agg filter args
+        if (aggCall.filterArg > -1) {
+            requiredInputSet.add(aggCall.filterArg);
+        }
+    }
+
+    private ImmutableBitSet requireDeterminismExcludeUpsertKey(
+            final StreamPhysicalRel inputRel, final ImmutableBitSet requireDeterminism) {
+        FlinkRelMetadataQuery fmq =
+                FlinkRelMetadataQuery.reuseOrCreate(inputRel.getCluster().getMetadataQuery());
+        Set<ImmutableBitSet> inputUpsertKeys = fmq.getUpsertKeys(inputRel);
+        ImmutableBitSet finalRequireDeterminism;
+        if (inputUpsertKeys == null || inputUpsertKeys.isEmpty()) {
+            finalRequireDeterminism = requireDeterminism;
+        } else {
+            if (inputUpsertKeys.stream().anyMatch(uk -> uk.contains(requireDeterminism))) {
+                // upsert keys can satisfy the requireDeterminism because they are always
+                // deterministic
+                finalRequireDeterminism = NO_REQUIRED_DETERMINISM;
+            } else {
+                // otherwise we should check the column(s) that not in upsert keys
+                List<ImmutableBitSet> leftKeys =
+                        inputUpsertKeys.stream()
+                                .map(requireDeterminism::except)
+                                .collect(Collectors.toList());
+                if (leftKeys.isEmpty()) {
+                    finalRequireDeterminism = NO_REQUIRED_DETERMINISM;
+                } else {
+                    leftKeys.sort(Comparator.comparingInt(ImmutableBitSet::cardinality));
+                    // use least require determinism
+                    finalRequireDeterminism = leftKeys.get(0);
+                }
+            }
+        }
+        return finalRequireDeterminism;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/StreamPlanner.scala
@@ -24,7 +24,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectRea
 import org.apache.flink.streaming.api.graph.StreamGraph
 import org.apache.flink.table.api.{ExplainDetail, PlanReference, TableConfig, TableException}
 import org.apache.flink.table.api.PlanReference.{ContentPlanReference, FilePlanReference, ResourcePlanReference}
-import org.apache.flink.table.api.internal.TableEnvironmentInternal
 import org.apache.flink.table.catalog.{CatalogManager, FunctionCatalog}
 import org.apache.flink.table.delegation.{Executor, InternalPlan}
 import org.apache.flink.table.module.ModuleManager
@@ -33,7 +32,7 @@ import org.apache.flink.table.planner.plan.`trait`._
 import org.apache.flink.table.planner.plan.ExecNodeGraphInternalPlan
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph
 import org.apache.flink.table.planner.plan.nodes.exec.processor.ExecNodeGraphProcessor
-import org.apache.flink.table.planner.plan.nodes.exec.serde.{JsonSerdeUtil, SerdeContext}
+import org.apache.flink.table.planner.plan.nodes.exec.serde.JsonSerdeUtil
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodePlanDumper
 import org.apache.flink.table.planner.plan.optimize.{Optimizer, StreamCommonSubGraphBasedOptimizer}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdModifiedMonotonicity.scala
@@ -333,11 +333,7 @@ class FlinkRelMdModifiedMonotonicity private extends MetadataHandler[ModifiedMon
   def getRelModifiedMonotonicity(
       rel: StreamPhysicalIncrementalGroupAggregate,
       mq: RelMetadataQuery): RelModifiedMonotonicity = {
-    getRelModifiedMonotonicityOnAggregate(
-      rel.getInput,
-      mq,
-      rel.finalAggCalls.toList,
-      rel.finalAggGrouping)
+    getRelModifiedMonotonicityOnAggregate(rel.getInput, mq, rel.aggCalls.toList, rel.grouping)
   }
 
   def getRelModifiedMonotonicity(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
@@ -18,6 +18,7 @@
 package org.apache.flink.table.planner.plan.nodes.physical.common
 
 import org.apache.flink.table.api.TableException
+import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.exec.spec.JoinSpec
 import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel
 import org.apache.flink.table.planner.plan.utils.JoinUtil

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/common/CommonPhysicalJoin.scala
@@ -80,4 +80,15 @@ abstract class CommonPhysicalJoin(
       .item("select", getRowType.getFieldNames.mkString(", "))
   }
 
+  def getUniqueKeys(input: RelNode, keys: Array[Int]): List[Array[Int]] = {
+    // TODO update method name in FLINK-28787
+    val upsertKeys = FlinkRelMetadataQuery
+      .reuseOrCreate(cluster.getMetadataQuery)
+      .getUpsertKeysInKeyGroupRange(input, keys)
+    if (upsertKeys == null || upsertKeys.isEmpty) {
+      List.empty
+    } else {
+      upsertKeys.map(_.asList.map(_.intValue).toArray).toList
+    }
+  }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCorrelateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalCorrelateBase.scala
@@ -32,9 +32,9 @@ import scala.collection.JavaConversions._
 abstract class StreamPhysicalCorrelateBase(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
-    inputRel: RelNode,
-    scan: FlinkLogicalTableFunctionScan,
-    condition: Option[RexNode],
+    val inputRel: RelNode,
+    val scan: FlinkLogicalTableFunctionScan,
+    val condition: Option[RexNode],
     outputRowType: RelDataType,
     joinType: JoinRelType)
   extends SingleRel(cluster, traitSet, inputRel)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalGroupAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalGroupAggregate.scala
@@ -40,14 +40,14 @@ class StreamPhysicalGlobalGroupAggregate(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall],
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
     val aggCallNeedRetractions: Array[Boolean],
     val localAggInputRowType: RelDataType,
     val needRetraction: Boolean,
     val partialFinalType: PartialFinalType,
     indexOfCountStar: Option[Int] = Option.empty)
-  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel) {
+  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel, grouping, aggCalls) {
 
   // if the indexOfCountStar is valid, the needRetraction should be true
   require(indexOfCountStar.isEmpty || indexOfCountStar.get >= 0 && needRetraction)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalWindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGlobalWindowAggregate.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.util.Litmus
 
@@ -58,11 +58,17 @@ class StreamPhysicalGlobalWindowAggregate(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     val inputRowTypeOfLocalAgg: RelDataType,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall],
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
     val windowing: WindowingStrategy,
-    val namedWindowProperties: Seq[NamedWindowProperty])
-  extends SingleRel(cluster, traitSet, inputRel)
+    namedWindowProperties: Seq[NamedWindowProperty])
+  extends StreamPhysicalWindowAggregateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    grouping,
+    aggCalls,
+    namedWindowProperties)
   with StreamPhysicalRel {
 
   private lazy val aggInfoList = AggregateUtil.deriveStreamWindowAggregateInfoList(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupAggregate.scala
@@ -44,10 +44,10 @@ class StreamPhysicalGroupAggregate(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall],
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
     var partialFinalType: PartialFinalType = PartialFinalType.NONE)
-  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel) {
+  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel, grouping, aggCalls) {
 
   private val aggInfoList =
     AggregateUtil.deriveAggregateInfoList(this, grouping.length, aggCalls)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupAggregateBase.scala
@@ -19,7 +19,7 @@ package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.{RelNode, SingleRel}
-import org.apache.calcite.rel.core.Aggregate
+import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
 
 /**
  * Base stream physical RelNode for unbounded group aggregate.
@@ -42,6 +42,8 @@ import org.apache.calcite.rel.core.Aggregate
 abstract class StreamPhysicalGroupAggregateBase(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
-    inputRel: RelNode)
+    inputRel: RelNode,
+    val grouping: Array[Int],
+    val aggCalls: Seq[AggregateCall])
   extends SingleRel(cluster, traitSet, inputRel)
   with StreamPhysicalRel {}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupTableAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupTableAggregateBase.scala
@@ -21,7 +21,7 @@ import org.apache.flink.table.planner.plan.utils._
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.core.AggregateCall
 
 /** Base Stream physical RelNode for unbounded group table aggregate. */
@@ -30,9 +30,9 @@ abstract class StreamPhysicalGroupTableAggregateBase(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall])
-  extends SingleRel(cluster, traitSet, inputRel)
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall])
+  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel, grouping, aggCalls)
   with StreamPhysicalRel {
 
   protected val aggInfoList: AggregateInfoList =

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalGroupWindowAggregateBase.scala
@@ -24,7 +24,7 @@ import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.core.AggregateCall
 
 /** Base streaming group window aggregate physical node for either aggregate or table aggregate. */
@@ -33,12 +33,18 @@ abstract class StreamPhysicalGroupWindowAggregateBase(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall],
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
     val window: LogicalWindow,
-    val namedWindowProperties: Seq[NamedWindowProperty],
+    namedWindowProperties: Seq[NamedWindowProperty],
     val emitStrategy: WindowEmitStrategy)
-  extends SingleRel(cluster, traitSet, inputRel)
+  extends StreamPhysicalWindowAggregateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    grouping,
+    aggCalls,
+    namedWindowProperties)
   with StreamPhysicalRel {
 
   override def requireWatermark: Boolean = window match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIncrementalGroupAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalIncrementalGroupAggregate.scala
@@ -62,14 +62,19 @@ class StreamPhysicalIncrementalGroupAggregate(
     inputRel: RelNode,
     val partialAggGrouping: Array[Int],
     val partialAggCalls: Array[AggregateCall],
-    val finalAggGrouping: Array[Int],
-    val finalAggCalls: Array[AggregateCall],
+    finalAggGrouping: Array[Int],
+    finalAggCalls: Array[AggregateCall],
     partialOriginalAggCalls: Array[AggregateCall],
     partialAggCallNeedRetractions: Array[Boolean],
     partialAggNeedRetraction: Boolean,
     partialLocalAggInputRowType: RelDataType,
     partialGlobalAggRowType: RelDataType)
-  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel) {
+  extends StreamPhysicalGroupAggregateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    finalAggGrouping,
+    finalAggCalls) {
 
   private lazy val incrementalAggInfo = AggregateUtil.createIncrementalAggInfoList(
     unwrapTypeFactory(inputRel),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalJoin.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalJoin.scala
@@ -18,7 +18,6 @@
 package org.apache.flink.table.planner.plan.nodes.physical.stream
 
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
-import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecJoin
 import org.apache.flink.table.planner.plan.nodes.physical.common.CommonPhysicalJoin
@@ -109,18 +108,6 @@ class StreamPhysicalJoin(
           getUniqueKeys(right, joinSpec.getRightKeys)
         )
       )
-  }
-
-  private def getUniqueKeys(input: RelNode, keys: Array[Int]): List[Array[Int]] = {
-    val upsertKeys = FlinkRelMetadataQuery
-      .reuseOrCreate(cluster.getMetadataQuery)
-      .getUpsertKeysInKeyGroupRange(input, keys)
-    if (upsertKeys == null || upsertKeys.isEmpty) {
-      List.empty
-    } else {
-      upsertKeys.map(_.asList.map(_.intValue).toArray).toList
-    }
-
   }
 
   override def computeSelfCost(planner: RelOptPlanner, metadata: RelMetadataQuery): RelOptCost = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalGroupAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalGroupAggregate.scala
@@ -41,12 +41,12 @@ class StreamPhysicalLocalGroupAggregate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall],
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
     aggCallNeedRetractions: Array[Boolean],
     needRetraction: Boolean,
     val partialFinalType: PartialFinalType)
-  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel) {
+  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel, grouping, aggCalls) {
 
   private lazy val aggInfoList = AggregateUtil.transformToStreamAggregateInfoList(
     unwrapTypeFactory(inputRel),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalWindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLocalWindowAggregate.scala
@@ -29,7 +29,7 @@ import org.apache.flink.table.runtime.groupwindow.{NamedWindowProperty, SliceEnd
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.util.Litmus
 
@@ -52,10 +52,10 @@ class StreamPhysicalLocalWindowAggregate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall],
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
     val windowing: WindowingStrategy)
-  extends SingleRel(cluster, traitSet, inputRel)
+  extends StreamPhysicalWindowAggregateBase(cluster, traitSet, inputRel, grouping, aggCalls)
   with StreamPhysicalRel {
 
   private lazy val aggInfoList = AggregateUtil.deriveStreamWindowAggregateInfoList(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalOverAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalOverAggregate.scala
@@ -36,7 +36,7 @@ class StreamPhysicalOverAggregate(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    val logicWindow: Window)
+    logicWindow: Window)
   extends StreamPhysicalOverAggregateBase(cluster, traitSet, inputRel, outputRowType, logicWindow) {
 
   override def copy(traitSet: RelTraitSet, inputs: util.List[RelNode]): RelNode = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalOverAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalOverAggregateBase.scala
@@ -37,7 +37,7 @@ abstract class StreamPhysicalOverAggregateBase(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    logicWindow: Window)
+    val logicWindow: Window)
   extends SingleRel(cluster, traitSet, inputRel)
   with StreamPhysicalRel {
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalPythonGroupAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalPythonGroupAggregate.scala
@@ -41,9 +41,9 @@ class StreamPhysicalPythonGroupAggregate(
     traitSet: RelTraitSet,
     inputRel: RelNode,
     outputRowType: RelDataType,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall])
-  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel) {
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall])
+  extends StreamPhysicalGroupAggregateBase(cluster, traitSet, inputRel, grouping, aggCalls) {
 
   private lazy val aggInfoList =
     AggregateUtil.deriveAggregateInfoList(this, grouping.length, aggCalls)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalRank.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalRank.scala
@@ -46,7 +46,7 @@ class StreamPhysicalRank(
     rankRange: RankRange,
     rankNumberType: RelDataTypeField,
     outputRankNumber: Boolean,
-    rankStrategy: RankProcessStrategy)
+    val rankStrategy: RankProcessStrategy)
   extends Rank(
     cluster,
     traitSet,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -25,14 +25,13 @@ import org.apache.flink.table.planner.plan.nodes.calcite.Sink
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink
-import org.apache.flink.table.planner.plan.utils.{ChangelogPlanUtils, RelDescriptionWriterImpl}
+import org.apache.flink.table.planner.plan.utils.ChangelogPlanUtils
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
-import org.apache.calcite.rel.RelNode
+import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.hint.RelHint
 
-import java.io.{PrintWriter, StringWriter}
 import java.util
 
 /**
@@ -46,7 +45,7 @@ class StreamPhysicalSink(
     contextResolvedTable: ContextResolvedTable,
     tableSink: DynamicTableSink,
     abilitySpecs: Array[SinkAbilitySpec],
-    upsertMaterialize: Boolean = false)
+    val upsertMaterialize: Boolean = false)
   extends Sink(cluster, traitSet, inputRel, hints, contextResolvedTable, tableSink)
   with StreamPhysicalRel {
 
@@ -89,17 +88,12 @@ class StreamPhysicalSink(
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
       upsertMaterialize,
-      getDescriptionWithUpsert(upsertMaterialize))
+      getRelDetailedDescription)
   }
 
-  /** The inputChangelogMode can only be obtained in translateToExecNode phase. */
-  def getDescriptionWithUpsert(upsertMaterialize: Boolean): String = {
-    val sw = new StringWriter
-    val pw = new PrintWriter(sw)
-    val relWriter = new RelDescriptionWriterImpl(pw)
-    this.explainTerms(relWriter)
-    relWriter.itemIf("upsertMaterialize", "true", upsertMaterialize)
-    relWriter.done(this)
-    sw.toString
+  override def explainTerms(pw: RelWriter): RelWriter = {
+    super
+      .explainTerms(pw)
+      .itemIf("upsertMaterialize", "true", upsertMaterialize)
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregate.scala
@@ -28,7 +28,7 @@ import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
-import org.apache.calcite.rel.{RelNode, RelWriter, SingleRel}
+import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.core.AggregateCall
 
 import java.util
@@ -47,11 +47,17 @@ class StreamPhysicalWindowAggregate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
-    val grouping: Array[Int],
-    val aggCalls: Seq[AggregateCall],
+    grouping: Array[Int],
+    aggCalls: Seq[AggregateCall],
     val windowing: WindowingStrategy,
-    val namedWindowProperties: Seq[NamedWindowProperty])
-  extends SingleRel(cluster, traitSet, inputRel)
+    namedWindowProperties: Seq[NamedWindowProperty])
+  extends StreamPhysicalWindowAggregateBase(
+    cluster,
+    traitSet,
+    inputRel,
+    grouping,
+    aggCalls,
+    namedWindowProperties)
   with StreamPhysicalRel {
 
   lazy val aggInfoList: AggregateInfoList = AggregateUtil.deriveStreamWindowAggregateInfoList(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregateBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowAggregateBase.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.nodes.physical.stream
+
+import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
+
+import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
+import org.apache.calcite.rel.{RelNode, SingleRel}
+import org.apache.calcite.rel.core.AggregateCall
+
+/** Base stream physical RelNode for both group window aggregate and window aggregate. */
+abstract class StreamPhysicalWindowAggregateBase(
+    cluster: RelOptCluster,
+    traitSet: RelTraitSet,
+    inputRel: RelNode,
+    val grouping: Array[Int],
+    val aggCalls: Seq[AggregateCall],
+    val namedWindowProperties: Seq[NamedWindowProperty] = Seq())
+  extends SingleRel(cluster, traitSet, inputRel)
+  with StreamPhysicalRel {}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowDeduplicate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalWindowDeduplicate.scala
@@ -42,8 +42,8 @@ class StreamPhysicalWindowDeduplicate(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     inputRel: RelNode,
-    partitionKeys: Array[Int],
-    orderKey: Int,
+    val partitionKeys: Array[Int],
+    val orderKey: Int,
     keepLastRow: Boolean,
     windowing: WindowingStrategy)
   extends SingleRel(cluster, traitSet, inputRel)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/StreamCommonSubGraphBasedOptimizer.scala
@@ -317,4 +317,7 @@ class StreamCommonSubGraphBasedOptimizer(planner: StreamPlanner)
     }
   }
 
+  override protected def postOptimize(expanded: Seq[RelNode]): Seq[RelNode] = {
+    StreamNonDeterministicPhysicalPlanResolver.resolvePhysicalPlan(expanded, planner.getTableConfig)
+  }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtil.scala
@@ -69,7 +69,8 @@ object FlinkRelOptUtil {
       detailLevel: SqlExplainLevel = SqlExplainLevel.DIGEST_ATTRIBUTES,
       withIdPrefix: Boolean = false,
       withChangelogTraits: Boolean = false,
-      withRowType: Boolean = false): String = {
+      withRowType: Boolean = false,
+      withUpsertKey: Boolean = false): String = {
     if (rel == null) {
       return null
     }
@@ -80,7 +81,8 @@ object FlinkRelOptUtil {
       withIdPrefix,
       withChangelogTraits,
       withRowType,
-      withTreeStyle = true)
+      withTreeStyle = true,
+      withUpsertKey)
     rel.explain(planWriter)
     sw.toString
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -585,6 +585,50 @@ object FlinkRexUtil {
     }
     false
   }
+
+  /**
+   * Returns whether a given expression is deterministic in streaming scenario, differs from
+   * calcite's [[RexUtil]], it considers both non-deterministic and dynamic functions.
+   */
+  def isDeterministicInStreaming(e: RexNode): Boolean = try {
+    val visitor = new RexVisitorImpl[Void](true) {
+      override def visitCall(call: RexCall): Void = {
+        // dynamic function call is also non-deterministic to streaming
+        if (!call.getOperator.isDeterministic || call.getOperator.isDynamicFunction)
+          throw Util.FoundOne.NULL
+        super.visitCall(call)
+      }
+    }
+    e.accept(visitor)
+    true
+  } catch {
+    case ex: Util.FoundOne =>
+      Util.swallow(ex, null)
+      false
+  }
+
+  /**
+   * Returns whether a given [[RexProgram]] is deterministic in streaming scenario, differs from
+   * calcite's [[RexUtil]], it considers both non-deterministic and dynamic functions.
+   * @return
+   *   true if any expression of the program is not deterministic in streaming
+   */
+  def isDeterministicInStreaming(rexProgram: RexProgram): Boolean = try {
+    if (null != rexProgram.getCondition) {
+      val rexCondi = rexProgram.expandLocalRef(rexProgram.getCondition)
+      if (!isDeterministicInStreaming(rexCondi)) {
+        return false
+      }
+    }
+    val projects = rexProgram.getProjectList.map(rexProgram.expandLocalRef)
+    projects.forall {
+      expr =>
+        expr match {
+          case rexNode: RexNode => isDeterministicInStreaming(rexNode)
+          case _ => true // ignore
+        }
+    }
+  }
 }
 
 /**

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/StreamOperatorNameTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/operator/StreamOperatorNameTest.xml
@@ -24,7 +24,7 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
+Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b], upsertMaterialize=[true])
 +- ChangelogNormalize(key=[a, b])
    +- Exchange(distribution=[hash[a, b]])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[c, a, b], metadata=[]]], fields=[c, a, b])
@@ -99,7 +99,7 @@ LogicalSink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
    +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b])
+Sink(table=[default_catalog.default_database.MySink], fields=[c, a, b], upsertMaterialize=[true])
 +- ChangelogNormalize(key=[a, b])
    +- Exchange(distribution=[hash[a, b]])
       +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[c, a, b], metadata=[]]], fields=[c, a, b])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTable.out
@@ -258,7 +258,7 @@
     },
     "projectionOnTemporalTable" : null,
     "filterOnTemporalTable" : null,
-    "inputInsertOnly" : true,
+    "inputChangelogMode" : [ "INSERT" ],
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -303,6 +303,7 @@
         "fieldType" : "INT"
       } ]
     },
+    "lookupKeyContainsPrimaryKey" : false,
     "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id, name, age])"
   }, {
     "id" : 5,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/LookupJoinJsonPlanTest_jsonplan/testJoinTemporalTableWithProjectionPushDown.out
@@ -262,7 +262,7 @@
       "type" : "INT"
     } ],
     "filterOnTemporalTable" : null,
-    "inputInsertOnly" : true,
+    "inputChangelogMode" : [ "INSERT" ],
     "inputProperties" : [ {
       "requiredDistribution" : {
         "type" : "UNKNOWN"
@@ -301,6 +301,7 @@
         "fieldType" : "INT"
       } ]
     },
+    "lookupKeyContainsPrimaryKey" : false,
     "description" : "LookupJoin(table=[default_catalog.default_database.LookupTable], joinType=[InnerJoin], async=[false], lookup=[id=a], select=[a, b, c, proctime, rowtime, id])"
   }, {
     "id" : 5,

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.xml
@@ -1,0 +1,3105 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAggWithNonDeterministicFilterArgs[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  a
+  ,count(*) cnt
+  ,cast(count(distinct c) filter (where b > UNIX_TIMESTAMP() - 180) as varchar) valid_uv
+from T
+group by a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, valid_uv])
++- LogicalProject(a=[$0], cnt=[$1], valid_uv=[CAST($2):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL])
+   +- LogicalAggregate(group=[{0}], cnt=[COUNT()], agg#1=[COUNT(DISTINCT $1) FILTER $2])
+      +- LogicalProject(a=[$0], c=[$2], $f2=[IS TRUE(>($1, -(UNIX_TIMESTAMP(), 180)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, valid_uv])
++- Calc(select=[a, cnt, CAST($f2 AS VARCHAR(2147483647)) AS valid_uv])
+   +- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) FILTER $f2 AS $f2])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, (b > (UNIX_TIMESTAMP() - 180)) IS TRUE AS $f2])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggWithNonDeterministicFilterArgs[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  a
+  ,count(*) cnt
+  ,cast(count(distinct c) filter (where b > UNIX_TIMESTAMP() - 180) as varchar) valid_uv
+from T
+group by a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, valid_uv])
++- LogicalProject(a=[$0], cnt=[$1], valid_uv=[CAST($2):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL])
+   +- LogicalAggregate(group=[{0}], cnt=[COUNT()], agg#1=[COUNT(DISTINCT $1) FILTER $2])
+      +- LogicalProject(a=[$0], c=[$2], $f2=[IS TRUE(>($1, -(UNIX_TIMESTAMP(), 180)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, valid_uv])
++- Calc(select=[a, cnt, CAST($f2 AS VARCHAR(2147483647)) AS valid_uv])
+   +- GroupAggregate(groupBy=[a], select=[a, COUNT(*) AS cnt, COUNT(DISTINCT c) FILTER $f2 AS $f2])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, (b > (UNIX_TIMESTAMP() - 180)) IS TRUE AS $f2])
+            +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggWithNonDeterministicFilterArgsOnCdcSource[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  a
+  ,count(*) cnt
+  ,cast(count(distinct c) filter (where b > UNIX_TIMESTAMP() - 180) as varchar) valid_uv
+from cdc
+group by a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, valid_uv])
++- LogicalProject(a=[$0], cnt=[$1], valid_uv=[CAST($2):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL])
+   +- LogicalAggregate(group=[{0}], cnt=[COUNT()], agg#1=[COUNT(DISTINCT $1) FILTER $2])
+      +- LogicalProject(a=[$0], c=[$2], $f2=[IS TRUE(>($1, -(UNIX_TIMESTAMP(), 180)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, valid_uv])
++- Calc(select=[a, cnt, CAST($f2 AS VARCHAR(2147483647)) AS valid_uv])
+   +- GroupAggregate(groupBy=[a], select=[a, COUNT_RETRACT(*) AS cnt, COUNT_RETRACT(DISTINCT c) FILTER $f2 AS $f2])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, (b > (UNIX_TIMESTAMP() - 180)) IS TRUE AS $f2])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c, b], metadata=[]]], fields=[a, c, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggWithNonDeterministicFilterArgsOnCdcSourceSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select
+  a
+  ,count(*) cnt
+  ,cast(count(distinct c) filter (where b > UNIX_TIMESTAMP() - 180) as varchar) valid_uv
+from cdc
+group by a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, cnt, valid_uv])
++- LogicalProject(a=[$0], cnt=[$1], valid_uv=[CAST($2):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL])
+   +- LogicalAggregate(group=[{0}], cnt=[COUNT()], agg#1=[COUNT(DISTINCT $1) FILTER $2])
+      +- LogicalProject(a=[$0], c=[$2], $f2=[IS TRUE(>($1, -(UNIX_TIMESTAMP(), 180)))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, cnt, valid_uv])
++- Calc(select=[a, cnt, CAST($f2 AS VARCHAR(2147483647)) AS valid_uv])
+   +- GroupAggregate(groupBy=[a], select=[a, COUNT_RETRACT(*) AS cnt, COUNT_RETRACT(DISTINCT c) FILTER $f2 AS $f2])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, (b > (UNIX_TIMESTAMP() - 180)) IS TRUE AS $f2])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c, b], metadata=[]]], fields=[a, c, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAntiJoinKeyContainsUk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t1.`c-day`, t1.b, t1.d
+from (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+ ) t1
+where t1.a not in (
+  select a from cdc where b > 100
+)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c-day=[$2], b=[$1], d=[$3])
++- LogicalFilter(condition=[NOT(IN($0, {
+LogicalProject(a=[$0])
+  LogicalFilter(condition=[>($1, 100)])
+    LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+}))])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c-day, b, d])
++- Join(joinType=[LeftAntiJoin], where=[(a = a0)], select=[a, b, c-day, d], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a], where=[(b > 100)])
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, filter=[], project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAntiJoinKeyContainsUk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t1.`c-day`, t1.b, t1.d
+from (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+ ) t1
+where t1.a not in (
+  select a from cdc where b > 100
+)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c-day=[$2], b=[$1], d=[$3])
++- LogicalFilter(condition=[NOT(IN($0, {
+LogicalProject(a=[$0])
+  LogicalFilter(condition=[>($1, 100)])
+    LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+}))])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c-day, b, d])
++- Join(joinType=[LeftAntiJoin], where=[(a = a0)], select=[a, b, c-day, d], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a], where=[(b > 100)])
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, filter=[], project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendRankOnMultiOverWithNonDeterministicUdafSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select a, nd, b from (
+ select
+  a, uv, b, nd,
+  row_number() over (partition by a order by uv desc) rn
+ from (
+  SELECT
+    a
+    ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+    ,b
+    ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+  FROM T1
+  )
+) where rn = 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, nd, b])
++- LogicalProject(a=[$0], nd=[$3], b=[$2])
+   +- LogicalFilter(condition=[=($4, 1)])
+      +- LogicalProject(a=[$0], uv=[$1], b=[$2], nd=[$3], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
+         +- LogicalProject(a=[$0], uv=[COUNT(DISTINCT $1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1], nd=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, nd, b])
++- Calc(select=[a, nd, b])
+   +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[uv DESC], select=[a, uv, b, nd])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, w0$o0 AS uv, b, w0$o1 AS nd])
+            +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, COUNT(DISTINCT b) AS w0$o0, ndAggFunc($3) AS w0$o1])
+               +- Exchange(distribution=[hash[a]])
+                  +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+                     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendRankOnMultiOverWithNonDeterministicUdafSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select a, nd, b from (
+ select
+  a, uv, b, nd,
+  row_number() over (partition by a order by uv desc) rn
+ from (
+  SELECT
+    a
+    ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+    ,b
+    ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+  FROM T1
+  )
+) where rn = 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, nd, b])
++- LogicalProject(a=[$0], nd=[$3], b=[$2])
+   +- LogicalFilter(condition=[=($4, 1)])
+      +- LogicalProject(a=[$0], uv=[$1], b=[$2], nd=[$3], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
+         +- LogicalProject(a=[$0], uv=[COUNT(DISTINCT $1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1], nd=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, nd, b])
++- Calc(select=[a, nd, b])
+   +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[uv DESC], select=[a, uv, b, nd])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, w0$o0 AS uv, b, w0$o1 AS nd])
+            +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, COUNT(DISTINCT b) AS w0$o0, ndAggFunc($3) AS w0$o1])
+               +- Exchange(distribution=[hash[a]])
+                  +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+                     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendRankOnMultiOverWithNonDeterministicUdafSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, uv, b, nd from (
+ select
+  a, uv, b, nd,
+  row_number() over (partition by a order by uv desc) rn
+ from (
+  SELECT
+    a
+    ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+    ,b
+    ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+  FROM T1
+  )
+) where rn = 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- LogicalProject(a=[$0], uv=[$1], b=[$2], nd=[$3])
+   +- LogicalFilter(condition=[=($4, 1)])
+      +- LogicalProject(a=[$0], uv=[$1], b=[$2], nd=[$3], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
+         +- LogicalProject(a=[$0], uv=[COUNT(DISTINCT $1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1], nd=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[uv DESC], select=[a, uv, b, nd])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, w0$o0 AS uv, b, w0$o1 AS nd])
+         +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, COUNT(DISTINCT b) AS w0$o0, ndAggFunc($3) AS w0$o1])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+                  +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAppendRankOnMultiOverWithNonDeterministicUdafSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, uv, b, nd from (
+ select
+  a, uv, b, nd,
+  row_number() over (partition by a order by uv desc) rn
+ from (
+  SELECT
+    a
+    ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+    ,b
+    ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+  FROM T1
+  )
+) where rn = 1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- LogicalProject(a=[$0], uv=[$1], b=[$2], nd=[$3])
+   +- LogicalFilter(condition=[=($4, 1)])
+      +- LogicalProject(a=[$0], uv=[$1], b=[$2], nd=[$3], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $1 DESC NULLS LAST)])
+         +- LogicalProject(a=[$0], uv=[COUNT(DISTINCT $1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1], nd=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=1], partitionBy=[a], orderBy=[uv DESC], select=[a, uv, b, nd])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, w0$o0 AS uv, b, w0$o1 AS nd])
+         +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, COUNT(DISTINCT b) AS w0$o0, ndAggFunc($3) AS w0$o1])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+                  +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcCorrelateNonDeterministicFuncNoLeftOutput[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk(a)
+select
+  cast(a1 as integer) a
+from cdc t1, lateral table(ndTableFunc(a)) as T(a1)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, EXPR$2])
++- LogicalProject(a=[CAST($4):INTEGER], EXPR$1=[null:BIGINT], EXPR$2=[null:VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalTableFunctionScan(invocation=[ndTableFunc($cor0.a)], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, EXPR$2], upsertMaterialize=[true])
++- Calc(select=[CAST(EXPR$0 AS INTEGER) AS a, null:BIGINT AS EXPR$1, null:VARCHAR(2147483647) AS EXPR$2])
+   +- Correlate(invocation=[ndTableFunc($cor0.a)], correlate=[table(ndTableFunc($cor0.a))], select=[a,b,c,d,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BIGINT d, VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcCorrelateNonDeterministicFuncNoRightOutput[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, b, c
+from cdc t1 join lateral table(ndTableFunc(a)) as T(a1) on true
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalTableFunctionScan(invocation=[ndTableFunc($cor0.a)], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], upsertMaterialize=[true])
++- Calc(select=[a, b, c])
+   +- Correlate(invocation=[ndTableFunc($cor0.a)], correlate=[table(ndTableFunc($cor0.a))], select=[a,b,c,d,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BIGINT d, VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcCorrelateNonDeterministicFuncNoRightOutput[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, b, c
+from cdc t1 join lateral table(ndTableFunc(a)) as T(a1) on true
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalTableFunctionScan(invocation=[ndTableFunc($cor0.a)], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], upsertMaterialize=[true])
++- Calc(select=[a, b, c])
+   +- Correlate(invocation=[ndTableFunc($cor0.a)], correlate=[table(ndTableFunc($cor0.a))], select=[a,b,c,d,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BIGINT d, VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcCorrelateNonDeterministicFuncSinkWithPK[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  t1.a, t1.b, a1
+from cdc t1, lateral table(ndTableFunc(a)) as T(a1)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, a1])
++- LogicalProject(a=[$0], b=[$1], a1=[$4])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0}])
+      :- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalTableFunctionScan(invocation=[ndTableFunc($cor0.a)], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, a1], upsertMaterialize=[true])
++- Calc(select=[a, b, EXPR$0 AS a1])
+   +- Correlate(invocation=[ndTableFunc($cor0.a)], correlate=[table(ndTableFunc($cor0.a))], select=[a,b,c,d,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BIGINT d, VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimNonDeterministicRemainingCondition[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t2.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+  -- non deterministic function in remaining condition
+  and t1.b > ndFunc(t2.b)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$6], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), >($cor0.b, ndFunc($1)))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], upsertMaterialize=[true])
++- Calc(select=[a, b0 AS b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], joinCondition=[(b > ndFunc(b0))], select=[a, b, a0, b0, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithoutPkSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_without_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_without_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_without_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithoutPkSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_without_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_without_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_without_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c], upsertMaterialize=[true])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithoutPkSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_without_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_without_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], upsertMaterialize=[true])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_without_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithoutPkSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_without_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_without_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], upsertMaterialize=[true])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_without_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c], upsertMaterialize=[true])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkNonDeterministicFuncSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select ndFunc(t2.a) a, t1.b, t1.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[ndFunc($5)], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[ndFunc(a0) AS a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, c, a])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkNonDeterministicLocalCondition2[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t2.b as version, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+  -- check dim table data's freshness
+  and t2.b > UNIX_TIMESTAMP() - 300
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, version, c])
++- LogicalProject(a=[$0], version=[$6], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), >($1, -(UNIX_TIMESTAMP(), 300)))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, version, c], upsertMaterialize=[true])
++- Calc(select=[a, b AS version, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], where=[(b > (UNIX_TIMESTAMP() - 300))], select=[a, a, b, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a], metadata=[]]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkNonDeterministicLocalCondition[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t1.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a and ndFunc(t2.b) > 100
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[AND(=($cor0.a, $0), >(ndFunc($1), 100))])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], where=[(ndFunc(b) > 100)], select=[a, b, c, a])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkOnlySinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t1.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, c, a])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkOnlySinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t1.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, c, a])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkOutputNoPkSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t2.b, t1.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$6], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, c, a, b])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c], metadata=[]]], fields=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkOutputNoPkSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t2.b, t1.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$6], c=[$2])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, c, a, b], upsertMaterialize=[true])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c], metadata=[]]], fields=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcLeftJoinDimWithoutPkSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 left join dim_without_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_without_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_without_pk], joinType=[LeftOuterJoin], async=[false], lookup=[a=a], select=[a, b, a, c], upsertMaterialize=[true])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c], upsertMaterialize=[true])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinDimWithPkSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[InnerJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinWithNonDeterministicCondition[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select
+  t1.a
+  ,t2.b
+  ,t1.c
+from cdc t1 join cdc t2
+  on ndFunc(t1.b) = ndFunc(t2.b)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$6], c=[$2])
+   +- LogicalJoin(condition=[=($4, $9)], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], $f4=[ndFunc($1)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], $f4=[ndFunc($1)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- Join(joinType=[InnerJoin], where=[($f4 = $f40)], select=[a, c, $f4, b, $f40], leftInputSpec=[HasUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Exchange(distribution=[hash[$f4]])
+      :  +- Calc(select=[a, c, ndFunc(b) AS $f4])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c, b], metadata=[]]], fields=[a, c, b])
+      +- Exchange(distribution=[hash[$f4]])
+         +- Calc(select=[b, ndFunc(b) AS $f4])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[b], metadata=[]]], fields=[b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcJoinWithNonDeterministicOutputSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+INSERT INTO t_join_sink
+SELECT ord.order_id,
+ord.order_name,
+logistics.logistics_id,
+logistics.logistics_target,
+logistics.logistics_source,
+now()
+FROM t_order AS ord
+LEFT JOIN t_logistics AS logistics ON ord.order_id=logistics.order_id
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.t_join_sink], fields=[order_id, order_name, logistics_id, logistics_target, logistics_source, logistics_time])
++- LogicalProject(order_id=[CAST($0):INTEGER], order_name=[$1], logistics_id=[$4], logistics_target=[$5], logistics_source=[$6], logistics_time=[CAST(NOW()):TIMESTAMP(6)])
+   +- LogicalJoin(condition=[=($0, $8)], joinType=[left])
+      :- LogicalTableScan(table=[[default_catalog, default_database, t_order]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t_logistics]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.t_join_sink], fields=[order_id, order_name, logistics_id, logistics_target, logistics_source, logistics_time], upsertMaterialize=[true])
++- Calc(select=[CAST(order_id AS INTEGER) AS order_id, order_name, logistics_id, logistics_target, logistics_source, CAST(NOW() AS TIMESTAMP(6)) AS logistics_time])
+   +- Join(joinType=[LeftOuterJoin], where=[(order_id = order_id0)], select=[order_id, order_name, logistics_id, logistics_target, logistics_source, order_id0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[HasUniqueKey])
+      :- Exchange(distribution=[hash[order_id]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, t_order, project=[order_id, order_name], metadata=[]]], fields=[order_id, order_name])
+      +- Exchange(distribution=[hash[order_id]])
+         +- TableSourceScan(table=[[default_catalog, default_database, t_logistics, project=[logistics_id, logistics_target, logistics_source, order_id], metadata=[]]], fields=[logistics_id, logistics_target, logistics_source, order_id])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcLeftJoinDimWithoutPkSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 left join dim_without_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_without_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_without_pk], joinType=[LeftOuterJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcLeftJoinDimWithPkSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 left join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[LeftOuterJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcLeftJoinDimWithPkSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t2.c
+from (
+  select *, proctime() proctime from cdc
+) t1 left join dim_with_pk for system_time as of t1.proctime as t2
+on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[left], requiredColumns=[{0, 4}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalFilter(condition=[=($cor0.a, $0)])
+         +- LogicalSnapshot(period=[$cor0.proctime])
+            +- LogicalTableScan(table=[[default_catalog, default_database, dim_with_pk]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a, b, c])
+   +- LookupJoin(table=[default_catalog.default_database.dim_with_pk], joinType=[LeftOuterJoin], async=[false], lookup=[a=a], select=[a, b, a, c])
+      +- DropUpdateBefore
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcProctimeIntervalJoinOnNonPkSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT t2.a, t2.b, t1.c FROM (
+ select *, proctime() proctime from cdc) t1 JOIN
+ (select *, proctime() proctime from cdc) t2 ON
+  t1.b = t2.b AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$5], b=[$6], c=[$2])
+   +- LogicalJoin(condition=[AND(=($1, $6), >($4, -($9, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a, b0 AS b, c])
+   +- Join(joinType=[InnerJoin], where=[((b = b0) AND (proctime > (proctime0 - 5000:INTERVAL SECOND)))], select=[b, c, proctime, a, b0, proctime0], leftInputSpec=[NoUniqueKey], rightInputSpec=[HasUniqueKey])
+      :- Exchange(distribution=[hash[b]])
+      :  +- Calc(select=[b, c, PROCTIME_MATERIALIZE(PROCTIME()) AS proctime])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[b, c], metadata=[]]], fields=[b, c])
+      +- Exchange(distribution=[hash[b]])
+         +- Calc(select=[a, b, PROCTIME_MATERIALIZE(PROCTIME()) AS proctime])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcProctimeIntervalJoinOnPkSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT t2.a, t2.b, t1.c FROM (
+ select *, proctime() proctime from cdc) t1 JOIN
+ (select *, proctime() proctime from cdc) t2 ON
+  t1.a = t2.a AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$5], b=[$6], c=[$2])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($4, -($9, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a0 AS a, b, c])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (proctime > (proctime0 - 5000:INTERVAL SECOND)))], select=[a, c, proctime, a0, b, proctime0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, c, PROCTIME_MATERIALIZE(PROCTIME()) AS proctime])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c], metadata=[]]], fields=[a, c])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, b, PROCTIME_MATERIALIZE(PROCTIME()) AS proctime])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcProctimeIntervalJoinOnPkSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT t2.a, t2.b, t1.c FROM (
+ select *, proctime() proctime from cdc) t1 JOIN
+ (select *, proctime() proctime from cdc) t2 ON
+  t1.a = t2.a AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$5], b=[$6], c=[$2])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($4, -($9, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], proctime=[PROCTIME()])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a0 AS a, b, c])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (proctime > (proctime0 - 5000:INTERVAL SECOND)))], select=[a, c, proctime, a0, b, proctime0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, c, PROCTIME_MATERIALIZE(PROCTIME()) AS proctime])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c], metadata=[]]], fields=[a, c])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, b, PROCTIME_MATERIALIZE(PROCTIME()) AS proctime])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcRowtimeIntervalJoinSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT t2.a, t1.b, t2.c FROM cdc_with_watermark t1 JOIN cdc_with_watermark t2 ON
+  t1.a = t2.a AND t1.op_ts > t2.op_ts - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$5], b=[$1], c=[$7])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($4, -($9, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+      +- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a0 AS a, b, c])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (op_ts > (op_ts0 - 5000:INTERVAL SECOND)))], select=[a, b, op_ts, a0, c, op_ts0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+      :     +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+      :        +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, b, op_ts], metadata=[]]], fields=[a, b, op_ts])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+            +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+               +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, c, op_ts], metadata=[]]], fields=[a, c, op_ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcRowtimeIntervalJoinSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT t2.a, t1.b, t2.c FROM cdc_with_watermark t1 JOIN cdc_with_watermark t2 ON
+  t1.a = t2.a AND t1.op_ts > t2.op_ts - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$5], b=[$1], c=[$7])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($4, -($9, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+      +- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Calc(select=[a0 AS a, b, c])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (op_ts > (op_ts0 - 5000:INTERVAL SECOND)))], select=[a, b, op_ts, a0, c, op_ts0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+      :     +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+      :        +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, b, op_ts], metadata=[]]], fields=[a, b, op_ts])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+            +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+               +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, c, op_ts], metadata=[]]], fields=[a, c, op_ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcRowtimeIntervalJoinSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+SELECT t2.a, t1.b, t2.c FROM cdc_with_watermark t1 JOIN cdc_with_watermark t2 ON
+  t1.a = t2.a AND t1.op_ts > t2.op_ts - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$5], b=[$1], c=[$7])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($4, -($9, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+      +- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a0 AS a, b, c])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (op_ts > (op_ts0 - 5000:INTERVAL SECOND)))], select=[a, b, op_ts, a0, c, op_ts0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+      :     +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+      :        +- DropUpdateBefore
+      :           +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, b, op_ts], metadata=[]]], fields=[a, b, op_ts])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+            +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+               +- DropUpdateBefore
+                  +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, c, op_ts], metadata=[]]], fields=[a, c, op_ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcRowtimeIntervalJoinSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+SELECT t2.a, t1.b, t2.c FROM cdc_with_watermark t1 JOIN cdc_with_watermark t2 ON
+  t1.a = t2.a AND t1.op_ts > t2.op_ts - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$5], b=[$1], c=[$7])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($4, -($9, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+      +- LogicalWatermarkAssigner(rowtime=[op_ts], watermark=[-($4, 5000:INTERVAL SECOND)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_watermark]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a0 AS a, b, c])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (op_ts > (op_ts0 - 5000:INTERVAL SECOND)))], select=[a, b, op_ts, a0, c, op_ts0], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+      :     +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+      :        +- DropUpdateBefore
+      :           +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, b, op_ts], metadata=[]]], fields=[a, b, op_ts])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, CAST(op_ts AS TIMESTAMP_WITH_LOCAL_TIME_ZONE(3)) AS op_ts])
+            +- WatermarkAssigner(rowtime=[op_ts], watermark=[(op_ts - 5000:INTERVAL SECOND)])
+               +- DropUpdateBefore
+                  +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_watermark, project=[a, c, op_ts], metadata=[]]], fields=[a, c, op_ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaCorrelateSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.metadata_1, T.c1
+from cdc_with_meta t1, lateral table(str_split(c)) as T(c1)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[CAST($0):INTEGER], b=[CAST($4):BIGINT], c=[$7])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{2}])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], metadata_1=[$4], metadata_2=[$5], metadata_3=[$6])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+      +- LogicalTableFunctionScan(invocation=[str_split($cor0.c)], rowType=[RecordType(VARCHAR(2147483647) EXPR$0)])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], upsertMaterialize=[true])
++- Calc(select=[CAST(a AS INTEGER) AS a, CAST(metadata_1 AS BIGINT) AS b, EXPR$0 AS c])
+   +- Correlate(invocation=[str_split($cor0.c)], correlate=[table(str_split($cor0.c))], select=[a,b,c,d,metadata_1,metadata_2,metadata_3,EXPR$0], rowType=[RecordType(INTEGER a, BIGINT b, VARCHAR(2147483647) c, BOOLEAN d, INTEGER metadata_1, VARCHAR(2147483647) metadata_2, BIGINT metadata_3, VARCHAR(2147483647) EXPR$0)], joinType=[INNER])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta]], fields=[a, b, c, d, metadata_1, metadata_2, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaLegacySinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into legacy_retract_sink
+select a, metadata_3, c
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`legacy_retract_sink`], fields=[a, b, c])
++- LogicalProject(a=[$0], metadata_3=[$6], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+LegacySink(name=[`default_catalog`.`default_database`.`legacy_retract_sink`], fields=[a, b, c])
++- Calc(select=[a, metadata_3, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaLegacySinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into legacy_upsert_sink
+select a, metadata_3, c
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
++- LogicalProject(a=[CAST($0):INTEGER], b=[$6], c=[CAST($2):VARCHAR(100) CHARACTER SET "UTF-16LE"])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+LegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
++- Calc(select=[CAST(a AS INTEGER) AS a, metadata_3 AS b, CAST(c AS VARCHAR(100)) AS c])
+   +- DropUpdateBefore
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaLegacySinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into legacy_upsert_sink
+select a, metadata_3, c
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalLegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
++- LogicalProject(a=[CAST($0):INTEGER], b=[$6], c=[CAST($2):VARCHAR(100) CHARACTER SET "UTF-16LE"])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+LegacySink(name=[`default_catalog`.`default_database`.`legacy_upsert_sink`], fields=[a, b, c])
++- Calc(select=[CAST(a AS INTEGER) AS a, metadata_3 AS b, CAST(c AS VARCHAR(100)) AS c])
+   +- DropUpdateBefore
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaRenameSinkWithCompositePk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, b, c, e from cdc_with_meta_rename
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, e])
++- LogicalProject(a=[$0], b=[$1], c=[$2], e=[$4])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta_rename]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, metadata_3])
++- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta_rename, project=[a, b, c], metadata=[metadata_3]]], fields=[a, b, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaSinkWithCompositePk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, b, c, metadata_3
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, metadata_3])
++- LogicalProject(a=[$0], b=[$1], c=[$2], metadata_3=[$6])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, metadata_3])
++- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, b, c], metadata=[metadata_3]]], fields=[a, b, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select a, metadata_3, c
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, metadata_3, c])
++- LogicalProject(a=[$0], metadata_3=[$6], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, metadata_3, c])
++- Calc(select=[a, metadata_3, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, metadata_3, c
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, metadata_3, c])
++- LogicalProject(a=[$0], metadata_3=[$6], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, metadata_3, c])
++- Calc(select=[a, metadata_3, c])
+   +- DropUpdateBefore
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithMetaSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, metadata_3, c
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, metadata_3, c])
++- LogicalProject(a=[$0], metadata_3=[$6], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, metadata_3, c])
++- Calc(select=[a, metadata_3, c])
+   +- DropUpdateBefore
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithNonDeterministicFilter[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t1.c
+from cdc t1
+where t1.b > UNIX_TIMESTAMP() - 300
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[>($1, -(UNIX_TIMESTAMP(), 300))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a, b, c], where=[(b > (UNIX_TIMESTAMP() - 300))])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithNonDeterministicFilter[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t1.b, t1.c
+from cdc t1
+where t1.b > UNIX_TIMESTAMP() - 300
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalFilter(condition=[>($1, -(UNIX_TIMESTAMP(), 300))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- Calc(select=[a, b, c], where=[(b > (UNIX_TIMESTAMP() - 300))])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithNonDeterministicFuncSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select a, ndFunc(b), c
+from cdc
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, c])
++- LogicalProject(a=[$0], EXPR$1=[ndFunc($1)], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, c])
++- Calc(select=[a, ndFunc(b) AS EXPR$1, c])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithNonDeterministicFuncSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, ndFunc(b), c
+from cdc
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, c])
++- LogicalProject(a=[$0], EXPR$1=[ndFunc($1)], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, c])
++- Calc(select=[a, ndFunc(b) AS EXPR$1, c])
+   +- DropUpdateBefore
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCdcWithNonDeterministicFuncSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, ndFunc(b), c
+from cdc
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, c])
++- LogicalProject(a=[$0], EXPR$1=[ndFunc($1)], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, EXPR$1, c])
++- Calc(select=[a, ndFunc(b) AS EXPR$1, c])
+   +- DropUpdateBefore
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGlobalNonDeterministicAggOnAppendSourceSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select
+  max(a)
+  ,ndAggFunc(b) ndCnt
+  ,max(c) mc
+from T
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[EXPR$0, ndCnt, mc])
++- LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], ndCnt=[ndAggFunc($1)], mc=[MAX($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[EXPR$0, ndCnt, mc])
++- GroupAggregate(select=[MAX(a) AS EXPR$0, ndAggFunc(b) AS ndCnt, MAX(c) AS mc])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[a, b, c])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGlobalNonDeterministicAggOnAppendSourceSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  max(a)
+  ,ndAggFunc(b) ndCnt
+  ,max(c) mc
+from T
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[EXPR$0, ndCnt, mc])
++- LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], ndCnt=[ndAggFunc($1)], mc=[MAX($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[EXPR$0, ndCnt, mc])
++- GroupAggregate(select=[MAX(a) AS EXPR$0, ndAggFunc(b) AS ndCnt, MAX(c) AS mc])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[a, b, c])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGlobalNonDeterministicAggOnAppendSourceSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  max(a)
+  ,ndAggFunc(b) ndCnt
+  ,max(c) mc
+from T
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[EXPR$0, ndCnt, mc])
++- LogicalAggregate(group=[{}], EXPR$0=[MAX($0)], ndCnt=[ndAggFunc($1)], mc=[MAX($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[EXPR$0, ndCnt, mc])
++- GroupAggregate(select=[MAX(a) AS EXPR$0, ndAggFunc(b) AS ndCnt, MAX(c) AS mc])
+   +- Exchange(distribution=[single])
+      +- Calc(select=[a, b, c])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupAggNonDeterministicFuncOnSourcePk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+select
+  `day`, count(*) cnt, sum(b) qmt
+from (
+  select *, concat(cast(a as varchar), DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) `day` from cdc
+) t
+group by `day`
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], cnt=[COUNT()], qmt=[SUM($1)])
++- LogicalProject(day=[CONCAT(CAST($0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], b=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(groupBy=[day], select=[day, COUNT_RETRACT(*) AS cnt, SUM_RETRACT(b) AS qmt])
++- Exchange(distribution=[hash[day]])
+   +- Calc(select=[CONCAT(CAST(a AS VARCHAR(2147483647)), DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS day, b])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupByNonDeterministicFuncWithCdcSource[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  a, count(*) cnt, `day`
+from (
+  select *, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') `day` from cdc
+) t
+group by `day`, a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, day])
++- LogicalProject(a=[$1], cnt=[$2], day=[$0])
+   +- LogicalAggregate(group=[{0, 1}], cnt=[COUNT()])
+      +- LogicalProject(day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')], a=[$0])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, cnt, day], upsertMaterialize=[true])
++- Calc(select=[a, cnt, day])
+   +- GroupAggregate(groupBy=[day, a], select=[day, a, COUNT_RETRACT(*) AS cnt])
+      +- Exchange(distribution=[hash[day, a]])
+         +- Calc(select=[DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd') AS day, a])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a], metadata=[]]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testGroupByNonDeterministicUdfWithCdcSource[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  ndFunc(a), count(*) cnt, c
+from cdc
+group by ndFunc(a), c
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[EXPR$0, cnt, c])
++- LogicalProject(EXPR$0=[$0], cnt=[$2], c=[$1])
+   +- LogicalAggregate(group=[{0, 1}], cnt=[COUNT()])
+      +- LogicalProject(EXPR$0=[ndFunc($0)], c=[$2])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[EXPR$0, cnt, c], upsertMaterialize=[true])
++- Calc(select=[EXPR$0, cnt, c])
+   +- GroupAggregate(groupBy=[EXPR$0, c], select=[EXPR$0, c, COUNT_RETRACT(*) AS cnt])
+      +- Exchange(distribution=[hash[EXPR$0, c]])
+         +- Calc(select=[ndFunc(a) AS EXPR$0, c])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, c], metadata=[]]], fields=[a, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHasBothSidesUk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t2.a, t2.`c-day`, t2.b, t2.d
+from (
+  select a, b, c, d
+  from cdc
+ ) t1
+join (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+) t2
+  on t1.b = t2.b
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], a0=[$4], c-day=[$6], b=[$5], d=[$7])
++- LogicalJoin(condition=[=($1, $5)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, a0, c-day, b0 AS b, d])
++- Join(joinType=[InnerJoin], where=[(b = b0)], select=[a, b, a0, b0, c-day, d], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[b]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHasBothSidesUk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t2.a, t2.`c-day`, t2.b, t2.d
+from (
+  select a, b, c, d
+  from cdc
+ ) t1
+join (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+) t2
+  on t1.b = t2.b
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], a0=[$4], c-day=[$6], b=[$5], d=[$7])
++- LogicalJoin(condition=[=($1, $5)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, a0, c-day, b0 AS b, d])
++- Join(joinType=[InnerJoin], where=[(b = b0)], select=[a, b, a0, b0, c-day, d], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+   :- Exchange(distribution=[hash[b]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHasBothSidesUkSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select t1.a, t2.a, t2.`c-day`
+from (
+  select a, b, c, d
+  from cdc
+ ) t1
+join (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+) t2
+  on t1.b = t2.b
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[CAST($0):INTEGER], b=[CAST($4):BIGINT], c=[$6])
+   +- LogicalJoin(condition=[=($1, $5)], joinType=[inner])
+      :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+      +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c], upsertMaterialize=[true])
++- Calc(select=[CAST(a AS INTEGER) AS a, CAST(a0 AS BIGINT) AS b, c-day AS c])
+   +- Join(joinType=[InnerJoin], where=[(b = b0)], select=[a, b, a0, b0, c-day], leftInputSpec=[HasUniqueKey], rightInputSpec=[HasUniqueKey])
+      :- Exchange(distribution=[hash[b]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+      +- Exchange(distribution=[hash[b]])
+         +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHasSingleSideUk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t2.`c-day`, t2.b, t2.d
+from (
+  select a, b, c, d
+  from cdc
+ ) t1
+join (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+) t2
+  on t1.b = t2.b
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c-day=[$6], b=[$5], d=[$7])
++- LogicalJoin(condition=[=($1, $5)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c-day, b0 AS b, d])
++- Join(joinType=[InnerJoin], where=[(b = b0)], select=[a, b, b0, c-day, d], leftInputSpec=[HasUniqueKey], rightInputSpec=[NoUniqueKey])
+   :- Exchange(distribution=[hash[b]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a, b], metadata=[]]], fields=[a, b])
+   +- Exchange(distribution=[hash[b]])
+      +- Calc(select=[b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[b, c, d], metadata=[]]], fields=[b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinKeyContainsUk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t2.`c-day`, t2.b, t2.d
+from (
+  select a, b, c, d
+  from cdc
+ ) t1
+join (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+) t2
+  on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c-day=[$6], b=[$5], d=[$7])
++- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c-day, b, d])
++- Join(joinType=[InnerJoin], where=[(a = a0)], select=[a, a0, b, c-day, d], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[a]])
+   :  +- DropUpdateBefore
+   :     +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a], metadata=[]]], fields=[a])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+         +- DropUpdateBefore
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinKeyContainsUk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t2.`c-day`, t2.b, t2.d
+from (
+  select a, b, c, d
+  from cdc
+ ) t1
+join (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+) t2
+  on t1.a = t2.a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c-day=[$6], b=[$5], d=[$7])
++- LogicalJoin(condition=[=($0, $4)], joinType=[inner])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c-day, b, d])
++- Join(joinType=[InnerJoin], where=[(a = a0)], select=[a, a0, b, c-day, d], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[a]])
+   :  +- DropUpdateBefore
+   :     +- TableSourceScan(table=[[default_catalog, default_database, cdc, project=[a], metadata=[]]], fields=[a])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+         +- DropUpdateBefore
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiOverWithNonDeterministicUdafSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+SELECT
+  a
+  ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+  ,b
+  ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+FROM T1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- LogicalProject(a=[$0], uv=[COUNT(DISTINCT $1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1], nd=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- Calc(select=[a, w0$o0 AS uv, b, w0$o1 AS nd])
+   +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, COUNT(DISTINCT b) AS w0$o0, ndAggFunc($3) AS w0$o1])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+            +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiOverWithNonDeterministicUdafSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+SELECT
+  a
+  ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+  ,b
+  ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+FROM T1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- LogicalProject(a=[$0], uv=[COUNT(DISTINCT $1) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1], nd=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, uv, b, nd])
++- Calc(select=[a, w0$o0 AS uv, b, w0$o1 AS nd])
+   +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, COUNT(DISTINCT b) AS w0$o0, ndAggFunc($3) AS w0$o1])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+            +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testMultiSinkOnJoinedView[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[a, day, EXPR$2, EXPR$3])
++- LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT(DISTINCT $3)])
+   +- LogicalProject(a=[$0], day=[$2], b=[$3], c=[$5])
+      +- LogicalJoin(condition=[=($0, $6)], joinType=[inner])
+         :- LogicalProject(a=[$0], b=[$1], day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')])
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+         +- LogicalProject(b=[$1], day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], c=[$2], d=[$3])
+            +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+
+LogicalSink(table=[default_catalog.default_database.sink2], fields=[a, day, b, c])
++- LogicalProject(a=[$0], day=[$1], b=[$2], c=[$3])
+   +- LogicalFilter(condition=[>($2, 100)])
+      +- LogicalProject(a=[$0], day=[$2], b=[$3], c=[$5])
+         +- LogicalJoin(condition=[=($0, $6)], joinType=[inner])
+            :- LogicalProject(a=[$0], b=[$1], day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')])
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, src1]])
+            +- LogicalProject(b=[$1], day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], c=[$2], d=[$3])
+               +- LogicalTableScan(table=[[default_catalog, default_database, src2]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Exchange(distribution=[hash[a]])(reuse_id=[1])
++- Calc(select=[a, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd') AS day])
+   +- TableSourceScan(table=[[default_catalog, default_database, src1, project=[a], metadata=[]]], fields=[a])
+
+Sink(table=[default_catalog.default_database.sink1], fields=[a, day, EXPR$2, EXPR$3])
++- GroupAggregate(groupBy=[a, day], select=[a, day, SUM_RETRACT(b) AS EXPR$2, COUNT_RETRACT(DISTINCT c) AS EXPR$3])
+   +- Exchange(distribution=[hash[a, day]])
+      +- Calc(select=[a, day, b, c])
+         +- Join(joinType=[InnerJoin], where=[(a = d)], select=[a, day, b, c, d], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+            :- Reused(reference_id=[1])
+            +- Exchange(distribution=[hash[d]])
+               +- TableSourceScan(table=[[default_catalog, default_database, src2, project=[b, c, d], metadata=[]]], fields=[b, c, d])
+
+Sink(table=[default_catalog.default_database.sink2], fields=[a, day, b, c])
++- Calc(select=[a, day, b, c])
+   +- Join(joinType=[InnerJoin], where=[(a = d)], select=[a, day, b, c, d], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Reused(reference_id=[1])
+      +- Exchange(distribution=[hash[d]])
+         +- Calc(select=[b, c, d], where=[(b > 100)])
+            +- TableSourceScan(table=[[default_catalog, default_database, src2, filter=[], project=[b, c, d], metadata=[]]], fields=[b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedAggWithNonDeterministicGroupingKeys[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  a, sum(b) qmt, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') `day`
+from (
+  select *, row_number() over (partition by a order by PROCTIME() desc) rn from src
+) t
+where rn = 1
+group by a, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, qmt, day])
++- LogicalProject(a=[$0], qmt=[$2], day=[$1])
+   +- LogicalAggregate(group=[{0, 1}], qmt=[SUM($2)])
+      +- LogicalProject(a=[$0], day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')], b=[$1])
+         +- LogicalFilter(condition=[=($4, 1)])
+            +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY PROCTIME() DESC NULLS LAST)])
+               +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, qmt, day], upsertMaterialize=[true])
++- Calc(select=[a, qmt, day])
+   +- GroupAggregate(groupBy=[a, day], select=[a, day, SUM_RETRACT(b) AS qmt])
+      +- Exchange(distribution=[hash[a, day]])
+         +- Calc(select=[a, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd') AS day, b])
+            +- Deduplicate(keep=[LastRow], key=[a], order=[PROCTIME])
+               +- Exchange(distribution=[hash[a]])
+                  +- Calc(select=[a, b, PROCTIME() AS $4])
+                     +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNestedSourceWithMultiSink[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink1], fields=[a, b, d])
++- LogicalProject(a=[$0], b=[$1], d=[CAST($2):BIGINT])
+   +- LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)])
+      +- LogicalProject(a=[$1.nested2.num], day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')], b=[+(+($1.nested1.value, $1.nested2.num), $3)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, nested_src]])
+
+LogicalSink(table=[default_catalog.default_database.sink2], fields=[a, b, d])
++- LogicalProject(a=[$1], b=[$2], d=[CAST($3):BIGINT])
+   +- LogicalFilter(condition=[>($3, 100)])
+      +- LogicalProject(id=[$0], a=[$1.nested2.num], name=[$1.nested1.name], b=[+(+($1.nested1.value, $1.nested2.num), $3)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, nested_src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink1], fields=[a, b, d])
++- Calc(select=[a, day AS b, CAST(EXPR$2 AS BIGINT) AS d])
+   +- GroupAggregate(groupBy=[a, day], select=[a, day, SUM_RETRACT(b) AS EXPR$2])
+      +- Exchange(distribution=[hash[a, day]])
+         +- Calc(select=[deepNested_nested2_num AS a, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd') AS day, ((deepNested_nested1_value + deepNested_nested2_num) + metadata_1) AS b])
+            +- TableSourceScan(table=[[default_catalog, default_database, nested_src, project=[deepNested_nested2_num, deepNested_nested1_value], metadata=[metadata_1]]], fields=[deepNested_nested2_num, deepNested_nested1_value, metadata_1])
+
+Sink(table=[default_catalog.default_database.sink2], fields=[a, b, d])
++- Calc(select=[deepNested.nested2.num AS a, deepNested.nested1.name AS b, CAST(((deepNested.nested1.value + deepNested.nested2.num) + metadata_1) AS BIGINT) AS d], where=[(((deepNested.nested1.value + deepNested.nested2.num) + metadata_1) > 100)])
+   +- TableSourceScan(table=[[default_catalog, default_database, nested_src, project=[deepNested], metadata=[metadata_1]]], fields=[deepNested, metadata_1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonDeterministicAggOnAppendSourceSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select
+  a
+  ,ndAggFunc(b) ndCnt
+  ,max(c) mc
+from T
+group by a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, ndCnt, mc])
++- LogicalAggregate(group=[{0}], ndCnt=[ndAggFunc($1)], mc=[MAX($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, ndCnt, mc])
++- GroupAggregate(groupBy=[a], select=[a, ndAggFunc(b) AS ndCnt, MAX(c) AS mc])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonDeterministicAggOnAppendSourceSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  a
+  ,ndAggFunc(b) ndCnt
+  ,max(c) mc
+from T
+group by a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, ndCnt, mc])
++- LogicalAggregate(group=[{0}], ndCnt=[ndAggFunc($1)], mc=[MAX($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, ndCnt, mc])
++- GroupAggregate(groupBy=[a], select=[a, ndAggFunc(b) AS ndCnt, MAX(c) AS mc])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testNonDeterministicAggOnAppendSourceSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select
+  a
+  ,ndAggFunc(b) ndCnt
+  ,max(c) mc
+from T
+group by a
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, ndCnt, mc])
++- LogicalAggregate(group=[{0}], ndCnt=[ndAggFunc($1)], mc=[MAX($2)])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, ndCnt, mc])
++- GroupAggregate(groupBy=[a], select=[a, ndAggFunc(b) AS ndCnt, MAX(c) AS mc])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a, b, c])
+         +- LegacyTableSourceScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverWithNonDeterministicUdafSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT
+  a
+  ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+  ,b
+FROM T1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, b])
++- LogicalProject(a=[$0], EXPR$1=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, b])
++- Calc(select=[a, w0$o0 AS EXPR$1, b])
+   +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, ndAggFunc($3) AS w0$o0])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+            +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRetractRankOutputRowNumberSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, cnt, c, rn from (
+ select
+  a, cnt, c, row_number() over (partition by a order by cnt desc) rn
+ from v1
+ ) t where t.rn <= 100
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- LogicalProject(a=[$0], cnt=[$1], c=[$2], rn=[$3])
+   +- LogicalFilter(condition=[<=($3, 100)])
+      +- LogicalProject(a=[$0], cnt=[$2], c=[$1], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
+         +- LogicalAggregate(group=[{0}], c=[MAX($1)], cnt=[SUM($2)])
+            +- LogicalProject(a=[$0], c=[$2], b=[$1])
+               +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- Calc(select=[a, cnt, c, rn])
+   +- Rank(strategy=[RetractStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[a], orderBy=[cnt DESC], select=[a, c, cnt, rn])
+      +- Exchange(distribution=[hash[a]])
+         +- GroupAggregate(groupBy=[a], select=[a, MAX(c) AS c, SUM(b) AS cnt])
+            +- Exchange(distribution=[hash[a]])
+               +- TableSourceScan(table=[[default_catalog, default_database, src, project=[a, c, b], metadata=[]]], fields=[a, c, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testOverWithNonDeterministicUdafSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT
+  a
+  ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+  ,b
+FROM T1
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, b])
++- LogicalProject(a=[$0], EXPR$1=[ndAggFunc(CAST($0):BIGINT) OVER (PARTITION BY $0 ORDER BY $3 NULLS FIRST ROWS 2 PRECEDING)], b=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, b])
++- Calc(select=[a, w0$o0 AS EXPR$1, b])
+   +- OverAggregate(partitionBy=[a], orderBy=[proctime ASC], window=[ ROWS BETWEEN 2 PRECEDING AND CURRENT ROW], select=[a, b, proctime, $3, ndAggFunc($3) AS w0$o0])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, b, proctime, CAST(a AS BIGINT) AS $3])
+            +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeIntervalJoinSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT t2.a, t2.c, t1.b FROM T1 t1 JOIN T1 t2 ON
+  t1.a = t2.a AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, c, b])
++- LogicalProject(a=[$5], c=[$7], b=[$1])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($3, -($8, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, c, b])
++- Calc(select=[a0 AS a, c, b])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (proctime > (proctime0 - 5000:INTERVAL SECOND)))], select=[a, b, proctime, a0, c, proctime0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime])
+      :     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])(reuse_id=[1])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, PROCTIME_MATERIALIZE(proctime) AS proctime])
+            +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testRetractRankOutputRowNumberSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, cnt, c, rn from (
+ select
+  a, cnt, c, row_number() over (partition by a order by cnt desc) rn
+ from v1
+ ) t where t.rn <= 100
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- LogicalProject(a=[$0], cnt=[$1], c=[$2], rn=[$3])
+   +- LogicalFilter(condition=[<=($3, 100)])
+      +- LogicalProject(a=[$0], cnt=[$2], c=[$1], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
+         +- LogicalAggregate(group=[{0}], c=[MAX($1)], cnt=[SUM($2)])
+            +- LogicalProject(a=[$0], c=[$2], b=[$1])
+               +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- Calc(select=[a, cnt, c, rn])
+   +- Rank(strategy=[RetractStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[a], orderBy=[cnt DESC], select=[a, c, cnt, rn])
+      +- Exchange(distribution=[hash[a]])
+         +- GroupAggregate(groupBy=[a], select=[a, MAX(c) AS c, SUM(b) AS cnt])
+            +- Exchange(distribution=[hash[a]])
+               +- TableSourceScan(table=[[default_catalog, default_database, src, project=[a, c, b], metadata=[]]], fields=[a, c, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpsertSourceSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select a, b, c
+from upsert_src
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsert_src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- ChangelogNormalize(key=[a])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[default_catalog, default_database, upsert_src, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testProctimeIntervalJoinSinkWithoutPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+SELECT t2.a, t2.c, t1.b FROM T1 t1 JOIN T1 t2 ON
+  t1.a = t2.a AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, c, b])
++- LogicalProject(a=[$5], c=[$7], b=[$1])
+   +- LogicalJoin(condition=[AND(=($0, $5), >($3, -($8, 5000:INTERVAL SECOND)))], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, c, b])
++- Calc(select=[a0 AS a, c, b])
+   +- Join(joinType=[InnerJoin], where=[((a = a0) AND (proctime > (proctime0 - 5000:INTERVAL SECOND)))], select=[a, b, proctime, a0, c, proctime0], leftInputSpec=[NoUniqueKey], rightInputSpec=[NoUniqueKey])
+      :- Exchange(distribution=[hash[a]])
+      :  +- Calc(select=[a, b, PROCTIME_MATERIALIZE(proctime) AS proctime])
+      :     +- DataStreamScan(table=[[default_catalog, default_database, T1]], fields=[a, b, c, proctime, rowtime])(reuse_id=[1])
+      +- Exchange(distribution=[hash[a]])
+         +- Calc(select=[a, c, PROCTIME_MATERIALIZE(proctime) AS proctime])
+            +- Reused(reference_id=[1])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSemiJoinKeyContainsUk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t1.`c-day`, t1.b, t1.d
+from (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+ ) t1
+where t1.a in (
+  select a from cdc where b > 100
+)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c-day=[$2], b=[$1], d=[$3])
++- LogicalFilter(condition=[IN($0, {
+LogicalProject(a=[$0])
+  LogicalFilter(condition=[>($1, 100)])
+    LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+})])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c-day, b, d])
++- Join(joinType=[LeftSemiJoin], where=[(a = a0)], select=[a, b, c-day, d], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a], where=[(b > 100)])
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, filter=[], project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSemiJoinKeyContainsUk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t1.`c-day`, t1.b, t1.d
+from (
+  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+  from cdc
+ ) t1
+where t1.a in (
+  select a from cdc where b > 100
+)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], c-day=[$2], b=[$1], d=[$3])
++- LogicalFilter(condition=[IN($0, {
+LogicalProject(a=[$0])
+  LogicalFilter(condition=[>($1, 100)])
+    LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+})])
+   +- LogicalProject(a=[$0], b=[$1], c-day=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, c-day, b, d])
++- Join(joinType=[LeftSemiJoin], where=[(a = a0)], select=[a, b, c-day, d], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey])
+   :- Exchange(distribution=[hash[a]])
+   :  +- Calc(select=[a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c-day, d])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
+   +- Exchange(distribution=[hash[a]])
+      +- Calc(select=[a], where=[(b > 100)])
+         +- TableSourceScan(table=[[default_catalog, default_database, cdc, filter=[], project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSemiJoinWithNonDeterministicConditionSingleSideHasUk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+select t1.a, t1.b, t1.c, t1.d
+from (
+  select a, b, c, d
+  from cdc
+ ) t1
+where t1.c in (
+  select CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) c from cdc where b > 100
+)
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
++- LogicalFilter(condition=[IN($2, {
+LogicalProject(c=[CONCAT($2, DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd'))])
+  LogicalFilter(condition=[>($1, 100)])
+    LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+})])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Join(joinType=[LeftSemiJoin], where=[(c = c0)], select=[a, b, c, d], leftInputSpec=[HasUniqueKey], rightInputSpec=[NoUniqueKey])
+:- Exchange(distribution=[hash[c]])
+:  +- TableSourceScan(table=[[default_catalog, default_database, cdc]], fields=[a, b, c, d])
++- Exchange(distribution=[hash[c]])
+   +- Calc(select=[CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd')) AS c], where=[(b > 100)])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc, filter=[], project=[b, c], metadata=[]]], fields=[b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSourceWithComputedColumnMultiSink[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, day])
++- LogicalProject(a=[$0], EXPR$1=[$2], day=[$1])
+   +- LogicalAggregate(group=[{0, 1}], EXPR$1=[SUM($2)])
+      +- LogicalProject(a=[$0], day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')], b=[$1])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_computed_col]])
+
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, day])
++- LogicalProject(a=[$0], b=[$1], day=[$4])
+   +- LogicalFilter(condition=[>($1, 100)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_computed_col]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, EXPR$1, day])
++- Calc(select=[a, EXPR$1, day])
+   +- GroupAggregate(groupBy=[a, day], select=[a, day, SUM_RETRACT(b) AS EXPR$1])
+      +- Exchange(distribution=[hash[a, day]])
+         +- Calc(select=[a, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd') AS day, b])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_computed_col, project=[a, b], metadata=[]]], fields=[a, b])
+
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, day], upsertMaterialize=[true])
++- Calc(select=[a, b, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd') AS day], where=[(b > 100)])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_computed_col, filter=[], project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSourceWithComputedColumnSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, b, `day`
+from cdc_with_computed_col
+where b > 100
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, day])
++- LogicalProject(a=[$0], b=[$1], day=[$4])
+   +- LogicalFilter(condition=[>($1, 100)])
+      +- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3], day=[DATE_FORMAT(CURRENT_TIMESTAMP, _UTF-16LE'yyMMdd')])
+         +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_computed_col]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, day], upsertMaterialize=[true])
++- Calc(select=[a, b, DATE_FORMAT(CURRENT_TIMESTAMP(), 'yyMMdd') AS day], where=[(b > 100)])
+   +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_computed_col, filter=[], project=[a, b], metadata=[]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionAllSinkWithCompositePk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, b, c, d
+from src
+union all
+select a, b, c, metadata_3
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, d])
++- LogicalUnion(all=[true])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], metadata_3=[$6])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, d], upsertMaterialize=[true])
++- Union(all=[true], union=[a, b, c, d])
+   :- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[a, b, c, d])
+   +- Calc(select=[CAST(a AS INTEGER) AS a, b, c, metadata_3])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, b, c], metadata=[metadata_3]]], fields=[a, b, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionAllSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select a, b, c
+from src
+union all
+select a, metadata_3, c
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalUnion(all=[true])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+   +- LogicalProject(a=[$0], metadata_3=[$6], c=[$2])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- Union(all=[true], union=[a, b, c])
+   :- TableSourceScan(table=[[default_catalog, default_database, src, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+   +- Calc(select=[CAST(a AS INTEGER) AS a, metadata_3, c])
+      +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, c], metadata=[metadata_3]]], fields=[a, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUnionSinkWithCompositePk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, b, c, d
+from src
+union
+select a, b, c, metadata_3
+from cdc_with_meta
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, d])
++- LogicalUnion(all=[false])
+   :- LogicalProject(a=[$0], b=[$1], c=[$2], d=[$3])
+   :  +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+   +- LogicalProject(a=[$0], b=[$1], c=[$2], metadata_3=[$6])
+      +- LogicalTableScan(table=[[default_catalog, default_database, cdc_with_meta]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, b, c, d], upsertMaterialize=[true])
++- GroupAggregate(groupBy=[a, b, c, d], select=[a, b, c, d])
+   +- Exchange(distribution=[hash[a, b, c, d]])
+      +- Union(all=[true], union=[a, b, c, d])
+         :- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[a, b, c, d])
+         +- Calc(select=[CAST(a AS INTEGER) AS a, b, c, metadata_3])
+            +- TableSourceScan(table=[[default_catalog, default_database, cdc_with_meta, project=[a, b, c], metadata=[metadata_3]]], fields=[a, b, c, metadata_3])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateRankOutputRowNumberSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, cnt, c, rn from (
+ select
+  a, cnt, c, row_number() over (partition by a order by cnt desc) rn
+ from v1
+ ) t where t.rn <= 100
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- LogicalProject(a=[$0], cnt=[$1], c=[$2], rn=[$3])
+   +- LogicalFilter(condition=[<=($3, 100)])
+      +- LogicalProject(a=[$0], cnt=[$2], c=[$1], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
+         +- LogicalAggregate(group=[{0}], c=[MAX($1)], cnt=[SUM($2) FILTER $3])
+            +- LogicalProject(a=[$0], c=[$2], b=[$1], $f3=[IS TRUE(>($1, 0))])
+               +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- Calc(select=[a, cnt, c, rn])
+   +- Rank(strategy=[UpdateFastStrategy[0]], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[a], orderBy=[cnt DESC], select=[a, c, cnt, rn])
+      +- Exchange(distribution=[hash[a]])
+         +- GroupAggregate(groupBy=[a], select=[a, MAX(c) AS c, SUM(b) FILTER $f3 AS cnt])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, c, b, (b > 0) IS TRUE AS $f3])
+                  +- TableSourceScan(table=[[default_catalog, default_database, src, project=[a, c, b], metadata=[]]], fields=[a, c, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpsertSourceSinkWithoutPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_without_pk
+select a, b, c
+from upsert_src
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsert_src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_without_pk], fields=[a, b, c])
++- ChangelogNormalize(key=[a])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[default_catalog, default_database, upsert_src, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpsertSourceSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, b, c
+from upsert_src
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsert_src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- ChangelogNormalize(key=[a])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[default_catalog, default_database, upsert_src, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpdateRankOutputRowNumberSinkWithPk[nonDeterministicUpdateStrategy=TRY_RESOLVE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_composite_pk
+select a, cnt, c, rn from (
+ select
+  a, cnt, c, row_number() over (partition by a order by cnt desc) rn
+ from v1
+ ) t where t.rn <= 100
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- LogicalProject(a=[$0], cnt=[$1], c=[$2], rn=[$3])
+   +- LogicalFilter(condition=[<=($3, 100)])
+      +- LogicalProject(a=[$0], cnt=[$2], c=[$1], rn=[ROW_NUMBER() OVER (PARTITION BY $0 ORDER BY $2 DESC NULLS LAST)])
+         +- LogicalAggregate(group=[{0}], c=[MAX($1)], cnt=[SUM($2) FILTER $3])
+            +- LogicalProject(a=[$0], c=[$2], b=[$1], $f3=[IS TRUE(>($1, 0))])
+               +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_composite_pk], fields=[a, cnt, c, rn])
++- Calc(select=[a, cnt, c, rn])
+   +- Rank(strategy=[UpdateFastStrategy[0]], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[a], orderBy=[cnt DESC], select=[a, c, cnt, rn])
+      +- Exchange(distribution=[hash[a]])
+         +- GroupAggregate(groupBy=[a], select=[a, MAX(c) AS c, SUM(b) FILTER $f3 AS cnt])
+            +- Exchange(distribution=[hash[a]])
+               +- Calc(select=[a, c, b, (b > 0) IS TRUE AS $f3])
+                  +- TableSourceScan(table=[[default_catalog, default_database, src, project=[a, c, b], metadata=[]]], fields=[a, c, b])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testUpsertSourceSinkWithPk[nonDeterministicUpdateStrategy=IGNORE]">
+    <Resource name="sql">
+      <![CDATA[
+insert into sink_with_pk
+select a, b, c
+from upsert_src
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalSink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- LogicalProject(a=[$0], b=[$1], c=[$2])
+   +- LogicalTableScan(table=[[default_catalog, default_database, upsert_src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Sink(table=[default_catalog.default_database.sink_with_pk], fields=[a, b, c])
++- ChangelogNormalize(key=[a])
+   +- Exchange(distribution=[hash[a]])
+      +- TableSourceScan(table=[[default_catalog, default_database, upsert_src, project=[a, b, c], metadata=[]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/RankTest.xml
@@ -234,7 +234,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, c, rn])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[a, c, w0$o0], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[a, c, w0$o0], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[a, c, w0$o0], changelogMode=[I,UB,UA,D])
    +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[b], orderBy=[c DESC], select=[a, b, c, w0$o0], changelogMode=[I,UB,UA,D])
       +- Exchange(distribution=[hash[b]], changelogMode=[I])
@@ -261,7 +261,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], upsertMaterialize=[true], changelogMode=[NONE])
 +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[a], orderBy=[c DESC], select=[a, b, c], changelogMode=[I,UB,UA,D])
    +- Exchange(distribution=[hash[a]], changelogMode=[I])
       +- Calc(select=[a, b, c], changelogMode=[I])
@@ -286,7 +286,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[a, b, c])
          +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[a, b, c], upsertMaterialize=[true], changelogMode=[NONE])
 +- Rank(strategy=[AppendFastStrategy], rankType=[ROW_NUMBER], rankRange=[rankStart=1, rankEnd=100], partitionBy=[b], orderBy=[c DESC], select=[a, b, c], changelogMode=[I,UB,UA,D])
    +- Exchange(distribution=[hash[b]], changelogMode=[I])
       +- Calc(select=[a, b, c], changelogMode=[I])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
@@ -349,7 +349,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[c, cnt])
       +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- GroupAggregate(groupBy=[c], select=[c, COUNT(*) AS cnt], changelogMode=[I,UB,UA])
    +- Exchange(distribution=[hash[c]], changelogMode=[I])
       +- Calc(select=[c], changelogMode=[I])
@@ -374,7 +374,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[c, cnt])
          +- LogicalTableScan(table=[[default_catalog, default_database, T, source: [TestTableSource(a, b, c, d)]]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[c, cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[c, cnt], changelogMode=[I,UB,UA])
    +- GroupAggregate(groupBy=[a, c], select=[a, c, COUNT(*) AS cnt], changelogMode=[I,UB,UA])
       +- Exchange(distribution=[hash[a, c]], changelogMode=[I])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/JoinTest.xml
@@ -552,7 +552,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[city_name, cu
       +- LogicalTableScan(table=[[default_catalog, default_database, source_city]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[city_name, customer_cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[city_name, customer_cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[city_name, customer_cnt], changelogMode=[I,UB,UA,D])
    +- Join(joinType=[InnerJoin], where=[=(city_id, id)], select=[city_id, customer_cnt, id, city_name], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], changelogMode=[I,UB,UA,D])
       :- Exchange(distribution=[hash[city_id]], changelogMode=[I,UB,UA,D])
@@ -642,7 +642,7 @@ LogicalSink(table=[default_catalog.default_database.sink], fields=[city_id, city
       +- LogicalTableScan(table=[[default_catalog, default_database, source_city]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.sink], fields=[city_id, city_name, customer_cnt], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.sink], fields=[city_id, city_name, customer_cnt], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[city_id, city_name, customer_cnt], changelogMode=[I,UB,UA,D])
    +- Join(joinType=[InnerJoin], where=[=(city_id, id)], select=[city_id, customer_cnt, id, city_name], leftInputSpec=[JoinKeyContainsUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], changelogMode=[I,UB,UA,D])
       :- Exchange(distribution=[hash[city_id]], changelogMode=[I,UB,UA,D])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -162,7 +162,7 @@ LogicalSink(table=[default_catalog.default_database.rowtime_default_sink], field
                +- LogicalTableScan(table=[[default_catalog, default_database, versioned_currency_with_multi_key]])
 
 == Optimized Physical Plan ==
-Sink(table=[default_catalog.default_database.rowtime_default_sink], fields=[order_id, currency, amount, order_time, rate, currency_time], changelogMode=[NONE])
+Sink(table=[default_catalog.default_database.rowtime_default_sink], fields=[order_id, currency, amount, order_time, rate, currency_time], upsertMaterialize=[true], changelogMode=[NONE])
 +- Calc(select=[order_id, currency, amount, order_time, rate, CAST(currency_time AS TIMESTAMP(3)) AS currency_time], changelogMode=[I,UB,UA,D])
    +- TemporalJoin(joinType=[InnerJoin], where=[AND(=(currency_no, currency_no0), =(currency, currency0), __TEMPORAL_JOIN_CONDITION(order_time, currency_time, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0, currency_no0), __TEMPORAL_JOIN_LEFT_KEY(currency_no, currency), __TEMPORAL_JOIN_RIGHT_KEY(currency_no0, currency0)))], select=[order_id, currency, currency_no, amount, order_time, currency0, currency_no0, rate, currency_time], changelogMode=[I,UB,UA,D])
       :- Exchange(distribution=[hash[currency_no, currency]], changelogMode=[I,UB,UA,D])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -2595,8 +2595,16 @@ class FlinkRelMdHandlerTestBase {
 
   // SELECT * FROM student AS T JOIN TemporalTable
   // FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id
-  protected lazy val (batchLookupJoin, streamLookupJoin) = {
-    val temporalTableSource = new TestTemporalTable
+  protected lazy val (batchLookupJoin, streamLookupJoin) = getLookupJoins()
+
+  protected lazy val (batchLookupJoinWithPk, streamLookupJoinWithPk) = getLookupJoins(Array("id"))
+
+  protected lazy val (batchLookupJoinNotContainsPk, streamLookupJoinNotContainsPk) = getLookupJoins(
+    Array("name"))
+
+  protected def getLookupJoins(
+      primaryKeys: Array[String] = Array()): (BatchPhysicalLookupJoin, StreamPhysicalLookupJoin) = {
+    val temporalTableSource = new TestTemporalTable(keys = primaryKeys)
     val batchSourceOp = new TableSourceQueryOperation[RowData](temporalTableSource, true)
     val batchScan = relBuilder.queryOperation(batchSourceOp).build().asInstanceOf[TableScan]
     val batchLookupJoin = new BatchPhysicalLookupJoin(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUniqueKeysTest.scala
@@ -343,6 +343,21 @@ class FlinkRelMdUniqueKeysTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetUniqueKeysOnLookupJoinWithPk(): Unit = {
+    Array(batchLookupJoinWithPk, streamLookupJoinWithPk).foreach {
+      join =>
+        assertEquals(uniqueKeys(Array(7), Array(0, 7), Array(0)), mq.getUniqueKeys(join).toSet)
+    }
+  }
+
+  @Test
+  def testGetUniqueKeysOnLookupJoinNotContainsPk(): Unit = {
+    Array(batchLookupJoinNotContainsPk, streamLookupJoinNotContainsPk).foreach {
+      join => assertEquals(uniqueKeys(), mq.getUniqueKeys(join).toSet)
+    }
+  }
+
+  @Test
   def testGetUniqueKeysOnSetOp(): Unit = {
     Array(logicalUnionAll, logicalIntersectAll, logicalMinusAll).foreach {
       setOp => assertEquals(uniqueKeys(), mq.getUniqueKeys(setOp).toSet)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeysTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeysTest.scala
@@ -367,6 +367,20 @@ class FlinkRelMdUpsertKeysTest extends FlinkRelMdHandlerTestBase {
   }
 
   @Test
+  def testGetUpsertKeysOnLookupJoinWithPk(): Unit = {
+    Array(batchLookupJoinWithPk, streamLookupJoinWithPk).foreach {
+      join => assertEquals(toBitSet(Array(7), Array(0, 7), Array(0)), mq.getUpsertKeys(join).toSet)
+    }
+  }
+
+  @Test
+  def testGetUpsertKeysOnLookupJoinNotContainsPk(): Unit = {
+    Array(batchLookupJoinNotContainsPk, streamLookupJoinNotContainsPk).foreach {
+      join => assertEquals(toBitSet(), mq.getUpsertKeys(join).toSet)
+    }
+  }
+
+  @Test
   def testGetUpsertKeysOnSetOp(): Unit = {
     Array(logicalUnionAll, logicalIntersectAll, logicalMinusAll).foreach {
       setOp => assertEquals(toBitSet(), mq.getUpsertKeys(setOp).toSet)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/NonDeterministicDagTest.scala
@@ -1,0 +1,1670 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.stream.sql
+
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.java.tuple
+import org.apache.flink.api.scala._
+import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
+import org.apache.flink.table.api._
+import org.apache.flink.table.api.config.OptimizerConfigOptions
+import org.apache.flink.table.api.config.OptimizerConfigOptions.NonDeterministicUpdateStrategy
+import org.apache.flink.table.api.internal.TableEnvironmentInternal
+import org.apache.flink.table.data.RowData
+import org.apache.flink.table.functions.{AggregateFunction, ScalarFunction, TableFunction}
+import org.apache.flink.table.planner.{JBoolean, JLong}
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.StringSplit
+import org.apache.flink.table.planner.utils.{CountAccumulator, StreamTableTestUtil, TableTestBase}
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
+import org.apache.flink.table.sinks.UpsertStreamTableSink
+import org.apache.flink.table.types.DataType
+import org.apache.flink.table.types.logical.{BigIntType, IntType, VarCharType}
+import org.apache.flink.table.types.utils.TypeConversions
+
+import org.junit.{Before, Test}
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+import java.util
+
+import scala.util.Random
+
+@RunWith(classOf[Parameterized])
+class NonDeterministicDagTest(nonDeterministicUpdateStrategy: NonDeterministicUpdateStrategy)
+  extends TableTestBase {
+
+  private val util: StreamTableTestUtil = streamTestUtil()
+  private val tryResolve =
+    nonDeterministicUpdateStrategy == NonDeterministicUpdateStrategy.TRY_RESOLVE
+
+  @Before
+  def before(): Unit = {
+    util.tableConfig.getConfiguration.set(
+      OptimizerConfigOptions.TABLE_OPTIMIZER_NONDETERMINISTIC_UPDATE_STRATEGY,
+      nonDeterministicUpdateStrategy)
+
+    util.addTableSource[(Int, Long, String, Boolean)]("T", 'a, 'b, 'c, 'd)
+    util.addDataStream[(Int, String, Long)]("T1", 'a, 'b, 'c, 'proctime.proctime, 'rowtime.rowtime)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table src (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | d bigint
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table cdc (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | d bigint,
+                               | primary key (a) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,UB,D'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table upsert_src (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | d boolean,
+                               | primary key (a) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,D'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table cdc_with_computed_col (
+                               |  a int,
+                               |  b bigint,
+                               |  c string,
+                               |  d int,
+                               |  `day` as DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd'),
+                               |  primary key(a, c) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,UB,D'
+                               |)""".stripMargin)
+    util.tableEnv.executeSql(
+      """
+        |create temporary table cdc_with_meta (
+        | a int,
+        | b bigint,
+        | c string,
+        | d boolean,
+        | metadata_1 int metadata,
+        | metadata_2 string metadata,
+        | metadata_3 bigint metadata,
+        | primary key (a) not enforced
+        |) with (
+        | 'connector' = 'values',
+        | 'changelog-mode' = 'I,UA,UB,D',
+        | 'readable-metadata' = 'metadata_1:INT, metadata_2:STRING, metadata_3:BIGINT'
+        |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table cdc_with_watermark (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | d boolean,
+                               | op_ts timestamp_ltz(3),
+                               | primary key (a) not enforced,
+                               | watermark for op_ts as op_ts - interval '5' second
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,UB,D',
+                               | 'readable-metadata' = 'op_ts:timestamp_ltz(3)'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table cdc_with_meta_and_wm (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | d boolean,
+                               | op_ts timestamp_ltz(3) metadata,
+                               | primary key (a) not enforced,
+                               | watermark for op_ts as op_ts - interval '5' second
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,UB,D',
+                               | 'readable-metadata' = 'op_ts:timestamp_ltz(3)'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink_with_composite_pk (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | d bigint,
+                               | primary key (a,d) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink_with_pk (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | primary key (a) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink_without_pk (
+                               | a int,
+                               | b bigint,
+                               | c string
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table dim_with_pk (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | primary key (a) not enforced
+                               |) with (
+                               | 'connector' = 'values'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table dim_without_pk (
+                               | a int,
+                               | b bigint,
+                               | c string
+                               |) with (
+                               | 'connector' = 'values'
+                               |)""".stripMargin)
+
+    // custom ND function
+    util.tableEnv.createTemporaryFunction("ndFunc", TestNonDeterministicUdf)
+    util.tableEnv.createTemporaryFunction("ndTableFunc", TestNonDeterministicUdtf)
+    util.tableEnv.createTemporaryFunction("ndAggFunc", TestTestNonDeterministicUdaf)
+    // deterministic table function
+    util.tableEnv.createTemporaryFunction("str_split", new StringSplit())
+  }
+
+  @Test
+  def testCdcWithMetaSinkWithPk(): Unit = {
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select a, metadata_3, c
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithMetaSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_3' in cdc source may cause wrong result or error")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select a, metadata_3, c
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithMetaLegacySinkWithPk(): Unit = {
+    val sinkWithPk = new TestingUpsertSink(
+      Array("a"),
+      Array("a", "b", "c"),
+      // pk column requires non-null type
+      Array(DataTypes.INT().notNull(), DataTypes.BIGINT(), DataTypes.VARCHAR(100)))
+
+    util.tableEnv
+      .asInstanceOf[TableEnvironmentInternal]
+      .registerTableSinkInternal("legacy_upsert_sink", sinkWithPk)
+
+    util.verifyExecPlanInsert(s"""
+                                 |insert into legacy_upsert_sink
+                                 |select a, metadata_3, c
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithMetaLegacySinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_3' in cdc source may cause wrong result or error")
+      thrown.expect(classOf[TableException])
+    }
+    val retractSink =
+      util.createRetractTableSink(
+        Array("a", "b", "c"),
+        Array(new IntType(), new BigIntType(), VarCharType.STRING_TYPE))
+    util.tableEnv
+      .asInstanceOf[TableEnvironmentInternal]
+      .registerTableSinkInternal("legacy_retract_sink", retractSink)
+
+    util.verifyExecPlanInsert(s"""
+                                 |insert into legacy_retract_sink
+                                 |select a, metadata_3, c
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithMetaSinkWithCompositePk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_3' in cdc source may cause wrong result or error")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_composite_pk
+                                 |select a, b, c, metadata_3
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithMetaRenameSinkWithCompositePk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_3' in cdc source may cause wrong result or error")
+      thrown.expect(classOf[TableException])
+    }
+    util.tableEnv.executeSql("""
+                               |create temporary table cdc_with_meta_rename (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | d boolean,
+                               | metadata_3 bigint metadata,
+                               | e as metadata_3,
+                               | primary key (a) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,UB,D',
+                               | 'readable-metadata' = 'metadata_3:BIGINT'
+                               |)""".stripMargin)
+
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_composite_pk
+                                 |select a, b, c, e from cdc_with_meta_rename
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testSourceWithComputedColumnSinkWithPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+
+    // can not infer pk from cdc source with computed column(s)
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select a, b, `day`
+                                 |from cdc_with_computed_col
+                                 |where b > 100
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testSourceWithComputedColumnMultiSink(): Unit = {
+    val stmtSet = util.tableEnv.createStatementSet()
+    stmtSet.addInsertSql(s"""
+                            |insert into sink_without_pk
+                            |select a, sum(b), `day`
+                            |from cdc_with_computed_col
+                            |group by a, `day`
+                            |""".stripMargin)
+    stmtSet.addInsertSql(s"""
+                            |insert into sink_with_pk
+                            |select a, b, `day`
+                            |from cdc_with_computed_col
+                            |where b > 100
+                            |""".stripMargin)
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlan(stmtSet)
+  }
+
+  @Test
+  def testCdcCorrelateNonDeterministicFuncSinkWithPK(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): EXPR$0(generated by non-deterministic function: ndTableFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select
+                                 |  t1.a, t1.b, a1
+                                 |from cdc t1, lateral table(ndTableFunc(a)) as T(a1)
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcCorrelateNonDeterministicFuncNoLeftOutput(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): EXPR$0(generated by non-deterministic function: ndTableFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk(a)
+                                 |select
+                                 |  cast(a1 as integer) a
+                                 |from cdc t1, lateral table(ndTableFunc(a)) as T(a1)
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcCorrelateNonDeterministicFuncNoRightOutput(): Unit = {
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select a, b, c
+                                 |from cdc t1 join lateral table(ndTableFunc(a)) as T(a1) on true
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcCorrelateOnNonDeterministicCondition(): Unit = {
+    // TODO update this after FLINK-7865 was fixed
+    thrown.expectMessage("unexpected correlate variable $cor0 in the plan")
+    thrown.expect(classOf[TableException])
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select a, b, c
+                                 |from cdc t1 join lateral table(str_split(c)) as T(c1)
+                                 | -- the join predicate can only be empty or literal true for now
+                                 |  on ndFunc(b) > 100
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithMetaCorrelateSinkWithPk(): Unit = {
+    // Under ignore mode, the generated execution plan may cause wrong result though
+    // upsertMaterialize has been enabled in sink, because
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_1' in cdc source may cause wrong result or error on downstream operators")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select t1.a, t1.metadata_1, T.c1
+                                 |from cdc_with_meta t1, lateral table(str_split(c)) as T(c1)
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithNonDeterministicFuncSinkWithPk(): Unit = {
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select a, ndFunc(b), c
+                                 |from cdc
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithNonDeterministicFuncSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): EXPR$1(generated by non-deterministic function: ndFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select a, ndFunc(b), c
+                                 |from cdc
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcWithNonDeterministicFilter(): Unit = {
+    // TODO should throw error if tryResolve is true after FLINK-28737 was fixed
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select t1.a, t1.b, t1.c
+                                 |from cdc t1
+                                 |where t1.b > UNIX_TIMESTAMP() - 300
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithPkSinkWithPk(): Unit = {
+    // The lookup key contains the dim table's pk, there will be no materialization.
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select t1.a, t1.b, t2.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithoutPkSinkWithPk(): Unit = {
+    // This case shows how costly is if the dim table does not define a pk.
+    // The lookup key doesn't contain the dim table's pk, there will be two more costly
+    // materialization compare to the one with pk.
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select t1.a, t1.b, t2.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_without_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcLeftJoinDimWithPkSinkWithPk(): Unit = {
+    // The lookup key contains the dim table's pk, there will be no materialization.
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select t1.a, t1.b, t2.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 left join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithPkSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select t1.a, t1.b, t2.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithoutPkSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select t1.a, t1.b, t2.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_without_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithPkOnlySinkWithoutPk(): Unit = {
+    // only select lookup key field, expect not affect NDU
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select t1.a, t1.b, t1.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcLeftJoinDimWithoutPkSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_without_pk
+         |select t1.a, t1.b, t2.c
+         |from (
+         |  select *, proctime() proctime from cdc
+         |) t1 left join dim_without_pk for system_time as of t1.proctime as t2
+         |on t1.a = t2.a
+         |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithPkOutputNoPkSinkWithoutPk(): Unit = {
+    // non lookup pk selected, expect materialize if tryResolve
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select t1.a, t2.b, t1.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithPkNonDeterministicFuncSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      // only select lookup key field, but with ND-call, expect exception
+      thrown.expectMessage(
+        "column(s): a(generated by non-deterministic function: ndFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select ndFunc(t2.a) a, t1.b, t1.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithPkNonDeterministicLocalCondition(): Unit = {
+    // use user defined function
+    if (tryResolve) {
+      // not select lookup source field, but with NonDeterministicCondition, expect exception
+      thrown.expectMessage(
+        "exists non deterministic function: 'ndFunc' in condition: '>(ndFunc($1), 100)' which may cause wrong result")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select t1.a, t1.b, t1.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a and ndFunc(t2.b) > 100
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimWithPkNonDeterministicLocalCondition2(): Unit = {
+    // use builtin temporal function
+    if (tryResolve) {
+      thrown.expectMessage(
+        "exists non deterministic function: 'UNIX_TIMESTAMP' in condition: '>($1, -(UNIX_TIMESTAMP(), 300))' which may cause wrong result")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select t1.a, t2.b as version, t2.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |  -- check dim table data's freshness
+                                 |  and t2.b > UNIX_TIMESTAMP() - 300
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinDimNonDeterministicRemainingCondition(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "exists non deterministic function: 'ndFunc' in condition: '>($1, ndFunc($3))' which may cause wrong result")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select t1.a, t2.b, t2.c
+                                 |from (
+                                 |  select *, proctime() proctime from cdc
+                                 |) t1 join dim_with_pk for system_time as of t1.proctime as t2
+                                 |on t1.a = t2.a
+                                 |  -- non deterministic function in remaining condition
+                                 |  and t1.b > ndFunc(t2.b)
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testGroupByNonDeterministicFuncWithCdcSource(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select
+                                 |  a, count(*) cnt, `day`
+                                 |from (
+                                 |  select *, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') `day` from cdc
+                                 |) t
+                                 |group by `day`, a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testGroupByNonDeterministicUdfWithCdcSource(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): EXPR$0(generated by non-deterministic function: ndFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select
+                                 |  ndFunc(a), count(*) cnt, c
+                                 |from cdc
+                                 |group by ndFunc(a), c
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testNestedAggWithNonDeterministicGroupingKeys(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_with_pk
+         |select
+         |  a, sum(b) qmt, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') `day`
+         |from (
+         |  select *, row_number() over (partition by a order by PROCTIME() desc) rn from src
+         |) t
+         |where rn = 1
+         |group by a, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')
+         |""".stripMargin)
+  }
+
+  @Test
+  def testGroupAggNonDeterministicFuncOnSourcePk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlan(
+      s"""
+         |select
+         |  `day`, count(*) cnt, sum(b) qmt
+         |from (
+         |  select *, concat(cast(a as varchar), DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) `day` from cdc
+         |) t
+         |group by `day`
+         |""".stripMargin)
+  }
+
+  @Test
+  def testAggWithNonDeterministicFilterArgs(): Unit = {
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_with_pk
+         |select
+         |  a
+         |  ,count(*) cnt
+         |  ,cast(count(distinct c) filter (where b > UNIX_TIMESTAMP() - 180) as varchar) valid_uv
+         |from T
+         |group by a
+         |""".stripMargin)
+  }
+
+  @Test
+  def testAggWithNonDeterministicFilterArgsOnCdcSource(): Unit = {
+    if (tryResolve) {
+      // though original pk was selected and same as the sink's pk, but the valid_uv was
+      // non-deterministic, will raise an error
+      thrown.expectMessage(
+        "column(s): $f2(generated by non-deterministic function: UNIX_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_with_pk
+         |select
+         |  a
+         |  ,count(*) cnt
+         |  ,cast(count(distinct c) filter (where b > UNIX_TIMESTAMP() - 180) as varchar) valid_uv
+         |from cdc
+         |group by a
+         |""".stripMargin)
+  }
+
+  @Test
+  def testAggWithNonDeterministicFilterArgsOnCdcSourceSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): $f2(generated by non-deterministic function: UNIX_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_without_pk
+         |select
+         |  a
+         |  ,count(*) cnt
+         |  ,cast(count(distinct c) filter (where b > UNIX_TIMESTAMP() - 180) as varchar) valid_uv
+         |from cdc
+         |group by a
+         |""".stripMargin)
+  }
+
+  @Test
+  def testNonDeterministicAggOnAppendSourceSinkWithPk(): Unit = {
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select
+                                 |  a
+                                 |  ,ndAggFunc(b) ndCnt
+                                 |  ,max(c) mc
+                                 |from T
+                                 |group by a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testNonDeterministicAggOnAppendSourceSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): ndCnt(generated by non-deterministic function: ndAggFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select
+                                 |  a
+                                 |  ,ndAggFunc(b) ndCnt
+                                 |  ,max(c) mc
+                                 |from T
+                                 |group by a
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testGlobalNonDeterministicAggOnAppendSourceSinkWithPk(): Unit = {
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select
+                                 |  max(a)
+                                 |  ,ndAggFunc(b) ndCnt
+                                 |  ,max(c) mc
+                                 |from T
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testGlobalNonDeterministicAggOnAppendSourceSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): ndCnt(generated by non-deterministic function: ndAggFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select
+                                 |  max(a)
+                                 |  ,ndAggFunc(b) ndCnt
+                                 |  ,max(c) mc
+                                 |from T
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testUpsertSourceSinkWithPk(): Unit = {
+    // contains normalize
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_pk
+                                 |select a, b, c
+                                 |from upsert_src
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testUpsertSourceSinkWithoutPk(): Unit = {
+    // contains normalize
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select a, b, c
+                                 |from upsert_src
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testMultiOverWithNonDeterministicUdafSinkWithPk(): Unit = {
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_composite_pk
+        |SELECT
+        |  a
+        |  ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+        |    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+        |  ,b
+        |  ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+        |    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+        |FROM T1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testOverWithNonDeterministicUdafSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_without_pk
+        |SELECT
+        |  a
+        |  ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+        |    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)
+        |  ,b
+        |FROM T1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testMultiOverWithNonDeterministicAggFilterSinkWithPk(): Unit = {
+    // agg with filter is not supported currently, should update this after it is supported.
+    thrown.expectMessage("OVER must be applied to aggregate function")
+    thrown.expect(classOf[ValidationException])
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_composite_pk
+        |SELECT
+        |  a
+        |  ,COUNT(distinct b) OVER (PARTITION BY a ORDER BY proctime
+        |    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+        |  ,b
+        |  ,SUM(a) filter (where b > UNIX_TIMESTAMP() - 180) OVER (PARTITION BY a ORDER BY proctime
+        |    ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+        |FROM T1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testAppendRankOnMultiOverWithNonDeterministicUdafSinkWithPk(): Unit = {
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_composite_pk
+        |select a, uv, b, nd from (
+        | select
+        |  a, uv, b, nd,
+        |  row_number() over (partition by a order by uv desc) rn
+        | from (
+        |  SELECT
+        |    a
+        |    ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+        |      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+        |    ,b
+        |    ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+        |      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+        |  FROM T1
+        |  )
+        |) where rn = 1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testAppendRankOnMultiOverWithNonDeterministicUdafSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_without_pk
+        |select a, nd, b from (
+        | select
+        |  a, uv, b, nd,
+        |  row_number() over (partition by a order by uv desc) rn
+        | from (
+        |  SELECT
+        |    a
+        |    ,COUNT(distinct b)  OVER (PARTITION BY a ORDER BY proctime
+        |      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) uv
+        |    ,b
+        |    ,ndAggFunc(a) OVER (PARTITION BY a ORDER BY proctime
+        |      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW) nd
+        |  FROM T1
+        |  )
+        |) where rn = 1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testUpdateRankOutputRowNumberSinkWithPk(): Unit = {
+    util.tableEnv.executeSql(s"""
+                                | create temporary view v1 as
+                                |  select a, max(c) c, sum(b) filter (where b > 0) cnt
+                                |  from src
+                                |  group by a
+                                | """.stripMargin)
+
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_with_composite_pk
+         |select a, cnt, c, rn from (
+         | select
+         |  a, cnt, c, row_number() over (partition by a order by cnt desc) rn
+         | from v1
+         | ) t where t.rn <= 100
+         |""".stripMargin)
+  }
+
+  @Test
+  def testRetractRankOutputRowNumberSinkWithPk(): Unit = {
+    util.tableEnv.executeSql(s"""
+                                | create temporary view v1 as
+                                |  select a, max(c) c, sum(b) cnt
+                                |  from src
+                                |  group by a
+                                | """.stripMargin)
+
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_with_composite_pk
+         |select a, cnt, c, rn from (
+         | select
+         |  a, cnt, c, row_number() over (partition by a order by cnt desc) rn
+         | from v1
+         | ) t where t.rn <= 100
+         |""".stripMargin)
+  }
+
+  @Test
+  def testUnionSinkWithCompositePk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_3' in cdc source may cause wrong result or error")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_composite_pk
+                                 |select a, b, c, d
+                                 |from src
+                                 |union
+                                 |select a, b, c, metadata_3
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testUnionAllSinkWithCompositePk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_3' in cdc source may cause wrong result or error")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_with_composite_pk
+                                 |select a, b, c, d
+                                 |from src
+                                 |union all
+                                 |select a, b, c, metadata_3
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testUnionAllSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "metadata column(s): 'metadata_3' in cdc source may cause wrong result or error")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select a, b, c
+                                 |from src
+                                 |union all
+                                 |select a, metadata_3, c
+                                 |from cdc_with_meta
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinWithNonDeterministicCondition(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): $f4(generated by non-deterministic function: ndFunc ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(s"""
+                                 |insert into sink_without_pk
+                                 |select
+                                 |  t1.a
+                                 |  ,t2.b
+                                 |  ,t1.c
+                                 |from cdc t1 join cdc t2
+                                 |  on ndFunc(t1.b) = ndFunc(t2.b)
+                                 |""".stripMargin)
+  }
+
+  @Test
+  def testProctimeIntervalJoinSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert("""
+                                |insert into sink_without_pk
+                                |SELECT t2.a, t2.c, t1.b FROM T1 t1 JOIN T1 t2 ON
+                                |  t1.a = t2.a AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      """.stripMargin)
+  }
+
+  @Test
+  def testCdcProctimeIntervalJoinOnPkSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert("""
+                                |insert into sink_without_pk
+                                |SELECT t2.a, t2.b, t1.c FROM (
+                                | select *, proctime() proctime from cdc) t1 JOIN
+                                | (select *, proctime() proctime from cdc) t2 ON
+                                |  t1.a = t2.a AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      """.stripMargin)
+  }
+
+  @Test
+  def testCdcProctimeIntervalJoinOnNonPkSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage("can not satisfy the determinism requirement")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert("""
+                                |insert into sink_without_pk
+                                |SELECT t2.a, t2.b, t1.c FROM (
+                                | select *, proctime() proctime from cdc) t1 JOIN
+                                | (select *, proctime() proctime from cdc) t2 ON
+                                |  t1.b = t2.b AND t1.proctime > t2.proctime - INTERVAL '5' SECOND
+      """.stripMargin)
+  }
+
+  @Test
+  def testCdcRowtimeIntervalJoinSinkWithoutPk(): Unit = {
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_without_pk
+        |SELECT t2.a, t1.b, t2.c FROM cdc_with_watermark t1 JOIN cdc_with_watermark t2 ON
+        |  t1.a = t2.a AND t1.op_ts > t2.op_ts - INTERVAL '5' SECOND
+      """.stripMargin)
+  }
+
+  @Test
+  def testCdcRowtimeIntervalJoinSinkWithPk(): Unit = {
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_pk
+        |SELECT t2.a, t1.b, t2.c FROM cdc_with_watermark t1 JOIN cdc_with_watermark t2 ON
+        |  t1.a = t2.a AND t1.op_ts > t2.op_ts - INTERVAL '5' SECOND
+      """.stripMargin)
+  }
+
+  @Test
+  def testJoinKeyContainsUk(): Unit = {
+    util.verifyExecPlan(
+      s"""
+         |select t1.a, t2.`c-day`, t2.b, t2.d
+         |from (
+         |  select a, b, c, d
+         |  from cdc
+         | ) t1
+         |join (
+         |  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+         |  from cdc
+         |) t2
+         |  on t1.a = t2.a
+         |""".stripMargin)
+  }
+
+  @Test
+  def testJoinHasBothSidesUk(): Unit = {
+    util.verifyExecPlan(
+      s"""
+         |select t1.a, t2.a, t2.`c-day`, t2.b, t2.d
+         |from (
+         |  select a, b, c, d
+         |  from cdc
+         | ) t1
+         |join (
+         |  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+         |  from cdc
+         |) t2
+         |  on t1.b = t2.b
+         |""".stripMargin)
+  }
+
+  @Test
+  def testJoinHasBothSidesUkSinkWithoutPk(): Unit = {
+    if (tryResolve) {
+      // sink require all columns be deterministic though join has both side uk
+      thrown.expectMessage(
+        "column(s): c-day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlanInsert(
+      s"""
+         |insert into sink_with_pk
+         |select t1.a, t2.a, t2.`c-day`
+         |from (
+         |  select a, b, c, d
+         |  from cdc
+         | ) t1
+         |join (
+         |  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+         |  from cdc
+         |) t2
+         |  on t1.b = t2.b
+         |""".stripMargin)
+  }
+
+  @Test
+  def testJoinHasSingleSideUk(): Unit = {
+    if (tryResolve) {
+      // the input side without uk requires all columns be deterministic
+      thrown.expectMessage("can not satisfy the determinism requirement")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlan(
+      s"""
+         |select t1.a, t2.`c-day`, t2.b, t2.d
+         |from (
+         |  select a, b, c, d
+         |  from cdc
+         | ) t1
+         |join (
+         |  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+         |  from cdc
+         |) t2
+         |  on t1.b = t2.b
+         |""".stripMargin)
+  }
+
+  @Test
+  def testSemiJoinKeyContainsUk(): Unit = {
+    util.verifyExecPlan(
+      s"""
+         |select t1.a, t1.`c-day`, t1.b, t1.d
+         |from (
+         |  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+         |  from cdc
+         | ) t1
+         |where t1.a in (
+         |  select a from cdc where b > 100
+         |)
+         |""".stripMargin)
+  }
+
+  @Test
+  def testAntiJoinKeyContainsUk(): Unit = {
+
+    util.verifyExecPlan(
+      s"""
+         |select t1.a, t1.`c-day`, t1.b, t1.d
+         |from (
+         |  select a, b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `c-day`, d
+         |  from cdc
+         | ) t1
+         |where t1.a not in (
+         |  select a from cdc where b > 100
+         |)
+         |""".stripMargin)
+  }
+
+  @Test
+  def testSemiJoinWithNonDeterministicConditionSingleSideHasUk(): Unit = {
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): c(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlan(
+      s"""
+         |select t1.a, t1.b, t1.c, t1.d
+         |from (
+         |  select a, b, c, d
+         |  from cdc
+         | ) t1
+         |where t1.c in (
+         |  select CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) c from cdc where b > 100
+         |)
+         |""".stripMargin)
+  }
+
+  @Test
+  def testCdcJoinWithNonDeterministicOutputSinkWithPk(): Unit = {
+    // a real case from FLINK-27369
+    if (tryResolve) {
+      thrown.expectMessage(
+        "The column(s): logistics_time(generated by non-deterministic function: NOW ) can not satisfy the determinism requirement")
+      thrown.expect(classOf[TableException])
+    }
+    util.tableEnv.executeSql(s"""
+                                |CREATE TEMPORARY TABLE t_order (
+                                | order_id INT,
+                                | order_name STRING,
+                                | product_id INT,
+                                | user_id INT,
+                                | PRIMARY KEY(order_id) NOT ENFORCED
+                                |) WITH (
+                                | 'connector' = 'values',
+                                | 'changelog-mode' = 'I,UA,UB,D'
+                                |)""".stripMargin)
+
+    util.tableEnv.executeSql(s"""
+                                |CREATE TEMPORARY TABLE t_logistics (
+                                | logistics_id INT,
+                                | logistics_target STRING,
+                                | logistics_source STRING,
+                                | logistics_time TIMESTAMP(0),
+                                | order_id INT,
+                                | PRIMARY KEY(logistics_id) NOT ENFORCED
+                                |) WITH (
+                                |  'connector' = 'values',
+                                | 'changelog-mode' = 'I,UA,UB,D'
+                                |)""".stripMargin)
+
+    util.tableEnv.executeSql(s"""
+                                |CREATE TEMPORARY TABLE t_join_sink (
+                                | order_id INT,
+                                | order_name STRING,
+                                | logistics_id INT,
+                                | logistics_target STRING,
+                                | logistics_source STRING,
+                                | logistics_time timestamp,
+                                | PRIMARY KEY(order_id) NOT ENFORCED
+                                |) WITH (
+                                | 'connector' = 'values',
+                                | 'sink-insert-only' = 'false'
+                                |)""".stripMargin)
+
+    util.verifyExecPlanInsert(
+      s"""
+         |INSERT INTO t_join_sink
+         |SELECT ord.order_id,
+         |ord.order_name,
+         |logistics.logistics_id,
+         |logistics.logistics_target,
+         |logistics.logistics_source,
+         |now()
+         |FROM t_order AS ord
+         |LEFT JOIN t_logistics AS logistics ON ord.order_id=logistics.order_id
+         |""".stripMargin)
+  }
+
+  @Test
+  def testProctimeDedupOnCdcWithMetadataSinkWithPk(): Unit = {
+    // TODO this should be updated after StreamPhysicalDeduplicate supports consuming update
+    thrown.expectMessage(
+      "StreamPhysicalDeduplicate doesn't support consuming update and delete changes")
+    thrown.expect(classOf[TableException])
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_pk
+        |SELECT a, metadata_3, c
+        |FROM (
+        |  SELECT *,
+        |    ROW_NUMBER() OVER (PARTITION BY a ORDER BY PROCTIME() ASC) as rowNum
+        |  FROM cdc_with_meta
+        |)
+        |WHERE rowNum = 1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testProctimeDedupOnCdcWithMetadataSinkWithoutPk(): Unit = {
+    // TODO this should be updated after StreamPhysicalDeduplicate supports consuming update
+    thrown.expectMessage(
+      "StreamPhysicalDeduplicate doesn't support consuming update and delete changes")
+    thrown.expect(classOf[TableException])
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_without_pk
+        |SELECT a, metadata_3, c
+        |FROM (
+        |  SELECT *,
+        |    ROW_NUMBER() OVER (PARTITION BY a ORDER BY PROCTIME() ASC) as rowNum
+        |  FROM cdc_with_meta
+        |)
+        |WHERE rowNum = 1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testRowtimeDedupOnCdcWithMetadataSinkWithPk(): Unit = {
+    // TODO this should be updated after StreamPhysicalDeduplicate supports consuming update
+    thrown.expectMessage(
+      "StreamPhysicalDeduplicate doesn't support consuming update and delete changes")
+    thrown.expect(classOf[TableException])
+    util.verifyExecPlanInsert(
+      """
+        |insert into sink_with_pk
+        |SELECT a, b, c
+        |FROM (
+        |  SELECT *,
+        |    ROW_NUMBER() OVER (PARTITION BY a ORDER BY op_ts ASC) as rowNum
+        |  FROM cdc_with_meta_and_wm
+        |)
+        |WHERE rowNum = 1
+      """.stripMargin
+    )
+  }
+
+  @Test
+  def testWindowDedupOnCdcWithMetadata(): Unit = {
+    // TODO this should be updated after StreamPhysicalWindowDeduplicate supports consuming update
+    thrown.expectMessage(
+      "StreamPhysicalWindowDeduplicate doesn't support consuming update and delete changes")
+    thrown.expect(classOf[TableException])
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink1 (
+                               | a int,
+                               | b bigint,
+                               | c string,
+                               | ts timestamp(3),
+                               | primary key (a,ts) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    util.verifyExecPlanInsert(
+      """
+        |INSERT INTO sink1
+        |SELECT a, b, c, window_start
+        |FROM (
+        |SELECT *,
+        |   ROW_NUMBER() OVER(PARTITION BY a, window_start, window_end
+        |   ORDER BY op_ts DESC) as rownum
+        |FROM TABLE(TUMBLE(TABLE cdc_with_meta_and_wm, DESCRIPTOR(op_ts), INTERVAL '1' MINUTE))
+        |)
+        |WHERE rownum <= 1""".stripMargin)
+
+  }
+
+  @Test
+  def testNestedSourceWithMultiSink(): Unit = {
+    val ddl =
+      s"""
+         |CREATE TABLE nested_src (
+         |  id int,
+         |  deepNested row<nested1 row<name string, `value` int>,
+         |    nested2 row<num int, flag boolean>>,
+         |  name string,
+         |  metadata_1 int metadata,
+         |  metadata_2 string metadata,
+         |  primary key(id, name) not enforced
+         |) WITH (
+         |  'connector' = 'values',
+         |  'nested-projection-supported' = 'true',
+         |  'changelog-mode' = 'I,UA,UB,D',
+         |  'readable-metadata' = 'metadata_1:INT, metadata_2:STRING, metadata_3:BIGINT'
+         |)
+         |""".stripMargin
+    util.tableEnv.executeSql(ddl)
+
+    util.tableEnv.executeSql(
+      """
+        |create view v1 as
+        |SELECT id,
+        |       deepNested.nested2.num AS a,
+        |       deepNested.nested1.name AS name,
+        |       deepNested.nested1.`value` + deepNested.nested2.num + metadata_1 as b
+        |FROM nested_src
+        |""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink1 (
+                               |  a int,
+                               |  b string,
+                               |  d bigint
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink2 (
+                               |  a int,
+                               |  b string,
+                               |  d bigint
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    val stmtSet = util.tableEnv.createStatementSet()
+    stmtSet.addInsertSql(
+      s"""
+         |insert into sink1
+         |select a, `day`, sum(b)
+         |from (select a, b, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') as `day` from v1) t
+         |group by a, `day`
+         |""".stripMargin)
+    stmtSet.addInsertSql(s"""
+                            |insert into sink2
+                            |select a, name, b
+                            |from v1
+                            |where b > 100
+                            |""".stripMargin)
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlan(stmtSet)
+  }
+
+  @Test
+  def testMultiSinkOnJoinedView(): Unit = {
+    util.tableEnv.executeSql("""
+                               |create temporary table src1 (
+                               |  a int,
+                               |  b bigint,
+                               |  c string,
+                               |  d int,
+                               |  primary key(a, c) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,UB,D'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table src2 (
+                               |  a int,
+                               |  b bigint,
+                               |  c string,
+                               |  d int,
+                               |  primary key(a, c) not enforced
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'changelog-mode' = 'I,UA,UB,D'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink1 (
+                               |  a int,
+                               |  b string,
+                               |  c bigint,
+                               |  d bigint
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql("""
+                               |create temporary table sink2 (
+                               |  a int,
+                               |  b string,
+                               |  c bigint,
+                               |  d string
+                               |) with (
+                               | 'connector' = 'values',
+                               | 'sink-insert-only' = 'false'
+                               |)""".stripMargin)
+
+    util.tableEnv.executeSql(
+      s"""
+         |create temporary view v1 as
+         |select
+         |  t1.a as a, t1.`day` as `day`, t2.b as b, t2.c as c
+         |from (
+         |  select a, b, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd') as `day`
+         |  from src1
+         | ) t1
+         |join (
+         |  select b, CONCAT(c, DATE_FORMAT(CURRENT_TIMESTAMP, 'yyMMdd')) as `day`, c, d
+         |  from src2
+         |) t2
+         | on t1.a = t2.d
+         |""".stripMargin)
+
+    val stmtSet = util.tableEnv.createStatementSet()
+    stmtSet.addInsertSql(s"""
+                            |insert into sink1
+                            |select a, `day`, sum(b), count(distinct c)
+                            |from v1
+                            |group by a, `day`
+                            |""".stripMargin)
+    stmtSet.addInsertSql(s"""
+                            |insert into sink2
+                            |select a, `day`, b, c
+                            |from v1
+                            |where b > 100
+                            |""".stripMargin)
+    if (tryResolve) {
+      thrown.expectMessage(
+        "column(s): day(generated by non-deterministic function: CURRENT_TIMESTAMP ) can not satisfy the determinism")
+      thrown.expect(classOf[TableException])
+    }
+    util.verifyExecPlan(stmtSet)
+  }
+
+  @SerialVersionUID(1L)
+  object TestNonDeterministicUdf extends ScalarFunction {
+    val random = new Random()
+
+    def eval(id: JLong): JLong = {
+      id + random.nextInt()
+    }
+
+    def eval(id: Int): Int = {
+      id + random.nextInt()
+    }
+
+    def eval(id: String): String = {
+      s"$id-${random.nextInt()}"
+    }
+
+    override def isDeterministic: Boolean = false
+  }
+
+  @SerialVersionUID(1L)
+  object TestNonDeterministicUdtf extends TableFunction[String] {
+
+    val random = new Random()
+
+    def eval(id: Int): Unit = {
+      collect(s"${id + random.nextInt()}")
+    }
+
+    def eval(id: String): Unit = {
+      id.split(",").foreach(str => collect(s"$str#${random.nextInt()}"))
+    }
+
+    override def isDeterministic: Boolean = false
+  }
+
+  object TestTestNonDeterministicUdaf extends AggregateFunction[JLong, CountAccumulator] {
+
+    val random = new Random()
+
+    def accumulate(acc: CountAccumulator, in: JLong): Unit = {
+      acc.f0 += (in + random.nextInt())
+    }
+
+    override def getValue(acc: CountAccumulator): JLong = acc.f0
+
+    override def createAccumulator(): CountAccumulator = new CountAccumulator
+
+    override def isDeterministic: Boolean = false
+  }
+
+  /**
+   * This upsert test sink does support getting primary key from table schema. We defined a similar
+   * test sink here not using existing {@link TestingUpsertTableSink} in {@link StreamTestSink}
+   * because it can not get a primary key via 'getTableSchema#getPrimaryKey' call.
+   */
+  final class TestingUpsertSink(
+      val keys: Array[String],
+      val fieldNames: Array[String],
+      val fieldTypes: Array[DataType])
+    extends UpsertStreamTableSink[RowData] {
+    var expectedKeys: Option[Array[String]] = None
+    var expectedIsAppendOnly: Option[Boolean] = None
+
+    override def getTableSchema: TableSchema = {
+      val builder = TableSchema.builder
+      assert(fieldNames.length == fieldTypes.length)
+      builder.fields(fieldNames, fieldTypes)
+      if (null != keys && keys.nonEmpty) {
+        builder.primaryKey(keys: _*)
+      }
+      builder.build()
+    }
+
+    override def setKeyFields(keys: Array[String]): Unit = {
+      if (expectedKeys.isDefined && keys == null) {
+        throw new AssertionError("Provided key fields should not be null.")
+      } else if (expectedKeys.isEmpty) {
+        return
+      }
+    }
+
+    override def setIsAppendOnly(isAppendOnly: JBoolean): Unit = {
+      if (expectedIsAppendOnly.isEmpty) {
+        return
+      }
+    }
+
+    override def getRecordType: TypeInformation[RowData] =
+      InternalTypeInfo.ofFields(fieldTypes.map(_.getLogicalType), fieldNames)
+
+    override def consumeDataStream(
+        dataStream: DataStream[tuple.Tuple2[JBoolean, RowData]]): DataStreamSink[_] = ???
+
+    override def configure(
+        fNames: Array[String],
+        fTypes: Array[TypeInformation[_]]): TestingUpsertSink = {
+      new TestingUpsertSink(keys, fNames, fTypes.map(TypeConversions.fromLegacyInfoToDataType(_)))
+    }
+  }
+
+}
+
+object NonDeterministicDagTest {
+
+  @Parameterized.Parameters(name = "nonDeterministicUpdateStrategy={0}")
+  def parameters(): util.Collection[NonDeterministicUpdateStrategy] = {
+    util.Arrays.asList(
+      NonDeterministicUpdateStrategy.TRY_RESOLVE,
+      NonDeterministicUpdateStrategy.IGNORE)
+  }
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtilTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelOptUtilTest.scala
@@ -24,6 +24,7 @@ import org.apache.flink.streaming.api.scala.StreamExecutionEnvironment
 import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment, _}
 import org.apache.flink.table.api.bridge.scala.{StreamTableEnvironment, _}
 import org.apache.flink.table.api.internal.TableEnvironmentImpl
+import org.apache.flink.table.planner.delegation.PlannerBase
 import org.apache.flink.table.planner.plan.`trait`.{MiniBatchInterval, MiniBatchMode}
 import org.apache.flink.table.planner.runtime.utils.BatchTableEnvUtil
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
@@ -32,8 +33,6 @@ import org.apache.flink.table.planner.utils.TableTestUtil
 import org.apache.calcite.sql.SqlExplainLevel
 import org.junit.{Before, Test}
 import org.junit.Assert.assertEquals
-
-import scala.collection.Seq
 
 class FlinkRelOptUtilTest {
 
@@ -98,6 +97,53 @@ class FlinkRelOptUtilTest {
         |         +- LogicalTableScan
       """.stripMargin
     assertEquals(expected2.trim, FlinkRelOptUtil.toString(rel, SqlExplainLevel.NO_ATTRIBUTES).trim)
+
+    // expect logical rel has no upsertKey info
+    assertEquals(
+      expected1.trim,
+      FlinkRelOptUtil.toString(rel, SqlExplainLevel.EXPPLAN_ATTRIBUTES, withUpsertKey = true).trim)
+  }
+
+  @Test
+  def testToStringWithUpsertKey(): Unit = {
+    val env = StreamExecutionEnvironment.createLocalEnvironment()
+    val tableEnv = StreamTableEnvironment.create(env, TableTestUtil.STREAM_SETTING)
+
+    val table = env.fromElements[(Int, Long, String)]().toTable(tableEnv, 'a, 'b, 'c)
+    tableEnv.registerTable("MyTable", table)
+
+    val sqlQuery =
+      """
+        |WITH t1 AS (SELECT a, c, count(*) cnt FROM MyTable group by a, c),
+        |     t2 AS (SELECT a, max(b) b FROM MyTable WHERE b < 50 group by a)
+        |
+        |SELECT * FROM t1 JOIN t2 ON t1.a = t2.a
+      """.stripMargin
+    val result = tableEnv.sqlQuery(sqlQuery)
+    val rel = TableTestUtil.toRelNode(result)
+    val planner = tableEnv.asInstanceOf[TableEnvironmentImpl].getPlanner.asInstanceOf[PlannerBase]
+    // build optimized rel plan
+    val optimized = planner.optimize(rel)
+    val expected1 =
+      """
+        |Join(joinType=[InnerJoin], where=[=(a, a0)], select=[a, c, cnt, a0, b], leftInputSpec=[HasUniqueKey], rightInputSpec=[JoinKeyContainsUniqueKey], upsertKeys=[[a, c, a0], [a, c]])
+        |:- Exchange(distribution=[hash[a]], upsertKeys=[[a, c]])
+        |:  +- GroupAggregate(groupBy=[a, c], select=[a, c, COUNT(*) AS cnt], upsertKeys=[[a, c]])
+        |:     +- Exchange(distribution=[hash[a, c]])
+        |:        +- Calc(select=[a, c])
+        |:           +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+        |+- Exchange(distribution=[hash[a]], upsertKeys=[[a]])
+        |   +- GroupAggregate(groupBy=[a], select=[a, MAX(b) AS b], upsertKeys=[[a]])
+        |      +- Exchange(distribution=[hash[a]])
+        |         +- Calc(select=[a, b], where=[<(b, 50)])
+        |            +- DataStreamScan(table=[[default_catalog, default_database, MyTable]], fields=[a, b, c])
+      """.stripMargin
+
+    assertEquals(
+      expected1.trim,
+      FlinkRelOptUtil
+        .toString(optimized, SqlExplainLevel.EXPPLAN_ATTRIBUTES, withUpsertKey = true)
+        .trim)
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of the change
this is two main parts of the parent issue FLINK-27849
1. FLINK-28570: Introduces a StreamNonDeterministicPlanResolver to validate and try to solve (lookup join only) the non-deterministic updates problem which may cause wrong result or error
 which introduce a new optimizer option: "table.optimizer.non-deterministic-update.handling" with default value  `IGNORE` to keep the compatibility. When user cares about the effects of non-deterministic updates, the option can be set to `TRY_RESOLVE`, then the inner `StreamNonDeterministicPlanResolver` will validate if there's any non-deterministic updates which may cause wrong result or error, and also try to eliminate the non determinism generated by lookup join node by adding materialization to a new physical lookup joins operator, will raise an error if there still exists other non-deterministic beside lookup join

2. FLINK-28568:  Implements a new lookup join operator (sync mode only) with state to eliminate the non determinism
 which is a followup issue of FLINK-28570 to finish the materialization support in runtime, note that only sync lookup function is supported for now due to some runtime limitation (async lookup join based on the AsyncWaitOperator which has operatror state, and the materialization requirement here needs a keyed state, so unless we invent a new KeyedAsyncWaitOperator here, the work can not be done for now)

## Brief change log
* add 'table.optimizer.non-deterministic-update.handling' to OptimizerConfigOptions
* implement a StreamNonDeterministicPlanResolver to visit all stream physical node and try to rewrite lookup join node with materialization enabled
* add new tests and update existing tests to best effortly covering the new logic 

## Verifying this change
NonDeterministicDagTest KeyedLookupJoinHarnessTest and existing tests


## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)