### PR TITLE
[FLINK-28843][StateBackend] Fix restore from incremental checkpoint with changelog checkpoint in claim mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/ChangelogStateBackendHandle.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.FSDataInputStream;
 import org.apache.flink.runtime.state.CheckpointBoundKeyedStateHandle;
+import org.apache.flink.runtime.state.IncrementalRemoteKeyedStateHandle;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.KeyGroupsSavepointStateHandle;
 import org.apache.flink.runtime.state.KeyGroupsStateHandle;
@@ -36,6 +37,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -149,29 +151,64 @@ public interface ChangelogStateBackendHandle
         private static KeyedStateHandle castToAbsolutePath(
                 KeyedStateHandle originKeyedStateHandle) {
             // For KeyedStateHandle, only KeyGroupsStateHandle and IncrementalKeyedStateHandle
-            // contain streamStateHandle, and the checkpointedStateScope of
-            // IncrementalKeyedStateHandle
-            // is shared, no need to
-            // cast. So, only KeyGroupsStateHandle need to cast.
-            if (!(originKeyedStateHandle instanceof KeyGroupsStateHandle)
-                    || originKeyedStateHandle instanceof KeyGroupsSavepointStateHandle) {
+            // contain streamStateHandle, and both of them need to be cast
+            // as they all have state handles of private checkpoint scope.
+            if (originKeyedStateHandle instanceof KeyGroupsSavepointStateHandle) {
                 return originKeyedStateHandle;
-            } else {
+            }
+            if (originKeyedStateHandle instanceof KeyGroupsStateHandle) {
                 StreamStateHandle streamStateHandle =
                         ((KeyGroupsStateHandle) originKeyedStateHandle).getDelegateStateHandle();
 
                 if (streamStateHandle instanceof FileStateHandle) {
-                    FileStateHandle fileStateHandle =
-                            new FileStateHandle(
-                                    ((FileStateHandle) streamStateHandle).getFilePath(),
-                                    streamStateHandle.getStateSize());
+                    StreamStateHandle fileStateHandle = restoreFileStateHandle(streamStateHandle);
                     return KeyGroupsStateHandle.restore(
                             ((KeyGroupsStateHandle) originKeyedStateHandle).getGroupRangeOffsets(),
                             fileStateHandle,
                             originKeyedStateHandle.getStateHandleId());
                 }
-                return originKeyedStateHandle;
             }
+            if (originKeyedStateHandle instanceof IncrementalRemoteKeyedStateHandle) {
+                IncrementalRemoteKeyedStateHandle incrementalRemoteKeyedStateHandle =
+                        (IncrementalRemoteKeyedStateHandle) originKeyedStateHandle;
+
+                StreamStateHandle castMetaStateHandle =
+                        restoreFileStateHandle(
+                                incrementalRemoteKeyedStateHandle.getMetaStateHandle());
+                Map<StateHandleID, StreamStateHandle> castSharedStates =
+                        incrementalRemoteKeyedStateHandle.getSharedState().entrySet().stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                Map.Entry::getKey,
+                                                e -> restoreFileStateHandle(e.getValue())));
+                Map<StateHandleID, StreamStateHandle> castPrivateStates =
+                        incrementalRemoteKeyedStateHandle.getPrivateState().entrySet().stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                Map.Entry::getKey,
+                                                e -> restoreFileStateHandle(e.getValue())));
+
+                return IncrementalRemoteKeyedStateHandle.restore(
+                        incrementalRemoteKeyedStateHandle.getBackendIdentifier(),
+                        incrementalRemoteKeyedStateHandle.getKeyGroupRange(),
+                        incrementalRemoteKeyedStateHandle.getCheckpointId(),
+                        castSharedStates,
+                        castPrivateStates,
+                        castMetaStateHandle,
+                        incrementalRemoteKeyedStateHandle.getCheckpointedSize(),
+                        incrementalRemoteKeyedStateHandle.getStateHandleId());
+            }
+            return originKeyedStateHandle;
+        }
+
+        private static StreamStateHandle restoreFileStateHandle(
+                StreamStateHandle streamStateHandle) {
+            if (streamStateHandle instanceof FileStateHandle) {
+                return new FileStateHandle(
+                        ((FileStateHandle) streamStateHandle).getFilePath(),
+                        streamStateHandle.getStateSize());
+            }
+            return streamStateHandle;
         }
 
         @Override

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationSwitchStateBackendITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ChangelogPeriodicMaterializationSwitchStateBackendITCase.java
@@ -20,6 +20,7 @@ package org.apache.flink.test.checkpointing;
 import org.apache.flink.changelog.fs.FsStateChangelogStorageFactory;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.RestoreMode;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
@@ -57,6 +58,8 @@ public class ChangelogPeriodicMaterializationSwitchStateBackendITCase
     public void setup() throws Exception {
         Configuration configuration = new Configuration();
         configuration.setInteger(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS, 1);
+        // reduce file threshold to reproduce FLINK-28843
+        configuration.set(CheckpointingOptions.FS_SMALL_FILE_THRESHOLD, MemorySize.parse("20b"));
         FsStateChangelogStorageFactory.configure(
                 configuration, TEMPORARY_FOLDER.newFolder(), Duration.ofMinutes(1), 10);
         cluster =


### PR DESCRIPTION
## What is the purpose of the change

During restore from changelog state backend , the native checkpoint could contain the relative file state handles (which size is greater than `state.storage.fs.memory-threshold`), file path in these file state handles would be resolve as relative which leads to FileNotFoundException.

File path in IncrementalKeyedStateHandle should be cast to absolute path during restore, so that the correct file path will be read.


## Brief change log

cast file path to absolute path in IncrementalRemoteKeyedStateHandle during restore in changelog state backend.

## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.test.checkpointing.ChangelogPeriodicMaterializationSwitchStateBackendITCase*.  (`state.storage.fs.memory-threshold` is reduced)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / **don't know**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no)**
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
