### PR TITLE
[FLINK-28804][formats] Use proper stand-ins for missing metric groups

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/DeserializationSchemaAdapter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/DeserializationSchemaAdapter.java
@@ -29,6 +29,7 @@ import org.apache.flink.connector.file.src.util.ArrayResultIterator;
 import org.apache.flink.core.fs.FileInputSplit;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.InstantiationUtil;
@@ -64,8 +65,7 @@ public class DeserializationSchemaAdapter implements BulkFormat<RowData, FileSou
                     new DeserializationSchema.InitializationContext() {
                         @Override
                         public MetricGroup getMetricGroup() {
-                            throw new UnsupportedOperationException(
-                                    "MetricGroup is unsupported in BulkFormat.");
+                            return new UnregisteredMetricsGroup();
                         }
 
                         @Override

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/SerializationSchemaAdapter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/SerializationSchemaAdapter.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.Encoder;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.util.UserCodeClassLoader;
 
@@ -59,8 +60,7 @@ public class SerializationSchemaAdapter implements Encoder<RowData> {
                         new SerializationSchema.InitializationContext() {
                             @Override
                             public MetricGroup getMetricGroup() {
-                                throw new UnsupportedOperationException(
-                                        "MetricGroup is unsupported in BulkFormat.");
+                                return new UnregisteredMetricsGroup();
                             }
 
                             @Override

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaRecordSerializationSchemaBuilderTest.java
@@ -19,10 +19,9 @@ package org.apache.flink.connector.kafka.sink;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
-import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.connector.testutils.formats.DummyInitializationContext;
 import org.apache.flink.streaming.connectors.kafka.partitioner.FlinkKafkaPartitioner;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.UserCodeClassLoader;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
@@ -351,28 +350,6 @@ public class KafkaRecordSerializationSchemaBuilderTest extends TestLogger {
     }
 
     private void open(KafkaRecordSerializationSchema<String> schema) throws Exception {
-        schema.open(
-                new SerializationSchema.InitializationContext() {
-                    @Override
-                    public MetricGroup getMetricGroup() {
-                        return null;
-                    }
-
-                    @Override
-                    public UserCodeClassLoader getUserCodeClassLoader() {
-                        return new UserCodeClassLoader() {
-                            @Override
-                            public ClassLoader asClassLoader() {
-                                return KafkaRecordSerializationSchemaBuilderTest.class
-                                        .getClassLoader();
-                            }
-
-                            @Override
-                            public void registerReleaseHookIfAbsent(
-                                    String releaseHookName, Runnable releaseHook) {}
-                        };
-                    }
-                },
-                null);
+        schema.open(new DummyInitializationContext(), null);
     }
 }


### PR DESCRIPTION
Resolve a few cases of undesired behavior when a schema attempts to access the metric group.
We shouldn't fail in that case but silently ignore it if we have to, as we do in other areas of Flink (because a lack of metrics should never fail a job).