### PR TITLE
[hotfix][docs] Fix typos in java doc

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumeratorTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Unit tests for the {@link ContinuousFileSplitEnumerator}. */
+/** Unit tests for the {@link StaticFileSplitEnumerator}. */
 class StaticFileSplitEnumeratorTest {
 
     // this is no JUnit temporary folder, because we don't create actual files, we just

--- a/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/converter/AbstractJdbcRowConverter.java
+++ b/flink-connectors/flink-connector-jdbc/src/main/java/org/apache/flink/connector/jdbc/converter/AbstractJdbcRowConverter.java
@@ -187,7 +187,7 @@ public abstract class AbstractJdbcRowConverter implements JdbcRowConverter {
         }
     }
 
-    /** Create a nullable JDBC f{@link JdbcSerializationConverter} from given sql type. */
+    /** Create a nullable JDBC {@link JdbcSerializationConverter} from given sql type. */
     protected JdbcSerializationConverter createNullableExternalConverter(LogicalType type) {
         return wrapIntoNullableExternalConverter(createExternalConverter(type), type);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
@@ -138,7 +138,7 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
     }
 
     /**
-     * Determines wether we can pushdown the filter into the source. we can not push filter twice,
+     * Determines whether we can push down the filter into the source. we can not push filter twice,
      * make sure FilterPushDownSpec has not been assigned as a capability.
      *
      * @param tableSourceTable Table scan to attempt to push into


### PR DESCRIPTION
## What is the purpose of the change

Fix typos in java doc

## Brief change log

Fix the wrong java doc.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
