### PR TITLE
[FLINK-28027][connectors/async-sink] Implement slow start strategy fo…

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
@@ -291,7 +291,7 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
                         INFLIGHT_MESSAGES_LIMIT_INCREASE_RATE,
                         INFLIGHT_MESSAGES_LIMIT_DECREASE_FACTOR,
                         maxBatchSize * maxInFlightRequests,
-                        maxBatchSize * maxInFlightRequests);
+                        INFLIGHT_MESSAGES_LIMIT_INCREASE_RATE);
 
         this.metrics = context.metricGroup();
         this.metrics.setCurrentSendTimeGauge(() -> this.ackTime - this.lastSendTimestamp);


### PR DESCRIPTION
## What is the purpose of the change

Implement slow start strategy for AIMD to avoid overloading destination on initialization.

## Brief change log

Adapt initialization of the AIMD strategy to set the maximum initial rate to a low number rather than starting with the theoretical maximum.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as `testInitialRateIsSetByConstructor`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes (during initialization of the sink)
  - Anything that affects deployment or recovery: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
