### PR TITLE
[FLINK-28961][python][docs] Add the doc how to support third party connector in Python DataStream API

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/formats/avro.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/avro.md
@@ -64,6 +64,8 @@ Flink 的 POJO 字段选择也适用于从 Avro schema 生成的 POJO 类。但�
 在 Avro 中如 `{"name": "type_double_test", "type": "double"},` 这样指定字段是可行的，但是如 (`{"name": "type_double_test", "type": ["double"]},`) 这样指定包含一个字段的复合类型就会生成 `Object` 类型的字段。注意，如 (`{"name": "type_double_test", "type": ["null", "double"]},`) 这样指定 nullable 类型字段也是可能产生 `Object` 类型的!
 
 
+## Python
+
 在 Python 作业中读取 Avro 文件，需要先定义 Avro schema，产生的 DataStream 元素为原生的 Python 对象 Generic。例如：
 
 ```python

--- a/docs/content.zh/docs/connectors/datastream/formats/csv.md
+++ b/docs/content.zh/docs/connectors/datastream/formats/csv.md
@@ -114,6 +114,8 @@ CsvReaderFormat<ComplexPojo> csvFormat =
                 TypeInformation.of(ComplexPojo.class));
 ```
 
+## Python
+
 For PyFlink users, a csv schema can be defined by manually adding columns, and the output type of the csv source will be a Row with each column mapped to a field.
 ```python
 schema = CsvSchema.builder() \

--- a/docs/content.zh/docs/dev/python/datastream/connectors.md
+++ b/docs/content.zh/docs/dev/python/datastream/connectors.md
@@ -1,0 +1,105 @@
+---
+title: "Connectors"
+weight: 32
+type: docs
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Bundled Connectors
+
+Apache Flink has supported many [bundled connectors]({{< ref "docs/connectors/datastream/overview" >}}). 
+In order to use the [bundled connectors]({{< ref "docs/connectors/datastream/overview" >}}) in PyFlink jobs, the corresponding dependencies are required.
+
+See [Python dependency management]({{< ref "docs/dev/python/dependency_management" >}}#jar-dependencies) for more details on how to use JARs in PyFlink.
+
+## Custom third-party Connectors
+
+Similar to [Bundled Connectors](#bundled-connectors), you need to add the corresponding dependencies. Besides that, you need to add the simple Python
+Wrapper Class to wrap your Java Implementation. We can take [RabbitMQ Connector]({{< ref "docs/connectors/datastream/rabbitmq" >}}) as example. 
+
+In RabbitMQ Connector API, it provides the following three classes for use.
+
+```java
+public class RMQConnectionConfig implements Serializable {
+    // ... methods
+}
+
+public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OUT, String, Long>
+        implements ResultTypeQueryable<OUT> {
+    // ... methods
+}
+
+public class RMQSink<IN> extends RichSinkFunction<IN> {
+    // ... methods
+}
+```
+
+We can take use of [py4j](https://github.com/py4j/py4j) to provide the Python wrapper class easily.
+
+```python
+class RMQConnectionConfig(object):
+    """
+    Connection Configuration for RMQ.
+    """
+
+    def __init__(self, j_rmq_connection_config):
+        # j_rmq_connection_config is the corresponding Java RMQConnectionConfig instance.
+        self._j_rmq_connection_config = j_rmq_connection_config
+
+    # Aligned with Java Methods
+    def get_host(self) -> str:
+        return self._j_rmq_connection_config.getHost()
+
+    # ... other methods
+
+
+
+class RMQSource(SourceFunction):
+    def __init__(self,
+                 connection_config: 'RMQConnectionConfig',
+                 queue_name: str,
+                 use_correlation_id: bool,
+                 deserialization_schema: DeserializationSchema
+                 ):
+    # use py4j to create the corresponding Java RMQSource.
+    JRMQSource = get_gateway().jvm.org.apache.flink.streaming.connectors.rabbitmq.RMQSource
+    j_rmq_source = JRMQSource(
+        connection_config._j_rmq_connection_config,
+        queue_name,
+        use_correlation_id,
+        deserialization_schema._j_deserialization_schema
+    )
+    super(RMQSource, self).__init__(source_func=j_rmq_source)
+
+
+class RMQSink(SinkFunction):
+    def __init__(self, connection_config: 'RMQConnectionConfig',
+                 queue_name: str, serialization_schema: SerializationSchema):
+        # use py4j to create the corresponding Java RMQSource.
+        JRMQSink = get_gateway().jvm.org.apache.flink.streaming.connectors.rabbitmq.RMQSink
+        j_rmq_sink = JRMQSink(
+            connection_config._j_rmq_connection_config,
+            queue_name,
+            serialization_schema._j_serialization_schema,
+        )
+        super(RMQSink, self).__init__(sink_func=j_rmq_sink)
+```
+
+For more details, you can refer to the [Python implementation of RabbitMQ Connector](https://github.com/apache/flink/blob/master/flink-python/pyflink/datastream/connectors/rabbitmq.py)

--- a/docs/content/docs/connectors/datastream/formats/avro.md
+++ b/docs/content/docs/connectors/datastream/formats/avro.md
@@ -63,6 +63,8 @@ Flink's POJO field selection also works with POJOs generated from Avro. However,
 Specifying a field in Avro like this `{"name": "type_double_test", "type": "double"},` works fine, however specifying it as a UNION-type with only one field (`{"name": "type_double_test", "type": ["double"]},`) will generate a field of type `Object`. Note that specifying nullable types (`{"name": "type_double_test", "type": ["null", "double"]},`) is possible!
 
 
+## Python
+
 For Python jobs, an Avro schema should be defined to read from Avro files, and the elements will be vanilla Python objects. For example:
 
 ```python

