### PR TITLE
[FLINK-28773][hive] Fix Hive sink not write a success file after finish writing in batch mode

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemCommitter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemCommitter.java
@@ -21,8 +21,8 @@ package org.apache.flink.connector.file.table;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 
-import java.io.Serializable;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,9 +48,7 @@ import static org.apache.flink.connector.file.table.PartitionTempFileManager.lis
  * <p>See: {@link PartitionTempFileManager}. {@link PartitionLoader}.
  */
 @Internal
-class FileSystemCommitter implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+class FileSystemCommitter {
 
     private final FileSystemFactory factory;
     private final TableMetaStoreFactory metaStoreFactory;
@@ -58,7 +56,9 @@ class FileSystemCommitter implements Serializable {
     private final boolean isToLocal;
     private final Path tmpPath;
     private final int partitionColumnSize;
+    private final ObjectIdentifier identifier;
     private final LinkedHashMap<String, String> staticPartitions;
+    private final List<PartitionCommitPolicy> policies;
 
     FileSystemCommitter(
             FileSystemFactory factory,
@@ -67,14 +67,18 @@ class FileSystemCommitter implements Serializable {
             Path tmpPath,
             int partitionColumnSize,
             boolean isToLocal,
-            LinkedHashMap<String, String> staticPartitions) {
+            ObjectIdentifier identifier,
+            LinkedHashMap<String, String> staticPartitions,
+            List<PartitionCommitPolicy> policies) {
         this.factory = factory;
         this.metaStoreFactory = metaStoreFactory;
         this.overwrite = overwrite;
         this.tmpPath = tmpPath;
         this.partitionColumnSize = partitionColumnSize;
         this.isToLocal = isToLocal;
+        this.identifier = identifier;
         this.staticPartitions = staticPartitions;
+        this.policies = policies;
     }
 
     /** For committing job's output after successful batch job completion. */
@@ -83,7 +87,8 @@ class FileSystemCommitter implements Serializable {
         List<Path> taskPaths = listTaskTemporaryPaths(fs, tmpPath);
 
         try (PartitionLoader loader =
-                new PartitionLoader(overwrite, fs, metaStoreFactory, isToLocal)) {
+                new PartitionLoader(
+                        overwrite, fs, metaStoreFactory, isToLocal, identifier, policies)) {
             if (partitionColumnSize > 0) {
                 if (taskPaths.isEmpty() && !staticPartitions.isEmpty()) {
                     loader.loadEmptyPartition(this.staticPartitions);

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemOutputFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemOutputFormat.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.catalog.ObjectIdentifier;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 
@@ -94,16 +95,19 @@ public class FileSystemOutputFormat<T> implements OutputFormat<T>, FinalizeOnMas
     @Override
     public void finalizeGlobal(int parallelism) {
         try {
-            List<PartitionCommitPolicy> policies =
-                    partitionCommitPolicyFactory.createPolicyChain(
-                            Thread.currentThread().getContextClassLoader(),
-                            () -> {
-                                try {
-                                    return fsFactory.create(tmpPath.toUri());
-                                } catch (IOException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
+            List<PartitionCommitPolicy> policies = Collections.emptyList();
+            if (partitionCommitPolicyFactory != null) {
+                policies =
+                        partitionCommitPolicyFactory.createPolicyChain(
+                                Thread.currentThread().getContextClassLoader(),
+                                () -> {
+                                    try {
+                                        return fsFactory.create(tmpPath.toUri());
+                                    } catch (IOException e) {
+                                        throw new RuntimeException(e);
+                                    }
+                                });
+            }
 
             FileSystemCommitter committer =
                     new FileSystemCommitter(

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicyFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.FileSystem;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/** A factory to create {@link PartitionCommitPolicy} chain. */
+@Internal
+public class PartitionCommitPolicyFactory implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String policyKind;
+    private final String customClass;
+    private final String successFileName;
+
+    public PartitionCommitPolicyFactory(
+            String policyKind, String customClass, String successFileName) {
+        this.policyKind = policyKind;
+        this.customClass = customClass;
+        this.successFileName = successFileName;
+    }
+
+    /** Create a policy chain. */
+    public List<PartitionCommitPolicy> createPolicyChain(
+            ClassLoader cl, Supplier<FileSystem> fsSupplier) {
+        if (policyKind == null) {
+            return Collections.emptyList();
+        }
+        String[] policyStrings = policyKind.split(",");
+        return Arrays.stream(policyStrings)
+                .map(
+                        name -> {
+                            switch (name.toLowerCase()) {
+                                case PartitionCommitPolicy.METASTORE:
+                                    return new MetastoreCommitPolicy();
+                                case PartitionCommitPolicy.SUCCESS_FILE:
+                                    return new SuccessFileCommitPolicy(
+                                            successFileName, fsSupplier.get());
+                                case PartitionCommitPolicy.CUSTOM:
+                                    try {
+                                        return (PartitionCommitPolicy)
+                                                cl.loadClass(customClass).newInstance();
+                                    } catch (ClassNotFoundException
+                                            | IllegalAccessException
+                                            | InstantiationException e) {
+                                        throw new RuntimeException(
+                                                "Can not create new instance for custom class from "
+                                                        + customClass,
+                                                e);
+                                    }
+                                default:
+                                    throw new UnsupportedOperationException(
+                                            "Unsupported policy: " + name);
+                            }
+                        })
+                .collect(Collectors.toList());
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionLoader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionLoader.java
@@ -22,13 +22,17 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FileStatus;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.apache.flink.table.utils.PartitionPathUtils.generatePartitionPath;
@@ -52,17 +56,23 @@ public class PartitionLoader implements Closeable {
     private final TableMetaStoreFactory.TableMetaStore metaStore;
     // whether it's to load files to local file system
     private final boolean isToLocal;
+    private final ObjectIdentifier identifier;
+    private final List<PartitionCommitPolicy> policies;
 
     public PartitionLoader(
             boolean overwrite,
             FileSystem sourceFs,
             TableMetaStoreFactory factory,
-            boolean isToLocal)
+            boolean isToLocal,
+            ObjectIdentifier identifier,
+            List<PartitionCommitPolicy> policies)
             throws Exception {
         this.overwrite = overwrite;
         this.fs = sourceFs;
         this.metaStore = factory.createTableMetaStore();
         this.isToLocal = isToLocal;
+        this.identifier = identifier;
+        this.policies = policies;
     }
 
     /** Load a single partition. */
@@ -77,13 +87,14 @@ public class PartitionLoader implements Closeable {
                                         generatePartitionPath(partSpec)));
 
         overwriteAndMoveFiles(srcDirs, path);
-        metaStore.createOrAlterPartition(partSpec, path);
+        commitPartition(partSpec, path);
     }
 
     /** Load a non-partition files to output path. */
     public void loadNonPartition(List<Path> srcDirs) throws Exception {
         Path tableLocation = metaStore.getLocationPath();
         overwriteAndMoveFiles(srcDirs, tableLocation);
+        commitPartition(new LinkedHashMap<>(), tableLocation);
     }
 
     /**
@@ -102,6 +113,7 @@ public class PartitionLoader implements Closeable {
     public void loadEmptyPartition(LinkedHashMap<String, String> partSpec) throws Exception {
         Optional<Path> pathFromMeta = metaStore.getPartition(partSpec);
         if (pathFromMeta.isPresent() && !overwrite) {
+            commitPartition(partSpec, pathFromMeta.get());
             return;
         }
         Path path = new Path(metaStore.getLocationPath(), generatePartitionPath(partSpec));
@@ -109,7 +121,7 @@ public class PartitionLoader implements Closeable {
             fs.delete(pathFromMeta.get(), true);
             fs.mkdirs(path);
         }
-        metaStore.createOrAlterPartition(partSpec, path);
+        commitPartition(partSpec, path);
     }
 
     private void overwriteAndMoveFiles(List<Path> srcDirs, Path destDir) throws Exception {
@@ -154,8 +166,78 @@ public class PartitionLoader implements Closeable {
         }
     }
 
+    /**
+     * Reuse of PartitionCommitPolicy mechanisms. The default in Batch mode is metastore and
+     * success-file.
+     */
+    private void commitPartition(LinkedHashMap<String, String> partitionSpec, Path path)
+            throws Exception {
+        PartitionCommitPolicy.Context context = new CommitPolicyContextImpl(partitionSpec, path);
+        for (PartitionCommitPolicy policy : policies) {
+            if (policy instanceof MetastoreCommitPolicy) {
+                if (partitionSpec.isEmpty()) {
+                    // Non partition table skip commit meta data.
+                    continue;
+                }
+                ((MetastoreCommitPolicy) policy).setMetastore(metaStore);
+            }
+            policy.commit(context);
+        }
+    }
+
     @Override
     public void close() throws IOException {
         metaStore.close();
+    }
+
+    private class CommitPolicyContextImpl implements PartitionCommitPolicy.Context {
+
+        private final Path partitionPath;
+        private final LinkedHashMap<String, String> partitionSpec;
+
+        private CommitPolicyContextImpl(
+                LinkedHashMap<String, String> partitionSpec, Path partitionPath) {
+            this.partitionSpec = partitionSpec;
+            this.partitionPath = partitionPath;
+        }
+
+        @Override
+        public String catalogName() {
+            return identifier.getCatalogName();
+        }
+
+        @Override
+        public String databaseName() {
+            return identifier.getDatabaseName();
+        }
+
+        @Override
+        public String tableName() {
+            return identifier.getObjectName();
+        }
+
+        @Override
+        public List<String> partitionKeys() {
+            List<String> partitionKeys = new LinkedList<>();
+            for (Map.Entry<String, String> entry : partitionSpec.entrySet()) {
+                partitionKeys.add(entry.getKey());
+            }
+            return partitionKeys;
+        }
+
+        @Override
+        public List<String> partitionValues() {
+            return new ArrayList<>(partitionSpec.values());
+        }
+
+        @Override
+        public Path partitionPath() {
+            return this.partitionPath;
+        }
+
+        @Override
+        public LinkedHashMap<String, String> partitionSpec() {
+            return partitionSpec;
+        }
     }
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionCommitter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/stream/PartitionCommitter.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.file.table.EmptyMetaStoreFactory;
 import org.apache.flink.connector.file.table.FileSystemFactory;
 import org.apache.flink.connector.file.table.MetastoreCommitPolicy;
 import org.apache.flink.connector.file.table.PartitionCommitPolicy;
+import org.apache.flink.connector.file.table.PartitionCommitPolicyFactory;
 import org.apache.flink.connector.file.table.TableMetaStoreFactory;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -115,12 +116,14 @@ public class PartitionCommitter extends AbstractStreamOperator<Void>
                         getUserCodeClassloader(),
                         partitionKeys,
                         getProcessingTimeService());
-        this.policies =
-                PartitionCommitPolicy.createPolicyChain(
-                        getUserCodeClassloader(),
+        PartitionCommitPolicyFactory partitionCommitPolicyFactory =
+                new PartitionCommitPolicyFactory(
                         conf.get(SINK_PARTITION_COMMIT_POLICY_KIND),
                         conf.get(SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                        conf.get(SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME));
+        this.policies =
+                partitionCommitPolicyFactory.createPolicyChain(
+                        getUserCodeClassloader(),
                         () -> {
                             try {
                                 return fsFactory.create(locationPath.toUri());

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.InlineElement;
+import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 
 import java.time.Duration;
 
@@ -107,6 +108,31 @@ public class HiveOptions {
                                     + " If it's disabled, there won't be extra sorting,"
                                     + " but it may throw OutOfMemory exception if there are too many dynamic partitions fall into same sink node."
                                     + " Note: it only works in batch mode.");
+
+    /**
+     * Hive users usually commit partition for metastore and a _SUCCESS file. That's why we create a
+     * same option with {@link FileSystemConnectorOptions#SINK_PARTITION_COMMIT_POLICY_KIND} with
+     * different default value.
+     */
+    public static final ConfigOption<String> SINK_PARTITION_COMMIT_POLICY_KIND =
+            key("sink.partition-commit.policy.kind")
+                    .stringType()
+                    .defaultValue("metastore,success-file")
+                    .withDescription(
+                            "Policy to commit a partition is to notify the downstream"
+                                    + " application that the partition has finished writing, the partition"
+                                    + " is ready to be read."
+                                    + " metastore: add partition to metastore. "
+                                    + " success-file: add a success file to the partition directory. The success file name can be configured by the 'sink.partition-commit.success-file.name' option."
+                                    + " Both can be configured at the same time: 'metastore,success-file'."
+                                    + " custom: use policy class to create a commit policy."
+                                    + " Support to configure multiple policies: 'metastore,success-file'.");
+
+    public static final ConfigOption<String> SINK_PARTITION_COMMIT_POLICY_CLASS =
+            FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_CLASS;
+
+    public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
+            FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
 
     public static final ConfigOption<Boolean> STREAMING_SOURCE_ENABLE =
             key("streaming-source.enable")

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -468,15 +468,7 @@ public class HiveDialectQueryITCase {
                                 dataDir))
                 .await();
         java.nio.file.Path[] files =
-                FileUtils.listFilesInDirectory(
-                                Paths.get(dataDir),
-                                (path) ->
-                                        !path.toFile().isHidden()
-                                                && !path.toFile()
-                                                        .getName()
-                                                        .equals(
-                                                                HiveOptions
-                                                                        .SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME))
+                FileUtils.listFilesInDirectory(Paths.get(dataDir), this::isDataFile)
                         .toArray(new Path[0]);
         assertThat(files.length).isEqualTo(1);
         String actualString = FileUtils.readFileUtf8(files[0].toFile());
@@ -506,6 +498,16 @@ public class HiveDialectQueryITCase {
                         tableEnv.executeSql("select * from d_table_agg").collect());
         // verify the data read from the external table
         assertThat(result.toString()).isEqualTo("[+I[2, 1]]");
+    }
+
+    /**
+     * Checks whether the give file is a data file which must not be a hidden file or a success
+     * file.
+     */
+    private boolean isDataFile(Path path) {
+        String successFileName =
+                tableEnv.getConfig().get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME);
+        return !path.toFile().isHidden() && !path.toFile().getName().equals(successFileName);
     }
 
     @Test

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -469,7 +469,14 @@ public class HiveDialectQueryITCase {
                 .await();
         java.nio.file.Path[] files =
                 FileUtils.listFilesInDirectory(
-                                Paths.get(dataDir), (path) -> !path.toFile().isHidden())
+                                Paths.get(dataDir),
+                                (path) ->
+                                        !path.toFile().isHidden()
+                                                && !path.toFile()
+                                                        .getName()
+                                                        .equals(
+                                                                HiveOptions
+                                                                        .SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME))
                         .toArray(new Path[0]);
         assertThat(files.length).isEqualTo(1);
         String actualString = FileUtils.readFileUtf8(files[0].toFile());

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -556,7 +556,7 @@ public class HiveTableSinkITCase {
                         + "PARTITIONED BY (`dt` string) "
                         + "TBLPROPERTIES ('sink.partition-commit.policy.kind' = 'metastore')");
         String onlyMetaTablePath = warehouse + "/zm_test_partition_table_only_meta";
-        ;
+
         tEnv.executeSql(
                         "INSERT INTO zm_test_partition_table_only_meta partition (dt='2022-08-15') values ('zm')")
                 .await();


### PR DESCRIPTION
## What is the purpose of the change

 Allow to write a success file after finish for Hive sink in batch mode


## Brief change log

 Allow PartitionLoader to use SuccessFileCommitPolicy to create success file when commit partition.

## Verifying this change

 add UT
*  FileSystemCommitterTest#testWriteSuccessFile

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
