### PR TITLE
[FLINK-28027][connectors] Implement slow start for AIMDRateLimitingSt…

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
@@ -291,7 +291,7 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
                         INFLIGHT_MESSAGES_LIMIT_INCREASE_RATE,
                         INFLIGHT_MESSAGES_LIMIT_DECREASE_FACTOR,
                         maxBatchSize * maxInFlightRequests,
-                        maxBatchSize * maxInFlightRequests);
+                        maxBatchSize);
 
         this.metrics = context.metricGroup();
         this.metrics.setCurrentSendTimeGauge(() -> this.ackTime - this.lastSendTimestamp);


### PR DESCRIPTION
…rategy

## What is the purpose of the change
Implement slow start for `AIMDRateLimitingStrategy` by starting from the `maxBatchSize` specified as the `initialRate`.

## Brief change log
- Reduce the `initialRate` for `AIMDRateLimitingStrategy` to `maxBatchSize`.

## Verifying this change
This change is already covered by existing tests, such as `AsyncSinkWriter` unit tests. Sinks extending `AsyncSinkWriter` have their own integration tests (e.g. AwsKinesisFirehoseSink, AwsKinesisStreamsSink)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
