### PR TITLE
[FLINK-28951][table] Make header with one line comments

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -215,9 +215,7 @@ class CodeGeneratorContext(val tableConfig: ReadableConfig, val classLoader: Cla
   /** @return Comment to be added as a header comment on the generated class */
   def getClassHeaderComment: String = {
     s"""
-       | //
        | // ${reusableHeaderComments.mkString("\n // ")}
-       | //
     """.stripMargin
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -215,9 +215,9 @@ class CodeGeneratorContext(val tableConfig: ReadableConfig, val classLoader: Cla
   /** @return Comment to be added as a header comment on the generated class */
   def getClassHeaderComment: String = {
     s"""
-       |/*
-       | * ${reusableHeaderComments.mkString("\n * ")}
-       | */
+       | //
+       | // ${reusableHeaderComments.mkString("\n // ")}
+       | //
     """.stripMargin
   }
 


### PR DESCRIPTION
## What is the purpose of the change

The PR changes multiline comments for headers in for janino generated java files to one line to prevent merging with line numbers and to keep class compiled even with line numbers generated.

## Brief change log
`flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
