### PR TITLE
[FLINK-28942][network] Fix the deadlock bug when recycling readers for SortMergeResultPartition

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -197,20 +197,20 @@ public class SortMergeResultPartition extends ResultPartition {
             if (resultFile == null && fileWriter != null) {
                 fileWriter.releaseQuietly();
             }
-
-            // delete the produced file only when no reader is reading now
-            readScheduler
-                    .release()
-                    .thenRun(
-                            () -> {
-                                synchronized (lock) {
-                                    if (resultFile != null) {
-                                        resultFile.deleteQuietly();
-                                        resultFile = null;
-                                    }
-                                }
-                            });
         }
+
+        // delete the produced file only when no reader is reading now
+        readScheduler
+                .release()
+                .thenRun(
+                        () -> {
+                            synchronized (lock) {
+                                if (resultFile != null) {
+                                    resultFile.deleteQuietly();
+                                    resultFile = null;
+                                }
+                            }
+                        });
     }
 
     @Override


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

After adding the logic of recycling buffers in CompositeBuffer in https://issues.apache.org/jira/browse/FLINK-28373, when reading data and recycling buffers simultaneously, the deadlock between the lock of SortMergeResultPartition and the lock of SingleInputGate may occur.

In short, the deadlock may occur as follows.

1. SingleInputGate.getNextBufferOrEvent (SingleInputGate lock)

CompositeBuffer.getFullBufferData -> CompositeBuffer.recycleBuffer -> waiting for 

SortMergeResultPartition lock;

2. ResultPartitionManager.releasePartition (SortMergeResultPartition lock) -> 

SortMergeSubpartitionReader.notifyDataAvailable -> 

SingleInputGate.notifyChannelNonEmpty -> waiting for SingleInputGate lock.

This change is to fix the deadlock bug.


## Brief change log

  - *Fix the deadlock bug when recycling readers for SortMergeResultPartition*


## Verifying this change

This change is already covered by existing tests, such as *SortMergeResultPartitionTest, SortMergeResultPartitionReadSchedulerTest, adaptive scheduler e2e test*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
