### PR TITLE
[WIP][FLINK-26372][runtime][state] Allow to configure Changelog Storage per program

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -142,10 +142,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     private long periodicMaterializeIntervalMillis =
             StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL.defaultValue().toMillis();
 
-    /** Max allowed number of consecutive failures for changelog materialization */
-    private int materializationMaxAllowedFailures =
-            StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED.defaultValue();
-
     /**
      * @deprecated Should no longer be used because it is subsumed by RestartStrategyConfiguration
      */
@@ -303,16 +299,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
     @Internal
     public void setPeriodicMaterializeIntervalMillis(Duration periodicMaterializeInterval) {
         this.periodicMaterializeIntervalMillis = periodicMaterializeInterval.toMillis();
-    }
-
-    @Internal
-    public int getMaterializationMaxAllowedFailures() {
-        return materializationMaxAllowedFailures;
-    }
-
-    @Internal
-    public void setMaterializationMaxAllowedFailures(int materializationMaxAllowedFailures) {
-        this.materializationMaxAllowedFailures = materializationMaxAllowedFailures;
     }
 
     /**
@@ -1158,13 +1144,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
         configuration
                 .getOptional(MetricOptions.LATENCY_INTERVAL)
                 .ifPresent(this::setLatencyTrackingInterval);
-
-        configuration
-                .getOptional(StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL)
-                .ifPresent(this::setPeriodicMaterializeIntervalMillis);
-        configuration
-                .getOptional(StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED)
-                .ifPresent(this::setMaterializationMaxAllowedFailures);
 
         configuration
                 .getOptional(PipelineOptions.MAX_PARALLELISM)

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.changelog.fs;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
@@ -31,7 +32,18 @@ import java.io.IOException;
 import java.time.Duration;
 
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.CACHE_IDLE_TIMEOUT;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.COMPRESSION_ENABLED;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.IN_FLIGHT_DATA_LIMIT;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.NUM_DISCARD_THREADS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.NUM_UPLOAD_THREADS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_DELAY;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_SIZE_THRESHOLD;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PREEMPTIVE_PERSIST_THRESHOLD;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.RETRY_DELAY_AFTER_FAILURE;
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.RETRY_MAX_ATTEMPTS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.RETRY_POLICY;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_BUFFER_SIZE;
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_TIMEOUT;
 import static org.apache.flink.configuration.StateChangelogOptions.STATE_CHANGE_LOG_STORAGE;
 
@@ -60,6 +72,26 @@ public class FsStateChangelogStorageFactory implements StateChangelogStorageFact
     public StateChangelogStorageView<?> createStorageView(Configuration configuration) {
         return new FsStateChangelogStorageForRecovery(
                 new ChangelogStreamHandleReaderWithCache(configuration));
+    }
+
+    @Override
+    public Configuration extractConfiguration(ReadableConfig src) {
+        Configuration dst = StateChangelogStorageFactory.super.extractConfiguration(src);
+        dst.set(BASE_PATH, src.get(BASE_PATH));
+        dst.set(COMPRESSION_ENABLED, src.get(COMPRESSION_ENABLED));
+        dst.set(PREEMPTIVE_PERSIST_THRESHOLD, src.get(PREEMPTIVE_PERSIST_THRESHOLD));
+        dst.set(PERSIST_DELAY, src.get(PERSIST_DELAY));
+        dst.set(PERSIST_SIZE_THRESHOLD, src.get(PERSIST_SIZE_THRESHOLD));
+        dst.set(UPLOAD_BUFFER_SIZE, src.get(UPLOAD_BUFFER_SIZE));
+        dst.set(NUM_UPLOAD_THREADS, src.get(NUM_UPLOAD_THREADS));
+        dst.set(NUM_DISCARD_THREADS, src.get(NUM_DISCARD_THREADS));
+        dst.set(IN_FLIGHT_DATA_LIMIT, src.get(IN_FLIGHT_DATA_LIMIT));
+        dst.set(RETRY_POLICY, src.get(RETRY_POLICY));
+        dst.set(UPLOAD_TIMEOUT, src.get(UPLOAD_TIMEOUT));
+        dst.set(RETRY_MAX_ATTEMPTS, src.get(RETRY_MAX_ATTEMPTS));
+        dst.set(RETRY_DELAY_AFTER_FAILURE, src.get(RETRY_DELAY_AFTER_FAILURE));
+        dst.set(CACHE_IDLE_TIMEOUT, src.get(CACHE_IDLE_TIMEOUT));
+        return dst;
     }
 
     public static void configure(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -634,7 +634,8 @@ public class JobGraph implements Serializable {
         }
     }
 
-    public void setChangelogStateBackendEnabled(TernaryBoolean changelogStateBackendEnabled) {
+    public void setChangelogStateBackendEnabled(
+            TernaryBoolean changelogStateBackendEnabled, Configuration changelogConfiguration) {
         if (changelogStateBackendEnabled == null
                 || TernaryBoolean.UNDEFINED.equals(changelogStateBackendEnabled)) {
             return;
@@ -642,6 +643,10 @@ public class JobGraph implements Serializable {
         this.jobConfiguration.setBoolean(
                 StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION,
                 changelogStateBackendEnabled.getAsBoolean());
+        if (changelogStateBackendEnabled.getOrDefault(false)) {
+            StateChangelogOptionsInternal.putConfiguration(
+                    jobConfiguration, changelogConfiguration);
+        }
     }
 
     public void setJobStatusHooks(List<JobStatusHook> hooks) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
-import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.FileUtils;
@@ -126,8 +125,7 @@ public class TaskExecutorLocalStateStoresManager {
             @Nonnull AllocationID allocationID,
             @Nonnull JobVertexID jobVertexID,
             @Nonnegative int subtaskIndex,
-            Configuration clusterConfiguration,
-            Configuration jobConfiguration) {
+            Configuration cfg) {
 
         synchronized (lock) {
             if (closed) {
@@ -169,16 +167,8 @@ public class TaskExecutorLocalStateStoresManager {
                 LocalRecoveryConfig localRecoveryConfig =
                         new LocalRecoveryConfig(directoryProvider);
 
-                boolean changelogEnabled =
-                        jobConfiguration
-                                .getOptional(
-                                        StateChangelogOptionsInternal
-                                                .ENABLE_CHANGE_LOG_FOR_APPLICATION)
-                                .orElse(
-                                        clusterConfiguration.getBoolean(
-                                                StateChangelogOptions.ENABLE_STATE_CHANGE_LOG));
-
-                if (localRecoveryConfig.isLocalRecoveryEnabled() && changelogEnabled) {
+                if (localRecoveryConfig.isLocalRecoveryEnabled()
+                        && cfg.getBoolean(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)) {
                     taskLocalStateStore =
                             new ChangelogTaskLocalStateStore(
                                     jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
@@ -21,10 +21,16 @@ package org.apache.flink.runtime.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 
 import java.io.IOException;
+
+import static org.apache.flink.configuration.StateChangelogOptions.ENABLE_STATE_CHANGE_LOG;
+import static org.apache.flink.configuration.StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED;
+import static org.apache.flink.configuration.StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL;
+import static org.apache.flink.configuration.StateChangelogOptions.STATE_CHANGE_LOG_STORAGE;
 
 /**
  * A factory for {@link StateChangelogStorage}. Please use {@link StateChangelogStorageLoader} to
@@ -45,4 +51,16 @@ public interface StateChangelogStorageFactory {
 
     /** Create the storage for recovery. */
     StateChangelogStorageView<?> createStorageView(Configuration configuration) throws IOException;
