### PR TITLE
[FLINK-28900] Fix RecreateOnResetOperatorCoordinatorTest compilation failure

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinatorTest.java
@@ -238,7 +238,11 @@ public class RecreateOnResetOperatorCoordinatorTest {
             assertThat(failedTasks)
                     .satisfiesAnyOf(
                             x -> assertThat(x).isEmpty(),
-                            x -> assertThat(x).hasSize(1).containsExactly(finalIndexOfCoordinator));
+                            x ->
+                                    assertThat(x)
+                                            .hasSize(1)
+                                            .element(0)
+                                            .isEqualTo(finalIndexOfCoordinator));
             assertThat(internalCoordinator)
                     .satisfiesAnyOf(
                             x -> assertThat(x.hasCompleteCheckpoint()).isFalse(),


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes the compilation failure thrown in RecreateOnResetOperatorCoordinatorTest.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
