### PR TITLE
[FLINK-28925] Fix the concurrency problem in hybrid shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
@@ -152,7 +152,10 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
         return bufferAndNextDataType.map(
                 tuple ->
                         new BufferAndBacklog(
-                                tuple.f0.getBuffer(), getBacklog(), tuple.f1, toConsumeIndex));
+                                tuple.f0.getBuffer().readOnlySlice(),
+                                getBacklog(),
+                                tuple.f1,
+                                toConsumeIndex));
     }
 
     @SuppressWarnings("FieldAccessNotGuarded")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
@@ -266,9 +266,11 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
                                 (indexAndChannel) -> {
                                     int bufferIndex = indexAndChannel.getBufferIndex();
                                     HsBufferContext bufferContext =
-                                            checkNotNull(bufferIndexToContexts.get(bufferIndex));
-                                    checkAndMarkBufferReadable(bufferContext);
-                                    releaseBuffer(bufferIndex);
+                                            bufferIndexToContexts.get(bufferIndex);
+                                    if (bufferContext != null) {
+                                        checkAndMarkBufferReadable(bufferContext);
+                                        releaseBuffer(bufferIndex);
+                                    }
                                 }));
     }
 


### PR DESCRIPTION
## What is the purpose of the change

- *`HsSubpartitionMemeoryDataManager#consumeBuffer` should return a readOnlySlice buffer to downstream instead of original buffer: If the spilling thread is processing while  downstream task is consuming the same buffer, the amount of data written to the disk will be smaller than the actual value. To solve this, we should let the consuming thread and the spilling thread share the same data but not index.*
- *`HsSubpartitionMemoryDataManager#releaseSubpartitionBuffers` should ignore the release decision if the buffer already removed from bufferIndexToContexts instead of throw an exception. It should be pointed out that although the actual release operation is synchronous, a double release can still happen. The reason is that non-global decisions do not need to be synchronized. In other words, the main task thread and the consumer thread may decide to release a buffer at the same time.*


## Brief change log

  - *`HsSubpartitionMemeoryDataManager` return a `readOnlySlice` to downstream instead of original buffer.*
  - *Fix the NPE problem caused by double release buffer.*

## Verifying this change

This change added tests and can be verified by `HsSubpartitionMemoryDataManagerTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
