### PR TITLE
[FLINK-28883][hive] Fix HiveTableSink failed to report statistic to hive metastore in batch mode

### DIFF
--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -510,12 +510,15 @@ INSERT INTO TABLE fact_tz PARTITION (day, hour) select 1, '2022-8-8', '14';
 - 目前，只有在 Flink 批模式下使用了 [Hive 方言]({{< ref "docs/connectors/table/hive/hive_dialect" >}})，才可以使用 `DISTRIBUTED BY` 和 `SORTED BY`。
 
 ### 自动收集统计信息
-在某些情况下，在使用 Flink 写入 Hive 表的时候，你可能想让 Flink 自动收集写入数据的统计信息。
-为了达到这个目的，你可以设置作业参数 `table.exec.hive.sink.statistic-auto-gather.enable` (默认是 `false`) 为 `true`.
-然后，Flink 在写 Hive 表的时候将会自动收集统计信息并将其提交至 Hive metastore 中。
+在使用 Flink 写入 Hive 表的时候，Flink 将默认自动收集写入数据的统计信息然后将其提交至 Hive metastore 中。
+但在某些情况下，你可能不想自动收集统计信息，因为收集这些统计信息可能会花费一定的时间。 
+为了避免 Flink 自动收集统计信息，你可以设置作业参数 `table.exec.hive.sink.statistic-auto-gather.enable` (默认是 `true`) 为 `false`。
 
 如果写入的 Hive 表是以 Parquet 或者 ORC 格式存储的时候，`numFiles`/`totalSize`/`numRows`/`rawDataSize` 这些统计信息可以被 Flink 收集到。
 否则, 只有 `numFiles`/`totalSize` 可以被收集到。
+
+对于 Parquet 或者 ORC 格式的表，为了快速收集到统计信息 `numRows`/`rawDataSize`， Flink 只会读取文件的 footer。但是在文件数量很多的情况下，这可能也会比较耗时，你可以通过
+设置作业参数 `table.exec.hive.sink.statistic-auto-gather.thread-num`（默认是 `3`）为一个更大的值来加快统计信息的收集。
 
 **注意：**
 - 只有批模式才支持自动收集统计信息，流模式目前还不支持自动收集统计信息。

--- a/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content.zh/docs/connectors/table/hive/hive_read_write.md
@@ -507,7 +507,18 @@ INSERT INTO TABLE fact_tz PARTITION (day, hour) select 1, '2022-8-8', '14';
 
 **注意：**
 - 该配置项 `table.exec.hive.sink.sort-by-dynamic-partition.enable` 只在批模式下生效。
-- 目前，只有在 Flink 批模式下使用了 [Hive 方言]({{< ref "docs/connectors/table/hive/hive_dialect" >}})，才可以使用 `DISTRIBUTED BY` and `SORTED BY`。
+- 目前，只有在 Flink 批模式下使用了 [Hive 方言]({{< ref "docs/connectors/table/hive/hive_dialect" >}})，才可以使用 `DISTRIBUTED BY` 和 `SORTED BY`。
+
+### 自动收集统计信息
+在某些情况下，在使用 Flink 写入 Hive 表的时候，你可能想让 Flink 自动收集写入数据的统计信息。
+为了达到这个目的，你可以设置作业参数 `table.exec.hive.sink.statistic-auto-gather.enable` (默认是 `false`) 为 `true`.
+然后，Flink 在写 Hive 表的时候将会自动收集统计信息并将其提交至 Hive metastore 中。
+
+如果写入的 Hive 表是以 Parquet 或者 ORC 格式存储的时候，`numFiles`/`totalSize`/`numRows`/`rawDataSize` 这些统计信息可以被 Flink 收集到。
+否则, 只有 `numFiles`/`totalSize` 可以被收集到。
+
+**注意：**
+- 只有批模式才支持自动收集统计信息，流模式目前还不支持自动收集统计信息。
 
 ## 格式
 

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -537,12 +537,18 @@ Also, you can manually add `SORTED BY <partition_field>` in your SQL statement t
 - Currently, `DISTRIBUTED BY` and `SORTED BY` is only supported when using [Hive dialect]({{< ref "docs/connectors/table/hive/hive_dialect" >}})  in Flink `BATCH` mode.
 
 ### Auto Gather Statistic
-In some case, you may want to make Flink gather statistic auto automatically during writing Hive table by Flink. 
-To achieve such a purpose, You can set the job configuration `table.exec.hive.sink.statistic-auto-gather.enable` (`false` by default) to `true`.
-Then the statistic will be gathered by Flink automatically and committed to Hive metastore.
+By default, Flink will gather the statistic automatically and then committed to Hive metastore during writing Hive table.
+
+But in some case, you may want to disable it as it may be time-consuming to gather the statistic.
+Then, you can set the job configuration `table.exec.hive.sink.statistic-auto-gather.enable` (`true` by default) to `false`
+to disable it.
 
 If the Hive table is stored as Parquet or ORC format, `numFiles`/`totalSize`/`numRows`/`rawDataSize` can be gathered.
 Otherwise, only `numFiles`/`totalSize` can be gathered.
+
+To gather statistic `numRows`/`rawDataSize` for Parquet and ORC format, Flink will only read the file's footer to do fast gathering.
+But it may still time-consuming when there are too many files, then you can configure the job configuration `table.exec.hive.sink.statistic-auto-gather.thread-num` (`3` by default) to 
+use more threads to speed the gathering.
 
 **NOTE:**
 - Only `BATCH` mode supports to auto gather statistic, `STREAMING` mode doesn't support it yet.

--- a/docs/content/docs/connectors/table/hive/hive_read_write.md
+++ b/docs/content/docs/connectors/table/hive/hive_read_write.md
@@ -536,6 +536,17 @@ Also, you can manually add `SORTED BY <partition_field>` in your SQL statement t
 - The configuration `table.exec.hive.sink.sort-by-dynamic-partition.enable` only works in Flink `BATCH` mode.
 - Currently, `DISTRIBUTED BY` and `SORTED BY` is only supported when using [Hive dialect]({{< ref "docs/connectors/table/hive/hive_dialect" >}})  in Flink `BATCH` mode.
 
