### PR TITLE
[FLINK-28922][docs-zh] Translate "ORDER BY clause" page into Chinese.

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/orderby.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/orderby.md
@@ -26,9 +26,9 @@ under the License.
 
 {{< label Batch >}} {{< label Streaming >}}
 
-The `ORDER BY` clause causes the result rows to be sorted according to the specified expression(s). If two rows are equal according to the leftmost expression, they are compared according to the next expression and so on. If they are equal according to all specified expressions, they are returned in an implementation-dependent order.
+`ORDER BY` 子句使结果行根据指定的表达式进行排序。 如果两行根据最左边的表达式相等，则根据下一个表达式进行比较，依此类推。 如果根据所有指定的表达式它们相等，则它们以与实现相关的顺序返回。
 
-When running in streaming mode, the primary sort order of a table must be ascending on a [time attribute]({{< ref "docs/dev/table/concepts/time_attributes" >}}). All subsequent orders can be freely chosen. But there is no this limitation in batch mode.
+在流模式下运行时，表的主要排序顺序必须按[时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}})升序。 所有后续的 orders 都可以自由选择。 但是批处理模式没有这个限制。
 
 ```sql
 SELECT *


### PR DESCRIPTION
## What is the purpose of the change

- Translate "ORDER BY clause" page into Chinese:  https://nightlies.apache.org/flink/flink-docs-master/zh/docs/dev/table/sql/queries/orderby/.
- The markdown file is located in "docs/content.zh/docs/dev/table/sql/queries/orderby.md". 
- Details See [FLINK-28922](https://issues.apache.org/jira/browse/FLINK-28922) for information.


## Brief change log

-  Translate "ORDER BY clause" page into Chinese.

## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
