### PR TITLE
[FLINK-28874][Tests] Use maven wrapper in run_mvn

### DIFF
--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -16,7 +16,7 @@
 
 # Utility for invoking Maven in CI
 function run_mvn {
-	MVN_CMD="mvn"
+	MVN_CMD="./mvnw"
 	if [[ "$M2_HOME" != "" ]]; then
 		MVN_CMD="${M2_HOME}/bin/mvn"
 	fi


### PR DESCRIPTION

## What is the purpose of the change

This PR makes `maven-utils` script using maven wrapper to avoid issues when new maven (e.g. locally installed) blocks http repo


## Brief change log

maven-utils.sh


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no )
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
