### PR TITLE
[FLINK-28924][docs-zh] Translate "LIMIT clause" page into Chinese.

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/limit.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/limit.md
@@ -26,9 +26,9 @@ under the License.
 
 {{< label Batch >}}
 
-`LIMIT` clause constrains the number of rows returned by the `SELECT` statement. In general, this clause is used in conjunction with ORDER BY to ensure that the results are deterministic.
+`LIMIT` 子句限制 `SELECT` 语句返回的行数。 通常，此子句与 ORDER BY 结合使用，以确保结果是确定性的。
 
-The following example selects the first 3 rows in `Orders` table.
+以下示例选择 `Orders` 表中的前 3 行。
 
 ```sql
 SELECT *


### PR DESCRIPTION

## What is the purpose of the change
- Translate "LIMIT clause" page into Chinese: https://nightlies.apache.org/flink/flink-docs-master/zh/docs/dev/table/sql/queries/limit/.
- The markdown file is located in "docs/content.zh/docs/dev/table/sql/queries/limit.md".
- Details See [FLINK-28924](https://issues.apache.org/jira/browse/FLINK-28924) for information.



## Brief change log

- Translate "LIMIT clause" page into Chinese.


## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