+### Auto Gather Statistic
+In some case, you may want to make Flink gather statistic auto automatically during writing Hive table by Flink. 
+To achieve such a purpose, You can set the job configuration `table.exec.hive.sink.statistic-auto-gather.enable` (`false` by default) to `true`.
+Then the statistic will be gathered by Flink automatically and committed to Hive metastore.
+
+If the Hive table is stored as Parquet or ORC format, `numFiles`/`totalSize`/`numRows`/`rawDataSize` can be gathered.
+Otherwise, only `numFiles`/`totalSize` can be gathered.
+
+**NOTE:**
+- Only `BATCH` mode supports to auto gather statistic, `STREAMING` mode doesn't support it yet.
+
 ## Formats
 
 Flink's Hive integration has been tested against the following file formats:

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionLoader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionLoader.java
@@ -95,6 +95,7 @@ public class PartitionLoader implements Closeable {
         Path tableLocation = metaStore.getLocationPath();
         overwriteAndMoveFiles(srcDirs, tableLocation);
         commitPartition(new LinkedHashMap<>(), tableLocation);
+        metaStore.finishWritingTable(tableLocation);
     }
 
     /**

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/TableMetaStoreFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/TableMetaStoreFactory.java
@@ -62,5 +62,11 @@ public interface TableMetaStoreFactory extends Serializable {
          */
         void createOrAlterPartition(LinkedHashMap<String, String> partitionSpec, Path partitionPath)
                 throws Exception;
+
+        /**
+         * After data has been inserted into table, some follow-up works related to metastore may
+         * need be done like report statistic to metastore.
+         */
+        default void finishWritingTable(Path tablePath) throws Exception {}
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -134,6 +134,17 @@ public class HiveOptions {
     public static final ConfigOption<String> SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME =
             FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
 
+    public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE =
+            key("table.exec.hive.sink.statistic-auto-gather.enable")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "If it's true, Flink will gather statistic automatically during writing Hive Table."
+                                    + " If it's false, no any statistic will be gathered. The default value is false."
+                                    + " For ORC and Parquet format, numFiles/totalSize/numRows/rawDataSize can be gathered."
+                                    + " For other format, only numFiles/totalSize can be gathered."
+                                    + " Note: only batch mode supports auto gather statistic, stream mode doesn't support it yet.");
+
     public static final ConfigOption<Boolean> STREAMING_SOURCE_ENABLE =
             key("streaming-source.enable")
                     .booleanType()

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -137,13 +137,23 @@ public class HiveOptions {
     public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE =
             key("table.exec.hive.sink.statistic-auto-gather.enable")
                     .booleanType()
-                    .defaultValue(false)
+                    .defaultValue(true)
                     .withDescription(
                             "If it's true, Flink will gather statistic automatically during writing Hive Table."
-                                    + " If it's false, no any statistic will be gathered. The default value is false."
+                                    + " If it's false, no any statistic will be gathered. The default value is true."
                                     + " For ORC and Parquet format, numFiles/totalSize/numRows/rawDataSize can be gathered."
                                     + " For other format, only numFiles/totalSize can be gathered."
                                     + " Note: only batch mode supports auto gather statistic, stream mode doesn't support it yet.");
+
+    public static final ConfigOption<Integer>
+            TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_THREAD_NUM =
+                    key("table.exec.hive.sink.statistic-auto-gather.thread-num")
+                            .intType()
+                            .defaultValue(3)
+                            .withDeprecatedKeys(
+                                    "The number of threads used to gather statistic during writing Hive Table"
+                                            + " when the table is stored as ORC or Parquet format."
+                                            + " The default value is 3.");
 
     public static final ConfigOption<Boolean> STREAMING_SOURCE_ENABLE =
             key("streaming-source.enable")

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableMetaStoreFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableMetaStoreFactory.java
@@ -351,7 +351,7 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
                 executorService =
                         gatherStatsThreadNum == 1
                                 ? newDirectExecutorService()
-                                : Executors.newFixedThreadPool(3);
+                                : Executors.newFixedThreadPool(gatherStatsThreadNum);
             }
             return executorService.submit(statsGatherTask);
         }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableMetaStoreFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableMetaStoreFactory.java
@@ -36,6 +36,9 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.io.StatsProvidingRecordReader;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.serde2.SerDeStats;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
@@ -43,6 +46,8 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.Reporter;
 import org.apache.hive.common.util.ReflectionUtil;
 import org.apache.thrift.TException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,8 +56,13 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.apache.flink.runtime.fs.hdfs.HadoopFileSystem.toHadoopPath;
