### PR TITLE
[FLINK-28822] Avoid create to VectorizedColumnBatch for each read in …

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowReader.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/arrow/ArrowReader.java
@@ -35,11 +35,12 @@ public final class ArrowReader {
     private final ColumnVector[] columnVectors;
 
     /** Reusable row used to hold the deserialized result. */
-    private ColumnarRowData reuseRow;
+    private final ColumnarRowData reuseRow;
 
     public ArrowReader(ColumnVector[] columnVectors) {
         this.columnVectors = Preconditions.checkNotNull(columnVectors);
         this.reuseRow = new ColumnarRowData();
+        this.reuseRow.setVectorizedColumnBatch(new VectorizedColumnBatch(columnVectors));
     }
 
     /** Gets the column vectors. */
@@ -49,7 +50,6 @@ public final class ArrowReader {
 
     /** Read the specified row from underlying Arrow format data. */
     public RowData read(int rowId) {
-        reuseRow.setVectorizedColumnBatch(new VectorizedColumnBatch(columnVectors));
         reuseRow.setRowId(rowId);
         return reuseRow;
     }


### PR DESCRIPTION
…ArrowReader

## What is the purpose of the change

This PR is meant to avoid to create VectorizedColumnBatch for each read in ArrowReader

## Verifying this change

This change is already covered by existing tests ArrowReaderWriterTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
