### PR TITLE
[FLINK-28871][table-planner] Force the output edges of dynamic filtering data collector to be BLOCKING

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DynamicFilteringDependencyProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DynamicFilteringDependencyProcessor.java
@@ -18,18 +18,29 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.processor;
 
+import org.apache.flink.api.common.BatchShuffleMode;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
+import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecEdge;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecDynamicFilteringDataCollector;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecExchange;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecMultipleInput;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecTableSourceScan;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * This processor future checks each dynamic filter source to see if it is chained with a multiple
@@ -41,6 +52,11 @@ public class DynamicFilteringDependencyProcessor implements ExecNodeGraphProcess
 
     @Override
     public ExecNodeGraph process(ExecNodeGraph execGraph, ProcessorContext context) {
+        ExecNodeGraph factSideProcessedGraph = checkIfFactSourceNeedEnforceDependency(execGraph);
+        return enforceDimSideBlockingExchange(factSideProcessedGraph, context);
+    }
+
+    private ExecNodeGraph checkIfFactSourceNeedEnforceDependency(ExecNodeGraph execGraph) {
         Map<BatchExecTableSourceScan, List<ExecNode<?>>> dynamicFilteringScanDescendants =
                 new HashMap<>();
 
@@ -83,5 +99,109 @@ public class DynamicFilteringDependencyProcessor implements ExecNodeGraphProcess
         }
 
         return execGraph;
+    }
+
+    private ExecNodeGraph enforceDimSideBlockingExchange(
+            ExecNodeGraph execGraph, ProcessorContext context) {
+        if (context.getPlanner()
+                        .getTableConfig()
+                        .getConfiguration()
+                        .get(ExecutionOptions.BATCH_SHUFFLE_MODE)
+                == BatchShuffleMode.ALL_EXCHANGES_BLOCKING) {
+            return execGraph;
+        }
+
+        Set<ExecNode<?>> nodesRequiredBlockingOutputs = new HashSet<>();
+        // Find all the dynamic filter collector node
+        AbstractExecNodeExactlyOnceVisitor nodesRequiredBlockingOutputsCollector =
+                new AbstractExecNodeExactlyOnceVisitor() {
+                    @Override
+                    protected void visitNode(ExecNode<?> node) {
+                        if (node instanceof BatchExecDynamicFilteringDataCollector) {
+                            nodesRequiredBlockingOutputs.add(node);
+                        }
+
+                        // Here either it is added in the above lines or by its children nodes.
+                        if (nodesRequiredBlockingOutputs.contains(node)) {
+                            node.getInputEdges().stream()
+                                    .map(ExecEdge::getSource)
+                                    .forEach(nodesRequiredBlockingOutputs::add);
+                        }
+
+                        visitInputs(node);
+                    }
+                };
+        execGraph
+                .getRootNodes()
+                .forEach(node -> node.accept(nodesRequiredBlockingOutputsCollector));
+
+        // Now we make all the output edges in nodesRequiredBlockingOutputs to be blocking.
+        AbstractExecNodeExactlyOnceVisitor blockingEnforcerVisitor =
+                new AbstractExecNodeExactlyOnceVisitor() {
+                    @Override
+                    protected void visitNode(ExecNode<?> node) {
+                        visitInputs(node);
+
+                        // We only contains the edges that the source is in the set, but
+                        // the target does not.
+                        if (nodesRequiredBlockingOutputs.contains(node)) {
+                            return;
+                        }
+
+                        for (int i = 0; i < node.getInputEdges().size(); ++i) {
+                            ExecEdge edge = node.getInputEdges().get(i);
+                            ExecNode<?> source = edge.getSource();
+
+                            // We only contains the edges that the source is in the set, but
+                            // the target does not.
+                            if (!nodesRequiredBlockingOutputs.contains(source)) {
+                                continue;
+                            }
+
+                            if (source instanceof BatchExecExchange) {
+                                ((BatchExecExchange) source)
+                                        .setRequiredExchangeMode(StreamExchangeMode.BATCH);
+                            } else if (node instanceof BatchExecExchange) {
+                                ((BatchExecExchange) node)
+                                        .setRequiredExchangeMode(StreamExchangeMode.BATCH);
+                            } else {
+                                BatchExecExchange exchange =
+                                        createExchange(
+                                                source,
+                                                node.getInputProperties().get(i),
+                                                context.getPlanner().getTableConfig());
+                                ExecEdge newEdge =
+                                        ExecEdge.builder().source(exchange).target(node).build();
+                                node.replaceInputEdge(i, newEdge);
+                            }
+                        }
+                    }
+                };
+        execGraph.getRootNodes().forEach(node -> node.accept(blockingEnforcerVisitor));
+
+        return execGraph;
+    }
+
+    private BatchExecExchange createExchange(
+            ExecNode<?> source, InputProperty inputProperty, TableConfig tableConfig) {
+        InputProperty newProperty =
+                InputProperty.builder()
+                        .requiredDistribution(
+                                inputProperty.getRequiredDistribution()
+                                                == InputProperty.UNKNOWN_DISTRIBUTION
+                                        ? InputProperty.ANY_DISTRIBUTION
+                                        : inputProperty.getRequiredDistribution())
+                        .damBehavior(inputProperty.getDamBehavior())
+                        .priority(inputProperty.getPriority())
+                        .build();
+
+        BatchExecExchange exchange =
+                new BatchExecExchange(
+                        tableConfig, newProperty, (RowType) source.getOutputType(), "Exchange");
+        exchange.setRequiredExchangeMode(StreamExchangeMode.BATCH);
+        ExecEdge execEdge = ExecEdge.builder().source(source).target(exchange).build();
+        exchange.setInputEdges(Collections.singletonList(execEdge));
+
+        return exchange;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DynamicFilteringDependencyProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/DynamicFilteringDependencyProcessor.java
@@ -112,7 +112,7 @@ public class DynamicFilteringDependencyProcessor implements ExecNodeGraphProcess
         }
 
         Set<ExecNode<?>> nodesRequiredBlockingOutputs = new HashSet<>();
