### PR TITLE
[FLINK-28732][state] Deprecate ambiguous StateTTLConfig#cleanFullSnapshot API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/state.md
@@ -429,7 +429,8 @@ ttl_config = StateTtlConfig \
 
 #### 全量快照时进行清理
 
-另外，你可以启用全量快照时进行清理的策略，这可以减少整个快照的大小。当前实现中不会清理本地的状态，但从上次快照恢复时，不会恢复那些已经删除的过期数据。
+另外，你可以启用全量扫描类型的快照(仅包括所有state-backend的标准格式的savepoint，hashmap state-backend的checkpoint或原生格式savepoint)时进行清理的策略，
+这可以减少整个快照的大小。当前实现中不会清理本地的状态，但从上次快照恢复时，不会恢复那些已经删除的过期数据。
 该策略可以通过 `StateTtlConfig` 配置进行配置：
 
 {{< tabs "77959bcd-25cb-476a-893f-53424a723f0e" >}}
@@ -440,7 +441,7 @@ import org.apache.flink.api.common.time.Time;
 
 StateTtlConfig ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
-    .cleanupFullSnapshot()
+    .cleanupOnFullScanSnapshot()
     .build();
 ```
 {{< /tab >}}
@@ -451,7 +452,7 @@ import org.apache.flink.api.common.time.Time
 
 val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
-    .cleanupFullSnapshot
+    .cleanupOnFullScanSnapshot
     .build
 ```
 {{< /tab >}}

--- a/docs/content/docs/dev/datastream/fault-tolerance/state.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/state.md
@@ -474,9 +474,10 @@ ttl_config = StateTtlConfig \
 For more fine-grained control over some special cleanup in background, you can configure it separately as described below.
 Currently, heap state backend relies on incremental cleanup and RocksDB backend uses compaction filter for background cleanup.
 
-##### Cleanup in full snapshot
+##### Cleanup in full scan snapshot
 
-Additionally, you can activate the cleanup at the moment of taking the full state snapshot which 
+Additionally, you can activate the cleanup at the moment of taking the full scan state snapshot (means the 
+canonical savepoint of all state-backends, or the checkpoint/native-savepoint of hashmap state-backend.), which 
 will reduce its size. The local state is not cleaned up under the current implementation 
 but it will not include the removed expired state in case of restoration from the previous snapshot.
 It can be configured in `StateTtlConfig`:
@@ -489,7 +490,7 @@ import org.apache.flink.api.common.time.Time;
 
 StateTtlConfig ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
-    .cleanupFullSnapshot()
+    .cleanupOnFullScanSnapshot()
     .build();
 ```
 {{< /tab >}}
@@ -500,7 +501,7 @@ import org.apache.flink.api.common.time.Time
 
 val ttlConfig = StateTtlConfig
     .newBuilder(Time.seconds(1))
-    .cleanupFullSnapshot
+    .cleanupOnFullScanSnapshot
     .build
 ```
 {{< /tab >}}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/StateTtlConfig.java
@@ -234,9 +234,21 @@ public class StateTtlConfig implements Serializable {
             return setTtlTimeCharacteristic(ProcessingTime);
         }
 
-        /** Cleanup expired state in full snapshot on checkpoint. */
+        /** @deprecated use {@link #cleanupOnFullScanSnapshot()} instead. */
         @Nonnull
