### PR TITLE
[FLINK-28010][state] Use deleteRange to optimize the clear method of RocksDBMapState.

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -226,6 +226,7 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
 
     /**
      * Similar to decimal addition, add 1 to the last digit to calculate the upper bound.
+     *
      * @param prefix the starting prefix for seek.
      * @return end prefix for seek.
      */

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -223,4 +223,26 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
         throw new UnsupportedOperationException(
                 "Global state entry iterator is unsupported for RocksDb backend");
     }
+
+    /**
+     * Similar to decimal addition, add 1 to the last digit to calculate the upper bound.
+     * @param prefix the starting prefix for seek.
+     * @return end prefix for seek.
+     */
+    protected final byte[] calculateUpperBound(byte[] prefix) {
+        byte[] upperBound = new byte[prefix.length];
+        System.arraycopy(prefix, 0, upperBound, 0, prefix.length);
+        boolean overFlow = true;
+        for (int i = prefix.length - 1; i >= 0; i--) {
+            int unsignedValue = prefix[i] & 0xff;
+            int result = unsignedValue + 1;
+            upperBound[i] = (byte) (result & 0xff);
+            if (result >> 8 == 0) {
+                overFlow = false;
+                break;
+            }
+        }
+        Preconditions.checkArgument(!overFlow, "The upper boundary overflows.");
+        return upperBound;
+    }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/AbstractRocksDBState.java
@@ -235,10 +235,8 @@ public abstract class AbstractRocksDBState<K, N, V> implements InternalKvState<K
         System.arraycopy(prefix, 0, upperBound, 0, prefix.length);
         boolean overFlow = true;
         for (int i = prefix.length - 1; i >= 0; i--) {
-            int unsignedValue = prefix[i] & 0xff;
-            int result = unsignedValue + 1;
-            upperBound[i] = (byte) (result & 0xff);
-            if (result >> 8 == 0) {
+            upperBound[i] = (byte) (prefix[i] + 1);
+            if (prefix[i] != (byte) 0xff) {
                 overFlow = false;
                 break;
             }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -138,7 +138,7 @@ public class RocksDBIncrementalCheckpointUtils {
      * @param beginKeyBytes the begin key bytes
      * @param endKeyBytes the end key bytes
      */
-    public static void deleteRange(
+    static void deleteRange(
             RocksDB db,
             List<ColumnFamilyHandle> columnFamilyHandles,
             byte[] beginKeyBytes,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBIncrementalCheckpointUtils.java
@@ -138,7 +138,7 @@ public class RocksDBIncrementalCheckpointUtils {
      * @param beginKeyBytes the begin key bytes
      * @param endKeyBytes the end key bytes
      */
-    private static void deleteRange(
+    public static void deleteRange(
             RocksDB db,
             List<ColumnFamilyHandle> columnFamilyHandles,
             byte[] beginKeyBytes,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBMapState.java
@@ -53,7 +53,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 
-import static org.apache.flink.contrib.streaming.state.RocksDBIncrementalCheckpointUtils.deleteRange;
 import static org.apache.flink.util.Preconditions.checkArgument;
 
 /**
@@ -283,7 +282,11 @@ class RocksDBMapState<K, N, UK, UV> extends AbstractRocksDBState<K, N, Map<UK, U
         try {
             final byte[] keyPrefixBytes = serializeCurrentKeyWithGroupAndNamespace();
             byte[] upperBound = calculateUpperBound(keyPrefixBytes);
-            deleteRange(backend.db, Collections.singletonList(columnFamily), keyPrefixBytes, upperBound);
+            RocksDBIncrementalCheckpointUtils.deleteRange(
+                    backend.db,
+                    Collections.singletonList(columnFamily),
+                    keyPrefixBytes,
+                    upperBound);
         } catch (RocksDBException e) {
             throw new FlinkRuntimeException("Error while cleaning the state in RocksDB.", e);
         }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/EmbeddedRocksDBStateBackendTest.java
@@ -637,7 +637,7 @@ public class EmbeddedRocksDBStateBackendTest
                             throw new RocksDBException("Artificial failure");
                         })
                 .when(keyedStateBackend.db)
-                .newIterator(any(ColumnFamilyHandle.class), any(ReadOptions.class));
+                .deleteRange(any(ColumnFamilyHandle.class), any(byte[].class), any(byte[].class));
 
         state.clear();
     }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBTestUtils.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.UncompressedStreamCompressionDecorator;
 import org.apache.flink.runtime.state.metrics.LatencyTrackingStateConfig;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
+import org.apache.flink.util.Preconditions;
 
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ColumnFamilyOptions;
@@ -85,7 +86,9 @@ public final class RocksDBTestUtils {
             TypeSerializer<K> keySerializer,
             RocksDB db,
             ColumnFamilyHandle defaultCFHandle,
-            ColumnFamilyOptions columnFamilyOptions) {
+            ColumnFamilyOptions columnFamilyOptions,
+            int numberOfKeyGroups) {
+        Preconditions.checkArgument(numberOfKeyGroups >= 1, "numberOfKeyGroups is less than 1.");
 
         final RocksDBResourceContainer optionsContainer = new RocksDBResourceContainer();
 
@@ -97,8 +100,8 @@ public final class RocksDBTestUtils {
                 stateName -> columnFamilyOptions,
                 new KvStateRegistry().createTaskRegistry(new JobID(), new JobVertexID()),
                 keySerializer,
-                2,
-                new KeyGroupRange(0, 1),
+                numberOfKeyGroups,
+                new KeyGroupRange(0, numberOfKeyGroups - 1),
                 new ExecutionConfig(),
                 TestLocalRecoveryConfig.disabled(),
                 EmbeddedRocksDBStateBackend.PriorityQueueStateType.HEAP,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pull request will use `deleteRange` to optimize the `clear` method of `RocksDBMapState`.



## Brief change log
Replace RocksDB's `Iterator` with `deleteRange`.


## Verifying this change
This change is already covered by existing tests, such as 

- org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackendTest#testMapStateClear
- org.apache.flink.runtime.state.StateBackendTestBase#testMapState

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
