### PR TITLE
[hotfix][core] Simplify Histogram

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/accumulators/Histogram.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/accumulators/Histogram.java
@@ -35,13 +35,11 @@ public class Histogram implements Accumulator<Integer, TreeMap<Integer, Integer>
 
     private static final long serialVersionUID = 1L;
 
-    private TreeMap<Integer, Integer> treeMap = new TreeMap<Integer, Integer>();
+    private TreeMap<Integer, Integer> treeMap = new TreeMap<>();
 
     @Override
     public void add(Integer value) {
-        Integer current = treeMap.get(value);
-        Integer newValue = (current != null ? current : 0) + 1;
-        this.treeMap.put(value, newValue);
+        treeMap.merge(value, 1, Integer::sum);
     }
 
     @Override
@@ -52,13 +50,8 @@ public class Histogram implements Accumulator<Integer, TreeMap<Integer, Integer>
     @Override
     public void merge(Accumulator<Integer, TreeMap<Integer, Integer>> other) {
         // Merge the values into this map
-        for (Map.Entry<Integer, Integer> entryFromOther : other.getLocalValue().entrySet()) {
-            Integer ownValue = this.treeMap.get(entryFromOther.getKey());
-            if (ownValue == null) {
-                this.treeMap.put(entryFromOther.getKey(), entryFromOther.getValue());
-            } else {
-                this.treeMap.put(entryFromOther.getKey(), entryFromOther.getValue() + ownValue);
-            }
+        for (Map.Entry<Integer, Integer> otherEntry : other.getLocalValue().entrySet()) {
+            treeMap.merge(otherEntry.getKey(), otherEntry.getValue(), Integer::sum);
         }
     }
 
@@ -73,9 +66,9 @@ public class Histogram implements Accumulator<Integer, TreeMap<Integer, Integer>
     }
 
     @Override
-    public Accumulator<Integer, TreeMap<Integer, Integer>> clone() {
+    public Histogram clone() {
         Histogram result = new Histogram();
-        result.treeMap = new TreeMap<Integer, Integer>(treeMap);
+        result.treeMap = new TreeMap<>(treeMap);
         return result;
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/accumulators/HistogramTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/accumulators/HistogramTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.accumulators;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Tests for {@link Histogram}. */
+public class HistogramTest {
+
+    private final Histogram histogram = new Histogram();
+
+    @Test
+    void testAddNotExistedValue() {
+        histogram.add(5);
+
+        Map<Integer, Integer> actualLocalValue = histogram.getLocalValue();
+        assertEquals(1, actualLocalValue.size());
+        assertEquals(1, actualLocalValue.get(5));
+    }
+
+    @Test
+    void testAddExistedValue() {
+        histogram.add(5);
+        histogram.add(5);
+
+        Map<Integer, Integer> actualLocalValue = histogram.getLocalValue();
+        assertEquals(1, actualLocalValue.size());
+        assertEquals(2, actualLocalValue.get(5));
+    }
+
+    @Test
+    void testAddMultipleValues() {
+        histogram.add(5);
+        histogram.add(10);
+
+        Map<Integer, Integer> actualLocalValue = histogram.getLocalValue();
+        assertEquals(2, actualLocalValue.size());
+        assertEquals(1, actualLocalValue.get(5));
+        assertEquals(1, actualLocalValue.get(10));
+    }
+
+    @Test
+    void testResetLocal() {
+        histogram.add(5);
+        histogram.resetLocal();
+
+        Map<Integer, Integer> actualLocalValue = histogram.getLocalValue();
+        assertTrue(actualLocalValue.isEmpty());
+    }
+
+    @Test
+    void testMergeEmptyAndEmpty() {
+        histogram.merge(new Histogram());
+        Map<Integer, Integer> actualLocalValue = histogram.getLocalValue();
+
+        assertTrue(actualLocalValue.isEmpty());
+    }
+
+    @Test
+    void testMergeNoIntersections() {
+        histogram.add(5);
+        Histogram otherHistogram = new Histogram();
+        otherHistogram.add(10);
+
+        histogram.merge(otherHistogram);
+
+        Map<Integer, Integer> actualLocalValue = histogram.getLocalValue();
+        assertEquals(2, actualLocalValue.size());
+        assertEquals(1, actualLocalValue.get(5));
+        assertEquals(1, actualLocalValue.get(10));
+    }
+
+    @Test
+    void testMergeWithIntersections() {
+        histogram.add(5);
+        Histogram otherHistogram = new Histogram();
+        otherHistogram.add(5);
+        otherHistogram.add(10);
+
+        histogram.merge(otherHistogram);
+
+        Map<Integer, Integer> actualLocalValue = histogram.getLocalValue();
+        assertEquals(2, actualLocalValue.size());
+        assertEquals(2, actualLocalValue.get(5));
+        assertEquals(1, actualLocalValue.get(10));
+    }
+
+    @Test
+    void testClone() {
+        histogram.add(5);
+        Histogram actualHistogram = histogram.clone();
+        histogram.add(10);
+
+        Map<Integer, Integer> actualLocalValue = actualHistogram.getLocalValue();
+        assertEquals(1, actualLocalValue.size());
+        assertEquals(1, actualLocalValue.get(5));
+    }
+}


### PR DESCRIPTION
### What is the purpose of the change
The goal of this PR is to simplify code in Histogram class and add absent unit tests for the class. **It is refactoring no logic changed**.

### Brief change log

- 54d101941e3487b302bac11780154372678f687d: Histogram class simplified and added tests for that.

### Verifying this change
Unit tests added: HistogramTest

### Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): (yes / **no**)
- The public API, i.e., is any changed class annotated with @Public(Evolving): (**yes** / no)
- The serializers: (yes / **no** / don't know)
- The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
- The S3 file system connector: (yes / **no** / don't know)

