### PR TITLE
[FLINK-25244][hbase] Enable Java 11 tests for HBase 2.2

### DIFF
--- a/flink-connectors/flink-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-connector-hbase-2.2/pom.xml
@@ -34,7 +34,6 @@ under the License.
 
 	<properties>
 		<hbase.version>2.2.3</hbase.version>
-		<hbase.guava.version>28.1-jre</hbase.guava.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-connector-hbase-2.2/pom.xml
@@ -420,26 +420,4 @@ under the License.
 		</dependencies>
 	</dependencyManagement>
 
-	<profiles>
-		<profile>
-			<id>java11</id>
-			<activation>
-				<jdk>[11,)</jdk>
-			</activation>
-
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<configuration>
-							<!-- hbase currently does not support Java 11, see HBASE-21110 -->
-							<skip>true</skip>
-						</configuration>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
-
 </project>


### PR DESCRIPTION
Successful Java 11 build: https://dev.azure.com/chesnay/flink/_build/results?buildId=2899&view=results