### PR TITLE
[FLINK-28895][python] Eliminate RowRowConverter between RowData source and sink

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/filesystem.md
+++ b/docs/content.zh/docs/connectors/datastream/filesystem.md
@@ -495,10 +495,7 @@ row_type = DataTypes.ROW([
     DataTypes.FIELD('string', DataTypes.STRING()),
     DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
 ])
-row_type_info = Types.ROW_NAMED(
-    ['string', 'int_array'],
-    [Types.STRING(), Types.LIST(Types.INT())]
-)
+
 sink = FileSink.for_bulk_format(
     OUTPUT_DIR, ParquetBulkWriter.for_row_type(
         row_type,
@@ -506,9 +503,7 @@ sink = FileSink.for_bulk_format(
         utc_timestamp=True,
     )
 ).build()
-# 如果 ds 是一个输出类型为 RowData 的源数据源，可以使用一个 map 来转换为 Row 类型
-ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
-# 否则
+
 ds.sink_to(sink)
 ```
 
@@ -811,8 +806,7 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
 {{< /tab >}}
 {{< /tabs >}}
 
-PyFlink 用户可以使用 `OrcBulkWriters.for_row_type` 来创建将 `Row` 数据写入 Orc 文件的 `BulkWriterFactory` 。
-注意如果 sink 的前置算子的输出类型为 `RowData` ，例如 CSV source ，则需要先转换为 `Row` 类型。
+PyFlink 用户可以使用 `OrcBulkWriter` 来创建将 `Row` 数据写入 Orc 文件的 `BulkWriterFactory` 。
 
 {{< py_download_link "orc" >}}
 
@@ -821,23 +815,16 @@ row_type = DataTypes.ROW([
     DataTypes.FIELD('name', DataTypes.STRING()),
     DataTypes.FIELD('age', DataTypes.INT()),
 ])
-row_type_info = Types.ROW_NAMED(
-    ['name', 'age'],
-    [Types.STRING(), Types.INT()]
-)
 
 sink = FileSink.for_bulk_format(
     OUTPUT_DIR,
-    OrcBulkWriters.for_row_type(
+    OrcBulkWriter.for_row_type(
         row_type=row_type,
         writer_properties=Configuration(),
         hadoop_config=Configuration(),
     )
 ).build()
 
-# 如果 ds 是产生 RowData 的数据源，可以使用一个 map 函数来指定其对应的 Row 类型。
-ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
-# 否则
 ds.sink_to(sink)
 ```
 

--- a/docs/content.zh/docs/connectors/datastream/formats/csv.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/csv.md
@@ -139,7 +139,7 @@ The corresponding CSV file:
 Similarly to the `TextLineInputFormat`, `CsvReaderFormat` can be used in both continues and batch modes (see [TextLineInputFormat]({{< ref "docs/connectors/datastream/formats/text_files" >}})  for examples).
 
 For PyFlink users, `CsvBulkWriter` could be used to create `BulkWriterFactory` to write `Row` records to files in CSV format.
-It should be noted that if the preceding operator of sink is an operator which produces `RowData` records, e.g. CSV source, it needs to be converted to `Row` records before writing to sink.
+
 ```python
 schema = CsvSchema.builder()
     .add_number_column('id', number_type=DataTypes.BIGINT())
@@ -150,8 +150,5 @@ schema = CsvSchema.builder()
 sink = FileSink.for_bulk_format(
     OUTPUT_DIR, CsvBulkWriter.for_schema(schema)).build()
 
-# If ds is a source stream producing RowData records, a map could be added to help converting RowData records into Row records.
-ds.map(lambda e: e, output_type=schema.get_type_info()).sink_to(sink)
-# Else
 ds.sink_to(sink)
 ```

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -493,10 +493,7 @@ row_type = DataTypes.ROW([
     DataTypes.FIELD('string', DataTypes.STRING()),
     DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
 ])
-row_type_info = Types.ROW_NAMED(
-    ['string', 'int_array'],
-    [Types.STRING(), Types.LIST(Types.INT())]
-)
+
 sink = FileSink.for_bulk_format(
     OUTPUT_DIR, ParquetBulkWriter.for_row_type(
         row_type,
@@ -504,9 +501,7 @@ sink = FileSink.for_bulk_format(
         utc_timestamp=True,
     )
 ).build()
-# If ds is a source stream producing RowData records, a map could be added to help converting RowData records into Row records.
-ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
-# Else
+
 ds.sink_to(sink)
 ```
 
@@ -816,8 +811,7 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
 {{< /tab >}}
 {{< /tabs >}}
 
-For PyFlink users, `OrcBulkWriters.for_row_type` could be used to create `BulkWriterFactory` to write `Row` records to files in Orc format.
-It should be noted that if the preceding operator of sink is an operator producing `RowData` records, e.g. CSV source, it needs to be converted to `Row` records before writing to sink.
+For PyFlink users, `OrcBulkWriter` could be used to create `BulkWriterFactory` to write `Row` records to files in Orc format.
 
 {{< py_download_link "orc" >}}
 
@@ -826,23 +820,16 @@ row_type = DataTypes.ROW([
     DataTypes.FIELD('name', DataTypes.STRING()),
     DataTypes.FIELD('age', DataTypes.INT()),
 ])
-row_type_info = Types.ROW_NAMED(
-    ['name', 'age'],
-    [Types.STRING(), Types.INT()]
-)
 
 sink = FileSink.for_bulk_format(
     OUTPUT_DIR,
-    OrcBulkWriters.for_row_type(
+    OrcBulkWriter.for_row_type(
         row_type=row_type,
         writer_properties=Configuration(),
         hadoop_config=Configuration(),
     )
 ).build()
 
-# If ds is a source stream producing RowData records, a map could be added to help converting RowData records into Row records.
-ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
-# Else
 ds.sink_to(sink)
 ```
 

--- a/docs/content/docs/connectors/datastream/formats/csv.md
+++ b/docs/content/docs/connectors/datastream/formats/csv.md
@@ -139,7 +139,7 @@ The corresponding CSV file:
 Similarly to the `TextLineInputFormat`, `CsvReaderFormat` can be used in both continues and batch modes (see [TextLineInputFormat]({{< ref "docs/connectors/datastream/formats/text_files" >}})  for examples).
 
 For PyFlink users, `CsvBulkWriter` could be used to create `BulkWriterFactory` to write `Row` records to files in CSV format.
-It should be noted that if the preceding operator of sink is an operator which produces `RowData` records, e.g. CSV source, it needs to be converted to `Row` records before writing to sink.
+
 ```python
 schema = CsvSchema.builder() \
     .add_number_column('id', number_type=DataTypes.BIGINT()) \
@@ -150,8 +150,5 @@ schema = CsvSchema.builder() \
 sink = FileSink.for_bulk_format(
     OUTPUT_DIR, CsvBulkWriter.for_schema(schema)).build()
 
-# If ds is a source stream producing RowData records, a map could be added to help converting RowData records into Row records.
-ds.map(lambda e: e, output_type=schema.get_type_info()).sink_to(sink)
-# Else
 ds.sink_to(sink)
 ```

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -514,6 +514,10 @@ under the License.
 								</artifactItem>
 								<artifactItem>
 									<groupId>org.apache.flink</groupId>
+									<artifactId>flink-sql-orc</artifactId>
+								</artifactItem>
+								<artifactItem>
+									<groupId>org.apache.flink</groupId>
 									<artifactId>flink-json</artifactId>
 								</artifactItem>
 								<artifactItem>

--- a/flink-python/pyflink/datastream/__init__.py
+++ b/flink-python/pyflink/datastream/__init__.py
@@ -236,7 +236,7 @@ Classes to define formats used together with source & sink:
     - :class:`formats.parquet.AvroParquetWriters`:
       Convenience builder to create ParquetWriterFactory instances for Avro types. Only
       GenericRecord is supported in PyFlink.
-    - :class:`formats.orc.OrcBulkWriters`:
+    - :class:`formats.orc.OrcBulkWriter`:
       Convenient builder to create a :class:`BulkWriterFactory` that writes Row records with a
       defined :class:`RowType` into Orc files.
 

--- a/flink-python/pyflink/datastream/formats/csv.py
+++ b/flink-python/pyflink/datastream/formats/csv.py
@@ -51,14 +51,6 @@ class CsvSchema(object):
         """
         return CsvSchemaBuilder()
 
-    def get_type_info(self):
-        if self._type_info is None:
-            jvm = get_gateway().jvm
-            j_type_info = jvm.org.apache.flink.table.types.utils.LegacyTypeInfoDataTypeConverter \
-                .toLegacyTypeInfo(_to_java_data_type(self._row_type))
-            self._type_info = _from_java_type(j_type_info)
-        return self._type_info
-
     def size(self):
         return self._j_schema.size()
 
@@ -335,8 +327,7 @@ class CsvBulkWriter(object):
         ...     .build()
         >>> sink = FileSink.for_bulk_format(
         ...     OUTPUT_DIR, CsvBulkWriter.for_schema(schema)).build()
-        >>> # If ds is a source stream, an identity map before sink is required
-        >>> ds.map(lambda e: e, output_type=schema.get_type_info()).sink_to(sink)
+        >>> ds.sink_to(sink)
 
     .. versionadded:: 1.16.0
     """

--- a/flink-python/pyflink/datastream/formats/orc.py
+++ b/flink-python/pyflink/datastream/formats/orc.py
@@ -25,14 +25,30 @@ from pyflink.table.types import _to_java_data_type, RowType
 from pyflink.util.java_utils import to_jarray
 
 __all__ = [
-    'OrcBulkWriters'
+    'OrcBulkWriter'
 ]
 
 
-class OrcBulkWriters(object):
+class OrcBulkWriter(object):
     """
     Convenient builder to create a :class:`~connectors.file_system.BulkWriterFactory` that writes
     Row records with a defined RowType into Orc files in a batch fashion.
+
+    Example:
+    ::
+
+        >>> row_type = DataTypes.ROW([
+        ...     DataTypes.FIELD('string', DataTypes.STRING()),
+        ...     DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
+        ... ])
+        >>> sink = FileSink.for_bulk_format(
+        ...     OUTPUT_DIR, OrcBulkWriter.for_row_type(
+        ...         row_type=row_type,
+        ...         writer_properties=Configuration(),
+        ...         hadoop_config=Configuration(),
+        ...     )
+        ... ).build()
+        >>> ds.sink_to(sink)
 
     .. versionadded:: 1.16.0
     """
@@ -46,29 +62,9 @@ class OrcBulkWriters(object):
         Create a RowDataBulkWriterFactory that writes Row records with a defined RowType into Orc
         files in a batch fashion.
 
-        Example:
-        ::
-
-            >>> row_type = DataTypes.ROW([
-            ...     DataTypes.FIELD('string', DataTypes.STRING()),
-            ...     DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
-            ... ])
-            >>> row_type_info = Types.ROW_NAMED(
-            ...     ['string', 'int_array'],
-            ...     [Types.STRING(), Types.LIST(Types.INT())]
-            ... )
-            >>> sink = FileSink.for_bulk_format(
-            ...     OUTPUT_DIR, OrcBulkWriters.for_row_type(
-            ...         row_type=row_type,
-            ...         writer_properties=Configuration(),
-            ...         hadoop_config=Configuration(),
-            ...     )
-            ... ).build()
-            >>> ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
-
-        Note that in the above example, an identity map to indicate its RowTypeInfo is necessary
-        before ``sink_to`` when ``ds`` is a source stream producing **RowData** records,
-        because RowDataBulkWriterFactory assumes the input record type is Row.
+        :param row_type: The RowType of records, it should match the RowTypeInfo of Row records.
+        :param writer_properties: Orc writer options.
+        :param hadoop_config: Hadoop configuration.
         """
         if not isinstance(row_type, RowType):
             raise TypeError('row_type must be an instance of RowType')

--- a/flink-python/pyflink/datastream/formats/parquet.py
+++ b/flink-python/pyflink/datastream/formats/parquet.py
@@ -166,6 +166,22 @@ class ParquetBulkWriter(object):
     Convenient builder to create a :class:`BulkWriterFactory` that writes Rows with a defined
     RowType into Parquet files in a batch fashion.
 
+    Example:
+    ::
+
+        >>> row_type = DataTypes.ROW([
+        ...     DataTypes.FIELD('string', DataTypes.STRING()),
+        ...     DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
+        ... ])
+        >>> sink = FileSink.for_bulk_format(
+        ...     OUTPUT_DIR, ParquetBulkWriter.for_row_type(
+        ...         row_type,
+        ...         hadoop_config=Configuration(),
+        ...         utc_timestamp=True,
+        ...     )
+        ... ).build()
+        >>> ds.sink_to(sink)
+
     .. versionadded:: 1.16.0
     """
 
@@ -176,29 +192,11 @@ class ParquetBulkWriter(object):
         Create a RowDataBulkWriterFactory that writes Rows records with a defined RowType into
         Parquet files in a batch fashion.
 
-        Example:
-        ::
-
-            >>> row_type = DataTypes.ROW([
-            ...     DataTypes.FIELD('string', DataTypes.STRING()),
-            ...     DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT()))
-            ... ])
-            >>> row_type_info = Types.ROW_NAMED(
-            ...     ['string', 'int_array'],
-            ...     [Types.STRING(), Types.LIST(Types.INT())]
-            ... )
-            >>> sink = FileSink.for_bulk_format(
-            ...     OUTPUT_DIR, ParquetBulkWriter.for_row_type(
-            ...         row_type,
-            ...         hadoop_config=Configuration(),
-            ...         utc_timestamp=True,
-            ...     )
-            ... ).build()
-            >>> ds.map(lambda e: e, output_type=row_type_info).sink_to(sink)
-
-        Note that in the above example, an identity map to indicate its RowTypeInfo is necessary
-        before ``sink_to`` when ``ds`` is a source stream producing **RowData** records, because
-        RowDataBulkWriterFactory assumes the input record type is **Row** .
+        :param row_type: The RowType of records, it should match the RowTypeInfo of Row records.
+        :param hadoop_config: Hadoop configuration.
+        :param utc_timestamp: Use UTC timezone or local timezone to the conversion between epoch
+            time and LocalDateTime. Hive 0.x/1.x/2.x use local timezone. But Hive 3.x use UTC
+            timezone.
         """
         if not hadoop_config:
             hadoop_config = Configuration()

--- a/flink-python/pyflink/datastream/formats/tests/test_csv.py
+++ b/flink-python/pyflink/datastream/formats/tests/test_csv.py
@@ -165,7 +165,7 @@ class FileSinkCsvBulkWriterTests(PyFlinkStreamingTestCase):
         sink = FileSink.for_bulk_format(
             self.csv_dir_name, CsvBulkWriter.for_schema(schema)
         ).build()
-        ds.map(lambda e: e, output_type=schema.get_type_info()).sink_to(sink)
+        ds.sink_to(sink)
 
     def _read_csv_file(self) -> List[str]:
         lines = []

--- a/flink-python/pyflink/datastream/formats/tests/test_parquet.py
+++ b/flink-python/pyflink/datastream/formats/tests/test_parquet.py
@@ -242,13 +242,8 @@ class FileSinkParquetBulkWriterTests(PyFlinkStreamingTestCase):
         _check_parquet_basic_results(self, results)
 
     def test_parquet_row_data_array_write(self):
-        (
-            row_type,
-            row_type_info,
-            conversion_row_type_info,
-            data,
-        ) = _create_parquet_array_row_and_data()
-        self._build_parquet_job(row_type, row_type_info, data, conversion_row_type_info)
+        row_type, row_type_info, data = _create_parquet_array_row_and_data()
+        self._build_parquet_job(row_type, row_type_info, data)
         self.env.execute('test_parquet_row_data_array_write')
         results = self._read_parquet_file()
         _check_parquet_array_results(self, results)
@@ -262,19 +257,11 @@ class FileSinkParquetBulkWriterTests(PyFlinkStreamingTestCase):
         results = self._read_parquet_file()
         _check_parquet_map_results(self, results)
 
-    def _build_parquet_job(
-        self,
-        row_type: RowType,
-        row_type_info: RowTypeInfo,
-        data: List[Row],
-        conversion_type_info: Optional[RowTypeInfo] = None,
-    ):
+    def _build_parquet_job(self, row_type: RowType, row_type_info: RowTypeInfo, data: List[Row]):
         sink = FileSink.for_bulk_format(
             self.parquet_dir_name, ParquetBulkWriter.for_row_type(row_type, utc_timestamp=True)
         ).build()
         ds = self.env.from_collection(data, type_info=row_type_info)
-        if conversion_type_info:
-            ds = ds.map(lambda e: e, output_type=conversion_type_info)
         ds.sink_to(sink)
 
     def _read_parquet_file(self):
@@ -380,10 +367,16 @@ def _check_parquet_basic_results(test, results):
     )
 
 
-def _create_parquet_array_row_and_data() -> Tuple[RowType, RowTypeInfo, RowTypeInfo, List[Row]]:
+def _create_parquet_array_row_and_data() -> Tuple[RowType, RowTypeInfo, List[Row]]:
     row_type = DataTypes.ROW([
-        DataTypes.FIELD('string_array', DataTypes.ARRAY(DataTypes.STRING())),
-        DataTypes.FIELD('int_array', DataTypes.ARRAY(DataTypes.INT())),
+        DataTypes.FIELD(
+            'string_array',
+            DataTypes.ARRAY(DataTypes.STRING()).bridged_to('java.util.ArrayList')
+        ),
+        DataTypes.FIELD(
+            'int_array',
+            DataTypes.ARRAY(DataTypes.INT()).bridged_to('java.util.ArrayList')
+        ),
     ])
     row_type_info = Types.ROW_NAMED([
         'string_array',
@@ -392,18 +385,11 @@ def _create_parquet_array_row_and_data() -> Tuple[RowType, RowTypeInfo, RowTypeI
         Types.LIST(Types.STRING()),
         Types.LIST(Types.INT()),
     ])
-    conversion_row_type_info = Types.ROW_NAMED([
-        'string_array',
-        'int_array',
-    ], [
-        Types.OBJECT_ARRAY(Types.STRING()),
-        Types.OBJECT_ARRAY(Types.INT()),
-    ])
     data = [Row(
         string_array=['a', 'b', 'c'],
         int_array=[1, 2, 3],
     )]
-    return row_type, row_type_info, conversion_row_type_info, data
+    return row_type, row_type_info, data
 
 
 def _check_parquet_array_results(test, results):


### PR DESCRIPTION
## What is the purpose of the change

This PR eliminates using a `RowRowConverter` between RowData sources and sinks, which frees users from creating a identity map to convert records type.

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)

