### PR TITLE
[FLINK-28972][python][connector/pulsar] Align Start/StopCursor method to java

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/pulsar.md
+++ b/docs/content.zh/docs/connectors/datastream/pulsar.md
@@ -352,9 +352,18 @@ Pulsar Source 使用 `setStartCursor(StartCursor)` 方法给定开始消费的�
   {{< /tabs >}}
 
 - 从给定的消息发布时间开始消费。
+  {{< tabs "pulsar-starting-position-publish-time" >}}
+  {{< tab "Java" >}}
   ```java
   StartCursor.fromPublishTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StartCursor.from_publish_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 {{< hint info >}}
 每条消息都有一个固定的序列号，这个序列号在 Pulsar 上有序排列，其包含了 ledger、entry、partition 等原始信息，用于在 Pulsar 底层存储上查找到具体的消息。
@@ -427,17 +436,35 @@ Pulsar Source 默认情况下使用流的方式消费数据。除非任务失败
   {{< /tabs >}}
 
 - 停止于某个给定的消息事件时间戳，比如 `Message<byte[]>.getEventTime()`，消费结果里不包含此时间戳的消息。
+  {{< tabs "pulsar-boundedness-at-event-time" >}} 
+  {{< tab "Java" >}}
   ```java
   StopCursor.atEventTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StopCursor.at_event_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 - 停止于某个给定的消息事件时间戳，比如 `Message<byte[]>.getEventTime()`，消费结果里包含此时间戳的消息。
+  {{< tabs "pulsar-boundedness-after-event-time" >}}
+  {{< tab "Java" >}}
   ```java
   StopCursor.afterEventTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StopCursor.after_event_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 - 停止于某个给定的消息发布时间戳，比如 `Message<byte[]>.getPublishTime()`，消费结果里不包含此时间戳的消息。
-  {{< tabs "pulsar-boundedness-publish-time" >}}
+  {{< tabs "pulsar-boundedness-at-publish-time" >}}
   {{< tab "Java" >}}
   ```java
   StopCursor.atPublishTime(long);
@@ -451,9 +478,18 @@ Pulsar Source 默认情况下使用流的方式消费数据。除非任务失败
   {{< /tabs >}}
 
 - 停止于某个给定的消息发布时间戳，比如 `Message<byte[]>.getPublishTime()`，消费结果里包含此时间戳的消息。
+  {{< tabs "pulsar-boundedness-after-publish-time" >}}
+  {{< tab "Java" >}}
   ```java
   StopCursor.afterPublishTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StopCursor.after_publish_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 ### Source 配置项
 

--- a/docs/content/docs/connectors/datastream/pulsar.md
+++ b/docs/content/docs/connectors/datastream/pulsar.md
@@ -392,9 +392,18 @@ You can use `StartCursor.fromPublishTime(long)` instead.
   {{< /tabs >}}
 
 - Start from the specified message publish time by `Message<byte[]>.getPublishTime()`.
+  {{< tabs "pulsar-starting-position-publish-time" >}}
+  {{< tab "Java" >}}
   ```java
   StartCursor.fromPublishTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StartCursor.from_publish_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 {{< hint info >}}
 Each Pulsar message belongs to an ordered sequence on its topic.
@@ -473,19 +482,37 @@ Built-in stop cursors include:
 
 - Stop at the specified event time by `Message<byte[]>.getEventTime()`. The message with the
 given event time won't be included in the consuming result.
+  {{< tabs "pulsar-boundedness-at-event-time" >}} 
+  {{< tab "Java" >}}
   ```java
   StopCursor.atEventTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StopCursor.at_event_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 - Stop after the specified event time by `Message<byte[]>.getEventTime()`. The message with the
 given event time will be included in the consuming result.
+  {{< tabs "pulsar-boundedness-after-event-time" >}}
+  {{< tab "Java" >}}
   ```java
   StopCursor.afterEventTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StopCursor.after_event_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 - Stop at the specified publish time by `Message<byte[]>.getPublishTime()`. The message with the
 given publish time won't be included in the consuming result.
