### PR TITLE
[kinesis][glue] Updating AWS SDK dependencies to latest versions 

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -33,10 +33,10 @@ under the License.
 	<artifactId>flink-connector-kinesis_${scala.binary.version}</artifactId>
 	<name>Flink : Connectors : Kinesis</name>
 	<properties>
-		<aws.sdk.version>1.12.7</aws.sdk.version>
-		<aws.sdkv2.version>2.16.86</aws.sdkv2.version>
-		<aws.kinesis-kcl.version>1.11.2</aws.kinesis-kcl.version>
-		<aws.kinesis-kpl.version>0.14.0</aws.kinesis-kpl.version>
+		<aws.sdk.version>1.12.276</aws.sdk.version>
+		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
+		<aws.kinesis-kcl.version>1.14.8</aws.kinesis-kcl.version>
+		<aws.kinesis-kpl.version>0.14.1</aws.kinesis-kpl.version>
 		<aws.dynamodbstreams-kinesis-adapter.version>1.5.3</aws.dynamodbstreams-kinesis-adapter.version>
 		<httpclient.version>4.5.9</httpclient.version>
 		<httpcore.version>4.4.11</httpcore.version>
@@ -44,6 +44,31 @@ under the License.
 	</properties>
 
 	<packaging>jar</packaging>