-        // Find all the dynamic filter collector node
+        // Find all the dynamic filter collector nodes and theirs inputs.
         AbstractExecNodeExactlyOnceVisitor nodesRequiredBlockingOutputsCollector =
                 new AbstractExecNodeExactlyOnceVisitor() {
                     @Override
@@ -142,7 +142,7 @@ public class DynamicFilteringDependencyProcessor implements ExecNodeGraphProcess
                     protected void visitNode(ExecNode<?> node) {
                         visitInputs(node);
 
-                        // We only contains the edges that the source is in the set, but
+                        // We only consider the edges that the source is in the set, but
                         // the target does not.
                         if (nodesRequiredBlockingOutputs.contains(node)) {
                             return;
@@ -152,7 +152,7 @@ public class DynamicFilteringDependencyProcessor implements ExecNodeGraphProcess
                             ExecEdge edge = node.getInputEdges().get(i);
                             ExecNode<?> source = edge.getSource();
 
-                            // We only contains the edges that the source is in the set, but
+                            // We only consider the edges that the source is in the set, but
                             // the target does not.
                             if (!nodesRequiredBlockingOutputs.contains(source)) {
                                 continue;

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DynamicFilteringTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DynamicFilteringTest.xml
@@ -16,7 +16,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <Root>
-  <TestCase name="testDynamicFilteringWithStaticPartitionPruning">
+  <TestCase name="testDynamicFilteringWithStaticPartitionPruning[mode = ALL_EXCHANGES_BLOCKING]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7])
@@ -116,7 +116,108 @@ HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testDuplicateFactTables">
+  <TestCase name="testDynamicFilteringWithStaticPartitionPruning[mode = ALL_EXCHANGES_PIPELINED]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7])
++- LogicalFilter(condition=[AND(=($3, $7), >($4, 10), >(CAST($3):BIGINT, 1))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, fact1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim]])
+
+== Optimized Physical Plan ==
+HashJoin(joinType=[InnerJoin], where=[=(p1, p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+:- Exchange(distribution=[hash[p1]])
+:  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1, partitions=[{p1=2}, {p1=3}]]], fields=[a1, b1, c1, p1])
+:     +- DynamicFilteringDataCollector(fields=[p])
+:        +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+:           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
++- Exchange(distribution=[hash[p]])
+   +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+
+== Optimized Execution Plan ==
+HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+:- Exchange(distribution=[hash[p1]])
+:  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1, partitions=[{p1=2}, {p1=3}]]], fields=[a1, b1, c1, p1])
+:     +- Exchange(distribution=[any], shuffle_mode=[BATCH])
+:        +- DynamicFilteringDataCollector(fields=[p])
+:           +- Calc(select=[x, y, z, p], where=[(x > 10)])(reuse_id=[1])
+:              +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
++- Exchange(distribution=[hash[p]], shuffle_mode=[BATCH])
+   +- Reused(reference_id=[1])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1, partitions=[{p1=2}, {p1=3}]]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Source: dim[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[x, y, z, p], where=[(x > 10)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "DynamicFilteringDataCollector[]",
+    "pact" : "Operator",
+    "contents" : "[]:DynamicFilteringDataCollector(fields=[p])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Order-Enforcer",
+    "pact" : "Operator",
+    "contents" : "Order-Enforcer",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashJoin[]",
+    "pact" : "Operator",
+    "contents" : "[]:HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH[p]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p1]",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDuplicateFactTables[mode = ALL_EXCHANGES_BLOCKING]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7], a10=[$8], b10=[$9], c10=[$10], p10=[$11])
@@ -275,7 +376,167 @@ Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testDynamicFilteringWithMultipleInput">
+  <TestCase name="testDuplicateFactTables[mode = ALL_EXCHANGES_PIPELINED]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7], a10=[$8], b10=[$9], c10=[$10], p10=[$11])
++- LogicalJoin(condition=[=($5, $12)], joinType=[inner])
+   :- LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7])
+   :  +- LogicalFilter(condition=[AND(=($3, $7), >($4, 10))])
+   :     +- LogicalJoin(condition=[true], joinType=[inner])
+   :        :- LogicalTableScan(table=[[default_catalog, default_database, fact1]])
+   :        +- LogicalTableScan(table=[[default_catalog, default_database, dim]])
+   +- LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], b10=[CAST($1):BIGINT])
+      +- LogicalTableScan(table=[[default_catalog, default_database, fact1]])
+
+== Optimized Physical Plan ==
+Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
++- HashJoin(joinType=[InnerJoin], where=[=(y, b100)], select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10, b100], build=[left])
+   :- Exchange(distribution=[hash[y]])
+   :  +- HashJoin(joinType=[InnerJoin], where=[=(p1, p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+   :     :- Exchange(distribution=[hash[p1]])
+   :     :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+   :     :     +- DynamicFilteringDataCollector(fields=[p])
+   :     :        +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+   :     :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+   :     +- Exchange(distribution=[hash[p]])
+   :        +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+   +- Exchange(distribution=[hash[b10]])
+      +- Calc(select=[a1, b1, c1, p1, CAST(b1 AS BIGINT) AS b10])
+         +- TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+
+== Optimized Execution Plan ==
+Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])
++- HashJoin(joinType=[InnerJoin], where=[(y = b100)], select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10, b100], build=[left])
+   :- Exchange(distribution=[hash[y]])
+   :  +- HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+   :     :- Exchange(distribution=[hash[p1]])
+   :     :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+   :     :     +- Exchange(distribution=[any], shuffle_mode=[BATCH])
+   :     :        +- DynamicFilteringDataCollector(fields=[p])
+   :     :           +- Calc(select=[x, y, z, p], where=[(x > 10)])(reuse_id=[1])
+   :     :              +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+   :     +- Exchange(distribution=[hash[p]], shuffle_mode=[BATCH])
+   :        +- Reused(reference_id=[1])
+   +- Exchange(distribution=[hash[b10]])
+      +- Calc(select=[a1, b1, c1, p1, CAST(b1 AS BIGINT) AS b10])
+         +- TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Source: dim[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[x, y, z, p], where=[(x > 10)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "DynamicFilteringDataCollector[]",
+    "pact" : "Operator",
+    "contents" : "[]:DynamicFilteringDataCollector(fields=[p])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Order-Enforcer",
+    "pact" : "Operator",
+    "contents" : "Order-Enforcer",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashJoin[]",
+    "pact" : "Operator",
+    "contents" : "[]:HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH[p]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p1]",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a1, b1, c1, p1, CAST(b1 AS BIGINT) AS b10])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashJoin[]",
+    "pact" : "Operator",
+    "contents" : "[]:HashJoin(joinType=[InnerJoin], where=[(y = b100)], select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10, b100], build=[left])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH[y]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[b10]",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a1, b1, c1, p1, x, y, z, p, a10, b10, c10, p10])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDynamicFilteringWithMultipleInput[mode = ALL_EXCHANGES_BLOCKING]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7], a2=[$8], b2=[$9], c2=[$10], p2=[$11])
@@ -392,7 +653,125 @@ MultipleInput(readOrder=[2,1,0], members=[\nHashJoin(joinType=[InnerJoin], where
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testLegacySource">
+  <TestCase name="testDynamicFilteringWithMultipleInput[mode = ALL_EXCHANGES_PIPELINED]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7], a2=[$8], b2=[$9], c2=[$10], p2=[$11])
++- LogicalFilter(condition=[AND(=($3, $7), =($3, $11), >($4, 10))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalJoin(condition=[true], joinType=[inner])
+      :  :- LogicalTableScan(table=[[default_catalog, default_database, fact1]])
+      :  +- LogicalTableScan(table=[[default_catalog, default_database, dim]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, fact2]])
+
+== Optimized Physical Plan ==
+HashJoin(joinType=[InnerJoin], where=[=(p1, p2)], select=[a1, b1, c1, p1, x, y, z, p, a2, b2, c2, p2], build=[left])
+:- HashJoin(joinType=[InnerJoin], where=[=(p1, p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+:  :- Exchange(distribution=[hash[p1]])
+:  :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+:  :     +- DynamicFilteringDataCollector(fields=[p])
+:  :        +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+:  :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+:  +- Exchange(distribution=[hash[p]])
+:     +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+:        +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
++- Exchange(distribution=[hash[p2]])
+   +- TableSourceScan(table=[[default_catalog, default_database, fact2]], fields=[a2, b2, c2, p2])
+
+== Optimized Execution Plan ==
+MultipleInput(readOrder=[2,1,0], members=[\nHashJoin(joinType=[InnerJoin], where=[(p1 = p2)], select=[a1, b1, c1, p1, x, y, z, p, a2, b2, c2, p2], build=[left])\n:- HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])\n:  :- [#2] Exchange(distribution=[hash[p1]])\n:  +- [#3] Exchange(distribution=[hash[p]])\n+- [#1] Exchange(distribution=[hash[p2]])\n])
+:- Exchange(distribution=[hash[p2]])
+:  +- TableSourceScan(table=[[default_catalog, default_database, fact2]], fields=[a2, b2, c2, p2])
+:- Exchange(distribution=[hash[p1]])
+:  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+:     +- Exchange(distribution=[any], shuffle_mode=[BATCH])
+:        +- DynamicFilteringDataCollector(fields=[p])
+:           +- Calc(select=[x, y, z, p], where=[(x > 10)])(reuse_id=[1])
+:              +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
++- Exchange(distribution=[hash[p]], shuffle_mode=[BATCH])
+   +- Reused(reference_id=[1])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: fact2[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, fact2]], fields=[a2, b2, c2, p2])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Source: dim[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[x, y, z, p], where=[(x > 10)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "DynamicFilteringDataCollector[]",
+    "pact" : "Operator",
+    "contents" : "[]:DynamicFilteringDataCollector(fields=[p])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Order-Enforcer",
+    "pact" : "Operator",
+    "contents" : "Order-Enforcer",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "MultipleInput[]",
+    "pact" : "Operator",
+    "contents" : "[]:MultipleInput(readOrder=[2,1,0], members=[\\nHashJoin(joinType=[InnerJoin], where=[(p1 = p2)], select=[a1, b1, c1, p1, x, y, z, p, a2, b2, c2, p2], build=[left])\\n:- HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])\\n:  :- [#2] Exchange(distribution=[hash[p1]])\\n:  +- [#3] Exchange(distribution=[hash[p]])\\n+- [#1] Exchange(distribution=[hash[p2]])\\n])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH[p]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p1]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p2]",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testLegacySource[mode = ALL_EXCHANGES_BLOCKING]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], p1=[$4], x=[$5], y=[$6], z=[$7], p=[$8])
@@ -461,7 +840,76 @@ HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, d1, p1, x, 
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testSimpleDynamicFiltering">
+  <TestCase name="testLegacySource[mode = ALL_EXCHANGES_PIPELINED]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], d1=[$3], p1=[$4], x=[$5], y=[$6], z=[$7], p=[$8])
++- LogicalFilter(condition=[AND(=($4, $8), >($5, 10))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, legacy_source]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim]])
+
+== Optimized Physical Plan ==
+HashJoin(joinType=[InnerJoin], where=[=(p1, p)], select=[a1, b1, c1, d1, p1, x, y, z, p], build=[right])
+:- Exchange(distribution=[hash[p1]])
+:  +- TableSourceScan(table=[[default_catalog, default_database, legacy_source]], fields=[a1, b1, c1, d1, p1])
++- Exchange(distribution=[hash[p]])
+   +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+
+== Optimized Execution Plan ==
+HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, d1, p1, x, y, z, p], build=[right])
+:- Exchange(distribution=[hash[p1]])
+:  +- TableSourceScan(table=[[default_catalog, default_database, legacy_source]], fields=[a1, b1, c1, d1, p1])
++- Exchange(distribution=[hash[p]])
+   +- Calc(select=[x, y, z, p], where=[(x > 10)])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: legacy_source[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, legacy_source]], fields=[a1, b1, c1, d1, p1])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Source: dim[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[x, y, z, p], where=[(x > 10)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashJoin[]",
+    "pact" : "Operator",
+    "contents" : "[]:HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, d1, p1, x, y, z, p], build=[right])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH[p]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p1]",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testSimpleDynamicFiltering[mode = ALL_EXCHANGES_BLOCKING]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7])
@@ -561,7 +1009,108 @@ HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z
 }]]>
     </Resource>
   </TestCase>
