### PR TITLE
[FLINK-28418][table] Add runtime provider interfaces for partial caching lookup

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/PartialCachingAsyncLookupProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/PartialCachingAsyncLookupProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.functions.AsyncLookupFunction;
+
+/**
+ * Provider for creating {@link AsyncLookupFunction} and {@link LookupCache} for storing lookup
+ * entries.
+ */
+@PublicEvolving
+public interface PartialCachingAsyncLookupProvider extends AsyncLookupFunctionProvider {
+
+    /**
+     * Build a {@link PartialCachingAsyncLookupProvider} from the specified {@link
+     * AsyncLookupFunction} and {@link LookupCache}.
+     */
+    static PartialCachingAsyncLookupProvider of(
+            AsyncLookupFunction asyncLookupFunction, LookupCache cache) {
+        return new PartialCachingAsyncLookupProvider() {
+            @Override
+            public LookupCache getCache() {
+                return cache;
+            }
+
+            @Override
+            public AsyncLookupFunction createAsyncLookupFunction() {
+                return asyncLookupFunction;
+            }
+        };
+    }
+
+    /** Get a new instance of {@link LookupCache}. */
+    LookupCache getCache();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/PartialCachingLookupProvider.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/PartialCachingLookupProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.functions.LookupFunction;
+
+/**
+ * Provider for creating {@link LookupFunction} and {@link LookupCache} for storing lookup entries.
+ */
+@PublicEvolving
+public interface PartialCachingLookupProvider extends LookupFunctionProvider {
+
+    /**
+     * Build a {@link PartialCachingLookupProvider} from the specified {@link LookupFunction} and
+     * {@link LookupCache}.
+     */
+    static PartialCachingLookupProvider of(LookupFunction lookupFunction, LookupCache cache) {
+        return new PartialCachingLookupProvider() {
+
+            @Override
+            public LookupCache getCache() {
+                return cache;
+            }
+
+            @Override
+            public LookupFunction createLookupFunction() {
+                return lookupFunction;
+            }
+        };
+    }
+
+    /** Get a new instance of {@link LookupCache}. */
+    LookupCache getCache();
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces 2 new interfaces, `PartialCachingLookupProvider` and `PartialCachingAsyncLookupProvider` for supporting partial caching lookup table.


## Brief change log
- Add runtime provider interfaces for partial caching lookup


## Verifying this change

This change only introduces two new interfaces so no tests are required.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
