### PR TITLE
[FLINK-28788][python] Support SideOutput in Thread Mode

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -557,13 +557,6 @@ class WindowTests(object):
                     'key a timestamp sum 15']
         self.assert_equals_sorted(expected, results)
 
-
-class ProcessWindowTests(WindowTests, PyFlinkStreamingTestCase):
-    def setUp(self) -> None:
-        super(ProcessWindowTests, self).setUp()
-        config = get_j_env_configuration(self.env._j_stream_execution_environment)
-        config.setString("python.execution-mode", "process")
-
     def test_side_output_late_data(self):
         self.env.set_parallelism(1)
         config = Configuration(
@@ -598,6 +591,13 @@ class ProcessWindowTests(WindowTests, PyFlinkStreamingTestCase):
         self.assert_equals_sorted(main_expected, main_sink.get_results())
         side_expected = ['+I[a, 4]']
         self.assert_equals_sorted(side_expected, side_sink.get_results())
+
+
+class ProcessWindowTests(WindowTests, PyFlinkStreamingTestCase):
+    def setUp(self) -> None:
+        super(ProcessWindowTests, self).setUp()
+        config = get_j_env_configuration(self.env._j_stream_execution_environment)
+        config.setString("python.execution-mode", "process")
 
 
 @pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7")

--- a/flink-python/pyflink/fn_execution/datastream/embedded/process_function.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/process_function.py
@@ -65,7 +65,7 @@ class InternalKeyedProcessFunctionContext(KeyedProcessFunction.Context,
     def __init__(self, context, key_type_info):
         self._context = context
         self._timer_service = TimerServiceImpl(self._context.timerService())
-        self._key_converter = from_type_info(key_type_info)
+        self._key_converter = from_type_info_proto(key_type_info)
 
     def get_current_key(self):
         return self._key_converter.to_internal(self._context.getCurrentKey())
@@ -85,7 +85,7 @@ class InternalKeyedProcessFunctionOnTimerContext(KeyedProcessFunction.OnTimerCon
     def __init__(self, context, key_type_info):
         self._context = context
         self._timer_service = TimerServiceImpl(self._context.timerService())
-        self._key_converter = from_type_info(key_type_info)
+        self._key_converter = from_type_info_proto(key_type_info)
 
     def timer_service(self) -> TimerService:
         return self._timer_service
@@ -103,7 +103,7 @@ class InternalKeyedProcessFunctionOnTimerContext(KeyedProcessFunction.OnTimerCon
 class InternalWindowTimerContext(object):
     def __init__(self, context, key_type_info, window_converter):
         self._context = context
-        self._key_converter = from_type_info(key_type_info)
+        self._key_converter = from_type_info_proto(key_type_info)
         self._window_converter = window_converter
 
     def timestamp(self) -> int:

--- a/flink-python/pyflink/fn_execution/datastream/embedded/side_output_context.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/side_output_context.py
@@ -29,9 +29,13 @@ class SideOutputContext(object):
              context.getAllSideOutputTypeInfoPayloads().items()})  # type: Dict[str, DataConverter]
 
     def collect(self, tag_id: str, record):
-        self._context.collectSideOutputById(
-            tag_id,
-            self._side_output_converters[tag_id].to_external(record))
+        try:
+            self._context.collectSideOutputById(
+                tag_id,
+                self._side_output_converters[tag_id].to_external(record))
+        except KeyError:
+            raise Exception("Unknown OutputTag id {0}, supported OutputTag ids are {1}".format(
+                tag_id, list(self._side_output_converters.keys())))
 
 
 def _parse_type_info_proto(type_info_payload):

--- a/flink-python/pyflink/fn_execution/datastream/embedded/side_output_context.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/side_output_context.py
@@ -1,0 +1,42 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+from typing import Dict
+
+from pyflink.fn_execution.embedded.converters import from_type_info_proto, DataConverter
+
+
+class SideOutputContext(object):
+    def __init__(self, context):
+        self._context = context
+        self._side_output_converters = (
+            {tag_id: from_type_info_proto(_parse_type_info_proto(payload))
+             for tag_id, payload in
+             context.getAllSideOutputTypeInfoPayloads().items()})  # type: Dict[str, DataConverter]
+
+    def collect(self, tag_id: str, record):
+        self._context.collectSideOutputById(
+            tag_id,
+            self._side_output_converters[tag_id].to_external(record))
+
+
+def _parse_type_info_proto(type_info_payload):
+    from pyflink.fn_execution import flink_fn_execution_pb2
+
+    type_info = flink_fn_execution_pb2.TypeInfo()
+    type_info.ParseFromString(type_info_payload)
+    return type_info

--- a/flink-python/pyflink/fn_execution/embedded/operation_utils.py
+++ b/flink-python/pyflink/fn_execution/embedded/operation_utils.py
@@ -103,7 +103,7 @@ def create_table_operation_from_proto(proto, input_coder_info, output_coder_into
 
 def create_one_input_user_defined_data_stream_function_from_protos(
         function_infos, input_coder_info, output_coder_info, runtime_context,
-        function_context, timer_context, job_parameters, keyed_state_backend,
+        function_context, timer_context, side_output_context, job_parameters, keyed_state_backend,
         operator_state_backend):
     serialized_fns = [pare_user_defined_data_stream_function_proto(proto)
                       for proto in function_infos]
@@ -119,6 +119,7 @@ def create_one_input_user_defined_data_stream_function_from_protos(
         runtime_context,
         function_context,
         timer_context,
+        side_output_context,
         job_parameters,
         keyed_state_backend,
         operator_state_backend)
@@ -128,7 +129,7 @@ def create_one_input_user_defined_data_stream_function_from_protos(
 
 def create_two_input_user_defined_data_stream_function_from_protos(
         function_infos, input_coder_info1, input_coder_info2, output_coder_info, runtime_context,
-        function_context, timer_context, job_parameters, keyed_state_backend,
+        function_context, timer_context, side_output_context, job_parameters, keyed_state_backend,
         operator_state_backend):
     serialized_fns = [pare_user_defined_data_stream_function_proto(proto)
                       for proto in function_infos]
@@ -150,6 +151,7 @@ def create_two_input_user_defined_data_stream_function_from_protos(
         runtime_context,
         function_context,
         timer_context,
+        side_output_context,
         job_parameters,
         keyed_state_backend,
         operator_state_backend)

--- a/flink-python/pyflink/fn_execution/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/embedded/operations.py
@@ -66,6 +66,7 @@ class OneInputFunctionOperation(FunctionOperation):
                  runtime_context,
                  function_context,
                  timer_context,
+                 side_output_context,
                  job_parameters,
                  keyed_state_backend,
                  operator_state_backend):
@@ -75,6 +76,7 @@ class OneInputFunctionOperation(FunctionOperation):
                 runtime_context,
                 function_context,
                 timer_context,
+                side_output_context,
                 job_parameters,
                 keyed_state_backend,
                 operator_state_backend)
@@ -100,6 +102,7 @@ class TwoInputFunctionOperation(FunctionOperation):
                  runtime_context,
                  function_context,
                  timer_context,
+                 side_output_context,
                  job_parameters,
                  keyed_state_backend,
                  operator_state_backend):
@@ -109,6 +112,7 @@ class TwoInputFunctionOperation(FunctionOperation):
                 runtime_context,
                 function_context,
                 timer_context,
+                side_output_context,
                 job_parameters,
                 keyed_state_backend,
                 operator_state_backend)

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -36,7 +36,6 @@ import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.python.AbstractPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
-import org.apache.flink.streaming.api.operators.python.process.AbstractExternalDataStreamPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.process.AbstractExternalOneInputPythonFunctionOperator;
 import org.apache.flink.streaming.api.transformations.AbstractMultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.OneInputTransformation;
