### PR TITLE
[FLINK-28884] Downstream task may never be notified of data available in hybrid shuffle when number of credits is zero.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
@@ -118,7 +118,12 @@ public class HsSubpartitionView
                     && cachedNextDataType == Buffer.DataType.EVENT_BUFFER) {
                 availability = true;
             }
-            return new AvailabilityWithBacklog(availability, getSubpartitionBacklog());
+
+            int backlog = getSubpartitionBacklog();
+            if (backlog == 0) {
+                needNotify = true;
+            }
+            return new AvailabilityWithBacklog(availability, backlog);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionView.java
@@ -43,7 +43,7 @@ public class HsSubpartitionView
     private int lastConsumedBufferIndex = -1;
 
     @GuardedBy("lock")
-    private boolean needNotify = false;
+    private boolean needNotify = true;
 
     @Nullable
     @GuardedBy("lock")


### PR DESCRIPTION
## What is the purpose of the change

*Fix the bug that downstream task may never be notified of data available in hybrid shuffle when number of credits is zero.*


## Brief change log

  - *`HsSubpartitionView` should be initialized to a notifiable state.*
  - *Reset needNotify to true when get a zero backlog.*

## Verifying this change

This change added test in `HsSubpartitionViewTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no