### PR TITLE
add field comment parse for hive ddl

### DIFF
--- a/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser-hive/src/main/codegen/includes/parserImpls.ftl
@@ -525,6 +525,11 @@ void TableColumnWithConstraint(HiveTableCreationContext context) :
             context.notNullTraits.add(constraintTrait);
             context.notNullCols.add(name);
         }
+    }
+    [ <COMMENT> <QUOTED_STRING> {
+        comment = createStringLiteral(token.image, getPos());
+    }]
+    {
         SqlTableColumn tableColumn = new SqlTableColumn.SqlRegularColumn(
             getPos(),
             name,
@@ -533,9 +538,6 @@ void TableColumnWithConstraint(HiveTableCreationContext context) :
             null);
         context.columnList.add(tableColumn);
     }
-    [ <COMMENT> <QUOTED_STRING> {
-        comment = createStringLiteral(token.image, getPos());
-    }]
 }
 
 SqlHiveConstraintTrait ConstraintTrait() :


### PR DESCRIPTION
## What is the purpose of the change

The field comment is lost when using hive parser.

```java
"set table.sql-dialect=hive;\n" +
"CREATE TABLE IF NOT EXISTS myhive.dev.shipu3_test_1125 (\n" +
"   `id` int COMMENT 'iadddd',\n" +
"   `cartdid` bigint COMMENT 'aaa',\n" +
"   `customer` string COMMENT 'vvvv',\n" +
"   `product` string COMMENT 'cccc',\n" +
"   `price` double COMMENT '',\n" +
"   `dt` STRING COMMENT ''\n" +
") PARTITIONED BY (dt STRING) STORED AS TEXTFILE TBLPROPERTIES (\n" +
"  'streaming-source.enable' = 'false',\n" +
"  'streaming-source.partition.include' = 'all',\n" +
"  'lookup.join.cache.ttl' = '12 h'\n" +
")"; 
```

## Brief change log

Add field comment for hive ddl




## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
