### PR TITLE
[FLINK-27449][Table] fix: The comment is lost when creating a Table from Datastream and Schema

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/SchemaTranslator.java
@@ -44,6 +44,7 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -292,6 +293,7 @@ public final class SchemaTranslator {
             boolean isTopLevelRecord, DataType patchedDataType, Schema declaredSchema) {
         final Schema.Builder builder = Schema.newBuilder();
 
+        final Map<String, String> commentMap = declaredSchema.getCommentMap();
         // physical columns
         if (isTopLevelRecord) {
             addPhysicalSourceDataTypeFields(builder, patchedDataType, null);
@@ -299,6 +301,8 @@ public final class SchemaTranslator {
             builder.column(
                     LogicalTypeUtils.getAtomicName(Collections.emptyList()), patchedDataType);
         }
+        // add comments for physical column
+        builder.setCommentsForColumn(commentMap);
 
         // remaining schema
         final List<UnresolvedColumn> nonPhysicalColumns =

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
@@ -88,8 +88,9 @@ final class ProjectionOperationFactory {
                         .map(ResolvedExpression::getOutputDataType)
                         .toArray(DataType[]::new);
 
-        return new ProjectQueryOperation(
-                finalExpression, child, ResolvedSchema.physical(fieldNames, fieldTypes));
+        ResolvedSchema resolvedSchema =
+                ResolvedSchema.physical(fieldNames, fieldTypes, child.getResolvedSchema());
+        return new ProjectQueryOperation(finalExpression, child, resolvedSchema);
     }
 
     private String[] validateAndGetUniqueNames(List<ResolvedExpression> namedExpressions) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/Schema.java
@@ -44,7 +44,9 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -114,6 +116,14 @@ public final class Schema {
 
     public Optional<UnresolvedPrimaryKey> getPrimaryKey() {
         return Optional.ofNullable(primaryKey);
+    }
+
+    public Map<String, String> getCommentMap() {
+        Map<String, String> map = new HashMap<>();
+        for (UnresolvedColumn column : columns) {
+            map.put(column.getName(), column.getComment().orElse(null));
+        }
+        return map;
     }
 
     /** Resolves the given {@link Schema} to a validated {@link ResolvedSchema}. */
@@ -233,6 +243,15 @@ public final class Schema {
         public Builder fromColumns(List<UnresolvedColumn> unresolvedColumns) {
             columns.addAll(unresolvedColumns);
             return this;
+        }
+
+        public void setCommentsForColumn(Map<String, String> commentMap) {
+            for (int i = 0; i < columns.size(); i++) {
+                UnresolvedColumn column = columns.get(i);
+                if (commentMap.containsKey(column.getName())) {
+                    columns.set(i, column.withComment(commentMap.get(column.getName())));
+                }
+            }
         }
 
         /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/ResolvedSchema.java
@@ -97,9 +97,36 @@ public final class ResolvedSchema {
         return new ResolvedSchema(columns, Collections.emptyList(), null);
     }
 
+    public static ResolvedSchema physical(
+            List<String> columnNames, List<DataType> columnDataTypes, ResolvedSchema fromSchema) {
+        Preconditions.checkArgument(
+                columnNames.size() == columnDataTypes.size(),
+                "Mismatch between number of columns names and data types.");
+        List<String> comments =
+                fromSchema.getColumns().stream()
+                        .map(column -> column.getComment().orElse(null))
+                        .collect(Collectors.toList());
+        Preconditions.checkArgument(
+                columnNames.size() == comments.size(),
+                "Mismatch between number of columns names and its comments.");
+        final List<Column> columns =
+                IntStream.range(0, columnNames.size())
+                        .mapToObj(
+                                i ->
+                                        Column.physical(columnNames.get(i), columnDataTypes.get(i))
+                                                .withComment(comments.get(i)))
+                        .collect(Collectors.toList());
+        return new ResolvedSchema(columns, Collections.emptyList(), null);
+    }
+
     /** Shortcut for a resolved schema of only physical columns. */
     public static ResolvedSchema physical(String[] columnNames, DataType[] columnDataTypes) {
         return physical(Arrays.asList(columnNames), Arrays.asList(columnDataTypes));
+    }
+
+    public static ResolvedSchema physical(
+            String[] columnNames, DataType[] columnDataTypes, ResolvedSchema fromSchema) {
+        return physical(Arrays.asList(columnNames), Arrays.asList(columnDataTypes), fromSchema);
     }
 
     /** Returns the number of {@link Column}s of this schema. */


### PR DESCRIPTION
## What is the purpose of the change

This pull request solves the issue that the comment was lost when creating a Table from Datastream and Schema. Previously, the method `StreamTableEnvironment::fromDataStream` will ignore comments of the physical columns defined in the schema. So all physical column comments will be lost. Furthermore, `Table::as` will ignore comments of all the columns defined in the schema when creating the new `ProjectQueryOperation`.


## Brief change log

  - *Make sure the comment is added to the physical column when executing `createConsumingResult()` in `SchemaTransaltor`*
  - *When creatting the new `ProjectQueryOperation`, the new resolved schema only creates from field name and field types which lost the comments again. Make sure the comment is added in this step.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added several tests in DataStreamJavaITCase*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature?  No.
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
