### PR TITLE
[FLINK-28823][network] Enlarge the max requested buffers for SortMergeResultPartitionReadScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -168,8 +168,7 @@ public class SortMergeResultPartition extends ResultPartition {
         // input balance of the downstream tasks
         this.subpartitionOrder = getRandomSubpartitionOrder(numSubpartitions);
         this.readScheduler =
-                new SortMergeResultPartitionReadScheduler(
-                        numSubpartitions, readBufferPool, readIOExecutor, lock);
+                new SortMergeResultPartitionReadScheduler(readBufferPool, readIOExecutor, lock);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -85,9 +85,6 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
     /** Executor to run the shuffle data reading task. */
     private final Executor ioExecutor;
 
-    /** Maximum number of buffers can be allocated by this partition reader. */
-    private final int maxRequestedBuffers;
-
     /**
      * Maximum time to wait when requesting read buffers from the buffer pool before throwing an
      * exception.
@@ -133,15 +130,11 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
     private volatile boolean isReleased;
 
     SortMergeResultPartitionReadScheduler(
-            int numSubpartitions,
-            BatchShuffleReadBufferPool bufferPool,
-            Executor ioExecutor,
-            Object lock) {
-        this(numSubpartitions, bufferPool, ioExecutor, lock, DEFAULT_BUFFER_REQUEST_TIMEOUT);
+            BatchShuffleReadBufferPool bufferPool, Executor ioExecutor, Object lock) {
+        this(bufferPool, ioExecutor, lock, DEFAULT_BUFFER_REQUEST_TIMEOUT);
     }
 
     SortMergeResultPartitionReadScheduler(
-            int numSubpartitions,
             BatchShuffleReadBufferPool bufferPool,
             Executor ioExecutor,
             Object lock,
@@ -150,11 +143,6 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         this.lock = checkNotNull(lock);
         this.bufferPool = checkNotNull(bufferPool);
         this.ioExecutor = checkNotNull(ioExecutor);
-        // one partition reader can consume at most Math.max(16M, numSubpartitions) (the expected
-        // buffers per request is 4M) buffers for data read, which means larger parallelism, more
-        // buffers. Currently, it is only an empirical strategy which can not be configured.
-        this.maxRequestedBuffers =
-                Math.max(4 * bufferPool.getNumBuffersPerRequest(), numSubpartitions);
         this.bufferRequestTimeout = checkNotNull(bufferRequestTimeout);
     }
 
@@ -392,6 +380,12 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
 
     private void mayTriggerReading() {
         assert Thread.holdsLock(lock);
+
+        // one partition reader can consume at most Math.max(16M, 2 * numReaders) (the expected
+        // buffers per request is 4M) buffers for data read, which means larger parallelism, more
+        // buffers. Currently, it is only an empirical strategy which can not be configured.
+        int maxRequestedBuffers =
+                Math.max(4 * bufferPool.getNumBuffersPerRequest(), 2 * allReaders.size());
 
         if (!isRunning
                 && !allReaders.isEmpty()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -105,9 +105,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                 new PartitionedFileReader(partitionedFile, 0, dataFileChannel, indexFileChannel);
         bufferPool = new BatchShuffleReadBufferPool(totalBytes, bufferSize);
         executor = Executors.newFixedThreadPool(numThreads);
-        readScheduler =
-                new SortMergeResultPartitionReadScheduler(
-                        numSubpartitions, bufferPool, executor, this);
+        readScheduler = new SortMergeResultPartitionReadScheduler(bufferPool, executor, this);
     }
 
     @After
@@ -254,7 +252,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
         List<MemorySegment> buffers = bufferPool.requestBuffers();
         SortMergeResultPartitionReadScheduler readScheduler =
                 new SortMergeResultPartitionReadScheduler(
-                        numSubpartitions, bufferPool, executor, this, bufferRequestTimeout);
+                        bufferPool, executor, this, bufferRequestTimeout);
 
         long startTimestamp = System.nanoTime();
         Assertions.assertThatThrownBy(readScheduler::allocateBuffers)
@@ -273,7 +271,7 @@ public class SortMergeResultPartitionReadSchedulerTest extends TestLogger {
                 new FakeBatchShuffleReadBufferPool(bufferSize * 3, bufferSize);
         SortMergeResultPartitionReadScheduler readScheduler =
                 new SortMergeResultPartitionReadScheduler(
-                        numSubpartitions, bufferPool, executor, this, bufferRequestTimeout);
+                        bufferPool, executor, this, bufferRequestTimeout);
         SortMergeSubpartitionReader subpartitionReader =
                 new SortMergeSubpartitionReader(new NoOpBufferAvailablityListener(), fileReader);
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

The num of the max requested buffers in SortMergeResultPartitionReadScheduler is determined by the num of subpartitions, which may be insufficient in some scenarios, such as speculative execution and partition reuse.

Therefore, we should increase the max requested buffers to make full use of available memory when TM memory is sufficient.


## Brief change log

  - *Enlarge the max requested buffers for SortMergeResultPartitionReadScheduler*


## Verifying this change

This change is already covered by existing tests, such as *SortMergeResultPartitionReadSchedulerTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes /  **no**)
  - The serializers: (yes /  **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes /  **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes /  **no** / don't know)
  - The S3 file system connector: (yes /  **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes /  **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
