### PR TITLE
[FLINK-28842][Connector/Kafka] Add client.id.prefix for the KafkaSink

### DIFF
--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -562,6 +562,16 @@ The following properties are **required** to build a KafkaSink:
 - If you configure the delivery guarantee with ```DeliveryGuarantee.EXACTLY_ONCE``` you also have
   use ```setTransactionalIdPrefix(String)```
 
+### Additional Properties
+In addition to properties described above, you can set arbitrary properties for KafkaSink and
+KafkaProducer by using ```setProperty(String, String)```.
+KafkaSink has following options for configuration:
+- ```client.id.prefix``` defines the prefix to use for Kafka producer's client ID
+
+For configurations of KafkaProducer, you can refer to
+<a href="http://kafka.apache.org/documentation/#producerconfigs">Apache Kafka documentation</a>
+for more details.
+
 ### Serializer
 
 You always need to supply a ```KafkaRecordSerializationSchema``` to transform incoming elements from
@@ -644,6 +654,15 @@ Kafka sink exposes the following metrics in the respective [scope]({{< ref "docs
     </tr>
   </tbody>
 </table>
+
+#### Kafka Producer Metrics
+
+In case you experience a warning with a stack trace containing
+`javax.management.InstanceAlreadyExistsException: kafka.producer:[...]`, you are probably trying to
+register multiple ```KafkaProducers``` with the same client.id. The warning indicates that not all
+available metrics are correctly forwarded to the metrics system. You must ensure that a different
+```client.id.prefix``` for every ```KafkaSink``` is configured and that no other
+```KafkaProducer``` in your job uses the same ```client.id```.
 
 ## Kafka Producer
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaCommitter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaCommitter.java
@@ -134,6 +134,8 @@ class KafkaCommitter implements Committer<KafkaCommittable>, Closeable {
      */
     private FlinkKafkaInternalProducer<?, ?> getRecoveryProducer(KafkaCommittable committable) {
         if (recoveryProducer == null) {
+            kafkaProducerConfig.setProperty(
+                    ProducerConfig.CLIENT_ID_CONFIG, createProducerClientId(kafkaProducerConfig));
             recoveryProducer =
                     new FlinkKafkaInternalProducer<>(
                             kafkaProducerConfig, committable.getTransactionalId());
@@ -142,5 +144,10 @@ class KafkaCommitter implements Committer<KafkaCommittable>, Closeable {
         }
         recoveryProducer.resumeTransaction(committable.getProducerId(), committable.getEpoch());
         return recoveryProducer;
+    }
+
+    private String createProducerClientId(Properties props) {
+        String prefix = props.getProperty(KafkaSinkOptions.CLIENT_ID_PREFIX.key());
+        return prefix + "-committer";
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkOptions.java
@@ -1,0 +1,14 @@
+package org.apache.flink.connector.kafka.sink;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/** Configurations for KafkaSink. */
+public class KafkaSinkOptions {
+
+    public static final ConfigOption<String> CLIENT_ID_PREFIX =
+            ConfigOptions.key("client.id.prefix")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The prefix to use for the Kafka producers.");
+}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkOptions.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaSinkOptions.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connector.kafka.sink;
 
 import org.apache.flink.configuration.ConfigOption;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriter.java
@@ -406,7 +406,7 @@ class KafkaWriter<IN>
 
     private String createProducerClientId(Properties props, int subtaskId) {
         String prefix = props.getProperty(KafkaSinkOptions.CLIENT_ID_PREFIX.key());
-        return prefix + "-" + subtaskId;
+        return prefix + "-writer-" + subtaskId;
     }
 
     private class WriterCallback implements Callback {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.util.UserCodeClassLoader;
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -371,6 +372,21 @@ public class KafkaWriterITCase {
             }
 
             assertThat(drainAllRecordsFromTopic(topic, properties, true)).hasSize(1);
+        }
+    }
+
+    @Test
+    void testClientIdProperty() throws Exception {
+        String clientIdPrefix = "test-client-id";
+
+        Properties props = getKafkaClientConfiguration();
+        props.setProperty(KafkaSinkOptions.CLIENT_ID_PREFIX.key(), clientIdPrefix);
+
+        try (final KafkaWriter<Integer> writer =
+                createWriterWithConfiguration(props, DeliveryGuarantee.AT_LEAST_ONCE)) {
+            String clientId =
+                    writer.getKafkaProducerConfig().getProperty(ProducerConfig.CLIENT_ID_CONFIG);
+            assertThat(clientId).isNotNull().startsWith(clientIdPrefix);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Adding a way to configure `client.id.prefix` for the KafkaSink, which, internally, configures `client.id` for the KafkaProducer. This implementation essentially copies the implementation of `client.id.prefix` in KafkaSource.

## Brief change log

- Added a new `CLIENT_ID_PREFIX` for the KafkaSink
- Added a way to configure it for the KafkaSink
- Updated KafkaWriter to use `CLIENT_ID_PREFIX` with the subtaskId to generate a `client.id` for the KafkaProducer
- Also updated the documentation and added a test

## Verifying this change

This change added a unit test and can be verified by running `KafkaWriterITCase`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs