### PR TITLE
[FLINK-28888] The statistics of HsResultPartition are not updated correctly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -150,6 +150,12 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
         spiller.release();
     }
 
+    public void setOutputMetrics(HsOutputMetrics metrics) {
+        for (int i = 0; i < numSubpartitions; i++) {
+            getSubpartitionMemoryDataManager(i).setOutputMetrics(metrics);
+        }
+    }
+
     // ------------------------------------
     //        For Spilling Strategy
     // ------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -151,6 +151,8 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
     }
 
     public void setOutputMetrics(HsOutputMetrics metrics) {
+        // HsOutputMetrics is not thread-safe. It can be shared by all the subpartitions because it
+        // is expected always updated from the producer task's mailbox thread.
         for (int i = 0; i < numSubpartitions; i++) {
             getSubpartitionMemoryDataManager(i).setOutputMetrics(metrics);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsOutputMetrics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsOutputMetrics.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.metrics.Counter;
+
+/** All metrics that {@link HsResultPartition} needs to count, except numBytesProduced. */
+public class HsOutputMetrics {
+    private final Counter numBytesOut;
+    private final Counter numBuffersOut;
+
+    public HsOutputMetrics(Counter numBytesOut, Counter numBuffersOut) {
+        this.numBytesOut = numBytesOut;
+        this.numBuffersOut = numBuffersOut;
+    }
+
+    public Counter getNumBytesOut() {
+        return numBytesOut;
+    }
+
+    public Counter getNumBuffersOut() {
+        return numBuffersOut;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createTestingOutputMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link HsMemoryDataManager}. */
@@ -193,30 +194,24 @@ class HsMemoryDataManagerTest {
 
     private HsMemoryDataManager createMemoryDataManager(HsSpillingStrategy spillStrategy)
             throws Exception {
-        NetworkBufferPool networkBufferPool = new NetworkBufferPool(NUM_BUFFERS, bufferSize);
-        BufferPool bufferPool = networkBufferPool.createBufferPool(poolSize, poolSize);
-        return new HsMemoryDataManager(
-                NUM_SUBPARTITIONS,
-                bufferSize,
-                bufferPool,
-                spillStrategy,
-                new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
-                dataFilePath,
-                null);
+        return createMemoryDataManager(spillStrategy, new HsFileDataIndexImpl(NUM_SUBPARTITIONS));
     }
 
     private HsMemoryDataManager createMemoryDataManager(
             HsSpillingStrategy spillStrategy, HsFileDataIndex fileDataIndex) throws Exception {
         NetworkBufferPool networkBufferPool = new NetworkBufferPool(NUM_BUFFERS, bufferSize);
         BufferPool bufferPool = networkBufferPool.createBufferPool(poolSize, poolSize);
-        return new HsMemoryDataManager(
-                NUM_SUBPARTITIONS,
-                bufferSize,
-                bufferPool,
-                spillStrategy,
-                fileDataIndex,
-                dataFilePath,
-                null);
+        HsMemoryDataManager memoryDataManager =
+                new HsMemoryDataManager(
+                        NUM_SUBPARTITIONS,
+                        bufferSize,
+                        bufferPool,
+                        spillStrategy,
+                        fileDataIndex,
+                        dataFilePath,
+                        null);
+        memoryDataManager.setOutputMetrics(createTestingOutputMetrics());
+        return memoryDataManager;
     }
 
     private static ByteBuffer createRecord(int value) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createTestingOutputMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -114,6 +115,7 @@ class HsSubpartitionViewTest {
                         new HsFileDataIndexImpl(1),
                         dataFilePath.resolve(".data"),
                         null);
+        memoryDataManager.setOutputMetrics(createTestingOutputMetrics());
         HsDataView hsDataView = memoryDataManager.registerSubpartitionView(0, subpartitionView);
         subpartitionView.setMemoryDataView(hsDataView);
         subpartitionView.setDiskDataView(TestingHsDataView.NO_OP);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleTestUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleTestUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.partition.hybrid;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.metrics.util.TestCounter;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
@@ -67,5 +68,9 @@ public class HybridShuffleTestUtils {
         return new BufferBuilder(
                 MemorySegmentFactory.allocateUnpooledSegment(bufferSize),
                 FreeingBufferRecycler.INSTANCE);
+    }
+
+    public static HsOutputMetrics createTestingOutputMetrics() {
+        return new HsOutputMetrics(new TestCounter(), new TestCounter());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Fix the problem of hybrid shuffle output metrics.*


## Brief change log

  - *`HsResultPartition` update output metric correctly*


## Verifying this change

This change added tests in `HsSubpartitionViewTest` and `HsResultPartitionTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
