### PR TITLE
[FLINK-28994][runtime-web] enable withCredentials for outgoing HTTP requests

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
@@ -37,7 +37,7 @@ export class AppInterceptor implements HttpInterceptor {
       nzStyle: { width: 'auto', 'white-space': 'pre-wrap' }
     };
 
-    return next.handle(req).pipe(
+    return next.handle(req.clone({ withCredentials: true })).pipe(
       catchError(res => {
         const errorMessage = res && res.error && res.error.errors && res.error.errors[0];
         if (


### PR DESCRIPTION
## What is the purpose of the change

Some environments require cookies to authenticate the Flink UI. By enabling the withCredentials
flag, Angular will send cookies along with the request.

Signed-off-by: Ingo Bürk <airblader@apache.org>

## Brief change log

* Set `withCredentials` in interceptor.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented