### PR TITLE
[FLINK-28976][state/changelog] Don't add extra delay to the 1st materialization

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -65,6 +65,7 @@ import org.apache.flink.runtime.state.ttl.TtlStateFactory;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.state.changelog.restore.ChangelogRestoreTarget;
 import org.apache.flink.state.changelog.restore.FunctionDelegationHelper;
+import org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationTarget;
 
 import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
 
@@ -95,7 +96,7 @@ import java.util.stream.Stream;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.flink.runtime.state.StateSnapshotTransformer.StateSnapshotTransformFactory.noTransform;
-import static org.apache.flink.state.changelog.PeriodicMaterializationManager.MaterializationRunnable;
+import static org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationRunnable;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -109,7 +110,8 @@ public class ChangelogKeyedStateBackend<K>
         implements CheckpointableKeyedStateBackend<K>,
                 CheckpointListener,
                 TestableKeyedStateBackend<K>,
-                InternalCheckpointListener {
+                InternalCheckpointListener,
+                MaterializationTarget {
     private static final Logger LOG = LoggerFactory.getLogger(ChangelogKeyedStateBackend.class);
 
     /**
@@ -754,6 +756,7 @@ public class ChangelogKeyedStateBackend<K>
      * @return a tuple of - future snapshot result from the underlying state backend - a {@link
      *     SequenceNumber} identifying the latest change in the changelog
      */
+    @Override
     public Optional<MaterializationRunnable> initMaterialization() throws Exception {
         SequenceNumber upTo = stateChangelogWriter.nextSequenceNumber();
         SequenceNumber lastMaterializedTo = changelogSnapshotState.lastMaterializedTo();
@@ -800,7 +803,8 @@ public class ChangelogKeyedStateBackend<K>
      * This method is not thread safe. It should be called either under a lock or through task
      * mailbox executor.
      */
-    public void updateChangelogSnapshotState(
+    @Override
+    public void handleMaterializationResult(
             SnapshotResult<KeyedStateHandle> materializedSnapshot,
             long materializationID,
             SequenceNumber upTo) {

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -34,6 +34,8 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.AsynchronousException;
 import org.apache.flink.state.changelog.restore.ChangelogBackendRestoreOperation;
 import org.apache.flink.state.changelog.restore.ChangelogBackendRestoreOperation.BaseBackendBuilder;
+import org.apache.flink.state.common.ChangelogMaterializationMetricGroup;
+import org.apache.flink.state.common.PeriodicMaterializationManager;
 import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackendTest.java
@@ -72,7 +72,7 @@ public class ChangelogKeyedStateBackendTest {
         MockKeyedStateBackend<Integer> mock = createMock();
         ChangelogKeyedStateBackend<Integer> changelog = createChangelog(mock);
         try {
-            changelog.updateChangelogSnapshotState(
+            changelog.handleMaterializationResult(
                     SnapshotResult.empty(), materializationId, SequenceNumber.of(Long.MAX_VALUE));
             checkpoint(changelog, checkpointId).get().discardState();
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMetricGroupTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogMetricGroupTest.java
@@ -37,6 +37,8 @@ import org.apache.flink.runtime.state.hashmap.HashMapStateBackend;
 import org.apache.flink.runtime.state.memory.MemCheckpointStreamFactory;
 import org.apache.flink.runtime.state.storage.JobManagerCheckpointStorage;
 import org.apache.flink.runtime.testutils.ExceptionallyDoneFuture;
+import org.apache.flink.state.common.ChangelogMaterializationMetricGroup;
+import org.apache.flink.state.common.PeriodicMaterializationManager;
 import org.apache.flink.util.Preconditions;
 
 import org.junit.Test;
@@ -48,13 +50,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RunnableFuture;
 
 import static org.apache.flink.runtime.state.StateBackendTestUtils.wrapStateBackendWithSnapshotFunction;
-import static org.apache.flink.state.changelog.ChangelogMaterializationMetricGroup.COMPLETED_MATERIALIZATION;
-import static org.apache.flink.state.changelog.ChangelogMaterializationMetricGroup.FAILED_MATERIALIZATION;
-import static org.apache.flink.state.changelog.ChangelogMaterializationMetricGroup.STARTED_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_FULL_SIZE_OF_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_FULL_SIZE_OF_NON_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_INC_SIZE_OF_MATERIALIZATION;
 import static org.apache.flink.state.changelog.ChangelogStateBackendMetricGroup.LATEST_INC_SIZE_OF_NON_MATERIALIZATION;
+import static org.apache.flink.state.common.ChangelogMaterializationMetricGroup.COMPLETED_MATERIALIZATION;
+import static org.apache.flink.state.common.ChangelogMaterializationMetricGroup.FAILED_MATERIALIZATION;
+import static org.apache.flink.state.common.ChangelogMaterializationMetricGroup.STARTED_MATERIALIZATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateBackendTestUtils.java
@@ -58,6 +58,8 @@ import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.testutils.statemigration.TestType;
+import org.apache.flink.state.common.ChangelogMaterializationMetricGroup;
+import org.apache.flink.state.common.PeriodicMaterializationManager;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.concurrent.Executors;

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogStateDiscardTest.java
@@ -450,7 +450,7 @@ public class ChangelogStateDiscardTest {
 
     private static void materialize(
             ChangelogKeyedStateBackend<String> backend, StateChangelogWriter<?> writer) {
-        backend.updateChangelogSnapshotState(empty(), 0L, writer.nextSequenceNumber());
+        backend.handleMaterializationResult(empty(), 0L, writer.nextSequenceNumber());
     }
 
     private static void truncate(

--- a/flink-state-backends/flink-statebackend-common/pom.xml
+++ b/flink-state-backends/flink-statebackend-common/pom.xml
@@ -28,10 +28,11 @@ under the License.
 		<groupId>org.apache.flink</groupId>
 		<artifactId>flink-state-backends</artifactId>
 		<version>1.16-SNAPSHOT</version>
+		<relativePath>..</relativePath>
 	</parent>
 
-	<artifactId>flink-statebackend-changelog</artifactId>
-	<name>Flink : State backends : Changelog</name>
+	<artifactId>flink-statebackend-common</artifactId>
+	<name>Flink : State backends : Common</name>
 
 	<packaging>jar</packaging>
 
@@ -56,52 +57,18 @@ under the License.
             <artifactId>flink-shaded-guava</artifactId>
         </dependency>
 
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-common</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
-		<!-- test dependencies -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils-junit</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-dstl-dfs</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-runtime</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-			<type>test-jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-rocksdb</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-			<type>test-jar</type>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-statebackend-rocksdb</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
+        <!-- test dependencies -->
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-streaming-java</artifactId>
+            <artifactId>flink-runtime</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-test-utils-junit</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
+++ b/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.flink.state.changelog;
+package org.apache.flink.state.common;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.MetricGroup;
@@ -24,24 +25,25 @@ import org.apache.flink.metrics.ThreadSafeSimpleCounter;
 import org.apache.flink.runtime.metrics.groups.ProxyMetricGroup;
 
 /** Metrics related to the materialization part of Changelog. */
-class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<MetricGroup> {
+@Internal
+public class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<MetricGroup> {
 
     private static final String PREFIX = "ChangelogMaterialization";
 
     @VisibleForTesting
-    static final String STARTED_MATERIALIZATION = PREFIX + ".startedMaterialization";
+    public static final String STARTED_MATERIALIZATION = PREFIX + ".startedMaterialization";
 
     @VisibleForTesting
-    static final String COMPLETED_MATERIALIZATION = PREFIX + ".completedMaterialization";
+    public static final String COMPLETED_MATERIALIZATION = PREFIX + ".completedMaterialization";
 
     @VisibleForTesting
-    static final String FAILED_MATERIALIZATION = PREFIX + ".failedMaterialization";
+    public static final String FAILED_MATERIALIZATION = PREFIX + ".failedMaterialization";
 
     private final Counter startedMaterializationCounter;
     private final Counter completedMaterializationCounter;
     private final Counter failedMaterializationCounter;
 
-    ChangelogMaterializationMetricGroup(MetricGroup parentMetricGroup) {
+    public ChangelogMaterializationMetricGroup(MetricGroup parentMetricGroup) {
         super(parentMetricGroup);
         this.startedMaterializationCounter =
                 counter(STARTED_MATERIALIZATION, new ThreadSafeSimpleCounter());

--- a/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/PeriodicMaterializationManager.java
+++ b/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/PeriodicMaterializationManager.java
@@ -147,7 +147,7 @@ public class PeriodicMaterializationManager implements Closeable {
 
             LOG.info("Task {} starts periodic materialization", subtaskName);
 
-            scheduleNextMaterialization(initialDelay);
+            scheduleNextMaterialization(periodicMaterializeDelay + initialDelay);
         }
     }
 
@@ -302,22 +302,19 @@ public class PeriodicMaterializationManager implements Closeable {
     }
 
     private void scheduleNextMaterialization() {
-        scheduleNextMaterialization(0);
+        scheduleNextMaterialization(periodicMaterializeDelay);
     }
 
     // task thread and asyncOperationsThreadPool can access this method
-    private synchronized void scheduleNextMaterialization(long offset) {
+    private synchronized void scheduleNextMaterialization(long delay) {
         if (started && !periodicExecutor.isShutdown()) {
 
             LOG.info(
                     "Task {} schedules the next materialization in {} seconds",
                     subtaskName,
-                    periodicMaterializeDelay / 1000);
+                    delay / 1000);
 
-            periodicExecutor.schedule(
-                    this::triggerMaterialization,
-                    periodicMaterializeDelay + offset,
-                    TimeUnit.MILLISECONDS);
+            periodicExecutor.schedule(this::triggerMaterialization, delay, TimeUnit.MILLISECONDS);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
+++ b/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.common;
+
+import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationTarget;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.Test;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.flink.shaded.guava30.com.google.common.collect.Iterators.getOnlyElement;
+import static org.apache.flink.util.concurrent.Executors.newDirectExecutorService;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/** {@link PeriodicMaterializationManager} test. */
+public class PeriodicMaterializationManagerTest extends TestLogger {
+
+    @Test
+    public void testInitialDelay() {
+        ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
+                new ManuallyTriggeredScheduledExecutorService();
+        long periodicMaterializeDelay = 10_000L;
+
+        try (PeriodicMaterializationManager test =
+                new PeriodicMaterializationManager(
+                        new SyncMailboxExecutor(),
+                        newDirectExecutorService(),
+                        "test",
+                        (message, exception) -> {},
+                        MaterializationTarget.NO_OP,
+                        new ChangelogMaterializationMetricGroup(
+                                UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup()),
+                        periodicMaterializeDelay,
+                        0,
+                        "subtask-0",
+                        scheduledExecutorService)) {
+            test.start();
+
+            assertThat(
+                    String.format(
+                            "task for initial materialization should be scheduled with a 0..%d delay",
+                            periodicMaterializeDelay),
+                    getOnlyElement(scheduledExecutorService.getAllScheduledTasks().iterator())
+                            .getDelay(MILLISECONDS),
+                    lessThanOrEqualTo(periodicMaterializeDelay));
+        }
+    }
+}

--- a/flink-state-backends/pom.xml
+++ b/flink-state-backends/pom.xml
@@ -39,5 +39,6 @@ under the License.
 		<module>flink-statebackend-rocksdb</module>
 		<module>flink-statebackend-heap-spillable</module>
 		<module>flink-statebackend-changelog</module>
+		<module>flink-statebackend-common</module>
 	</modules>
 </project>

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/TestStreamEnvironment.java
@@ -138,8 +138,7 @@ public class TestStreamEnvironment extends StreamExecutionEnvironment {
                             Duration.ofMillis(500),
                             Duration.ofSeconds(1),
                             Duration.ofSeconds(5),
-                            Duration.ofSeconds(
-                                    Long.MAX_VALUE / 1000 /* max allowed by Duration.toMillis */));
+                            Duration.ofSeconds(-1));
                     miniCluster.overrideRestoreModeForChangelogStateBackend();
                 }
             }

--- a/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRecoveryCachingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/ChangelogRecoveryCachingITCase.java
@@ -177,7 +177,7 @@ public class ChangelogRecoveryCachingITCase extends TestLogger {
         conf.set(LOCAL_RECOVERY, false); // force download
         // tune changelog
         conf.set(PREEMPTIVE_PERSIST_THRESHOLD, MemorySize.ofMebiBytes(10));
-        conf.set(PERIODIC_MATERIALIZATION_INTERVAL, Duration.ofDays(365));
+        conf.set(PERIODIC_MATERIALIZATION_INTERVAL, Duration.ofDays(-1));
 
         conf.set(ENABLE_UNALIGNED, true); // speedup
         conf.set(ALIGNED_CHECKPOINT_TIMEOUT, Duration.ZERO); // prevent randomization


### PR DESCRIPTION
## What is the purpose of the change

Spread changelog materialization and consequently deletion, more evenly in time.

To ease the creation of `PeriodicMaterializationManager` in test, this PR includes c7865f9663ffec5ca668a7781e2dc274ff7a35c9 from #19312.

## Verifying this change

- added `PeriodicMaterializationManagerTest.testInitialDelay`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