-  <TestCase name="testReuseDimSide">
+  <TestCase name="testSimpleDynamicFiltering[mode = ALL_EXCHANGES_PIPELINED]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7])
++- LogicalFilter(condition=[AND(=($3, $7), >($4, 10))])
+   +- LogicalJoin(condition=[true], joinType=[inner])
+      :- LogicalTableScan(table=[[default_catalog, default_database, fact1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, dim]])
+
+== Optimized Physical Plan ==
+HashJoin(joinType=[InnerJoin], where=[=(p1, p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+:- Exchange(distribution=[hash[p1]])
+:  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+:     +- DynamicFilteringDataCollector(fields=[p])
+:        +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+:           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
++- Exchange(distribution=[hash[p]])
+   +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+      +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+
+== Optimized Execution Plan ==
+HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+:- Exchange(distribution=[hash[p1]])
+:  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+:     +- Exchange(distribution=[any], shuffle_mode=[BATCH])
+:        +- DynamicFilteringDataCollector(fields=[p])
+:           +- Calc(select=[x, y, z, p], where=[(x > 10)])(reuse_id=[1])
+:              +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
++- Exchange(distribution=[hash[p]], shuffle_mode=[BATCH])
+   +- Reused(reference_id=[1])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Source: dim[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[x, y, z, p], where=[(x > 10)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "DynamicFilteringDataCollector[]",
+    "pact" : "Operator",
+    "contents" : "[]:DynamicFilteringDataCollector(fields=[p])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Order-Enforcer",
+    "pact" : "Operator",
+    "contents" : "Order-Enforcer",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashJoin[]",
+    "pact" : "Operator",
+    "contents" : "[]:HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH[p]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p1]",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReuseDimSide[mode = ALL_EXCHANGES_BLOCKING]">
     <Resource name="explain">
       <![CDATA[== Abstract Syntax Tree ==
 LogicalUnion(all=[true])
@@ -609,6 +1158,157 @@ MultipleInput(readOrder=[1,0,1,0], members=[\nUnion(all=[true], union=[a1, b1, c
 :- Exchange(distribution=[hash[p2]])
 :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact2]], fields=[a2, b2, c2, p2])
 :     +- Reused(reference_id=[2])
++- Reused(reference_id=[3])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: fact1[]",
+    "pact" : "Data Source",
+    "contents" : "[]:DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Source: dim[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[x, y, z, p], where=[(x > 10)])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "DynamicFilteringDataCollector[]",
+    "pact" : "Operator",
+    "contents" : "[]:DynamicFilteringDataCollector(fields=[p])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Order-Enforcer",
+    "pact" : "Operator",
+    "contents" : "Order-Enforcer",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Source: fact2[]",
+    "pact" : "Data Source",
+    "contents" : "[]:DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact2]], fields=[a2, b2, c2, p2])",
+    "parallelism" : 10
+  }, {
+    "id" : ,
+    "type" : "Order-Enforcer",
+    "pact" : "Operator",
+    "contents" : "Order-Enforcer",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "MultipleInput[]",
+    "pact" : "Operator",
+    "contents" : "[]:MultipleInput(readOrder=[1,0,1,0], members=[\\nUnion(all=[true], union=[a1, b1, c1, p1, x, y, z, p])\\n:- HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])\\n:  :- [#1] Exchange(distribution=[hash[p1]])\\n:  +- [#2] Exchange(distribution=[hash[p]])\\n+- HashJoin(joinType=[InnerJoin], where=[(p2 = p)], select=[a2, b2, c2, p2, x, y, z, p], build=[right])\\n   :- [#3] Exchange(distribution=[hash[p2]])\\n   +- [#2] Exchange(distribution=[hash[p]])\\n])",
+    "parallelism" : 10,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "HASH[p]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p1]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p]",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "HASH[p2]",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testReuseDimSide[mode = ALL_EXCHANGES_PIPELINED]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalUnion(all=[true])
+:- LogicalProject(a1=[$0], b1=[$1], c1=[$2], p1=[$3], x=[$4], y=[$5], z=[$6], p=[$7])
+:  +- LogicalFilter(condition=[AND(=($3, $7), >($4, 10))])
+:     +- LogicalJoin(condition=[true], joinType=[inner])
+:        :- LogicalTableScan(table=[[default_catalog, default_database, fact1]])
+:        +- LogicalTableScan(table=[[default_catalog, default_database, dim]])
++- LogicalProject(a2=[$0], b2=[$1], c2=[$2], p2=[$3], x=[$4], y=[$5], z=[$6], p=[$7])
+   +- LogicalFilter(condition=[AND(=($3, $7), >($4, 10))])
+      +- LogicalJoin(condition=[true], joinType=[inner])
+         :- LogicalTableScan(table=[[default_catalog, default_database, fact2]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, dim]])
+
+== Optimized Physical Plan ==
+Union(all=[true], union=[a1, b1, c1, p1, x, y, z, p])
+:- HashJoin(joinType=[InnerJoin], where=[=(p1, p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])
+:  :- Exchange(distribution=[hash[p1]])
+:  :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+:  :     +- DynamicFilteringDataCollector(fields=[p])
+:  :        +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+:  :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+:  +- Exchange(distribution=[hash[p]])
+:     +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+:        +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
++- HashJoin(joinType=[InnerJoin], where=[=(p2, p)], select=[a2, b2, c2, p2, x, y, z, p], build=[right])
+   :- Exchange(distribution=[hash[p2]])
+   :  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact2]], fields=[a2, b2, c2, p2])
+   :     +- DynamicFilteringDataCollector(fields=[p])
+   :        +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+   :           +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+   +- Exchange(distribution=[hash[p]])
+      +- Calc(select=[x, y, z, p], where=[>(x, 10)])
+         +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+
+== Optimized Execution Plan ==
+MultipleInput(readOrder=[1,0,1,0], members=[\nUnion(all=[true], union=[a1, b1, c1, p1, x, y, z, p])\n:- HashJoin(joinType=[InnerJoin], where=[(p1 = p)], select=[a1, b1, c1, p1, x, y, z, p], build=[right])\n:  :- [#1] Exchange(distribution=[hash[p1]])\n:  +- [#2] Exchange(distribution=[hash[p]])\n+- HashJoin(joinType=[InnerJoin], where=[(p2 = p)], select=[a2, b2, c2, p2, x, y, z, p], build=[right])\n   :- [#3] Exchange(distribution=[hash[p2]])\n   +- [#2] Exchange(distribution=[hash[p]])\n])
+:- Exchange(distribution=[hash[p1]])
+:  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact1]], fields=[a1, b1, c1, p1])
+:     +- Exchange(distribution=[any], shuffle_mode=[BATCH])
+:        +- DynamicFilteringDataCollector(fields=[p])(reuse_id=[2])
+:           +- Calc(select=[x, y, z, p], where=[(x > 10)])(reuse_id=[1])
+:              +- TableSourceScan(table=[[default_catalog, default_database, dim, filter=[]]], fields=[x, y, z, p])
+:- Exchange(distribution=[hash[p]], shuffle_mode=[BATCH])(reuse_id=[3])
+:  +- Reused(reference_id=[1])
+:- Exchange(distribution=[hash[p2]])
+:  +- DynamicFilteringTableSourceScan(table=[[default_catalog, default_database, fact2]], fields=[a2, b2, c2, p2])
+:     +- Exchange(distribution=[any], shuffle_mode=[BATCH])
+:        +- Reused(reference_id=[2])
 +- Reused(reference_id=[3])
 
 == Physical Execution Plan ==


### PR DESCRIPTION
## What is the purpose of the change

This PR forces the output edges of DynamicFilteringDataCollector to be blocking, thus ensures the task finished before the fact source get scheduled. 

This is done by inserts the BatchExecExchange between all the output edges from BatchExecDynamicFilteringDataCollector and its precedent tasks. Note that currently once two tasks are connected via pipeline regions, it would be divided into the same region and the blocking edge would not work, thus we have to make all the parents' output edges to be blocking. 

## Brief change log

- e57d925f6f4c4970004bb28f9e1b506869aabc9c does the above change.

## Verifying this change

This change added tests and can be verified as follows:

- Added tests that are BatchExecExchange is inserted correctly.
- Added ITCases to demonstrate the blocking edge works correctly. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
