### PR TITLE
[FLINK-28808][csv] Create mapper on server-side

### DIFF
--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
@@ -166,15 +166,17 @@ public class CsvFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
                 final RowDataToCsvConverter converter =
                         RowDataToCsvConverters.createRowConverter(rowType);
 
-                final CsvMapper mapper = new CsvMapper();
-                final ObjectNode container = mapper.createObjectNode();
+                return out -> {
+                    final CsvMapper mapper = new CsvMapper();
+                    final ObjectNode container = mapper.createObjectNode();
 
-                final RowDataToCsvConverter.RowDataToCsvFormatConverterContext converterContext =
-                        new RowDataToCsvConverter.RowDataToCsvFormatConverterContext(
-                                mapper, container);
-
-                return out ->
-                        CsvBulkWriter.forSchema(mapper, schema, converter, converterContext, out);
+                    final RowDataToCsvConverter.RowDataToCsvFormatConverterContext
+                            converterContext =
+                                    new RowDataToCsvConverter.RowDataToCsvFormatConverterContext(
+                                            mapper, container);
+                    return CsvBulkWriter.forSchema(
+                            mapper, schema, converter, converterContext, out);
+                };
             }
 
             @Override

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
@@ -163,26 +163,27 @@ public class CsvFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
                 final RowType rowType = (RowType) physicalDataType.getLogicalType();
                 final CsvSchema schema = buildCsvSchema(rowType, formatOptions);
 
-                final RowDataToCsvConverter converter =
-                        RowDataToCsvConverters.createRowConverter(rowType);
-
-                return out -> {
-                    final CsvMapper mapper = new CsvMapper();
-                    final ObjectNode container = mapper.createObjectNode();
-
-                    final RowDataToCsvConverter.RowDataToCsvFormatConverterContext
-                            converterContext =
-                                    new RowDataToCsvConverter.RowDataToCsvFormatConverterContext(
-                                            mapper, container);
-                    return CsvBulkWriter.forSchema(
-                            mapper, schema, converter, converterContext, out);
-                };
+                return createCsvBulkWriterFactory(schema, rowType);
             }
 
             @Override
             public ChangelogMode getChangelogMode() {
                 return ChangelogMode.insertOnly();
             }
+        };
+    }
+
+    static BulkWriter.Factory<RowData> createCsvBulkWriterFactory(
+            CsvSchema schema, RowType rowType) {
+        final RowDataToCsvConverter converter = RowDataToCsvConverters.createRowConverter(rowType);
+
+        return out -> {
+            final CsvMapper mapper = new CsvMapper();
+            final ObjectNode container = mapper.createObjectNode();
+
+            final RowDataToCsvConverter.RowDataToCsvFormatConverterContext converterContext =
+                    new RowDataToCsvConverter.RowDataToCsvFormatConverterContext(mapper, container);
+            return CsvBulkWriter.forSchema(mapper, schema, converter, converterContext, out);
         };
     }
 

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowDataToCsvConverters.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/RowDataToCsvConverters.java
@@ -65,7 +65,7 @@ public class RowDataToCsvConverters implements Serializable {
          * Converter context for passing the {@code CsvMapper} and the {@code container} that can be
          * reused between transformations of the individual elements for performance reasons.
          */
-        class RowDataToCsvFormatConverterContext implements Serializable {
+        class RowDataToCsvFormatConverterContext {
             CsvMapper csvMapper;
             ContainerNode<?> container;
 

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -79,6 +79,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-files</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-csv</artifactId>
 			<version>${project.version}</version>
 			<scope>provided</scope>

--- a/flink-python/pyflink/datastream/formats/csv.py
+++ b/flink-python/pyflink/datastream/formats/csv.py
@@ -340,17 +340,9 @@ class CsvBulkWriter(object):
         Builds a :class:`BulkWriterFactory` for writing records to files in CSV format.
         """
         jvm = get_gateway().jvm
-        jackson = jvm.org.apache.flink.shaded.jackson2.com.fasterxml.jackson
         csv = jvm.org.apache.flink.formats.csv
 
-        j_converter = csv.RowDataToCsvConverters.createRowConverter(
-            _to_java_data_type(schema._row_type).getLogicalType())
-        j_mapper = jackson.dataformat.csv.CsvMapper()
-        j_container = j_mapper.createObjectNode()
-        j_context = csv.PythonCsvUtils.createRowDataToCsvFormatConverterContext(
-            j_mapper, j_container)
-
         j_factory = csv.PythonCsvUtils.createCsvBulkWriterFactory(
-            j_mapper, schema._j_schema, j_converter, j_context
-        )
+            schema._j_schema,
+            _to_java_data_type(schema._row_type))
         return RowDataBulkWriterFactory(j_factory, schema._row_type)

--- a/flink-python/src/main/java/org/apache/flink/formats/csv/PythonCsvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/formats/csv/PythonCsvUtils.java
@@ -18,7 +18,7 @@
 package org.apache.flink.formats.csv;
 
 import org.apache.flink.api.common.serialization.BulkWriter;
-import org.apache.flink.formats.common.Converter;
+import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
@@ -62,8 +62,10 @@ public class PythonCsvUtils {
     /**
      * Util for creating a {@link BulkWriter.Factory} that wraps {@link CsvBulkWriter#forSchema}.
      */
-    public static <T, R, C> BulkWriter.Factory<T> createCsvBulkWriterFactory(
-            CsvMapper mapper, CsvSchema schema, Converter<T, R, C> converter, C converterContext) {
-        return (out) -> CsvBulkWriter.forSchema(mapper, schema, converter, converterContext, out);
+    public static BulkWriter.Factory<RowData> createCsvBulkWriterFactory(
+            CsvSchema schema, DataType physicalDataType) {
+
+        return CsvFileFormatFactory.createCsvBulkWriterFactory(
+                schema, (RowType) physicalDataType.getLogicalType());
     }
 }


### PR DESCRIPTION
Since we shouldn't assume that jackson mappers are serializable (due to non-serializable extension) the RowDataToCsvFormatConverterContext also shouldn't be serializable.


With that in mind the CsvFileFormatFactory should create the context when the writer is created, not beforehand.