+import static org.apache.flink.util.concurrent.Executors.newDirectExecutorService;
 
 /**
  * Hive {@link TableMetaStoreFactory}, use {@link HiveMetastoreClientWrapper} to communicate with
@@ -62,6 +72,8 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOG = LoggerFactory.getLogger(HiveTableMetaStoreFactory.class);
+
     private final JobConfWrapper conf;
     private final FileSystemFactory fileSystemFactory;
     private final String hiveVersion;
@@ -69,6 +81,8 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
     private final String tableName;
     private final boolean autoGatherStatistic;
     private final String successFileName;
+    private final int gatherStatsThreadNum;
+    private ExecutorService executorService;
 
     HiveTableMetaStoreFactory(
             JobConf conf,
@@ -76,14 +90,16 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
             String hiveVersion,
             String database,
             String tableName,
+            String successFileName,
             boolean autoGatherStatistic,
-            String successFileName) {
+            int gatherStatsThreadNum) {
         this.conf = new JobConfWrapper(conf);
         this.fileSystemFactory = fileSystemFactory;
         this.hiveVersion = hiveVersion;
         this.database = database;
         this.tableName = tableName;
         this.autoGatherStatistic = autoGatherStatistic;
+        this.gatherStatsThreadNum = gatherStatsThreadNum;
         this.successFileName = successFileName;
     }
 
@@ -196,83 +212,90 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
         private Map<String, String> gatherStats(Path path, boolean isForAlterPartition)
                 throws Exception {
             Map<String, String> statistic = new HashMap<>();
-            InputFormat<?, ?> inputFormat =
-                    ReflectionUtil.newInstance(getInputFormatClz(sd.getInputFormat()), conf.conf());
-            long numRows = 0;
-            long fileSize = 0;
-            int numFiles = 0;
-            long rawDataSize = 0;
-            List<FileStatus> fileStatuses =
-                    listDataFileRecursively(fileSystemFactory.create(path.toUri()), path);
-            for (FileStatus file : fileStatuses) {
-                InputSplit dummySplit =
-                        new FileSplit(
-                                toHadoopPath(file.getPath()),
-                                0,
-                                -1,
-                                new String[] {sd.getLocation()});
-                org.apache.hadoop.mapred.RecordReader<?, ?> recordReader =
-                        inputFormat.getRecordReader(dummySplit, conf.conf(), Reporter.NULL);
-                try {
-                    if (recordReader instanceof StatsProvidingRecordReader) {
-                        StatsProvidingRecordReader statsRR =
-                                (StatsProvidingRecordReader) recordReader;
-                        rawDataSize += statsRR.getStats().getRawDataSize();
-                        numRows += statsRR.getStats().getRowCount();
-                        fileSize += file.getLen();
+            Optional<Map<String, String>> stats = gatherFullStats(path);
+            if (stats.isPresent()) {
+                return stats.get();
+            } else {
+                // now, we only gather fileSize and numFiles.
+                // but if it's for collect stats to alter partition, we can skip
+                // calculate totalSize and numFiles since it'll be calculated by Hive metastore
+                // forcibly while altering partition. so we return -1 directly to avoid gathering
+                // statistic in here since it's redundant and time-consuming
+                long fileSize = 0;
+                int numFiles = 0;
+                if (isForAlterPartition) {
+                    statistic.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(-1));
+                    statistic.put(StatsSetupConst.NUM_FILES, String.valueOf(-1));
+                } else {
+                    for (FileStatus fileStatus :
+                            listDataFileRecursively(fileSystemFactory.create(path.toUri()), path)) {
                         numFiles += 1;
-                    } else {
-                        // if the reader initialized according to input format class isn't instance
-                        // of StatsProvidingRecordReader, which means the store format is neither
-                        // orc nor parquet. we only calculate totalSize and numFiles.
-
-                        // but when it's for collect stats to alter partition, we can skip calculate
-                        // totalSize and numFiles since it'll be calculated by Hive metastore
-                        // forcibly while altering partition.
-                        // so we return -1 directly to avoid gathering statistic in here since it's
-                        // redundant and time-consuming
-                        if (isForAlterPartition) {
-                            statistic.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(-1));
-                            statistic.put(StatsSetupConst.NUM_FILES, String.valueOf(-1));
-                            return statistic;
-                        } else {
-                            fileSize =
-                                    fileStatuses.stream()
-                                            .map(FileStatus::getLen)
-                                            .reduce(Long::sum)
-                                            .orElse(0L);
-                            statistic.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(fileSize));
-                            statistic.put(
-                                    StatsSetupConst.NUM_FILES, String.valueOf(fileStatuses.size()));
-                        }
-                        return statistic;
+                        fileSize += fileStatus.getLen();
                     }
-                } finally {
-                    recordReader.close();
+                    statistic.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(fileSize));
+                    statistic.put(StatsSetupConst.NUM_FILES, String.valueOf(numFiles));
                 }
+                return statistic;
             }
-            CatalogTableStatistics tableStatistics =
-                    new CatalogTableStatistics(numRows, numFiles, fileSize, rawDataSize);
-            HiveStatsUtil.updateStats(tableStatistics, statistic);
-            return statistic;
         }
 
         @Override
         public void close() {
             client.close();
+            if (executorService != null) {
+                executorService.shutdown();
+            }
         }
 
-        private boolean isDataFile(FileStatus fileStatus) {
-            String fileName = fileStatus.getPath().getName();
-            return !fileName.startsWith(".") && !fileName.equals(successFileName);
-        }
-
-        private boolean isStagingDir(Path path) {
-            // in batch mode, the name for staging dir starts with '.staging_', see
-            // HiveTableSink#toStagingDir
-            // in stream mode, the stage dir is the partition/table location, but the staging files
-            // start with '.'
-            return path.getPath().startsWith(".");
+        private Optional<Map<String, String>> gatherFullStats(Path path) throws Exception {
+            Map<String, String> statistic = new HashMap<>();
+            InputFormat<?, ?> inputFormat =
+                    ReflectionUtil.newInstance(getInputFormatClz(sd.getInputFormat()), conf.conf());
+            if (inputFormat instanceof OrcInputFormat
+                    || inputFormat instanceof MapredParquetInputFormat) {
+                List<Future<CatalogTableStatistics>> statsFutureList = new ArrayList<>();
+                for (FileStatus fileStatus :
+                        listDataFileRecursively(fileSystemFactory.create(path.toUri()), path)) {
+                    InputSplit dummySplit =
+                            new FileSplit(
+                                    toHadoopPath(fileStatus.getPath()),
+                                    0,
+                                    -1,
+                                    new String[] {sd.getLocation()});
+                    org.apache.hadoop.mapred.RecordReader<?, ?> recordReader =
+                            inputFormat.getRecordReader(dummySplit, conf.conf(), Reporter.NULL);
+                    if (recordReader instanceof StatsProvidingRecordReader) {
+                        statsFutureList.add(
+                                submitStatsGatherTask(
+                                        new FileStatisticGather(
+                                                fileStatus,
+                                                (StatsProvidingRecordReader) recordReader)));
+                    } else {
+                        // won't fall into here theoretically if the inputFormat is instanceof
+                        // OrcInputFormat or MapredParquetInputFormat, but the Hive's implementation
+                        // may change which may cause falling into here.
+                        LOG.warn(
+                                "The inputFormat is instanceof OrcInputFormat or MapredParquetInputFormat,"
+                                        + " but the RecordReader from the inputFormat is not instance of StatsProvidingRecordReader."
+                                        + " So the statistic numRows/rawDataSize can't be gathered");
+                        statsFutureList.forEach(
+                                catalogTableStatisticsFuture ->
+                                        catalogTableStatisticsFuture.cancel(true));
+                        return Optional.empty();
+                    }
+                }
+                List<CatalogTableStatistics> statsList = new ArrayList<>();
+                for (Future<CatalogTableStatistics> future : statsFutureList) {
+                    statsList.add(future.get());
+                }
+                HiveStatsUtil.updateStats(accumulate(statsList), statistic);
+                return Optional.of(statistic);
+            } else {
+                // if the input format is neither OrcInputFormat nor MapredParquetInputFormat,
+                // we can't gather full statistic in current implementation.
+                // so return empty.
+                return Optional.empty();
+            }
         }
 
         /** List data files recursively. */
