### PR TITLE
[FLINK-28853][connector-base] Add FLIP-217 support for watermark alignment of source splits

### DIFF
--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -128,5 +128,11 @@
             <td>Boolean</td>
             <td>Whether name of vertex includes topological index or not. When it is true, the name will have a prefix of index of the vertex, like '[vertex-0]Source: source'. It is false by default</td>
         </tr>
+        <tr>
+            <td><h5>pipeline.watermark-alignment.allow-unaligned-source-splits</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If watermark alignment is used, sources with multiple splits will attempt to pause/resume split readers to avoid watermark drift of source splits. However, if split readers don't support pause/resume an UnsupportedOperationException will be thrown when there is an attempt to pause/resume. To allow use of split readers that don't support pause/resume and, hence, to allow unaligned splits while still using watermark alignment, set this parameter to true. The default value is false. <br /><br /> Note: This parameter may be removed in future releases.</td>
+        </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -132,7 +132,7 @@
             <td><h5>pipeline.watermark-alignment.allow-unaligned-source-splits</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>If watermark alignment is used, sources with multiple splits will attempt to pause/resume split readers to avoid watermark drift of source splits. However, if split readers don't support pause/resume an UnsupportedOperationException will be thrown when there is an attempt to pause/resume. To allow use of split readers that don't support pause/resume and, hence, to allow unaligned splits while still using watermark alignment, set this parameter to true. The default value is false. <br /><br /> Note: This parameter may be removed in future releases.</td>
+            <td>If watermark alignment is used, sources with multiple splits will attempt to pause/resume split readers to avoid watermark drift of source splits. However, if split readers don't support pause/resume an UnsupportedOperationException will be thrown when there is an attempt to pause/resume. To allow use of split readers that don't support pause/resume and, hence, t allow unaligned splits while still using watermark alignment, set this parameter to true. The default value is false. Note: This parameter may be removed in future releases.</td>
         </tr>
     </tbody>
 </table>

--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -17,8 +17,8 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -52,6 +52,14 @@
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 			<type>test-jar</type>

--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -17,8 +17,8 @@
   ~ limitations under the License.
   -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -94,7 +94,7 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
             SourceReaderContext context) {
         super(
                 elementsQueue,
-                new SingleThreadFetcherManager<>(elementsQueue, splitReaderSupplier),
+                new SingleThreadFetcherManager<>(elementsQueue, splitReaderSupplier, config),
                 recordEmitter,
                 config,
                 context);

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -156,7 +156,6 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
                 // rather than emitting nothing and waiting for the caller to call us again.
                 return pollNext(output);
             }
-            // else fall through the loop
         }
     }
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -255,6 +256,12 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
     }
 
     @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {
+        splitFetcherManager.pauseOrResumeSplits(splitsToPause, splitsToResume);
+    }
+
+    @Override
     public void close() throws Exception {
         LOG.info("Closing Source Reader.");
         splitFetcherManager.close(options.sourceReaderCloseTimeout);
@@ -315,7 +322,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 
         final String splitId;
         final SplitStateT state;
-        SourceOutput<T> sourceOutput;
+        @Nullable SourceOutput<T> sourceOutput;
 
         private SplitContext(String splitId, SplitStateT state) {
             this.state = state;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/PauseOrResumeSplitsTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/PauseOrResumeSplitsTask.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.reader.fetcher;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Changes the paused splits of a n{@link SplitReader}. The task is used by default in {@link
+ * SplitFetcherManager} and assumes that a {@link SplitFetcher} has multiple splits. For {@code
+ * SplitFetchers} with single splits, it's instead recommended to subclass {@link
+ * SplitFetcherManager} and pause the whole {@code SplitFetcher}.
+ *
+ * @param <SplitT> the type of the split
+ */
+@Internal
+class PauseOrResumeSplitsTask<SplitT extends SourceSplit> implements SplitFetcherTask {
+
+    private final SplitReader<?, SplitT> splitReader;
+    private final Collection<SplitT> splitsToPause;
+    private final Collection<SplitT> splitsToResume;
+
+    PauseOrResumeSplitsTask(
+            SplitReader<?, SplitT> splitReader,
+            Collection<SplitT> splitsToPause,
+            Collection<SplitT> splitsToResume) {
+        this.splitReader = checkNotNull(splitReader);
+        this.splitsToPause = checkNotNull(splitsToPause);
+        this.splitsToResume = checkNotNull(splitsToResume);
+    }
+
+    @Override
+    public boolean run() throws IOException {
+        splitReader.pauseOrResumeSplits(splitsToPause, splitsToResume);
+        return true;
+    }
+
+    @Override
+    public void wakeUp() {}
+
+    @Override
+    public String toString() {
+        return "AlignmentTask{"
+                + "splitsToResume="
+                + splitsToResume
+                + ", splitsToPause="
+                + splitsToPause
+                + '}';
+    }
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/PauseOrResumeSplitsTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/PauseOrResumeSplitsTask.java
@@ -31,7 +31,7 @@ import java.util.Collection;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Changes the paused splits of a n{@link SplitReader}. The task is used by default in {@link
+ * Changes the paused splits of a {@link SplitReader}. The task is used by default in {@link
  * SplitFetcherManager} and assumes that a {@link SplitFetcher} has multiple splits. For {@code
  * SplitFetchers} with single splits, it's instead recommended to subclass {@link
  * SplitFetcherManager} and pause the whole {@code SplitFetcher}.
@@ -63,7 +63,7 @@ class PauseOrResumeSplitsTask<SplitT extends SourceSplit> implements SplitFetche
             splitReader.pauseOrResumeSplits(splitsToPause, splitsToResume);
         } catch (UnsupportedOperationException e) {
             if (!allowUnalignedSourceSplits) {
-                throw new UnsupportedOperationException("", e);
+                throw e;
             }
         }
         return true;

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.base.source.reader.fetcher;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
@@ -55,8 +56,9 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
      */
     public SingleThreadFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
-            Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            Configuration configuration) {
+        super(elementsQueue, splitReaderSupplier, configuration);
     }
 
     /**
@@ -73,8 +75,9 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
     public SingleThreadFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            Configuration configuration,
             Consumer<Collection<String>> splitFinishedHook) {
-        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
+        super(elementsQueue, splitReaderSupplier, configuration, splitFinishedHook);
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -23,11 +23,13 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
@@ -59,6 +61,9 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
     @GuardedBy("lock")
     private boolean closed;
 
+    @GuardedBy("lock")
+    private boolean paused;
+
     private final FetchTask<E, SplitT> fetchTask;
 
     @GuardedBy("lock")
@@ -69,6 +74,9 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 
     @GuardedBy("lock")
     private final Condition nonEmpty = lock.newCondition();
+
+    @GuardedBy("lock")
+    private final Condition resumed = lock.newCondition();
 
     SplitFetcher(
             int id,
@@ -187,23 +195,28 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
     @Nullable
     private SplitFetcherTask getNextTaskUnsafe() {
         assert lock.isHeldByCurrentThread();
-        if (!taskQueue.isEmpty()) {
-            // a specific task is avail, so take that in FIFO
-            return taskQueue.poll();
-        } else if (!assignedSplits.isEmpty()) {
-            // use fallback task = fetch if there is at least one split
-            return fetchTask;
-        } else {
-            // nothing to do, wait for signal
-            try {
-                nonEmpty.await();
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-
-                throw new RuntimeException(
-                        "The thread was interrupted while waiting for a fetcher task.");
+        try {
+            if (paused) {
+                resumed.await();
+                // if it was paused, ensure that fetcher was not shutdown
+                return null;
             }
-            return taskQueue.poll();
+            if (!taskQueue.isEmpty()) {
+                // a specific task is avail, so take that in FIFO
+                return taskQueue.poll();
+            } else if (!assignedSplits.isEmpty()) {
+                // use fallback task = fetch if there is at least one split
+                return fetchTask;
+            } else {
+                // nothing to do, wait for signal
+                nonEmpty.await();
+                return taskQueue.poll();
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+
+            throw new RuntimeException(
+                    "The thread was interrupted while waiting for a fetcher task.");
         }
     }
 
@@ -251,6 +264,7 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
         try {
             if (!closed) {
                 closed = true;
+                paused = false;
                 LOG.info("Shutting down split fetcher {}", id);
                 wakeUpUnsafe(false);
             }
@@ -318,6 +332,26 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
             // Only wake up when the thread has started and there is no running task.
             LOG.debug("Waking up fetcher thread.");
             nonEmpty.signal();
+            resumed.signal();
+        }
+    }
+
+    public void pause() {
+        lock.lock();
+        try {
+            paused = true;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void resume() {
+        lock.lock();
+        try {
+            paused = false;
+            resumed.signal();
+        } finally {
+            lock.unlock();
         }
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -23,49 +23,52 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
-
+import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.BlockingDeque;
-import java.util.concurrent.LinkedBlockingDeque;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** The internal fetcher runnable responsible for polling message from the external system. */
 @Internal
 public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(SplitFetcher.class);
-    private static final SplitFetcherTask WAKEUP_TASK = new DummySplitFetcherTask("WAKEUP_TASK");
 
     private final int id;
-    private final BlockingDeque<SplitFetcherTask> taskQueue;
+
+    @GuardedBy("lock")
+    private final Deque<SplitFetcherTask> taskQueue = new ArrayDeque<>();
     // track the assigned splits so we can suspend the reader when there is no splits assigned.
-    private final Map<String, SplitT> assignedSplits;
+    private final Map<String, SplitT> assignedSplits = new HashMap<>();
     private final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue;
     private final SplitReader<E, SplitT> splitReader;
     private final Consumer<Throwable> errorHandler;
     private final Runnable shutdownHook;