@@ -60,6 +59,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -150,11 +150,12 @@ public class PythonConfigUtil {
                 final Transformation<?> upTransform =
                         Iterables.getOnlyElement(sideTransform.getInputs());
                 if (PythonConfigUtil.isPythonDataStreamOperator(upTransform)) {
-                    final AbstractExternalDataStreamPythonFunctionOperator<?> upOperator =
-                            (AbstractExternalDataStreamPythonFunctionOperator<?>)
+                    final DataStreamPythonFunctionOperator<?> upOperator =
+                            (DataStreamPythonFunctionOperator<?>)
                                     ((SimpleOperatorFactory<?>) getOperatorFactory(upTransform))
                                             .getOperator();
-                    upOperator.addSideOutputTag(sideTransform.getOutputTag());
+                    upOperator.addSideOutputTags(
+                            Collections.singletonList(sideTransform.getOutputTag()));
                 }
             }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/DataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/DataStreamPythonFunctionOperator.java
@@ -22,6 +22,9 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.util.OutputTag;
+
+import java.util.Collection;
 
 /** Interface for Python DataStream operators. */
 @Internal
@@ -35,6 +38,12 @@ public interface DataStreamPythonFunctionOperator<OUT> extends ResultTypeQueryab
 
     /** Returns the underlying {@link DataStreamPythonFunctionInfo}. */
     DataStreamPythonFunctionInfo getPythonFunctionInfo();
