### PR TITLE
[FLINK-28899][table-planner] Fix LOOKUP hint with retry option on async lookup mode

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -542,12 +542,12 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                             isLeftOuterJoin,
                             asyncLookupOptions.asyncBufferCapacity);
         }
-        // TODO async retry to be supported, can not directly enable retry on 'AsyncWaitOperator'
-        // because of two reasons: 1. AsyncLookupJoinRunner has a 'stateful' resultFutureBuffer bind
-        // to each input record (it's non-reenter-able) 2. can not lookup new value if cache empty
-        // enabled when chained with the new AsyncCachingLookupFunction. This two issues should be
-        // resolved first before enable async retry.
 
+        // Why not directly enable retry on 'AsyncWaitOperator'? because of two reasons:
+        // 1. AsyncLookupJoinRunner has a 'stateful' resultFutureBuffer bind to each input record
+        // (it's non-reenter-able) 2. can not lookup new value if cache empty values enabled when
+        // chained with the new AsyncCachingLookupFunction. So similar to sync lookup join with
+        // retry, use a 'RetryableAsyncLookupFunctionDelegator' to support retry.
         return new AsyncWaitOperatorFactory<>(
                 asyncFunc,
                 asyncLookupOptions.asyncTimeout,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/LookupJoinUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/LookupJoinUtil.java
@@ -205,13 +205,13 @@ public final class LookupJoinUtil {
      * error if both candidates not found.
      *
      * <pre>{@code
-     * 1. if upsertMaterialize == true : require sync lookup orElse error
+     * 1. if upsertMaterialize == true : require sync lookup or else error
      *
      * 2. preferAsync = except there is a hint option 'async' = 'false'
      *  if (preferAsync) {
-     *    async lookup != null ? async : sync orElse error
+     *    async lookup != null ? async : sync or else error
      *  } else {
-     *    sync lookup != null ? sync : async orElse error
+     *    sync lookup != null ? sync : async or else error
      *  }
      * }</pre>
      */

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/AsyncLookupJoinITCase.scala
@@ -475,7 +475,7 @@ class AsyncLookupJoinITCase(
 
     val expected = if (legacyTableSource) {
       // test legacy lookup source do not support lookup threshold
-      // for real async lookup functions(both new and legacy api) do support retry
+      // also legacy lookup source do not support retry
       Seq("1,12,Julian,Julian", "2,15,Hello,Jark", "3,15,Fabian,Fabian")
     } else {
       // the user_table_with_lookup_threshold3 will return null result before 3rd lookup
@@ -503,14 +503,7 @@ class AsyncLookupJoinITCase(
       .addSink(sink)
     env.execute()
 
-    val expected = if (legacyTableSource) {
-      // test legacy lookup source do not support lookup threshold
-      // for real async lookup functions(both new and legacy api) do support retry
-      Seq("1,12,Julian,Julian", "2,15,Hello,Jark", "3,15,Fabian,Fabian")
-    } else {
-      // TODO retry on async is not supported currently, this should be updated after supported
-      Seq()
-    }
+    val expected = Seq("1,12,Julian,Julian", "2,15,Hello,Jark", "3,15,Fabian,Fabian")
     assertEquals(expected.sorted, sink.getAppendResults.sorted)
   }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/ResultRetryStrategy.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/ResultRetryStrategy.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.runtime.operators.join.lookup;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.streaming.api.functions.async.AsyncRetryPredicate;
 import org.apache.flink.streaming.api.functions.async.AsyncRetryStrategy;
 import org.apache.flink.streaming.util.retryable.AsyncRetryStrategies;
@@ -36,7 +37,8 @@ public class ResultRetryStrategy implements AsyncRetryStrategy<RowData> {
             new ResultRetryStrategy(AsyncRetryStrategies.NO_RETRY_STRATEGY);
     private AsyncRetryStrategy retryStrategy;
 
-    private ResultRetryStrategy(AsyncRetryStrategy retryStrategy) {
+    @VisibleForTesting
+    public ResultRetryStrategy(AsyncRetryStrategy retryStrategy) {
         this.retryStrategy = retryStrategy;
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/RetryableAsyncLookupFunctionDelegator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/lookup/RetryableAsyncLookupFunctionDelegator.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join.lookup;
+
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.AsyncLookupFunction;
+import org.apache.flink.table.functions.FunctionContext;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
+
+/** A delegator holds user's {@link AsyncLookupFunction} to handle retries. */
+public class RetryableAsyncLookupFunctionDelegator extends AsyncLookupFunction {
+
+    private final AsyncLookupFunction userLookupFunction;
+
+    private final ResultRetryStrategy retryStrategy;
+
+    private final boolean retryEnabled;
+
+    private transient Predicate<Collection<RowData>> retryResultPredicate;
+
+    public RetryableAsyncLookupFunctionDelegator(
+            @Nonnull AsyncLookupFunction userLookupFunction,
+            @Nonnull ResultRetryStrategy retryStrategy) {
+        this.userLookupFunction = userLookupFunction;
+        this.retryStrategy = retryStrategy;
+        this.retryEnabled = retryStrategy.getRetryPredicate().resultPredicate().isPresent();
+    }
+
+    @Override
+    public CompletableFuture<Collection<RowData>> asyncLookup(RowData keyRow) {
+        if (!retryEnabled) {
+            return userLookupFunction.asyncLookup(keyRow);
+        }
+        CompletableFuture<Collection<RowData>> resultFuture = new CompletableFuture<>();
+        lookupWithRetry(resultFuture, 1, keyRow);
+        return resultFuture;
+    }
+
+    private void lookupWithRetry(
+            final CompletableFuture<Collection<RowData>> resultFuture,
+            final int currentAttempts,
+            final RowData keyRow) {
+        CompletableFuture<Collection<RowData>> lookupFuture =
+                userLookupFunction.asyncLookup(keyRow);
+
+        lookupFuture.whenCompleteAsync(
+                (result, throwable) -> {
+                    if (retryResultPredicate.test(result)
+                            && retryStrategy.canRetry(currentAttempts)) {
+                        long backoff = retryStrategy.getBackoffTimeMillis(currentAttempts);
+                        try {
+                            Thread.sleep(backoff);
+                        } catch (InterruptedException e) {
+                            // Do not raise an error when interrupted, just complete with last
+                            // result intermediately.
+                            resultFuture.complete(result);
+                            return;
+                        }
+                        lookupWithRetry(resultFuture, currentAttempts + 1, keyRow);
+                    } else {
+                        resultFuture.complete(result);
+                    }
+                });
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        super.open(context);
+        userLookupFunction.open(context);
+        retryResultPredicate =
+                retryStrategy.getRetryPredicate().resultPredicate().orElse(ignore -> false);
+    }
+
+    @Override
+    public void close() throws Exception {
+        userLookupFunction.close();
+        super.close();
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RetryableAsyncLookupFunctionDelegatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/RetryableAsyncLookupFunctionDelegatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.join;
+
+import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
+import org.apache.flink.streaming.util.retryable.RetryPredicates;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.AsyncLookupFunction;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.runtime.operators.join.lookup.ResultRetryStrategy;
+import org.apache.flink.table.runtime.operators.join.lookup.RetryableAsyncLookupFunctionDelegator;
+import org.apache.flink.table.runtime.util.RowDataHarnessAssertor;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.apache.flink.table.data.StringData.fromString;
+
+/** Harness tests for {@link RetryableAsyncLookupFunctionDelegator}. */
+public class RetryableAsyncLookupFunctionDelegatorTest {
+
+    private final AsyncLookupFunction userLookupFunc = new TestingAsyncLookupFunction();
+
+    private final ResultRetryStrategy retryStrategy =
+            ResultRetryStrategy.fixedDelayRetry(3, 10, RetryPredicates.EMPTY_RESULT_PREDICATE);
+
+    private final RetryableAsyncLookupFunctionDelegator delegator =
+            new RetryableAsyncLookupFunctionDelegator(userLookupFunc, retryStrategy);
+
+    private static final Map<RowData, Collection<RowData>> data = new HashMap<>();
+
+    static {
+        data.put(
+                GenericRowData.of(1),
+                Collections.singletonList(GenericRowData.of(1, fromString("Julian"))));
+        data.put(
+                GenericRowData.of(3),
+                Arrays.asList(
+                        GenericRowData.of(3, fromString("Jark")),
+                        GenericRowData.of(3, fromString("Jackson"))));
+        data.put(
+                GenericRowData.of(4),
+                Collections.singletonList(GenericRowData.of(4, fromString("Fabian"))));
+    }
+
+    private final RowDataHarnessAssertor assertor =
+            new RowDataHarnessAssertor(
+                    new LogicalType[] {
+                        DataTypes.INT().getLogicalType(), DataTypes.STRING().getLogicalType()
+                    });
+
+    @Test
+    public void testLookupWithRetry() throws Exception {
+        delegator.open(new FunctionContext(new MockStreamingRuntimeContext(false, 1, 1)));
+        for (int i = 1; i <= 5; i++) {
+            RowData key = GenericRowData.of(i);
+            assertor.assertOutputEquals(
+                    "output wrong",
+                    Collections.singleton(data.get(key)),
+                    Collections.singleton(delegator.asyncLookup(key)));
+        }
+        delegator.close();
+    }
+
+    /** The {@link TestingAsyncLookupFunction} is a {@link AsyncLookupFunction} for testing. */
+    private static final class TestingAsyncLookupFunction extends AsyncLookupFunction {
+
+        private static final long serialVersionUID = 1L;
+
+        private final Random random = new Random();
+        private transient ExecutorService executor;
+
+        @Override
+        public void open(FunctionContext context) throws Exception {
+            super.open(context);
+            this.executor = Executors.newFixedThreadPool(2);
+        }
+
+        @Override
+        public CompletableFuture<Collection<RowData>> asyncLookup(RowData keyRow) {
+            return CompletableFuture.supplyAsync(
+                    () -> {
+                        try {
+                            Thread.sleep(random.nextInt(5));
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        return data.get(keyRow);
+                    },
+                    executor);
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (null != executor && !executor.isShutdown()) {
+                executor.shutdown();
+            }
+            super.close();
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
FLINK-28848 introduces a new LOOKUP hint to support retry both on sync and async lookup, but the async path doesn't works because of two reasons: 1. AsyncLookupJoinRunner has a 'stateful' resultFutureBuffer (which is very important for performance) bind to each input record (it's non-reenter-able)  2. can not lookup new value if cache empty values enabled when chained with the new AsyncCachingLookupFunction. So this can not be done by directly enabling retry on 'AsyncWaitOperator', so similar to sync lookup join with retry, we fix this by using a 'RetryableAsyncLookupFunctionDelegator' to support retry.

## Brief change log
* fix async lookup it case with retry
* add new RetryableAsyncLookupFunctionDelegator

## Verifying this change
* RetryableAsyncLookupFunctionDelegatorTest
* AsyncLookupJoinITCase

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)