### PR TITLE
[FLINK-28904][python][docs] Add missing connector/format doc

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/filesystem.md
+++ b/docs/content.zh/docs/connectors/datastream/filesystem.md
@@ -74,6 +74,15 @@ FileSource.forRecordStreamFormat(StreamFormat,Path...);
 FileSource.forBulkFileFormat(BulkFormat,Path...);
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+# 从文件流中读取文件内容
+FileSource.for_record_stream_format(stream_format, *path)
+
+# 从文件中一次读取一批记录
+FileSource.for_bulk_file_format(bulk_format, *path)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 可以通过创建 `FileSource.FileSourceBuilder` 设置 File Source 的所有参数。
@@ -91,6 +100,13 @@ final FileSource<String> source =
         FileSource.forRecordStreamFormat(...)
         .monitorContinuously(Duration.ofMillis(5))  
         .build();
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+source = FileSource.for_record_stream_format(...) \
+    .monitor_continously(Duration.of_millis(5)) \
+    .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -351,6 +367,19 @@ val sink: FileSink[String] = FileSink
 
 input.sinkTo(sink)
 
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+data_stream = ...
+
+sink = FileSink \
+    .for_row_format(OUTPUT_PATH, Encoder.simple_string_encoder("UTF-8")) \
+    .with_rolling_policy(RollingPolicy.default_rolling_policy(
+        part_size=1024 ** 3, rollover_interval=15 * 60 * 1000, inactivity_interval=5 * 60 * 1000)) \
+    .build()
+
+data_stream.sink_to(sink)
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -915,6 +944,10 @@ Flink 内置了两种 BucketAssigners：
 - `DateTimeBucketAssigner` ：默认的基于时间的分配器
 - `BasePathBucketAssigner` ：分配所有文件存储在基础路径上（单个全局桶）
 
+{{< hint info >}}
+PyFlink 只支持 `DateTimeBucketAssigner` 和 `BasePathBucketAssigner` 。
+{{< /hint >}}
+
 <a name="rolling-policy"></a>
 
 ### 滚动策略
@@ -927,6 +960,10 @@ Flink 内置了两种 RollingPolicies：
 
 - `DefaultRollingPolicy`
 - `OnCheckpointRollingPolicy`
+
+{{< hint info >}}
+PyFlink 只支持 `DefaultRollingPolicy` 和 `OnCheckpointRollingPolicy` 。
+{{< /hint >}}
 
 <a name="part-file-lifecycle"></a>
 
@@ -1046,6 +1083,22 @@ val sink = FileSink
 			
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+config = OutputFileConfig \
+    .builder() \
+    .with_part_prefix("prefix") \
+    .with_part_suffix(".ext") \
+    .build()
+
+sink = FileSink \
+    .for_row_format(OUTPUT_PATH, Encoder.simple_string_encoder("UTF-8")) \
+    .with_bucket_assigner(BucketAssigner.base_path_bucket_assigner()) \
+    .with_rolling_policy(RollingPolicy.on_checkpoint_rolling_policy()) \
+    .with_output_file_config(config) \
+    .build()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 <a name="compaction"></a>
@@ -1091,6 +1144,19 @@ val fileSink: FileSink[Integer] =
 
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+file_sink = FileSink \
+    .for_row_format(PATH, Encoder.simple_string_encoder()) \
+    .enable_compact(
+        FileCompactStrategy.builder()
+            .set_size_threshold(1024)
+            .enable_compaction_on_checkpoint(5)
+            .build(),
+        FileCompactor.concat_file_compactor()) \
+    .build()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 这一功能开启后，在文件转为 `pending` 状态与文件最终提交之间会进行文件合并。这些 `pending` 状态的文件将首先被提交为一个以 `.` 开头的
@@ -1116,6 +1182,10 @@ val fileSink: FileSink[Integer] =
 **注意事项1** 一旦启用了文件合并功能，此后若需要再关闭，必须在构建`FileSink`时显式调用`disableCompact`方法。
 
 **注意事项2** 如果启用了文件合并功能，文件可见的时间会被延长。
