### PR TITLE
[FLINK-28862][python][format/parquet] Support ParquetRowDataWriter

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/filesystem.md
+++ b/docs/content.zh/docs/connectors/datastream/filesystem.md
@@ -488,6 +488,30 @@ input.sinkTo(sink)
 {{< /tab >}}
 {{< /tabs >}}
 
+PyFlink 用户可以使用 `ParquetBulkWriter` 来创建一个将 `Row` 数据写入 Parquet 文件的 `BulkWriterFactory` 。
+
+```python
+row_type = DataTypes.ROW([
+    DataTypes.FIELD('string', DataTypes.STRING()),
+    DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
+])
+row_type_info = Types.ROW_NAMED(
+    ['string', 'int_array'],
+    [Types.STRING(), Types.LIST(Types.INT())]
+)
+sink = FileSink.for_bulk_format(
+    OUTPUT_DIR, ParquetBulkWriter.for_row_type(
+        row_type,
+        hadoop_config=Configuration(),
+        utc_timestamp=True,
+    )
+).build()
+# 如果 ds 是一个输出类型为 RowData 的源数据源，可以使用一个 map 来转换为 Row 类型
+ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
+# 否则
+ds.sink_to(sink)
+```
+
 <a name="avro-format"></a>
 
 ##### Avro Format

