### PR TITLE
[FLINK-28771][runtime] Assign speculative execution attempt with correct CREATED timestamp

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeSchedulerTest.java
@@ -132,11 +132,17 @@ class SpeculativeSchedulerTest {
 
         assertThat(testExecutionOperations.getDeployedExecutions()).hasSize(1);
 
+        final long timestamp = System.currentTimeMillis();
         notifySlowTask(scheduler, attempt1);
 
         assertThat(testExecutionOperations.getDeployedExecutions()).hasSize(2);
         assertThat(testBlocklistOperations.getAllBlockedNodeIds())
                 .containsExactly(attempt1.getAssignedResourceLocation().getNodeId());
+
+        final Execution attempt2 = getExecution(ev, 1);
+        assertThat(attempt2.getState()).isEqualTo(ExecutionState.DEPLOYING);
+        assertThat(attempt2.getStateTimestamp(ExecutionState.CREATED))
+                .isGreaterThanOrEqualTo(timestamp);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Currently, newly created speculative execution attempt is assigned with a wrong CREATED timestamp in SpeculativeScheduler. We need to fix it.

## Verifying this change
  - *Added unit tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
