### PR TITLE
[FLINK-27588][python][docs] Update broadcast state related docs

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/broadcast_state.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/broadcast_state.md
@@ -38,16 +38,28 @@ under the License.
 
 在`图形`流中，我们需要首先使用`颜色`将流进行进行分区（keyBy），这能确保相同颜色的图形会流转到相同的物理机上。
 
+{{< tabs "colorPartitionedStream" >}}
+{{< tab "Java" >}}
 ```java
 // 将图形使用颜色进行划分
 KeyedStream<Item, Color> colorPartitionedStream = itemStream
                         .keyBy(new KeySelector<Item, Color>(){...});
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+# 将图形使用颜色进行划分
+color_partitioned_stream = item_stream.key_by(lambda item: ...)
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 对于`规则`流，它应该被广播到所有的下游 task 中，下游 task 应当存储这些规则并根据它寻找满足规则的图形对。下面这段代码会完成：
 i)  将`规则`广播给所有下游 task；
 ii) 使用 `MapStateDescriptor` 来描述并创建 broadcast state 在下游的存储结构
 
+{{< tabs "ruleBroadcastStream" >}}
+{{< tab "Java" >}}
 ```java
 
 // 一个 map descriptor，它描述了用于存储规则名称与规则本身的 map 存储结构
@@ -60,6 +72,17 @@ MapStateDescriptor<String, Rule> ruleStateDescriptor = new MapStateDescriptor<>(
 BroadcastStream<Rule> ruleBroadcastStream = ruleStream
                         .broadcast(ruleStateDescriptor);
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+# 一个 map descriptor，它描述了用于存储规则名称与规则本身的 map 存储结构
+rule_state_descriptor = MapStateDescriptor("RuleBroadcastState", Types.STRING(), Types.PICKLED_BYTE_ARRAY())
+
+# 广播流，广播规则并且创建 broadcast state
+rule_broadcast_stream = rule_stream.broadcast(rule_state_descriptor)
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 最终，为了使用`规则`来筛选`图形`序列，我们需要：
  1. 将两个流关联起来
@@ -77,6 +100,8 @@ BroadcastStream<Rule> ruleBroadcastStream = ruleStream
 `connect()` 方法需要由非广播流来进行调用，`BroadcastStream` 作为参数传入。
 {{< /hint >}}
 
+{{< tabs "connect" >}}
+{{< tab "Java" >}}
 ```java
 DataStream<String> output = colorPartitionedStream
                  .connect(ruleBroadcastStream)
@@ -93,12 +118,27 @@ DataStream<String> output = colorPartitionedStream
                      }
                  );
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+class MyKeyedBroadcastProcessFunction(KeyedBroadcastProcessFunction):
+    # 模式匹配逻辑
+    ...
+
+output = color_partitioned_stream \
+    .connect(rule_broadcast_stream) \
+    .process(MyKeyedBroadcastProcessFunction())
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ### BroadcastProcessFunction 和 KeyedBroadcastProcessFunction
 
 在传入的 `BroadcastProcessFunction` 或 `KeyedBroadcastProcessFunction` 中，我们需要实现两个方法。`processBroadcastElement()` 方法负责处理广播流中的元素，`processElement()` 负责处理非广播流中的元素。
 两个子类型定义如下：
 
+{{< tabs "ProcessFunctions" >}}
+{{< tab "Java" >}}
 ```java
 public abstract class BroadcastProcessFunction<IN1, IN2, OUT> extends BaseBroadcastProcessFunction {
 
@@ -118,13 +158,55 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> {
     public void onTimer(long timestamp, OnTimerContext ctx, Collector<OUT> out) throws Exception;
 }
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+class BroadcastProcessFunction(BaseBroadcastProcessFunction, Generic[IN1, IN2, OUT]):
+
+    @abstractmethod
+    def process_element(value: IN1, ctx: ReadOnlyContext):
+        pass
+    
+    @abstractmethod
+    def process_broadcast_element(value: IN2, ctx: Context):
+        pass
+```
+
+```python
+class KeyedBroadcastProcessFunction(BaseBrodcastProcessFunction, Generic[KEY, IN1, IN2, OUT]):
+
+    @abstractmethod
+    def process_element(value: IN1, ctx: ReadOnlyContext):
+        pass
+    
+    @abstractmethod
+    def process_broadcast_element(value: IN2, ctx: Context):
+        pass
+    
+    def on_timer(timestamp: int, ctx: OnTimerContext):
+        pass
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 需要注意的是 `processBroadcastElement()` 负责处理广播流的元素，而 `processElement()` 负责处理另一个流的元素。两个方法的第二个参数(Context)不同，均有以下方法：
+
+{{< tabs "ctx" >}}
+{{< tab "Java" >}}
  1. 得到广播流的存储状态：`ctx.getBroadcastState(MapStateDescriptor<K, V> stateDescriptor)`
  2. 查询元素的时间戳：`ctx.timestamp()`
  3. 查询目前的Watermark：`ctx.currentWatermark()`
  4. 目前的处理时间(processing time)：`ctx.currentProcessingTime()`
  5. 产生旁路输出：`ctx.output(OutputTag<X> outputTag, X value)`
+ {{< /tab >}}
+ {{< tab "Python" >}}
+ 1. 得到广播流的存储状态：`ctx.get_broadcast_state(stateDescriptor: MapStateDescriptor)`
+ 2. 查询元素的时间戳：`ctx.timestamp()`
+ 3. 查询目前的Watermark：`ctx.current_watermark()`
+ 4. 目前的处理时间(processing time)：`ctx.current_processing_time()`
+ 5. 产生旁路输出：`yield output_tag, value`
+ {{< /tab >}}
+ {{< /tabs >}}
 
 在 `getBroadcastState()` 方法中传入的 `stateDescriptor` 应该与调用 `.broadcast(ruleStateDescriptor)` 的参数相同。
 
@@ -142,7 +224,7 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> {
   - 查询当前触发的是一个事件还是处理时间的定时器
   - 查询定时器关联的key
  2. `processBroadcastElement()` 方法中的参数 `Context` 会提供方法 `applyToKeyedState(StateDescriptor<S, VS> stateDescriptor, KeyedStateFunction<KS, S> function)`。
- 这个方法使用一个 `KeyedStateFunction` 能够对 `stateDescriptor` 对应的 state 中**所有 key 的存储状态**进行某些操作。
+ 这个方法使用一个 `KeyedStateFunction` 能够对 `stateDescriptor` 对应的 state 中**所有 key 的存储状态**进行某些操作。目前 PyFlink 不支持 `apply_to_keyed_state`。
 
 {{< hint warning >}}
 注册一个定时器只能在 `KeyedBroadcastProcessFunction` 的 `processElement()` 方法中进行。
@@ -151,6 +233,8 @@ public abstract class KeyedBroadcastProcessFunction<KS, IN1, IN2, OUT> {
 
 回到我们当前的例子中，`KeyedBroadcastProcessFunction` 应该实现如下：
 
+{{< tabs "KeyedBroadcastProcessFunction" >}}
+{{< tab "Java" >}}
 ```java
 new KeyedBroadcastProcessFunction<Color, Item, Rule, String>() {
 
@@ -215,6 +299,46 @@ new KeyedBroadcastProcessFunction<Color, Item, Rule, String>() {
     }
 }
 ```
+{{< /tab >}}
+{{< tab "Python" >}}
+```python
+class MyKeyedBroadcastProcessFunction(KeyedBroadcastProcessFunction):
+
+    def __init__(self):
+        self._map_state_desc = MapStateDescriptor("item", Types.STRING(), Types.LIST(Types.PICKLED_BYTE_ARRAY()))
+        self._rule_state_desc = MapStateDescriptor("RulesBroadcastState", Types.STRING(), Types.PICKLED_BYTE_ARRAY())
+        self._map_state = None
+    
+    def open(self, ctx: RuntimeContext):
+        self._map_state = ctx.get_map_state(self._map_state_desc)
+    
+    def process_broadcast_element(value: Rule, ctx: KeyedBroadcastProcessFunction.Context):
+        ctx.get_broadcast_state(self._rule_state_desc).put(value.name, value)
+    
+    def process_element(value: Item, ctx: KeyedBroadcastProcessFunction.ReadOnlyContext):
+        shape = value.get_shape()
+
+        for rule_name, rule in ctx.get_broadcast_state(self._rule_state_desc).items():
+
+            stored = self._map_state.get(rule_name)
+            if stored is None:
+                stored = []
+            
+            if shape == rule.second and len(stored) > 0:
+                for i in stored:
+                    yield "MATCH: {} - {}".format(i, value)
+                stored = []
+            
+            if shape == rule.first:
+                stored.append(value)
+            
+            if len(stored) == 0:
+                self._map_state.remove(rule_name)
+            else:
+                self._map_state.put(rule_name, stored)
+```
+{{< /tab >}}
+{{< /tabs >}}
 
 ## 重要注意事项
 


### PR DESCRIPTION
## What is the purpose of the change

This PR adds missing broadcast state doc for PyFlink.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
