### PR TITLE
[FLINK-28814][Connectors][JDBC] Update org.postgresql:postgresql to 42.4.1

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<postgres.version>42.3.3</postgres.version>
+		<postgres.version>42.4.1</postgres.version>
 		<oracle.version>19.3.0.0</oracle.version>
 	</properties>
 


### PR DESCRIPTION
## What is the purpose of the change
This a simple update of postgres jdbc driver to cope with CVE-2022-31197
https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-r38f-c4h4-hqq2

## Brief change log

pom file


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no )
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
