### PR TITLE
[FLINK-28908][python] Coder for LIST type is incorrectly chosen

### DIFF
--- a/flink-python/pyflink/common/typeinfo.py
+++ b/flink-python/pyflink/common/typeinfo.py
@@ -439,7 +439,7 @@ class RowTypeInfo(TypeInformation):
                     zip(self.get_field_names(), self._field_types, self._need_conversion))
             elif isinstance(obj, Row) and hasattr(obj, "_fields"):
                 return (obj.get_row_kind().value,) + tuple(
-                    f.to_internal_type(obj.get(n)) if c else obj.get(n)
+                    f.to_internal_type(obj[n]) if c else obj[n]
                     for n, f, c in
                     zip(self.get_field_names(), self._field_types, self._need_conversion))
             elif isinstance(obj, Row):
@@ -463,7 +463,7 @@ class RowTypeInfo(TypeInformation):
                 return (RowKind.INSERT.value,) + tuple(obj.get(n) for n in self.get_field_names())
             elif isinstance(obj, Row) and hasattr(obj, "_fields"):
                 return (obj.get_row_kind().value,) + tuple(
-                    obj.get(n) for n in self.get_field_names())
+                    obj[n] for n in self.get_field_names())
             elif isinstance(obj, Row):
                 return (obj.get_row_kind().value,) + tuple(obj)
             elif isinstance(obj, (list, tuple)):

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -817,7 +817,7 @@ class DataStreamTests(object):
         ds = self.env.from_collection([Row(list=[1, 2, 3])], type_info=row_type_info)
         ds.map(lambda e: str(e), Types.STRING()).add_sink(self.test_sink)
         self.env.execute('test_java_list_deserialization')
-        expected = ['[1, 2, 3]']
+        expected = ['Row(list=[1, 2, 3])']
         self.assert_equals(self.test_sink.get_results(), expected)
 
 

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -812,6 +812,24 @@ class DataStreamTests(object):
         expected = ['(hi,3)']
         self.assert_equals_sorted(expected, results)
 
+    def test_java_list_deserialization(self):
+        jvm = get_gateway().jvm
+        j_item = jvm.java.util.ArrayList()
+        j_item.add(1)
+        j_item.add(2)
+        j_item.add(3)
+        j_list = jvm.java.util.ArrayList()
+        j_list.add(j_item)
+        type_info = Types.LIST(Types.INT())
+        ds = DataStream(self.env._j_stream_execution_environment.fromCollection(
+            j_list, type_info.get_java_type_info()
+        ))
+        ds.map(lambda e: str(e), Types.STRING()).add_sink(self.test_sink)
+
+        self.env.execute('test_java_list_deserialization')
+        expected = ['[1, 2, 3]']
+        self.assert_equals(self.test_sink.get_results(), expected)
+
 
 class StreamingModeDataStreamTests(DataStreamTests, PyFlinkStreamingTestCase):
     def test_data_stream_name(self):

--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -813,19 +813,9 @@ class DataStreamTests(object):
         self.assert_equals_sorted(expected, results)
 
     def test_java_list_deserialization(self):
-        jvm = get_gateway().jvm
-        j_item = jvm.java.util.ArrayList()
-        j_item.add(1)
-        j_item.add(2)
-        j_item.add(3)
-        j_list = jvm.java.util.ArrayList()
-        j_list.add(j_item)
-        type_info = Types.LIST(Types.INT())
-        ds = DataStream(self.env._j_stream_execution_environment.fromCollection(
-            j_list, type_info.get_java_type_info()
-        ))
+        row_type_info = Types.ROW_NAMED(['list'], [Types.LIST(Types.INT())])
+        ds = self.env.from_collection([Row(list=[1, 2, 3])], type_info=row_type_info)
         ds.map(lambda e: str(e), Types.STRING()).add_sink(self.test_sink)
-
         self.env.execute('test_java_list_deserialization')
         expected = ['[1, 2, 3]']
         self.assert_equals(self.test_sink.get_results(), expected)

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -679,13 +679,17 @@ def from_type_info_proto(type_info):
             return RowCoder(
                 [from_type_info_proto(f.field_type) for f in type_info.row_type_info.fields],
                 [f.field_name for f in type_info.row_type_info.fields])
-        elif field_type_name == type_info_name.PRIMITIVE_ARRAY:
+        elif field_type_name in (
+            type_info_name.PRIMITIVE_ARRAY,
+            type_info_name.LIST,
+        ):
             if type_info.collection_element_type.type_name == type_info_name.BYTE:
                 return BinaryCoder()
             return PrimitiveArrayCoder(from_type_info_proto(type_info.collection_element_type))
-        elif field_type_name in (type_info_name.BASIC_ARRAY,
-                                 type_info_name.OBJECT_ARRAY,
-                                 type_info_name.LIST):
+        elif field_type_name in (
+            type_info_name.BASIC_ARRAY,
+            type_info_name.OBJECT_ARRAY,
+        ):
             return GenericArrayCoder(from_type_info_proto(type_info.collection_element_type))
         elif field_type_name == type_info_name.TUPLE:
             return TupleCoder([from_type_info_proto(field_type)

--- a/flink-python/pyflink/table/types.py
+++ b/flink-python/pyflink/table/types.py
@@ -1250,7 +1250,7 @@ class RowType(DataType):
                     for n, f, c in zip(self.names, self.fields, self._need_conversion))
             elif isinstance(obj, Row) and hasattr(obj, "_fields"):
                 return (obj.get_row_kind().value,) + tuple(
-                    f.to_sql_type(obj.get(n)) if c else obj.get(n)
+                    f.to_sql_type(obj[n]) if c else obj[n]
                     for n, f, c in zip(self.names, self.fields, self._need_conversion))
             elif isinstance(obj, Row):
                 return (obj.get_row_kind().value, ) + tuple(


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes incorrect coder for deserializing `Types.LIST` data from Java. This needs to be cherry-picked to release-1.14 too.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