@@ -292,6 +315,21 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
             return fileStatusList;
         }
 
+        private boolean isStagingDir(Path path) {
+            // in batch mode, the name for staging dir starts with '.staging_', see
+            // HiveTableSink#toStagingDir
+            // in stream mode, the stage dir is the partition/table location, but the staging files
+            // start with '.'
+            return path.getPath().startsWith(".");
+        }
+
+        private boolean isDataFile(FileStatus fileStatus) {
+            String fileName = fileStatus.getPath().getName();
+            return !fileName.startsWith(".")
+                    && !fileName.startsWith("_")
+                    && !fileName.equals(successFileName);
+        }
+
         private Class<? extends InputFormat<?, ?>> getInputFormatClz(String inputFormatClz) {
             try {
                 return (Class<? extends InputFormat<?, ?>>)
@@ -306,5 +344,53 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
                         e);
             }
         }
+
+        private Future<CatalogTableStatistics> submitStatsGatherTask(
+                Callable<CatalogTableStatistics> statsGatherTask) {
+            if (executorService == null) {
+                executorService =
+                        gatherStatsThreadNum == 1
+                                ? newDirectExecutorService()
+                                : Executors.newFixedThreadPool(3);
+            }
+            return executorService.submit(statsGatherTask);
+        }
+    }
+
+    /** Used to gather statistic for a single file. */
+    static final class FileStatisticGather implements Callable<CatalogTableStatistics> {
+        private final StatsProvidingRecordReader statsRR;
+        private final FileStatus fileStatus;
+
+        public FileStatisticGather(
+                FileStatus fileStatus, StatsProvidingRecordReader statsProvidingRecordReader) {
+            this.fileStatus = fileStatus;
+            this.statsRR = statsProvidingRecordReader;
+        }
+
+        @Override
+        public CatalogTableStatistics call() throws Exception {
+            SerDeStats serDeStats = statsRR.getStats();
+            return new CatalogTableStatistics(
+                    serDeStats.getRowCount(),
+                    1,
+                    fileStatus.getLen(),
+                    statsRR.getStats().getRawDataSize());
+        }
+    }
+
+    private static CatalogTableStatistics accumulate(
+            List<CatalogTableStatistics> catalogTableStatistics) {
+        long rowCount = 0;
+        int fileCount = 0;
+        long totalSize = 0;
+        long rawDataSize = 0;
+        for (CatalogTableStatistics statistics : catalogTableStatistics) {
+            rowCount += statistics.getRowCount();
+            fileCount += statistics.getFileCount();
+            totalSize += statistics.getTotalSize();
+            rawDataSize += statistics.getRawDataSize();
+        }
+        return new CatalogTableStatistics(rowCount, fileCount, totalSize, rawDataSize);
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableMetaStoreFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableMetaStoreFactory.java
@@ -18,23 +18,41 @@
 
 package org.apache.flink.connectors.hive;
 
+import org.apache.flink.connector.file.table.FileSystemFactory;
 import org.apache.flink.connector.file.table.TableMetaStoreFactory;
 import org.apache.flink.connectors.hive.util.HiveConfUtils;
+import org.apache.flink.core.fs.FileStatus;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
+import org.apache.flink.table.catalog.hive.util.HiveStatsUtil;
 import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 
+import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.io.StatsProvidingRecordReader;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hive.common.util.ReflectionUtil;
 import org.apache.thrift.TException;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+
+import static org.apache.flink.runtime.fs.hdfs.HadoopFileSystem.toHadoopPath;
 
 /**
  * Hive {@link TableMetaStoreFactory}, use {@link HiveMetastoreClientWrapper} to communicate with
@@ -45,15 +63,28 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
     private static final long serialVersionUID = 1L;
 
     private final JobConfWrapper conf;
+    private final FileSystemFactory fileSystemFactory;
     private final String hiveVersion;
     private final String database;
     private final String tableName;
+    private final boolean autoGatherStatistic;
+    private final String successFileName;
 
-    HiveTableMetaStoreFactory(JobConf conf, String hiveVersion, String database, String tableName) {
+    HiveTableMetaStoreFactory(
+            JobConf conf,
+            FileSystemFactory fileSystemFactory,
+            String hiveVersion,
+            String database,
+            String tableName,
+            boolean autoGatherStatistic,
+            String successFileName) {
         this.conf = new JobConfWrapper(conf);
+        this.fileSystemFactory = fileSystemFactory;
         this.hiveVersion = hiveVersion;
         this.database = database;
         this.tableName = tableName;
+        this.autoGatherStatistic = autoGatherStatistic;
+        this.successFileName = successFileName;
     }
 
     @Override
@@ -63,14 +94,16 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
 
     private class HiveTableMetaStore implements TableMetaStore {
 
-        private HiveMetastoreClientWrapper client;
-        private StorageDescriptor sd;
+        private final HiveMetastoreClientWrapper client;
+        private final StorageDescriptor sd;
+        private final Table table;
 
         private HiveTableMetaStore() throws TException {
             client =
                     HiveMetastoreClientFactory.create(
                             HiveConfUtils.create(conf.conf()), hiveVersion);
-            sd = client.getTable(database, tableName).getSd();
+            table = client.getTable(database, tableName);
+            sd = table.getSd();
         }
 
         @Override
@@ -110,6 +143,17 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
             alterPartition(partitionSpec, partitionPath, partition);
         }
 
+        @Override
+        public void finishWritingTable(Path tablePath) throws Exception {
+            if (autoGatherStatistic) {
+                Map<String, String> newStats = gatherStats(tablePath, false);
+                if (HiveStatsUtil.tableStatsChanged(newStats, table.getParameters())) {
+                    table.getParameters().putAll(newStats);
+                    client.alter_table(database, tableName, table);
+                }
+            }
+        }
+
         private void createPartition(LinkedHashMap<String, String> partSpec, Path path)
                 throws Exception {
             StorageDescriptor newSd = new StorageDescriptor(sd);
@@ -122,6 +166,9 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
                             newSd,
                             new HashMap<>());
             partition.setValues(new ArrayList<>(partSpec.values()));
+            if (autoGatherStatistic) {
+                partition.getParameters().putAll(gatherStats(path, false));
+            }
             client.add_partition(partition);
         }
 
@@ -140,12 +187,124 @@ public class HiveTableMetaStoreFactory implements TableMetaStoreFactory {
             partSD.setNumBuckets(sd.getNumBuckets());
             partSD.setSortCols(sd.getSortCols());
             partSD.setLocation(partitionPath.toString());
+            if (autoGatherStatistic) {
+                currentPartition.getParameters().putAll(gatherStats(partitionPath, true));
+            }
             client.alter_partition(database, tableName, currentPartition);
+        }
+
+        private Map<String, String> gatherStats(Path path, boolean isForAlterPartition)
+                throws Exception {
+            Map<String, String> statistic = new HashMap<>();
+            InputFormat<?, ?> inputFormat =
+                    ReflectionUtil.newInstance(getInputFormatClz(sd.getInputFormat()), conf.conf());
+            long numRows = 0;
+            long fileSize = 0;
+            int numFiles = 0;
+            long rawDataSize = 0;
+            List<FileStatus> fileStatuses =
+                    listDataFileRecursively(fileSystemFactory.create(path.toUri()), path);
+            for (FileStatus file : fileStatuses) {
+                InputSplit dummySplit =
+                        new FileSplit(
+                                toHadoopPath(file.getPath()),
+                                0,
+                                -1,
+                                new String[] {sd.getLocation()});
+                org.apache.hadoop.mapred.RecordReader<?, ?> recordReader =
+                        inputFormat.getRecordReader(dummySplit, conf.conf(), Reporter.NULL);
+                try {
+                    if (recordReader instanceof StatsProvidingRecordReader) {
+                        StatsProvidingRecordReader statsRR =
+                                (StatsProvidingRecordReader) recordReader;
+                        rawDataSize += statsRR.getStats().getRawDataSize();
+                        numRows += statsRR.getStats().getRowCount();
+                        fileSize += file.getLen();
+                        numFiles += 1;
+                    } else {
+                        // if the reader initialized according to input format class isn't instance
+                        // of StatsProvidingRecordReader, which means the store format is neither
+                        // orc nor parquet. we only calculate totalSize and numFiles.
+
+                        // but when it's for collect stats to alter partition, we can skip calculate
+                        // totalSize and numFiles since it'll be calculated by Hive metastore
+                        // forcibly while altering partition.
+                        // so we return -1 directly to avoid gathering statistic in here since it's
+                        // redundant and time-consuming
+                        if (isForAlterPartition) {
+                            statistic.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(-1));
+                            statistic.put(StatsSetupConst.NUM_FILES, String.valueOf(-1));
+                            return statistic;
+                        } else {
+                            fileSize =
+                                    fileStatuses.stream()
+                                            .map(FileStatus::getLen)
+                                            .reduce(Long::sum)
+                                            .orElse(0L);
+                            statistic.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(fileSize));
+                            statistic.put(
+                                    StatsSetupConst.NUM_FILES, String.valueOf(fileStatuses.size()));
+                        }
+                        return statistic;
+                    }
+                } finally {
+                    recordReader.close();
+                }
+            }
+            CatalogTableStatistics tableStatistics =
+                    new CatalogTableStatistics(numRows, numFiles, fileSize, rawDataSize);
+            HiveStatsUtil.updateStats(tableStatistics, statistic);
+            return statistic;
         }
 
         @Override
         public void close() {
             client.close();
+        }
+
+        private boolean isDataFile(FileStatus fileStatus) {
+            String fileName = fileStatus.getPath().getName();
+            return !fileName.startsWith(".") && !fileName.equals(successFileName);
+        }
+
+        private boolean isStagingDir(Path path) {
+            // in batch mode, the name for staging dir starts with '.staging_', see
+            // HiveTableSink#toStagingDir
+            // in stream mode, the stage dir is the partition/table location, but the staging files
+            // start with '.'
+            return path.getPath().startsWith(".");
+        }
+
+        /** List data files recursively. */
+        private List<FileStatus> listDataFileRecursively(FileSystem fileSystem, Path f)
+                throws IOException {
+            List<FileStatus> fileStatusList = new ArrayList<>();
+            for (FileStatus fileStatus : fileSystem.listStatus(f)) {
+                if (fileStatus.isDir() && !isStagingDir(fileStatus.getPath())) {
+                    fileStatusList.addAll(
+                            listDataFileRecursively(fileSystem, fileStatus.getPath()));
+                } else {
+                    if (isDataFile(fileStatus)) {
+                        fileStatusList.add(fileStatus);
+                    }
+                }
+            }
+            return fileStatusList;
+        }
+
+        private Class<? extends InputFormat<?, ?>> getInputFormatClz(String inputFormatClz) {
+            try {
+                return (Class<? extends InputFormat<?, ?>>)
+                        Class.forName(
+                                inputFormatClz,
+                                true,
+                                Thread.currentThread().getContextClassLoader());
+            } catch (ClassNotFoundException e) {
+                throw new FlinkHiveException(
+                        String.format(
+                                "Unable to load the class of the input format %s.", inputFormatClz),
+                        e);
+            }
         }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -27,6 +27,7 @@ import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 import org.apache.flink.connector.file.table.FileSystemOutputFormat;
 import org.apache.flink.connector.file.table.FileSystemTableSink;
 import org.apache.flink.connector.file.table.FileSystemTableSink.TableBucketAssigner;
+import org.apache.flink.connector.file.table.PartitionCommitPolicy;
 import org.apache.flink.connector.file.table.PartitionCommitPolicyFactory;
 import org.apache.flink.connector.file.table.TableMetaStoreFactory;
 import org.apache.flink.connector.file.table.stream.PartitionCommitInfo;
@@ -50,6 +51,7 @@ import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSin
 import org.apache.flink.streaming.api.functions.sink.filesystem.StreamingFileSink.BucketsBuilder;
 import org.apache.flink.streaming.api.functions.sink.filesystem.rollingpolicies.CheckpointRollingPolicy;
 import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogPropertiesUtil;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -94,6 +96,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,6 +131,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
     private LinkedHashMap<String, String> staticPartitionSpec = new LinkedHashMap<>();
     private boolean overwrite = false;
     private boolean dynamicGrouping = false;
+    private final boolean autoGatherStatistic;
 
     @Nullable private final Integer configuredParallelism;
 
@@ -141,6 +145,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER),
                 flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_WRITER),
                 flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_DYNAMIC_GROUPING_ENABLED),
