### PR TITLE
[FLINK-28837][chinese-translation] Translate "Hybrid Source" page of …

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/hybridsource.md
+++ b/docs/content.zh/docs/connectors/datastream/hybridsource.md
@@ -25,35 +25,34 @@ under the License.
 
 # Hybrid Source
 
-`HybridSource` is a source that contains a list of concrete [sources]({{< ref "docs/dev/datastream/sources" >}}).
-It solves the problem of sequentially reading input from heterogeneous sources to produce a single input stream.
+`HybridSource` 是一个包含一系列数据源的 [sources]({{< ref "docs/dev/datastream/sources" >}})
+它解决了从异构数据源顺序读取输入以产生单个输入流的问题。
 
-For example, a bootstrap use case may need to read several days worth of bounded input from S3 before continuing with the latest unbounded input from Kafka.
-`HybridSource` switches from `FileSource` to `KafkaSource` when the bounded file input finishes without  interrupting the application.
+例如，一个 bootstrap 用例可能需要从 S3 读取几天的有界输入，然后再继续从 Kafka 读取最新的无界输入。当有边界的文件输入结束时，
+`HybridSource` 从 `FileSource` 切换到 `KafkaSource` 而不中断应用程序。
 
-Prior to `HybridSource`, it was necessary to create a topology with multiple sources and define a switching mechanism in user land, which leads to operational complexity and inefficiency.
+在使用 `HybridSource` 之前, 需要创建具有多个数据源的拓扑，并在用户域内定义切换机制，这导致了操作的复杂性和效率低下。
 
-With `HybridSource` the multiple sources appear as a single source in the Flink job graph and from `DataStream` API perspective.
+使用 `HybridSource` 多个数据源在 Flink 作业 DAG 中和从 `DataStream` API 的角度显示为单个数据源。
 
-For more background see [FLIP-150](https://cwiki.apache.org/confluence/display/FLINK/FLIP-150%3A+Introduce+Hybrid+Source)
+有关更多的背景信息，请参阅 [FLIP-150](https://cwiki.apache.org/confluence/display/FLINK/FLIP-150%3A+Introduce+Hybrid+Source)
 
-To use the connector, add the ```flink-connector-base``` dependency to your project:
+想要使用 connector, 请将 ```flink-connector-base``` 依赖添加到项目中:
 
 {{< artifact flink-connector-base >}}
 
-(Typically comes as transitive dependency with concrete sources.)
+(通常作为具体数据源的可传递依赖。)
 
 ## Start position for next source
 
-To arrange multiple sources in a `HybridSource`, all sources except the last one need to be bounded. Therefore, the sources typically need to be assigned a start and end position. The last source may be bounded in which case the `HybridSource` is bounded and unbounded otherwise.
-Details depend on the specific source and the external storage systems.
+为了在 `HybridSource` 中安排多个数据源， 除最后一个数据源外的所有数据源都需要被绑定。因此，通常需要为数据源分配一个开始和结束位置。最后一个数据源可能是有界的，在这种情况下，`HybridSource` 是有界的，否则是无界的。
+具体情况取决于具体的存储数据源和外部存储系统。
 
-Here we cover the most basic and then a more complex scenario, following the File/Kafka example. 
+在这里，我们将介绍最基本的场景，然后是一个更复杂的场景，下面是 File/Kafka 示例。 
 
 #### Fixed start position at graph construction time
 
-Example: Read till pre-determined switch time from files and then continue reading from Kafka.
-Each source covers an upfront known range and therefore the contained sources can be created upfront as if they were used directly:
+例如: 从文件中读取直到预定的切换时间，然后继续从 Kafka 中读取。每个数据源覆盖了一个预知范围，因此所包含的数据源可以预先创建，就好像它们是直接使用的。
 
 ```java
 long switchTimestamp = ...; // derive from file input paths
@@ -71,13 +70,10 @@ HybridSource<String> hybridSource =
 
 #### Dynamic start position at switch time
 
-Example: File source reads a very large backlog, taking potentially longer than retention available for next source.
-Switch needs to occur at "current time - X". This requires the start time for the next source to be set at switch time.
-Here we require transfer of end position from the previous file enumerator for deferred construction of `KafkaSource`
-by implementing `SourceFactory`.
+示例: 文件数据源读取一个非常大的积压数据，花费的时间可能比下一个数据源的保留时间更长。开关需要发生在 “current time- X”。这要求下一个数据源的开始时间设置在切换时间。在这里，我们通过实现 `SourceFactory` 来实现 `KafkaSource` 的延迟构造，需要从之前的文件枚举器转移结束位置。 
 
-Note that enumerators need to support getting the end timestamp. This may currently require a source customization.
-Adding support for dynamic end position to `FileSource` is tracked in [FLINK-23633](https://issues.apache.org/jira/browse/FLINK-23633).
+注意，枚举器需要支持获取结束时间戳。 目前可能需要对源代码进行定制。
+在 [FLINK-23633](https://issues.apache.org/jira/browse/FLINK-23633) 中跟踪了向 `FileSource` 添加动态结束位置的支持。
 
 ```java
 FileSource<String> fileSource = CustomFileSource.readTillOneDayFromLatest();


### PR DESCRIPTION


## What is the purpose of the change

*Translate "Hybrid Source" page of "DataStream Connectors" into Chinese*


## Brief change log

*Translate "Hybrid Source" page of "DataStream Connectors" into Chinese*
 


## Verifying this change



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
