### PR TITLE
[FLINK-28778][SQL/API] Bulk fetch of table and column statistics for given partitions

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.catalog.hive;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.java.hadoop.mapred.utils.HadoopUtils;
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connectors.hive.HiveDynamicTableFactory;
 import org.apache.flink.connectors.hive.HiveTableFactory;
 import org.apache.flink.sql.parser.hive.ddl.HiveDDLUtils;
@@ -1700,6 +1701,76 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
+    public List<CatalogTableStatistics> getPartitionsStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException {
+
+        return getPartitions(tablePath, partitionSpecs).f0.stream()
+                .map(p -> createCatalogTableStatistics(p.getParameters()))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * @return Partitions and names of partitions
+     */
+    private Tuple2<List<Partition>, List<String>> getPartitions(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException {
+
+        checkNotNull(partitionSpecs);
+
+        // if TableNotExistException is thrown while getting the hive table,
+        // use the first partitionSpec to a new PartitionNotExistException.
+        CatalogPartitionSpec partitionSpec = partitionSpecs.get(0);
+        List<Partition> partitions = new ArrayList<>(partitionSpecs.size());
+        List<String> partitionsNames = new ArrayList<>(partitionSpecs.size());
+
+        try {
+            Table hiveTable = getHiveTable(tablePath);
+
+            for (CatalogPartitionSpec partSpec : partitionSpecs) {
+                partitionSpec = partSpec;
+                partitionsNames.add(getEscapedPartitionName(tablePath, partSpec, hiveTable));
+            }
+
+            partitions.addAll(
+                    client.getPartitionsByNames(
+                            hiveTable.getDbName(), hiveTable.getTableName(), partitionsNames));
+        } catch (TableNotExistException | PartitionSpecInvalidException e) {
+            throw new PartitionNotExistException(getName(), tablePath, partitionSpec, e);
+        } catch (TException e) {
+            throw new CatalogException(
+                    String.format(
+                            "Failed to get partition stats of table %s 's partition %s",
+                            tablePath.getFullName(), String.valueOf(partitionSpec)),
+                    e);
+        }
+
+        return Tuple2.of(partitions, partitionsNames);
+    }
+
+    private Tuple2<Table, List<String>> getPartitionsNames(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException {
+
+        CatalogPartitionSpec partitionSpec = partitionSpecs.get(0);
+        List<String> partitionsNames = new ArrayList<>(partitionSpecs.size());
+        Table hiveTable = null;
+
+        try {
+            hiveTable = getHiveTable(tablePath);
+
+            for (CatalogPartitionSpec partSpec : partitionSpecs) {
+                partitionSpec = partSpec;
+                partitionsNames.add(getEscapedPartitionName(tablePath, partSpec, hiveTable));
+            }
+        } catch (TableNotExistException | PartitionSpecInvalidException e) {
+            throw new PartitionNotExistException(getName(), tablePath, partitionSpec, e);
+        }
+        return Tuple2.of(hiveTable, partitionsNames);
+    }
+
+    @Override
     public CatalogColumnStatistics getPartitionColumnStatistics(
             ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
             throws PartitionNotExistException, CatalogException {
@@ -1732,6 +1803,49 @@ public class HiveCatalog extends AbstractCatalog {
                             tablePath.getFullName(), String.valueOf(partitionSpec)),
                     e);
         }
+    }
+
+    @Override
+    public List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException {
+
+        checkNotNull(partitionSpecs);
+
+        List<CatalogColumnStatistics> result = new ArrayList<>(partitionSpecs.size());
+
+        final Tuple2<Table, List<String>> partitionsTuple2 =
+                getPartitionsNames(tablePath, partitionSpecs);
+
+        try {
+            Map<String, List<ColumnStatisticsObj>> partitionColumnStatistics =
+                    client.getPartitionColumnStatistics(
+                            partitionsTuple2.f0.getDbName(),
+                            partitionsTuple2.f0.getTableName(),
+                            partitionsTuple2.f1,
+                            getFieldNames(partitionsTuple2.f0.getSd().getCols()));
+
+            for (String partitionName : partitionsTuple2.f1) {
+                List<ColumnStatisticsObj> columnStatisticsObjs =
+                        partitionColumnStatistics.get(partitionName);
+                if (columnStatisticsObjs != null && !columnStatisticsObjs.isEmpty()) {
+                    result.add(
+                            new CatalogColumnStatistics(
+                                    HiveStatsUtil.createCatalogColumnStats(
+                                            columnStatisticsObjs, hiveVersion)));
+                } else {
+                    result.add(CatalogColumnStatistics.UNKNOWN);
+                }
+            }
+        } catch (TException e) {
+            throw new CatalogException(
+                    String.format(
+                            "Failed to get table stats of table %s 's partitions %s",
+                            tablePath.getFullName(), String.valueOf(partitionSpecs)),
+                    e);
+        }
+
+        return result;
     }
 
     @Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -1717,7 +1717,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public List<CatalogTableStatistics> getTableStatistics(
+    public List<CatalogTableStatistics> bulkGetPartitionStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 
@@ -1726,9 +1726,7 @@ public class HiveCatalog extends AbstractCatalog {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * @return Partitions and names of partitions
-     */
+    /** @return Partitions and names of partitions. */
     private Tuple3<Table, List<Partition>, List<String>> getTableAndPartitions(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
@@ -1755,9 +1753,7 @@ public class HiveCatalog extends AbstractCatalog {
         return Tuple3.of(partitionsNamesTuple2.f0, partitions, partitionsNamesTuple2.f1);
     }
 
-    /**
-     * @return Table and names of partitions.
-     */
+    /** @return Table and names of partitions. */
     private Tuple2<Table, List<String>> getTableAndPartitionsNames(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException {
@@ -1819,7 +1815,7 @@ public class HiveCatalog extends AbstractCatalog {
     }
 
     @Override
-    public List<CatalogColumnStatistics> getTableColumnStatistics(
+    public List<CatalogColumnStatistics> bulkGetPartitionColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataDate;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataDouble;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataLong;
 import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
+import org.apache.flink.table.catalog.stats.Date;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 
@@ -379,5 +380,72 @@ public class HiveStatsUtil {
             long v = Long.parseLong(value);
             return v > 0 ? v : DEFAULT_UNKNOWN_STATS_VALUE;
         }
+    }
+
+    // Utilities for merge statistic
+    private static Double average(Double a, Long ac, Double b, Long bc) {
+        if (a == null || ac == null) {
+            return b;
+        }
+        if (b == null || bc == null) {
+            return a;
+        }
+        return ac + bc == 0 ? null : (a * ac + b * bc) / (ac + bc);
+    }
+
+    public static Long min(Long a, Long b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+
+        return Math.min(a, b);
+    }
+
+    private static Double min(Double a, Double b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+
+        return Math.min(a, b);
+    }
+
+    private static Date min(Date a, Date b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+
+        return a.getDaysSinceEpoch() <= b.getDaysSinceEpoch() ? a : b;
+    }
+
+    public static Long max(Long a, Long b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+
+        return Math.max(a, b);
+    }
+
+    private static Double max(Double a, Double b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+
+        return Math.max(a, b);
+    }
+
+    private static Date max(Date a, Date b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+
+        return a.getDaysSinceEpoch() >= b.getDaysSinceEpoch() ? a : b;
+    }
+
+    public static Long add(Long a, Long b) {
+        if (a == null || b == null) {
+            return a == null ? b : a;
+        }
+
+        return a + b;
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/catalog/hive/HiveCatalogHiveMetadataTest.java
@@ -298,11 +298,11 @@ class HiveCatalogHiveMetadataTest extends HiveCatalogMetadataTestBase {
                         .collect(Collectors.toList());
 
         final List<CatalogTableStatistics> partitionStatistics =
-                catalog.getTableStatistics(path1, catalogPartitionSpecList);
+                catalog.bulkGetPartitionStatistics(path1, catalogPartitionSpecList);
         assertThat(partitionStatistics.size()).isEqualTo(partitionSpecs.size());
 
         final List<CatalogColumnStatistics> tableColumnStatistics =
-                catalog.getTableColumnStatistics(path1, catalogPartitionSpecList);
+                catalog.bulkGetPartitionColumnStatistics(path1, catalogPartitionSpecList);
 
         assertThat(tableColumnStatistics.size()).isEqualTo(catalogPartitionSpecList.size() + 1);
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -63,6 +63,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -79,6 +80,7 @@ import static org.apache.flink.connector.jdbc.table.JdbcConnectorOptions.USERNAM
 import static org.apache.flink.connector.jdbc.table.JdbcDynamicTableFactory.IDENTIFIER;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Abstract catalog for any JDBC catalogs. */
 public abstract class AbstractJdbcCatalog extends AbstractCatalog {
@@ -436,6 +438,38 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
             ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
             throws PartitionNotExistException, CatalogException {
         return CatalogTableStatistics.UNKNOWN;
+    }
+
+    @Override
+    public List<CatalogTableStatistics> getPartitionsStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException {
+
+        checkNotNull(partitionSpecs);
+        int size = partitionSpecs.size();
+
+        List<CatalogTableStatistics> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            result.add(CatalogTableStatistics.UNKNOWN);
+        }
+
+        return result;
+    }
+
+    @Override
+    public List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException {
+
+        checkNotNull(partitionSpecs);
+        int size = partitionSpecs.size();
+
+        List<CatalogColumnStatistics> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            result.add(CatalogColumnStatistics.UNKNOWN);
+        }
+
+        return result;
     }
 
     @Override

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -441,7 +441,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
     }
 
     @Override
-    public List<CatalogTableStatistics> getTableStatistics(
+    public List<CatalogTableStatistics> bulkGetPartitionStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 
@@ -457,7 +457,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
     }
 
     @Override
-    public List<CatalogColumnStatistics> getTableColumnStatistics(
+    public List<CatalogColumnStatistics> bulkGetPartitionColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/catalog/AbstractJdbcCatalog.java
@@ -441,7 +441,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
     }
 
     @Override
-    public List<CatalogTableStatistics> getPartitionsStatistics(
+    public List<CatalogTableStatistics> getTableStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 
@@ -457,7 +457,7 @@ public abstract class AbstractJdbcCatalog extends AbstractCatalog {
     }
 
     @Override
-    public List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+    public List<CatalogColumnStatistics> getTableColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -725,7 +725,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
      * CatalogPartitionSpec)} for each partition.
      */
     @Override
-    public List<CatalogTableStatistics> getTableStatistics(
+    public List<CatalogTableStatistics> bulkGetPartitionStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 
@@ -759,7 +759,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
      * CatalogPartitionSpec)} for each partition.
      */
     @Override
-    public List<CatalogColumnStatistics> getTableColumnStatistics(
+    public List<CatalogColumnStatistics> bulkGetPartitionColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -725,7 +725,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
      * CatalogPartitionSpec)} for each partition.
      */
     @Override
-    public List<CatalogTableStatistics> getPartitionsStatistics(
+    public List<CatalogTableStatistics> getTableStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 
@@ -759,7 +759,7 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
      * CatalogPartitionSpec)} for each partition.
      */
     @Override
-    public List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+    public List<CatalogColumnStatistics> getTableColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/GenericInMemoryCatalog.java
@@ -720,6 +720,25 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
         return result != null ? result.copy() : CatalogTableStatistics.UNKNOWN;
     }
 
+    /**
+     * For in memory catalog, just iteratively call {@link #getPartitionStatistics(ObjectPath,
+     * CatalogPartitionSpec)} for each partition.
+     */
+    @Override
+    public List<CatalogTableStatistics> getPartitionsStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException {
+
+        checkNotNull(partitionSpecs);
+        List<CatalogTableStatistics> result = new ArrayList<>(partitionSpecs.size());
+
+        for (CatalogPartitionSpec partitionSpec : partitionSpecs) {
+            result.add(getPartitionStatistics(tablePath, partitionSpec));
+        }
+
+        return result;
+    }
+
     @Override
     public CatalogColumnStatistics getPartitionColumnStatistics(
             ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
@@ -733,6 +752,25 @@ public class GenericInMemoryCatalog extends AbstractCatalog {
 
         CatalogColumnStatistics result = partitionColumnStats.get(tablePath).get(partitionSpec);
         return result != null ? result.copy() : CatalogColumnStatistics.UNKNOWN;
+    }
+
+    /**
+     * For in memory catalog, just iteratively call {@link #getPartitionColumnStatistics(ObjectPath,
+     * CatalogPartitionSpec)} for each partition.
+     */
+    @Override
+    public List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException {
+
+        checkNotNull(partitionSpecs);
+        List<CatalogColumnStatistics> result = new ArrayList<>(partitionSpecs.size());
+
+        for (CatalogPartitionSpec partitionSpec : partitionSpecs) {
+            result.add(getPartitionColumnStatistics(tablePath, partitionSpec));
+        }
+
+        return result;
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -40,6 +40,7 @@ import org.apache.flink.table.factories.Factory;
 import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.factories.TableFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -573,9 +574,11 @@ public interface Catalog {
      * @throws PartitionNotExistException if one partition does not exist
      * @throws CatalogException in case of any runtime exception
      */
-    List<CatalogTableStatistics> getTableStatistics(
+    default List<CatalogTableStatistics> bulkGetPartitionStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
-            throws PartitionNotExistException, CatalogException;
+            throws PartitionNotExistException, CatalogException {
+        return new ArrayList<>(0);
+    }
 
     /**
      * Get the column statistics of a partition.
@@ -601,9 +604,21 @@ public interface Catalog {
      * @throws PartitionNotExistException if one partition does not exist
      * @throws CatalogException in case of any runtime exception
      */
-    List<CatalogColumnStatistics> getTableColumnStatistics(
+    default List<CatalogColumnStatistics> bulkGetPartitionColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
-            throws PartitionNotExistException, CatalogException;
+            throws PartitionNotExistException, CatalogException {
+        return new ArrayList<>(0);
+    }
+
+    /**
+     * SQL planner can use this method to identify if the catalog implementation support bulk get or
+     * not. The default catalog implementation does not support bulk get.
+     *
+     * @return true means bulk get is supported.
+     */
+    default boolean isBulkGetSupported() {
+        return false;
+    }
 
     /**
      * Update the statistics of a table.

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -311,11 +311,7 @@ public interface Catalog {
     void alterTable(ObjectPath tablePath, CatalogBaseTable newTable, boolean ignoreIfNotExists)
             throws TableNotExistException, CatalogException;
 
-    /**
-     * If true, tables which do not specify a connector will be translated to managed tables.
-     *
-     * @see CatalogBaseTable.TableKind#MANAGED
-     */
+    /** If true, tables which do not specify a connector will be translated to managed tables. */
     default boolean supportsManagedTable() {
         return false;
     }
@@ -567,6 +563,19 @@ public interface Catalog {
             throws PartitionNotExistException, CatalogException;
 
     /**
+     * Get a list of statistics of given partitions.
+     *
+     * @param tablePath path of the table
+     * @param partitionSpecs partition specs of partitions
+     * @return list of statistics of given partitions
+     * @throws PartitionNotExistException if one partition does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    List<CatalogTableStatistics> getPartitionsStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+            throws PartitionNotExistException, CatalogException;
+
+    /**
      * Get the column statistics of a partition.
      *
      * @param tablePath path of the table
@@ -577,6 +586,19 @@ public interface Catalog {
      */
     CatalogColumnStatistics getPartitionColumnStatistics(
             ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
+            throws PartitionNotExistException, CatalogException;
+
+    /**
+     * Get a list of column statistics for given partitions.
+     *
+     * @param tablePath path of the table
+     * @param partitionSpecs partition specs of partitions
+     * @return list of column statistics for given partitions
+     * @throws PartitionNotExistException if one partition does not exist
+     * @throws CatalogException in case of any runtime exception
+     */
+    List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+            ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException;
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -566,7 +566,9 @@ public interface Catalog {
      * Get a list of statistics of given partitions.
      *
      * @param tablePath path of the table
-     * @param partitionSpecs partition specs of partitions
+     * @param partitionSpecs partition specs of partitions that will be used to filter out all other
+     *     unrelated statistics, i.e. the statistics fetch will be limited within the given
+     *     partitions
      * @return list of statistics of given partitions
      * @throws PartitionNotExistException if one partition does not exist
      * @throws CatalogException in case of any runtime exception
@@ -592,7 +594,9 @@ public interface Catalog {
      * Get a list of column statistics for given partitions.
      *
      * @param tablePath path of the table
-     * @param partitionSpecs partition specs of partitions
+     * @param partitionSpecs partition specs of partitions that will be used to filter out all other
+     *     unrelated statistics, i.e. the statistics fetch will be limited within the given
+     *     partitions
      * @return list of column statistics for given partitions
      * @throws PartitionNotExistException if one partition does not exist
      * @throws CatalogException in case of any runtime exception

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -44,6 +44,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * This interface is responsible for reading and writing metadata such as database/table/views/UDFs
  * from a registered catalog. It connects a registered catalog and Flink's Table API. This interface
@@ -577,7 +579,15 @@ public interface Catalog {
     default List<CatalogTableStatistics> bulkGetPartitionStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
-        return new ArrayList<>(0);
+
+        checkNotNull(partitionSpecs, "partitionSpecs cannot be null");
+
+        List<CatalogTableStatistics> result = new ArrayList<>(partitionSpecs.size());
+        for (CatalogPartitionSpec partitionSpec : partitionSpecs) {
+            result.add(getPartitionStatistics(tablePath, partitionSpec));
+        }
+
+        return result;
     }
 
     /**
@@ -607,17 +617,15 @@ public interface Catalog {
     default List<CatalogColumnStatistics> bulkGetPartitionColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException {
-        return new ArrayList<>(0);
-    }
 
-    /**
-     * SQL planner can use this method to identify if the catalog implementation support bulk get or
-     * not. The default catalog implementation does not support bulk get.
-     *
-     * @return true means bulk get is supported.
-     */
-    default boolean isBulkGetSupported() {
-        return false;
+        checkNotNull(partitionSpecs, "partitionSpecs cannot be null");
+
+        List<CatalogColumnStatistics> result = new ArrayList<>(partitionSpecs.size());
+        for (CatalogPartitionSpec partitionSpec : partitionSpecs) {
+            result.add(getPartitionColumnStatistics(tablePath, partitionSpec));
+        }
+
+        return result;
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -571,7 +571,7 @@ public interface Catalog {
      * @throws PartitionNotExistException if one partition does not exist
      * @throws CatalogException in case of any runtime exception
      */
-    List<CatalogTableStatistics> getPartitionsStatistics(
+    List<CatalogTableStatistics> getTableStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException;
 
@@ -597,7 +597,7 @@ public interface Catalog {
      * @throws PartitionNotExistException if one partition does not exist
      * @throws CatalogException in case of any runtime exception
      */
-    List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+    List<CatalogColumnStatistics> getTableColumnStatistics(
             ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
             throws PartitionNotExistException, CatalogException;
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticDataBuilder.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticDataBuilder.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.stats;
+
+/** Builder interface for builders of classes implement {@link CatalogColumnStatisticsDataBase}. */
+public interface CatalogColumnStatisticDataBuilder<D extends CatalogColumnStatisticsDataBase> {
+
+    D build();
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBase.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBase.java
@@ -54,4 +54,25 @@ public abstract class CatalogColumnStatisticsDataBase {
      * @return a deep copy
      */
     public abstract CatalogColumnStatisticsDataBase copy();
+
+    /**
+     * Abstract builder static inner class that builder in the subclass of {@link
+     * CatalogColumnStatisticsDataBase} should extend.
+     */
+    public abstract class Builder {
+        private Long nullCount;
+        private Map<String, String> properties;
+
+        public Builder nullCount(Long nullCount) {
+            this.nullCount = nullCount;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public abstract CatalogColumnStatisticsDataBase build();
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBinary.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBinary.java
@@ -54,4 +54,51 @@ public class CatalogColumnStatisticsDataBinary extends CatalogColumnStatisticsDa
         return new CatalogColumnStatisticsDataBinary(
                 maxLength, avgLength, getNullCount(), new HashMap<>(getProperties()));
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@link CatalogColumnStatisticsDataBinary} builder static inner class. */
+    public static final class Builder
+            implements CatalogColumnStatisticDataBuilder<CatalogColumnStatisticsDataBinary> {
+        private Long nullCount;
+        private Map<String, String> properties;
+        private Long maxLength;
+        private Double avgLength;
+
+        private Long count = 0L;
+
+        private Builder() {}
+
+        public Builder nullCount(Long nullCount) {
+            this.nullCount = nullCount;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder maxLength(Long maxLength) {
+            this.maxLength = StatisticDataUtils.max(this.maxLength, maxLength);
+            return this;
+        }
+
+        public Builder accumulateAvgLength(Long newLength) {
+            this.avgLength =
+                    StatisticDataUtils.acculmulateAverage(
+                            this.avgLength, this.count, newLength, 1L);
+
+            this.count++;
+            return this;
+        }
+
+        @Override
+        public CatalogColumnStatisticsDataBinary build() {
+            return new CatalogColumnStatisticsDataBinary(
+                    maxLength, avgLength, nullCount, properties);
+        }
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBoolean.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataBoolean.java
@@ -54,4 +54,45 @@ public class CatalogColumnStatisticsDataBoolean extends CatalogColumnStatisticsD
         return new CatalogColumnStatisticsDataBoolean(
                 trueCount, falseCount, getNullCount(), new HashMap<>(getProperties()));
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@link CatalogColumnStatisticsDataBoolean} builder static inner class. */
+    public static final class Builder
+            implements CatalogColumnStatisticDataBuilder<CatalogColumnStatisticsDataBoolean> {
+        private Long nullCount;
+        private Map<String, String> properties;
+        private Long trueCount = 0L;
+        private Long falseCount = 0L;
+
+        private Builder() {}
+
+        public Builder nullCount(Long nullCount) {
+            this.nullCount = nullCount;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder increasTrueCount(Long trueCount) {
+            this.trueCount += trueCount;
+            return this;
+        }
+
+        public Builder increaseFalseCount(Long falseCount) {
+            this.falseCount += falseCount;
+            return this;
+        }
+
+        @Override
+        public CatalogColumnStatisticsDataBoolean build() {
+            return new CatalogColumnStatisticsDataBoolean(
+                    trueCount, falseCount, nullCount, properties);
+        }
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDate.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDate.java
@@ -63,4 +63,59 @@ public class CatalogColumnStatisticsDataDate extends CatalogColumnStatisticsData
         return new CatalogColumnStatisticsDataDate(
                 min, max, ndv, getNullCount(), new HashMap<>(getProperties()));
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@link CatalogColumnStatisticsDataDate} builder static inner class. */
+    public static final class Builder
+            implements CatalogColumnStatisticDataBuilder<CatalogColumnStatisticsDataDate> {
+        private Long nullCount;
+        private Map<String, String> properties;
+        private Date min;
+        private Date max;
+        private Long ndv;
+
+        private Builder() {}
+
+        public Builder nullCount(Long nullCount) {
+            this.nullCount = nullCount;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder min(Date min) {
+            if (this.min == null || min == null) {
+                this.min = this.min == null ? min : this.min;
+            } else {
+                this.min = this.min.getDaysSinceEpoch() <= min.getDaysSinceEpoch() ? this.min : min;
+            }
+
+            return this;
+        }
+
+        public Builder max(Date max) {
+            if (this.max == null || max == null) {
+                this.max = this.max == null ? max : this.max;
+            } else {
+                this.max = this.max.getDaysSinceEpoch() >= max.getDaysSinceEpoch() ? this.max : max;
+            }
+            return this;
+        }
+
+        public Builder ndv(Long ndv) {
+            this.ndv = ndv;
+            return this;
+        }
+
+        @Override
+        public CatalogColumnStatisticsDataDate build() {
+            return new CatalogColumnStatisticsDataDate(min, max, ndv, nullCount, properties);
+        }
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDouble.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataDouble.java
@@ -63,4 +63,50 @@ public class CatalogColumnStatisticsDataDouble extends CatalogColumnStatisticsDa
         return new CatalogColumnStatisticsDataDouble(
                 min, max, ndv, getNullCount(), new HashMap<>(getProperties()));
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@link CatalogColumnStatisticsDataDouble} builder static inner class. */
+    public static final class Builder
+            implements CatalogColumnStatisticDataBuilder<CatalogColumnStatisticsDataDouble> {
+        private Long nullCount;
+        private Map<String, String> properties;
+        private Double min;
+        private Double max;
+        private Long ndv;
+
+        private Builder() {}
+
+        public Builder nullCount(Long nullCount) {
+            this.nullCount = nullCount;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder min(Double min) {
+            this.min = StatisticDataUtils.min(this.min, min);
+            return this;
+        }
+
+        public Builder max(Double max) {
+            this.max = StatisticDataUtils.max(this.max, max);
+            return this;
+        }
+
+        public Builder ndv(Long ndv) {
+            this.ndv = ndv;
+            return this;
+        }
+
+        @Override
+        public CatalogColumnStatisticsDataDouble build() {
+            return new CatalogColumnStatisticsDataDouble(min, max, ndv, nullCount, properties);
+        }
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataLong.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataLong.java
@@ -63,4 +63,50 @@ public class CatalogColumnStatisticsDataLong extends CatalogColumnStatisticsData
         return new CatalogColumnStatisticsDataLong(
                 min, max, ndv, getNullCount(), new HashMap<>(getProperties()));
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@link CatalogColumnStatisticsDataLong} builder static inner class. */
+    public static final class Builder
+            implements CatalogColumnStatisticDataBuilder<CatalogColumnStatisticsDataLong> {
+        private Long nullCount;
+        private Map<String, String> properties;
+        private Long min;
+        private Long max;
+        private Long ndv;
+
+        private Builder() {}
+
+        public Builder nullCount(Long nullCount) {
+            this.nullCount = nullCount;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder min(Long min) {
+            this.min = StatisticDataUtils.min(this.min, min);
+            return this;
+        }
+
+        public Builder max(Long max) {
+            this.max = StatisticDataUtils.max(this.max, max);
+            return this;
+        }
+
+        public Builder ndv(Long ndv) {
+            this.ndv = ndv;
+            return this;
+        }
+
+        @Override
+        public CatalogColumnStatisticsDataLong build() {
+            return new CatalogColumnStatisticsDataLong(min, max, ndv, nullCount, properties);
+        }
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataString.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogColumnStatisticsDataString.java
@@ -68,4 +68,56 @@ public class CatalogColumnStatisticsDataString extends CatalogColumnStatisticsDa
         return new CatalogColumnStatisticsDataString(
                 maxLength, avgLength, ndv, getNullCount(), new HashMap<>(getProperties()));
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** {@link CatalogColumnStatisticsDataString} builder static inner class. */
+    public static final class Builder
+            implements CatalogColumnStatisticDataBuilder<CatalogColumnStatisticsDataString> {
+        private Long nullCount;
+        private Map<String, String> properties;
+        private Long maxLength;
+        private Double avgLength;
+        private Long count = 0L;
+        private Long ndv;
+
+        private Builder() {}
+
+        public Builder nullCount(Long nullCount) {
+            this.nullCount = nullCount;
+            return this;
+        }
+
+        public Builder properties(Map<String, String> properties) {
+            this.properties = properties;
+            return this;
+        }
+
+        public Builder maxLength(Long maxLength) {
+            this.maxLength = StatisticDataUtils.max(this.maxLength, maxLength);
+            return this;
+        }
+
+        public Builder accumulateAvgLength(Long newLength) {
+            this.avgLength =
+                    StatisticDataUtils.acculmulateAverage(
+                            this.avgLength, this.count, newLength, 1L);
+
+            this.count++;
+            return this;
+        }
+
+        public Builder ndv(Long ndv) {
+            this.ndv = ndv;
+            return this;
+        }
+
+        @Override
+        public CatalogColumnStatisticsDataString build() {
+            return new CatalogColumnStatisticsDataString(
+                    maxLength, avgLength, ndv, nullCount, properties);
+        }
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogTableStatistics.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/CatalogTableStatistics.java
@@ -26,7 +26,10 @@ import java.util.Map;
 /** Statistics for a non-partitioned table or a partition of a partitioned table. */
 @PublicEvolving
 public class CatalogTableStatistics {
+
     public static final CatalogTableStatistics UNKNOWN = new CatalogTableStatistics(-1, -1, -1, -1);
+
+    public static final CatalogTableStatistics EMPTY = new CatalogTableStatistics(0, 0, 0, 0);
 
     /** The number of rows in the table or partition. */
     private final long rowCount;

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/StatisticDataUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/stats/StatisticDataUtils.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.catalog.stats;
+
+/** Utils class for catalog column statistics. */
+public class StatisticDataUtils {
+
+    public static Double acculmulateAverage(
+            Double oldAvgLength, Long oldCount, Long newLength, Long newCount) {
+        if (oldAvgLength == null || oldCount == null) {
+            return Double.valueOf(newLength);
+        }
+        if (newLength == null || newCount == null) {
+            return oldAvgLength;
+        }
+        return oldCount + newCount == 0
+                ? null
+                : (oldAvgLength * oldCount + newLength * newCount) / (oldCount + newCount);
+    }
+
+    public static Long min(Long oldLength, Long newLength) {
+        if (oldLength == null || newLength == null) {
+            return oldLength == null ? newLength : oldLength;
+        }
+
+        return Math.min(oldLength, newLength);
+    }
+
+    public static Double min(Double oldLength, Double newLength) {
+        if (oldLength == null || newLength == null) {
+            return oldLength == null ? newLength : oldLength;
+        }
+
+        return Math.min(oldLength, newLength);
+    }
+
+    public static Long max(Long oldLength, Long newLength) {
+        if (oldLength == null || newLength == null) {
+            return oldLength == null ? newLength : oldLength;
+        }
+
+        return Math.max(oldLength, newLength);
+    }
+
+    public static Double max(Double oldLength, Double newLength) {
+        if (oldLength == null || newLength == null) {
+            return oldLength == null ? newLength : oldLength;
+        }
+
+        return Math.max(oldLength, newLength);
+    }
+}

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
@@ -211,6 +211,11 @@ public final class ColumnStats {
      * @return The merged column stats.
      */
     public ColumnStats merge(ColumnStats other) {
+
+        if (other == null) {
+            return this;
+        }
+
         Long ndv = combineIfNonNull(Long::sum, this.ndv, other.ndv);
         Long nullCount = combineIfNonNull(Long::sum, this.nullCount, other.nullCount);
         Double avgLen = combineIfNonNull((a1, a2) -> (a1 + a2) / 2, this.avgLen, other.avgLen);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
@@ -81,6 +81,16 @@ public final class TableStats {
      */
     @Nonnull
     public TableStats merge(TableStats other) {
+        return new TableStats(mergeRowCount(other), mergeColumnStates(other));
+    }
+
+    private long mergeRowCount(TableStats other) {
+        return this.rowCount >= 0 && other.rowCount >= 0
+                ? this.rowCount + other.rowCount
+                : UNKNOWN.rowCount;
+    }
+
+    private Map<String, ColumnStats> mergeColumnStates(TableStats other) {
         Map<String, ColumnStats> colStats = new HashMap<>();
         for (Map.Entry<String, ColumnStats> entry : this.colStats.entrySet()) {
             String col = entry.getKey();
@@ -90,11 +100,7 @@ public final class TableStats {
                 colStats.put(col, stats.merge(otherStats));
             }
         }
-        return new TableStats(
-                this.rowCount >= 0 && other.rowCount >= 0
-                        ? this.rowCount + other.rowCount
-                        : UNKNOWN.rowCount,
-                colStats);
+        return colStats;
     }
 
     @Override

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
@@ -81,7 +81,10 @@ public final class TableStats {
      */
     @Nonnull
     public TableStats merge(TableStats other) {
-        return new TableStats(mergeRowCount(other), mergeColumnStates(other));
+        long rowCount = mergeRowCount(other);
+        return rowCount == UNKNOWN.rowCount
+                ? UNKNOWN
+                : new TableStats(mergeRowCount(other), mergeColumnStates(other));
     }
 
     private long mergeRowCount(TableStats other) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestCatalogFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestCatalogFactory.java
@@ -317,10 +317,24 @@ public class TestCatalogFactory implements CatalogFactory {
         }
 
         @Override
+        public List<CatalogTableStatistics> getPartitionsStatistics(
+                ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+                throws PartitionNotExistException, CatalogException {
+            throw new UnsupportedClassVersionError();
+        }
+
+        @Override
         public CatalogColumnStatistics getPartitionColumnStatistics(
                 ObjectPath tablePath, CatalogPartitionSpec partitionSpec)
                 throws PartitionNotExistException, CatalogException {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+                ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
+                throws PartitionNotExistException, CatalogException {
+            throw new UnsupportedClassVersionError();
         }
 
         @Override

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestCatalogFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestCatalogFactory.java
@@ -317,7 +317,7 @@ public class TestCatalogFactory implements CatalogFactory {
         }
 
         @Override
-        public List<CatalogTableStatistics> getTableStatistics(
+        public List<CatalogTableStatistics> bulkGetPartitionStatistics(
                 ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
                 throws PartitionNotExistException, CatalogException {
             throw new UnsupportedClassVersionError();
@@ -331,7 +331,7 @@ public class TestCatalogFactory implements CatalogFactory {
         }
 
         @Override
-        public List<CatalogColumnStatistics> getTableColumnStatistics(
+        public List<CatalogColumnStatistics> bulkGetPartitionColumnStatistics(
                 ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
                 throws PartitionNotExistException, CatalogException {
             throw new UnsupportedClassVersionError();

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestCatalogFactory.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/factories/TestCatalogFactory.java
@@ -317,7 +317,7 @@ public class TestCatalogFactory implements CatalogFactory {
         }
 
         @Override
-        public List<CatalogTableStatistics> getPartitionsStatistics(
+        public List<CatalogTableStatistics> getTableStatistics(
                 ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
                 throws PartitionNotExistException, CatalogException {
             throw new UnsupportedClassVersionError();
@@ -331,7 +331,7 @@ public class TestCatalogFactory implements CatalogFactory {
         }
 
         @Override
-        public List<CatalogColumnStatistics> getPartitionsColumnStatistics(
+        public List<CatalogColumnStatistics> getTableColumnStatistics(
                 ObjectPath tablePath, List<CatalogPartitionSpec> partitionSpecs)
                 throws PartitionNotExistException, CatalogException {
             throw new UnsupportedClassVersionError();

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
@@ -202,8 +202,8 @@ public class FlinkRecomputeStatisticsProgram implements FlinkOptimizeProgram<Bat
 
             return Optional.of(
                     convertToAccumulatedTableStates(
-                            catalog.getTableStatistics(tablePath, partitionSpecs),
-                            catalog.getTableColumnStatistics(tablePath, partitionSpecs)));
+                            catalog.bulkGetPartitionStatistics(tablePath, partitionSpecs),
+                            catalog.bulkGetPartitionColumnStatistics(tablePath, partitionSpecs)));
         } catch (PartitionNotExistException e) {
             return Optional.empty();
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
@@ -203,12 +203,12 @@ public class FlinkRecomputeStatisticsProgram implements FlinkOptimizeProgram<Bat
                             .collect(Collectors.toList());
 
             final Optional<TableStats> rowCountMergedTableStats =
-                    catalog.getPartitionsStatistics(tablePath, partitionSpecs).stream()
+                    catalog.getTableStatistics(tablePath, partitionSpecs).stream()
                             .map(p -> CatalogTableStatisticsConverter.convertToTableStats(p, null))
                             .reduce((s1, s2) -> s1.merge(s2));
 
             final Optional<TableStats> columnStatsMergedTableStats =
-                    catalog.getPartitionsColumnStatistics(tablePath, partitionSpecs).stream()
+                    catalog.getTableColumnStatistics(tablePath, partitionSpecs).stream()
                             .map(
                                     p ->
                                             CatalogTableStatisticsConverter.convertToTableStats(


### PR DESCRIPTION

## What is the purpose of the change

Currently the statistics information about tables can only be fetched from the catalog by each given partition iteratively. Since getting statistics information from catalogs is a very heavy operation, in order to improve the query performance, we’d better provide functionality to fetch the statistics information of a table for all given partitions in one shot.

Based on the manual performance test, for 2000 partitions, the cost will be improved from 10s to 2s. The improvement result is 500%.


## Brief change log

- Implementations for new added methods will be done in all classes that implement the Catalog interface. 
- For the concrete HiveCatalog, __HIVE_DEFAULT_PARTITION__ will be taken care of while fetching the column statistics. - - All currently supported types for partition column will be taken into consideration.
- The logic of getting TableStates in FlinkRecomputeStatisticsProgram will be optimized from calling the catalog iteratively to bulk fetch.
- Logic of TableStates conversion will be consolidated into the CatalogTableStatisticsConverter class to make the domain design a little bit cleaner. 


## Verifying this change

This change is already covered by existing tests, such as HiveCatalogHiveMetadataTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