+                flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE),
                 jobConf,
                 identifier,
                 table,
@@ -151,6 +156,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
             boolean fallbackMappedReader,
             boolean fallbackMappedWriter,
             boolean dynamicGroupingEnabled,
+            boolean autoUpdateStatistic,
             JobConf jobConf,
             ObjectIdentifier identifier,
             CatalogTable table,
@@ -158,6 +164,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         this.fallbackMappedReader = fallbackMappedReader;
         this.fallbackMappedWriter = fallbackMappedWriter;
         this.dynamicGroupingEnabled = dynamicGroupingEnabled;
+        this.autoGatherStatistic = autoUpdateStatistic;
         this.jobConf = jobConf;
         this.identifier = identifier;
         this.catalogTable = table;
@@ -168,6 +175,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         hiveShim = HiveShimLoader.loadHiveShim(hiveVersion);
         tableSchema = TableSchemaUtils.getPhysicalSchema(table.getSchema());
         this.configuredParallelism = configuredParallelism;
+        validateAutoGatherStatistic(autoGatherStatistic, catalogTable);
     }
 
     @Override
@@ -181,6 +189,32 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 return consume(providerContext, dataStream, context.isBounded(), converter);
             }
         };
+    }
+
+    private void validateAutoGatherStatistic(
+            boolean autoGatherStatistic, CatalogTable catalogTable) {
+        if (autoGatherStatistic && catalogTable.isPartitioned()) {
+            // if auto gather statistic and the table is partitioned,
+            // the table's option "SINK_PARTITION_COMMIT_POLICY_KIND" should contain 'metastore'
+            org.apache.flink.configuration.Configuration flinkConf =
+                    org.apache.flink.configuration.Configuration.fromMap(catalogTable.getOptions());
+            String policyKind = flinkConf.getString(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND);
+            String[] policyStrings = policyKind.split(",");
+            Arrays.stream(policyStrings)
+                    .filter(policy -> policy.equalsIgnoreCase(PartitionCommitPolicy.METASTORE))
+                    .findAny()
+                    .orElseThrow(
+                            () ->
+                                    new ValidationException(
+                                            String.format(
+                                                    "When %s is set to true, the option %s for the table %s should contains %s.",
+                                                    HiveOptions
+                                                            .TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE
+                                                            .key(),
+                                                    HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS,
+                                                    identifier,
+                                                    PartitionCommitPolicy.METASTORE)));
+        }
     }
 
     private DataStreamSink<?> consume(
@@ -263,7 +297,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                         isInsertDirectory
                                 ? new EmptyMetaStoreFactory(
                                         new org.apache.flink.core.fs.Path(sd.getLocation()))
-                                : msFactory();
+                                : msFactory(autoGatherStatistic);
                 // default to use the dest location as the parent directory of staging directory
                 String stagingParentDir = sd.getLocation();
                 if (isToLocal) {
@@ -470,7 +504,8 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 path,
                 identifier,
                 getPartitionKeys(),
-                msFactory(),
+                // todo: support gather statistic in FLINK-29027
+                msFactory(false),
                 fsFactory(),
                 conf);
     }
