### PR TITLE
[FLINK-28776][table-planner] RowTimeMiniBatchAssginerOperator doesn't…

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssginerOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/wmassigners/RowTimeMiniBatchAssginerOperator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.runtime.operators.wmassigners;
 
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -57,6 +58,7 @@ public class RowTimeMiniBatchAssginerOperator extends AbstractStreamOperator<Row
 
     public RowTimeMiniBatchAssginerOperator(long minibatchInterval) {
         this.minibatchInterval = minibatchInterval;
+        this.chainingStrategy = ChainingStrategy.ALWAYS;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*RowTimeMiniBatchAssginerOperator doesn't need separate chain with upstream WatermarkAssignerOperator*