-  {{< tabs "pulsar-boundedness-publish-time" >}}
+  {{< tabs "pulsar-boundedness-at-publish-time" >}}
   {{< tab "Java" >}}
   ```java
   StopCursor.atPublishTime(long);
@@ -500,9 +527,18 @@ given publish time won't be included in the consuming result.
 
 - Stop after the specified publish time by `Message<byte[]>.getPublishTime()`. The message with the
 given publish time will be included in the consuming result.
+  {{< tabs "pulsar-boundedness-after-publish-time" >}}
+  {{< tab "Java" >}}
   ```java
   StopCursor.afterPublishTime(long);
   ```
+  {{< /tab >}}
+  {{< tab "Python" >}}
+  ```python
+  StopCursor.after_publish_time(int)
+  ```
+  {{< /tab >}}
+  {{< /tabs >}}
 
 ### Source Configurable Options
 

--- a/flink-python/pyflink/datastream/connectors/pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/pulsar.py
@@ -177,6 +177,15 @@ class StartCursor(object):
             .fromByteArray(message_id)
         return StartCursor(JStartCursor.fromMessageId(j_message_id, inclusive))
 
+    @staticmethod
+    def from_publish_time(timestamp: int) -> 'StartCursor':
+        """
+        Seek the start position by using message publish time.
+        """
+        JStartCursor = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor
+        return StartCursor(JStartCursor.fromPublishTime(timestamp))
+
 
 class StopCursor(object):
     """
@@ -206,11 +215,21 @@ class StopCursor(object):
 
     @staticmethod
     def at_event_time(timestamp: int) -> 'StopCursor':
-        warnings.warn(
-            "at_event_time is deprecated. Use at_publish_time instead.", DeprecationWarning)
+        """
+        Stop consuming when message eventTime is greater than or equals the specified timestamp.
+        """
         JStopCursor = get_gateway().jvm \
             .org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor
         return StopCursor(JStopCursor.atEventTime(timestamp))
+
+    @staticmethod
+    def after_event_time(timestamp: int) -> 'StopCursor':
+        """
+        Stop consuming when message eventTime is greater than the specified timestamp.
+        """
+        JStopCursor = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor
+        return StopCursor(JStopCursor.afterEventTime(timestamp))
 
     @staticmethod
     def at_publish_time(timestamp: int) -> 'StopCursor':
@@ -220,6 +239,15 @@ class StopCursor(object):
         JStopCursor = get_gateway().jvm \
             .org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor
         return StopCursor(JStopCursor.atPublishTime(timestamp))
+
+    @staticmethod
+    def after_publish_time(timestamp: int) -> 'StopCursor':
+        """
+        Stop consuming when message publishTime is greater than the specified timestamp.
+        """
+        JStopCursor = get_gateway().jvm \
+            .org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor
+        return StopCursor(JStopCursor.afterPublishTime(timestamp))
 
     @staticmethod
     def at_message_id(message_id: bytes) -> 'StopCursor':

--- a/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
+++ b/flink-python/pyflink/datastream/connectors/tests/test_pulsar.py
@@ -127,6 +127,31 @@ class FlinkPulsarTest(PyFlinkStreamingTestCase):
                 .long_type()
                 .no_default_value()._j_config_option), 1000)
 
+    def test_stop_cursor_publish_time(self):
+        PulsarSource.builder() \
+            .set_service_url('pulsar://localhost:6650') \
+            .set_admin_url('http://localhost:8080') \
+            .set_topics('ada') \
+            .set_subscription_name('ff') \
+            .set_deserialization_schema(
+                PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_start_cursor(StartCursor.from_publish_time(2)) \
+            .set_bounded_stop_cursor(StopCursor.at_publish_time(14)) \
+            .set_bounded_stop_cursor(StopCursor.after_publish_time(24)) \
+            .build()
+
+    def test_stop_cursor_event_time(self):
+        PulsarSource.builder() \
+            .set_service_url('pulsar://localhost:6650') \
+            .set_admin_url('http://localhost:8080') \
+            .set_topics('ada') \
+            .set_subscription_name('ff') \
+            .set_deserialization_schema(
+                PulsarDeserializationSchema.flink_schema(SimpleStringSchema())) \
+            .set_bounded_stop_cursor(StopCursor.after_event_time(14)) \
+            .set_bounded_stop_cursor(StopCursor.at_event_time(24)) \
+            .build()
+
     def test_pulsar_sink(self):
         ds = self.env.from_collection([('ab', 1), ('bdc', 2), ('cfgs', 3), ('deeefg', 4)],
                                       type_info=Types.ROW([Types.STRING(), Types.INT()]))


### PR DESCRIPTION
## What is the purpose of the change

Add fromPublishTime in the StartCursor class
Add afterEventTime and afterPublishTime in the StopCursor class

## Brief change log

  - *Add from_publish_time in the StartCursor class*
  - *Add after_event_time and after_publish_time in the StopCursor class*
  - *Add EN and CN docs*

## Verifying this change

This change added tests and can be verified as follows:

  - *Added StopCursor event_time and publist_time test case*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (docs)