+
+    /** Extract the relevant to this factory portion of the configuration. */
+    default Configuration extractConfiguration(ReadableConfig src) {
+        Configuration dst = new Configuration();
+        dst.set(PERIODIC_MATERIALIZATION_INTERVAL, src.get(PERIODIC_MATERIALIZATION_INTERVAL));
+        dst.set(
+                MATERIALIZATION_MAX_FAILURES_ALLOWED,
+                src.get(MATERIALIZATION_MAX_FAILURES_ALLOWED));
+        dst.set(ENABLE_STATE_CHANGE_LOG, src.get(ENABLE_STATE_CHANGE_LOG));
+        dst.set(STATE_CHANGE_LOG_STORAGE, src.get(STATE_CHANGE_LOG_STORAGE));
+        return dst;
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -166,12 +166,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         TaskLocalStateStore taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID,
-                        allocationID,
-                        jobVertexID,
-                        subtaskIdx,
-                        new Configuration(),
-                        new Configuration());
+                        jobID, allocationID, jobVertexID, subtaskIdx, new Configuration());
 
         Assert.assertFalse(taskLocalStateStore.getLocalRecoveryConfig().isLocalRecoveryEnabled());
         Assert.assertNull(
@@ -207,12 +202,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         TaskLocalStateStore taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID,
-                        allocationID,
-                        jobVertexID,
-                        subtaskIdx,
-                        new Configuration(),
-                        new Configuration());
+                        jobID, allocationID, jobVertexID, subtaskIdx, new Configuration());
 
         LocalRecoveryDirectoryProvider directoryProvider =
                 taskLocalStateStore