--- a/docs/content.zh/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/parquet.md
@@ -184,8 +184,8 @@ row_type = DataTypes.ROW([
     DataTypes.FIELD('f99', DataTypes.VARCHAR()),
 ])
 source = FileSource.for_bulk_file_format(ParquetColumnarRowInputFormat(
-    hadoop_config=Configuration(),
     row_type=row_type,
+    hadoop_config=Configuration(),
     batch_size=500,
     is_utc_timestamp=False,
     is_case_sensitive=True,

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -486,6 +486,30 @@ input.sinkTo(sink)
 {{< /tab >}}
 {{< /tabs >}}
 
+For PyFlink users, `ParquetBulkWriter` could be used to create a `BulkWriterFactory` that writes `Row`s into Parquet files.
+
+```python
+row_type = DataTypes.ROW([
+    DataTypes.FIELD('string', DataTypes.STRING()),
+    DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
+])
+row_type_info = Types.ROW_NAMED(
+    ['string', 'int_array'],
+    [Types.STRING(), Types.LIST(Types.INT())]
+)
+sink = FileSink.for_bulk_format(
+    OUTPUT_DIR, ParquetBulkWriter.for_row_type(
+        row_type,
+        hadoop_config=Configuration(),
+        utc_timestamp=True,
+    )
+).build()
+# If ds is a source stream producing RowData records, a map could be added to help converting RowData records into Row records.
+ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
+# Else
+ds.sink_to(sink)
+```
+
 ##### Avro format
 
 Flink also provides built-in support for writing data into Avro files. A list of convenience methods to create

--- a/docs/content/docs/connectors/datastream/formats/parquet.md
+++ b/docs/content/docs/connectors/datastream/formats/parquet.md
@@ -181,8 +181,8 @@ row_type = DataTypes.ROW([
     DataTypes.FIELD('f99', DataTypes.VARCHAR()),
 ])
 source = FileSource.for_bulk_file_format(ParquetColumnarRowInputFormat(
-    hadoop_config=Configuration(),
     row_type=row_type,
+    hadoop_config=Configuration(),
     batch_size=500,
     is_utc_timestamp=False,
     is_case_sensitive=True,

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
@@ -123,7 +123,7 @@ public class ParquetSchemaConverter {
                         repetition,
                         name,
                         MAP_REPEATED_NAME,
-                        convertToParquetType("key", mapType.getKeyType()),
+                        convertToParquetType("key", mapType.getKeyType(), Type.Repetition.REQUIRED),
                         convertToParquetType("value", mapType.getValueType()));
             case ROW:
                 RowType rowType = (RowType) type;

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/utils/ParquetSchemaConverter.java
@@ -123,7 +123,7 @@ public class ParquetSchemaConverter {
                         repetition,
                         name,
                         MAP_REPEATED_NAME,
-                        convertToParquetType("key", mapType.getKeyType(), Type.Repetition.REQUIRED),
+                        convertToParquetType("key", mapType.getKeyType()),
                         convertToParquetType("value", mapType.getValueType()));
             case ROW:
                 RowType rowType = (RowType) type;

--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -21,7 +21,7 @@ import time
 from enum import Enum
 from typing import List, Union
 
-from py4j.java_gateway import JavaClass, JavaObject, get_java_class
+from py4j.java_gateway import JavaClass, JavaObject
 
 from pyflink.java_gateway import get_gateway
 
@@ -463,7 +463,7 @@ class RowTypeInfo(TypeInformation):
                 return (RowKind.INSERT.value,) + tuple(obj.get(n) for n in self.get_field_names())
             elif isinstance(obj, Row) and hasattr(obj, "_fields"):
                 return (obj.get_row_kind().value,) + tuple(
-                    obj.get(n) for n in self.get_field_names())
+                    obj[n] for n in self.get_field_names())
             elif isinstance(obj, Row):
                 return (obj.get_row_kind().value,) + tuple(obj)
             elif isinstance(obj, (list, tuple)):
@@ -744,21 +744,6 @@ class ExternalTypeInfo(TypeInformation):
         return 'ExternalTypeInfo<{}>'.format(self._type_info)
 
 
-class JavaTypeInfo(TypeInformation):
-
-    def __init__(self, j_class):
-        super().__init__()
-        self._j_class = j_class
-
-    def get_java_type_info(self) -> JavaObject:
-        if not self._j_typeinfo:
-            jvm = get_gateway().jvm
-            self._j_typeinfo = jvm.org.apache.flink.api.common.typeinfo.TypeInformation.of(
-                self._j_class
-            )
-        return self._j_typeinfo
-
-
 class Types(object):
     """
     This class gives access to the type information of the most common types for which Flink has
@@ -959,10 +944,6 @@ class Types(object):
         :param element_type_info: The type of the elements in the list
         """
         return ListTypeInfo(element_type_info)
-
-    @staticmethod
-    def JAVA(clz) -> TypeInformation:
-        return JavaTypeInfo(get_java_class(clz))
 
 
 def _from_java_type(j_type_info: JavaObject) -> TypeInformation:

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -211,23 +211,23 @@ Classes to define source & sink:
 Classes to define formats used together with source & sink:
 
     - :class:`formats.csv.CsvReaderFormat`:
-      A :class:`connectors.file_system.StreamFormat` to read CSV files into Row data.
+      A :class:`~connectors.file_system.StreamFormat` to read CSV files into Row data.
     - :class:`formats.csv.CsvBulkWriter`:
-      Creates :class:`connectors.file_system.BulkWriterFactory` to write Row data into CSV files.
+      Creates :class:`~connectors.file_system.BulkWriterFactory` to write Row data into CSV files.
     - :class:`formats.avro.GenericRecordAvroTypeInfo`:
-      A :class:`pyflink.common.typeinfo.TypeInformation` to indicate vanilla Python records will be
+      A :class:`~pyflink.common.typeinfo.TypeInformation` to indicate vanilla Python records will be
       translated to GenericRecordAvroTypeInfo on the Java side.
     - :class:`formats.avro.AvroInputFormat`:
-      A :class:`connector.file_system.InputFormat` to read avro files in a streaming fashion.
+      A :class:`~connector.file_system.InputFormat` to read avro files in a streaming fashion.
     - :class:`formats.avro.AvroWriters`:
-      A class to provide :class:`connector.file_system.BulkWriterFactory` to write vanilla Python
+      A class to provide :class:`~connector.file_system.BulkWriterFactory` to write vanilla Python
       objects into avro files in a batch fashion.
     - :class:`formats.parquet.ParquetColumnarRowInputFormat`:
-      A :class:`connectors.file_system.BulkFormat` to read columnar parquet files into Row data in a
-      batch-processing fashion.
-    - :class:`formats.parquet.ParquetRowDataWriter`:
-      Convenient builder to create a :class:`BulkWriterFactory` that writes Rows with a defined
-      :class:`RowType` into Parquet files in a batch fashion.
+      A :class:`~connectors.file_system.BulkFormat` to read columnar parquet files into Row data in
+      a batch-processing fashion.
+    - :class:`formats.parquet.ParquetBulkWriter`:
+      Convenient builder to create a :class:`~connectors.file_system.BulkWriterFactory` that writes
+      Rows with a defined RowType into Parquet files in a batch fashion.
     - :class:`formats.parquet.AvroParquetReaders`:
       A convenience builder to create reader format that reads individual Avro records from a
       Parquet stream. Only GenericRecord is supported in PyFlink.

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -225,6 +225,9 @@ Classes to define formats used together with source & sink:
     - :class:`formats.parquet.ParquetColumnarRowInputFormat`:
       A :class:`connectors.file_system.BulkFormat` to read columnar parquet files into Row data in a
       batch-processing fashion.
+    - :class:`formats.parquet.ParquetRowDataWriter`:
+      Convenient builder to create a :class:`BulkWriterFactory` that writes Rows with a defined
+      :class:`RowType` into Parquet files in a batch fashion.
     - :class:`formats.parquet.AvroParquetReaders`:
       A convenience builder to create reader format that reads individual Avro records from a
       Parquet stream. Only GenericRecord is supported in PyFlink.

--- a/flink-python/pyflink/datastream/formats/tests/test_parquet.py
+++ b/flink-python/pyflink/datastream/formats/tests/test_parquet.py
@@ -19,12 +19,19 @@ import glob
 import os
 import tempfile
 import unittest
-from typing import List
+from datetime import date, time, datetime
+from decimal import Decimal
+from typing import List, Optional, Tuple
 
-from pyflink.common import Configuration
+import pandas as pd
+import pytz
+from py4j.java_gateway import get_java_class
+
+from pyflink.common import Configuration, Row
+from pyflink.common.typeinfo import RowTypeInfo, Types
 from pyflink.common.watermark_strategy import WatermarkStrategy
-from pyflink.datastream import MapFunction
 from pyflink.datastream.connectors.file_system import FileSource, FileSink
+from pyflink.datastream.data_stream import DataStream
 from pyflink.datastream.formats.tests.test_avro import \
     _create_basic_avro_schema_and_py_objects, _check_basic_avro_schema_results, \
     _create_enum_avro_schema_and_py_objects, _check_enum_avro_schema_results, \
@@ -36,11 +43,12 @@ from pyflink.datastream.formats.tests.test_avro import \
     _create_basic_avro_schema_and_records, _import_avro_classes
 from pyflink.datastream.formats.avro import GenericRecordAvroTypeInfo, AvroSchema
 from pyflink.datastream.formats.parquet import AvroParquetReaders, ParquetColumnarRowInputFormat, \
-    AvroParquetWriters
+    AvroParquetWriters, ParquetRowDataWriter
 from pyflink.datastream.tests.test_util import DataStreamTestSinkFunction
 from pyflink.java_gateway import get_gateway
-from pyflink.table.types import RowType, DataTypes
-from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase
+from pyflink.table.types import RowType, DataTypes, _to_java_data_type
+from pyflink.testing.test_case_utils import PyFlinkStreamingTestCase, to_java_data_structure
+from pyflink.util.java_utils import to_jarray
 
 
 @unittest.skipIf(os.environ.get('HADOOP_CLASSPATH') is None,
@@ -106,7 +114,7 @@ class FileSourceAvroParquetReadersTests(PyFlinkStreamingTestCase):
             WatermarkStrategy.for_monotonous_timestamps(),
             "parquet-source"
         )
-        ds.map(PassThroughMapFunction()).add_sink(self.test_sink)
+        ds.map(lambda e: e).add_sink(self.test_sink)
 
     @staticmethod
     def _create_parquet_avro_file(file_path: str, schema: AvroSchema, records: list):
@@ -192,40 +200,238 @@ class FileSourceParquetColumnarRowInputFormatTests(PyFlinkStreamingTestCase):
     def setUp(self):
         super().setUp()
         self.test_sink = DataStreamTestSinkFunction()
-        _import_avro_classes()
+        self.parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
 
-    def test_parquet_columnar_basic(self):
-        parquet_file_name = tempfile.mktemp(suffix='.parquet', dir=self.tempdir)
-        schema, records = _create_basic_avro_schema_and_records()
-        FileSourceAvroParquetReadersTests._create_parquet_avro_file(
-            parquet_file_name, schema, records)
-        row_type = DataTypes.ROW([
-            DataTypes.FIELD('null', DataTypes.STRING()),  # DataTypes.NULL cannot be serialized
-            DataTypes.FIELD('boolean', DataTypes.BOOLEAN()),
-            DataTypes.FIELD('int', DataTypes.INT()),
-            DataTypes.FIELD('long', DataTypes.BIGINT()),
-            DataTypes.FIELD('float', DataTypes.FLOAT()),
-            DataTypes.FIELD('double', DataTypes.DOUBLE()),
-            DataTypes.FIELD('string', DataTypes.STRING()),
-            DataTypes.FIELD('unknown', DataTypes.STRING())
-        ])
-        self._build_parquet_columnar_job(row_type, parquet_file_name)
-        self.env.execute('test_parquet_columnar_basic')
+    def test_parquet_columnar_basic_read(self):
+        os.environ['TZ'] = 'Asia/Shanghai'
+        row_type, _, data = _create_parquet_basic_row_and_data()
+        _write_row_data_to_parquet_file(self.parquet_file_name, row_type, data)
+        self._build_parquet_columnar_job(row_type)
+        self.env.execute('test_parquet_columnar_basic_read')
         results = self.test_sink.get_results(True, False)
-        _check_basic_avro_schema_results(self, results)
-        self.assertIsNone(results[0]['unknown'])
-        self.assertIsNone(results[1]['unknown'])
+        _check_parquet_basic_results(self, results)
 
-    def _build_parquet_columnar_job(self, row_type: RowType, parquet_file_name: str):
+    def _build_parquet_columnar_job(self, row_type: RowType):
         source = FileSource.for_bulk_file_format(
-            ParquetColumnarRowInputFormat(Configuration(), row_type, 10, True, True),
-            parquet_file_name
+            ParquetColumnarRowInputFormat(row_type, Configuration(), 10, False, False),
+            self.parquet_file_name
         ).build()
         ds = self.env.from_source(source, WatermarkStrategy.no_watermarks(), 'parquet-source')
-        ds.map(PassThroughMapFunction()).add_sink(self.test_sink)
+        ds.map(lambda e: e).add_sink(self.test_sink)
 
 
-class PassThroughMapFunction(MapFunction):
+@unittest.skipIf(os.environ.get('HADOOP_CLASSPATH') is None,
+                 'Some Hadoop lib is needed for Parquet RowData format tests')
+class FileSinkParquetRowDataWriterTests(PyFlinkStreamingTestCase):
 
-    def map(self, value):
-        return value
+    def setUp(self):
+        super().setUp()
+        # NOTE: parallelism == 1 is required to keep the order of results
+        self.env.set_parallelism(1)
+        self.parquet_dir_name = tempfile.mkdtemp(dir=self.tempdir)
+
+    def test_parquet_row_data_basic_write(self):
+        os.environ['TZ'] = 'Asia/Shanghai'
+        row_type, row_type_info, data = _create_parquet_basic_row_and_data()
+        self._build_parquet_job(row_type, row_type_info, data)
+        self.env.execute('test_parquet_row_data_basic_write')
+        results = self._read_parquet_file()
+        _check_parquet_basic_results(self, results)
+
+    def test_parquet_row_data_array_write(self):
+        (
+            row_type,
+            row_type_info,
+            conversion_row_type_info,
+            data,
+        ) = _create_parquet_array_row_and_data()
+        self._build_parquet_job(row_type, row_type_info, data, conversion_row_type_info)
+        self.env.execute('test_parquet_row_data_array_write')
+        results = self._read_parquet_file()
+        _check_parquet_array_results(self, results)
+
+    def test_parquet_row_data_map_write(self):
+        row_type, row_type_info, data = _create_parquet_map_row_and_data()
+        self._build_parquet_job(row_type, row_type_info, data)
+        self.env.execute('test_parquet_row_data_map_write')
+        results = self._read_parquet_file()
+        _check_parquet_map_results(self, results)
+
+    def _build_parquet_job(
+        self,
+        row_type: RowType,
+        row_type_info: RowTypeInfo,
+        data: List[Row],
+        conversion_type_info: Optional[RowTypeInfo] = None,
+    ):
+        jvm = get_gateway().jvm
+        sink = FileSink.for_bulk_format(
+            self.parquet_dir_name, ParquetRowDataWriter.for_row_type(row_type, utc_timestamp=True)
+        ).build()
+        j_list = jvm.java.util.ArrayList()
+        for d in data:
+            j_list.add(to_java_data_structure(d))
+        ds = DataStream(self.env._j_stream_execution_environment.fromCollection(
+            j_list,
+            row_type_info.get_java_type_info()
+        ))
+        if conversion_type_info:
+            ds = ds.map(lambda e: e, output_type=conversion_type_info)
+        ds.sink_to(sink)
+
+    def _read_parquet_file(self):
+        records = []
+        for file in glob.glob(os.path.join(os.path.join(self.parquet_dir_name, '**/*'))):
+            df = pd.read_parquet(file)
+            for i in range(df.shape[0]):
+                records.append(df.loc[i])
+        return records
+
+
+def _write_row_data_to_parquet_file(path: str, row_type: RowType, rows: List[Row]):
+    jvm = get_gateway().jvm
+    flink = jvm.org.apache.flink
+
+    j_output_stream = flink.core.fs.local.LocalDataOutputStream(jvm.java.io.File(path))
+    constructor = get_java_class(flink.formats.parquet.StreamOutputFile).getDeclaredConstructor(
+        to_jarray(jvm.Class, [get_java_class(flink.core.fs.FSDataOutputStream)])
+    )
+    constructor.setAccessible(True)
+    j_output_file = constructor.newInstance(to_jarray(jvm.Object, [j_output_stream]))
+
+    j_parquet_writer = flink.formats.parquet.row.ParquetRowDataBuilder(
+        j_output_file, _to_java_data_type(row_type).getLogicalType(), False
+    ).build()
+    row_row_converter = flink.table.data.conversion.RowRowConverter.create(
+        _to_java_data_type(row_type)
+    )
+    row_row_converter.open(row_row_converter.getClass().getClassLoader())
+    for row in rows:
+        j_parquet_writer.write(
+            row_row_converter.toInternal(to_java_data_structure(row))
+        )
+    j_parquet_writer.close()
+
+
+def _create_parquet_basic_row_and_data() -> Tuple[RowType, RowTypeInfo, List[Row]]:
+    jvm = get_gateway().jvm
+    row_type = DataTypes.ROW([
+        DataTypes.FIELD('char', DataTypes.CHAR(10)),
+        DataTypes.FIELD('varchar', DataTypes.VARCHAR(10)),
+        DataTypes.FIELD('binary', DataTypes.BINARY(10)),
+        DataTypes.FIELD('varbinary', DataTypes.VARBINARY(10)),
+        DataTypes.FIELD('boolean', DataTypes.BOOLEAN()),
+        DataTypes.FIELD('decimal', DataTypes.DECIMAL(2, 0)),
+        DataTypes.FIELD('int', DataTypes.INT()),
+        DataTypes.FIELD('bigint', DataTypes.BIGINT()),
+        DataTypes.FIELD('double', DataTypes.DOUBLE()),
+        DataTypes.FIELD('date', DataTypes.DATE()),
+        DataTypes.FIELD('time', DataTypes.TIME()),
+        DataTypes.FIELD('timestamp', DataTypes.TIMESTAMP(3)),
+        DataTypes.FIELD('timestamp_ltz', DataTypes.TIMESTAMP_LTZ(3)),
+    ])
+    row_type_info = Types.ROW_NAMED(
+        ['char', 'varchar', 'binary', 'varbinary', 'boolean', 'decimal', 'int', 'bigint', 'double',
+         'date', 'time', 'timestamp', 'timestamp_ltz'],
+        [Types.STRING(), Types.STRING(), Types.PRIMITIVE_ARRAY(Types.BYTE()),
+         Types.PRIMITIVE_ARRAY(Types.BYTE()), Types.BOOLEAN(), Types.BIG_DEC(), Types.INT(),
+         Types.LONG(), Types.DOUBLE(), Types.JAVA(jvm.java.time.LocalDate),
+         Types.JAVA(jvm.java.time.LocalTime), Types.JAVA(jvm.java.time.LocalDateTime),
+         Types.INSTANT()]
+    )
+    data = [Row(
+        char='char',
+        varchar='varchar',
+        binary=b'binary',
+        varbinary=b'varbinary',
+        boolean=True,
+        decimal=Decimal(1.5),
+        int=2147483647,
+        bigint=-9223372036854775808,
+        double=2e-308,
+        date=date(1970, 1, 1),
+        time=time(1, 1, 1),
+        timestamp=datetime(1970, 1, 2, 3, 4, 5, 600000),
+        timestamp_ltz=datetime(1970, 2, 3, 4, 5, 6, 700000, tzinfo=pytz.timezone('UTC')),
+    )]
+    return row_type, row_type_info, data
+
+
+def _check_parquet_basic_results(test, results):
+    row = results[0]
+    test.assertEqual(row['char'], 'char')
+    test.assertEqual(row['varchar'], 'varchar')
+    test.assertEqual(row['binary'], b'binary')
+    test.assertEqual(row['varbinary'], b'varbinary')
+    test.assertEqual(row['boolean'], True)
+    test.assertAlmostEqual(row['decimal'], 2)
+    test.assertEqual(row['int'], 2147483647)
+    test.assertEqual(row['bigint'], -9223372036854775808)
+    test.assertAlmostEqual(row['double'], 2e-308, delta=1e-311)
+    test.assertEqual(row['date'], date(1970, 1, 1))
+    test.assertEqual(row['time'], time(1, 1, 1))
+    ts = row['timestamp']
+    if isinstance(ts, pd.Timestamp):
+        ts = ts.to_pydatetime()
+    test.assertEqual(ts, datetime(1970, 1, 2, 3, 4, 5, 600000))
+    ts_ltz = row['timestamp_ltz']
+    if isinstance(ts_ltz, pd.Timestamp):
+        ts_ltz = pytz.timezone('Asia/Shanghai').localize(ts_ltz.to_pydatetime())
+    test.assertEqual(
+        ts_ltz,
+        pytz.timezone('Asia/Shanghai').localize(datetime(1970, 2, 3, 12, 5, 6, 700000))
+    )
+
+
+def _create_parquet_array_row_and_data() -> Tuple[RowType, RowTypeInfo, RowTypeInfo, List[Row]]:
+    row_type = DataTypes.ROW([
+        DataTypes.FIELD('string_array', DataTypes.ARRAY(DataTypes.STRING())),
+        DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT())),
+    ])
+    row_type_info = Types.ROW_NAMED([
+        'string_array',
+        'int_array',
+    ], [
+        Types.LIST(Types.STRING()),
+        Types.LIST(Types.INT()),
+    ])
+    conversion_row_type_info = Types.ROW_NAMED([
+        'string_array',
+        'int_array',
+    ], [
+        Types.OBJECT_ARRAY(Types.STRING()),
+        Types.OBJECT_ARRAY(Types.INT()),
+    ])
+    data = [Row(
+        string_array=['a', 'b', 'c'],
+        int_array=[1, 2, 3],
+    )]
+    return row_type, row_type_info, conversion_row_type_info, data
+
+
+def _check_parquet_array_results(test, results):
+    row = results[0]
+    test.assertEqual(row['string_array'][0], 'a')
+    test.assertEqual(row['string_array'][1], 'b')
+    test.assertEqual(row['string_array'][2], 'c')
+    test.assertEqual(row['int_array'][0], 1)
+    test.assertEqual(row['int_array'][1], 2)
+    test.assertEqual(row['int_array'][2], 3)
+
+
+def _create_parquet_map_row_and_data() -> Tuple[RowType, RowTypeInfo, List[Row]]:
+    row_type = DataTypes.ROW([
+        DataTypes.FIELD('map', DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())),
+    ])
+    row_type_info = Types.ROW_NAMED(['map'], [Types.MAP(Types.INT(), Types.STRING())])
+    data = [Row(
+        map={0: 'a', 1: 'b', 2: 'c'}
+    )]
+    return row_type, row_type_info, data
+
+
+def _check_parquet_map_results(test, results):
+    m = {k: v for k, v in results[0]['map']}
+    test.assertEqual(m[0], 'a')
+    test.assertEqual(m[1], 'b')
+    test.assertEqual(m[2], 'c')

