### PR TITLE
[FLINK-27908][network] HsSubpartitionView should calculate backlog no less than true value

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
@@ -83,7 +83,7 @@ public class HsSubpartitionView
                     bufferToConsume = memoryDataView.consumeBuffer(lastConsumedBufferIndex + 1);
                 }
                 updateConsumingStatus(bufferToConsume);
-                return bufferToConsume.orElse(null);
+                return bufferToConsume.map(this::handleBacklog).orElse(null);
             } catch (Throwable cause) {
                 releaseInternal(cause);
                 return null;
@@ -118,7 +118,7 @@ public class HsSubpartitionView
                     && cachedNextDataType == Buffer.DataType.EVENT_BUFFER) {
                 availability = true;
             }
-            return new AvailabilityWithBacklog(availability, diskDataView.getBacklog());
+            return new AvailabilityWithBacklog(availability, getSubpartitionBacklog());
         }
     }
 
@@ -182,16 +182,16 @@ public class HsSubpartitionView
         // the ack, as there are no checkpoints
     }
 
-    @SuppressWarnings("FieldAccessNotGuarded")
     @Override
     public int unsynchronizedGetNumberOfQueuedBuffers() {
-        return diskDataView.getBacklog();
+        return getSubpartitionBacklog();
     }
 
-    @SuppressWarnings("FieldAccessNotGuarded")
     @Override
     public int getNumberOfQueuedBuffers() {
-        return diskDataView.getBacklog();
+        synchronized (lock) {
+            return getSubpartitionBacklog();
+        }
     }
 
     @Override
@@ -202,6 +202,25 @@ public class HsSubpartitionView
     // -------------------------------
     //       Internal Methods
     // -------------------------------
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    private int getSubpartitionBacklog() {
+        if (memoryDataView == null || diskDataView == null) {
+            return 0;
+        }
+        return Math.max(memoryDataView.getBacklog(), diskDataView.getBacklog());
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private BufferAndBacklog handleBacklog(BufferAndBacklog bufferToConsume) {
+        return bufferToConsume.buffersInBacklog() == 0
+                ? new BufferAndBacklog(
+                        bufferToConsume.buffer(),
+                        getSubpartitionBacklog(),
+                        bufferToConsume.getNextDataType(),
+                        bufferToConsume.getSequenceNumber())
+                : bufferToConsume;
+    }
 
     @GuardedBy("lock")
     private Optional<BufferAndBacklog> tryReadFromDisk() throws Throwable {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
@@ -211,7 +211,6 @@ public class HsSubpartitionView
         return Math.max(memoryDataView.getBacklog(), diskDataView.getBacklog());
     }
 
-    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     private BufferAndBacklog handleBacklog(BufferAndBacklog bufferToConsume) {
         return bufferToConsume.buffersInBacklog() == 0
                 ? new BufferAndBacklog(


### PR DESCRIPTION
## What is the purpose of the change

*HsSubpartitionView calculate backlog no less than true value*


## Brief change log

  - *Change logical of calculate backlog in HsSubpartitionView.*

## Verifying this change

This change added `testGetNextBufferZeroBacklog` in `HsSubpartitionViewTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