--- a/docs/content/docs/connectors/datastream/formats/csv.md
+++ b/docs/content/docs/connectors/datastream/formats/csv.md
@@ -55,7 +55,7 @@ The schema for CSV parsing, in this case, is automatically derived based on the 
 Note: you might need to add `@JsonPropertyOrder({field1, field2, ...})` annotation to your class definition with the fields order exactly matching those of the CSV file columns.
 {{< /hint >}}
 
-### Advanced configuration
+## Advanced configuration
 
 If you need more fine-grained control over the CSV schema or the parsing options, use the more low-level `forSchema` static factory method of `CsvReaderFormat`:
 
@@ -113,6 +113,8 @@ CsvReaderFormat<ComplexPojo> csvFormat =
                         .build(),
                 TypeInformation.of(ComplexPojo.class));
 ```
+
+## Python
 
 For PyFlink users, a csv schema can be defined by manually adding columns, and the output type of the csv source will be a Row with each column mapped to a field.
 ```python

--- a/docs/content/docs/dev/python/datastream/connectors.md
+++ b/docs/content/docs/dev/python/datastream/connectors.md
@@ -1,0 +1,105 @@
+---
+title: "Connectors"
+weight: 32
+type: docs
+---
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+## Bundled Connectors
+
+Apache Flink has supported many [bundled connectors]({{< ref "docs/connectors/datastream/overview" >}}). 
+In order to use the [bundled connectors]({{< ref "docs/connectors/datastream/overview" >}}) in PyFlink jobs, the corresponding dependencies are required.
+
+See [Python dependency management]({{< ref "docs/dev/python/dependency_management" >}}#jar-dependencies) for more details on how to use JARs in PyFlink.
+
+## Custom third-party Connectors
+
+Similar to [Bundled Connectors](#bundled-connectors), you need to add the corresponding dependencies. Besides that, you need to add the simple Python
+Wrapper Class to wrap your Java Implementation. We can take [RabbitMQ Connector]({{< ref "docs/connectors/datastream/rabbitmq" >}}) as example. 
+
+In RabbitMQ Connector API, it provides the following three classes for use.
+
+```java
+public class RMQConnectionConfig implements Serializable {
+    // ... methods
+}
+
+public class RMQSource<OUT> extends MultipleIdsMessageAcknowledgingSourceBase<OUT, String, Long>
+        implements ResultTypeQueryable<OUT> {
+    // ... methods
+}
+
+public class RMQSink<IN> extends RichSinkFunction<IN> {
+    // ... methods
+}
+```
+
+We can take use of [py4j](https://github.com/py4j/py4j) to provide the Python wrapper class easily.
+
+```python
+class RMQConnectionConfig(object):
+    """
+    Connection Configuration for RMQ.
+    """
+
+    def __init__(self, j_rmq_connection_config):
+        # j_rmq_connection_config is the corresponding Java RMQConnectionConfig instance.
+        self._j_rmq_connection_config = j_rmq_connection_config
+
+    # Aligned with Java Methods
+    def get_host(self) -> str:
+        return self._j_rmq_connection_config.getHost()
+
+    # ... other methods
+
+
+
+class RMQSource(SourceFunction):
+    def __init__(self,
+                 connection_config: 'RMQConnectionConfig',
+                 queue_name: str,
+                 use_correlation_id: bool,
+                 deserialization_schema: DeserializationSchema
+                 ):
+    # use py4j to create the corresponding Java RMQSource.
+    JRMQSource = get_gateway().jvm.org.apache.flink.streaming.connectors.rabbitmq.RMQSource
+    j_rmq_source = JRMQSource(
+        connection_config._j_rmq_connection_config,
+        queue_name,
+        use_correlation_id,
+        deserialization_schema._j_deserialization_schema
+    )
+    super(RMQSource, self).__init__(source_func=j_rmq_source)
+
+
+class RMQSink(SinkFunction):
+    def __init__(self, connection_config: 'RMQConnectionConfig',
+                 queue_name: str, serialization_schema: SerializationSchema):
+        # use py4j to create the corresponding Java RMQSource.
+        JRMQSink = get_gateway().jvm.org.apache.flink.streaming.connectors.rabbitmq.RMQSink
+        j_rmq_sink = JRMQSink(
+            connection_config._j_rmq_connection_config,
+            queue_name,
+            serialization_schema._j_serialization_schema,
+        )
+        super(RMQSink, self).__init__(sink_func=j_rmq_sink)
+```
+
+For more details, you can refer to the [Python implementation of RabbitMQ Connector](https://github.com/apache/flink/blob/master/flink-python/pyflink/datastream/connectors/rabbitmq.py)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add the doc how to support third party connector in Python DataStream API*

## Brief change log

  - *Add the doc how to support third party connector in Python DataStream API*

## Verifying this change

This change added tests and can be verified as follows:

  - *execute `build_docs.sh`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
