### PR TITLE
[FLINK-27856][flink-kubernetes]solve the NPE error of no spec field in taskmanager pod template.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -430,7 +430,7 @@ public class KubernetesUtils {
             }
             pod.getInternalResource().getSpec().setContainers(otherContainers);
         } else {
-            // Set empty spec for taskmanager pod template
+            // Set an empty spec for pod template
             pod.getInternalResource().setSpec(new PodSpecBuilder().build());
         }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesPodTemplateTestUtils.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesPodTemplateTestUtils.java
@@ -45,11 +45,23 @@ public class KubernetesPodTemplateTestUtils {
 
     private static final String TESTING_TEMPLATE_FILE_NAME = "testing-pod-template.yaml";
 
+    private static final String TESTING_NO_SPEC_TEMPLATE_FILE_NAME =
+            "testing-nospec-pod-template.yaml";
+
     public static File getPodTemplateFile() {
         final URL podTemplateUrl =
                 KubernetesPodTemplateTestUtils.class
                         .getClassLoader()
                         .getResource(TESTING_TEMPLATE_FILE_NAME);
+        assertThat(podTemplateUrl).isNotNull();
+        return new File(podTemplateUrl.getPath());
+    }
+
+    public static File getNoSpecPodTemplateFile() {
+        final URL podTemplateUrl =
+                KubernetesPodTemplateTestUtils.class
+                        .getClassLoader()
+                        .getResource(TESTING_NO_SPEC_TEMPLATE_FILE_NAME);
         assertThat(podTemplateUrl).isNotNull();
         return new File(podTemplateUrl.getPath());
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/utils/KubernetesUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/utils/KubernetesUtilsTest.java
@@ -83,6 +83,17 @@ class KubernetesUtilsTest extends KubernetesTestBase {
     }
 
     @Test
+    void testLoadPodFromNoSpecTemplate() {
+        final FlinkPod flinkPod =
+                KubernetesUtils.loadPodFromTemplateFile(
+                        flinkKubeClient,
+                        KubernetesPodTemplateTestUtils.getNoSpecPodTemplateFile(),
+                        KubernetesPodTemplateTestUtils.TESTING_MAIN_CONTAINER_NAME);
+        assertThat(flinkPod.getMainContainer()).isEqualTo(EMPTY_POD.getMainContainer());
+        assertThat(flinkPod.getPodWithoutMainContainer().getSpec().getContainers()).hasSize(0);
+    }
+
+    @Test
     void testLoadPodFromTemplateWithNonExistPathShouldFail() {
         final String nonExistFile = "/path/of/non-exist.yaml";
         final String msg = String.format("Pod template file %s does not exist.", nonExistFile);

--- a/flink-kubernetes/src/test/resources/testing-nospec-pod-template.yaml
+++ b/flink-kubernetes/src/test/resources/testing-nospec-pod-template.yaml
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-template-no-spec
+  annotations:
+    a1: v1-pod-template
+    annotation-key-of-pod-template: annotation-value-of-pod-template
+  labels:
+    label1: value1-pod-template
+    label-key-of-pod-template: label-value-of-pod-template


### PR DESCRIPTION
## What is the purpose of the change

This pull request fix the NPE error of TM pod template file without spec field.

## Brief change log
Add validation for TM pod template file spec field.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:
  - Added test that validates TM pod template without spec field: `KubernetesUtilsTest.testLoadPodFromNoSpecTemplate`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes(fixed the JM crash on kubernetes when tm pod template file without spec field.)

## Documentation

  - Does this pull request introduce a new feature? no