--- a/flink-python/pyflink/datastream/formats/tests/test_parquet.py
+++ b/flink-python/pyflink/datastream/formats/tests/test_parquet.py
@@ -253,6 +253,8 @@ class FileSinkParquetBulkWriterTests(PyFlinkStreamingTestCase):
         results = self._read_parquet_file()
         _check_parquet_array_results(self, results)
 
+    @unittest.skip('ParquetSchemaConverter in flink-parquet annotate map keys as optional, but '
+                   'Arrow restricts them to be required')
     def test_parquet_row_data_map_write(self):
         row_type, row_type_info, data = _create_parquet_map_row_and_data()
         self._build_parquet_job(row_type, row_type_info, data)

--- a/flink-python/pyflink/datastream/utils.py
+++ b/flink-python/pyflink/datastream/utils.py
@@ -20,7 +20,7 @@ import datetime
 import pickle
 from abc import abstractmethod
 
-from pyflink.common import Row, RowKind
+from pyflink.common import Row, RowKind, Configuration
 from pyflink.common.typeinfo import (RowTypeInfo, TupleTypeInfo, Types, BasicArrayTypeInfo,
                                      PrimitiveArrayTypeInfo, MapTypeInfo, ListTypeInfo,
                                      ObjectArrayTypeInfo, ExternalTypeInfo, TypeInformation)