@@ -487,9 +522,16 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 fallbackMappedReader);
     }
 
-    private HiveTableMetaStoreFactory msFactory() {
+    private HiveTableMetaStoreFactory msFactory(boolean autoGatherStatistic) {
         return new HiveTableMetaStoreFactory(
-                jobConf, hiveVersion, identifier.getDatabaseName(), identifier.getObjectName());
+                jobConf,
+                fsFactory(),
+                hiveVersion,
+                identifier.getDatabaseName(),
+                identifier.getObjectName(),
+                autoGatherStatistic,
+                org.apache.flink.configuration.Configuration.fromMap(catalogTable.getOptions())
+                        .get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME));
     }
 
     private HadoopFileSystemFactory fsFactory() {
@@ -600,6 +642,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                         fallbackMappedReader,
                         fallbackMappedWriter,
                         dynamicGroupingEnabled,
+                        autoGatherStatistic,
                         jobConf,
                         identifier,
                         catalogTable,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -132,6 +132,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
     private boolean overwrite = false;
     private boolean dynamicGrouping = false;
     private final boolean autoGatherStatistic;
+    private final int gatherStatsThreadNum;
 
     @Nullable private final Integer configuredParallelism;
 
@@ -146,6 +147,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_WRITER),
                 flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_DYNAMIC_GROUPING_ENABLED),
                 flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE),
+                flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_THREAD_NUM),
                 jobConf,
                 identifier,
                 table,
@@ -156,7 +158,8 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
             boolean fallbackMappedReader,
             boolean fallbackMappedWriter,
             boolean dynamicGroupingEnabled,
-            boolean autoUpdateStatistic,
+            boolean autoGatherStatistic,
+            int gatherStatsThreadNum,
             JobConf jobConf,
             ObjectIdentifier identifier,
             CatalogTable table,
@@ -164,7 +167,8 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
         this.fallbackMappedReader = fallbackMappedReader;
         this.fallbackMappedWriter = fallbackMappedWriter;
         this.dynamicGroupingEnabled = dynamicGroupingEnabled;
-        this.autoGatherStatistic = autoUpdateStatistic;
+        this.autoGatherStatistic = autoGatherStatistic;
+        this.gatherStatsThreadNum = gatherStatsThreadNum;
         this.jobConf = jobConf;
         this.identifier = identifier;
         this.catalogTable = table;
@@ -529,9 +533,10 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 hiveVersion,
                 identifier.getDatabaseName(),
                 identifier.getObjectName(),
-                autoGatherStatistic,
                 org.apache.flink.configuration.Configuration.fromMap(catalogTable.getOptions())
