### PR TITLE
[FLINK-28817][connector/common] NullPointerException in HybridSource when restoring from checkpoint

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumerator.java
@@ -218,7 +218,11 @@ public class HybridSourceSplitEnumerator
             }
 
             if (subtaskSourceIndex < currentSourceIndex) {
-                subtaskSourceIndex++;
+                // find initial or next index for the reader
+                subtaskSourceIndex =
+                        subtaskSourceIndex == -1
+                                ? switchedSources.getFirstSourceIndex()
+                                : ++subtaskSourceIndex;
                 sendSwitchSourceEvent(subtaskId, subtaskSourceIndex);
                 return;
             }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/hybrid/SwitchedSources.java
@@ -25,10 +25,12 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
 
 /** Sources that participated in switching with cached serializers. */
 class SwitchedSources {
-    private final Map<Integer, Source> sources = new HashMap<>();
+    private final SortedMap<Integer, Source> sources = new TreeMap<>();
     private final Map<Integer, SimpleVersionedSerializer<SourceSplit>> cachedSerializers =
             new HashMap<>();
 
@@ -44,5 +46,9 @@ class SwitchedSources {
 
     public void put(int sourceIndex, Source source) {
         sources.put(sourceIndex, Preconditions.checkNotNull(source));
+    }
+
+    public int getFirstSourceIndex() {
+        return sources.firstKey();
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
@@ -183,6 +183,25 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
+    public void testRestoreEnumeratorAfterFirstSourceWithoutRestoredSplits() throws Exception {
+        setupEnumeratorAndTriggerSourceSwitch();
+        HybridSourceEnumeratorState enumeratorState = enumerator.snapshotState(0);
+        MockSplitEnumerator underlyingEnumerator = getCurrentEnumerator(enumerator);
+        Assert.assertThat(
+                (List<MockSourceSplit>) Whitebox.getInternalState(underlyingEnumerator, "splits"),
+                Matchers.iterableWithSize(0));
+        enumerator =
+                (HybridSourceSplitEnumerator) source.restoreEnumerator(context, enumeratorState);
+        enumerator.start();
+        // subtask starts at -1 since it has no splits after restore
+        enumerator.handleSourceEvent(SUBTASK0, new SourceReaderFinishedEvent(-1));
+        underlyingEnumerator = getCurrentEnumerator(enumerator);
+        Assert.assertThat(
+                (List<MockSourceSplit>) Whitebox.getInternalState(underlyingEnumerator, "splits"),
+                Matchers.iterableWithSize(0));
+    }
+
+    @Test
     public void testDefaultMethodDelegation() throws Exception {
         setupEnumeratorAndTriggerSourceSwitch();
         SplitEnumerator<MockSourceSplit, Object> underlyingEnumeratorSpy =


### PR DESCRIPTION
## What is the purpose of the change

This is a backport of #20530

## Brief change log

For the new SourceReaderFinishedEvent, get an available source.

## Verifying this change

This change added tests and can be verified as follows:

  - Added testRestoreEnumeratorWith2ndSource in HybridSourceSplitEnumeratorTest

## Does this pull request potentially affect one of the following parts:

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)

## Documentation

  - Does this pull request introduce a new feature? (no)
