### PR TITLE
[FLINK-28785][network] Hybrid shuffle consumer thread and upstream thread may have deadlock

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -190,7 +190,11 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
         for (int channel = 0; channel < numSubpartitions; channel++) {
             HsSubpartitionViewInternalOperations viewOperation =
                     subpartitionViewOperationsMap.get(channel);
-            consumeIndexes.add(viewOperation == null ? -1 : viewOperation.getConsumingOffset() + 1);
+            // Access consuming offset without lock to prevent deadlock.
+            // A consuming thread may being blocked on the memory data manager lock, while holding
+            // the viewOperation lock.
+            consumeIndexes.add(
+                    viewOperation == null ? -1 : viewOperation.getConsumingOffset(false) + 1);
         }
         return consumeIndexes;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -184,7 +184,9 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
     /** Refresh downstream consumption progress for another round scheduling of reading. */
     @Override
     public void prepareForScheduling() {
-        bufferIndexManager.updateLastConsumed(operations.getConsumingOffset());
+        // Access the consuming offset with lock, to prevent loading any buffer released from the
+        // memory data manager that is already consumed.
+        bufferIndexManager.updateLastConsumed(operations.getConsumingOffset(true));
     }
 
     /** Provides priority calculation logic for io scheduler. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
@@ -134,8 +134,12 @@ public class HsSubpartitionView
         }
     }
 
+    @SuppressWarnings("FieldAccessNotGuarded")
     @Override
-    public int getConsumingOffset() {
+    public int getConsumingOffset(boolean withLock) {
+        if (!withLock) {
+            return lastConsumedBufferIndex;
+        }
         synchronized (lock) {
             return lastConsumedBufferIndex;
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewInternalOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewInternalOperations.java
@@ -27,6 +27,13 @@ public interface HsSubpartitionViewInternalOperations {
     /** Callback for new data become available. */
     void notifyDataAvailable();
 
-    /** Get the latest consuming offset of the subpartition. */
-    int getConsumingOffset();
+    /**
+     * Get the latest consuming offset of the subpartition.
+     *
+     * @param withLock If true, read the consuming offset outside the guarding of lock. This is
+     *     sometimes desired to avoid lock contention, if the caller does not depend on any other
+     *     states to change atomically with the consuming offset.
+     * @return latest consuming offset.
+     */
+    int getConsumingOffset(boolean withLock);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
@@ -176,7 +176,7 @@ class HsSubpartitionFileReaderImplTest {
 
         subpartitionOperation.advanceConsumptionProgress();
         subpartitionOperation.advanceConsumptionProgress();
-        assertThat(subpartitionOperation.getConsumingOffset()).isEqualTo(1);
+        assertThat(subpartitionOperation.getConsumingOffset(true)).isEqualTo(1);
         // update consumptionProgress
         subpartitionFileReader.prepareForScheduling();
         // read buffer, expected buffer with index: 2

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionViewInternalOperation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionViewInternalOperation.java
@@ -32,7 +32,7 @@ public class TestingSubpartitionViewInternalOperation
     }
 
     @Override
-    public int getConsumingOffset() {
+    public int getConsumingOffset(boolean withLock) {
         return consumingOffset;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

In hybrid shuffle mode, subpartition view lock will be acquired by consumer thread, and further wait the read lock of MemoryDataManager. But MemoryDataManager may acquire write lock to make a global spilling decision, and then wait subpartition view lock to get consuming offset. In this case, deadlock will occurs.

consumer thread : acqurie subpartition lock -> wait read lock.

upstream thread  : acquire write lock -> wait subpartition lock.

## Brief change log

  - *FileDataManager get consuming offset with lock.*
  - *MemoryDataManager get consuming offset without lock*

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
