### PR TITLE
[FLINK-28932][Table/SQL] Use Builder#withConfiguration instead of deprecated EnvironmentSettings#fromConfiguration

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -235,7 +235,8 @@ public class SessionContext {
 
         final ModuleManager moduleManager = new ModuleManager();
 
-        final EnvironmentSettings settings = EnvironmentSettings.fromConfiguration(configuration);
+        final EnvironmentSettings settings =
+                EnvironmentSettings.newInstance().withConfiguration(configuration).build();
 
         CatalogManager catalogManager =
                 CatalogManager.newBuilder()


### PR DESCRIPTION
## What is the purpose of the change

The PR makes use of `Builder#withConfiguration(Configuration)` instead of deprecated `org.apache.flink.table.api.EnvironmentSettings#fromConfiguration`

## Brief change log
`flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java`


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
