### PR TITLE
[FLINK-28208][Connectors/Hive] Set parallelism for map operator in class HiveTableSink's method createBatchSink

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -339,6 +339,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         builder.setOutputFileConfig(fileNaming);
         return dataStream
                 .map((MapFunction<RowData, Row>) value -> (Row) converter.toExternal(value))
+                .setParallelism(parallelism)
                 .writeUsingOutputFormat(builder.build())
                 .setParallelism(parallelism);
     }

--- a/flink-connectors/flink-connector-hive/src/test/resources/explain/testHiveTableSinkWithParallelismInBatch.out
+++ b/flink-connectors/flink-connector-hive/src/test/resources/explain/testHiveTableSinkWithParallelismInBatch.out
@@ -37,10 +37,10 @@ Sink(table=[test-catalog.db1.test_table], fields=[EXPR$0, EXPR$1])
     "type" : "Map",
     "pact" : "Operator",
     "contents" : "Map",
-    "parallelism" : 1,
+    "parallelism" : 8,
     "predecessors" : [ {
       "id" : ,
-      "ship_strategy" : "FORWARD",
+      "ship_strategy" : "REBALANCE",
       "side" : "second"
     } ]
   }, {
@@ -51,7 +51,7 @@ Sink(table=[test-catalog.db1.test_table], fields=[EXPR$0, EXPR$1])
     "parallelism" : 8,
     "predecessors" : [ {
       "id" : ,
-      "ship_strategy" : "REBALANCE",
+      "ship_strategy" : "FORWARD",
       "side" : "second"
     } ]
   } ]


### PR DESCRIPTION
## What is the purpose of the change

*Set parallelism for map operator in class HiveTableSink's method createBatchSink in order to keep consistent with HiveTableSink. If not so, the operators in sink can not be chained togather.*


## Brief change log

  - *Set parallelism for map operator in class HiveTableSink's method createBatchSink*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