+{{< /hint >}}
+
+{{< hint info >}}
+PyFlink 只支持 `ConcatFileCompactor` 和 `IdenticalFileCompactor` 。
 {{< /hint >}}
 
 <a name="important-considerations"></a>

--- a/docs/content.zh/docs/connectors/datastream/firehose.md
+++ b/docs/content.zh/docs/connectors/datastream/firehose.md
@@ -33,6 +33,8 @@ To use the connector, add the following Maven dependency to your project:
 
 {{< artifact flink-connector-aws-kinesis-firehose >}}
 
+{{< py_download_link "aws-kinesis-firehose" >}}
+
 The `KinesisFirehoseSink` uses [AWS v2 SDK for Java](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html) to write data from a Flink stream into a Firehose delivery stream.
 
 {{< tabs "42vs28vdth5-nm76-6dz1-5m7s-5y345bu56se5u66je" >}}

--- a/docs/content.zh/docs/connectors/datastream/formats/json.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/json.md
@@ -35,6 +35,8 @@ To use the JSON format you need to add the Flink JSON dependency to your project
 </dependency>
 ```
 
+For PyFlink users, you could use it directly in your jobs.
+
 Flink supports reading/writing JSON records via the `JsonSerializationSchema/JsonDeserializationSchema`.
 These utilize the [Jackson](https://github.com/FasterXML/jackson) library, and support any type that is supported by Jackson, including, but not limited to, `POJO`s and `ObjectNode`.
 
@@ -74,4 +76,32 @@ JsonSerializationSchema<SomeClass> jsonFormat = new JsonSerializationSchema<>(
     () -> new ObjectMapper()
         .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS))
         .registerModule(new ParameterNamesModule());
+```
+
+## Python
+
+In PyFlink, `JsonRowSerializationSchema` and `JsonRowDeserializationSchema` are built-in support for `Row` type.
+For example to use it in `KafkaSource` and `KafkaSink`:
+
+```python
+row_type_info = Types.ROW_NAMED(['name', 'age'], [Types.STRING(), Types.INT()])
+json_format = JsonRowDeserializationSchema.builder().type_info(row_type_info).build()
+
+source = KafkaSource.builder() \
+    .set_value_only_deserializer(json_format) \
+    ...
+```
+
+```python
+row_type_info = Types.ROW_NAMED(['name', 'age'], [Types.STRING(), Types.INT()])
+json_format = JsonRowSerializationSchema.builder().with_type_info(row_type_info).build()
+
+source = KafkaSink.builder() \
+    .set_record_serializer(
+        KafkaRecordSerializationSchema.builder()
+            .set_topic('test')
+            .set_value_serialization_schema(json_format)
+            .build()
+    ) \
+    ...
 ```

--- a/docs/content.zh/docs/connectors/datastream/formats/text_files.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/text_files.md
@@ -39,6 +39,8 @@ Flink 支持使用 `TextLineInputFormat` 从文件中读取文本行。此 forma
 </dependency>
 ```
 
+PyFlink 用户可直接使用相关接口，无需添加依赖。
+
 此 format 与新 Source 兼容，可以在批处理和流模式下使用。
 因此，你可以通过两种方式使用此 format：
 - 批处理模式的有界读取
@@ -49,6 +51,8 @@ Flink 支持使用 `TextLineInputFormat` 从文件中读取文本行。此 forma
 在此示例中，我们创建了一个 DataStream，其中包含作为字符串的文本文件的行。
 此处不需要水印策略，因为记录不包含事件时间戳。
 
+{{< tabs "bounded" >}}
+{{< tab "Java" >}}
 ```java
 final FileSource<String> source =
   FileSource.forRecordStreamFormat(new TextLineInputFormat(), /* Flink Path */)
