### PR TITLE
[FLINK-28762][python][format] Support AvroParquetWriters

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/filesystem.md
+++ b/docs/content.zh/docs/connectors/datastream/filesystem.md
@@ -394,6 +394,8 @@ Flink 内置了为 Avro Format 数据创建 Parquet 写入工厂的快捷方法�
 
 {{< artifact flink-parquet withScalaVersion >}}
 
+{{< py_download_link "parquet" >}}
+
 类似这样使用 `FileSink` 写入 Parquet Format 的 Avro 数据：
 
 {{< tabs "4ff7b496-3a80-46f4-9b7d-7a9222672927" >}}
@@ -430,6 +432,21 @@ val sink: FileSink[GenericRecord] = FileSink
 
 input.sinkTo(sink)
 
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+schema = AvroSchema.parse_string(JSON_SCHEMA)
+# data_stream 的数据类型可以为符合 schema 的原生 Python 数据结构，其类型为默认的 Types.PICKLED_BYTE_ARRAY()
+data_stream = ...
+
+avro_type_info = GenericRecordAvroTypeInfo(schema)
+sink = FileSink \
+    .for_bulk_format(OUTPUT_BASE_PATH, AvroParquetWriters.for_generic_record(schema)) \
+    .build()
+
+# 必须通过 map 操作来指定其 Avro 类型信息，用于数据的序列化
+data_stream.map(lambda e: e, output_type=avro_type_info).sink_to(sink)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -391,6 +391,8 @@ To use the Parquet bulk encoder in your application you need to add the followin
 
 {{< artifact flink-parquet withScalaVersion >}}
 
+{{< py_download_link "parquet" >}}
+
 A `FileSink` that writes Avro data to Parquet format can be created like this:
 
 {{< tabs "4ff7b496-3a80-46f4-9b7d-7a9222672927" >}}
@@ -427,6 +429,22 @@ val sink: FileSink[GenericRecord] = FileSink
 
 input.sinkTo(sink)
 
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+schema = AvroSchema.parse_string(JSON_SCHEMA)
+# The element could be vanilla Python data structure matching the schema,
+# which is annotated with default Types.PICKLED_BYTE_ARRAY()
+data_stream = ...
+
+avro_type_info = GenericRecordAvroTypeInfo(schema)
+sink = FileSink \
+    .for_bulk_format(OUTPUT_BASE_PATH, AvroParquetWriters.for_generic_record(schema)) \
+    .build()
+
+# A map to indicate its Avro type info is necessary for serialization
+data_stream.map(lambda e: e, output_type=avro_type_info).sink_to(sink)
 ```
 {{< /tab >}}
 {{< /tabs >}}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetWriters.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetWriters.java
@@ -63,7 +63,15 @@ public class AvroParquetWriters {
     public static ParquetWriterFactory<GenericRecord> forGenericRecord(Schema schema) {
         final String schemaString = schema.toString();
         final ParquetBuilder<GenericRecord> builder =
-                (out) -> createAvroParquetWriter(schemaString, GenericData.get(), out);
+                // Must override the lambda representation because of a bug in shading lambda
+                // serialization, see similar issue FLINK-28043 for more details.
+                new ParquetBuilder<GenericRecord>() {
+                    @Override
+                    public ParquetWriter<GenericRecord> createWriter(OutputFile out)
+                            throws IOException {
+                        return createAvroParquetWriter(schemaString, GenericData.get(), out);
+                    }
+                };
         return new ParquetWriterFactory<>(builder);
     }
 

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -215,6 +215,9 @@ Classes to define formats used together with source & sink:
     - :class:`formats.AvroParquetReaders`:
       A convenience builder to create reader format that reads individual Avro records from a
       Parquet stream. Only GenericRecord is supported in PyFlink.
+    - :class:`formats.AvroParquetWriters`:
+      Convenience builder to create ParquetWriterFactory instances for Avro types. Only
+      GenericRecord is supported in PyFlink.
 
 Other important classes:
 

--- a/flink-python/pyflink/datastream/formats/__init__.py
+++ b/flink-python/pyflink/datastream/formats/__init__.py
@@ -17,11 +17,12 @@
 ################################################################################
 from .avro import AvroSchema, AvroInputFormat, AvroWriters, GenericRecordAvroTypeInfo
 from .csv import CsvSchema, CsvReaderFormat
-from .parquet import AvroParquetReaders, ParquetColumnarRowInputFormat
+from .parquet import AvroParquetReaders, AvroParquetWriters, ParquetColumnarRowInputFormat
 
 __all__ = [
     'AvroInputFormat',
     'AvroParquetReaders',
+    'AvroParquetWriters',
     'AvroSchema',
     'AvroWriters',
     'CsvReaderFormat',

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -16,7 +16,7 @@
 # limitations under the License.
 ################################################################################
 from pyflink.common import Configuration
-from pyflink.datastream.connectors.file_system import StreamFormat, BulkFormat
+from pyflink.datastream.connectors.file_system import StreamFormat, BulkFormat, BulkWriterFactory
 from pyflink.datastream.formats.avro import AvroSchema
 from pyflink.java_gateway import get_gateway
 from pyflink.table.types import RowType, _to_java_data_type
@@ -104,3 +104,12 @@ class ParquetColumnarRowInputFormat(BulkFormat):
         for k, v in config.to_dict().items():
             hadoop_config.set(k, v)
         return hadoop_config
+
+
+class AvroParquetWriters(object):
+
+    @staticmethod
+    def for_generic_record(schema: 'AvroSchema') -> 'BulkWriterFactory':
+        jvm = get_gateway().jvm
+        JAvroParquetWriters = jvm.org.apache.flink.formats.parquet.avro.AvroParquetWriters
+        return BulkWriterFactory(JAvroParquetWriters.forGenericRecord(schema._j_schema))


### PR DESCRIPTION

## What is the purpose of the change

This PR ports `AvroParquetWriters.forGenericRecords` to PyFlink, that users can write vanilla Python objects under a certain Avro schema to Parquet files.

## Verifying this change

This change added tests and can be verified as follows:
- `FileSinkAvroParquetWritersTests` in test_file_system.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs & Python Sphinx doc)