@@ -268,12 +258,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID,
-                        otherAllocationID,
-                        jobVertexID,
-                        subtaskIdx,
-                        new Configuration(),
-                        new Configuration());
+                        jobID, otherAllocationID, jobVertexID, subtaskIdx, new Configuration());
 
         directoryProvider =
                 taskLocalStateStore
@@ -353,14 +338,9 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         // register local state stores
         taskExecutorLocalStateStoresManager.localStateStoreForSubtask(
-                jobId,
-                retainedAllocationId,
-                jobVertexId,
-                0,
-                new Configuration(),
-                new Configuration());
+                jobId, retainedAllocationId, jobVertexId, 0, new Configuration());
         taskExecutorLocalStateStoresManager.localStateStoreForSubtask(
-                jobId, otherAllocationId, jobVertexId, 1, new Configuration(), new Configuration());
+                jobId, otherAllocationId, jobVertexId, 1, new Configuration());
 
         final Collection<Path> allocationDirectories =
                 TaskExecutorLocalStateStoresManager.listAllocationDirectoriesIn(localStateStore);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
@@ -21,6 +21,8 @@ package org.apache.flink.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -44,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -197,5 +200,15 @@ public abstract class AbstractChangelogStateBackend
                 .filter(Objects::nonNull)
                 .map(ChangelogStateBackendHandleImpl::getChangelogStateBackendHandle)
                 .collect(Collectors.toList());
