### PR TITLE
[FLINK-28990][table-planner] Fix BatchPhysicalDynamicFilteringDataCollector with empty output type

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRule.java
@@ -152,9 +152,15 @@ public abstract class DynamicPartitionPruningRule extends RelRule<RelRule.Config
             }
         }
 
-        return acceptedFields.stream()
-                .map(f -> factScan.getRowType().getFieldNames().indexOf(f))
-                .collect(Collectors.toList());
+        if (factCalc == null) {
+            return acceptedFields.stream()
+                    .map(f -> factScan.getRowType().getFieldNames().indexOf(f))
+                    .collect(Collectors.toList());
+        } else {
+            return acceptedFields.stream()
+                    .map(f -> factCalc.getRowType().getFieldNames().indexOf(f))
+                    .collect(Collectors.toList());
+        }
     }
 
     protected BatchPhysicalDynamicFilteringTableSourceScan createDynamicFilteringTableSourceScan(
@@ -200,7 +206,6 @@ public abstract class DynamicPartitionPruningRule extends RelRule<RelRule.Config
                         .projectStructType(
                                 dimSide.getRowType(),
                                 dynamicFilteringFieldIndices.stream().mapToInt(i -> i).toArray());
-
         return new BatchPhysicalDynamicFilteringDataCollector(
                 dimSide.getCluster(),
                 dimSide.getTraitSet(),

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRule.java
@@ -142,6 +142,10 @@ public abstract class DynamicPartitionPruningRule extends RelRule<RelRule.Config
         List<String> acceptedFields =
                 ((SupportsDynamicFiltering) tableSource).applyDynamicFiltering(candidateFields);
 
+        if (acceptedFields == null) {
+            return new ArrayList<>();
+        }
+
         for (String field : acceptedFields) {
             if (!candidateFields.contains(field)) {
                 throw new TableException(
@@ -162,14 +166,10 @@ public abstract class DynamicPartitionPruningRule extends RelRule<RelRule.Config
     }
 
     private static List<Integer> getAcceptedFieldsIndicesInCalc(
-            @Nullable List<String> acceptedFields,
+            List<String> acceptedFields,
             List<Integer> factJoinKeys,
             BatchPhysicalCalc factCalc,
             BatchPhysicalTableSourceScan factScan) {
-        if (acceptedFields == null) {
-            return new ArrayList<>();
-        }
-
         List<Integer> acceptedFieldsIndicesInFactScan =
                 acceptedFields.stream()
                         .map(f -> factScan.getRowType().getFieldNames().indexOf(f))

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRuleTest.java
@@ -274,6 +274,24 @@ public class DynamicPartitionPruningRuleTest extends TableTestBase {
     }
 
     @Test
+    public void testPartitionKeysOrderIsChangedInFactSide() {
+        // Dynamic filtering will succeed for this query.
+        String query =
+                "Select * from dim join (select fact_date_sk, id, name, amount, price from fact_part) t1"
+                        + " on t1.fact_date_sk = dim_date_sk and t1.price > 200 and dim.price < 500";
+        util.verifyRelPlan(query);
+    }
+
+    @Test
+    public void testPartitionKeysNameIsChangedInFactSide() {
+        // Dynamic filtering will succeed for this query.
+        String query =
+                "Select * from dim join (select id, name, amount, price, fact_date_sk as fact_date_sk1 from fact_part) t1"
+                        + " on t1.fact_date_sk1 = dim_date_sk and t1.price > 200 and dim.price < 500";
+        util.verifyRelPlan(query);
+    }
+
+    @Test
     public void testDynamicFilteringFieldIsComputeColumnsInFactSide()
             throws TableNotExistException {
         CatalogTableStatistics tableStatistics = new CatalogTableStatistics(1, 1, 1, 1);

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/batch/DynamicPartitionPruningRuleTest.xml
@@ -66,7 +66,7 @@ HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk1, dim_date_sk)], select=[id
 +- Exchange(distribution=[hash[fact_date_sk1]])
    +- Calc(select=[fact_date_sk AS fact_date_sk1, +(price, 1) AS price1], where=[>(+(price, 1), 200)])
       +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, filter=[], project=[price, fact_date_sk], metadata=[]]], fields=[price, fact_date_sk])
-         +- DynamicFilteringDataCollector(fields=[])
+         +- DynamicFilteringDataCollector(fields=[dim_date_sk])
             +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
                +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
 ]]>