+
+    /** Add a collection of {@link OutputTag}s to the operator. */
+    void addSideOutputTags(Collection<OutputTag<?>> outputTags);
+
+    /** Gets the {@link OutputTag}s belongs to the operator. */
+    Collection<OutputTag<?>> getSideOutputTags();
 
     /**
      * Make a copy of the DataStreamPythonFunctionOperator with the given pythonFunctionInfo and

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractOneInputEmbeddedPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractOneInputEmbeddedPythonFunctionOperator.java
@@ -117,6 +117,7 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
         interpreter.set("job_parameters", getJobParameters());
         interpreter.set("keyed_state_backend", getKeyedStateBackend());
         interpreter.set("operator_state_backend", getOperatorStateBackend());
+        interpreter.set("side_output_context", sideOutputContext);
 
         interpreter.exec(
                 "from pyflink.fn_execution.embedded.operation_utils import create_one_input_user_defined_data_stream_function_from_protos");
@@ -129,6 +130,7 @@ public abstract class AbstractOneInputEmbeddedPythonFunctionOperator<IN, OUT>
                         + "runtime_context,"
                         + "function_context,"
                         + "timer_context,"
+                        + "side_output_context,"
                         + "job_parameters,"
                         + "keyed_state_backend,"
                         + "operator_state_backend)");

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractTwoInputEmbeddedPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractTwoInputEmbeddedPythonFunctionOperator.java
@@ -135,6 +135,7 @@ public abstract class AbstractTwoInputEmbeddedPythonFunctionOperator<IN1, IN2, O
         interpreter.set("runtime_context", getRuntimeContext());
         interpreter.set("function_context", getFunctionContext());
         interpreter.set("timer_context", getTimerContext());
+        interpreter.set("side_output_context", sideOutputContext);
         interpreter.set("keyed_state_backend", getKeyedStateBackend());
         interpreter.set("job_parameters", getJobParameters());
         interpreter.set("operator_state_backend", getOperatorStateBackend());
@@ -151,6 +152,7 @@ public abstract class AbstractTwoInputEmbeddedPythonFunctionOperator<IN1, IN2, O
                         + "runtime_context,"
                         + "function_context,"
                         + "timer_context,"
+                        + "side_output_context,"
                         + "job_parameters,"
                         + "keyed_state_backend,"
                         + "operator_state_backend)");

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonCoProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonCoProcessOperator.java
@@ -77,7 +77,7 @@ public class EmbeddedPythonCoProcessOperator<IN1, IN2, OUT>
                 inBatchExecutionMode(getKeyedStateBackend()),
                 config.get(PYTHON_METRIC_ENABLED),
                 config.get(PYTHON_PROFILE_ENABLED),
-                false,
+                hasSideOutput,
                 config.get(STATE_CACHE_SIZE),
                 config.get(MAP_STATE_READ_CACHE_SIZE),
                 config.get(MAP_STATE_WRITE_CACHE_SIZE));

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonKeyedCoProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonKeyedCoProcessOperator.java
@@ -105,7 +105,7 @@ public class EmbeddedPythonKeyedCoProcessOperator<K, IN1, IN2, OUT>
                 inBatchExecutionMode(getKeyedStateBackend()),
                 config.get(PYTHON_METRIC_ENABLED),
                 config.get(PYTHON_PROFILE_ENABLED),
-                false,
+                hasSideOutput,
                 config.get(STATE_CACHE_SIZE),
                 config.get(MAP_STATE_READ_CACHE_SIZE),
                 config.get(MAP_STATE_WRITE_CACHE_SIZE));

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonKeyedProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonKeyedProcessOperator.java
@@ -104,7 +104,7 @@ public class EmbeddedPythonKeyedProcessOperator<K, IN, OUT>
                 inBatchExecutionMode(getKeyedStateBackend()),
                 config.get(PYTHON_METRIC_ENABLED),
                 config.get(PYTHON_PROFILE_ENABLED),
-                false,
+                hasSideOutput,
                 config.get(STATE_CACHE_SIZE),
                 config.get(MAP_STATE_READ_CACHE_SIZE),
                 config.get(MAP_STATE_WRITE_CACHE_SIZE));

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonProcessOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonProcessOperator.java
@@ -76,7 +76,7 @@ public class EmbeddedPythonProcessOperator<IN, OUT>
                 inBatchExecutionMode(getKeyedStateBackend()),
                 config.get(PYTHON_METRIC_ENABLED),
                 config.get(PYTHON_PROFILE_ENABLED),
-                false,
+                hasSideOutput,
                 config.get(STATE_CACHE_SIZE),
                 config.get(MAP_STATE_READ_CACHE_SIZE),
                 config.get(MAP_STATE_WRITE_CACHE_SIZE));

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
@@ -105,7 +105,7 @@ public class EmbeddedPythonWindowOperator<K, IN, OUT, W extends Window>
                 inBatchExecutionMode(getKeyedStateBackend()),
                 config.get(PYTHON_METRIC_ENABLED),
                 config.get(PYTHON_PROFILE_ENABLED),
-                false,
+                hasSideOutput,
                 config.get(STATE_CACHE_SIZE),
                 config.get(MAP_STATE_READ_CACHE_SIZE),
                 config.get(MAP_STATE_WRITE_CACHE_SIZE));

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/process/AbstractExternalDataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/process/AbstractExternalDataStreamPythonFunctionOperator.java
@@ -117,17 +117,15 @@ public abstract class AbstractExternalDataStreamPythonFunctionOperator<OUT>
     // Side outputs
     // ----------------------------------------------------------------------
 
-    public void addSideOutputTag(OutputTag<?> outputTag) {
-        sideOutputTags.put(outputTag.getId(), outputTag);
-    }
-
     protected OutputTag<?> getOutputTagById(String id) {
         Preconditions.checkArgument(sideOutputTags.containsKey(id));
         return sideOutputTags.get(id);
     }
 
     public void addSideOutputTags(Collection<OutputTag<?>> outputTags) {
-        outputTags.forEach(this::addSideOutputTag);
+        for (OutputTag<?> outputTag : outputTags) {
+            sideOutputTags.put(outputTag.getId(), outputTag);
+        }
     }
 
     public Collection<OutputTag<?>> getSideOutputTags() {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support SideOutput in Thread Mode*


## Brief change log

  - *Support SideOutput in Thread Mode*

## Verifying this change

This change added tests and can be verified as follows:

  - *`EmbeddedDataStreamStreamTests` and `EmbeddedDataStreamBatchTests` in `test_data_stream.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
