### PR TITLE
[FLINK-28713][yarn] Bump curator-test dependency

### DIFF
--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -187,6 +187,16 @@ under the License.
 
 	</dependencies>
 
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.curator</groupId>
+				<artifactId>curator-test</artifactId>
+				<version>${curator.version}</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
Bumps the transitive curator-test dependency to match what the flink-runtime test-jar expects.

I'm not sure why this wasn't caught in the original PR, but here is a private build that passed: https://dev.azure.com/chesnay/flink/_build/results?buildId=2932&view=results