@@ -56,11 +60,21 @@ final FileSource<String> source =
 final DataStream<String> stream =
   env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+source = FileSource.for_record_stream_format(StreamFormat.text_line_format(), *path).build()
+stream = env.from_source(source, WatermarkStrategy.no_watermarks(), "file-source")
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 **连续读取示例**:
 在此示例中，我们创建了一个 DataStream，随着新文件被添加到目录中，其中包含的文本文件行的字符串流将无限增长。我们每秒会进行新文件监控。
 此处不需要水印策略，因为记录不包含事件时间戳。
 
+{{< tabs "continous" >}}
+{{< tab "Java" >}}
 ```java
 final FileSource<String> source =
     FileSource.forRecordStreamFormat(new TextLineInputFormat(), /* Flink Path */)
@@ -69,3 +83,13 @@ final FileSource<String> source =
 final DataStream<String> stream =
   env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+source = FileSource \
+    .for_record_stream_format(StreamFormat.text_line_format(), *path) \
+    .monitor_continously(Duration.of_seconds(1)) \
+    .build()
+stream = env.from_source(source, WatermarkStrategy.no_watermarks(), "file-source")
+```
+{{< /tab >}}

--- a/docs/content.zh/docs/connectors/datastream/kinesis.md
+++ b/docs/content.zh/docs/connectors/datastream/kinesis.md
@@ -52,6 +52,8 @@ Kinesis 连接器提供访问 [Amazon Kinesis Data Streams](http://aws.amazon.co
 
 由于许可证问题，以前的版本中 `flink-connector-kinesis` 工件没有部署到Maven中心库。有关更多信息，请参阅特定版本的文档。
 
+{{< py_download_link "kinesis" >}}
+
 ## 使用亚马逊 Kinesis 流服务
 遵循 [Amazon Kinesis Streams Developer Guide](https://docs.aws.amazon.com/streams/latest/dev/learning-kinesis-module-one-create-stream.html) 的指令建立 Kinesis 流。
 

--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -34,6 +34,8 @@ Pulsar Source 当前支持 Pulsar 2.8.1 之后的版本，但是 Pulsar Source �
 
 {{< artifact flink-connector-pulsar >}}
 
+{{< py_download_link "pulsar" >}}
+
 Flink 的流连接器并不会放到发行文件里面一同发布，阅读[此文档]({{< ref "docs/dev/configuration/overview" >}})，了解如何将连接器添加到集群实例内。
 
 ## Pulsar Source

--- a/docs/content.zh/docs/connectors/datastream/rabbitmq.md
+++ b/docs/content.zh/docs/connectors/datastream/rabbitmq.md
@@ -40,6 +40,8 @@ Flink 自身既没有复用 "RabbitMQ AMQP Java Client" 的代码，也没有将
 
 {{< artifact flink-connector-rabbitmq >}}
 
+{{< py_download_link "rabbitmq" >}}
+
 注意连接器现在没有包含在二进制发行版中。集群执行的相关信息请参考 [这里]({{< ref "docs/dev/configuration/overview" >}}).
 
 ### 安装 RabbitMQ

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -71,6 +71,15 @@ FileSource.forRecordStreamFormat(StreamFormat,Path...);
 FileSource.forBulkFileFormat(BulkFormat,Path...);
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+# reads the contents of a file from a file stream.
+FileSource.for_record_stream_format(stream_format, *path)
+
+# reads batches of records from a file at a time
+FileSource.for_bulk_file_format(bulk_format, *path)
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 This creates a `FileSource.FileSourceBuilder` on which you can configure all the properties of the File Source.
@@ -89,6 +98,13 @@ final FileSource<String> source =
         FileSource.forRecordStreamFormat(...)
         .monitorContinuously(Duration.ofMillis(5))  
         .build();
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+source = FileSource.for_record_stream_format(...) \
+    .monitor_continously(Duration.of_millis(5)) \
+    .build()
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -349,6 +365,19 @@ val sink: FileSink[String] = FileSink
 
 input.sinkTo(sink)
 
+```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+data_stream = ...
+
+sink = FileSink \
+    .for_row_format(OUTPUT_PATH, Encoder.simple_string_encoder("UTF-8")) \
+    .with_rolling_policy(RollingPolicy.default_rolling_policy(
+        part_size=1024 ** 3, rollover_interval=15 * 60 * 1000, inactivity_interval=5 * 60 * 1000)) \
+    .build()
+
+data_stream.sink_to(sink)
 ```
 {{< /tab >}}
 {{< /tabs >}}
@@ -918,6 +947,10 @@ Flink comes with two built-in BucketAssigners:
  - `DateTimeBucketAssigner` : Default time based assigner
  - `BasePathBucketAssigner` : Assigner that stores all part files in the base path (single global bucket)
 
+{{< hint info >}}
+Note: PyFlink only supports `DateTimeBucketAssigner` and `BasePathBucketAssigner`.
+{{< /hint >}}
+
 ### Rolling Policy
 
 The `RollingPolicy` defines when a given in-progress part file will be closed and moved to the pending and later to finished state.
@@ -930,6 +963,10 @@ Flink comes with two built-in RollingPolicies:
 
  - `DefaultRollingPolicy`
  - `OnCheckpointRollingPolicy`
+
+{{< hint info >}}
+Note: PyFlink only supports `DefaultRollingPolicy` and `OnCheckpointRollingPolicy`.
+{{< /hint >}}
 
 ### Part file lifecycle
 
@@ -1046,6 +1083,22 @@ val sink = FileSink
 			
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+config = OutputFileConfig \
+    .builder() \
+    .with_part_prefix("prefix") \
+    .with_part_suffix(".ext") \
+    .build()
+
+sink = FileSink \
+    .for_row_format(OUTPUT_PATH, Encoder.simple_string_encoder("UTF-8")) \
+    .with_bucket_assigner(BucketAssigner.base_path_bucket_assigner()) \
+    .with_rolling_policy(RollingPolicy.on_checkpoint_rolling_policy()) \
+    .with_output_file_config(config) \
+    .build()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 ### Compaction
@@ -1090,6 +1143,19 @@ val fileSink: FileSink[Integer] =
 
 ```
 {{< /tab >}}
+{{< tab "Python" >}}
+```python
+file_sink = FileSink \
+    .for_row_format(PATH, Encoder.simple_string_encoder()) \
+    .enable_compact(
+        FileCompactStrategy.builder()
+            .set_size_threshold(1024)
+            .enable_compaction_on_checkpoint(5)
+            .build(),
+        FileCompactor.concat_file_compactor()) \
+    .build()
+```
+{{< /tab >}}
 {{< /tabs >}}
 
 Once enabled, the compaction happens between the files become `pending` and get committed. The pending files will
@@ -1119,6 +1185,10 @@ the give list of `Path` and write the result file. It could be classified into t
 **Important Note 1** Once the compaction is enabled, you must explicitly call `disableCompact` when building the `FileSink` if you want to disable compaction.
 
 **Important Note 2** When the compaction is enabled, the written files need to wait for longer time before they get visible.
+{{< /hint >}}
+
+{{< hint info >}}
+Note: PyFlink only supports `ConcatFileCompactor` and `IdenticalFileCompactor`.
 {{< /hint >}}
 
 ### Important Considerations

--- a/docs/content/docs/connectors/datastream/firehose.md
+++ b/docs/content/docs/connectors/datastream/firehose.md
@@ -33,6 +33,8 @@ To use the connector, add the following Maven dependency to your project:
 
 {{< artifact flink-connector-aws-kinesis-firehose >}}
 
+{{< py_download_link "aws-kinesis-firehose" >}}
+
 The `KinesisFirehoseSink` uses [AWS v2 SDK for Java](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/home.html) to write data from a Flink stream into a Firehose delivery stream.
 
 {{< tabs "42vs28vdth5-nm76-6dz1-5m7s-5y345bu56se5u66je" >}}

--- a/docs/content/docs/connectors/datastream/formats/json.md
+++ b/docs/content/docs/connectors/datastream/formats/json.md
@@ -35,6 +35,8 @@ To use the JSON format you need to add the Flink JSON dependency to your project
 </dependency>
 ```
 
+For PyFlink users, you could use it directly in your jobs.
+
 Flink supports reading/writing JSON records via the `JsonSerializationSchema/JsonDeserializationSchema`.
 These utilize the [Jackson](https://github.com/FasterXML/jackson) library, and support any type that is supported by Jackson, including, but not limited to, `POJO`s and `ObjectNode`.
 
@@ -74,4 +76,32 @@ JsonSerializationSchema<SomeClass> jsonFormat=new JsonSerializationSchema<>(
     () -> new ObjectMapper()
         .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS))
         .registerModule(new ParameterNamesModule());
+```
+
+## Python
+
+In PyFlink, `JsonRowSerializationSchema` and `JsonRowDeserializationSchema` are built-in support for `Row` type.
+For example to use it in `KafkaSource` and `KafkaSink`:
+
+```python
+row_type_info = Types.ROW_NAMED(['name', 'age'], [Types.STRING(), Types.INT()])
+json_format = JsonRowDeserializationSchema.builder().type_info(row_type_info).build()
+
+source = KafkaSource.builder() \
+    .set_value_only_deserializer(json_format) \
+    ...
+```
+
+```python
+row_type_info = Types.ROW_NAMED(['name', 'age'], [Types.STRING(), Types.INT()])
+json_format = JsonRowSerializationSchema.builder().with_type_info(row_type_info).build()
+
+source = KafkaSink.builder() \
+    .set_record_serializer(
+        KafkaRecordSerializationSchema.builder()
+            .set_topic('test')
+            .set_value_serialization_schema(json_format)
+            .build()
+    ) \
+    ...
 ```

--- a/docs/content/docs/connectors/datastream/formats/text_files.md
+++ b/docs/content/docs/connectors/datastream/formats/text_files.md
@@ -39,6 +39,8 @@ To use the format you need to add the Flink Connector Files dependency to your p
 </dependency>
 ```
 
+For PyFlink users, you could use it directly in your jobs.
+
 This format is compatible with the new Source that can be used in both batch and streaming modes.
 Thus, you can use this format in two ways:
 - Bounded read for batch mode
@@ -49,6 +51,8 @@ Thus, you can use this format in two ways:
 In this example we create a DataStream containing the lines of a text file as Strings. 
 There is no need for a watermark strategy as records do not contain event timestamps.
 
+{{< tabs "bounded" >}}
+{{< tab "Java" >}}
 ```java
 final FileSource<String> source =
   FileSource.forRecordStreamFormat(new TextLineInputFormat(), /* Flink Path */)
@@ -56,12 +60,22 @@ final FileSource<String> source =
 final DataStream<String> stream =
   env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+source = FileSource.for_record_stream_format(StreamFormat.text_line_format(), *path).build()
+stream = env.from_source(source, WatermarkStrategy.no_watermarks(), "file-source")
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 **Continuous read example**:
 In this example, we create a DataStream containing the lines of text files as Strings that will infinitely grow 
 as new files are added to the directory. We monitor for new files each second.
 There is no need for a watermark strategy as records do not contain event timestamps.
 
+{{< tabs "continous" >}}
+{{< tab "Java" >}}
 ```java
 final FileSource<String> source =
     FileSource.forRecordStreamFormat(new TextLineInputFormat(), /* Flink Path */)
@@ -70,3 +84,13 @@ final FileSource<String> source =
 final DataStream<String> stream =
   env.fromSource(source, WatermarkStrategy.noWatermarks(), "file-source");
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+source = FileSource \
+    .for_record_stream_format(StreamFormat.text_line_format(), *path) \
+    .monitor_continously(Duration.of_seconds(1)) \
+    .build()
+stream = env.from_source(source, WatermarkStrategy.no_watermarks(), "file-source")
+```
+{{< /tab >}}

--- a/docs/content/docs/connectors/datastream/kinesis.md
+++ b/docs/content/docs/connectors/datastream/kinesis.md
@@ -52,6 +52,8 @@ To use this connector, add one or more of the following dependencies to your pro
 
 Due to the licensing issue, the `flink-connector-kinesis` artifact is not deployed to Maven central for the prior versions. Please see the version specific documentation for further information.
 
+{{< py_download_link "kinesis" >}}
+
 ## Using the Amazon Kinesis Streams Service
 Follow the instructions from the [Amazon Kinesis Streams Developer Guide](https://docs.aws.amazon.com/streams/latest/dev/learning-kinesis-module-one-create-stream.html)
 to setup Kinesis streams.

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -34,6 +34,8 @@ Details on Pulsar compatibility can be found in [PIP-72](https://github.com/apac
 
 {{< artifact flink-connector-pulsar >}}
 
+{{< py_download_link "pulsar" >}}
+
 Flink's streaming connectors are not part of the binary distribution.
 See how to link with them for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).
 

--- a/docs/content/docs/connectors/datastream/rabbitmq.md
+++ b/docs/content/docs/connectors/datastream/rabbitmq.md
@@ -44,6 +44,8 @@ This connector provides access to data streams from [RabbitMQ](http://www.rabbit
 
 {{< artifact flink-connector-rabbitmq >}}
 
+{{< py_download_link "rabbitmq" >}}
+
 Note that the streaming connectors are currently not part of the binary distribution. See linking with them for cluster execution [here]({{< ref "docs/dev/configuration/overview" >}}).
 
 ### Installing RabbitMQ

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -172,3 +172,20 @@ kinesis:
     maven: flink-connector-kinesis
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kinesis/$version/flink-sql-connector-kinesis-$version.jar
 
+aws-kinesis-firehose:
+  name: AWS Kinesis Firehose
+  category: connector
+  maven: flink-connector-kinesis-firehose
+  sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/$version/flink-sql-connector-aws-kinesis-firehose-$version.jar
+
+pulsar:
+    name: Pulsar
+    category: connector
+    maven: flink-connector-pulsar
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-pulsar/$version/flink-sql-connector-pulsar-$version.jar
+
+rabbitmq:
+    name: RabbitMQ
+    category: connector
+    maven: flink-connector-rabbitmq
+    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-rabbitmq/$version/flink-sql-connector-rabbitmq-$version.jar

--- a/flink-python/pyflink/datastream/connectors/file_system.py
+++ b/flink-python/pyflink/datastream/connectors/file_system.py
@@ -603,14 +603,14 @@ class FileCompactor(JavaObjectWrapper):
             return FileCompactor(JConcatFileCompactor())
 
     @staticmethod
-    def identity_file_compactor():
+    def identical_file_compactor():
         """
         Returns a file compactor that directly copy the content of the only input file to the
         output.
         """
-        JIdentityFileCompactor = get_gateway().jvm.org.apache.flink.connector.file.sink.compactor.\
-            IdentityFileCompactor
-        return FileCompactor(JIdentityFileCompactor())
+        JIdenticalFileCompactor = get_gateway().jvm.org.apache.flink.connector.file.sink.compactor.\
+            IdenticalFileCompactor
+        return FileCompactor(JIdenticalFileCompactor())
 
 
 class FileSink(Sink, SupportsPreprocessing):


### PR DESCRIPTION
## What is the purpose of the change

This PR add missing connector/format docs for PyFlink.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
