### PR TITLE
[FLINK-28815][docs] Translate the Real Time Reporting with the Table API page into Chinese

### DIFF
--- a/docs/content.zh/docs/try-flink/datastream.md
+++ b/docs/content.zh/docs/try-flink/datastream.md
@@ -111,9 +111,9 @@ $ mvn archetype:generate \
 
 {{< unstable >}}
 {{< hint warning >}}
-    Maven 3.0 及更高版本，不再支持通过命令行指定仓库（-DarchetypeCatalog）。有关这个改动的详细信息，
-    请参阅 [Maven 官方文档](http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html)
-    如果你希望使用快照仓库，则需要在 settings.xml 文件中添加一个仓库条目。例如：
+Maven 3.0 及更高版本，不再支持通过命令行指定仓库（-DarchetypeCatalog）。有关这个改动的详细信息，
+请参阅 [Maven 官方文档](http://maven.apache.org/archetype/maven-archetype-plugin/archetype-repository.html)
+如果你希望使用快照仓库，则需要在 settings.xml 文件中添加一个仓库条目。例如：
 ```xml
 <settings>
   <activeProfiles>

--- a/docs/content.zh/docs/try-flink/table_api.md
+++ b/docs/content.zh/docs/try-flink/table_api.md
@@ -184,7 +184,7 @@ EnvironmentSettings settings = EnvironmentSettings.inBatchMode();
 TableEnvironment tEnv = TableEnvironment.create(settings); 
 ```
 
-提供批流统一的语义是 Flink 的特性，这意味着应用的开发和测试可以在批模式下使用静态数据集完成，而实际部署到生产时再切换为流式。
+提供批流统一的语义是 Flink 的重要特性，这意味着应用的开发和测试可以在批模式下使用静态数据集完成，而实际部署到生产时再切换为流式。
 
 ## 尝试下
 
@@ -214,7 +214,7 @@ public static Table report(Table transactions) {
 ## 用户自定义函数
 
 Flink 内置的函数是有限的，有时是需要通过 [用户自定义函数]({{< ref "docs/dev/table/functions/udfs" >}})来拓展这些函数。
-假如没有预设好的 `floor` 函数，也可以自己实现一个。
+假如 `floor` 函数不是系统预设函数，也可以自己实现。
 
 ```java
 import java.time.LocalDateTime;
@@ -254,9 +254,9 @@ public static Table report(Table transactions) {
 
 ## 添加窗口函数
 
-在数据处理中，按照时间做分组是一个典型的操作，尤其是在处理无限流时。
+在数据处理中，按照时间做分组是常见操作，在处理无限流时更是如此。
 按时间分组的函数叫 [window]({{< ref "docs/dev/datastream/operators/windows" >}})，Flink 提供了灵活的窗口函数语法。
-最常见的窗口是 `Tumble` ，此窗口固定窗口区间并且每个区间都不重叠。
+最常见的窗口是 `Tumble` ，窗口区间长度固定，并且区间不重叠。
 
 ```java
 public static Table report(Table transactions) {
@@ -270,8 +270,8 @@ public static Table report(Table transactions) {
 }
 ```
 
-上面的代码含义为：应用使用滚动窗口，窗口按照指定的时间戳字段划分，区间为一小时。
-所以，时间戳为 `2019-06-01 01:23:47` 的行会进入窗口 `2019-06-01 01:00:00`中。
+上面的代码含义为：使用滚动窗口，窗口按照指定的时间戳字段划分，区间为一小时。
+比如，时间戳为 `2019-06-01 01:23:47` 的行会进入窗口 `2019-06-01 01:00:00`中。
 
 不同于其他属性，时间在一个持续不断的流式应用中总是向前移动，因此基于时间的聚合总是不重复的。
 
@@ -282,8 +282,8 @@ public static Table report(Table transactions) {
 
 ## 再用流式处理一次！
 
-这次的编写的应用是一个功能齐全、有状态的分布式流式应用！
-查询语句持续消费 Kafka 中流式的交易数据，然后计算每小时的消费，最后当窗口结束时立刻提交结果。
+这次编写的应用是一个功能齐全、有状态的分布式流式应用！
+查询语句持续消费 Kafka 中交易数据流，然后计算每小时的消费，最后当窗口结束时立刻提交结果。
 由于输入是无边界的，停止作业需要手工操作。
 同时，由于作业使用了窗口函数，Flink 会执行一些特定的优化，例如当框架检测出窗口结束时，清理状态数据。
 

--- a/docs/content.zh/docs/try-flink/table_api.md
+++ b/docs/content.zh/docs/try-flink/table_api.md
@@ -111,8 +111,8 @@ report(transactions).executeInsert("spend_report");
 
 #### 执行环境
 
-前两行创建的是 `TableEnvironment`（表环境）。
-通过表环境，你可以设置作业属性，定义应用的批流模式，以及创建数据源。
+前两行代码创建了 `TableEnvironment`（表环境）。
+创建表环境时，你可以设置作业属性，定义应用的批流模式，以及创建数据源。
 我们先创建一个标准的表环境，并选择流式执行器。
 
 ```java
@@ -166,7 +166,7 @@ tEnv.executeSql("CREATE TABLE spend_report (\n" +
 #### 查询数据
 
 配置好环境并注册好表后，你就可以开始开发你的第一个应用了。
-通过 `TableEnvironment` ，你可以 `from` 输入表读取数据，然后将结果调用 `executeInsert` 写入到输出表。
+通过 `TableEnvironment` 实例 ，你可以使用函数 `from` 从输入表读取数据，然后将结果调用 `executeInsert` 写入到输出表。
 函数 `report` 用于实现具体的业务逻辑，这里暂时未实现。
 
 ```java
@@ -191,7 +191,7 @@ TableEnvironment tEnv = TableEnvironment.create(settings);
 在作业拉起来的大体处理框架下，你可以再添加一些业务逻辑。
 现在的目标是创建一个报表，报表按照账户显示一天中每个小时的总支出。因此，毫秒粒度的时间戳字段需要向下舍入到小时。 
 
-Flink 支持纯 [SQL]({{< ref "docs/dev/table/sql/overview" >}}) 或者 [Table API]({{< ref "docs/dev/table/tableApi" >}}) 开发关系型数据应用。
+Flink 支持使用纯 [SQL]({{< ref "docs/dev/table/sql/overview" >}}) 或者 [Table API]({{< ref "docs/dev/table/tableApi" >}}) 开发关系型数据应用。
 
 其中，Table API 是受 SQL 启发设计出的一套链式 DSL，可以用 Python、Java 或者 Scala 开发，在 IDE 中也集成的很好。
 同时也如 SQL 查询一样，Table 应用可以按列查询，或者按列分组。
@@ -211,7 +211,7 @@ public static Table report(Table transactions) {
 }
 ```
 
-## 用户定义函数
+## 用户自定义函数
 
 Flink 内置的函数是有限的，有时是需要通过 [用户自定义函数]({{< ref "docs/dev/table/functions/udfs" >}})来拓展这些函数。
 假如没有预设好的 `floor` 函数，也可以自己实现一个。


### PR DESCRIPTION
## What is the purpose of the change

Improve the docs in chinese. 

## Brief change log

- **Translate the "Real Time Reporting with the Table API" page into Chinese**
- **This also fixed a typo on page "Fraud Detection with the DataStream API" in chinese**


## Verifying this change

No test cases.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( yes )
  - If yes, how is the feature documented? ( docs )
