### PR TITLE
[FLINK-28768][tests][testinfrastructure] Update junit to 5.9.1

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendSavepointTest.java
@@ -288,7 +288,7 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
     }
 
     @BeforeEach
-    private void replaceStdOutAndStdErr() {
+    void replaceStdOutAndStdErr() {
         stdOut = System.out;
         stdErr = System.err;
         buffer = new ByteArrayOutputStream();
@@ -298,7 +298,7 @@ class CliFrontendSavepointTest extends CliFrontendTestBase {
     }
 
     @AfterEach
-    private void restoreStdOutAndStdErr() {
+    void restoreStdOutAndStdErr() {
         System.setOut(stdOut);
         System.setErr(stdErr);
     }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
@@ -70,7 +70,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /** smoke test for the kafka connectors. */
 @ExtendWith({TestLoggerExtension.class})
 @Testcontainers
-public class SmokeKafkaITCase {
+class SmokeKafkaITCase {
 
     private static final Logger LOG = LoggerFactory.getLogger(SmokeKafkaITCase.class);
     private static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
@@ -107,7 +107,7 @@ public class SmokeKafkaITCase {
     }
 
     @BeforeAll
-    private static void setUp() {
+    static void setUp() {
         final Map<String, Object> adminProperties = new HashMap<>();
         adminProperties.put(
                 CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
@@ -122,7 +122,7 @@ public class SmokeKafkaITCase {
     }
 
     @AfterAll
-    private static void teardown() {
+    static void teardown() {
         admin.close();
         producer.close();
     }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/dist/DynamicParameterITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/test/java/org/apache/flink/dist/DynamicParameterITCase.java
@@ -59,13 +59,13 @@ class DynamicParameterITCase {
     private FlinkDistribution dist;
 
     @BeforeEach
-    private void setup(@TempDir Path tmp) throws IOException {
+    void setup(@TempDir Path tmp) throws IOException {
         TestUtils.copyDirectory(originalDist, tmp);
         dist = new FlinkDistribution(tmp);
     }
 
     @AfterEach
-    private void cleanup() throws IOException {
+    void cleanup() throws IOException {
         if (dist != null) {
             dist.stopFlinkCluster();
         }

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarDeleteHandlerTest.java
@@ -59,7 +59,7 @@ class JarDeleteHandlerTest {
     private Path jarDir;
 
     @BeforeEach
-    private void setUp(@TempDir File tempDir) throws Exception {
+    void setUp(@TempDir File tempDir) throws Exception {
         jarDir = tempDir.toPath();
         restfulGateway = new TestingRestfulGateway.Builder().build();
         jarDeleteHandler =

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/handlers/JarHandlerParameterTest.java
@@ -124,7 +124,7 @@ abstract class JarHandlerParameterTest<
     }
 
     @BeforeEach
-    private void reset() {
+    void reset() {
         ParameterProgram.actualArguments = null;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestExternalHandlersITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/RestExternalHandlersITCase.java
@@ -33,13 +33,14 @@ import org.apache.flink.runtime.rest.util.TestRestServerEndpoint;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.testutils.junit.extensions.ContextClassLoaderExtension;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -54,7 +55,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /** IT cases for {@link RestClient} and {@link RestServerEndpoint}. */
-public class RestExternalHandlersITCase extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+class RestExternalHandlersITCase {
 
     private static final Time timeout = Time.seconds(10L);
     private static final String REQUEST_URL = "/nonExisting1";
@@ -102,14 +104,14 @@ public class RestExternalHandlersITCase extends TestLogger {
     }
 
     @BeforeEach
-    private void setup() throws Exception {
+    void setup() throws Exception {
         serverEndpoint = TestRestServerEndpoint.builder(config).buildAndStart();
         restClient = new RestClient(config, EXECUTOR_RESOURCE.getExecutor());
         serverAddress = serverEndpoint.getServerAddress();
     }
 
     @AfterEach
-    private void teardown() throws Exception {
+    void teardown() throws Exception {
         if (restClient != null) {
             restClient.shutdown(timeout);
             restClient = null;

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@ under the License.
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
-		<junit5.version>5.8.1</junit5.version>
+		<junit5.version>5.9.1</junit5.version>
 		<archunit.version>0.22.0</archunit.version>
 		<mockito.version>3.4.6</mockito.version>
 		<powermock.version>2.0.9</powermock.version>


### PR DESCRIPTION
## What is the purpose of the change

*   Update JUnit5 dependency to the latest available version (5.9.1)
*   Remove `private` modifiers from methods annotated with `BeforeAll`, `AfterAll`, `BeforeEach`, `AfterEach` since now it fails (also mentioned in junit's release notes https://junit.org/junit5/docs/current/release-notes/#deprecations-and-breaking-changes-2)


## Brief change log

* Updated reference in POM
* Updated test classes (modofiers)


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no )
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
