### PR TITLE
[FLINK-28094][kinesis] Removing references to Regions enum and instea…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxy.java
@@ -23,8 +23,7 @@ import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAdapterClient;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.model.DescribeStreamResult;
@@ -91,8 +90,7 @@ public class DynamoDBStreamsProxy extends KinesisProxy {
         if (configProps.containsKey(AWS_ENDPOINT)) {
             adapterClient.setEndpoint(configProps.getProperty(AWS_ENDPOINT));
         } else {
-            adapterClient.setRegion(
-                    Region.getRegion(Regions.fromName(configProps.getProperty(AWS_REGION))));
+            adapterClient.setRegion(RegionUtils.getRegion(configProps.getProperty(AWS_REGION)));
         }
 
         return adapterClient;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -102,8 +102,7 @@ public class AWSUtil {
                             configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
                             configProps.getProperty(AWSConfigConstants.AWS_REGION)));
         } else {
-            builder.withRegion(
-                    Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION)));
+            builder.withRegion(configProps.getProperty(AWSConfigConstants.AWS_REGION));
         }
         return builder.build();
     }


### PR DESCRIPTION
…d using RegionUtils so that we include future AWS Regions as well

## What is the purpose of the change

Removing the dependency on AWS `Regions` enum (for AWS SDK v1) so that region support for new AWS regions is automatic, and wouldn't need a PR.

## Brief change log
- Change calls from `Regions` class to calls from `RegionUtils` class


## Verifying this change
- Unit tests/e2e tests
- Manually verified that Kinesis connector with this fix works in region not present in `Regions` enum

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
