### PR TITLE
[FLINK-28420] Support partial caching in sync and async lookup runner

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/LookupCacheManager.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/LookupCacheManager.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source.lookup.cache;
+
+import org.apache.flink.annotation.Internal;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Managing shared caches across different subtasks.
+ *
+ * <p>In order to reduce the memory usage of cache, different subtasks of the same lookup join
+ * runner will share the same cache instance. Caches are managed by the identifier of the lookup
+ * table for which it is serving.
+ */
+@Internal
+public class LookupCacheManager {
+    private static LookupCacheManager instance;
+    private final Map<String, LookupCache> cachesByTableIdentifier = new HashMap<>();
+
+    /** Get the shared instance of {@link LookupCacheManager}. */
+    public static synchronized LookupCacheManager getInstance() {
+        if (instance == null) {
+            instance = new LookupCacheManager();
+        }
+        return instance;
+    }
+
+    /**
+     * Register a cache instance with table identifier to the manager.
+     *
+     * <p>If the cache with the given table identifier is already registered in the manager, this
+     * method will return the registered one, otherwise this method will register the given cache
+     * into the manager then return.
+     *
+     * @param tableIdentifier table identifier
+     * @param cache instance of cache trying to register
+     * @return instance of the shared cache
+     */
+    public synchronized LookupCache registerCache(String tableIdentifier, LookupCache cache) {
+        checkNotNull(cache, "Could not register null cache in the manager");
+        if (cachesByTableIdentifier.containsKey(tableIdentifier)) {
+            return cachesByTableIdentifier.get(tableIdentifier);
+        } else {
+            cachesByTableIdentifier.put(tableIdentifier, cache);
+            return cache;
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -384,7 +384,16 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                             generatedResultFuture,
                             InternalSerializers.create(rightRowType),
                             isLeftOuterJoin,
-                            asyncBufferCapacity);
+                            asyncBufferCapacity,
+                            LookupJoinUtil.getPartialLookupCacheHandler(
+                                            temporalTable,
+                                            config,
+                                            classLoader,
+                                            inputRowType,
+                                            tableSourceRowType,
+                                            lookupKeys,
+                                            false)
+                                    .orElse(null));
         } else {
             // right type is the same as table source row type, because no calc after temporal table
             asyncFunc =
@@ -394,7 +403,16 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                             generatedResultFuture,
                             InternalSerializers.create(rightRowType),
                             isLeftOuterJoin,
-                            asyncBufferCapacity);
+                            asyncBufferCapacity,
+                            LookupJoinUtil.getPartialLookupCacheHandler(
+                                            temporalTable,
+                                            config,
+                                            classLoader,
+                                            inputRowType,
+                                            tableSourceRowType,
+                                            lookupKeys,
+                                            false)
+                                    .orElse(null));
         }
 
         return new AsyncWaitOperatorFactory<>(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -479,7 +479,16 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                             generatedCalc,
                             generatedCollector,
                             isLeftOuterJoin,
-                            rightRowType.getFieldCount());
+                            rightRowType.getFieldCount(),
+                            LookupJoinUtil.getPartialLookupCacheHandler(
+                                            temporalTable,
+                                            config,
+                                            classLoader,
+                                            inputRowType,
+                                            tableSourceRowType,
+                                            lookupKeys,
+                                            isObjectReuseEnabled)
+                                    .orElse(null));
         } else {
             // right type is the same as table source row type, because no calc after temporal table
             processFunc =
@@ -487,7 +496,16 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                             generatedFetcher,
                             generatedCollector,
                             isLeftOuterJoin,
-                            rightRowType.getFieldCount());
+                            rightRowType.getFieldCount(),
+                            LookupJoinUtil.getPartialLookupCacheHandler(
+                                            temporalTable,
+                                            config,
+                                            classLoader,
+                                            inputRowType,
+                                            tableSourceRowType,
+                                            lookupKeys,
+                                            isObjectReuseEnabled)
+                                    .orElse(null));
         }
         return SimpleOperatorFactory.of(new ProcessOperator<>(processFunc));
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/LookupJoinCodeGenerator.scala
@@ -25,7 +25,7 @@ import org.apache.flink.table.catalog.DataTypeFactory
 import org.apache.flink.table.connector.source.{LookupTableSource, ScanTableSource}
 import org.apache.flink.table.data.{GenericRowData, RowData}
 import org.apache.flink.table.data.utils.JoinedRowData
