### PR TITLE
[FLINK-28800][network] HsFileDataManager should avoid busy-loop when fileReader has not data to read

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -59,7 +59,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.METRIC_GROUP_INPUT;
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.METRIC_GROUP_OUTPUT;
@@ -104,7 +104,7 @@ public class NettyShuffleEnvironment
 
     private final BatchShuffleReadBufferPool batchShuffleReadBufferPool;
 
-    private final ExecutorService batchShuffleReadIOExecutor;
+    private final ScheduledExecutorService batchShuffleReadIOExecutor;
 
     private boolean isClosed;
 
@@ -119,7 +119,7 @@ public class NettyShuffleEnvironment
             SingleInputGateFactory singleInputGateFactory,
             Executor ioExecutor,
             BatchShuffleReadBufferPool batchShuffleReadBufferPool,
-            ExecutorService batchShuffleReadIOExecutor) {
+            ScheduledExecutorService batchShuffleReadIOExecutor) {
         this.taskExecutorResourceId = taskExecutorResourceId;
         this.config = config;
         this.networkBufferPool = networkBufferPool;
@@ -160,7 +160,7 @@ public class NettyShuffleEnvironment
     }
 
     @VisibleForTesting
-    public ExecutorService getBatchShuffleReadIOExecutor() {
+    public ScheduledExecutorService getBatchShuffleReadIOExecutor() {
         return batchShuffleReadIOExecutor;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -46,8 +46,8 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.util.Arrays;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory.registerShuffleMetrics;
@@ -182,8 +182,8 @@ public class NettyShuffleServiceFactory
         // we create a separated IO executor pool here for batch shuffle instead of reusing the
         // TaskManager IO executor pool directly to avoid the potential side effects of execution
         // contention, for example, too long IO or waiting time leading to starvation or timeout
-        ExecutorService batchShuffleReadIOExecutor =
-                Executors.newFixedThreadPool(
+        ScheduledExecutorService batchShuffleReadIOExecutor =
+                Executors.newScheduledThreadPool(
                         Math.max(
                                 1,
                                 Math.min(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -40,7 +40,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** Factory for {@link ResultPartition} to use in {@link NettyShuffleEnvironment}. */
 public class ResultPartitionFactory {
@@ -55,7 +55,7 @@ public class ResultPartitionFactory {
 
     private final BatchShuffleReadBufferPool batchShuffleReadBufferPool;
 
-    private final ExecutorService batchShuffleReadIOExecutor;
+    private final ScheduledExecutorService batchShuffleReadIOExecutor;
 
     private final BoundedBlockingSubpartitionType blockingSubpartitionType;
 
@@ -84,7 +84,7 @@ public class ResultPartitionFactory {
             FileChannelManager channelManager,
             BufferPoolFactory bufferPoolFactory,
             BatchShuffleReadBufferPool batchShuffleReadBufferPool,
-            ExecutorService batchShuffleReadIOExecutor,
+            ScheduledExecutorService batchShuffleReadIOExecutor,
             BoundedBlockingSubpartitionType blockingSubpartitionType,
             int configuredNetworkBuffersPerChannel,
             int floatingNetworkBuffersPerGate,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
@@ -48,7 +48,7 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -63,7 +63,7 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
     private static final Logger LOG = LoggerFactory.getLogger(HsFileDataManager.class);
 
     /** Executor to run the shuffle data reading task. */
-    private final Executor ioExecutor;
+    private final ScheduledExecutorService ioExecutor;
 
     /** Maximum number of buffers can be allocated by this partition reader. */
     private final int maxRequestedBuffers;
@@ -121,7 +121,7 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
 
     public HsFileDataManager(
             BatchShuffleReadBufferPool bufferPool,
-            Executor ioExecutor,
+            ScheduledExecutorService ioExecutor,
             HsFileDataIndex dataIndex,
             Path dataFilePath,
             HsSubpartitionFileReader.Factory fileReaderFactory,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
@@ -49,6 +49,7 @@ import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -275,16 +276,16 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
         return new ArrayDeque<>();
     }
 
-    @GuardedBy("lock")
     private void mayTriggerReading() {
-        assert Thread.holdsLock(lock);
-
-        if (!isRunning
-                && !allReaders.isEmpty()
-                && numRequestedBuffers + bufferPool.getNumBuffersPerRequest() <= maxRequestedBuffers
-                && numRequestedBuffers < bufferPool.getAverageBuffersPerRequester()) {
-            isRunning = true;
-            ioExecutor.execute(this);
+        synchronized (lock) {
+            if (!isRunning
+                    && !allReaders.isEmpty()
+                    && numRequestedBuffers + bufferPool.getNumBuffersPerRequest()
+                            <= maxRequestedBuffers
+                    && numRequestedBuffers < bufferPool.getAverageBuffersPerRequester()) {
+                isRunning = true;
+                ioExecutor.execute(this);
+            }
         }
     }
 
@@ -364,8 +365,16 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
         synchronized (lock) {
             numRequestedBuffers += numBuffersRead;
             isRunning = false;
-            mayTriggerReading();
             mayNotifyReleased();
+        }
+        if (numBuffersRead == 0) {
+            // When fileReader has no data to read, for example, most of the data is
+            // consumed from memory. HsFileDataManager will encounter busy-loop
+            // problem, which will lead to a meaningless surge in CPU utilization
+            // and seriously affect performance.
+            ioExecutor.schedule(this::mayTriggerReading, 5, TimeUnit.MILLISECONDS);
+        } else {
+            mayTriggerReading();
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -44,7 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -79,7 +79,7 @@ public class HsResultPartition extends ResultPartition {
             int numSubpartitions,
             int numTargetKeyGroups,
             BatchShuffleReadBufferPool readBufferPool,
-            Executor readIOExecutor,
+            ScheduledExecutorService readIOExecutor,
             ResultPartitionManager partitionManager,
             String dataFileBashPath,
             int networkBufferSize,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -24,12 +24,12 @@ import org.apache.flink.runtime.io.disk.NoOpFileChannelManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.function.SupplierWithException;
 
 import java.io.IOException;
 import java.util.Optional;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 /** Utility class to encapsulate the logic of building a {@link ResultPartition} instance. */
 public class ResultPartitionBuilder {
@@ -56,7 +56,8 @@ public class ResultPartitionBuilder {
     private BatchShuffleReadBufferPool batchShuffleReadBufferPool =
             new BatchShuffleReadBufferPool(64 * 32 * 1024, 32 * 1024);
 
-    private ExecutorService batchShuffleReadIOExecutor = Executors.newDirectExecutorService();
+    private ScheduledExecutorService batchShuffleReadIOExecutor =
+            Executors.newSingleThreadScheduledExecutor();
 
     private int networkBuffersPerChannel = 1;
 
@@ -145,7 +146,7 @@ public class ResultPartitionBuilder {
     }
 
     public ResultPartitionBuilder setBatchShuffleReadIOExecutor(
-            ExecutorService batchShuffleReadIOExecutor) {
+            ScheduledExecutorService batchShuffleReadIOExecutor) {
         this.batchShuffleReadIOExecutor = batchShuffleReadIOExecutor;
         return this;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -27,13 +27,13 @@ import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
 import org.apache.flink.util.TestLogger;
-import org.apache.flink.util.concurrent.Executors;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.concurrent.Executors;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -149,7 +149,7 @@ public class ResultPartitionFactoryTest extends TestLogger {
                         fileChannelManager,
                         new NetworkBufferPool(1, SEGMENT_SIZE),
                         new BatchShuffleReadBufferPool(10 * SEGMENT_SIZE, SEGMENT_SIZE),
-                        Executors.newDirectExecutorService(),
+                        Executors.newSingleThreadScheduledExecutor(),
                         BoundedBlockingSubpartitionType.AUTO,
                         1,
                         1,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
@@ -20,12 +20,12 @@ package org.apache.flink.runtime.io.network.partition.hybrid;
 
 import org.apache.flink.core.memory.MemorySegment;
 import org.apache.flink.core.testutils.CheckedThread;
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.BufferRecycler;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
 import org.apache.flink.util.TestLoggerExtension;
-import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.function.BiConsumerWithException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -66,7 +66,7 @@ class HsFileDataManagerTest {
 
     private final byte[] dataBytes = new byte[BUFFER_SIZE];
 
-    private ManuallyTriggeredScheduledExecutor ioExecutor;
+    private ManuallyTriggeredScheduledExecutorService ioExecutor;
 
     private BatchShuffleReadBufferPool bufferPool;
 
@@ -85,7 +85,7 @@ class HsFileDataManagerTest {
         Random random = new Random();
         random.nextBytes(dataBytes);
         bufferPool = new BatchShuffleReadBufferPool(BUFFER_POOL_SIZE * BUFFER_SIZE, BUFFER_SIZE);
-        ioExecutor = new ManuallyTriggeredScheduledExecutor();
+        ioExecutor = new ManuallyTriggeredScheduledExecutorService();
         dataFilePath = Files.createFile(tempDir.resolve(".data"));
         dataFileChannel = openFileChannel(dataFilePath);
         factory = new TestingHsSubpartitionFileReader.Factory();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
@@ -59,8 +59,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Queue;
 import java.util.Random;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 
@@ -85,7 +85,7 @@ class HsResultPartitionTest {
 
     private BatchShuffleReadBufferPool readBufferPool;
 
-    private ExecutorService readIOExecutor;
+    private ScheduledExecutorService readIOExecutor;
 
     private TaskIOMetricGroup taskIOMetricGroup;
 
@@ -97,7 +97,7 @@ class HsResultPartitionTest {
                 new FileChannelManagerImpl(new String[] {tempDataPath.toString()}, "testing");
         globalPool = new NetworkBufferPool(totalBuffers, bufferSize);
         readBufferPool = new BatchShuffleReadBufferPool(totalBytes, bufferSize);
-        readIOExecutor = Executors.newFixedThreadPool(numThreads);
+        readIOExecutor = Executors.newScheduledThreadPool(numThreads);
     }
 
     @AfterEach


### PR DESCRIPTION
## What is the purpose of the change

*When fileReader has no data to read, for example, most of the data is consumed from memory. HsFileDataManager will encounter busy-loop problem, which will lead to a meaningless surge in CPU utilization and seriously affect performance.*


## Brief change log

  - *Sleep a very short time for `HsFileDataManager` once read empty.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