+        @Deprecated
         public Builder cleanupFullSnapshot() {
+            return cleanupOnFullScanSnapshot();
+        }
+
+        /**
+         * Cleanup expired state in full scan snapshot on checkpoint/savepoint.
+         *
+         * <p>Note: "Full scan snapshot" means the canonical savepoint of all state-backends, or the
+         * checkpoint/native-savepoint of hashmap state-backend.
+         */
+        @Nonnull
+        public Builder cleanupOnFullScanSnapshot() {
             strategies.put(CleanupStrategies.Strategies.FULL_STATE_SCAN_SNAPSHOT, EMPTY_STRATEGY);
             return this;
         }

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/DataStreamStateTTLTestProgram.java
@@ -60,7 +60,7 @@ public class DataStreamStateTTLTestProgram {
 
         TtlTestConfig config = TtlTestConfig.fromArgs(pt);
         StateTtlConfig ttlConfig =
-                StateTtlConfig.newBuilder(config.ttl).cleanupFullSnapshot().build();
+                StateTtlConfig.newBuilder(config.ttl).cleanupOnFullScanSnapshot().build();
 
         env.addSource(
                         new TtlStateUpdateSource(

--- a/flink-python/src/main/java/org/apache/flink/python/util/ProtoUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/ProtoUtils.java
@@ -454,7 +454,7 @@ public enum ProtoUtils {
             if (strategyProto
                     == FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
                             .FULL_STATE_SCAN_SNAPSHOT) {
-                builder.cleanupFullSnapshot();
+                builder.cleanupOnFullScanSnapshot();
             } else if (strategyProto
                     == FlinkFnApi.StateDescriptor.StateTTLConfig.CleanupStrategies.Strategies
                             .INCREMENTAL_CLEANUP) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/ttl/TtlStateTestBase.java
@@ -95,7 +95,7 @@ public abstract class TtlStateTestBase {
                 new TtlReducingStateTestContext());
     }
 
-    public boolean isSavepoint() {
+    public boolean isFullScanSnapshot() {
         return true;
     }
 
@@ -354,8 +354,8 @@ public abstract class TtlStateTestBase {
 
     @Test
     public void testMultipleKeysWithSnapshotCleanup() throws Exception {
-        assumeTrue("full snapshot strategy", isSavepoint());
-        initTest(getConfBuilder(TTL).cleanupFullSnapshot().build());
+        assumeTrue("full snapshot strategy", isFullScanSnapshot());
+        initTest(getConfBuilder(TTL).cleanupOnFullScanSnapshot().build());
         // set time back after restore to see entry unexpired if it was not cleaned up in snapshot
         // properly
         testMultipleStateIds(id -> sbetc.setCurrentKey(id), true);
@@ -369,8 +369,8 @@ public abstract class TtlStateTestBase {
 
     @Test
     public void testMultipleNamespacesWithSnapshotCleanup() throws Exception {
-        assumeTrue("full snapshot strategy", isSavepoint());
-        initTest(getConfBuilder(TTL).cleanupFullSnapshot().build());
+        assumeTrue("full snapshot strategy", isFullScanSnapshot());
+        initTest(getConfBuilder(TTL).cleanupOnFullScanSnapshot().build());
         // set time back after restore to see entry unexpired if it was not cleaned up in snapshot
         // properly
         testMultipleStateIds(id -> ctx().ttlState.setCurrentNamespace(id), true);

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/FullSnapshotRocksDbTtlStateTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/FullSnapshotRocksDbTtlStateTest.java
@@ -29,7 +29,7 @@ public class FullSnapshotRocksDbTtlStateTest extends RocksDBTtlStateTestBase {
     }
 
     @Override
-    public boolean isSavepoint() {
+    public boolean isFullScanSnapshot() {
         return false;
     }
 }

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/IncSnapshotRocksDbTtlStateTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/ttl/IncSnapshotRocksDbTtlStateTest.java
@@ -29,7 +29,7 @@ public class IncSnapshotRocksDbTtlStateTest extends RocksDBTtlStateTestBase {
     }
 
     @Override
-    public boolean isSavepoint() {
+    public boolean isFullScanSnapshot() {
         return false;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR deprecates the ambiguous StateTTLConfig#cleanFullSnapshot API with the newly introduced `#cleanupOnFullScanSnapshot` API.

## Brief change log
1. Deprecate the StateTTLConfig#cleanFullSnapshot API
2. Introduce StateTTLConfig#cleanupOnFullScanSnapshot API
3. Add docs to describe the difference.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