@@ -41,6 +41,14 @@ class JavaObjectWrapper(object):
 
     def get_java_object(self):
         return self._j_object
+
+
+def create_hadoop_configuration(config: Configuration):
+    jvm = get_gateway().jvm
+    hadoop_config = jvm.org.apache.hadoop.conf.Configuration()
+    for k, v in config.to_dict().items():
+        hadoop_config.set(k, v)
+    return hadoop_config
 
 
 def convert_to_python_obj(data, type_info):

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -725,13 +725,17 @@ def from_type_info_proto(type_info):
             return RowCoder(
                 [from_type_info_proto(f.field_type) for f in type_info.row_type_info.fields],
                 [f.field_name for f in type_info.row_type_info.fields])
-        elif field_type_name == type_info_name.PRIMITIVE_ARRAY:
+        elif field_type_name in (
+            type_info_name.PRIMITIVE_ARRAY,
+            type_info_name.LIST,
+        ):
             if type_info.collection_element_type.type_name == type_info_name.BYTE:
                 return BinaryCoder()
             return PrimitiveArrayCoder(from_type_info_proto(type_info.collection_element_type))
-        elif field_type_name in (type_info_name.BASIC_ARRAY,
-                                 type_info_name.OBJECT_ARRAY,
-                                 type_info_name.LIST):
+        elif field_type_name in (
+            type_info_name.BASIC_ARRAY,
+            type_info_name.OBJECT_ARRAY,
+        ):
             return GenericArrayCoder(from_type_info_proto(type_info.collection_element_type))
         elif field_type_name == type_info_name.TUPLE:
             return TupleCoder([from_type_info_proto(field_type)

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/PythonTypeUtils.java
@@ -418,7 +418,7 @@ public class PythonTypeUtils {
                 InternalTypeInfo<?> internalTypeInfo, ClassLoader userClassLoader) {
             ArrayType arrayType = (ArrayType) internalTypeInfo.toLogicalType();
             return FlinkFnApi.TypeInfo.newBuilder()
-                    .setTypeName(FlinkFnApi.TypeInfo.TypeName.LIST)
+                    .setTypeName(FlinkFnApi.TypeInfo.TypeName.OBJECT_ARRAY)
                     .setCollectionElementType(
                             toTypeInfoProto(
                                     InternalTypeInfo.of(arrayType.getElementType()),


### PR DESCRIPTION

## What is the purpose of the change

This PR supports `ParquetRowDataWriter.for_row_type` API in PyFlink, to create a `BulkWriterFactory` that writes `Row` records into Parquet files in a batch fashion.


## Verifying this change

This change added tests and can be verified as follows:

- `FileSinkParquetRowDataWriterTests` in test_parquet.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (Python Sphinx doc)