-    private final AtomicBoolean wakeUp;
-    private final AtomicBoolean closed;
-    private final FetchTask<E, SplitT> fetchTask;
-    private volatile SplitFetcherTask runningTask = null;
 
-    private final Object lock = new Object();
-
-    /**
-     * Flag whether this fetcher has no work assigned at the moment. Fetcher that have work (a
-     * split) assigned but are currently blocked (for example enqueueing a fetch and hitting the
-     * element queue limit) are NOT considered idle.
-     */
     @GuardedBy("lock")
-    private volatile boolean isIdle;
+    private boolean closed;
+
+    private final FetchTask<E, SplitT> fetchTask;
+
+    @GuardedBy("lock")
+    @Nullable
+    private SplitFetcherTask runningTask = null;
+
+    private final ReentrantLock lock = new ReentrantLock();
+
+    @GuardedBy("lock")
+    private final Condition nonEmpty = lock.newCondition();
 
     SplitFetcher(
             int id,
@@ -75,15 +78,10 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
             Runnable shutdownHook,
             Consumer<Collection<String>> splitFinishedHook) {
         this.id = id;
-        this.taskQueue = new LinkedBlockingDeque<>();
-        this.elementsQueue = elementsQueue;
-        this.assignedSplits = new HashMap<>();
-        this.splitReader = splitReader;
-        this.errorHandler = errorHandler;
-        this.shutdownHook = shutdownHook;
-        this.isIdle = true;
-        this.wakeUp = new AtomicBoolean(false);
-        this.closed = new AtomicBoolean(false);
+        this.elementsQueue = checkNotNull(elementsQueue);
+        this.splitReader = checkNotNull(splitReader);
+        this.errorHandler = checkNotNull(errorHandler);
+        this.shutdownHook = checkNotNull(shutdownHook);
 
         this.fetchTask =
                 new FetchTask<>(
@@ -101,8 +99,8 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
     public void run() {
         LOG.info("Starting split fetcher {}", id);
         try {
-            while (!closed.get()) {
-                runOnce();
+            while (runOnce()) {
+                // nothing to do, everything is inside #runOnce.
             }
         } catch (Throwable t) {
             errorHandler.accept(t);
@@ -111,40 +109,45 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
                 splitReader.close();
             } catch (Exception e) {
                 errorHandler.accept(e);
+            } finally {
+                LOG.info("Split fetcher {} exited.", id);
+                // This executes after possible errorHandler.accept(t). If these operations bear
+                // a happens-before relation, then we can checking side effect of
+                // errorHandler.accept(t)
+                // to know whether it happened after observing side effect of shutdownHook.run().
+                shutdownHook.run();
             }
-            LOG.info("Split fetcher {} exited.", id);
-            // This executes after possible errorHandler.accept(t). If these operations bear
-            // a happens-before relation, then we can checking side effect of errorHandler.accept(t)
-            // to know whether it happened after observing side effect of shutdownHook.run().
-            shutdownHook.run();
         }
     }
 
     /** Package private method to help unit test. */
-    void runOnce() {
+    boolean runOnce() {
+        // first blocking call = get next task. blocks only if there are no active splits and queued
+        // tasks.
+        SplitFetcherTask task;
+        lock.lock();
         try {
-            // The fetch task should run if the split assignment is not empty or there is a split
-            // change.
-            if (shouldRunFetchTask()) {
-                runningTask = fetchTask;
-            } else {
-                runningTask = taskQueue.take();
+            if (closed) {
+                return false;
             }
-            // Now the running task is not null. If wakeUp() is called after this point,
-            // task.wakeUp() will be called. On the other hand, if the wakeUp() call was make before
-            // this point, the wakeUp flag must have already been set. The code hence checks the
-            // wakeUp
-            // flag first to avoid an unnecessary task run.
-            // Note that the runningTask may still encounter the case that the task is waken up
-            // before
-            // the it starts running.
-            LOG.debug("Prepare to run {}", runningTask);
-            if (!wakeUp.get() && runningTask.run()) {
-                LOG.debug("Finished running task {}", runningTask);
-                // the task has finished running. Set it to null so it won't be enqueued.
-                runningTask = null;
-                checkAndSetIdle();
+
+            task = getNextTaskUnsafe();
+            if (task == null) {
+                // (spurious) wakeup, so just repeat
+                return true;
             }
+
+            LOG.debug("Prepare to run {}", task);
+            // store task for #wakeUp
+            this.runningTask = task;
+        } finally {
+            lock.unlock();
+        }
+
+        // execute the task outside of lock, so that it can be woken up
+        boolean taskFinished;
+        try {
+            taskFinished = task.run();
         } catch (Exception e) {
             throw new RuntimeException(
                     String.format(
@@ -152,16 +155,55 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
                             id),
                     e);
         }
-        // If the task is not null that means this task needs to be re-executed. This only
-        // happens when the task is the fetching task or the task was interrupted.
-        maybeEnqueueTask(runningTask);
-        synchronized (wakeUp) {
-            // Set the running task to null. It is necessary for the shutdown method to avoid
-            // unnecessarily interrupt the running task.
-            runningTask = null;
-            // Set the wakeUp flag to false.
-            wakeUp.set(false);
-            LOG.debug("Cleaned wakeup flag.");
+
+        // re-acquire lock as all post-processing steps, need it
+        lock.lock();
+        try {
+            this.runningTask = null;
+            processTaskResultUnsafe(task, taskFinished);
+        } finally {
+            lock.unlock();
+        }
+        return true;
+    }
+
+    private void processTaskResultUnsafe(SplitFetcherTask task, boolean taskFinished) {
+        assert lock.isHeldByCurrentThread();
+        if (taskFinished) {
+            LOG.debug("Finished running task {}", task);
+            if (assignedSplits.isEmpty() && taskQueue.isEmpty()) {
+                // because the method might get invoked past the point when the source reader
+                // last checked the elements queue, we need to notify availability in the case
+                // when we become idle
+                elementsQueue.notifyAvailable();
+            }
+        } else if (task != fetchTask) {
+            // task was woken up, so repeat
+            taskQueue.addFirst(task);
+            LOG.debug("Reenqueuing woken task {}", task);
+        }
+    }
+
+    @Nullable
+    private SplitFetcherTask getNextTaskUnsafe() {
+        assert lock.isHeldByCurrentThread();
+        if (!taskQueue.isEmpty()) {
+            // a specific task is avail, so take that in FIFO
+            return taskQueue.poll();
+        } else if (!assignedSplits.isEmpty()) {
+            // use fallback task = fetch if there is at least one split
+            return fetchTask;
+        } else {
+            // nothing to do, wait for signal
+            try {
+                nonEmpty.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+
+                throw new RuntimeException(
+                        "The thread was interrupted while waiting for a fetcher task.");
+            }
+            return taskQueue.poll();
         }
     }
 
@@ -171,15 +213,28 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
      * @param splitsToAdd the splits to add.
      */
     public void addSplits(List<SplitT> splitsToAdd) {
-        enqueueTask(new AddSplitsTask<>(splitReader, splitsToAdd, assignedSplits));
-        wakeUp(true);
+        lock.lock();
+        try {
+            enqueueTaskUnsafe(new AddSplitsTask<>(splitReader, splitsToAdd, assignedSplits));
+            wakeUpUnsafe(true);
+        } finally {
+            lock.unlock();
+        }
     }
 
     public void enqueueTask(SplitFetcherTask task) {
-        synchronized (lock) {
-            taskQueue.offer(task);
-            isIdle = false;
+        lock.lock();
+        try {
+            enqueueTaskUnsafe(task);
+        } finally {
+            lock.unlock();
         }
+    }
+
+    private void enqueueTaskUnsafe(SplitFetcherTask task) {
+        assert lock.isHeldByCurrentThread();
+        taskQueue.add(task);
+        nonEmpty.signal();
     }
 
     public SplitReader<E, SplitT> getSplitReader() {
@@ -192,9 +247,15 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 
     /** Shutdown the split fetcher. */
     public void shutdown() {
-        if (closed.compareAndSet(false, true)) {
-            LOG.info("Shutting down split fetcher {}", id);
-            wakeUp(false);
+        lock.lock();
+        try {
+            if (!closed) {
+                closed = true;
+                LOG.info("Shutting down split fetcher {}", id);
+                wakeUpUnsafe(false);
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
@@ -210,138 +271,53 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
     /**
      * Package private for unit test.
      *
-     * @return true if task queue is not empty, false otherwise.
+     * @return true if task queue is empty, false otherwise.
      */
     boolean isIdle() {
-        return isIdle;
-    }
-
-    /**
-     * Check whether the fetch task should run. The fetch task should only run when all the
-     * following conditions are met. 1. there is no task in the task queue to run. 2. there are
-     * assigned splits Package private for testing purpose.
-     *
-     * @return whether the fetch task should be run.
-     */
-    boolean shouldRunFetchTask() {
-        return taskQueue.isEmpty() && !assignedSplits.isEmpty();
+        lock.lock();
+        try {
+            return assignedSplits.isEmpty() && taskQueue.isEmpty() && runningTask == null;
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**
      * Wake up the fetcher thread. There are only two blocking points in a running fetcher. 1.
-     * Taking the next task out of the task queue. 2. Running a task.
+     * Waiting for the next task in an idle fetcher. 2. Running a task.
      *
      * <p>They need to be waken up differently. If the fetcher is blocking waiting on the next task
-     * in the task queue, we should just interrupt the fetcher thread. If the fetcher is running the
-     * user split reader, we should call SplitReader.wakeUp() instead of naively interrupt the
-     * thread.
+     * in the task queue, we should just notify that a task is available. If the fetcher is running
+     * the user split reader, we should call SplitReader.wakeUp() instead.
      *
-     * <p>The correctness can be think of in the following way. The purpose of wake up is to let the
-     * fetcher thread go to the very beginning of the running loop. There are three major events in
-     * each run of the loop.
-     *
-     * <ol>
-     *   <li>pick a task (blocking)
-     *   <li>assign the task to runningTask variable.
-     *   <li>run the runningTask. (blocking)
-     * </ol>
-     *
-     * <p>We don't need to worry about things after step 3 because there is no blocking point
-     * anymore.
-     *
-     * <p>We always first set the wakeup flag when waking up the fetcher, then use the value of
-     * running task to determine where the fetcher thread is.
-     *
-     * <ul>
-     *   <li>If runningThread is null, it is before step 2, so we should interrupt fetcher. This
-     *       interruption will not be propagated to the split reader, because the wakeUp flag will
-     *       prevent the fetchTask from running.
-     *   <li>If runningThread is not null, it is after step 2. so we should wakeUp the split reader
-     *       instead of interrupt the fetcher.
-     * </ul>
-     *
-     * <p>The above logic only works in the same {@link #runOnce()} invocation. So we need to
-     * synchronize to ensure the wake up logic do not touch a different invocation.
+     * <p>The correctness can be thought of in the following way. The purpose of wake up is to let
+     * the fetcher thread go to the very beginning of the running loop.
      */
     void wakeUp(boolean taskOnly) {
         // Synchronize to make sure the wake up only works for the current invocation of runOnce().
-        synchronized (wakeUp) {
-            // Do not wake up repeatedly.
-            wakeUp.set(true);
-            // Now the wakeUp flag is set.
-            SplitFetcherTask currentTask = runningTask;
-            if (isRunningTask(currentTask)) {
-                // The running task may have missed our wakeUp flag and running, wake it up.
-                LOG.debug("Waking up running task {}", currentTask);
-                currentTask.wakeUp();
-            } else if (!taskOnly) {
-                // The task has not started running yet, and it will not run for this
-                // runOnce() invocation due to the wakeUp flag. But we might have to
-                // wake up the fetcher thread in case it is blocking on the task queue.
-                // Only wake up when the thread has started and there is no running task.
-                LOG.debug("Waking up fetcher thread.");
-                taskQueue.add(WAKEUP_TASK);
-            }
+        lock.lock();
+        try {
+            wakeUpUnsafe(taskOnly);
+        } finally {
+            lock.unlock();
         }
     }
 
-    private void maybeEnqueueTask(SplitFetcherTask task) {
-        // Only enqueue unfinished non-fetch task.
-        if (!closed.get()
-                && isRunningTask(task)
-                && task != fetchTask
-                && !taskQueue.offerFirst(task)) {
-            throw new RuntimeException(
-                    "The task queue is full. This is only theoretically possible when really bad thing happens.");
-        }
-        if (task != null) {
-            LOG.debug("Enqueued task {}", task);
-        }
-    }
+    private void wakeUpUnsafe(boolean taskOnly) {
+        assert lock.isHeldByCurrentThread();
 
-    private boolean isRunningTask(SplitFetcherTask task) {
-        return task != null && task != WAKEUP_TASK;
-    }
-
-    private void checkAndSetIdle() {
-        if (shouldIdle()) {
-            synchronized (lock) {
-                if (shouldIdle()) {
-                    isIdle = true;
-                }
-            }
-
-            // because the method might get invoked past the point when the source reader last
-            // checked
-            // the elements queue, we need to notify availability in the case when we become idle
-            elementsQueue.notifyAvailable();
-        }
-    }
-
-    private boolean shouldIdle() {
-        return assignedSplits.isEmpty() && taskQueue.isEmpty();
-    }
-
-    // --------------------- Helper class ------------------
-
-    private static class DummySplitFetcherTask implements SplitFetcherTask {
-        private final String name;
-
-        private DummySplitFetcherTask(String name) {
-            this.name = name;
-        }
-
-        @Override
-        public boolean run() {
-            return false;
-        }
-
-        @Override
-        public void wakeUp() {}
-
-        @Override
-        public String toString() {
-            return name;
+        SplitFetcherTask currentTask = runningTask;
+        if (currentTask != null) {
+            // The running task may have missed our wakeUp flag and running, wake it up.
+            LOG.debug("Waking up running task {}", currentTask);
+            currentTask.wakeUp();
+        } else if (!taskOnly) {
+            // The task has not started running yet, and it will not run for this
+            // runOnce() invocation due to the wakeUp flag. But we might have to
+            // wake up the fetcher thread in case it is blocking on the task queue.
+            // Only wake up when the thread has started and there is no running task.
+            LOG.debug("Waking up fetcher thread.");
+            nonEmpty.signal();
         }
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -90,6 +90,8 @@ public interface SplitReader<E, SplitT extends SourceSplit> {
     default void pauseOrResumeSplits(
             Collection<SplitT> splitsToPause, Collection<SplitT> splitsToResume) {
         throw new UnsupportedOperationException(
-                "This split reader does not support pause or resume.");
+                "This split reader does not support pause or resume. (To use watermark alignment "
+                        + "and allow unaligned source splits set configuration parameter "
+                        + "'pipeline.watermark-alignment.allow-unaligned-source-splits' to true.)");
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * An interface used to read from splits. The implementation could either read from a single split
@@ -68,4 +69,27 @@ public interface SplitReader<E, SplitT extends SourceSplit> {
      * @throws Exception if closing the split reader failed.
      */
     void close() throws Exception;
+
+    /**
+     * Pauses or resumes reading of individual splits readers.
+     *
+     * <p>Note that no other methods can be called in parallel, so it's fine to non-atomically
+     * update subscriptions. This method is simply providing connectors with more expressive APIs
+     * the opportunity to update all subscriptions at once.
+     *
+     * <p>This is currently used to align the watermarks of splits, if watermark alignment is used
+     * and the source reads from more than one split.
+     *
+     * <p>The default implementation throws an {@link UnsupportedOperationException} where the
+     * default implementation will be removed in future releases. To be compatible with future
+     * releases, it is recommended to implement this method and override the default implementation.
+     *
+     * @param splitsToPause the splits to pause
+     * @param splitsToResume the splits to resume
+     */
+    default void pauseOrResumeSplits(
+            Collection<SplitT> splitsToPause, Collection<SplitT> splitsToResume) {
+        throw new UnsupportedOperationException(
+                "This split reader does not support pause or resume.");
+    }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -90,8 +90,12 @@ public interface SplitReader<E, SplitT extends SourceSplit> {
     default void pauseOrResumeSplits(
             Collection<SplitT> splitsToPause, Collection<SplitT> splitsToResume) {
         throw new UnsupportedOperationException(
-                "This split reader does not support pause or resume. (To use watermark alignment "
-                        + "and allow unaligned source splits set configuration parameter "
-                        + "'pipeline.watermark-alignment.allow-unaligned-source-splits' to true.)");
+                "This split reader does not support pausing or resuming splits which can lead to unaligned splits.\n"
+                        + "Unaligned splits are splits where the output watermarks of the splits have diverged more than the allowed limit.\n"
+                        + "It is highly discouraged to use unaligned source splits, as this leads to unpredictable\n"
+                        + "watermark alignment if there is more than a single split per reader. It is recommended to implement pausing splits\n"
+                        + "for this source. At your own risk, you can allow unaligned source splits by setting the\n"
+                        + "configuration parameter `pipeline.watermark-alignment.allow-unaligned-source-splits' to true.\n"
+                        + "Beware that this configuration parameter will be dropped in a future Flink release.");
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -239,7 +239,8 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
                         .setBlockingFetch(true)
                         .build();
         BlockingShutdownSplitFetcherManager<int[], MockSourceSplit> splitFetcherManager =
-                new BlockingShutdownSplitFetcherManager<>(elementsQueue, () -> mockSplitReader);
+                new BlockingShutdownSplitFetcherManager<>(
+                        elementsQueue, () -> mockSplitReader, getConfig());
         final MockSourceReader sourceReader =
                 new MockSourceReader(
                         elementsQueue,
@@ -448,8 +449,9 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
 
         public BlockingShutdownSplitFetcherManager(
                 FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
-                Supplier<SplitReader<E, SplitT>> splitReaderSupplier) {
-            super(elementsQueue, splitReaderSupplier);
+                Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+                Configuration configuration) {
+            super(elementsQueue, splitReaderSupplier, configuration);
             this.inShutdownSplitFetcherFuture = new CompletableFuture<>();
         }
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -44,7 +44,6 @@ import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
 import org.apache.flink.streaming.api.operators.SourceOperator;
-import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
@@ -499,7 +498,8 @@ public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> 
         }
 
         @Override
-        public void emitWatermark(Watermark watermark) throws Exception {
+        public void emitWatermark(org.apache.flink.streaming.api.watermark.Watermark watermark)
+                throws Exception {
             watermarks.add(watermark.getTimestamp());
         }
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.base.source.reader.fetcher;
 
 import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.mocks.TestingRecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.mocks.TestingSourceSplit;
@@ -109,7 +110,7 @@ public class SplitFetcherManagerTest {
             final SplitReader<E, TestingSourceSplit> reader) {
 
         final SingleThreadFetcherManager<E, TestingSourceSplit> fetcher =
-                new SingleThreadFetcherManager<>(queue, () -> reader);
+                new SingleThreadFetcherManager<>(queue, () -> reader, new Configuration());
         fetcher.addSplits(Collections.singletonList(new TestingSourceSplit(splitId)));
         return fetcher;
     }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherPauseResumeSplitReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherPauseResumeSplitReaderTest.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.reader.fetcher;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.mocks.MockSourceReader;
+import org.apache.flink.connector.base.source.reader.mocks.MockSplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
+import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.core.io.InputStatus;
+import org.apache.flink.core.testutils.CommonTestUtils;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests {@link SplitFetcher} integration to pause or resume {@link SplitReader} based on {@link
+ * SourceReader} output.
+ */
+public class SplitFetcherPauseResumeSplitReaderTest {
+
+    /**
+     * Tests if pause or resume shows expected behavior which requires creation and execution of
+     * {@link SplitFetcher} tasks.
+     *
+     * @throws Exception on error.
+     */
+    @ParameterizedTest(name = "Individual reader per split: {0}")
+    @ValueSource(booleans = {false, true})
+    public void testPauseResumeSplitReaders(boolean individualReader) throws Exception {
+        final AtomicInteger numSplitReaders = new AtomicInteger();
+        final MockSplitReader.Builder readerBuilder =
+                SteppingSourceReaderTestHarness.createSplitReaderBuilder();
+        final SteppingSourceReaderTestHarness testHarness =
+                new SteppingSourceReaderTestHarness(
+                        () -> {
+                            numSplitReaders.getAndIncrement();
+                            return readerBuilder.build();
+                        },
+                        new Configuration());
+
+        if (individualReader) {
+            testHarness.addPrefilledSplitsIndividualReader(2, 5);
+            assertThat(numSplitReaders.get()).isEqualTo(2);
+        } else {
+            testHarness.addPrefilledSplitsSingleReader(2, 5);
+            assertThat(numSplitReaders.get()).isEqualTo(1);
+        }
+
+        TestingReaderOutput output = new TestingReaderOutput<>();
+        testHarness.runUntilRecordsEmitted(output, 10, 2);
+        Set<Integer> recordSet = new HashSet<>(output.getEmittedRecords());
+        assertThat(recordSet).containsExactlyInAnyOrder(new Integer[] {0, 1});
+
+        testHarness.pauseOrResumeSplits(Collections.singleton("0"), Collections.emptyList());
+
+        testHarness.runUntilRecordsEmitted(output, 10, 5);
+        Set<Integer> recordSet2 = new HashSet<>(output.getEmittedRecords());
+        assertThat(recordSet2).containsExactlyInAnyOrder(new Integer[] {0, 1, 3, 5, 7});
+
+        testHarness.pauseOrResumeSplits(Collections.emptyList(), Collections.singleton("0"));
+
+        testHarness.runUntilAllRecordsEmitted(output, 10);
+        Set<Integer> recordSet3 = new HashSet<>(output.getEmittedRecords());
+        assertThat(recordSet3)
+                .containsExactlyInAnyOrder(new Integer[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+    }
+
+    /**
+     * Tests if pause or resume shows expected behavior in case of {@link SplitReader} that does not
+     * support split or resume for scenarios (1) allowed and (2) not allowed.
+     *
+     * @throws Exception on error.
+     */
+    @ParameterizedTest(name = "Allow unaligned source splits: {0}")
+    @ValueSource(booleans = {true, false})
+    public void testPauseResumeUnsupported(boolean allowUnalignedSourceSplits) throws Exception {
+        final AtomicInteger numSplitReaders = new AtomicInteger();
+        final Configuration configuration = new Configuration();
+        configuration.setBoolean(
+                "pipeline.watermark-alignment.allow-unaligned-source-splits",
+                allowUnalignedSourceSplits);
+        final MockSplitReader.Builder readerBuilder =
+                SteppingSourceReaderTestHarness.createSplitReaderBuilder();
+
+        final SteppingSourceReaderTestHarness testHarness =
+                new SteppingSourceReaderTestHarness(
+                        () -> {
+                            if (numSplitReaders.getAndIncrement() == 0) {
+                                return MockSplitReaderUnsupportedPause.cloneBuilder(readerBuilder)
+                                        .build();
+                            } else {
+                                return readerBuilder.build();
+                            }
+                        },
+                        configuration);
+
+        testHarness.addPrefilledSplitsIndividualReader(2, 5);
+        assertThat(numSplitReaders.get()).isEqualTo(2);
+
+        TestingReaderOutput output = new TestingReaderOutput<>();
+        testHarness.runUntilRecordsEmitted(output, 10, 2);
+        Set<Integer> recordSet = new HashSet<>(output.getEmittedRecords());
+        assertThat(recordSet).containsExactlyInAnyOrder(new Integer[] {0, 1});
+
+        testHarness.pauseOrResumeSplits(Collections.singleton("1"), Collections.emptyList());
+
+        testHarness.runUntilRecordsEmitted(output, 10, 5);
+        Set<Integer> recordSet2 = new HashSet<>(output.getEmittedRecords());
+        assertThat(recordSet2).containsExactlyInAnyOrder(new Integer[] {0, 1, 2, 4, 6});
+
+        testHarness.pauseOrResumeSplits(Collections.singleton("0"), Collections.singleton("1"));
+
+        if (allowUnalignedSourceSplits) {
+            testHarness.runUntilAllRecordsEmitted(output, 10);
+            Set<Integer> recordSet3 = new HashSet<>(output.getEmittedRecords());
+            assertThat(recordSet3)
+                    .containsExactlyInAnyOrder(new Integer[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        } else {
+            assertThatThrownBy(() -> testHarness.runUntilAllRecordsEmitted(output, 10))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasCauseInstanceOf(UnsupportedOperationException.class);
+        }
+    }
+
+    private static class MockSteppingSplitFetcherManager<E, SplitT extends SourceSplit>
+            extends SingleThreadFetcherManager<E, SplitT> {
+
+        public MockSteppingSplitFetcherManager(
+                FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+                Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+                Configuration configuration) {
+            super(elementsQueue, splitReaderSupplier, configuration);
+        }
+
+        @Override
+        public void addSplits(List<SplitT> splitsToAdd) {
+            SplitFetcher<E, SplitT> fetcher = createSplitFetcher();
+            fetcher.addSplits(splitsToAdd);
+        }
+
+        public void runEachOnce() {
+            for (SplitFetcher<E, SplitT> fetcher : fetchers.values()) {
+                fetcher.runOnce();
+            }
+        }
+    }
+
+    private static class MockSplitReaderUnsupportedPause extends MockSplitReader {
+        public MockSplitReaderUnsupportedPause(
+                int numRecordsPerSplitPerFetch,
+                boolean separatedFinishedRecord,
+                boolean blockingFetch) {
+            super(numRecordsPerSplitPerFetch, separatedFinishedRecord, blockingFetch);
+        }
+
+        @Override
+        public void pauseOrResumeSplits(
+                Collection<MockSourceSplit> splitsToPause,
+                Collection<MockSourceSplit> splitsToResume) {
+            throw new UnsupportedOperationException();
+        }
+
+        public static class Builder extends MockSplitReader.Builder {
+            public Builder(MockSplitReader.Builder other) {
+                super(other);
+            }
+
+            @Override
+            public MockSplitReader build() {
+                return new MockSplitReaderUnsupportedPause(
+                        numRecordsPerSplitPerFetch, separatedFinishedRecord, blockingFetch);
+            }
+        }
+
+        public static Builder cloneBuilder(MockSplitReader.Builder other) {
+            return new MockSplitReaderUnsupportedPause.Builder(other);
+        }
+    }
+
+    private static class SteppingSourceReaderTestHarness {
+        private final MockSteppingSplitFetcherManager<int[], MockSourceSplit> fetcherManager;
+        private final MockSourceReader sourceReader;
+
+        public SteppingSourceReaderTestHarness(
+                Supplier<SplitReader<int[], MockSourceSplit>> splitReaderSupplier,
+                Configuration configuration) {
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> queue =
+                    new FutureCompletingBlockingQueue<>(10);
+            this.fetcherManager =
+                    new MockSteppingSplitFetcherManager<>(
+                            queue, splitReaderSupplier, configuration);
+            this.sourceReader =
+                    new MockSourceReader(
+                            queue, fetcherManager, configuration, new TestingReaderContext());
+        }
+
+        private static List<MockSourceSplit> createPrefilledSplits(int numSplits, int numRecords) {
+            final List<MockSourceSplit> splits = new ArrayList<>(numSplits);
+            for (int splitId = 0; splitId < numSplits; splitId++) {
+                MockSourceSplit split = new MockSourceSplit(splitId, 0, numRecords);
+                for (int i = 0; i < numRecords; i++) {
+                    split.addRecord(i * numSplits + splitId);
+                }
+                splits.add(split);
+            }
+            return splits;
+        }
+
+        public void addPrefilledSplitsSingleReader(int numSplits, int numRecords) {
+            sourceReader.addSplits(createPrefilledSplits(numSplits, numRecords));
+            sourceReader.notifyNoMoreSplits();
+        }
+
+        public void addPrefilledSplitsIndividualReader(int numSplits, int numRecords) {
+            for (MockSourceSplit split : createPrefilledSplits(numSplits, numRecords)) {
+                sourceReader.addSplits(Collections.singletonList(split));
+            }
+            sourceReader.notifyNoMoreSplits();
+        }
+
+        public static MockSplitReader.Builder createSplitReaderBuilder() {
+            return MockSplitReader.newBuilder()
+                    .setNumRecordsPerSplitPerFetch(1)
+                    .setBlockingFetch(false)
+                    .setSeparatedFinishedRecord(true);
+        }
+
+        public int runUntilRecordsEmitted(
+                TestingReaderOutput readerOutput, int timeoutSeconds, int numRecords)
+                throws Exception {
+            final AtomicReference<Exception> exception = new AtomicReference<>();
+            final AtomicInteger numFetches = new AtomicInteger();
+            CommonTestUtils.waitUtil(
+                    () -> {
+                        try {
+                            this.fetcherManager.runEachOnce();
+                            numFetches.getAndIncrement();
+                            InputStatus status = this.sourceReader.pollNext(readerOutput);
+                            while (status == InputStatus.MORE_AVAILABLE) {
+                                status = this.sourceReader.pollNext(readerOutput);
+                            }
+                            if (status == InputStatus.END_OF_INPUT) {
+                                return true;
+                            } else if (numRecords < 0) {
+                                return false;
+                            } else {
+                                return readerOutput.getEmittedRecords().size() >= numRecords;
+                            }
+                        } catch (Exception e) {
+                            exception.set(e);
+                            return true;
+                        }
+                    },
+                    Duration.ofSeconds(timeoutSeconds),
+                    String.format(
+                            "%d %s records fetched within timeout",
+                            readerOutput.getEmittedRecords().size(),
+                            numRecords < 0 ? "but not all" : "out of " + numRecords));
+            if (exception.get() != null) {
+                throw exception.get();
+            }
+            return numFetches.get();
+        }
+
+        public int runUntilAllRecordsEmitted(TestingReaderOutput readerOutput, int timeoutSeconds)
+                throws Exception {
+            return runUntilRecordsEmitted(readerOutput, timeoutSeconds, -1);
+        }
+
+        public void pauseOrResumeSplits(
+                Collection<String> splitsToPause, Collection<String> splitsToResume) {
+            sourceReader.pauseOrResumeSplits(splitsToPause, splitsToResume);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherPauseResumeSplitReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherPauseResumeSplitReaderTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.base.source.reader.fetcher;
 
+import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
@@ -57,8 +58,6 @@ public class SplitFetcherPauseResumeSplitReaderTest {
     /**
      * Tests if pause or resume shows expected behavior which requires creation and execution of
      * {@link SplitFetcher} tasks.
-     *
-     * @throws Exception on error.
      */
     @ParameterizedTest(name = "Individual reader per split: {0}")
     @ValueSource(booleans = {false, true})
@@ -85,27 +84,24 @@ public class SplitFetcherPauseResumeSplitReaderTest {
         TestingReaderOutput output = new TestingReaderOutput<>();
         testHarness.runUntilRecordsEmitted(output, 10, 2);
         Set<Integer> recordSet = new HashSet<>(output.getEmittedRecords());
-        assertThat(recordSet).containsExactlyInAnyOrder(new Integer[] {0, 1});
+        assertThat(recordSet).containsExactlyInAnyOrder(0, 1);
 
         testHarness.pauseOrResumeSplits(Collections.singleton("0"), Collections.emptyList());
 
         testHarness.runUntilRecordsEmitted(output, 10, 5);
         Set<Integer> recordSet2 = new HashSet<>(output.getEmittedRecords());
-        assertThat(recordSet2).containsExactlyInAnyOrder(new Integer[] {0, 1, 3, 5, 7});
+        assertThat(recordSet2).containsExactlyInAnyOrder(0, 1, 3, 5, 7);
 
         testHarness.pauseOrResumeSplits(Collections.emptyList(), Collections.singleton("0"));
 
         testHarness.runUntilAllRecordsEmitted(output, 10);
         Set<Integer> recordSet3 = new HashSet<>(output.getEmittedRecords());
-        assertThat(recordSet3)
-                .containsExactlyInAnyOrder(new Integer[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+        assertThat(recordSet3).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     }
 
     /**
      * Tests if pause or resume shows expected behavior in case of {@link SplitReader} that does not
      * support split or resume for scenarios (1) allowed and (2) not allowed.
-     *
-     * @throws Exception on error.
      */
     @ParameterizedTest(name = "Allow unaligned source splits: {0}")
     @ValueSource(booleans = {true, false})
@@ -136,21 +132,20 @@ public class SplitFetcherPauseResumeSplitReaderTest {
         TestingReaderOutput output = new TestingReaderOutput<>();
         testHarness.runUntilRecordsEmitted(output, 10, 2);
         Set<Integer> recordSet = new HashSet<>(output.getEmittedRecords());
-        assertThat(recordSet).containsExactlyInAnyOrder(new Integer[] {0, 1});
+        assertThat(recordSet).containsExactlyInAnyOrder(0, 1);
 
         testHarness.pauseOrResumeSplits(Collections.singleton("1"), Collections.emptyList());
 
         testHarness.runUntilRecordsEmitted(output, 10, 5);
         Set<Integer> recordSet2 = new HashSet<>(output.getEmittedRecords());
-        assertThat(recordSet2).containsExactlyInAnyOrder(new Integer[] {0, 1, 2, 4, 6});
+        assertThat(recordSet2).containsExactlyInAnyOrder(0, 1, 2, 4, 6);
 
         testHarness.pauseOrResumeSplits(Collections.singleton("0"), Collections.singleton("1"));
 
         if (allowUnalignedSourceSplits) {
             testHarness.runUntilAllRecordsEmitted(output, 10);
             Set<Integer> recordSet3 = new HashSet<>(output.getEmittedRecords());
-            assertThat(recordSet3)
-                    .containsExactlyInAnyOrder(new Integer[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
+            assertThat(recordSet3).containsExactlyInAnyOrder(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
         } else {
             assertThatThrownBy(() -> testHarness.runUntilAllRecordsEmitted(output, 10))
                     .isInstanceOf(RuntimeException.class)

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -257,7 +257,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testCloseAfterPause() {
+    public void testCloseAfterPause() throws InterruptedException {
         final FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
                 new FutureCompletingBlockingQueue<>();
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
@@ -268,9 +268,11 @@ public class SplitFetcherTest {
 
         fetcher.pause();
 
-        new Thread(fetcher::shutdown).start();
+        Thread fetcherThread = new Thread(fetcher::shutdown);
+        fetcherThread.start();
+        fetcherThread.join();
 
-        fetcher.runOnce();
+        assertThat(fetcher.runOnce()).isFalse();
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -182,7 +182,8 @@ public class SplitFetcherTest {
                                 .build(),
                         ExceptionUtils::rethrow,
                         () -> {},
-                        (ignore) -> {});
+                        (ignore) -> {},
+                        false);
 
         // Prepare the splits.
         List<MockSourceSplit> splits = new ArrayList<>();
@@ -289,7 +290,7 @@ public class SplitFetcherTest {
             final SplitReader<E, TestingSourceSplit> reader,
             final FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> queue) {
         return new SplitFetcher<>(
-                0, queue, reader, ExceptionUtils::rethrow, () -> {}, (ignore) -> {});
+                0, queue, reader, ExceptionUtils::rethrow, () -> {}, (ignore) -> {}, false);
     }
 
     private static <E> SplitFetcher<E, TestingSourceSplit> createFetcherWithSplit(

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -255,6 +255,23 @@ public class SplitFetcherTest {
         assertThat(splitReader.isClosed()).isTrue();
     }
 
+    @Test
+    public void testCloseAfterPause() {
+        final FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
+                new FutureCompletingBlockingQueue<>();
+        final SplitFetcher<Object, TestingSourceSplit> fetcher =
+                createFetcherWithSplit(
+                        "test-split",
+                        queue,
+                        new TestingSplitReader<>(finishedSplitFetch("test-split")));
+
+        fetcher.pause();
+
+        new Thread(fetcher::shutdown).start();
+
+        fetcher.runOnce();
+    }
+
     // ------------------------------------------------------------------------
     //  testing utils
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSplitReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSplitReader.java
@@ -52,7 +52,7 @@ public class MockSplitReader implements SplitReader<int[], MockSourceSplit> {
     private boolean wokenUp;
     private Set<MockSourceSplit> pausedSplits = new HashSet<>();
 
-    private MockSplitReader(
+    protected MockSplitReader(
             int numRecordsPerSplitPerFetch,
             boolean separatedFinishedRecord,
             boolean blockingFetch) {
@@ -160,9 +160,17 @@ public class MockSplitReader implements SplitReader<int[], MockSourceSplit> {
 
     /** Builder for {@link MockSplitReader}. */
     public static class Builder {
-        private int numRecordsPerSplitPerFetch = 2;
-        private boolean separatedFinishedRecord = false;
-        private boolean blockingFetch = false;
+        protected int numRecordsPerSplitPerFetch = 2;
+        protected boolean separatedFinishedRecord = false;
+        protected boolean blockingFetch = false;
+
+        protected Builder() {}
+
+        protected Builder(Builder other) {
+            this.numRecordsPerSplitPerFetch = other.numRecordsPerSplitPerFetch;
+            this.separatedFinishedRecord = other.separatedFinishedRecord;
+            this.blockingFetch = other.blockingFetch;
+        }
 
         public Builder setNumRecordsPerSplitPerFetch(int numRecordsPerSplitPerFetch) {
             this.numRecordsPerSplitPerFetch = numRecordsPerSplitPerFetch;

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -227,6 +227,20 @@ public class KafkaPartitionSplitReader
         consumer.close();
     }
 
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<KafkaPartitionSplit> splitsToPause,
+            Collection<KafkaPartitionSplit> splitsToResume) {
+        consumer.resume(
+                splitsToResume.stream()
+                        .map(KafkaPartitionSplit::getTopicPartition)
+                        .collect(Collectors.toList()));
+        consumer.pause(
+                splitsToPause.stream()
+                        .map(KafkaPartitionSplit::getTopicPartition)
+                        .collect(Collectors.toList()));
+    }
+
     // ---------------
 
     public void notifyCheckpointComplete(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -38,6 +38,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -183,6 +184,12 @@ public class KafkaSourceReader<T>
     @Override
     protected KafkaPartitionSplit toSplitType(String splitId, KafkaPartitionSplitState splitState) {
         return splitState.toKafkaPartitionSplit();
+    }
+
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {
+        splitFetcherManager.pauseOrResumeSplits(splitsToPause, splitsToResume);
     }
 
     // ------------------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/fetcher/KafkaSourceFetcherManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.kafka.source.reader.fetcher;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
@@ -68,7 +69,7 @@ public class KafkaSourceFetcherManager
             Supplier<SplitReader<ConsumerRecord<byte[], byte[]>, KafkaPartitionSplit>>
                     splitReaderSupplier,
             Consumer<Collection<String>> splitFinishedHook) {
-        super(elementsQueue, splitReaderSupplier, splitFinishedHook);
+        super(elementsQueue, splitReaderSupplier, new Configuration(), splitFinishedHook);
     }
 
     public void commitOffsets(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -423,7 +423,7 @@ public abstract class AbstractFetcher<T, KPH> {
                                 kafkaTopicPartition.getTopic()
                                         + '-'
                                         + kafkaTopicPartition.getPartition();
-                        watermarkOutputMultiplexer.registerNewOutput(partitionId);
+                        watermarkOutputMultiplexer.registerNewOutput(partitionId, watermark -> {});
                         WatermarkOutput immediateOutput =
                                 watermarkOutputMultiplexer.getImmediateOutput(partitionId);
                         WatermarkOutput deferredOutput =

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarFetcherManagerBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarFetcherManagerBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.pulsar.source.reader.fetcher;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
@@ -57,8 +58,9 @@ public abstract class PulsarFetcherManagerBase<T>
      */
     protected PulsarFetcherManagerBase(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<T>>> elementsQueue,
-            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier,
+            Configuration configuration) {
+        super(elementsQueue, splitReaderSupplier, configuration);
     }
 
     /**

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarOrderedFetcherManager.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarOrderedFetcherManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.pulsar.source.reader.fetcher;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
@@ -49,8 +50,9 @@ public class PulsarOrderedFetcherManager<T> extends PulsarFetcherManagerBase<T> 
 
     public PulsarOrderedFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<T>>> elementsQueue,
-            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier,
+            Configuration configuration) {
+        super(elementsQueue, splitReaderSupplier, configuration);
     }
 
     public void acknowledgeMessages(Map<TopicPartition, MessageId> cursorsToCommit) {

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarUnorderedFetcherManager.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarUnorderedFetcherManager.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.pulsar.source.reader.fetcher;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcher;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
@@ -49,8 +50,9 @@ public class PulsarUnorderedFetcherManager<T> extends PulsarFetcherManagerBase<T
 
     public PulsarUnorderedFetcherManager(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<PulsarMessage<T>>> elementsQueue,
-            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier) {
-        super(elementsQueue, splitReaderSupplier);
+            Supplier<SplitReader<PulsarMessage<T>, PulsarPartitionSplit>> splitReaderSupplier,
+            Configuration configuration) {
+        super(elementsQueue, splitReaderSupplier, configuration);
     }
 
     public List<PulsarPartitionSplit> snapshotState() {

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarOrderedSourceReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarOrderedSourceReader.java
@@ -75,7 +75,8 @@ public class PulsarOrderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT> 
             PulsarAdmin pulsarAdmin) {
         super(
                 elementsQueue,
-                new PulsarOrderedFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                new PulsarOrderedFetcherManager<>(
+                        elementsQueue, splitReaderSupplier::get, context.getConfiguration()),
                 context,
                 sourceConfiguration,
                 pulsarClient,

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
@@ -32,6 +32,8 @@ import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitState;
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.PulsarClient;
 
+import java.util.Collection;
+
 /**
  * The common pulsar source reader for both ordered & unordered message consuming.
  *
@@ -73,6 +75,12 @@ abstract class PulsarSourceReaderBase<OUT>
     protected PulsarPartitionSplit toSplitType(
             String splitId, PulsarPartitionSplitState splitState) {
         return splitState.toPulsarPartitionSplit();
+    }
+
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<String> splitsToPause, Collection<String> splitsToResume) {
+        splitFetcherManager.pauseOrResumeSplits(splitsToPause, splitsToResume);
     }
 
     @Override

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
@@ -72,7 +72,8 @@ public class PulsarUnorderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT
             @Nullable TransactionCoordinatorClient coordinatorClient) {
         super(
                 elementsQueue,
-                new PulsarUnorderedFetcherManager<>(elementsQueue, splitReaderSupplier::get),
+                new PulsarUnorderedFetcherManager<>(
+                        elementsQueue, splitReaderSupplier::get, context.getConfiguration()),
                 context,
                 sourceConfiguration,
                 pulsarClient,

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
@@ -50,6 +50,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -175,6 +176,21 @@ abstract class PulsarPartitionSplitReaderBase<OUT>
         afterCreatingConsumer(registeredSplit, pulsarConsumer);
 
         LOG.info("Register split {} consumer for current reader.", registeredSplit);
+    }
+
+    @Override
+    public void pauseOrResumeSplits(
+            Collection<PulsarPartitionSplit> splitsToPause,
+            Collection<PulsarPartitionSplit> splitsToResume) {
+        if (splitsToPause.size() > 1 || splitsToResume.size() > 1) {
+            throw new IllegalStateException("This pulsar split reader only support one split.");
+        }
+
+        if (!splitsToPause.isEmpty()) {
+            pulsarConsumer.pause();
+        } else if (!splitsToResume.isEmpty()) {
+            pulsarConsumer.resume();
+        }
     }
 
     @Override

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
@@ -160,7 +160,7 @@ abstract class PulsarPartitionSplitReaderBase<OUT>
 
         List<PulsarPartitionSplit> newSplits = splitsChanges.splits();
         Preconditions.checkArgument(
-                newSplits.size() == 1, "This pulsar split reader only support one split.");
+                newSplits.size() == 1, "This pulsar split reader only supports one split.");
         this.registeredSplit = newSplits.get(0);
 
         // Open stop cursor.
@@ -182,9 +182,10 @@ abstract class PulsarPartitionSplitReaderBase<OUT>
     public void pauseOrResumeSplits(
             Collection<PulsarPartitionSplit> splitsToPause,
             Collection<PulsarPartitionSplit> splitsToResume) {
-        if (splitsToPause.size() > 1 || splitsToResume.size() > 1) {
-            throw new IllegalStateException("This pulsar split reader only support one split.");
-        }
+        // This shouldn't happen but just in case...
+        Preconditions.checkState(
+                splitsToPause.size() + splitsToResume.size() <= 1,
+                "This pulsar split reader only supports one split.");
 
         if (!splitsToPause.isEmpty()) {
             pulsarConsumer.pause();

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/CombinedWatermarkStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/CombinedWatermarkStatus.java
@@ -95,6 +95,12 @@ final class CombinedWatermarkStatus {
     static class PartialWatermark {
         private long watermark = Long.MIN_VALUE;
         private boolean idle = false;
+        private final WatermarkOutputMultiplexer.SplitWatermarkUpdateListener onWatermarkUpdate;
+
+        public PartialWatermark(
+                WatermarkOutputMultiplexer.SplitWatermarkUpdateListener onWatermarkUpdate) {
+            this.onWatermarkUpdate = onWatermarkUpdate;
+        }
 
         /**
          * Returns the current watermark timestamp. This will throw {@link IllegalStateException} if
@@ -114,7 +120,10 @@ final class CombinedWatermarkStatus {
         public boolean setWatermark(long watermark) {
             this.idle = false;
             final boolean updated = watermark > this.watermark;
-            this.watermark = Math.max(watermark, this.watermark);
+            if (updated) {
+                this.onWatermarkUpdate.updateWatermark(watermark);
+                this.watermark = Math.max(watermark, this.watermark);
+            }
             return updated;
         }
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/CombinedWatermarkStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/CombinedWatermarkStatus.java
@@ -95,10 +95,10 @@ final class CombinedWatermarkStatus {
     static class PartialWatermark {
         private long watermark = Long.MIN_VALUE;
         private boolean idle = false;
-        private final WatermarkOutputMultiplexer.SplitWatermarkUpdateListener onWatermarkUpdate;
+        private final WatermarkOutputMultiplexer.WatermarkUpdateListener onWatermarkUpdate;
 
         public PartialWatermark(
-                WatermarkOutputMultiplexer.SplitWatermarkUpdateListener onWatermarkUpdate) {
+                WatermarkOutputMultiplexer.WatermarkUpdateListener onWatermarkUpdate) {
             this.onWatermarkUpdate = onWatermarkUpdate;
         }
 
@@ -121,7 +121,7 @@ final class CombinedWatermarkStatus {
             this.idle = false;
             final boolean updated = watermark > this.watermark;
             if (updated) {
-                this.onWatermarkUpdate.updateWatermark(watermark);
+                this.onWatermarkUpdate.onWatermarkUpdate(watermark);
                 this.watermark = Math.max(watermark, this.watermark);
             }
             return updated;

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/IndexedCombinedWatermarkStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/IndexedCombinedWatermarkStatus.java
@@ -42,7 +42,8 @@ public final class IndexedCombinedWatermarkStatus {
     public static IndexedCombinedWatermarkStatus forInputsCount(int inputsCount) {
         CombinedWatermarkStatus.PartialWatermark[] partialWatermarks =
                 IntStream.range(0, inputsCount)
-                        .mapToObj(i -> new CombinedWatermarkStatus.PartialWatermark())
+                        .mapToObj(
+                                i -> new CombinedWatermarkStatus.PartialWatermark(watermark -> {}))
                         .toArray(CombinedWatermarkStatus.PartialWatermark[]::new);
         CombinedWatermarkStatus combinedWatermarkStatus = new CombinedWatermarkStatus();
         for (CombinedWatermarkStatus.PartialWatermark partialWatermark : partialWatermarks) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexer.java
@@ -48,6 +48,12 @@ import static org.apache.flink.util.Preconditions.checkState;
  */
 @Internal
 public class WatermarkOutputMultiplexer {
+    /** A callback for propagating changes to split based watermarks. */
+    @FunctionalInterface
+    @Internal
+    public interface SplitWatermarkUpdateListener {
+        void updateWatermark(long watermark);
+    }
 
     /**
      * The {@link WatermarkOutput} that we use to emit our multiplexed watermark updates. We assume
@@ -78,8 +84,8 @@ public class WatermarkOutputMultiplexer {
      * an output ID that can be used to get a deferred or immediate {@link WatermarkOutput} for that
      * output.
      */
-    public void registerNewOutput(String id) {
-        final PartialWatermark outputState = new PartialWatermark();
+    public void registerNewOutput(String id, SplitWatermarkUpdateListener onWatermarkUpdate) {
+        final PartialWatermark outputState = new PartialWatermark(onWatermarkUpdate);
 
         final PartialWatermark previouslyRegistered =
                 watermarkPerOutputId.putIfAbsent(id, outputState);

--- a/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexer.java
@@ -51,8 +51,9 @@ public class WatermarkOutputMultiplexer {
     /** A callback for propagating changes to split based watermarks. */
     @FunctionalInterface
     @Internal
-    public interface SplitWatermarkUpdateListener {
-        void updateWatermark(long watermark);
+    public interface WatermarkUpdateListener {
+        /** Called when the watermark increases. */
+        void onWatermarkUpdate(long watermark);
     }
 
     /**
@@ -84,7 +85,7 @@ public class WatermarkOutputMultiplexer {
      * an output ID that can be used to get a deferred or immediate {@link WatermarkOutput} for that
      * output.
      */
-    public void registerNewOutput(String id, SplitWatermarkUpdateListener onWatermarkUpdate) {
+    public void registerNewOutput(String id, WatermarkUpdateListener onWatermarkUpdate) {
         final PartialWatermark outputState = new PartialWatermark(onWatermarkUpdate);
 
         final PartialWatermark previouslyRegistered =

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SourceReader.java
@@ -143,9 +143,9 @@ public interface SourceReader<T, SplitT extends SourceSplit>
     /**
      * Pauses or resumes reading of individual source splits.
      *
-     * <p>Note that no other methods can be called in parallel, so it's fine to non-atomically
-     * update subscriptions. This method is simply providing connectors with more expressive APIs
-     * the opportunity to update all subscriptions at once.
+     * <p>Note that no other methods can be called in parallel, so updating subscriptions can be
+     * done atomically. This method is simply providing connectors with more expressive APIs the
+     * opportunity to update all subscriptions at once.
      *
      * <p>This is currently used to align the watermarks of splits, if watermark alignment is used
      * and the source reads from more than one split.
@@ -161,6 +161,12 @@ public interface SourceReader<T, SplitT extends SourceSplit>
     default void pauseOrResumeSplits(
             Collection<String> splitsToPause, Collection<String> splitsToResume) {
         throw new UnsupportedOperationException(
-                "This source reader does not support pause or resume splits.");
+                "This source reader does not support pausing or resuming splits which can lead to unaligned splits.\n"
+                        + "Unaligned splits are splits where the output watermarks of the splits have diverged more than the allowed limit.\n"
+                        + "It is highly discouraged to use unaligned source splits, as this leads to unpredictable\n"
+                        + "watermark alignment if there is more than a single split per reader. It is recommended to implement pausing splits\n"
+                        + "for this source. At your own risk, you can allow unaligned source splits by setting the\n"
+                        + "configuration parameter `pipeline.watermark-alignment.allow-unaligned-source-splits' to true.\n"
+                        + "Beware that this configuration parameter will be dropped in a future Flink release.");
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -282,4 +282,21 @@ public class PipelineOptions {
                     .withDescription(
                             "Whether name of vertex includes topological index or not. "
                                     + "When it is true, the name will have a prefix of index of the vertex, like '[vertex-0]Source: source'. It is false by default");
+
+    @PublicEvolving
+    public static final ConfigOption<Boolean> ALLOW_UNALIGNED_SOURCE_SPLITS =
+            key("pipeline.watermark-alignment.allow-unaligned-source-splits")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If watermark alignment is used, sources with multiple splits will "
+                                    + "attempt to pause/resume split readers to avoid watermark "
+                                    + "drift of source splits. "
+                                    + "However, if split readers don't support pause/resume an "
+                                    + "UnsupportedOperationException will be thrown when there is "
+                                    + "an attempt to pause/resume. To allow use of split readers that "
+                                    + "don't support pause/resume and, hence, t allow unaligned splits "
+                                    + "while still using watermark alignment, set this parameter to true. "
+                                    + "The default value is false. Note: This parameter may be "
+                                    + "removed in future releases.");
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -283,7 +283,7 @@ public class PipelineOptions {
                             "Whether name of vertex includes topological index or not. "
                                     + "When it is true, the name will have a prefix of index of the vertex, like '[vertex-0]Source: source'. It is false by default");
 
-    @PublicEvolving
+    /** Will be removed in future Flink releases. */
     public static final ConfigOption<Boolean> ALLOW_UNALIGNED_SOURCE_SPLITS =
             key("pipeline.watermark-alignment.allow-unaligned-source-splits")
                     .booleanType()

--- a/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/eventtime/WatermarkOutputMultiplexerTest.java
@@ -270,7 +270,7 @@ public class WatermarkOutputMultiplexerTest {
                 new WatermarkOutputMultiplexer(underlyingWatermarkOutput);
 
         final String id = "test-id";
-        multiplexer.registerNewOutput(id);
+        multiplexer.registerNewOutput(id, watermark -> {});
         WatermarkOutput immediateOutput = multiplexer.getImmediateOutput(id);
         WatermarkOutput deferredOutput = multiplexer.getDeferredOutput(id);
 
@@ -294,7 +294,7 @@ public class WatermarkOutputMultiplexerTest {
                 new WatermarkOutputMultiplexer(underlyingWatermarkOutput);
 
         final String id = "1234-test";
-        multiplexer.registerNewOutput(id);
+        multiplexer.registerNewOutput(id, watermark -> {});
         WatermarkOutput immediateOutput = multiplexer.getImmediateOutput(id);
         WatermarkOutput deferredOutput = multiplexer.getDeferredOutput(id);
 
@@ -312,8 +312,8 @@ public class WatermarkOutputMultiplexerTest {
         final long lowTimestamp = 156765L;
         final long highTimestamp = lowTimestamp + 10;
 
-        multiplexer.registerNewOutput("lower");
-        multiplexer.registerNewOutput("higher");
+        multiplexer.registerNewOutput("lower", watermark -> {});
+        multiplexer.registerNewOutput("higher", watermark -> {});
         multiplexer.getImmediateOutput("lower").emitWatermark(new Watermark(lowTimestamp));
 
         multiplexer.unregisterOutput("lower");
@@ -330,8 +330,8 @@ public class WatermarkOutputMultiplexerTest {
         final long lowTimestamp = -4343L;
         final long highTimestamp = lowTimestamp + 10;
 
-        multiplexer.registerNewOutput("lower");
-        multiplexer.registerNewOutput("higher");
+        multiplexer.registerNewOutput("lower", watermark -> {});
+        multiplexer.registerNewOutput("higher", watermark -> {});
         multiplexer.getImmediateOutput("lower").emitWatermark(new Watermark(lowTimestamp));
         multiplexer.getImmediateOutput("higher").emitWatermark(new Watermark(highTimestamp));
 
@@ -348,11 +348,11 @@ public class WatermarkOutputMultiplexerTest {
         final long lowTimestamp = 1L;
         final long highTimestamp = 2L;
 
-        multiplexer.registerNewOutput("higher");
+        multiplexer.registerNewOutput("higher", watermark -> {});
         multiplexer.getImmediateOutput("higher").emitWatermark(new Watermark(highTimestamp));
         multiplexer.unregisterOutput("higher");
 
-        multiplexer.registerNewOutput("lower");
+        multiplexer.registerNewOutput("lower", watermark -> {});
         multiplexer.getImmediateOutput("lower").emitWatermark(new Watermark(lowTimestamp));
 
         assertEquals(highTimestamp, underlyingWatermarkOutput.lastWatermark().getTimestamp());
@@ -363,7 +363,7 @@ public class WatermarkOutputMultiplexerTest {
         final TestingWatermarkOutput underlyingWatermarkOutput = createTestingWatermarkOutput();
         final WatermarkOutputMultiplexer multiplexer =
                 new WatermarkOutputMultiplexer(underlyingWatermarkOutput);
-        multiplexer.registerNewOutput("does-exist");
+        multiplexer.registerNewOutput("does-exist", watermark -> {});
 
         final boolean unregistered = multiplexer.unregisterOutput("does-exist");
 
@@ -389,7 +389,7 @@ public class WatermarkOutputMultiplexerTest {
 
         Watermark emittedWatermark = new Watermark(1);
         final String id = UUID.randomUUID().toString();
-        multiplexer.registerNewOutput(id);
+        multiplexer.registerNewOutput(id, watermark -> {});
         WatermarkOutput immediateOutput = multiplexer.getImmediateOutput(id);
         immediateOutput.emitWatermark(emittedWatermark);
         multiplexer.unregisterOutput(id);
@@ -405,7 +405,7 @@ public class WatermarkOutputMultiplexerTest {
      */
     private static WatermarkOutput createImmediateOutput(WatermarkOutputMultiplexer multiplexer) {
         final String id = UUID.randomUUID().toString();
-        multiplexer.registerNewOutput(id);
+        multiplexer.registerNewOutput(id, watermark -> {});
         return multiplexer.getImmediateOutput(id);
     }
 
@@ -415,7 +415,7 @@ public class WatermarkOutputMultiplexerTest {
      */
     private static WatermarkOutput createDeferredOutput(WatermarkOutputMultiplexer multiplexer) {
         final String id = UUID.randomUUID().toString();
-        multiplexer.registerNewOutput(id);
+        multiplexer.registerNewOutput(id, watermark -> {});
         return multiplexer.getDeferredOutput(id);
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSourceReader.java
@@ -36,7 +36,7 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
     private final List<Long> completedCheckpoints = new ArrayList<>();
     private final List<Long> abortedCheckpoints = new ArrayList<>();
     private final boolean markIdleOnNoSplits;
-
+    private final boolean usePerSplitOutputs;
     private int currentSplitIndex = 0;
     private boolean started;
     private int timesClosed;
@@ -44,7 +44,8 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
     private SplitsAssignmentState splitsAssignmentState = SplitsAssignmentState.NO_SPLITS_ASSIGNED;
     private boolean idle = false;
 
-    enum WaitingForSplits {
+    /** Controls when the source finishes in respect to assigned splits. */
+    public enum WaitingForSplits {
         WAIT_FOR_INITIAL,
         WAIT_UNTIL_ALL_SPLITS_ASSIGNED,
         DO_NOT_WAIT_FOR_SPLITS
@@ -73,11 +74,19 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
 
     public MockSourceReader(
             WaitingForSplits waitingForSplitsBehaviour, boolean markIdleOnNoSplits) {
+        this(waitingForSplitsBehaviour, markIdleOnNoSplits, false);
+    }
+
+    public MockSourceReader(
+            WaitingForSplits waitingForSplitsBehaviour,
+            boolean markIdleOnNoSplits,
+            boolean usePerSplitOutputs) {
         this.started = false;
         this.timesClosed = 0;
         this.availableFuture = CompletableFuture.completedFuture(null);
         this.waitingForSplitsBehaviour = waitingForSplitsBehaviour;
         this.markIdleOnNoSplits = markIdleOnNoSplits;
+        this.usePerSplitOutputs = usePerSplitOutputs;
     }
 
     @Override
@@ -109,7 +118,13 @@ public class MockSourceReader implements SourceReader<Integer, MockSourceSplit> 
             if (idle) {
                 sourceOutput.markActive();
             }
-            sourceOutput.collect(assignedSplits.get(currentSplitIndex).getNext(false)[0]);
+            final MockSourceSplit sourceSplit = assignedSplits.get(currentSplitIndex);
+            final int record = sourceSplit.getNext(false)[0];
+            if (usePerSplitOutputs) {
+                sourceOutput.createOutputForSplit(sourceSplit.splitId()).collect(record);
+            } else {
+                sourceOutput.collect(record);
+            }
             return InputStatus.MORE_AVAILABLE;
         } else if (finished) {
             // In case no split has available record, return depending on whether all the splits has

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/TimestampsAndWatermarks.java
@@ -53,6 +53,9 @@ public interface TimestampsAndWatermarks<T> {
          * watermark.
          */
         void updateCurrentEffectiveWatermark(long watermark);
+
+        /** Notifies about changes to per split watermarks. */
+        void updateCurrentSplitWatermark(String splitId, long watermark);
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/source/WatermarkToDataOutput.java
@@ -42,7 +42,15 @@ public final class WatermarkToDataOutput implements WatermarkOutput {
 
     @VisibleForTesting
     public WatermarkToDataOutput(PushingAsyncDataInput.DataOutput<?> output) {
-        this(output, watermark -> {});
+        this(
+                output,
+                new TimestampsAndWatermarks.WatermarkUpdateListener() {
+                    @Override
+                    public void updateCurrentEffectiveWatermark(long watermark) {}
+
+                    @Override
+                    public void updateCurrentSplitWatermark(String splitId, long watermark) {}
+                });
     }
 
     /** Creates a new WatermarkOutput against the given DataOutput. */

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/SourceOperatorSplitWatermarkAlignmentTest.java
@@ -1,0 +1,144 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.eventtime.Watermark;
+import org.apache.flink.api.common.eventtime.WatermarkGenerator;
+import org.apache.flink.api.common.eventtime.WatermarkOutput;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.mocks.MockSourceReader;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
+import org.apache.flink.api.connector.source.mocks.MockSourceSplitSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.execution.Environment;
+import org.apache.flink.runtime.operators.coordination.MockOperatorEventGateway;
+import org.apache.flink.runtime.operators.testutils.MockInputSplitProvider;
+import org.apache.flink.runtime.source.event.AddSplitEvent;
+import org.apache.flink.runtime.source.event.WatermarkAlignmentEvent;
+import org.apache.flink.runtime.state.TestTaskStateManager;
+import org.apache.flink.runtime.state.memory.MemoryStateBackend;
+import org.apache.flink.streaming.api.operators.source.CollectingDataOutput;
+import org.apache.flink.streaming.api.operators.source.TestingSourceOperator;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamMockEnvironment;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
+
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit test for split alignment in {@link SourceOperator}. */
+public class SourceOperatorSplitWatermarkAlignmentTest {
+    public static final WatermarkGenerator<Integer> WATERMARK_GENERATOR =
+            new WatermarkGenerator<Integer>() {
+
+                private long maxWatermark = Long.MIN_VALUE;
+
+                @Override
+                public void onEvent(Integer event, long eventTimestamp, WatermarkOutput output) {
+                    if (eventTimestamp > maxWatermark) {
+                        this.maxWatermark = eventTimestamp;
+                        output.emitWatermark(new Watermark(maxWatermark));
+                    }
+                }
+
+                @Override
+                public void onPeriodicEmit(WatermarkOutput output) {
+                    output.emitWatermark(new Watermark(maxWatermark));
+                }
+            };
+
+    @Test
+    public void testSplitWatermarkAlignment() throws Exception {
+
+        final SplitAligningSourceReader sourceReader = new SplitAligningSourceReader();
+        SourceOperator<Integer, MockSourceSplit> operator =
+                new TestingSourceOperator<>(
+                        sourceReader,
+                        WatermarkStrategy.forGenerator(ctx -> WATERMARK_GENERATOR)
+                                .withTimestampAssigner((r, l) -> r)
+                                .withWatermarkAlignment("group-1", Duration.ofMillis(1)),
+                        new TestProcessingTimeService(),
+                        new MockOperatorEventGateway(),
+                        1,
+                        5,
+                        true);
+        Environment env = getTestingEnvironment();
+        operator.setup(
+                new SourceOperatorStreamTask<Integer>(env),
+                new MockStreamConfig(new Configuration(), 1),
+                new MockOutput<>(new ArrayList<>()));
+        operator.initializeState(new StreamTaskStateInitializerImpl(env, new MemoryStateBackend()));
+
+        operator.open();
+        final MockSourceSplit split1 = new MockSourceSplit(0, 0, 10);
+        final MockSourceSplit split2 = new MockSourceSplit(1, 10, 20);
+        split1.addRecord(5);
+        split1.addRecord(6);
+        split1.addRecord(11);
+        operator.handleOperatorEvent(
+                new AddSplitEvent<>(
+                        Arrays.asList(split1, split2), new MockSourceSplitSerializer()));
+        final CollectingDataOutput<Integer> dataOutput = new CollectingDataOutput<>();
+
+        operator.emitNext(dataOutput); // 5
+        operator.handleOperatorEvent(
+                new WatermarkAlignmentEvent(4)); // pause by coordinator message
+        assertThat(sourceReader.pausedSplits).containsExactly("0");
+        operator.handleOperatorEvent(new WatermarkAlignmentEvent(5));
+        assertThat(sourceReader.pausedSplits).isEmpty();
+        operator.emitNext(dataOutput); // 6, pause by increasing watermark
+        assertThat(sourceReader.pausedSplits).containsExactly("0");
+    }
+
+    private Environment getTestingEnvironment() {
+        return new StreamMockEnvironment(
+                new Configuration(),
+                new Configuration(),
+                new ExecutionConfig(),
+                1L,
+                new MockInputSplitProvider(),
+                1,
+                new TestTaskStateManager());
+    }
+
+    private static class SplitAligningSourceReader extends MockSourceReader {
+        Set<String> pausedSplits = new HashSet<>();
+
+        public SplitAligningSourceReader() {
+            super(WaitingForSplits.DO_NOT_WAIT_FOR_SPLITS, false, true);
+        }
+
+        public void pauseOrResumeSplits(
+                Collection<String> splitsToPause, Collection<String> splitsToResume) {
+            pausedSplits.removeAll(splitsToResume);
+            pausedSplits.addAll(splitsToPause);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

* The change implements FLIP-217 (https://cwiki.apache.org/confluence/display/FLINK/FLIP-217+Support+watermark+alignment+of+source+splits) to support watermark alignment of source splits.

## Brief change log

* Revised `SplitFetcher` threading model and add support to pause/resume `SplitFetcher`
* Adds support for watermark alignment of individual source splits controlled by `SourceOperator`
* Adds support for split watermark alignment for Kafka and Pulsar sources
* Adds configuration parameter to allow unaligned splits as migration plan to support legacy sources that lack support for split alignment


## Verifying this change

This change added and extended tests and can be verified as follows:

* `SplitFetcherTest` extended to test pause/resume of`SplitFetcher`
* `SourceOperatorSplitWatermarkAlignmentTest` added to test split alignment based on split reader watermarks
* `SplitFetcherPauseResumeSplitReaderITCase` added to test pause/resume of individual split readers

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **yes** (according to FLIP-217)
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **yes**
  - If yes, how is the feature documented? **docs** (configuration parameter) and **JavaDocs** (changes of public APIs)
