### PR TITLE
[FLINK-28373][network] Read a full buffer of data per file IO read request for sort-shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/CompositeBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/CompositeBuffer.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.buffer;
+
+import org.apache.flink.core.memory.MemorySegment;
+
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
+import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBufAllocator;
+import org.apache.flink.shaded.netty4.io.netty.buffer.CompositeByteBuf;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An implementation of {@link Buffer} which contains multiple partial buffers for network data
+ * communication.
+ */
+public class CompositeBuffer implements Buffer {
+
+    private final DataType dataType;
+
+    private final int length;
+
+    private final boolean isCompressed;
+
+    private final List<Buffer> partialBuffers = new ArrayList<>();
+
+    private int currentLength;
+
+    private ByteBufAllocator allocator;
+
+    public CompositeBuffer(DataType dataType, int length, boolean isCompressed) {
+        this.dataType = checkNotNull(dataType);
+        this.length = length;
+        this.isCompressed = isCompressed;
+    }
+
+    public CompositeBuffer(BufferHeader header) {
+        this(header.getDataType(), header.getLength(), header.isCompressed());
+    }
+
+    @Override
+    public boolean isBuffer() {
+        return dataType.isBuffer();
+    }
+
+    @Override
+    public void recycleBuffer() {
+        for (Buffer partialBuffer : partialBuffers) {
+            partialBuffer.recycleBuffer();
+        }
+    }
+
+    @Override
+    public Buffer retainBuffer() {
+        for (Buffer partialBuffer : partialBuffers) {
+            partialBuffer.retainBuffer();
+        }
+        return this;
+    }
+
+    @Override
+    public int getSize() {
+        return currentLength;
+    }
+
+    @Override
+    public int readableBytes() {
+        return currentLength;
+    }
+
+    @Override
+    public void setAllocator(ByteBufAllocator allocator) {
+        this.allocator = allocator;
+    }
+
+    @Override
+    public ByteBuf asByteBuf() {
+        CompositeByteBuf compositeByteBuf = checkNotNull(allocator).compositeDirectBuffer();
+        for (Buffer buffer : partialBuffers) {
+            compositeByteBuf.addComponent(buffer.asByteBuf());
+        }
+        compositeByteBuf.writerIndex(currentLength);
+        return compositeByteBuf;
+    }
+
+    @Override
+    public boolean isCompressed() {
+        return isCompressed;
+    }
+
+    @Override
+    public DataType getDataType() {
+        return dataType;
+    }
+
+    public int numPartialBuffers() {
+        return partialBuffers.size();
+    }
+
+    /**
+     * Returns the full buffer data in one piece of {@link MemorySegment}. If there is multiple
+     * partial buffers, the partial data will be copied to the given target {@link MemorySegment}.
+     */
+    public Buffer getFullBufferData(MemorySegment segment) {
+        checkState(!partialBuffers.isEmpty());
+        checkState(currentLength <= segment.size());
+
+        if (partialBuffers.size() == 1) {
+            return partialBuffers.get(0);
+        }
+
+        int offset = 0;
+        for (Buffer buffer : partialBuffers) {
+            segment.put(offset, buffer.getNioBufferReadable(), buffer.readableBytes());
+            offset += buffer.readableBytes();
+        }
+        recycleBuffer();
+        return new NetworkBuffer(
+                segment,
+                BufferRecycler.DummyBufferRecycler.INSTANCE,
+                dataType,
+                isCompressed,
+                currentLength);
+    }
+
+    public void addPartialBuffer(Buffer buffer) {
+        buffer.setDataType(dataType);
+        buffer.setCompressed(isCompressed);
+        partialBuffers.add(buffer);
+        currentLength += buffer.readableBytes();
+        checkState(currentLength <= length);
+    }
+
+    public int missingLength() {
+        return length - currentLength;
+    }
+
+    @Override
+    public MemorySegment getMemorySegment() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getMemorySegmentOffset() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public BufferRecycler getRecycler() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isRecycled() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Buffer readOnlySlice() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Buffer readOnlySlice(int index, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getMaxCapacity() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getReaderIndex() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setReaderIndex(int readerIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSize(int writerIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuffer getNioBufferReadable() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ByteBuffer getNioBuffer(int index, int length) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setCompressed(boolean isCompressed) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setDataType(DataType dataType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int refCnt() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
@@ -44,6 +44,8 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
     private boolean isCompressed = false;
 
+    private DataType dataType;
+
     /**
      * Creates a buffer which shares the memory segment of the given buffer and exposed the given
      * sub-region only.
@@ -58,6 +60,7 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
     ReadOnlySlicedNetworkBuffer(NetworkBuffer buffer, int index, int length) {
         super(new SlicedByteBuf(buffer, index, length));
         this.memorySegmentOffset = buffer.getMemorySegmentOffset() + index;
+        this.dataType = buffer.getDataType();
     }
 
     /**
@@ -79,6 +82,7 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
         super(new SlicedByteBuf(buffer, index, length));
         this.memorySegmentOffset = memorySegmentOffset + index;
         this.isCompressed = isCompressed;
+        this.dataType = getBuffer().getDataType();
     }
 
     @Override
@@ -88,7 +92,7 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
     @Override
     public boolean isBuffer() {
-        return getBuffer().isBuffer();
+        return dataType.isBuffer();
     }
 
     /**
@@ -223,12 +227,12 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
     @Override
     public DataType getDataType() {
-        return getBuffer().getDataType();
+        return dataType;
     }
 
     @Override
     public void setDataType(DataType dataType) {
-        throw new ReadOnlyBufferException();
+        this.dataType = dataType;
     }
 
     private Buffer getBuffer() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyMessage.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.event.TaskEvent;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.io.network.api.serialization.EventSerializer;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.FileRegionBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannel;
 import org.apache.flink.runtime.io.network.partition.consumer.InputChannelID;
@@ -345,7 +346,11 @@ public abstract class NettyMessage {
 
                 headerBuf = fillHeader(allocator);
                 out.write(headerBuf);
-                out.write(buffer, promise);
+                if (buffer instanceof FileRegionBuffer) {
+                    out.write(buffer, promise);
+                } else {
+                    out.write(buffer.asByteBuf(), promise);
+                }
             } catch (Throwable t) {
                 handleException(headerBuf, buffer, t);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -127,22 +127,7 @@ class SortMergeSubpartitionReader
 
     /** This method is called by the IO thread of {@link SortMergeResultPartitionReadScheduler}. */
     boolean readBuffers(Queue<MemorySegment> buffers, BufferRecycler recycler) throws IOException {
-        while (!buffers.isEmpty()) {
-            MemorySegment segment = buffers.poll();
-
-            Buffer buffer;
-            try {
-                if ((buffer = fileReader.readCurrentRegion(segment, recycler)) == null) {
-                    buffers.add(segment);
-                    break;
-                }
-            } catch (Throwable throwable) {
-                buffers.add(segment);
-                throw throwable;
-            }
-            addBuffer(buffer);
-        }
-        return fileReader.hasRemaining();
+        return fileReader.readCurrentRegion(buffers, recycler, this::addBuffer);
     }
 
     CompletableFuture<?> getReleaseFuture() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedBufferTest.java
@@ -26,12 +26,12 @@ import org.apache.flink.runtime.io.network.netty.NettyBufferPool;
 
 import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ReadOnlyBufferException;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -66,14 +66,20 @@ public class ReadOnlySlicedBufferTest {
         assertEquals(eventBuffer.isBuffer(), eventBuffer.readOnlySlice(1, 2).isBuffer());
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetDataTypeThrows1() {
-        buffer.readOnlySlice().setDataType(Buffer.DataType.EVENT_BUFFER);
+    @Test
+    public void testSetDataType1() {
+        ReadOnlySlicedNetworkBuffer readOnlyBuffer = buffer.readOnlySlice();
+        readOnlyBuffer.setDataType(Buffer.DataType.EVENT_BUFFER);
+        Assertions.assertThat(readOnlyBuffer.getDataType()).isEqualTo(Buffer.DataType.EVENT_BUFFER);
     }
 
-    @Test(expected = ReadOnlyBufferException.class)
-    public void testSetDataTypeThrows2() {
-        buffer.readOnlySlice(1, 2).setDataType(Buffer.DataType.EVENT_BUFFER);
+    @Test
+    public void testSetDataType2() {
+        ReadOnlySlicedNetworkBuffer readOnlyBuffer = buffer.readOnlySlice(1, 2);
+        readOnlyBuffer.setDataType(Buffer.DataType.EVENT_BUFFER);
+        Assertions.assertThat(readOnlyBuffer.getDataType()).isEqualTo(Buffer.DataType.EVENT_BUFFER);
+        Assertions.assertThat(buffer.readOnlySlice(1, 2).getDataType())
+                .isNotEqualTo(Buffer.DataType.EVENT_BUFFER);
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -22,7 +22,7 @@ import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
 import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
@@ -49,11 +49,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link SortMergeResultPartitionReadScheduler}. */
 public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
@@ -62,7 +58,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
 
     private static final byte[] dataBytes = new byte[bufferSize];
 
-    private static final int totalBytes = bufferSize;
+    private static final int totalBytes = bufferSize * 2;
 
     private static final int numThreads = 4;
 
@@ -105,7 +101,8 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                 new PartitionedFileReader(partitionedFile, 0, dataFileChannel, indexFileChannel);
         bufferPool = new BatchShuffleReadBufferPool(totalBytes, bufferSize);
         executor = Executors.newFixedThreadPool(numThreads);
-        readScheduler = new SortMergeResultPartitionReadScheduler(bufferPool, executor, this);
+        readScheduler =
+                new SortMergeResultPartitionReadScheduler(bufferPool, executor, new Object());
     }
 
     @After
@@ -123,18 +120,21 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                 readScheduler.createSubpartitionReader(
                         new NoOpBufferAvailablityListener(), 0, partitionedFile);
 
-        assertTrue(readScheduler.isRunning());
-        assertTrue(readScheduler.getDataFileChannel().isOpen());
-        assertTrue(readScheduler.getIndexFileChannel().isOpen());
+        assertThat(readScheduler.isRunning()).isTrue();
+        assertThat(readScheduler.getDataFileChannel().isOpen()).isTrue();
+        assertThat(readScheduler.getIndexFileChannel().isOpen()).isTrue();
 
         int numBuffersRead = 0;
         while (numBuffersRead < numBuffersPerSubpartition) {
             ResultSubpartition.BufferAndBacklog bufferAndBacklog =
                     subpartitionReader.getNextBuffer();
             if (bufferAndBacklog != null) {
-                Buffer buffer = bufferAndBacklog.buffer();
-                assertEquals(ByteBuffer.wrap(dataBytes), buffer.getNioBufferReadable());
-                buffer.recycleBuffer();
+                int numBytes = bufferAndBacklog.buffer().readableBytes();
+                MemorySegment segment = MemorySegmentFactory.allocateUnpooledSegment(numBytes);
+                Buffer fullBuffer =
+                        ((CompositeBuffer) bufferAndBacklog.buffer()).getFullBufferData(segment);
+                assertThat(ByteBuffer.wrap(dataBytes)).isEqualTo(fullBuffer.getNioBufferReadable());
+                fullBuffer.recycleBuffer();
                 ++numBuffersRead;
             }
         }
@@ -160,10 +160,10 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         Thread.sleep(1000);
         readScheduler.release();
 
-        assertNotNull(subpartitionReader.getFailureCause());
-        assertTrue(subpartitionReader.isReleased());
-        assertEquals(0, subpartitionReader.unsynchronizedGetNumberOfQueuedBuffers());
-        assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
+        assertThat(subpartitionReader.getFailureCause()).isNotNull();
+        assertThat(subpartitionReader.isReleased()).isTrue();
+        assertThat(subpartitionReader.unsynchronizedGetNumberOfQueuedBuffers()).isEqualTo(0);
+        assertThat(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable()).isTrue();
 
         readScheduler.getReleaseFuture().get();
         assertAllResourcesReleased();
@@ -199,8 +199,8 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         }
 
         waitUntilReadFinish();
-        assertNotNull(subpartitionReader.getFailureCause());
-        assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
+        assertThat(subpartitionReader.getFailureCause()).isNotNull();
+        assertThat(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable()).isTrue();
         assertAllResourcesReleased();
     }
 
@@ -213,14 +213,15 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         bufferPool.destroy();
         waitUntilReadFinish();
 
-        assertTrue(subpartitionReader.isReleased());
-        assertNotNull(subpartitionReader.getFailureCause());
-        assertTrue(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable());
+        assertThat(subpartitionReader.isReleased()).isTrue();
+        assertThat(subpartitionReader.getFailureCause()).isNotNull();
+        assertThat(subpartitionReader.getAvailabilityAndBacklog(0).isAvailable()).isTrue();
         assertAllResourcesReleased();
     }
 
     @Test(timeout = 60000)
     public void testNoDeadlockWhenReadAndReleaseBuffers() throws Exception {
+        bufferPool.initialize();
         SortMergeSubpartitionReader subpartitionReader =
                 new SortMergeSubpartitionReader(new NoOpBufferAvailablityListener(), fileReader);
         Thread readAndReleaseThread =
@@ -229,7 +230,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                             Queue<MemorySegment> segments = new ArrayDeque<>();
                             segments.add(MemorySegmentFactory.allocateUnpooledSegment(bufferSize));
                             try {
-                                assertTrue(fileReader.hasRemaining());
+                                assertThat(fileReader.hasRemaining()).isTrue();
                                 subpartitionReader.readBuffers(segments, readScheduler);
                                 subpartitionReader.releaseAllResources();
                                 subpartitionReader.readBuffers(segments, readScheduler);
@@ -258,7 +259,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         Assertions.assertThatThrownBy(readScheduler::allocateBuffers)
                 .isInstanceOf(TimeoutException.class);
         long requestDuration = System.nanoTime() - startTimestamp;
-        Assertions.assertThat(requestDuration > bufferRequestTimeout.toNanos()).isTrue();
+        assertThat(requestDuration > bufferRequestTimeout.toNanos()).isTrue();
 
         bufferPool.recycle(buffers);
         readScheduler.release();
@@ -279,9 +280,9 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         Queue<MemorySegment> allocatedBuffers = readScheduler.allocateBuffers();
         long requestDuration = System.nanoTime() - startTimestamp;
 
-        assertEquals(3, allocatedBuffers.size());
-        assertTrue(requestDuration > bufferRequestTimeout.toNanos() * 2);
-        assertNull(subpartitionReader.getFailureCause());
+        assertThat(allocatedBuffers.size()).isEqualTo(3);
+        assertThat(requestDuration > bufferRequestTimeout.toNanos() * 2).isTrue();
+        assertThat(subpartitionReader.getFailureCause()).isNull();
 
         bufferPool.recycle(allocatedBuffers);
         bufferPool.destroy();
@@ -314,21 +315,14 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         return FileChannel.open(path, StandardOpenOption.READ);
     }
 
-    private static void assertExpectedTimeoutException(Throwable throwable) {
-        assertNotNull(throwable);
-        assertTrue(
-                ExceptionUtils.findThrowableWithMessage(throwable, "Buffer request timeout")
-                        .isPresent());
-    }
-
     private void assertAllResourcesReleased() {
-        assertNull(readScheduler.getDataFileChannel());
-        assertNull(readScheduler.getIndexFileChannel());
-        assertFalse(readScheduler.isRunning());
-        assertEquals(0, readScheduler.getNumPendingReaders());
+        assertThat(readScheduler.getDataFileChannel()).isNull();
+        assertThat(readScheduler.getIndexFileChannel()).isNull();
+        assertThat(readScheduler.isRunning()).isFalse();
+        assertThat(readScheduler.getNumPendingReaders()).isEqualTo(0);
 
         if (!bufferPool.isDestroyed()) {
-            assertEquals(bufferPool.getNumTotalBuffers(), bufferPool.getAvailableBuffers());
+            assertThat(bufferPool.getNumTotalBuffers()).isEqualTo(bufferPool.getAvailableBuffers());
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, for sort blocking shuffle, the corresponding data readers read shuffle data in buffer granularity. Before compression, each buffer is 32K by default, after compression the size will become smaller (may less than 10K). For file IO, this is pretty smaller.

To achieve better performance and reduce IOPS, we can read more data per IO read request and parse buffer header and data in memory.


## Brief change log

  - *Read a full buffer of data per file IO read request for sort-shuffle.*
  - *Migrate PartitionedFileWriteReadTest to Junit5/AssertJ.*


## Verifying this change

This change is already covered by existing tests, such as *SortMergeResultPartitionTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
