### PR TITLE
[FLINK-28688][python] Support DataStream PythonWindowOperator in Thread Mode

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -31,6 +31,6 @@ numpy>=1.14.3,<1.20; python_version < '3.7'
 fastavro>=1.1.0,<1.4.8
 grpcio>=1.29.0,<1.47
 grpcio-tools>=1.3.5,<=1.14.2
-pemja==0.2.3; python_version >= '3.7' and platform_system != 'Windows'
+pemja==0.2.4; python_version >= '3.7' and platform_system != 'Windows'
 httplib2>=0.19.0,<=0.20.4
 protobuf<3.18

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -110,7 +110,7 @@ under the License.
 		<dependency>
 			<groupId>com.alibaba</groupId>
 			<artifactId>pemja</artifactId>
-			<version>0.2.3</version>
+			<version>0.2.4</version>
 		</dependency>
 
 		<!-- Protobuf dependencies -->

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -2740,7 +2740,12 @@ def _get_one_input_stream_operator(data_stream: DataStream,
         else:
             j_namespace_serializer = \
                 gateway.jvm.org.apache.flink.streaming.api.utils.ByteArrayWrapperSerializer()
-        j_python_function_operator = gateway.jvm.ExternalPythonKeyedProcessOperator(
+        if python_execution_mode == 'thread':
+            JDataStreamPythonWindowFunctionOperator = gateway.jvm.EmbeddedPythonWindowOperator
+        else:
+            JDataStreamPythonWindowFunctionOperator = gateway.jvm.ExternalPythonKeyedProcessOperator
+
+        j_python_function_operator = JDataStreamPythonWindowFunctionOperator(
             j_conf,
             j_data_stream_python_function_info,
             j_input_types,

--- a/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
@@ -15,13 +15,19 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-
+from pyflink.datastream.window import WindowOperationDescriptor
 from pyflink.fn_execution import pickle
+from pyflink.fn_execution.coders import TimeWindowCoder, CountWindowCoder
 from pyflink.fn_execution.datastream import operations
 from pyflink.fn_execution.datastream.embedded.process_function import (
     InternalProcessFunctionContext, InternalKeyedProcessFunctionContext,
-    InternalKeyedProcessFunctionOnTimerContext)
+    InternalKeyedProcessFunctionOnTimerContext, InternalWindowTimerContext)
 from pyflink.fn_execution.datastream.embedded.runtime_context import StreamingRuntimeContext
+from pyflink.fn_execution.datastream.embedded.timerservice_impl import InternalTimerServiceImpl
+from pyflink.fn_execution.datastream.window.window_operator import WindowOperator
+from pyflink.fn_execution.embedded.converters import (TimeWindowConverter, CountWindowConverter,
+                                                      GlobalWindowConverter)
+from pyflink.fn_execution.embedded.state_impl import KeyedStateBackend
 
 
 class OneInputOperation(operations.OneInputOperation):
@@ -73,7 +79,7 @@ class TwoInputOperation(operations.TwoInputOperation):
 
 
 def extract_process_function(
-        user_defined_function_proto, runtime_context, function_context, timer_context,
+        user_defined_function_proto, j_runtime_context, j_function_context, j_timer_context,
         job_parameters):
     from pyflink.fn_execution import flink_fn_execution_pb2
 
@@ -83,7 +89,7 @@ def extract_process_function(
 
     UserDefinedDataStreamFunction = flink_fn_execution_pb2.UserDefinedDataStreamFunction
 
-    runtime_context = StreamingRuntimeContext.of(runtime_context, job_parameters)
+    runtime_context = StreamingRuntimeContext.of(j_runtime_context, job_parameters)
 
     def open_func():
         if hasattr(user_defined_func, "open"):
@@ -94,7 +100,7 @@ def extract_process_function(
             user_defined_func.close()
 
     if func_type == UserDefinedDataStreamFunction.PROCESS:
-        function_context = InternalProcessFunctionContext(function_context)
+        function_context = InternalProcessFunctionContext(j_function_context)
 
         process_element = user_defined_func.process_element
 
@@ -106,10 +112,10 @@ def extract_process_function(
     elif func_type == UserDefinedDataStreamFunction.KEYED_PROCESS:
 
         function_context = InternalKeyedProcessFunctionContext(
-            function_context, user_defined_function_proto.key_type_info)
+            j_function_context, user_defined_function_proto.key_type_info)
 
         timer_context = InternalKeyedProcessFunctionOnTimerContext(
-            timer_context, user_defined_function_proto.key_type_info)
+            j_timer_context, user_defined_function_proto.key_type_info)
 
         on_timer = user_defined_func.on_timer
 
@@ -125,7 +131,7 @@ def extract_process_function(
         return OneInputOperation(open_func, close_func, process_element_func, on_timer_func)
 
     elif func_type == UserDefinedDataStreamFunction.CO_PROCESS:
-        function_context = InternalProcessFunctionContext(function_context)
+        function_context = InternalProcessFunctionContext(j_function_context)
 
         process_element1 = user_defined_func.process_element1
         process_element2 = user_defined_func.process_element2
@@ -142,10 +148,10 @@ def extract_process_function(
     elif func_type == UserDefinedDataStreamFunction.KEYED_CO_PROCESS:
 
         function_context = InternalKeyedProcessFunctionContext(
-            function_context, user_defined_function_proto.key_type_info)
+            j_function_context, user_defined_function_proto.key_type_info)
 
         timer_context = InternalKeyedProcessFunctionOnTimerContext(
-            timer_context, user_defined_function_proto.key_type_info)
+            j_timer_context, user_defined_function_proto.key_type_info)
 
         on_timer = user_defined_func.on_timer
 
@@ -166,6 +172,85 @@ def extract_process_function(
 
         return TwoInputOperation(
             open_func, close_func, process_element_func1, process_element_func2, on_timer_func)
+
+    elif func_type == UserDefinedDataStreamFunction.WINDOW:
+
+        window_operation_descriptor = (
+            user_defined_func
+        )  # type: WindowOperationDescriptor
+
+        def user_key_selector(normal_data):
+            return normal_data
+
+        window_assigner = window_operation_descriptor.assigner
+        window_trigger = window_operation_descriptor.trigger
+        allowed_lateness = window_operation_descriptor.allowed_lateness
+        late_data_output_tag = window_operation_descriptor.late_data_output_tag
+        window_state_descriptor = window_operation_descriptor.window_state_descriptor
+        internal_window_function = window_operation_descriptor.internal_window_function
+        window_serializer = window_operation_descriptor.window_serializer
+        window_coder = window_serializer._get_coder()
+
+        if isinstance(window_coder, TimeWindowCoder):
+            window_converter = TimeWindowConverter()
+        elif isinstance(window_coder, CountWindowCoder):
+            window_converter = CountWindowConverter()
+        else:
+            window_converter = GlobalWindowConverter()
+
+        internal_timer_service = InternalTimerServiceImpl(
+            j_timer_context.timerService(), window_converter)
+
+        function_context = InternalKeyedProcessFunctionContext(
+            j_function_context, user_defined_function_proto.key_type_info)
+
+        window_timer_context = InternalWindowTimerContext(
+            j_timer_context,
+            user_defined_function_proto.key_type_info,
+            window_converter)
+
+        keyed_state_backend = KeyedStateBackend(
+            function_context,
+            j_function_context.getCurrentKeyedStateBackend(),
+            j_function_context.getWindowSerializer(),
+            window_converter)
+
+        runtime_context = StreamingRuntimeContext.of(
+            j_runtime_context,
+            job_parameters,
+            keyed_state_backend)
+
+        window_operator = WindowOperator(
+            window_assigner,
+            keyed_state_backend,
+            user_key_selector,
+            window_state_descriptor,
+            internal_window_function,
+            window_trigger,
+            allowed_lateness,
+            late_data_output_tag)
+
+        def open_func():
+            window_operator.open(runtime_context, internal_timer_service)
+
+        def close_func():
+            window_operator.close()
+
+        def process_element_func(value):
+            yield from window_operator.process_element(value[1], function_context.timestamp())
+
+        if window_assigner.is_event_time():
+            def on_timer_func(timestamp):
+                window = window_timer_context.window()
+                key = window_timer_context.get_current_key()
+                yield from window_operator.on_event_time(timestamp, key, window)
+        else:
+            def on_timer_func(timestamp):
+                window = window_timer_context.window()
+                key = window_timer_context.get_current_key()
+                yield from window_operator.on_processing_time(timestamp, key, window)
+
+        return OneInputOperation(open_func, close_func, process_element_func, on_timer_func)
 
     else:
         raise Exception("Unknown function type {0}.".format(func_type))

--- a/flink-python/pyflink/fn_execution/datastream/embedded/process_function.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/process_function.py
@@ -90,3 +90,19 @@ class InternalKeyedProcessFunctionOnTimerContext(KeyedProcessFunction.OnTimerCon
 
     def get_current_key(self):
         return self._key_converter.to_internal(self._context.getCurrentKey())
+
+
+class InternalWindowTimerContext(object):
+    def __init__(self, context, key_type_info, window_converter):
+        self._context = context
+        self._key_converter = from_type_info(key_type_info)
+        self._window_converter = window_converter
+
+    def timestamp(self) -> int:
+        return self._context.timestamp()
+
+    def window(self):
+        return self._window_converter.to_internal(self._context.getWindow())
+
+    def get_current_key(self):
+        return self._key_converter.to_internal(self._context.getCurrentKey())

--- a/flink-python/pyflink/fn_execution/datastream/embedded/runtime_context.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/runtime_context.py
@@ -28,9 +28,11 @@ from pyflink.fn_execution.embedded.java_utils import to_java_state_descriptor
 
 
 class StreamingRuntimeContext(RuntimeContext):
-    def __init__(self, runtime_context, job_parameters):
+    def __init__(self, runtime_context, job_parameters, keyed_state_backend=None):
         self._runtime_context = runtime_context
         self._job_parameters = job_parameters
+        if keyed_state_backend:
+            self._keyed_state_backend = keyed_state_backend
 
     def get_task_name(self) -> str:
         """
@@ -82,33 +84,48 @@ class StreamingRuntimeContext(RuntimeContext):
         return self._runtime_context.getMetricGroup()
 
     def get_state(self, state_descriptor: ValueStateDescriptor) -> ValueState:
-        return ValueStateImpl(
-            self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
-            from_type_info(state_descriptor.type_info))
+        if hasattr(self, '_keyed_state_backend'):
+            return self._keyed_state_backend.get_value_state(state_descriptor)
+        else:
+            return ValueStateImpl(
+                self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
+                from_type_info(state_descriptor.type_info))
 
     def get_list_state(self, state_descriptor: ListStateDescriptor) -> ListState:
-        return ListStateImpl(
-            self._runtime_context.getListState(to_java_state_descriptor(state_descriptor)),
-            from_type_info(state_descriptor.type_info))
+        if hasattr(self, '_keyed_state_backend'):
+            return self._keyed_state_backend.get_list_state(state_descriptor)
+        else:
+            return ListStateImpl(
+                self._runtime_context.getListState(to_java_state_descriptor(state_descriptor)),
+                from_type_info(state_descriptor.type_info))
 
     def get_map_state(self, state_descriptor: MapStateDescriptor) -> MapState:
-        return MapStateImpl(
-            self._runtime_context.getMapState(to_java_state_descriptor(state_descriptor)),
-            from_type_info(state_descriptor.type_info))
+        if hasattr(self, '_keyed_state_backend'):
+            return self._keyed_state_backend.get_map_state(state_descriptor)
+        else:
+            return MapStateImpl(
+                self._runtime_context.getMapState(to_java_state_descriptor(state_descriptor)),
+                from_type_info(state_descriptor.type_info))
 
     def get_reducing_state(self, state_descriptor: ReducingStateDescriptor) -> ReducingState:
-        return ReducingStateImpl(
-            self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
-            from_type_info(state_descriptor.type_info),
-            state_descriptor.get_reduce_function())
+        if hasattr(self, '_keyed_state_backend'):
+            return self._keyed_state_backend.get_reducing_state(state_descriptor)
+        else:
+            return ReducingStateImpl(
+                self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
+                from_type_info(state_descriptor.type_info),
+                state_descriptor.get_reduce_function())
 
     def get_aggregating_state(self,
                               state_descriptor: AggregatingStateDescriptor) -> AggregatingState:
-        return AggregatingStateImpl(
-            self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
-            from_type_info(state_descriptor.type_info),
-            state_descriptor.get_agg_function())
+        if hasattr(self, '_keyed_state_backend'):
+            return self._keyed_state_backend.get_aggregating_state(state_descriptor)
+        else:
+            return AggregatingStateImpl(
+                self._runtime_context.getState(to_java_state_descriptor(state_descriptor)),
+                from_type_info(state_descriptor.type_info),
+                state_descriptor.get_agg_function())
 
     @staticmethod
-    def of(runtime_context, job_parameters):
-        return StreamingRuntimeContext(runtime_context, job_parameters)
+    def of(runtime_context, job_parameters, keyed_state_backend=None):
+        return StreamingRuntimeContext(runtime_context, job_parameters, keyed_state_backend)

--- a/flink-python/pyflink/fn_execution/datastream/embedded/state_impl.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/state_impl.py
@@ -15,27 +15,42 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
-from typing import List, Iterable, Tuple, Dict
+from abc import ABC
+from typing import List, Iterable, Tuple, Dict, Collection
 
 from pyflink.datastream import ReduceFunction, AggregateFunction
-from pyflink.datastream.state import (ValueState, T, State, ListState, IN, OUT, ReducingState,
-                                      AggregatingState, MapState, V, K)
+from pyflink.datastream.state import (T, IN, OUT, V, K)
 from pyflink.fn_execution.embedded.converters import (DataConverter, DictDataConverter,
                                                       ListDataConverter)
+from pyflink.fn_execution.internal_state import (InternalValueState, InternalKvState,
+                                                 InternalListState, InternalReducingState,
+                                                 InternalAggregatingState, InternalMapState,
+                                                 N)
 
 
-class StateImpl(State):
-    def __init__(self, state, value_converter: DataConverter):
+class StateImpl(InternalKvState, ABC):
+    def __init__(self,
+                 state,
+                 value_converter: DataConverter,
+                 window_converter: DataConverter = None):
         self._state = state
         self._value_converter = value_converter
+        self._window_converter = window_converter
 
     def clear(self):
         self._state.clear()
 
+    def set_current_namespace(self, namespace) -> None:
+        j_window = self._window_converter.to_external(namespace)
+        self._state.setCurrentNamespace(j_window)
 
-class ValueStateImpl(StateImpl, ValueState):
-    def __init__(self, value_state, value_converter: DataConverter):
-        super(ValueStateImpl, self).__init__(value_state, value_converter)
+
+class ValueStateImpl(StateImpl, InternalValueState):
+    def __init__(self,
+                 value_state,
+                 value_converter: DataConverter,
+                 window_converter: DataConverter = None):
+        super(ValueStateImpl, self).__init__(value_state, value_converter, window_converter)
 
     def value(self) -> T:
         return self._value_converter.to_internal(self._state.value())
@@ -44,10 +59,13 @@ class ValueStateImpl(StateImpl, ValueState):
         self._state.update(self._value_converter.to_external(value))
 
 
-class ListStateImpl(StateImpl, ListState):
+class ListStateImpl(StateImpl, InternalListState):
 
-    def __init__(self, list_state, value_converter: ListDataConverter):
-        super(ListStateImpl, self).__init__(list_state, value_converter)
+    def __init__(self,
+                 list_state,
+                 value_converter: ListDataConverter,
+                 window_converter: DataConverter = None):
+        super(ListStateImpl, self).__init__(list_state, value_converter, window_converter)
         self._element_converter = value_converter._field_converter
 
     def update(self, values: List[T]) -> None:
@@ -62,14 +80,20 @@ class ListStateImpl(StateImpl, ListState):
     def add(self, value: IN) -> None:
         self._state.add(self._element_converter.to_external(value))
 
+    def merge_namespaces(self, target: N, sources: Collection[N]) -> None:
+        j_target = self._window_converter.to_external(target)
+        j_sources = [self._window_converter.to_external(window) for window in sources]
+        self._state.mergeNamespaces(j_target, j_sources)
 
-class ReducingStateImpl(StateImpl, ReducingState):
+
+class ReducingStateImpl(StateImpl, InternalReducingState):
 
     def __init__(self,
                  value_state,
                  value_converter: DataConverter,
-                 reduce_function: ReduceFunction):
-        super(ReducingStateImpl, self).__init__(value_state, value_converter)
+                 reduce_function: ReduceFunction,
+                 window_converter: DataConverter = None):
+        super(ReducingStateImpl, self).__init__(value_state, value_converter, window_converter)
         self._reduce_function = reduce_function
 
     def get(self) -> OUT:
@@ -88,13 +112,32 @@ class ReducingStateImpl(StateImpl, ReducingState):
 
             self._state.update(self._value_converter.to_external(reduce_value))
 
+    def merge_namespaces(self, target: N, sources: Collection[N]) -> None:
+        merged = None
+        for source in sources:
+            self.set_current_namespace(source)
+            source_state = self.get()
+            self.clear()
+            if merged and source_state:
+                if merged:
+                    merged = self._reduce_function.reduce(merged, source_state)
+                else:
+                    merged = source_state
+            elif merged is None:
+                merged = source_state
 
-class AggregatingStateImpl(StateImpl, AggregatingState):
+        if merged:
+            self.set_current_namespace(target)
+            self._state.update(self._value_converter.to_external(merged))
+
+
+class AggregatingStateImpl(StateImpl, InternalAggregatingState):
     def __init__(self,
                  value_state,
                  value_converter,
-                 agg_function: AggregateFunction):
-        super(AggregatingStateImpl, self).__init__(value_state, value_converter)
+                 agg_function: AggregateFunction,
+                 window_converter: DataConverter = None):
+        super(AggregatingStateImpl, self).__init__(value_state, value_converter, window_converter)
         self._agg_function = agg_function
 
     def get(self) -> OUT:
@@ -117,10 +160,28 @@ class AggregatingStateImpl(StateImpl, AggregatingState):
             accumulator = self._agg_function.add(value, accumulator)
             self._state.update(self._value_converter.to_external(accumulator))
 
+    def merge_namespaces(self, target: N, sources: Collection[N]) -> None:
+        merged = None
+        for source in sources:
+            self.set_current_namespace(source)
+            source_state = self.get()
+            self.clear()
+            if merged and source_state:
+                merged = self._agg_function.merge(merged, source_state)
+            elif merged is None:
+                merged = source_state
 
-class MapStateImpl(StateImpl, MapState):
-    def __init__(self, map_state, map_converter: DictDataConverter):
-        super(MapStateImpl, self).__init__(map_state, map_converter)
+        if merged:
+            self.set_current_namespace(target)
+            self._state.update(self._value_converter.to_external(merged))
+
+
+class MapStateImpl(StateImpl, InternalMapState):
+    def __init__(self,
+                 map_state,
+                 map_converter: DictDataConverter,
+                 window_converter: DataConverter = None):
+        super(MapStateImpl, self).__init__(map_state, map_converter, window_converter)
         self._k_converter = map_converter._key_converter
         self._v_converter = map_converter._value_converter
 

--- a/flink-python/pyflink/fn_execution/datastream/embedded/timerservice_impl.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/timerservice_impl.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 ################################################################################
 from pyflink.datastream import TimerService
+from pyflink.fn_execution.datastream.timerservice import InternalTimerService, N
 
 
 class TimerServiceImpl(TimerService):
@@ -39,3 +40,31 @@ class TimerServiceImpl(TimerService):
 
     def delete_event_time_timer(self, timestamp: int):
         self._timer_service.deleteEventTimeTimer(timestamp)
+
+
+class InternalTimerServiceImpl(InternalTimerService[N]):
+    def __init__(self, timer_service, window_converter):
+        self._timer_service = timer_service
+        self._window_converter = window_converter
+
+    def current_processing_time(self):
+        return self._timer_service.currentProcessingTime()
+
+    def current_watermark(self):
+        return self._timer_service.currentWatermark()
+
+    def register_processing_time_timer(self, namespace: N, timestamp: int):
+        window = self._window_converter.to_external(namespace)
+        self._timer_service.registerProcessingTimeTimer(window, timestamp)
+
+    def register_event_time_timer(self, namespace: N, timestamp: int):
+        window = self._window_converter.to_external(namespace)
+        self._timer_service.registerEventTimeTimer(window, timestamp)
+
+    def delete_event_time_timer(self, namespace: N, timestamp: int):
+        window = self._window_converter.to_external(namespace)
+        self._timer_service.deleteEventTimeTimer(window, timestamp)
+
+    def delete_processing_time_timer(self, namespace: N, timestamp: int):
+        window = self._window_converter.to_external(namespace)
+        self._timer_service.deleteProcessingTimeTimer(window, timestamp)

--- a/flink-python/pyflink/fn_execution/datastream/window/window_operator.py
+++ b/flink-python/pyflink/fn_execution/datastream/window/window_operator.py
@@ -19,6 +19,7 @@ import typing
 from typing import TypeVar, Iterable, Collection, Optional
 
 from pyflink.common.constants import MAX_LONG_VALUE
+from pyflink.common.typeinfo import PickledBytesTypeInfo
 from pyflink.datastream import WindowAssigner, Trigger, MergingWindowAssigner, TriggerResult
 from pyflink.datastream.functions import KeyedStateStore, RuntimeContext, InternalWindowFunction
 from pyflink.datastream.output_tag import OutputTag
@@ -322,9 +323,16 @@ class WindowOperator(object):
             if isinstance(self.window_state, InternalMergingState):
                 self.window_merging_state = self.window_state
 
-            window_coder = self.keyed_state_backend.namespace_coder
-            self.merging_sets_state = self.keyed_state_backend.get_map_state(
-                "merging-window-set", window_coder, window_coder)
+            if hasattr(self.keyed_state_backend, 'namespace_coder'):
+                window_coder = self.keyed_state_backend.namespace_coder
+                self.merging_sets_state = self.keyed_state_backend.get_map_state(
+                    "merging-window-set", window_coder, window_coder)
+            else:
+                state_descriptor = MapStateDescriptor(
+                    "merging-window-set",
+                    PickledBytesTypeInfo(),
+                    PickledBytesTypeInfo())
+                self.merging_sets_state = self.keyed_state_backend.get_map_state(state_descriptor)
 
         self.merge_function = WindowMergeFunction(self)
 

--- a/flink-python/pyflink/fn_execution/embedded/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/embedded/operation_utils.py
@@ -103,7 +103,7 @@ def create_table_operation_from_proto(proto, input_coder_info, output_coder_into
 
 def create_one_input_user_defined_data_stream_function_from_protos(
         function_infos, input_coder_info, output_coder_info, runtime_context,
-        function_context, timer_context, job_parameters):
+        function_context, timer_context, job_parameters, keyed_state_backend):
     serialized_fns = [pare_user_defined_data_stream_function_proto(proto)
                       for proto in function_infos]
     input_data_converter = (
@@ -118,14 +118,15 @@ def create_one_input_user_defined_data_stream_function_from_protos(
         runtime_context,
         function_context,
         timer_context,
-        job_parameters)
+        job_parameters,
+        keyed_state_backend)
 
     return function_operation
 
 
 def create_two_input_user_defined_data_stream_function_from_protos(
         function_infos, input_coder_info1, input_coder_info2, output_coder_info, runtime_context,
-        function_context, timer_context, job_parameters):
+        function_context, timer_context, job_parameters, keyed_state_backend):
     serialized_fns = [pare_user_defined_data_stream_function_proto(proto)
                       for proto in function_infos]
 
@@ -146,6 +147,7 @@ def create_two_input_user_defined_data_stream_function_from_protos(
         runtime_context,
         function_context,
         timer_context,
-        job_parameters)
+        job_parameters,
+        keyed_state_backend)
 
     return function_operation

--- a/flink-python/pyflink/fn_execution/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/embedded/operations.py
@@ -66,14 +66,16 @@ class OneInputFunctionOperation(FunctionOperation):
                  runtime_context,
                  function_context,
                  timer_context,
-                 job_parameters):
+                 job_parameters,
+                 keyed_state_backend):
         operations = (
             [extract_process_function(
                 serialized_fn,
                 runtime_context,
                 function_context,
                 timer_context,
-                job_parameters)
+                job_parameters,
+                keyed_state_backend)
                 for serialized_fn in serialized_fns])
         super(OneInputFunctionOperation, self).__init__(operations, output_data_converter)
         self._input_data_converter = input_data_converter
@@ -96,14 +98,16 @@ class TwoInputFunctionOperation(FunctionOperation):
                  runtime_context,
                  function_context,
                  timer_context,
-                 job_parameters):
+                 job_parameters,
+                 keyed_state_backend):
         operations = (
             [extract_process_function(
                 serialized_fn,
                 runtime_context,
                 function_context,
                 timer_context,
-                job_parameters)
+                job_parameters,
+                keyed_state_backend)
                 for serialized_fn in serialized_fns])
         super(TwoInputFunctionOperation, self).__init__(operations, output_data_converter)
         self._input_data_converter1 = input_data_converter1

--- a/flink-python/pyflink/fn_execution/embedded/state_impl.py
+++ b/flink-python/pyflink/fn_execution/embedded/state_impl.py
@@ -1,0 +1,80 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+from pemja import findClass
+
+from pyflink.datastream.state import (ValueStateDescriptor, ListStateDescriptor, MapStateDescriptor,
+                                      StateDescriptor, ReducingStateDescriptor,
+                                      AggregatingStateDescriptor)
+from pyflink.fn_execution.datastream.embedded.state_impl import (ValueStateImpl, ListStateImpl,
+                                                                 MapStateImpl, ReducingStateImpl,
+                                                                 AggregatingStateImpl)
+from pyflink.fn_execution.embedded.converters import from_type_info
+from pyflink.fn_execution.embedded.java_utils import to_java_state_descriptor
+
+JVoidNamespace = findClass('org.apache.flink.runtime.state.VoidNamespace')
+JVoidNamespace_INSTANCE = JVoidNamespace.INSTANCE
+
+
+class KeyedStateBackend(object):
+    def __init__(self, function_context, keyed_state_backend, window_serializer, window_converter):
+        self._function_context = function_context
+        self._keyed_state_backend = keyed_state_backend
+        self._window_serializer = window_serializer
+        self._window_converter = window_converter
+
+    def get_current_key(self):
+        return self._function_context.get_current_key()
+
+    def get_value_state(self, state_descriptor: ValueStateDescriptor) -> ValueStateImpl:
+        return ValueStateImpl(
+            self._get_or_create_keyed_state(state_descriptor),
+            from_type_info(state_descriptor.type_info),
+            self._window_converter)
+
+    def get_list_state(self, state_descriptor: ListStateDescriptor) -> ListStateImpl:
+        return ListStateImpl(
+            self._get_or_create_keyed_state(state_descriptor),
+            from_type_info(state_descriptor.type_info),
+            self._window_converter)
+
+    def get_map_state(self, state_descriptor: MapStateDescriptor) -> MapStateImpl:
+        return MapStateImpl(
+            self._get_or_create_keyed_state(state_descriptor),
+            from_type_info(state_descriptor.type_info),
+            self._window_converter)
+
+    def get_reducing_state(self, state_descriptor: ReducingStateDescriptor):
+        return ReducingStateImpl(
+            self._get_or_create_keyed_state(state_descriptor),
+            from_type_info(state_descriptor.type_info),
+            state_descriptor.get_reduce_function(),
+            self._window_converter)
+
+    def get_aggregating_state(self, state_descriptor: AggregatingStateDescriptor):
+        return AggregatingStateImpl(
+            self._get_or_create_keyed_state(state_descriptor),
+            from_type_info(state_descriptor.type_info),
+            state_descriptor.get_agg_function(),
+            self._window_converter)
+
+    def _get_or_create_keyed_state(self, state_descriptor: StateDescriptor):
+        return self._keyed_state_backend.getPartitionedState(
+            JVoidNamespace_INSTANCE,
+            self._window_serializer,
+            to_java_state_descriptor(state_descriptor))

--- a/flink-python/pyflink/fn_execution/embedded/state_impl.py
+++ b/flink-python/pyflink/fn_execution/embedded/state_impl.py
@@ -28,11 +28,18 @@ from pyflink.fn_execution.embedded.converters import from_type_info
 from pyflink.fn_execution.embedded.java_utils import to_java_state_descriptor
 
 JVoidNamespace = findClass('org.apache.flink.runtime.state.VoidNamespace')
+JVoidNamespaceSerializer = findClass('org.apache.flink.runtime.state.VoidNamespaceSerializer')
+
 JVoidNamespace_INSTANCE = JVoidNamespace.INSTANCE
+JVoidNamespaceSerializer_INSTANCE = JVoidNamespaceSerializer.INSTANCE
 
 
 class KeyedStateBackend(object):
-    def __init__(self, function_context, keyed_state_backend, window_serializer, window_converter):
+    def __init__(self,
+                 function_context,
+                 keyed_state_backend,
+                 window_serializer=JVoidNamespaceSerializer_INSTANCE,
+                 window_converter=None):
         self._function_context = function_context
         self._keyed_state_backend = keyed_state_backend
         self._window_serializer = window_serializer

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -309,7 +309,7 @@ try:
                         'cloudpickle==2.1.0', 'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
                         'pytz>=2018.3', 'fastavro>=1.1.0,<1.4.8', 'requests>=2.26.0',
                         'protobuf<3.18',
-                        'pemja==0.2.3;'
+                        'pemja==0.2.4;'
                         'python_full_version >= "3.7" and platform_system != "Windows"',
                         'httplib2>=0.19.0,<=0.20.4', apache_flink_libraries_dependency]
 

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -37,6 +37,7 @@ import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonCo
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonKeyedCoProcessOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonKeyedProcessOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonProcessOperator;
+import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonWindowOperator;
 import org.apache.flink.streaming.api.operators.python.process.AbstractExternalDataStreamPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.process.ExternalPythonCoProcessOperator;
 import org.apache.flink.streaming.api.operators.python.process.ExternalPythonKeyedCoProcessOperator;
@@ -429,7 +430,8 @@ public class PythonOperatorChainingOptimizer {
                         && (upOperator instanceof EmbeddedPythonKeyedProcessOperator
                                 || upOperator instanceof EmbeddedPythonKeyedCoProcessOperator
                                 || upOperator instanceof EmbeddedPythonProcessOperator
-                                || upOperator instanceof EmbeddedPythonCoProcessOperator));
+                                || upOperator instanceof EmbeddedPythonCoProcessOperator
+                                || upOperator instanceof EmbeddedPythonWindowOperator));
     }
 
     private static boolean arePythonOperatorsInSameExecutionEnvironment(

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractOneInputEmbeddedPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractOneInputEmbeddedPythonFunctionOperator.java
@@ -115,6 +115,7 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
         interpreter.set("function_context", getFunctionContext());
         interpreter.set("timer_context", getTimerContext());
         interpreter.set("job_parameters", getJobParameters());
+        interpreter.set("keyed_state_backend", getKeyedStateBackend());
 
         interpreter.exec(
                 "from pyflink.fn_execution.embedded.operation_utils import create_one_input_user_defined_data_stream_function_from_protos");
@@ -127,7 +128,8 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
                         + "runtime_context,"
                         + "function_context,"
                         + "timer_context,"
-                        + "job_parameters)");
+                        + "job_parameters,"
+                        + "keyed_state_backend)");
 
         interpreter.invokeMethod("operation", "open");
     }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractTwoInputEmbeddedPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractTwoInputEmbeddedPythonFunctionOperator.java
@@ -135,6 +135,7 @@ public abstract class AbstractTwoInputEmbeddedPythonFunctionOperator<IN1, IN2, O
         interpreter.set("runtime_context", getRuntimeContext());
         interpreter.set("function_context", getFunctionContext());
         interpreter.set("timer_context", getTimerContext());
+        interpreter.set("keyed_state_backend", getKeyedStateBackend());
         interpreter.set("job_parameters", getJobParameters());
 
         interpreter.exec(
@@ -149,7 +150,8 @@ public abstract class AbstractTwoInputEmbeddedPythonFunctionOperator<IN1, IN2, O
                         + "runtime_context,"
                         + "function_context,"
                         + "timer_context,"
-                        + "job_parameters)");
+                        + "job_parameters,"
+                        + "keyed_state_backend)");
 
         interpreter.invokeMethod("operation", "open");
     }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators.python.embedded;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.java.typeutils.RowTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.fnexecution.v1.FlinkFnApi;
+import org.apache.flink.python.util.ProtoUtils;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
+import org.apache.flink.streaming.api.utils.PythonTypeUtils;
+import org.apache.flink.table.runtime.operators.window.Window;
+import org.apache.flink.types.Row;
+
+import pemja.core.object.PyIterator;
+
+import java.util.List;
+
+import static org.apache.flink.python.PythonOptions.MAP_STATE_READ_CACHE_SIZE;
+import static org.apache.flink.python.PythonOptions.MAP_STATE_WRITE_CACHE_SIZE;
+import static org.apache.flink.python.PythonOptions.PYTHON_METRIC_ENABLED;
+import static org.apache.flink.python.PythonOptions.PYTHON_PROFILE_ENABLED;
+import static org.apache.flink.python.PythonOptions.STATE_CACHE_SIZE;
+import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchExecutionMode;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * {@link EmbeddedPythonWindowOperator} is responsible for executing user defined python
+ * ProcessWindowFunction in embedded Python environment.
+ */
+@Internal
+public class EmbeddedPythonWindowOperator<K, IN, OUT, W extends Window>
+        extends AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
+        implements Triggerable<K, W> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** For serializing the window in checkpoints. */
+    private final TypeSerializer<W> windowSerializer;
+
+    /** The TypeInformation of the key. */
+    private transient TypeInformation<K> keyTypeInfo;
+
+    private transient PythonTypeUtils.DataConverter<K, Object> keyConverter;
+
+    private transient WindowContextImpl windowContext;
+
+    private transient WindowTimerContextImpl windowTimerContext;
+
+    public EmbeddedPythonWindowOperator(
+            Configuration config,
+            DataStreamPythonFunctionInfo pythonFunctionInfo,
+            TypeInformation<IN> inputTypeInfo,
+            TypeInformation<OUT> outputTypeInfo,
+            TypeSerializer<W> windowSerializer) {
+        super(config, pythonFunctionInfo, inputTypeInfo, outputTypeInfo);
+        this.windowSerializer = checkNotNull(windowSerializer);
+    }
+
+    @Override
+    public void open() throws Exception {
+        keyTypeInfo = ((RowTypeInfo) this.getInputTypeInfo()).getTypeAt(0);
+
+        keyConverter = PythonTypeUtils.TypeInfoToDataConverter.typeInfoDataConverter(keyTypeInfo);
+
+        InternalTimerService<W> internalTimerService =
+                getInternalTimerService("window-timers", windowSerializer, this);
+
+        windowContext = new WindowContextImpl(internalTimerService);
+
+        windowTimerContext = new WindowTimerContextImpl(internalTimerService);
+
+        super.open();
+    }
+
+    @Override
+    public List<FlinkFnApi.UserDefinedDataStreamFunction> createUserDefinedFunctionsProto() {
+        return ProtoUtils.createUserDefinedDataStreamStatefulFunctionProtos(
+                getPythonFunctionInfo(),
+                getRuntimeContext(),
+                getJobParameters(),
+                keyTypeInfo,
+                inBatchExecutionMode(getKeyedStateBackend()),
+                config.get(PYTHON_METRIC_ENABLED),
+                config.get(PYTHON_PROFILE_ENABLED),
+                false,
+                config.get(STATE_CACHE_SIZE),
+                config.get(MAP_STATE_READ_CACHE_SIZE),
+                config.get(MAP_STATE_WRITE_CACHE_SIZE));
+    }
+
+    @Override
+    public void onEventTime(InternalTimer<K, W> timer) throws Exception {
+        collector.setAbsoluteTimestamp(timer.getTimestamp());
+        invokeUserFunction(timer);
+    }
+
+    @Override
+    public void onProcessingTime(InternalTimer<K, W> timer) throws Exception {
+        collector.eraseTimestamp();
+        invokeUserFunction(timer);
+    }
+
+    @Override
+    public Object getFunctionContext() {
+        return windowContext;
+    }
+
+    @Override
+    public Object getTimerContext() {
+        return windowTimerContext;
+    }
+
+    @Override
+    public <T> DataStreamPythonFunctionOperator<T> copy(
+            DataStreamPythonFunctionInfo pythonFunctionInfo, TypeInformation<T> outputTypeInfo) {
+        return null;
+    }
+
+    private void invokeUserFunction(InternalTimer<K, W> timer) throws Exception {
+        windowTimerContext.timer = timer;
+        interpreter.invokeMethod("operation", "on_timer", timer.getTimestamp());
+
+        PyIterator results =
+                (PyIterator)
+                        interpreter.invokeMethod("operation", "on_timer", timer.getTimestamp());
+
+        while (results.hasNext()) {
+            OUT result = outputDataConverter.toInternal(results.next());
+            collector.collect(result);
+        }
+        results.close();
+
+        windowTimerContext.timer = null;
+    }
+
+    private class WindowContextImpl {
+        private final InternalTimerService<W> timerService;
+
+        WindowContextImpl(InternalTimerService<W> timerService) {
+            this.timerService = timerService;
+        }
+
+        public TypeSerializer<W> getWindowSerializer() {
+            return windowSerializer;
+        }
+
+        public KeyedStateBackend<K> getCurrentKeyedStateBackend() {
+            return getKeyedStateBackend();
+        }
+
+        public long timestamp() {
+            return timestamp;
+        }
+
+        public InternalTimerService<W> timerService() {
+            return timerService;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Object getCurrentKey() {
+            return keyConverter.toExternal(
+                    (K) ((Row) EmbeddedPythonWindowOperator.this.getCurrentKey()).getField(0));
+        }
+    }
+
+    private class WindowTimerContextImpl {
+        private final InternalTimerService<W> timerService;
+
+        private InternalTimer<K, W> timer;
+
+        WindowTimerContextImpl(InternalTimerService<W> timerService) {
+            this.timerService = timerService;
+        }
+
+        public InternalTimerService<W> timerService() {
+            return timerService;
+        }
+
+        public long timestamp() {
+            return timer.getTimestamp();
+        }
+
+        public W getWindow() {
+            return timer.getNamespace();
+        }
+
+        @SuppressWarnings("unchecked")
+        public Object getCurrentKey() {
+            return keyConverter.toExternal((K) ((Row) timer.getKey()).getField(0));
+        }
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
@@ -25,7 +25,6 @@ import org.apache.flink.api.java.typeutils.RowTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.python.util.ProtoUtils;
-import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
 import org.apache.flink.streaming.api.operators.InternalTimer;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
@@ -166,10 +165,6 @@ public class EmbeddedPythonWindowOperator<K, IN, OUT, W extends Window>
 
         public TypeSerializer<W> getWindowSerializer() {
             return windowSerializer;
-        }
-
-        public KeyedStateBackend<K> getCurrentKeyedStateBackend() {
-            return getKeyedStateBackend();
         }
 
         public long timestamp() {

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -28,7 +28,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.beam:beam-vendor-sdks-java-extensions-protobuf:2.38.0
 - org.apache.beam:beam-vendor-guava-26_0-jre:0.1
 - org.apache.beam:beam-vendor-grpc-1_43_2:0.1
-- com.alibaba:pemja:0.2.3
+- com.alibaba:pemja:0.2.4
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support DataStream PythonWindowOperator in Thread Mode*


## Brief change log

  - *Support DataStream PythonWindowOperator in Thread Mode*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests for end-to-end deployment with large payloads (100MB)*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