-import org.apache.flink.table.functions.{AsyncTableFunction, LookupFunction, TableFunction, UserDefinedFunction, UserDefinedFunctionHelper}
+import org.apache.flink.table.functions.{AsyncLookupFunction, AsyncTableFunction, LookupFunction, TableFunction, UserDefinedFunction, UserDefinedFunctionHelper}
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.codegen.CodeGenUtils._
 import org.apache.flink.table.planner.codegen.GenerateUtils._
@@ -248,11 +248,15 @@ object LookupJoinCodeGenerator {
         val defaultArgDataTypes = callContext.getArgumentDataTypes.asScala
         val defaultOutputDataType = callContext.getOutputDataType.get()
 
-        val outputClass = if (udf.getClass.getSuperclass == classOf[LookupFunction]) {
-          Some(classOf[RowData])
-        } else {
-          toScala(extractSimpleGeneric(baseClass, udf.getClass, 0))
-        }
+        val outputClass =
+          if (
+            udf.getClass.getSuperclass == classOf[
+              LookupFunction] || udf.getClass.getSuperclass == classOf[AsyncLookupFunction]
+          ) {
+            Some(classOf[RowData])
+          } else {
+            toScala(extractSimpleGeneric(baseClass, udf.getClass, 0))
+          }
         val (argDataTypes, outputDataType) = outputClass match {
           case Some(c) if c == classOf[Row] =>
             (defaultArgDataTypes, defaultOutputDataType)

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinWithCalcRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/AsyncLookupJoinWithCalcRunner.java
@@ -31,6 +31,8 @@ import org.apache.flink.table.runtime.generated.GeneratedResultFuture;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.util.Collector;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collection;
 
@@ -48,14 +50,16 @@ public class AsyncLookupJoinWithCalcRunner extends AsyncLookupJoinRunner {
             GeneratedResultFuture<TableFunctionResultFuture<RowData>> generatedResultFuture,
             RowDataSerializer rightRowSerializer,
             boolean isLeftOuterJoin,
-            int asyncBufferCapacity) {
+            int asyncBufferCapacity,
+            @Nullable LookupCacheHandler cacheHandler) {
         super(
                 generatedFetcher,
                 fetcherConverter,
                 generatedResultFuture,
                 rightRowSerializer,
                 isLeftOuterJoin,
-                asyncBufferCapacity);
+                asyncBufferCapacity,
+                cacheHandler);
         this.generatedCalc = generatedCalc;
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupCacheHandler.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupCacheHandler.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.lookup;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.groups.CacheMetricGroup;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCacheManager;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.generated.GeneratedProjection;
+import org.apache.flink.table.runtime.generated.Projection;
+import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
+import org.apache.flink.types.RowKind;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** A helper class providing utils for accessing {@link LookupCache}. */
+@Internal
+public class LookupCacheHandler implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final String tableIdentifier;
+
+    // A projection which convert the input from left table to a row that only keeps the joining
+    // keys. The cache should only store the joining keys as the cache key.
+    private final GeneratedProjection generatedCacheKeyProjection;
+
+    // Serializer for deep copy the key and value to be stored in the cache.
+    // Make as nullable since copying is only required when object reuse is enabled.
+    @Nullable private final RowDataSerializer cacheKeySerializer;
+    @Nullable private final RowDataSerializer cacheValueSerializer;
+
+    private LookupCache cache;
+    private boolean initialized = false;
+
+    // The runtime instance of the cache key projection
+    private transient Projection<RowData, RowData> cacheKeyProjection;
+
+    public LookupCacheHandler(
+            LookupCache cache,
+            String tableIdentifier,
+            GeneratedProjection generatedCacheKeyProjection) {
+        this(cache, tableIdentifier, generatedCacheKeyProjection, null, null);
+    }
+
+    public LookupCacheHandler(
+            LookupCache cache,
+            String tableIdentifier,
+            GeneratedProjection generatedCacheKeyProjection,
+            @Nullable RowDataSerializer cacheKeySerializer,
+            @Nullable RowDataSerializer cacheValueSerializer) {
+        this.cache = cache;
+        this.tableIdentifier = tableIdentifier;
+        this.generatedCacheKeyProjection = checkNotNull(generatedCacheKeyProjection);
+        this.cacheKeySerializer = cacheKeySerializer;
+        this.cacheValueSerializer = cacheValueSerializer;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void open(CacheMetricGroup metricGroup, ClassLoader classLoader) {
+        // Try to register the holding cache into the manager, and the manager will return the
+        // actual shared cache to use
+        cache = LookupCacheManager.getInstance().registerCache(tableIdentifier, cache);
+        cache.open(metricGroup);
+        cacheKeyProjection = generatedCacheKeyProjection.newInstance(classLoader);
+        initialized = true;
+    }
+
+    /** Project the input row from left table to get the key row. */
+    public RowData getKeyRowFromInput(RowData in) {
+        RowData keyRow = cacheKeyProjection.apply(in);
+        keyRow.setRowKind(RowKind.INSERT);
+        return keyRow;
+    }
+
+    /**
+     * Put the key value pair into the cache. If object reuse is enabled, copy the key value pair
+     * before storing into the cache.
+     */
+    public void maybeCopyThenPut(RowData key, Collection<RowData> value) {
+        if (cacheKeySerializer != null && cacheValueSerializer != null) {
+            RowData copiesKey = cacheKeySerializer.copy(key);
+            Collection<RowData> copiedValues =
+                    value.stream()
+                            .map(cacheValueSerializer::copy)
+                            .collect(Collectors.toCollection(ArrayList::new));
+            getCache().put(copiesKey, copiedValues);
+        } else {
+            getCache().put(key, value);
+        }
+    }
+
+    public LookupCache getCache() {
+        checkInitialized();
+        return cache;
+    }
+
+    private void checkInitialized() {
+        checkState(initialized, "The cache handler is not initialized");
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupJoinRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupJoinRunner.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.table.runtime.operators.join.lookup;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.functions.util.FunctionUtils;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.metrics.groups.InternalCacheMetricGroup;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.utils.JoinedRowData;
@@ -30,29 +33,48 @@ import org.apache.flink.table.runtime.generated.GeneratedCollector;
 import org.apache.flink.table.runtime.generated.GeneratedFunction;
 import org.apache.flink.util.Collector;
 
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /** The join runner to lookup the dimension table. */
 public class LookupJoinRunner extends ProcessFunction<RowData, RowData> {
     private static final long serialVersionUID = -4521543015709964733L;
+
+    public static final String LOOKUP_CACHE_METRIC_GROUP = "lookupCache";
 
     private final GeneratedFunction<FlatMapFunction<RowData, RowData>> generatedFetcher;
     private final GeneratedCollector<TableFunctionCollector<RowData>> generatedCollector;
     private final boolean isLeftOuterJoin;
     private final int tableFieldsCount;
 
+    // For handling lookup caching, mark as nullable since caching might not be enabled
+    @Nullable private final LookupCacheHandler cacheHandler;
+
     private transient FlatMapFunction<RowData, RowData> fetcher;
     protected transient TableFunctionCollector<RowData> collector;
     private transient GenericRowData nullRow;
     private transient JoinedRowData outRow;
 
+    // For storing entries into the cache before collecting, mark as nullable since caching might
+    // not be enabled
+    @Nullable protected transient ResultCachingCollector cachingCollector;
+
     public LookupJoinRunner(
             GeneratedFunction<FlatMapFunction<RowData, RowData>> generatedFetcher,
             GeneratedCollector<TableFunctionCollector<RowData>> generatedCollector,
             boolean isLeftOuterJoin,
-            int tableFieldsCount) {
+            int tableFieldsCount,
+            @Nullable LookupCacheHandler cacheHandler) {
         this.generatedFetcher = generatedFetcher;
         this.generatedCollector = generatedCollector;
         this.isLeftOuterJoin = isLeftOuterJoin;
         this.tableFieldsCount = tableFieldsCount;
+        this.cacheHandler = cacheHandler;
     }
 
     @Override
@@ -61,7 +83,9 @@ public class LookupJoinRunner extends ProcessFunction<RowData, RowData> {
         this.fetcher = generatedFetcher.newInstance(getRuntimeContext().getUserCodeClassLoader());
         this.collector =
                 generatedCollector.newInstance(getRuntimeContext().getUserCodeClassLoader());
-
+        if (cacheHandler != null) {
+            cachingCollector = new ResultCachingCollector(cacheHandler);
+        }
         FunctionUtils.setFunctionRuntimeContext(fetcher, getRuntimeContext());
         FunctionUtils.setFunctionRuntimeContext(collector, getRuntimeContext());
         FunctionUtils.openFunction(fetcher, parameters);
@@ -69,22 +93,62 @@ public class LookupJoinRunner extends ProcessFunction<RowData, RowData> {
 
         this.nullRow = new GenericRowData(tableFieldsCount);
         this.outRow = new JoinedRowData();
+        maybeInitializeCacheHandler();
     }
 
     @Override
     public void processElement(RowData in, Context ctx, Collector<RowData> out) throws Exception {
+        // Setup collector
         collector.setCollector(out);
         collector.setInput(in);
         collector.reset();
 
-        // fetcher has copied the input field when object reuse is enabled
-        fetcher.flatMap(in, getFetcherCollector());
-
-        if (isLeftOuterJoin && !collector.isCollected()) {
-            outRow.replace(in, nullRow);
-            outRow.setRowKind(in.getRowKind());
-            out.collect(outRow);
+        if (cacheHandler != null) {
+            lookupViaCache(in, out);
+        } else {
+            fetcher.flatMap(in, getFetcherCollector());
+            maybeEmitNullForLeftOuterJoin(in, out);
         }
+    }
+
+    /**
+     * Make a lookup via the cache.
+     *
+     * <p>This function checks the cache first and emits cached records to the collector directly on
+     * cache hit, otherwise it will trigger a lookup in fetcher (user-provided logic) then store the
+     * result into the cache.
+     *
+     * <p>Please notice that the key row stored in the cache will be the input from left table after
+     * applying {@link LookupCacheHandler#getKeyRowFromInput}, and the value will be the raw value
+     * returned by user's fetcher, which means no calculation and projection. For example:
+     *
+     * <p>- Input from left table (id, name): +I(1, Alice)
+     *
+     * <p>- Value return by user's fetcher (id, age, gender): +I(1, 18, female)
+     *
+     * <p>Then the entry stored in the cache would be: +I(1), +I(1, 18, female), even calculation
+     * (age + 1) and projection (keep column "age" only) are applied.
+     *
+     * @param in input from left table
+     * @param out final output collector, after applying projection on the lookup result (and
+     *     calculating if using {@link LookupJoinWithCalcRunner}).
+     */
+    private void lookupViaCache(RowData in, Collector<RowData> out) throws Exception {
+        assert cacheHandler != null;
+        RowData keyRow = cacheHandler.getKeyRowFromInput(in);
+        Collection<RowData> cachedValues = cacheHandler.getCache().getIfPresent(keyRow);
+        if (cachedValues != null) {
+            // Cache hit, collect rows stored in the cache directly
+            cachedValues.forEach(getFetcherCollector()::collect);
+        } else {
+            assert cachingCollector != null;
+            // Cache miss, trigger a lookup in fetcher and store the result in the cache
+            cachingCollector.setDelegate(getFetcherCollector());
+            cachingCollector.reset();
+            fetcher.flatMap(in, cachingCollector);
+            cachingCollector.storeInCache(keyRow);
+        }
+        maybeEmitNullForLeftOuterJoin(in, out);
     }
 
     public Collector<RowData> getFetcherCollector() {
@@ -100,5 +164,68 @@ public class LookupJoinRunner extends ProcessFunction<RowData, RowData> {
         if (collector != null) {
             FunctionUtils.closeFunction(collector);
         }
+        if (cacheHandler != null) {
+            cacheHandler.getCache().close();
+        }
+    }
+
+    @Nullable
+    @VisibleForTesting
+    public LookupCache getLookupCache() {
+        return cacheHandler == null ? null : cacheHandler.getCache();
+    }
+
+    // ---------------------------- Helper methods --------------------------
+
+    private void maybeEmitNullForLeftOuterJoin(RowData in, Collector<RowData> out) {
+        if (!collector.isCollected() && isLeftOuterJoin) {
+            outRow.replace(in, nullRow);
+            outRow.setRowKind(in.getRowKind());
+            out.collect(outRow);
+        }
+    }
+
+    private void maybeInitializeCacheHandler() {
+        if (cacheHandler == null) {
+            return;
+        }
+        cacheHandler.open(
+                new InternalCacheMetricGroup(
+                        getRuntimeContext().getMetricGroup(), LOOKUP_CACHE_METRIC_GROUP),
+                getRuntimeContext().getUserCodeClassLoader());
+    }
+
+    // ----------------------------- Helper classes --------------------------
+
+    private static class ResultCachingCollector implements Collector<RowData> {
+
+        private Collector<RowData> delegate;
+        private final LookupCacheHandler cacheHandler;
+        private List<RowData> currentValues = new ArrayList<>();
+
+        public ResultCachingCollector(LookupCacheHandler cacheHandler) {
+            this.cacheHandler = checkNotNull(cacheHandler);
+        }
+
+        public void setDelegate(Collector<RowData> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void collect(RowData record) {
+            currentValues.add(record);
+            delegate.collect(record);
+        }
+
+        public void storeInCache(RowData keyRow) {
+            cacheHandler.maybeCopyThenPut(keyRow, currentValues);
+        }
+
+        public void reset() {
+            currentValues = new ArrayList<>();
+        }
+
+        @Override
+        public void close() {}
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupJoinWithCalcRunner.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/LookupJoinWithCalcRunner.java
@@ -27,6 +27,8 @@ import org.apache.flink.table.runtime.generated.GeneratedCollector;
 import org.apache.flink.table.runtime.generated.GeneratedFunction;
 import org.apache.flink.util.Collector;
 
+import javax.annotation.Nullable;
+
 /** The join runner with an additional calculate function on the dimension table. */
 public class LookupJoinWithCalcRunner extends LookupJoinRunner {
 
@@ -41,8 +43,14 @@ public class LookupJoinWithCalcRunner extends LookupJoinRunner {
             GeneratedFunction<FlatMapFunction<RowData, RowData>> generatedCalc,
             GeneratedCollector<TableFunctionCollector<RowData>> generatedCollector,
             boolean isLeftOuterJoin,
-            int tableFieldsCount) {
-        super(generatedFetcher, generatedCollector, isLeftOuterJoin, tableFieldsCount);
+            int tableFieldsCount,
+            @Nullable LookupCacheHandler cacheHandler) {
+        super(
+                generatedFetcher,
+                generatedCollector,
+                isLeftOuterJoin,
+                tableFieldsCount,
+                cacheHandler);
         this.generatedCalc = generatedCalc;
     }
 

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedFunctionWrapper.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedFunctionWrapper.java
@@ -20,25 +20,35 @@ package org.apache.flink.table.runtime.generated;
 
 import org.apache.flink.api.common.functions.Function;
 
+import java.util.function.Consumer;
+
 /**
  * A wrapper for {@link GeneratedFunction} which wraps a class instead of generated code in it. It
  * is only used for easy testing.
  */
 public class GeneratedFunctionWrapper<F extends Function> extends GeneratedFunction<F> {
 
-    private static final long serialVersionUID = 3964204655565783705L;
+    private static final long serialVersionUID = 5441271500290946721L;
     private final Class<F> clazz;
+    private final Consumer<F> newInstanceConsumer;
 
     public GeneratedFunctionWrapper(F function) {
+        this(function, (ignored) -> {});
+    }
+
+    public GeneratedFunctionWrapper(F function, Consumer<F> newInstanceConsumer) {
         super(function.getClass().getSimpleName(), "", new Object[0]);
         //noinspection unchecked
         this.clazz = (Class<F>) function.getClass();
+        this.newInstanceConsumer = newInstanceConsumer;
     }
 
     @Override
     public F newInstance(ClassLoader classLoader) {
         try {
-            return clazz.newInstance();
+            F function = clazz.newInstance();
+            newInstanceConsumer.accept(function);
+            return function;
         } catch (Exception e) {
             throw new RuntimeException(
                     "Could not instantiate class " + clazz.getCanonicalName(), e);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedProjectionWrapper.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/generated/GeneratedProjectionWrapper.java
@@ -18,32 +18,25 @@
 
 package org.apache.flink.table.runtime.generated;
 
-import org.apache.flink.util.Collector;
+import org.apache.flink.table.data.RowData;
 
-import java.util.function.Consumer;
+@SuppressWarnings("rawtypes")
+public class GeneratedProjectionWrapper<IN extends RowData, OUT extends RowData>
+        extends GeneratedProjection {
 
-/**
- * A wrapper for {@link GeneratedCollector} which wraps a class instead of generated code in it. It
- * is only used for easy testing.
- */
-public class GeneratedCollectorWrapper<C extends Collector<?>> extends GeneratedCollector<C> {
+    private static final long serialVersionUID = 1L;
+    private final Class<Projection> clazz;
 
-    private static final long serialVersionUID = 3964204655565783705L;
-    private final Class<C> clazz;
-    private final Consumer<C> newInstanceConsumer;
-
-    public GeneratedCollectorWrapper(C collector, Consumer<C> newInstanceConsumer) {
-        super(collector.getClass().getSimpleName(), "", new Object[0]);
-        this.clazz = (Class<C>) collector.getClass();
-        this.newInstanceConsumer = newInstanceConsumer;
+    @SuppressWarnings("unchecked")
+    public GeneratedProjectionWrapper(Projection<IN, OUT> projection) {
+        super(projection.getClass().getSimpleName(), "", new Object[0]);
+        this.clazz = (Class<Projection>) projection.getClass();
     }
 
     @Override
-    public C newInstance(ClassLoader classLoader) {
+    public Projection newInstance(ClassLoader classLoader) {
         try {
-            C collector = clazz.newInstance();
-            newInstanceConsumer.accept(collector);
-            return collector;
+            return clazz.newInstance();
         } catch (Exception e) {
             throw new RuntimeException(
                     "Could not instantiate class " + clazz.getCanonicalName(), e);
@@ -51,7 +44,7 @@ public class GeneratedCollectorWrapper<C extends Collector<?>> extends Generated
     }
 
     @Override
-    public Class<C> compile(ClassLoader classLoader) {
+    public Class<Projection> compile(ClassLoader classLoader) {
         return clazz;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request add partial caching functionality in sync and async lookup runners, which is a part of FLIP-221.

## Brief change log
- Support partial caching for sync lookup table
- Port TestValuesLookupFunction onto new LookupFunction API and add tests for sync lookup
- Support partial caching for async lookup table
- Port AsyncTestValuesLookupFunction onto new AsyncLookupFunction and add tests for async lookup

## Verifying this change

This change modifies some existing tests, including *LookupJoinHarnessTest* and *LookupJoinITCase*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (**yes** / no)
  - If yes, how is the feature documented? (not applicable / docs / **JavaDocs** / not documented)
