### PR TITLE
[FLINK-28870][Connector/Pulsar] Improve the Pulsar source performance when meeting small data source

### DIFF
--- a/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/optimizer_config_configuration.html
@@ -30,6 +30,12 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td>Tells the optimizer whether to split distinct aggregation (e.g. COUNT(DISTINCT col), SUM(DISTINCT col)) into two level. The first aggregation is shuffled by an additional key which is calculated using the hashcode of distinct_key and number of buckets. This optimization is very useful when there is data skew in distinct aggregation and gives the ability to scale-up the job. Default is false.</td>
         </tr>
         <tr>
+            <td><h5>table.optimizer.dynamic-filtering.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>When it is true, the optimizer will try to push dynamic filtering into scan table source, the irrelevant partitions or input data will be filtered to reduce scan I/O in runtime.</td>
+        </tr>
+        <tr>
             <td><h5>table.optimizer.join-reorder-enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -76,12 +82,6 @@ ONE_PHASE: Enforce to use one stage aggregate which only has CompleteGlobalAggre
             <td style="word-wrap: break-word;">true</td>
             <td>Boolean</td>
             <td>When it is true, the optimizer will collect and use the statistics from source connectors if the source extends from SupportsStatisticReport and the statistics from catalog is UNKNOWN.Default value is true.</td>
-        </tr>
-        <tr>
-            <td><h5>table.optimizer.dynamic-filtering.enabled</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>When it is true, the optimizer will try to push dynamic filtering into scan table source, the irrelevant partitions or input data will be filtered to reduce scan I/O in runtime.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
+++ b/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
@@ -15,6 +15,12 @@
             <td>This option is used only when the user disables the checkpoint and uses Exclusive or Failover subscription. We would automatically commit the cursor using the given period (in ms).</td>
         </tr>
         <tr>
+            <td><h5>pulsar.source.defaultFetchTime</h5></td>
+            <td style="word-wrap: break-word;">100</td>
+            <td>Long</td>
+            <td>The time (in ms) for fetching messages from Pulsar. If time exceed and no message returned from Pulsar. We would consider there is no record at the current topic and stop fetch until next switch.</td>
+        </tr>
+        <tr>
             <td><h5>pulsar.source.enableAutoAcknowledgeMessage</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceOptions.java