-                        .get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME));
+                        .get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME),
+                autoGatherStatistic,
+                gatherStatsThreadNum);
     }
 
     private HadoopFileSystemFactory fsFactory() {
@@ -643,6 +648,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                         fallbackMappedWriter,
                         dynamicGroupingEnabled,
                         autoGatherStatistic,
+                        gatherStatsThreadNum,
                         jobConf,
                         identifier,
                         catalogTable,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/HiveCatalog.java
@@ -87,7 +87,6 @@ import org.apache.flink.util.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
-import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
@@ -139,8 +138,6 @@ import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.NOT_NULL_C
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.NOT_NULL_CONSTRAINT_TRAITS;
 import static org.apache.flink.sql.parser.hive.ddl.SqlCreateHiveTable.PK_CONSTRAINT_TRAIT;
 import static org.apache.flink.table.catalog.CatalogPropertiesUtil.FLINK_PROPERTY_PREFIX;
-import static org.apache.flink.table.catalog.hive.util.HiveStatsUtil.parsePositiveIntStat;
-import static org.apache.flink.table.catalog.hive.util.HiveStatsUtil.parsePositiveLongStat;
 import static org.apache.flink.table.catalog.hive.util.HiveTableUtil.getHadoopConfiguration;
 import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
 import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
@@ -1498,8 +1495,8 @@ public class HiveCatalog extends AbstractCatalog {
                         "Alter table stats is not supported in Hive version " + hiveVersion);
             }
             // Set table stats
-            if (statsChanged(tableStatistics, hiveTable.getParameters())) {
-                updateStats(tableStatistics, hiveTable.getParameters());
+            if (HiveStatsUtil.statsChanged(tableStatistics, hiveTable.getParameters())) {
+                HiveStatsUtil.updateStats(tableStatistics, hiveTable.getParameters());
                 client.alter_table(
                         tablePath.getDatabaseName(), tablePath.getObjectName(), hiveTable);
             }
@@ -1546,39 +1543,6 @@ public class HiveCatalog extends AbstractCatalog {
         }
     }
 