+
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-bom</artifactId>
+				<version>${aws.sdk.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>${aws.sdkv2.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.httpcomponents</groupId>
+				<artifactId>httpclient</artifactId>
+				<version>4.5.9</version>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
 
 	<dependencies>
 		<!-- AWS dependencies -->
@@ -58,32 +83,26 @@ under the License.
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-kinesis</artifactId>
-			<version>${aws.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-sts</artifactId>
-			<version>${aws.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-kms</artifactId>
-			<version>${aws.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-s3</artifactId>
-			<version>${aws.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-dynamodb</artifactId>
-			<version>${aws.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-cloudwatch</artifactId>
-			<version>${aws.sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>
@@ -196,19 +215,16 @@ under the License.
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>kinesis</artifactId>
-			<version>${aws.sdkv2.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>netty-nio-client</artifactId>
-			<version>${aws.sdkv2.version}</version>
 		</dependency>
 
 		<dependency>
 			<groupId>software.amazon.awssdk</groupId>
 			<artifactId>sts</artifactId>
-			<version>${aws.sdkv2.version}</version>
 		</dependency>
 
 		<dependency>
@@ -228,18 +244,6 @@ under the License.
 		</dependency>
 
 	</dependencies>
-
-	<dependencyManagement>
-		<dependencies>
-
-			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>4.5.9</version>
-			</dependency>
-
-		</dependencies>
-	</dependencyManagement>
 
 	<build>
 		<plugins>

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxy.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxy.java
@@ -23,8 +23,7 @@ import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ClientConfigurationFactory;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
+import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.services.dynamodbv2.streamsadapter.AmazonDynamoDBStreamsAdapterClient;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.model.DescribeStreamResult;
@@ -91,8 +90,7 @@ public class DynamoDBStreamsProxy extends KinesisProxy {
         if (configProps.containsKey(AWS_ENDPOINT)) {
             adapterClient.setEndpoint(configProps.getProperty(AWS_ENDPOINT));
         } else {
-            adapterClient.setRegion(
-                    Region.getRegion(Regions.fromName(configProps.getProperty(AWS_REGION))));
+            adapterClient.setRegion(RegionUtils.getRegion(configProps.getProperty(AWS_REGION)));
         }
 
         return adapterClient;

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -102,8 +102,7 @@ public class AWSUtil {
                             configProps.getProperty(AWSConfigConstants.AWS_ENDPOINT),
                             configProps.getProperty(AWSConfigConstants.AWS_REGION)));
         } else {
-            builder.withRegion(
-                    Regions.fromName(configProps.getProperty(AWSConfigConstants.AWS_REGION)));
+            builder.withRegion(configProps.getProperty(AWSConfigConstants.AWS_REGION));
         }
         return builder.build();
     }

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -6,55 +6,60 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt) 
 
-- com.amazonaws:amazon-kinesis-client:1.11.2
-- com.amazonaws:amazon-kinesis-producer:0.14.0
-- com.amazonaws:aws-java-sdk-core:1.12.7
-- com.amazonaws:aws-java-sdk-dynamodb:1.12.7
-- com.amazonaws:aws-java-sdk-kinesis:1.12.7
-- com.amazonaws:aws-java-sdk-kms:1.12.7
-- com.amazonaws:aws-java-sdk-s3:1.12.7
-- com.amazonaws:aws-java-sdk-sts:1.12.7
+- com.amazonaws:amazon-kinesis-client:1.14.8
+- com.amazonaws:amazon-kinesis-producer:0.14.1
+- com.amazonaws:aws-java-sdk-core:1.12.276
+- com.amazonaws:aws-java-sdk-dynamodb:1.12.276
+- com.amazonaws:aws-java-sdk-kinesis:1.12.276
+- com.amazonaws:aws-java-sdk-kms:1.12.276
+- com.amazonaws:aws-java-sdk-s3:1.12.276
+- com.amazonaws:aws-java-sdk-sts:1.12.276
+- com.amazonaws:aws-java-sdk-cloudwatch:1.12.276
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.3
-- com.amazonaws:jmespath-java:1.12.7
+- com.amazonaws:jmespath-java:1.12.276
 - com.amazonaws:aws-java-sdk-cloudwatch:1.12.7
 - org.apache.httpcomponents:httpclient:4.5.9
 - org.apache.httpcomponents:httpcore:4.4.11
 - software.amazon.ion:ion-java:1.0.2
-- software.amazon.awssdk:kinesis:2.16.86
-- software.amazon.awssdk:aws-cbor-protocol:2.16.86
-- software.amazon.awssdk:aws-json-protocol:2.16.86
-- software.amazon.awssdk:protocol-core:2.16.86
-- software.amazon.awssdk:profiles:2.16.86
-- software.amazon.awssdk:sdk-core:2.16.86
-- software.amazon.awssdk:auth:2.16.86
+- software.amazon.awssdk:kinesis:2.17.247
+- software.amazon.awssdk:aws-cbor-protocol:2.17.247
+- software.amazon.awssdk:aws-json-protocol:2.17.247
+- software.amazon.awssdk:third-party-jackson-dataformat-cbor:2.17.247
+- software.amazon.awssdk:third-party-jackson-core:2.17.247
+- software.amazon.awssdk:protocol-core:2.17.247
+- software.amazon.awssdk:profiles:2.17.247
+- software.amazon.awssdk:sdk-core:2.17.247
+- software.amazon.awssdk:auth:2.17.247
 - software.amazon.eventstream:eventstream:1.0.1
-- software.amazon.awssdk:http-client-spi:2.16.86
-- software.amazon.awssdk:regions:2.16.86
-- software.amazon.awssdk:annotations:2.16.86
-- software.amazon.awssdk:utils:2.16.86
-- software.amazon.awssdk:aws-core:2.16.86
-- software.amazon.awssdk:metrics-spi:2.16.86
-- software.amazon.awssdk:apache-client:2.16.86
-- software.amazon.awssdk:netty-nio-client:2.16.86
-- software.amazon.awssdk:sts:2.16.86
-- software.amazon.awssdk:aws-query-protocol:2.16.86
-- io.netty:netty-codec-http:4.1.63.Final
-- io.netty:netty-codec-http2:4.1.63.Final
-- io.netty:netty-codec:4.1.63.Final
-- io.netty:netty-transport:4.1.63.Final
-- io.netty:netty-resolver:4.1.63.Final
-- io.netty:netty-common:4.1.63.Final
-- io.netty:netty-buffer:4.1.63.Final
-- io.netty:netty-handler:4.1.63.Final
-- io.netty:netty-transport-native-epoll:linux-x86_64:4.1.63.Final
-- io.netty:netty-transport-native-unix-common:4.1.63.Final
+- software.amazon.awssdk:http-client-spi:2.17.247
+- software.amazon.awssdk:regions:2.17.247
+- software.amazon.awssdk:annotations:2.17.247
+- software.amazon.awssdk:utils:2.17.247
+- software.amazon.awssdk:json-utils:2.17.247
+- software.amazon.awssdk:aws-core:2.17.247
+- software.amazon.awssdk:metrics-spi:2.17.247
+- software.amazon.awssdk:apache-client:2.17.247
+- software.amazon.awssdk:netty-nio-client:2.17.247
+- software.amazon.awssdk:sts:2.17.247
+- software.amazon.awssdk:aws-query-protocol:2.17.247
+- io.netty:netty-codec-http:4.1.77.Final
+- io.netty:netty-codec-http2:4.1.77.Final
+- io.netty:netty-codec:4.1.77.Final
+- io.netty:netty-transport:4.1.77.Final
+- io.netty:netty-resolver:4.1.77.Final
+- io.netty:netty-common:4.1.77.Final
+- io.netty:netty-buffer:4.1.77.Final
+- io.netty:netty-handler:4.1.77.Final
+- io.netty:netty-transport-classes-epoll:4.1.77.Final
+- io.netty:netty-transport-native-epoll:linux-x86_64:4.1.77.Final
+- io.netty:netty-transport-native-unix-common:4.1.77.Final
 - com.typesafe.netty:netty-reactive-streams-http:2.0.5
 - com.typesafe.netty:netty-reactive-streams:2.0.5
 
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- com.google.protobuf:protobuf-java:2.6.1
+- com.google.protobuf:protobuf-java:3.11.4
 
 This project bundles the following dependencies under the Creative Commons Zero license (https://creativecommons.org/publicdomain/zero/1.0/).
 

--- a/flink-end-to-end-tests/flink-glue-schema-registry-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-test/pom.xml
@@ -33,137 +33,108 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<httpclient.version>4.5.9</httpclient.version>
-		<httpcore.version>4.4.11</httpcore.version>
-		<aws.sdk.version>1.11.754</aws.sdk.version>
-		<aws.sdkv2.version>2.15.32</aws.sdkv2.version>
-		<reactivestreams.version>1.0.2</reactivestreams.version>
-		<lz4.version>1.6.0</lz4.version>
-		<netty.version>4.1.53.Final</netty.version>
-		<guava.version>29.0-jre</guava.version>
+		<aws.sdk.version>1.12.276</aws.sdk.version>
+		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
+		<kotlin.version>1.3.50</kotlin.version>
 	</properties>
 
-	<!-- ============================= -->
-	<!-- DEPENDENCY MANAGEMENT -->
-	<!-- ============================= -->
 	<dependencyManagement>
 		<dependencies>
-			<!-- dependencies to solve enforcer check issue -->
-			<!-- can be removed once new version of Glue Schema Registry releases -->
-
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>http-client-spi</artifactId>
+				<artifactId>bom</artifactId>
 				<version>${aws.sdkv2.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
-
 			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>aws-core</artifactId>
-				<version>${aws.sdkv2.version}</version>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk-bom</artifactId>
+				<version>${aws.sdk.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 
+			<!-- For dependency convergence -->
 			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>protocol-core</artifactId>
-				<version>${aws.sdkv2.version}</version>
+				<groupId>com.google.protobuf</groupId>
+				<artifactId>protobuf-java</artifactId>
+				<version>3.19.4</version>
 			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>annotations</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>utils</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>apache-client</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.reactivestreams</groupId>
-				<artifactId>reactive-streams</artifactId>
-				<version>${reactivestreams.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.lz4</groupId>
-				<artifactId>lz4-java</artifactId>
-				<version>${lz4.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>aws-json-protocol</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>regions</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>sdk-core</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-codec-http</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>netty-nio-client</artifactId>
-				<version>${aws.sdkv2.version}</version>
-				<scope>runtime</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>auth</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>metrics-spi</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-handler</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-
 			<dependency>
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
-				<version>${guava.version}</version>
+				<version>29.0-jre</version>
 			</dependency>
-
 			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpclient</artifactId>
-				<version>${httpclient.version}</version>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-reflect</artifactId>
+				<version>${kotlin.version}</version>
 			</dependency>
-
 			<dependency>
-				<groupId>org.apache.httpcomponents</groupId>
-				<artifactId>httpcore</artifactId>
-				<version>${httpcore.version}</version>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-common</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlinx</groupId>
+				<artifactId>kotlinx-serialization-core-jvm</artifactId>
+				<version>1.0.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.checkerframework</groupId>
+				<artifactId>checker-qual</artifactId>
+				<version>3.5.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.squareup.okio</groupId>
+				<artifactId>okio</artifactId>
+				<version>2.8.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains</groupId>
+				<artifactId>annotations</artifactId>
+				<version>17.0.0</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.docker-java</groupId>
+				<artifactId>docker-java-api</artifactId>
+				<version>3.2.13</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.docker-java</groupId>
+				<artifactId>docker-java-transport-zerodep</artifactId>
+				<version>3.2.13</version>
+			</dependency>
+			<dependency>
+				<groupId>com.github.docker-java</groupId>
+				<artifactId>docker-java-transport</artifactId>
+				<version>3.2.13</version>
+			</dependency>
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>amazon-kinesis-client</artifactId>
+				<version>1.14.7</version>
+			</dependency>
+			<dependency>
+				<groupId>org.reactivestreams</groupId>
+				<artifactId>reactive-streams</artifactId>
+				<version>1.0.3</version>
+			</dependency>
+			<dependency>
+				<groupId>org.lz4</groupId>
+				<artifactId>lz4-java</artifactId>
+				<version>1.7.1</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
@@ -213,14 +184,8 @@ under the License.
 		</dependency>
 
 		<dependency>
-			<groupId>software.amazon.awssdk</groupId>
-			<artifactId>sdk-core</artifactId>
-			<version>${aws.sdkv2.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>com.amazonaws</groupId>
 			<artifactId>aws-java-sdk-kinesis</artifactId>
-			<version>${aws.sdk.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -34,118 +34,61 @@ under the License.
 
 	<properties>
 		<glue.schema.registry.version>1.0.1</glue.schema.registry.version>
-		<aws.sdkv2.version>2.15.32</aws.sdkv2.version>
-		<reactivestreams.version>1.0.2</reactivestreams.version>
-		<lz4.version>1.6.0</lz4.version>
-		<netty.version>4.1.53.Final</netty.version>
+		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
+		<kotlin.version>1.3.50</kotlin.version>
 	</properties>
 
-	<!-- ============================= -->
-	<!-- DEPENDENCY MANAGEMENT -->
-	<!-- ============================= -->
 	<dependencyManagement>
 		<dependencies>
-			<!-- dependencies to solve enforcer check issue -->
-			<!-- can be removed once new version of Glue Schema Registry releases -->
-
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>http-client-spi</artifactId>
+				<artifactId>bom</artifactId>
 				<version>${aws.sdkv2.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 
+			<!-- For dependency convergence -->
 			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>aws-core</artifactId>
-				<version>${aws.sdkv2.version}</version>
+				<groupId>com.google.protobuf</groupId>
+				<artifactId>protobuf-java</artifactId>
+				<version>3.19.4</version>
 			</dependency>
-
 			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>protocol-core</artifactId>
-				<version>${aws.sdkv2.version}</version>
+				<groupId>com.google.guava</groupId>
+				<artifactId>guava</artifactId>
+				<version>29.0-jre</version>
 			</dependency>
-
 			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-reflect</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-common</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlinx</groupId>
+				<artifactId>kotlinx-serialization-core-jvm</artifactId>
+				<version>1.0.1</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains</groupId>
 				<artifactId>annotations</artifactId>
-				<version>${aws.sdkv2.version}</version>
+				<version>17.0.0</version>
 			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>utils</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>apache-client</artifactId>
-				<version>${aws.sdkv2.version}</version>
-				<scope>test</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>org.reactivestreams</groupId>
-				<artifactId>reactive-streams</artifactId>
-				<version>${reactivestreams.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.lz4</groupId>
-				<artifactId>lz4-java</artifactId>
-				<version>${lz4.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>aws-json-protocol</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>regions</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>sdk-core</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-codec-http</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>netty-nio-client</artifactId>
-				<version>${aws.sdkv2.version}</version>
-				<scope>runtime</scope>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>auth</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>software.amazon.awssdk</groupId>
-				<artifactId>metrics-spi</artifactId>
-				<version>${aws.sdkv2.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>io.netty</groupId>
-				<artifactId>netty-handler</artifactId>
-				<version>${netty.version}</version>
-			</dependency>
-
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
## What is the purpose of the change

- Updating AWS SDK dependencies to latest versions to pull recent bug fixes and add support for new AWS regions.
- Removing the dependency on AWS `Regions` enum (for AWS SDK v1) so that region support for new AWS regions is automatic, and wouldn't need a PR.

## Brief change log

This is a backport of https://github.com/apache/flink/pull/20476 and https://github.com/apache/flink/pull/20496 from `1.16` to `1.13`.

Upgrading dependencies:
* AWS SDK v2 from `2.16.86` to `2.17.247`
* AWS SDK v1 from `1.12.7` to `1.12.276`
* Kinesis Consumer Library from `1.11.1` to `1.14.8`
* Kinesis Producer Library from `0.14.0` to `0.14.1`

For the following connectors/formats:
* Kinesis Data Streams
* Kinesis Data Firehose
* Glue Schema Registry AVRO

- Change calls from `Regions` class to calls from `RegionUtils` class

## Verifying this change

- Unit tests/e2e tests
- Manual regression
  - `flink-glue-schema-registry-test` :: `mvn clean test -Pe2e-travis1` (providing GSR keys)
  - `flink-connector-kinesis` :: Verified with local test app (EFO source/Polling source/Sink)
- Manually verified that Kinesis connector with this fix works in region not present in `Regions` enum

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
