### PR TITLE
[FLINK-28916][e2e] Add e2e test for create function using jar syntax

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/UsingRemoteJarITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/UsingRemoteJarITCase.java
@@ -43,7 +43,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-/** ITCase for adding remote jar. */
+/** End to End tests for using remote jar. */
 public class UsingRemoteJarITCase extends SqlITCaseBase {
     private static final Path HADOOP_CLASSPATH = TestUtils.getResource(".*hadoop.classpath");
 
@@ -104,6 +104,45 @@ public class UsingRemoteJarITCase extends SqlITCaseBase {
         runAndCheckSQL(
                 "remote_jar_e2e.sql",
                 generateReplaceVars(),
+                2,
+                Arrays.asList(
+                        "{\"before\":null,\"after\":{\"user_name\":\"Alice\",\"order_cnt\":1},\"op\":\"c\"}",
+                        "{\"before\":null,\"after\":{\"user_name\":\"Bob\",\"order_cnt\":2},\"op\":\"c\"}"));
+    }
+
+    @Test
+    public void testCreateTemporarySystemFunctionUsingRemoteJar() throws Exception {
+        Map<String, String> replaceVars = generateReplaceVars();
+        replaceVars.put("$TEMPORARY", "TEMPORARY SYSTEM");
+        runAndCheckSQL(
+                "create_function_using_remote_jar_e2e.sql",
+                replaceVars,
+                2,
+                Arrays.asList(
+                        "{\"before\":null,\"after\":{\"user_name\":\"Alice\",\"order_cnt\":1},\"op\":\"c\"}",
+                        "{\"before\":null,\"after\":{\"user_name\":\"Bob\",\"order_cnt\":2},\"op\":\"c\"}"));
+    }
+
+    @Test
+    public void testCreateCatalogFunctionUsingRemoteJar() throws Exception {
+        Map<String, String> replaceVars = generateReplaceVars();
+        replaceVars.put("$TEMPORARY", "");
+        runAndCheckSQL(
+                "create_function_using_remote_jar_e2e.sql",
+                replaceVars,
+                2,
+                Arrays.asList(
+                        "{\"before\":null,\"after\":{\"user_name\":\"Alice\",\"order_cnt\":1},\"op\":\"c\"}",
+                        "{\"before\":null,\"after\":{\"user_name\":\"Bob\",\"order_cnt\":2},\"op\":\"c\"}"));
+    }
+
+    @Test
+    public void testCreateTemporaryCatalogFunctionUsingRemoteJar() throws Exception {
+        Map<String, String> replaceVars = generateReplaceVars();
+        replaceVars.put("$TEMPORARY", "TEMPORARY");
+        runAndCheckSQL(
+                "create_function_using_remote_jar_e2e.sql",
+                replaceVars,
                 2,
                 Arrays.asList(
                         "{\"before\":null,\"after\":{\"user_name\":\"Alice\",\"order_cnt\":1},\"op\":\"c\"}",

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/resources/create_function_using_remote_jar_e2e.sql
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/resources/create_function_using_remote_jar_e2e.sql
@@ -1,0 +1,41 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one
+ *  or more contributor license agreements.  See the NOTICE file
+ *  distributed with this work for additional information
+ *  regarding copyright ownership.  The ASF licenses this file
+ *  to you under the Apache License, Version 2.0 (the
+ *  "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+CREATE TABLE JsonTable (
+   user_name STRING,
+   order_cnt BIGINT
+) WITH (
+    'connector' = 'filesystem',
+    'path' = '$RESULT',
+    'sink.rolling-policy.rollover-interval' = '2s',
+    'sink.rolling-policy.check-interval' = '2s',
+    'format' = 'debezium-json'
+);
+
+CREATE $TEMPORARY FUNCTION count_agg AS 'org.apache.flink.table.toolbox.CountAggFunction'
+    LANGUAGE JAVA USING JAR '$JAR_PATH';
+
+SET execution.runtime-mode = $MODE;
+SET table.exec.mini-batch.enabled = true;
+SET table.exec.mini-batch.size = 5;
+SET table.exec.mini-batch.allow-latency = 2s;
+
+INSERT INTO JsonTable
+SELECT user_name, count_agg(order_id)
+FROM (VALUES (1, 'Bob'), (2, 'Bob'), (1, 'Alice')) T(order_id, user_name)
+GROUP BY user_name;


### PR DESCRIPTION
## What is the purpose of the change

Add e2e test for create function using jar syntax that using remote hdfs jar

## Brief change log

  - *Add e2e test for create function using jar syntax that using remote hdfs jar*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added e2e tests in UsingRemoteJarITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