-    /**
-     * Determine if statistics need to be updated or not.
-     *
-     * @param newTableStats new catalog table statistics.
-     * @param parameters original hive table statistics parameters.
-     * @return whether need to update stats.
-     */
-    private boolean statsChanged(
-            CatalogTableStatistics newTableStats, Map<String, String> parameters) {
-        return newTableStats.getRowCount()
-                        != parsePositiveLongStat(parameters, StatsSetupConst.ROW_COUNT)
-                || newTableStats.getTotalSize()
-                        != parsePositiveLongStat(parameters, StatsSetupConst.TOTAL_SIZE)
-                || newTableStats.getFileCount()
-                        != parsePositiveIntStat(parameters, StatsSetupConst.NUM_FILES)
-                || newTableStats.getRawDataSize()
-                        != parsePositiveLongStat(parameters, StatsSetupConst.NUM_FILES);
-    }
-
-    /**
-     * Update original table statistics parameters.
-     *
-     * @param newTableStats new catalog table statistics.
-     * @param parameters original hive table statistics parameters.
-     */
-    private void updateStats(CatalogTableStatistics newTableStats, Map<String, String> parameters) {
-        parameters.put(StatsSetupConst.ROW_COUNT, String.valueOf(newTableStats.getRowCount()));
-        parameters.put(StatsSetupConst.TOTAL_SIZE, String.valueOf(newTableStats.getTotalSize()));
-        parameters.put(StatsSetupConst.NUM_FILES, String.valueOf(newTableStats.getFileCount()));
-        parameters.put(
-                StatsSetupConst.RAW_DATA_SIZE, String.valueOf(newTableStats.getRawDataSize()));
-    }
-
     @Override
     public void alterPartitionStatistics(
             ObjectPath tablePath,
@@ -1589,8 +1553,8 @@ public class HiveCatalog extends AbstractCatalog {
         try {
             Partition hivePartition = getHivePartition(tablePath, partitionSpec);
             // Set table stats
-            if (statsChanged(partitionStatistics, hivePartition.getParameters())) {
-                updateStats(partitionStatistics, hivePartition.getParameters());
+            if (HiveStatsUtil.statsChanged(partitionStatistics, hivePartition.getParameters())) {
+                HiveStatsUtil.updateStats(partitionStatistics, hivePartition.getParameters());
                 client.alter_partition(
                         tablePath.getDatabaseName(), tablePath.getObjectName(), hivePartition);
             }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -600,6 +600,8 @@ public class HiveTableSinkITCase {
         tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
         tEnv.useCatalog(hiveCatalog.getName());
         String wareHouse = hiveCatalog.getHiveConf().getVar(HiveConf.ConfVars.METASTOREWAREHOUSE);
+        // disable auto statistic first
+        tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE, false);
         // test non-partition table
         tEnv.executeSql("create table t1(x int)");
         tEnv.executeSql("create table t2(x int) stored as orc");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -33,9 +33,11 @@ import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.CollectionUtil;
@@ -50,9 +52,12 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -587,6 +592,147 @@ public class HiveTableSinkITCase {
         assertThat(new File(changeFileNameTablePath, "dt=2022-08-15/" + successFileName))
                 .doesNotExist();
         assertThat(new File(changeFileNameTablePath, "dt=2022-08-15/_ZM")).exists();
+    }
+
+    @Test
+    public void testAutoGatherStatisticForBatchWriting() throws Exception {
+        TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
+        tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
+        tEnv.useCatalog(hiveCatalog.getName());
+        String wareHouse = hiveCatalog.getHiveConf().getVar(HiveConf.ConfVars.METASTOREWAREHOUSE);
+        // test non-partition table
+        tEnv.executeSql("create table t1(x int)");
+        tEnv.executeSql("create table t2(x int) stored as orc");
+        tEnv.executeSql("create table t3(x int) stored as parquet");
+        tEnv.executeSql("insert into t1 values (1)").await();
+        tEnv.executeSql("insert into t2 values (1)").await();
+        tEnv.executeSql("insert into t3 values (1)").await();
+        // check the statistic for these table
+        // the statistics should be empty since the auto gather statistic is disabled
+        for (int i = 1; i <= 3; i++) {
+            CatalogTableStatistics statistics =
+                    hiveCatalog.getTableStatistics(new ObjectPath("default", "t" + i));
+            assertThat(statistics).isEqualTo(CatalogTableStatistics.UNKNOWN);
+        }
+        // now enable auto gather statistic
+        tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE, true);
+        tEnv.executeSql("insert into t1 values (1)").await();
+        tEnv.executeSql("insert into t2 values (1)").await();
+        tEnv.executeSql("insert into t3 values (1)").await();
+        CatalogTableStatistics statistics =
+                hiveCatalog.getTableStatistics(new ObjectPath("default", "t1"));
+        // t1 is neither stored as orc nor parquet, so only fileCount and totalSize is
+        // calculated
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                -1, 2, getPathSize(Paths.get(wareHouse, "t1")), -1));
+        statistics = hiveCatalog.getTableStatistics(new ObjectPath("default", "t2"));
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                2, 2, getPathSize(Paths.get(wareHouse, "t2")), 8));
+        statistics = hiveCatalog.getTableStatistics(new ObjectPath("default", "t3"));
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                2, 2, getPathSize(Paths.get(wareHouse, "t3")), 66));
+
+        // test partition table
+        tEnv.executeSql("create table pt1(x int) partitioned by (y int)");
+        tEnv.executeSql("create table pt2(x int) partitioned by (y int) stored as orc");
+        tEnv.executeSql("create table pt3(x int) partitioned by (y int) stored as parquet");
+        tEnv.executeSql("insert into pt1 partition(y=1) values (1)").await();
+        tEnv.executeSql("insert into pt2 partition(y=2) values (2)").await();
+        tEnv.executeSql("insert into pt3 partition(y=3) values (3)").await();
+
+        // verify statistic
+        statistics =
+                hiveCatalog.getPartitionStatistics(
+                        new ObjectPath("default", "pt1"),
+                        new CatalogPartitionSpec(Collections.singletonMap("y", "1")));
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                -1, 1, getPathSize(Paths.get(wareHouse, "pt1", "y=1")), -1));
+        statistics =
+                hiveCatalog.getPartitionStatistics(
+                        new ObjectPath("default", "pt2"),
+                        new CatalogPartitionSpec(Collections.singletonMap("y", "2")));
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                1, 1, getPathSize(Paths.get(wareHouse, "pt2", "y=2")), 4));
+        statistics =
+                hiveCatalog.getPartitionStatistics(
+                        new ObjectPath("default", "pt3"),
+                        new CatalogPartitionSpec(Collections.singletonMap("y", "3")));
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                1, 1, getPathSize(Paths.get(wareHouse, "pt3", "y=3")), 33));
+
+        // insert data into partition again
+        tEnv.executeSql("insert into pt1 partition(y=1) values (1)").await();
+        tEnv.executeSql("insert into pt2 partition(y=2) values (2)").await();
+        tEnv.executeSql("insert into pt3 partition(y=3) values (3)").await();
+
+        // verify statistic
+        statistics =
+                hiveCatalog.getPartitionStatistics(
+                        new ObjectPath("default", "pt1"),
+                        new CatalogPartitionSpec(Collections.singletonMap("y", "1")));
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                -1, 2, getPathSize(Paths.get(wareHouse, "pt1", "y=1")), -1));
+
+        statistics =
+                hiveCatalog.getPartitionStatistics(
+                        new ObjectPath("default", "pt2"),
+                        new CatalogPartitionSpec(Collections.singletonMap("y", "2")));
+
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                2, 2, getPathSize(Paths.get(wareHouse, "pt2", "y=2")), 8));
+
+        statistics =
+                hiveCatalog.getPartitionStatistics(
+                        new ObjectPath("default", "pt3"),
+                        new CatalogPartitionSpec(Collections.singletonMap("y", "3")));
+        assertThat(statistics)
+                .isEqualTo(
+                        new CatalogTableStatistics(
+                                2, 2, getPathSize(Paths.get(wareHouse, "pt3", "y=3")), 66));
+
+        // test overwrite table/partition
+        tEnv.executeSql("create table src(x int)");
+        tEnv.executeSql("insert overwrite table pt1 partition(y=1) select * from src").await();
+        tEnv.executeSql("insert overwrite table pt2 partition(y=2) select * from src").await();
+        tEnv.executeSql("insert overwrite table pt3 partition(y=3) select * from src").await();
+
+        for (int i = 1; i <= 3; i++) {
+            statistics =
+                    hiveCatalog.getPartitionStatistics(
+                            new ObjectPath("default", "pt" + i),
+                            new CatalogPartitionSpec(
+                                    Collections.singletonMap("y", String.valueOf(i))));
+            assertThat(statistics).isEqualTo(CatalogTableStatistics.UNKNOWN);
+        }
+    }
+
+    private long getPathSize(java.nio.file.Path path) throws IOException {
+        String defaultSuccessFileName =
+                HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME.defaultValue();
+        return Files.list(path)
+                .filter(
+                        p ->
+                                !p.toFile().isHidden()
+                                        && !p.toFile().getPath().equals(defaultSuccessFileName))
+                .map(p -> p.toFile().length())
+                .reduce(Long::sum)
+                .orElse(0L);
     }
 
     private static List<String> fetchRows(Iterator<Row> iter, int size) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -56,6 +56,9 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         hiveCatalog = HiveTestUtils.createHiveCatalog();
         hiveCatalog.open();
 
+        // we disable auto gather statistic in this test to avoid skipping
+        // method HiveTableSource#reportStatistics
+        tEnv.getConfig().set(HiveOptions.TABLE_EXEC_HIVE_SINK_STATISTIC_AUTO_GATHER_ENABLE, false);
         tEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
         tEnv.registerCatalog(catalogName, hiveCatalog);
         tEnv.useCatalog(catalogName);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix the issue that HiveTableSInk fails to report [statistic](https://cwiki.apache.org/confluence/display/hive/statsdev) to Hive metastore.



## Brief change log
  -  When commit non-partition table/partition, try to collect statistic from files in non-partition table/partition, and then put these statistic to metastore.
  - When collect statistic from files, try to get `RecordReader` according to table's input format. If the `RecordReader` is intance of `StatsProvidingRecordReader`, which means it's orc or parquet format,  we collect the statistic `numRows`, `fileSize`, `numFiles`, `rawDataSize`.  If not, we only collect `fileSize` and `numFiles` since other statistic is hard to collect efficiently.
  - While commit partition, put these statistic collected to partition properties.


## Verifying this change
Added UT.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