+    }
+
+    protected Configuration createMergedConfiguration(Environment env)
+            throws IOException, ClassNotFoundException {
+        Configuration configuration =
+                new Configuration(env.getTaskManagerInfo().getConfiguration());
+        configuration.addAll(
+                StateChangelogOptionsInternal.getConfiguration(
+                        env.getJobConfiguration(), getClass().getClassLoader()));
+        return configuration;
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/DeactivatedChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/DeactivatedChangelogStateBackend.java
@@ -68,7 +68,7 @@ public class DeactivatedChangelogStateBackend extends AbstractChangelogStateBack
         ChangelogStateFactory changelogStateFactory = new ChangelogStateFactory();
 
         return ChangelogBackendRestoreOperation.restore(
-                env.getTaskManagerInfo().getConfiguration(),
+                createMergedConfiguration(env),
                 env.getUserCodeClassLoader().asClassLoader(),
                 env.getTaskStateManager(),
                 stateBackendHandles,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
@@ -126,7 +127,8 @@ public class StreamGraph implements Pipeline {
     protected Map<Integer, String> vertexIDtoBrokerID;
     protected Map<Integer, Long> vertexIDtoLoopTimeout;
     private StateBackend stateBackend;
-    private TernaryBoolean changelogStateBackendEnabled;
+    private TernaryBoolean changelogStateBackendEnabled = TernaryBoolean.UNDEFINED; // todo: remove?
+    private Configuration changelogConfiguration = new Configuration();
     private CheckpointStorage checkpointStorage;
     private Path savepointDir;
     private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
@@ -201,8 +203,10 @@ public class StreamGraph implements Pipeline {
         return this.stateBackend;
     }
 
-    public void setChangelogStateBackendEnabled(TernaryBoolean changelogStateBackendEnabled) {
+    public void setChangelogStateBackendEnabled(
+            TernaryBoolean changelogStateBackendEnabled, Configuration changelogConfiguration) {
         this.changelogStateBackendEnabled = changelogStateBackendEnabled;
+        this.changelogConfiguration = changelogConfiguration;
     }
 
     public TernaryBoolean isChangelogStateBackendEnabled() {
@@ -1064,5 +1068,9 @@ public class StreamGraph implements Pipeline {
 
     public List<JobStatusHook> getJobStatusHooks() {
         return this.jobStatusHooks;
+    }
+
+    public Configuration getChangelogConfiguration() {
+        return this.changelogConfiguration;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -35,6 +35,7 @@ import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.jobgraph.JobType;
@@ -42,6 +43,7 @@ import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
@@ -98,6 +100,7 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -160,8 +163,6 @@ public class StreamGraphGenerator {
     private Path savepointDir;
 
     private StateBackend stateBackend;
-
-    private TernaryBoolean changelogStateBackendEnabled;
 
     private CheckpointStorage checkpointStorage;
 
@@ -252,12 +253,6 @@ public class StreamGraphGenerator {
 
     public StreamGraphGenerator setStateBackend(StateBackend stateBackend) {
         this.stateBackend = stateBackend;
-        return this;
-    }
-
-    public StreamGraphGenerator setChangelogStateBackendEnabled(
-            TernaryBoolean changelogStateBackendEnabled) {
-        this.changelogStateBackendEnabled = changelogStateBackendEnabled;
         return this;
     }
 
@@ -383,7 +378,7 @@ public class StreamGraphGenerator {
         graph.setJobName(deriveJobName(DEFAULT_STREAMING_JOB_NAME));
 
         graph.setStateBackend(stateBackend);
-        graph.setChangelogStateBackendEnabled(changelogStateBackendEnabled);
+        configureChangelogStorage(graph);
         graph.setCheckpointStorage(checkpointStorage);
         graph.setSavepointDirectory(savepointDir);
         graph.setGlobalStreamExchangeMode(deriveGlobalStreamExchangeModeStreaming());
@@ -434,12 +429,29 @@ public class StreamGraphGenerator {
         if (useStateBackend) {
             LOG.debug("Using BATCH execution state backend and timer service.");
             graph.setStateBackend(new BatchExecutionStateBackend());
-            graph.setChangelogStateBackendEnabled(TernaryBoolean.FALSE);
+            graph.setChangelogStateBackendEnabled(TernaryBoolean.FALSE, new Configuration());
             graph.setCheckpointStorage(new BatchExecutionCheckpointStorage());
             graph.setTimerServiceProvider(BatchExecutionInternalTimeServiceManager::create);
         } else {
             graph.setStateBackend(stateBackend);
-            graph.setChangelogStateBackendEnabled(changelogStateBackendEnabled);
+            configureChangelogStorage(graph);
+        }
+    }
+
+    private void configureChangelogStorage(StreamGraph graph) {
+        Optional<Boolean> enabled =
+                configuration.getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG);
+        if (!enabled.isPresent()) {
+            graph.setChangelogStateBackendEnabled(TernaryBoolean.UNDEFINED, new Configuration());
+        } else if (!enabled.get()) {
+            graph.setChangelogStateBackendEnabled(TernaryBoolean.FALSE, new Configuration());
+        } else {
+            graph.setChangelogStateBackendEnabled(
+                    TernaryBoolean.TRUE,
+                    // assumption: if any factory option is passed here then the correct factory
+                    // must also be chosen
+                    StateChangelogStorageLoader.loadFactory(configuration)
+                            .extractConfiguration(configuration));
         }
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -258,7 +258,9 @@ public class StreamingJobGraphGenerator {
                             + "This indicates that non-serializable types (like custom serializers) were registered");
         }
 
-        jobGraph.setChangelogStateBackendEnabled(streamGraph.isChangelogStateBackendEnabled());
+        jobGraph.setChangelogStateBackendEnabled(
+                streamGraph.isChangelogStateBackendEnabled(),
+                streamGraph.getChangelogConfiguration());
 
         addVertexIndexPrefixInVertexName();
 


### PR DESCRIPTION
```
Because different changelog implementations might have different
options, the configuration is passed as a (serialized) string map.

To extract the relevant KV-pairs (and not pass the whole configuration),
Changelog factory is used on JM.

On TM, its configuration is combined with the one from job.

The path in common cases is as follows:
env -> streamGraphGenerator -> streamGraph -> jobGraph -> TM
```