### PR TITLE
[FLINK-28817] NullPointerException in HybridSource when restoring from checkpoint

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -219,7 +219,10 @@ public class HybridSourceSplitEnumerator
 
             if (subtaskSourceIndex < currentSourceIndex) {
                 // find initial or next index for the reader
-                subtaskSourceIndex = switchedSources.getNextSubtaskSourceIndex(subtaskSourceIndex);
+                subtaskSourceIndex =
+                        subtaskSourceIndex == -1
+                                ? switchedSources.getFirstSourceIndex()
+                                : ++subtaskSourceIndex;
                 sendSwitchSourceEvent(subtaskId, subtaskSourceIndex);
                 return;
             }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -218,7 +218,8 @@ public class HybridSourceSplitEnumerator
             }
 
             if (subtaskSourceIndex < currentSourceIndex) {
-                subtaskSourceIndex = switchedSources.getSourceIndex(subtaskSourceIndex);
+                // find initial or next index for the reader
+                subtaskSourceIndex = switchedSources.getNextSubtaskSourceIndex(subtaskSourceIndex);
                 sendSwitchSourceEvent(subtaskId, subtaskSourceIndex);
                 return;
             }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -218,7 +218,7 @@ public class HybridSourceSplitEnumerator
             }
 
             if (subtaskSourceIndex < currentSourceIndex) {
-                subtaskSourceIndex++;
+                subtaskSourceIndex = switchedSources.getSourceIndex(subtaskSourceIndex);
                 sendSwitchSourceEvent(subtaskId, subtaskSourceIndex);
                 return;
             }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
@@ -48,7 +48,7 @@ class SwitchedSources {
         sources.put(sourceIndex, Preconditions.checkNotNull(source));
     }
 
-    public Integer getNextSubtaskSourceIndex(int previousSubtaskSourceIndex) {
-        return previousSubtaskSourceIndex == -1 ? sources.firstKey() : ++previousSubtaskSourceIndex;
+    public int getFirstSourceIndex() {
+        return sources.firstKey();
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
@@ -49,6 +49,6 @@ class SwitchedSources {
     }
 
     public Integer getNextSubtaskSourceIndex(int previousSubtaskSourceIndex) {
-        return previousSubtaskSourceIndex == -1 ? sources.firstKey() : previousSubtaskSourceIndex++;
+        return previousSubtaskSourceIndex == -1 ? sources.firstKey() : ++previousSubtaskSourceIndex;
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
@@ -25,10 +25,12 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /** Sources that participated in switching with cached serializers. */
 class SwitchedSources {
-    private final Map<Integer, Source> sources = new HashMap<>();
+    private final SortedMap<Integer, Source> sources = new TreeMap<>();
     private final Map<Integer, SimpleVersionedSerializer<SourceSplit>> cachedSerializers =
             new HashMap<>();
 
@@ -44,5 +46,15 @@ class SwitchedSources {
 
     public void put(int sourceIndex, Source source) {
         sources.put(sourceIndex, Preconditions.checkNotNull(source));
+    }
+
+    public Integer getSourceIndex(int subtaskSourceIndex) {
+        Integer integer = sources.firstKey();
+
+        if (subtaskSourceIndex == -1) {
+            subtaskSourceIndex += integer;
+        }
+        subtaskSourceIndex++;
+        return subtaskSourceIndex;
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
@@ -48,13 +48,7 @@ class SwitchedSources {
         sources.put(sourceIndex, Preconditions.checkNotNull(source));
     }
 
-    public Integer getSourceIndex(int subtaskSourceIndex) {
-        Integer integer = sources.firstKey();
-
-        if (subtaskSourceIndex == -1) {
-            subtaskSourceIndex += integer;
-        }
-        subtaskSourceIndex++;
-        return subtaskSourceIndex;
+    public Integer getNextSubtaskSourceIndex(int previousSubtaskSourceIndex) {
+        return previousSubtaskSourceIndex == -1 ? sources.firstKey() : previousSubtaskSourceIndex++;
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
@@ -189,6 +189,7 @@ public class HybridSourceSplitEnumeratorTest {
         enumerator =
                 (HybridSourceSplitEnumerator) source.restoreEnumerator(context, enumeratorState);
         enumerator.start();
+        // subtask starts at -1 since it has no splits after restore
         enumerator.handleSourceEvent(SUBTASK0, new SourceReaderFinishedEvent(-1));
         underlyingEnumerator = getCurrentEnumerator(enumerator);
         assertThat(

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
@@ -178,7 +178,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testRestoreEnumeratorWith2ndSource() throws Exception {
+    public void testRestoreEnumeratorAfterFirstSourceWithoutRestoredSplits() throws Exception {
         setupEnumeratorAndTriggerSourceSwitch();
         HybridSourceEnumeratorState enumeratorState = enumerator.snapshotState(0);
         MockSplitEnumerator underlyingEnumerator = getCurrentEnumerator(enumerator);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
@@ -178,6 +178,26 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
+    public void testRestoreEnumeratorWith2ndSource() throws Exception {
+        setupEnumeratorAndTriggerSourceSwitch();
+        HybridSourceEnumeratorState enumeratorState = enumerator.snapshotState(0);
+        MockSplitEnumerator underlyingEnumerator = getCurrentEnumerator(enumerator);
+        assertThat(
+                        (List<MockSourceSplit>)
+                                Whitebox.getInternalState(underlyingEnumerator, "splits"))
+                .hasSize(0);
+        enumerator =
+                (HybridSourceSplitEnumerator) source.restoreEnumerator(context, enumeratorState);
+        enumerator.start();
+        enumerator.handleSourceEvent(SUBTASK0, new SourceReaderFinishedEvent(-1));
+        underlyingEnumerator = getCurrentEnumerator(enumerator);
+        assertThat(
+                        (List<MockSourceSplit>)
+                                Whitebox.getInternalState(underlyingEnumerator, "splits"))
+                .hasSize(0);
+    }
+
+    @Test
     public void testDefaultMethodDelegation() throws Exception {
         setupEnumeratorAndTriggerSourceSwitch();
         SplitEnumerator<MockSourceSplit, Object> underlyingEnumeratorSpy =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->


## What is the purpose of the change

This pull request fix NullPointerException in HybridSource when restoring from checkpoint.

After the recovery action is triggered, only the source with sourceIndex = 1 is loaded in the switchedSources in the HybridSourceSplitEnumerator

For the new SourceReaderFinishedEvent that triggers the load of a new source, the default is to get the source with sourceIndex = 0, which triggers the NPE.

Please correct me if there is a mistake.

## Brief change log

For the new SourceReaderFinishedEvent, get an available source.

## Verifying this change

This change added tests and can be verified as follows:

  - Added testRestoreEnumeratorWith2ndSource in HybridSourceSplitEnumeratorTest

## Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
