### PR TITLE
[FLINK-28799] Hybrid shuffle should supports schedule the graph contains blocking edge

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegion.java
@@ -40,7 +40,7 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
 
     private final Map<ExecutionVertexID, DefaultExecutionVertex> executionVertices;
 
-    private Set<ConsumedPartitionGroup> blockingConsumedPartitionGroups;
+    private Set<ConsumedPartitionGroup> nonPipelinedConsumedPartitionGroups;
 
     private Set<ConsumedPartitionGroup> releaseBySchedulerConsumedPartitionGroups;
 
@@ -78,7 +78,7 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
     }
 
     private void initializeConsumedPartitionGroups() {
-        final Set<ConsumedPartitionGroup> blockingConsumedPartitionGroupSet = new HashSet<>();
+        final Set<ConsumedPartitionGroup> nonPipelinedConsumedPartitionGroupSet = new HashSet<>();
         final Set<ConsumedPartitionGroup> releaseBySchedulerConsumedPartitionGroupSet =
                 new HashSet<>();
         for (DefaultExecutionVertex executionVertex : executionVertices.values()) {
@@ -87,8 +87,8 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
                 SchedulingResultPartition consumedPartition =
                         resultPartitionRetriever.apply(consumedPartitionGroup.getFirst());
 
-                if (!consumedPartition.getResultType().canBePipelinedConsumed()) {
-                    blockingConsumedPartitionGroupSet.add(consumedPartitionGroup);
+                if (!consumedPartition.getResultType().mustBePipelinedConsumed()) {
+                    nonPipelinedConsumedPartitionGroupSet.add(consumedPartitionGroup);
                 }
                 if (consumedPartition.getResultType().isReleaseByScheduler()) {
                     releaseBySchedulerConsumedPartitionGroupSet.add(consumedPartitionGroup);
@@ -96,18 +96,18 @@ public class DefaultSchedulingPipelinedRegion implements SchedulingPipelinedRegi
             }
         }
 
-        this.blockingConsumedPartitionGroups =
-                Collections.unmodifiableSet(blockingConsumedPartitionGroupSet);
+        this.nonPipelinedConsumedPartitionGroups =
+                Collections.unmodifiableSet(nonPipelinedConsumedPartitionGroupSet);
         this.releaseBySchedulerConsumedPartitionGroups =
                 Collections.unmodifiableSet(releaseBySchedulerConsumedPartitionGroupSet);
     }
 
     @Override
-    public Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups() {
-        if (blockingConsumedPartitionGroups == null) {
+    public Iterable<ConsumedPartitionGroup> getAllNonPipelinedConsumedPartitionGroups() {
+        if (nonPipelinedConsumedPartitionGroups == null) {
             initializeConsumedPartitionGroups();
         }
-        return blockingConsumedPartitionGroups;
+        return nonPipelinedConsumedPartitionGroups;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -53,6 +53,10 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     private final Map<SchedulingPipelinedRegion, List<ExecutionVertexID>> regionVerticesSorted =
             new IdentityHashMap<>();
 
+    /** All ConsumedPartitionGroups of one schedulingPipelinedRegion. */
+    private final Map<SchedulingPipelinedRegion, Set<ConsumedPartitionGroup>>
+            consumedPartitionGroupsOfRegion = new IdentityHashMap<>();
+
     /** The ConsumedPartitionGroups which are produced by multiple regions. */
     private final Set<ConsumedPartitionGroup> crossRegionConsumedPartitionGroups =
             Collections.newSetFromMap(new IdentityHashMap<>());
@@ -75,12 +79,29 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 
         initPartitionGroupConsumerRegions();
 
+        initConsumedPartitionGroupsOfRegion();
+
         for (SchedulingExecutionVertex vertex : schedulingTopology.getVertices()) {
             final SchedulingPipelinedRegion region =
                     schedulingTopology.getPipelinedRegionOfVertex(vertex.getId());
             regionVerticesSorted
                     .computeIfAbsent(region, r -> new ArrayList<>())
                     .add(vertex.getId());
+        }
+    }
+
+    private void initConsumedPartitionGroupsOfRegion() {
+        for (SchedulingPipelinedRegion region : schedulingTopology.getAllPipelinedRegions()) {
+            Set<ConsumedPartitionGroup> consumedPartitionGroupsSetOfRegion = new HashSet<>();
+            for (SchedulingExecutionVertex executionVertex : region.getVertices()) {
+                consumedPartitionGroupsSetOfRegion.addAll(
+                        IterableUtils.toStream(executionVertex.getProducedResults())
+                                .flatMap(
+                                        partition ->
+                                                partition.getConsumedPartitionGroups().stream())
+                                .collect(Collectors.toSet()));
+            }
+            consumedPartitionGroupsOfRegion.put(region, consumedPartitionGroupsSetOfRegion);
         }
     }
 
@@ -91,7 +112,7 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         for (SchedulingPipelinedRegion pipelinedRegion :
                 schedulingTopology.getAllPipelinedRegions()) {
             for (ConsumedPartitionGroup consumedPartitionGroup :
-                    pipelinedRegion.getAllBlockingConsumedPartitionGroups()) {
+                    pipelinedRegion.getAllNonPipelinedConsumedPartitionGroups()) {
                 producerRegionsByConsumedPartitionGroup.computeIfAbsent(
                         consumedPartitionGroup, this::getProducerRegionsForConsumedPartitionGroup);
             }
@@ -100,7 +121,7 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         for (SchedulingPipelinedRegion pipelinedRegion :
                 schedulingTopology.getAllPipelinedRegions()) {
             for (ConsumedPartitionGroup consumedPartitionGroup :
-                    pipelinedRegion.getAllBlockingConsumedPartitionGroups()) {
+                    pipelinedRegion.getAllNonPipelinedConsumedPartitionGroups()) {
                 final Set<SchedulingPipelinedRegion> producerRegions =
                         producerRegionsByConsumedPartitionGroup.get(consumedPartitionGroup);
                 if (producerRegions.size() > 1 && producerRegions.contains(pipelinedRegion)) {
@@ -128,7 +149,7 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     private void initPartitionGroupConsumerRegions() {
         for (SchedulingPipelinedRegion region : schedulingTopology.getAllPipelinedRegions()) {
             for (ConsumedPartitionGroup consumedPartitionGroup :
-                    region.getAllBlockingConsumedPartitionGroups()) {
+                    region.getAllNonPipelinedConsumedPartitionGroups()) {
                 if (crossRegionConsumedPartitionGroups.contains(consumedPartitionGroup)
                         || isExternalConsumedPartitionGroup(consumedPartitionGroup, region)) {
                     partitionGroupConsumerRegions
@@ -137,6 +158,18 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
                 }
             }
         }
+    }
+
+    private Set<SchedulingPipelinedRegion> getDownstreamRegionsOfVertex(
+            SchedulingExecutionVertex executionVertex) {
+        return IterableUtils.toStream(executionVertex.getProducedResults())
+                .flatMap(partition -> partition.getConsumedPartitionGroups().stream())
+                .flatMap(
+                        partitionGroup ->
+                                partitionGroupConsumerRegions
+                                        .getOrDefault(partitionGroup, Collections.emptySet())
+                                        .stream())
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -150,7 +183,7 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 
     private boolean isSourceRegion(SchedulingPipelinedRegion region) {
         for (ConsumedPartitionGroup consumedPartitionGroup :
-                region.getAllBlockingConsumedPartitionGroups()) {
+                region.getAllNonPipelinedConsumedPartitionGroups()) {
             if (crossRegionConsumedPartitionGroups.contains(consumedPartitionGroup)
                     || isExternalConsumedPartitionGroup(consumedPartitionGroup, region)) {
                 return false;
@@ -173,32 +206,8 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     public void onExecutionStateChange(
             final ExecutionVertexID executionVertexId, final ExecutionState executionState) {
         if (executionState == ExecutionState.FINISHED) {
-            final Set<ConsumedPartitionGroup> finishedConsumedPartitionGroups =
-                    IterableUtils.toStream(
-                                    schedulingTopology
-                                            .getVertex(executionVertexId)
-                                            .getProducedResults())
-                            .filter(
-                                    partition ->
-                                            partition.getState() == ResultPartitionState.CONSUMABLE)
-                            .flatMap(partition -> partition.getConsumedPartitionGroups().stream())
-                            .filter(
-                                    group ->
-                                            crossRegionConsumedPartitionGroups.contains(group)
-                                                    || group.areAllPartitionsFinished())
-                            .collect(Collectors.toSet());
-
-            final Set<SchedulingPipelinedRegion> consumerRegions =
-                    finishedConsumedPartitionGroups.stream()
-                            .flatMap(
-                                    partitionGroup ->
-                                            partitionGroupConsumerRegions
-                                                    .getOrDefault(
-                                                            partitionGroup, Collections.emptySet())
-                                                    .stream())
-                            .collect(Collectors.toSet());
-
-            maybeScheduleRegions(consumerRegions);
+            maybeScheduleRegions(
+                    getDownstreamRegionsOfVertex(schedulingTopology.getVertex(executionVertexId)));
         }
     }
 
@@ -211,17 +220,34 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
                         schedulingTopology, regions);
 
         final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache = new HashMap<>();
+        final Set<SchedulingPipelinedRegion> downstreamSchedulableRegions = new HashSet<>();
         for (SchedulingPipelinedRegion region : regionsSorted) {
-            maybeScheduleRegion(region, consumableStatusCache);
+            if (maybeScheduleRegion(region, consumableStatusCache)) {
+                downstreamSchedulableRegions.addAll(
+                        consumedPartitionGroupsOfRegion.getOrDefault(region, Collections.emptySet())
+                                .stream()
+                                .flatMap(
+                                        consumedPartitionGroups ->
+                                                partitionGroupConsumerRegions
+                                                        .getOrDefault(
+                                                                consumedPartitionGroups,
+                                                                Collections.emptySet())
+                                                        .stream())
+                                .collect(Collectors.toSet()));
+            }
+        }
+
+        if (!downstreamSchedulableRegions.isEmpty()) {
+            maybeScheduleRegions(downstreamSchedulableRegions);
         }
     }
 
-    private void maybeScheduleRegion(
+    private boolean maybeScheduleRegion(
             final SchedulingPipelinedRegion region,
             final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
         if (scheduledRegions.contains(region)
                 || !areRegionInputsAllConsumable(region, consumableStatusCache)) {
-            return;
+            return false;
         }
 
         checkState(
@@ -230,20 +256,23 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
 
         schedulerOperations.allocateSlotsAndDeploy(regionVerticesSorted.get(region));
         scheduledRegions.add(region);
+        return true;
     }
 
     private boolean areRegionInputsAllConsumable(
             final SchedulingPipelinedRegion region,
             final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
         for (ConsumedPartitionGroup consumedPartitionGroup :
-                region.getAllBlockingConsumedPartitionGroups()) {
+                region.getAllNonPipelinedConsumedPartitionGroups()) {
             if (crossRegionConsumedPartitionGroups.contains(consumedPartitionGroup)) {
-                if (!isCrossRegionConsumedPartitionConsumable(consumedPartitionGroup, region)) {
+                if (!isDownstreamOfCrossRegionConsumedPartitionSchedulable(
+                        consumedPartitionGroup, region)) {
                     return false;
                 }
             } else if (isExternalConsumedPartitionGroup(consumedPartitionGroup, region)) {
                 if (!consumableStatusCache.computeIfAbsent(
-                        consumedPartitionGroup, this::isConsumedPartitionGroupConsumable)) {
+                        consumedPartitionGroup,
+                        this::isDownstreamConsumedPartitionGroupSchedulable)) {
                     return false;
                 }
             }
@@ -251,25 +280,42 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         return true;
     }
 
-    private boolean isConsumedPartitionGroupConsumable(
+    private boolean isDownstreamConsumedPartitionGroupSchedulable(
             final ConsumedPartitionGroup consumedPartitionGroup) {
-        for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
-            if (schedulingTopology.getResultPartition(partitionId).getState()
-                    != ResultPartitionState.CONSUMABLE) {
-                return false;
+        if (consumedPartitionGroup.getResultPartitionType().canBePipelinedConsumed()) {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                if (!scheduledRegions.contains(getProducerRegion(partitionId))) {
+                    return false;
+                }
+            }
+        } else {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                if (schedulingTopology.getResultPartition(partitionId).getState()
+                        != ResultPartitionState.CONSUMABLE) {
+                    return false;
+                }
             }
         }
         return true;
     }
 
-    private boolean isCrossRegionConsumedPartitionConsumable(
+    private boolean isDownstreamOfCrossRegionConsumedPartitionSchedulable(
             final ConsumedPartitionGroup consumedPartitionGroup,
             final SchedulingPipelinedRegion pipelinedRegion) {
-        for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
-            if (isExternalConsumedPartition(partitionId, pipelinedRegion)
-                    && schedulingTopology.getResultPartition(partitionId).getState()
-                            != ResultPartitionState.CONSUMABLE) {
-                return false;
+        if (consumedPartitionGroup.getResultPartitionType().canBePipelinedConsumed()) {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                if (isExternalConsumedPartition(partitionId, pipelinedRegion)
+                        && !scheduledRegions.contains(getProducerRegion(partitionId))) {
+                    return false;
+                }
+            }
+        } else {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                if (isExternalConsumedPartition(partitionId, pipelinedRegion)
+                        && schedulingTopology.getResultPartition(partitionId).getState()
+                                != ResultPartitionState.CONSUMABLE) {
+                    return false;
+                }
             }
         }
         return true;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingPipelinedRegion.java
@@ -35,7 +35,7 @@ public interface SchedulingPipelinedRegion
      *
      * @return set of {@link ConsumedPartitionGroup}s
      */
-    Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups();
+    Iterable<ConsumedPartitionGroup> getAllNonPipelinedConsumedPartitionGroups();
 
     /**
      * Get all distinct releaseByScheduler {@link ConsumedPartitionGroup}s.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultSchedulingPipelinedRegionTest.java
@@ -147,7 +147,7 @@ public class DefaultSchedulingPipelinedRegionTest extends TestLogger {
         final Set<IntermediateResultPartitionID> secondPipelinedRegionConsumedResults =
                 new HashSet<>();
         for (ConsumedPartitionGroup consumedPartitionGroup :
-                secondPipelinedRegion.getAllBlockingConsumedPartitionGroups()) {
+                secondPipelinedRegion.getAllNonPipelinedConsumedPartitionGroups()) {
             for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
                 if (!secondPipelinedRegion.contains(
                         topology.getResultPartition(partitionId).getProducer().getId())) {
@@ -157,7 +157,10 @@ public class DefaultSchedulingPipelinedRegionTest extends TestLogger {
         }
 
         assertThat(
-                firstPipelinedRegion.getAllBlockingConsumedPartitionGroups().iterator().hasNext(),
+                firstPipelinedRegion
+                        .getAllNonPipelinedConsumedPartitionGroups()
+                        .iterator()
+                        .hasNext(),
                 is(false));
         assertThat(secondPipelinedRegionConsumedResults, contains(b0ConsumedResultPartition));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategyTest.java
@@ -29,12 +29,11 @@ import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -46,16 +45,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.scheduler.strategy.StrategyTestUtil.assertLatestScheduledVerticesAreEqualTo;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link PipelinedRegionSchedulingStrategy}. */
-public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+class PipelinedRegionSchedulingStrategyTest {
+    @RegisterExtension
+    public static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
+            TestingUtils.defaultExecutorExtension();
 
     private TestingSchedulerOperations testingSchedulerOperation;
 
@@ -71,8 +67,8 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
 
     private List<TestingSchedulingExecutionVertex> sink;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testingSchedulerOperation = new TestingSchedulerOperations();
 
         buildTopology();
@@ -121,7 +117,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
     }
 
     @Test
-    public void testStartScheduling() {
+    void testStartScheduling() {
         startScheduling(testingSchedulingTopology);
 
         final List<List<TestingSchedulingExecutionVertex>> expectedScheduledVertices =
@@ -135,7 +131,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
     }
 
     @Test
-    public void testRestartTasks() {
+    void testRestartTasks() {
         final PipelinedRegionSchedulingStrategy schedulingStrategy =
                 startScheduling(testingSchedulingTopology);
 
@@ -158,7 +154,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
     }
 
     @Test
-    public void testNotifyingBlockingResultPartitionProducerFinished() {
+    void testNotifyingBlockingResultPartitionProducerFinished() {
         final PipelinedRegionSchedulingStrategy schedulingStrategy =
                 startScheduling(testingSchedulingTopology);
 
@@ -167,13 +163,13 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         schedulingStrategy.onExecutionStateChange(upstream1.getId(), ExecutionState.FINISHED);
 
         // sinks' inputs are not all consumable yet so they are not scheduled
-        assertThat(testingSchedulerOperation.getScheduledVertices(), hasSize(4));
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(4);
 
         final TestingSchedulingExecutionVertex upstream2 = map2.get(1);
         upstream2.getProducedResults().iterator().next().markFinished();
         schedulingStrategy.onExecutionStateChange(upstream2.getId(), ExecutionState.FINISHED);
 
-        assertThat(testingSchedulerOperation.getScheduledVertices(), hasSize(6));
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(6);
 
         final List<List<TestingSchedulingExecutionVertex>> expectedScheduledVertices =
                 new ArrayList<>();
@@ -184,7 +180,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
     }
 
     @Test
-    public void testSchedulingTopologyWithPersistentBlockingEdges() {
+    void testSchedulingTopologyWithPersistentBlockingEdges() {
         final TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
         final List<TestingSchedulingExecutionVertex> v1 =
@@ -207,7 +203,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
     }
 
     @Test
-    public void testComputingCrossRegionConsumedPartitionGroupsCorrectly() throws Exception {
+    void testComputingCrossRegionConsumedPartitionGroupsCorrectly() throws Exception {
         final JobVertex v1 = createJobVertex("v1", 4);
         final JobVertex v2 = createJobVertex("v2", 3);
         final JobVertex v3 = createJobVertex("v3", 2);
@@ -236,7 +232,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         final Set<ConsumedPartitionGroup> crossRegionConsumedPartitionGroups =
                 schedulingStrategy.getCrossRegionConsumedPartitionGroups();
 
-        assertEquals(1, crossRegionConsumedPartitionGroups.size());
+        assertThat(crossRegionConsumedPartitionGroups).hasSize(1);
 
         final ConsumedPartitionGroup expected =
                 executionGraph
@@ -245,11 +241,11 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
                         .getAllConsumedPartitionGroups()
                         .get(0);
 
-        assertTrue(crossRegionConsumedPartitionGroups.contains(expected));
+        assertThat(crossRegionConsumedPartitionGroups).contains(expected);
     }
 
     @Test
-    public void testNoCrossRegionConsumedPartitionGroupsWithAllToAllBlockingEdge() {
+    void testNoCrossRegionConsumedPartitionGroupsWithAllToAllBlockingEdge() {
         final TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
         final List<TestingSchedulingExecutionVertex> producer =
@@ -267,11 +263,11 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         final Set<ConsumedPartitionGroup> crossRegionConsumedPartitionGroups =
                 schedulingStrategy.getCrossRegionConsumedPartitionGroups();
 
-        assertEquals(0, crossRegionConsumedPartitionGroups.size());
+        assertThat(crossRegionConsumedPartitionGroups).isEmpty();
     }
 
     @Test
-    public void testSchedulingTopologyWithCrossRegionConsumedPartitionGroups() throws Exception {
+    void testSchedulingTopologyWithCrossRegionConsumedPartitionGroups() throws Exception {
         final JobVertex v1 = createJobVertex("v1", 4);
         final JobVertex v2 = createJobVertex("v2", 3);
         final JobVertex v3 = createJobVertex("v3", 2);
@@ -296,7 +292,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         // Test whether the topology is built correctly
         final List<SchedulingPipelinedRegion> regions = new ArrayList<>();
         schedulingTopology.getAllPipelinedRegions().forEach(regions::add);
-        assertEquals(2, regions.size());
+        assertThat(regions).hasSize(2);
 
         final ExecutionVertex v31 = executionGraph.getJobVertex(v3.getID()).getTaskVertices()[0];
 
@@ -305,7 +301,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
                 .getPipelinedRegionOfVertex(v31.getID())
                 .getVertices()
                 .forEach(vertex -> region1.add(vertex.getId()));
-        assertEquals(5, region1.size());
+        assertThat(region1).hasSize(5);
 
         final ExecutionVertex v32 = executionGraph.getJobVertex(v3.getID()).getTaskVertices()[1];
 
@@ -314,18 +310,18 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
                 .getPipelinedRegionOfVertex(v32.getID())
                 .getVertices()
                 .forEach(vertex -> region2.add(vertex.getId()));
-        assertEquals(4, region2.size());
+        assertThat(region2).hasSize(4);
 
         // Test whether region 1 is scheduled correctly
         PipelinedRegionSchedulingStrategy schedulingStrategy = startScheduling(schedulingTopology);
 
-        assertEquals(1, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(1);
         final List<ExecutionVertexID> scheduledVertices1 =
                 testingSchedulerOperation.getScheduledVertices().get(0);
-        assertEquals(5, scheduledVertices1.size());
+        assertThat(scheduledVertices1).hasSize(5);
 
         for (ExecutionVertexID vertexId : scheduledVertices1) {
-            assertTrue(region1.contains(vertexId));
+            assertThat(region1).contains(vertexId);
         }
 
         // Test whether the region 2 is scheduled correctly when region 1 is finished
@@ -333,18 +329,18 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         v22.finishAllBlockingPartitions();
 
         schedulingStrategy.onExecutionStateChange(v22.getID(), ExecutionState.FINISHED);
-        assertEquals(2, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(2);
         final List<ExecutionVertexID> scheduledVertices2 =
                 testingSchedulerOperation.getScheduledVertices().get(1);
-        assertEquals(4, scheduledVertices2.size());
+        assertThat(scheduledVertices2).hasSize(4);
 
         for (ExecutionVertexID vertexId : scheduledVertices2) {
-            assertTrue(region2.contains(vertexId));
+            assertThat(region2).contains(vertexId);
         }
     }
 
     @Test
-    public void testScheduleBlockingDownstreamTaskIndividually() throws Exception {
+    void testScheduleBlockingDownstreamTaskIndividually() throws Exception {
         final JobVertex v1 = createJobVertex("v1", 2);
         final JobVertex v2 = createJobVertex("v2", 2);
 
@@ -364,17 +360,17 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         final PipelinedRegionSchedulingStrategy schedulingStrategy =
                 startScheduling(schedulingTopology);
 
-        assertEquals(2, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(2);
 
         final ExecutionVertex v11 = executionGraph.getJobVertex(v1.getID()).getTaskVertices()[0];
         v11.finishAllBlockingPartitions();
 
         schedulingStrategy.onExecutionStateChange(v11.getID(), ExecutionState.FINISHED);
-        assertEquals(3, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(3);
     }
 
     @Test
-    public void testFinishHybridPartitionWillNotRescheduleDownstream() throws Exception {
+    void testFinishHybridPartitionWillNotRescheduleDownstream() throws Exception {
         final JobVertex v1 = createJobVertex("v1", 1);
         final JobVertex v2 = createJobVertex("v2", 1);
 
@@ -393,17 +389,17 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         PipelinedRegionSchedulingStrategy schedulingStrategy = startScheduling(schedulingTopology);
 
         // all regions will be scheduled
-        assertEquals(2, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(2);
 
         final ExecutionVertex v11 = executionGraph.getJobVertex(v1.getID()).getTaskVertices()[0];
         schedulingStrategy.onExecutionStateChange(v11.getID(), ExecutionState.FINISHED);
 
-        assertEquals(2, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(2);
     }
 
     /** Inner non-pipelined edge will not affect it's region be scheduled. */
     @Test
-    public void testSchedulingRegionWithInnerNonPipelinedEdge() throws Exception {
+    void testSchedulingRegionWithInnerNonPipelinedEdge() throws Exception {
         final JobVertex v1 = createJobVertex("v1", 1);
         final JobVertex v2 = createJobVertex("v2", 1);
         final JobVertex v3 = createJobVertex("v3", 1);
@@ -431,10 +427,10 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
 
         startScheduling(schedulingTopology);
 
-        assertEquals(1, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(1);
         List<ExecutionVertexID> executionVertexIds =
                 testingSchedulerOperation.getScheduledVertices().get(0);
-        assertEquals(4, executionVertexIds.size());
+        assertThat(executionVertexIds).hasSize(4);
     }
 
     /**
@@ -442,7 +438,7 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
      * after it's all blocking edge finished, non-blocking edge don't block scheduling.
      */
     @Test
-    public void testDownstreamRegionWillBeBlockedByBlockingEdge() throws Exception {
+    void testDownstreamRegionWillBeBlockedByBlockingEdge() throws Exception {
         final JobVertex v1 = createJobVertex("v1", 1);
         final JobVertex v2 = createJobVertex("v2", 1);
         final JobVertex v3 = createJobVertex("v3", 1);
@@ -464,12 +460,12 @@ public class PipelinedRegionSchedulingStrategyTest extends TestLogger {
         final PipelinedRegionSchedulingStrategy schedulingStrategy =
                 startScheduling(schedulingTopology);
 
-        assertEquals(2, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(2);
 
         final ExecutionVertex v11 = executionGraph.getJobVertex(v1.getID()).getTaskVertices()[0];
         v11.finishAllBlockingPartitions();
         schedulingStrategy.onExecutionStateChange(v11.getID(), ExecutionState.FINISHED);
-        assertEquals(3, testingSchedulerOperation.getScheduledVertices().size());
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(3);
     }
 
     private static JobVertex createJobVertex(String vertexName, int parallelism) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/StrategyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/StrategyTestUtil.java
@@ -21,12 +21,10 @@ package org.apache.flink.runtime.scheduler.strategy;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Strategy test utilities. */
-public class StrategyTestUtil {
+class StrategyTestUtil {
 
     static void assertLatestScheduledVerticesAreEqualTo(
             final List<List<TestingSchedulingExecutionVertex>> expected,
@@ -34,11 +32,10 @@ public class StrategyTestUtil {
         final List<List<ExecutionVertexID>> allScheduledVertices =
                 testingSchedulerOperation.getScheduledVertices();
         final int expectedScheduledBulks = expected.size();
-        assertThat(expectedScheduledBulks, lessThanOrEqualTo(allScheduledVertices.size()));
+        assertThat(expectedScheduledBulks).isLessThanOrEqualTo(allScheduledVertices.size());
         for (int i = 0; i < expectedScheduledBulks; i++) {
-            assertEquals(
-                    idsFromVertices(expected.get(expectedScheduledBulks - i - 1)),
-                    allScheduledVertices.get(allScheduledVertices.size() - i - 1));
+            assertThat(allScheduledVertices.get(allScheduledVertices.size() - i - 1))
+                    .isEqualTo(idsFromVertices(expected.get(expectedScheduledBulks - i - 1)));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingPipelinedRegion.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingPipelinedRegion.java
@@ -82,7 +82,7 @@ public class TestingSchedulingPipelinedRegion implements SchedulingPipelinedRegi
     }
 
     @Override
-    public Iterable<ConsumedPartitionGroup> getAllBlockingConsumedPartitionGroups() {
+    public Iterable<ConsumedPartitionGroup> getAllNonPipelinedConsumedPartitionGroups() {
         return Collections.unmodifiableSet(blockingConsumedPartitionGroups);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Based on TPC-DS test, we found that hybrid shuffle can't schedule the graph contains blocking edge. The reason is that some batch operators will forcibly set the exchange mode to blocking, which breaks ALL_ EDGE_HYBRID‘s constraint and may cause scheduling deadlock. We should use a better way to support the scheduling of all kinds of edges, including hybrid edge.*


## Brief change log
  - *Migrate `PipelinedRegionSchedulingStrategyTest` and `StrategyTestUtil` to Junit5 and AssertJ.*
  - *`PipelinedRegionSchedulingStrategy` supports all `ResultPartitionType`.*

## Verifying this change

This change added tests in `PipelinedRegionSchedulingStrategyTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
