### PR TITLE
[FLINK-28828][network] Sorting all unfinished readers in batches at one time in SortMergeResultPartitionReadScheduler

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -171,28 +171,39 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             removeFinishedAndFailedReaders(0, finishedReaders);
             return;
         }
+        checkState(!buffers.isEmpty(), "No buffer available.");
         int numBuffersAllocated = buffers.size();
 
-        SortMergeSubpartitionReader subpartitionReader = addPreviousAndGetNextReader(null, true);
-        while (subpartitionReader != null && !buffers.isEmpty()) {
+        ArrayList<SortMergeSubpartitionReader> unfinishedReaders = new ArrayList<>();
+        SortMergeSubpartitionReader subpartitionReader = getNextReader();
+        while (subpartitionReader != null) {
             try {
                 if (!subpartitionReader.readBuffers(buffers, this)) {
                     // there is no resource to release for finished readers currently
                     finishedReaders.add(subpartitionReader);
-                    subpartitionReader = null;
+                } else {
+                    unfinishedReaders.add(subpartitionReader);
                 }
             } catch (Throwable throwable) {
                 failSubpartitionReaders(Collections.singletonList(subpartitionReader), throwable);
-                subpartitionReader = null;
                 LOG.debug("Failed to read shuffle data.", throwable);
             }
-            subpartitionReader =
-                    addPreviousAndGetNextReader(subpartitionReader, !buffers.isEmpty());
+
+            if (buffers.isEmpty()) {
+                break;
+            }
+
+            subpartitionReader = getNextReader();
+            if (subpartitionReader == null && !unfinishedReaders.isEmpty()) {
+                returnUnfinishedReaders(unfinishedReaders);
+                subpartitionReader = getNextReader();
+            }
         }
 
         int numBuffersRead = numBuffersAllocated - buffers.size();
         releaseBuffers(buffers);
 
+        returnUnfinishedReaders(unfinishedReaders);
         removeFinishedAndFailedReaders(numBuffersRead, finishedReaders);
     }
 
@@ -296,20 +307,22 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
     }
 
     @Nullable
-    private SortMergeSubpartitionReader addPreviousAndGetNextReader(
-            SortMergeSubpartitionReader previousReader, boolean pollNext) {
+    private SortMergeSubpartitionReader getNextReader() {
         synchronized (lock) {
-            if (previousReader != null) {
-                sortedReaders.add(previousReader);
-            }
-            if (!pollNext) {
-                return null;
-            }
             SortMergeSubpartitionReader subpartitionReader = sortedReaders.poll();
             while (subpartitionReader != null && failedReaders.contains(subpartitionReader)) {
                 subpartitionReader = sortedReaders.poll();
             }
             return subpartitionReader;
+        }
+    }
+
+    private void returnUnfinishedReaders(ArrayList<SortMergeSubpartitionReader> readers) {
+        if (readers != null && !readers.isEmpty()) {
+            synchronized (lock) {
+                sortedReaders.addAll(readers);
+                readers.clear();
+            }
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -164,6 +164,13 @@ class SortMergeSubpartitionReader
 
     @Override
     public int compareTo(SortMergeSubpartitionReader that) {
+        int thisQueuedBuffers = unsynchronizedGetNumberOfQueuedBuffers();
+        int thatQueuedBuffers = that.unsynchronizedGetNumberOfQueuedBuffers();
+        if (thisQueuedBuffers != thatQueuedBuffers
+                && (thisQueuedBuffers == 0 || thatQueuedBuffers == 0)) {
+            return thisQueuedBuffers > thatQueuedBuffers ? 1 : -1;
+        }
+
         long thisPriority = fileReader.getPriority();
         long thatPriority = that.fileReader.getPriority();
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, when reading data in SortMergeResultPartitionReadScheduler, the reader is added to the priority queue immediately. However, the data read from this reader may not have been consumed, which will cause this reader to be ranked later in the queue, which is unfavorable to sequential reading.

To solve the issue, After reading the data, we should sort all unfinished readers in batches at one time, that is, add all unfinished readers to the priority queue, which is more conducive to sequential reading.


## Brief change log

  - *Sorting all unfinished readers in batches at one time in SortMergeResultPartitionReadScheduler*


## Verifying this change

This change is already covered by existing tests, such as *SortMergeResultPartitionReadSchedulerTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