@@ -768,6 +768,34 @@ HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk1, dim_date_sk)], select=[id
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPartitionKeysNameIsChangedInFactSide">
+    <Resource name="sql">
+      <![CDATA[Select * from dim join (select id, name, amount, price, fact_date_sk as fact_date_sk1 from fact_part) t1 on t1.fact_date_sk1 = dim_date_sk and t1.price > 200 and dim.price < 500]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], male=[$1], amount=[$2], price=[$3], dim_date_sk=[$4], id0=[$5], name=[$6], amount0=[$7], price0=[$8], fact_date_sk1=[$9])
++- LogicalJoin(condition=[AND(=($9, $4), >($8, 200), <($3, 500))], joinType=[inner])
+   :- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+   +- LogicalProject(id=[$0], name=[$1], amount=[$2], price=[$3], fact_date_sk1=[$4])
+      +- LogicalTableScan(table=[[testCatalog, test_database, fact_part]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id, male, amount, price, dim_date_sk, id0, name, amount0, price0, fact_date_sk], build=[left])
+:- Exchange(distribution=[hash[dim_date_sk]])
+:  +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
+:     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
++- Exchange(distribution=[hash[fact_date_sk]])
+   +- Calc(select=[id, name, amount, price, fact_date_sk], where=[>(price, 200)])
+      +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, filter=[]]], fields=[id, name, amount, price, fact_date_sk])
+         +- DynamicFilteringDataCollector(fields=[dim_date_sk])
+            +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
+               +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testSemiJoin">
     <Resource name="sql">
       <![CDATA[Select * from fact_part where fact_part.fact_date_sk in (select dim_date_sk from dim where dim.price < 500)]]>
@@ -794,6 +822,34 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(fact_date_sk, dim_date_sk)], select=[
 +- Exchange(distribution=[hash[dim_date_sk]])
    +- Calc(select=[dim_date_sk], where=[<(price, 500)])
       +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[], project=[price, dim_date_sk], metadata=[]]], fields=[price, dim_date_sk])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPartitionKeysOrderIsChangedInFactSide">
+    <Resource name="sql">
+      <![CDATA[Select * from dim join (select fact_date_sk, id, name, amount, price from fact_part) t1 on t1.fact_date_sk = dim_date_sk and t1.price > 200 and dim.price < 500]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(id=[$0], male=[$1], amount=[$2], price=[$3], dim_date_sk=[$4], fact_date_sk=[$5], id0=[$6], name=[$7], amount0=[$8], price0=[$9])
++- LogicalJoin(condition=[AND(=($5, $4), >($9, 200), <($3, 500))], joinType=[inner])
+   :- LogicalTableScan(table=[[testCatalog, test_database, dim]])
+   +- LogicalProject(fact_date_sk=[$4], id=[$0], name=[$1], amount=[$2], price=[$3])
+      +- LogicalTableScan(table=[[testCatalog, test_database, fact_part]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashJoin(joinType=[InnerJoin], where=[=(fact_date_sk, dim_date_sk)], select=[id, male, amount, price, dim_date_sk, fact_date_sk, id0, name, amount0, price0], build=[left])
+:- Exchange(distribution=[hash[dim_date_sk]])
+:  +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
+:     +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
++- Exchange(distribution=[hash[fact_date_sk]])
+   +- Calc(select=[fact_date_sk, id, name, amount, price], where=[>(price, 200)])
+      +- DynamicFilteringTableSourceScan(table=[[testCatalog, test_database, fact_part, filter=[]]], fields=[id, name, amount, price, fact_date_sk])
+         +- DynamicFilteringDataCollector(fields=[dim_date_sk])
+            +- Calc(select=[id, male, amount, price, dim_date_sk], where=[<(price, 500)])
+               +- TableSourceScan(table=[[testCatalog, test_database, dim, filter=[]]], fields=[id, male, amount, price, dim_date_sk])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When dpp fact side have calc node, and partition key index was changed in calc node,  `BatchPhysicalDynamicFilteringDataCollector` will be set with a empty output type, which will throw exception in 
`HiveSourceDynamicFileEnumerator` while argument check `Preconditions.checkArgument(rowType.getFieldCount() == dynamicFilterPartitionKeys.size()); ` in method `setDynamicFilteringData`.


## Brief change log

- For fact side with calc node, and partition key index was changed in calc node, we get accepted field indices in calc node. 


## Verifying this change

No test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? no