@@ -147,6 +147,14 @@ public final class PulsarSourceOptions {
     public static final ConfigOption<Long> PULSAR_TRANSACTION_TIMEOUT_MILLIS =
             PULSAR_READ_TRANSACTION_TIMEOUT;
 
+    public static final ConfigOption<Long> PULSAR_DEFAULT_FETCH_TIME =
+            ConfigOptions.key(SOURCE_CONFIG_PREFIX + "defaultFetchTime")
+                    .longType()
+                    .defaultValue(100L)
+                    .withDescription(
+                            "The time (in ms) for fetching messages from Pulsar. If time exceed and no message returned from Pulsar."
+                                    + " We would consider there is no record at the current topic and stop fetch until next switch.");
+
     public static final ConfigOption<Long> PULSAR_MAX_FETCH_TIME =
             ConfigOptions.key(SOURCE_CONFIG_PREFIX + "maxFetchTime")
                     .longType()

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/SourceConfiguration.java
@@ -35,6 +35,7 @@ import java.util.Objects;
 
 import static org.apache.flink.connector.base.source.reader.SourceReaderOptions.ELEMENT_QUEUE_CAPACITY;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_AUTO_COMMIT_CURSOR_INTERVAL;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_DEFAULT_FETCH_TIME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_RECORDS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_TIME;
@@ -55,6 +56,7 @@ public class SourceConfiguration extends PulsarConfiguration {
     private final boolean enableAutoAcknowledgeMessage;
     private final long autoCommitCursorInterval;
     private final long transactionTimeoutMillis;
+    private final Duration defaultFetchTime;
     private final Duration maxFetchTime;
     private final int maxFetchRecords;
     private final CursorVerification verifyInitialOffsets;
@@ -70,6 +72,7 @@ public class SourceConfiguration extends PulsarConfiguration {
         this.enableAutoAcknowledgeMessage = get(PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE);
         this.autoCommitCursorInterval = get(PULSAR_AUTO_COMMIT_CURSOR_INTERVAL);
         this.transactionTimeoutMillis = get(PULSAR_READ_TRANSACTION_TIMEOUT);
+        this.defaultFetchTime = get(PULSAR_DEFAULT_FETCH_TIME, Duration::ofMillis);
         this.maxFetchTime = get(PULSAR_MAX_FETCH_TIME, Duration::ofMillis);
         this.maxFetchRecords = get(PULSAR_MAX_FETCH_RECORDS);
         this.verifyInitialOffsets = get(PULSAR_VERIFY_INITIAL_OFFSETS);
@@ -125,6 +128,14 @@ public class SourceConfiguration extends PulsarConfiguration {
      */
     public long getTransactionTimeoutMillis() {
         return transactionTimeoutMillis;
+    }
+
+    /**
+     * The fetch time for polling one message. We would stop polling message and return the message
+     * in {@link RecordsWithSplitIds} when timeout and no message consumed.
+     */
+    public Duration getDefaultFetchTime() {
+        return defaultFetchTime;
     }
 
     /**
@@ -205,8 +216,9 @@ public class SourceConfiguration extends PulsarConfiguration {
                 && enableAutoAcknowledgeMessage == that.enableAutoAcknowledgeMessage
                 && autoCommitCursorInterval == that.autoCommitCursorInterval
                 && transactionTimeoutMillis == that.transactionTimeoutMillis
-                && maxFetchRecords == that.maxFetchRecords
+                && Objects.equals(defaultFetchTime, that.defaultFetchTime)
                 && Objects.equals(maxFetchTime, that.maxFetchTime)
+                && maxFetchRecords == that.maxFetchRecords
                 && verifyInitialOffsets == that.verifyInitialOffsets
                 && Objects.equals(subscriptionName, that.subscriptionName)
                 && subscriptionType == that.subscriptionType
@@ -221,6 +233,7 @@ public class SourceConfiguration extends PulsarConfiguration {
                 enableAutoAcknowledgeMessage,
                 autoCommitCursorInterval,
                 transactionTimeoutMillis,
+                defaultFetchTime,
                 maxFetchTime,
                 maxFetchRecords,
                 verifyInitialOffsets,

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
@@ -104,15 +104,14 @@ abstract class PulsarPartitionSplitReaderBase<OUT>
         PulsarMessageCollector<OUT> collector = new PulsarMessageCollector<>(splitId, builder);
         Deadline deadline = Deadline.fromNow(sourceConfiguration.getMaxFetchTime());
 
-        // Consume message from pulsar until it was woke up by flink reader.
+        // Consume messages from pulsar until it was waked up by flink reader.
         for (int messageNum = 0;
                 messageNum < sourceConfiguration.getMaxFetchRecords()
                         && deadline.hasTimeLeft()
                         && isNotWakeup();
                 messageNum++) {
             try {
-                Duration timeout = deadline.timeLeftIfAny();
-                Message<byte[]> message = pollMessage(timeout);
+                Message<byte[]> message = pollMessage(sourceConfiguration.getDefaultFetchTime());
                 if (message == null) {
                     break;
                 }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StopCursorTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StopCursorTest.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_DEFAULT_FETCH_TIME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_RECORDS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_TIME;
@@ -97,7 +98,8 @@ public class StopCursorTest extends PulsarTestSuiteBase {
     private SourceConfiguration sourceConfig() {
         Configuration config = operator().config();
         config.set(PULSAR_MAX_FETCH_RECORDS, 1);
-        config.set(PULSAR_MAX_FETCH_TIME, 1000L);
+        config.set(PULSAR_DEFAULT_FETCH_TIME, 2000L);
+        config.set(PULSAR_MAX_FETCH_TIME, 3000L);
         config.set(PULSAR_SUBSCRIPTION_NAME, randomAlphabetic(10));
         config.set(PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE, true);
         return new SourceConfiguration(config);

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderTestBase.java
@@ -60,6 +60,7 @@ import java.util.Random;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_DEFAULT_FETCH_TIME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_RECORDS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_TIME;
@@ -130,7 +131,8 @@ abstract class PulsarSourceReaderTestBase extends PulsarTestSuiteBase {
             boolean autoAcknowledgementEnabled, SubscriptionType subscriptionType) {
         Configuration configuration = operator().config();
         configuration.set(PULSAR_MAX_FETCH_RECORDS, 1);
-        configuration.set(PULSAR_MAX_FETCH_TIME, 1000L);
+        configuration.set(PULSAR_DEFAULT_FETCH_TIME, 2000L);
+        configuration.set(PULSAR_MAX_FETCH_TIME, 3000L);
         configuration.set(PULSAR_SUBSCRIPTION_NAME, randomAlphabetic(10));
         configuration.set(PULSAR_SUBSCRIPTION_TYPE, subscriptionType);
         if (autoAcknowledgementEnabled

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderTestBase.java
@@ -63,6 +63,7 @@ import static java.util.Collections.singletonList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyAdmin;
 import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyThrow;
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_DEFAULT_FETCH_TIME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_RECORDS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_MAX_FETCH_TIME;
@@ -96,7 +97,8 @@ public abstract class PulsarPartitionSplitReaderTestBase extends PulsarTestSuite
     private SourceConfiguration sourceConfig() {
         Configuration config = operator().config();
         config.set(PULSAR_MAX_FETCH_RECORDS, 1);
-        config.set(PULSAR_MAX_FETCH_TIME, 1000L);
+        config.set(PULSAR_DEFAULT_FETCH_TIME, 2000L);
+        config.set(PULSAR_MAX_FETCH_TIME, 3000L);
         config.set(PULSAR_SUBSCRIPTION_NAME, randomAlphabetic(10));
         config.set(PULSAR_ENABLE_AUTO_ACKNOWLEDGE_MESSAGE, true);
 


### PR DESCRIPTION
## What is the purpose of the change

When using Pulsar Source to consume data, if the data rate is small, e.g. 2 msg/s, there will be long periods of time when no messages are consumed.

This is caused by the default `PulsarSourceOptions.PULSAR_MAX_FETCH_TIME` and `PulsarSourceOptions.PULSAR_MAX_FETCH_RECORDS` options. Pulsar Source will try to pull messages until any conditions exceed. Such as fetch until 100 messages or fetch 10 seconds.

We have to add a new fetch time option for Pulsar Source. We would consider there is no message on the current topic if this fetch time exceeds. This would make sure the source would stop fetching messages when the 100ms exceed. Avoid hanging on small message income rates.

## Brief change log

  - Add new `PulsarSourceOptions.PULSAR_DEFAULT_FETCH_TIME` option.
  - Change the polling timeout to `PulsarSourceOptions.PULSAR_DEFAULT_FETCH_TIME`.

## Verifying this change

This change is already covered by existing tests, such as *PulsarOrderedPartitionSplitReaderTest*, *PulsarUnorderedPartitionSplitReaderTest*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
