### PR TITLE
[FLINK-28992][table-planner] fix: Change Ndv takes the max value instead of sum of all partitions when getting partition table column stats

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/util/HiveStatsUtil.java
@@ -314,18 +314,11 @@ public class HiveStatsUtil {
                                                             .getRowCount()))
                             .collect(Collectors.toList());
 
-            if (catalogTableStatistics.isEmpty()) {
-                return 0L;
-            }
-
-            TableStats resultTableStats = catalogTableStatistics.get(0);
-            for (int i = 1; i < catalogTableStatistics.size(); i++) {
-                resultTableStats =
-                        resultTableStats.merge(
-                                catalogTableStatistics.get(i),
-                                getFieldNames(hiveTable.getPartitionKeys()));
-            }
-
+            Set<String> partitionKeys = getFieldNames(hiveTable.getPartitionKeys());
+            TableStats resultTableStats =
+                    catalogTableStatistics.stream()
+                            .reduce((s1, s2) -> s1.merge(s2, partitionKeys))
+                            .orElse(TableStats.UNKNOWN);
             if (resultTableStats == TableStats.UNKNOWN || resultTableStats.getRowCount() < 0) {
                 return null;
             } else {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
@@ -218,7 +218,7 @@ public final class ColumnStats {
             return UNKNOWN;
         }
 
-        Long ndv = combineIfNonNull(Long::sum, this.ndv, other.ndv);
+        Long ndv = combineIfNonNull(Long::max, this.ndv, other.ndv);
         Long nullCount = combineIfNonNull(Long::sum, this.nullCount, other.nullCount);
         Double avgLen = combineIfNonNull((a1, a2) -> (a1 + a2) / 2, this.avgLen, other.avgLen);
         Integer maxLen = combineIfNonNull(Math::max, this.maxLen, other.maxLen);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/ColumnStats.java
@@ -213,12 +213,17 @@ public final class ColumnStats {
      * @param other The other column stats to merge.
      * @return The merged column stats.
      */
-    public ColumnStats merge(ColumnStats other) {
+    public ColumnStats merge(ColumnStats other, boolean isPartitionKey) {
         if (this == UNKNOWN || other == UNKNOWN) {
             return UNKNOWN;
         }
+        Long ndv;
+        if (isPartitionKey) {
+            ndv = combineIfNonNull(Long::sum, this.ndv, other.ndv);
+        } else {
+            ndv = combineIfNonNull(Long::max, this.ndv, other.ndv);
+        }
 
-        Long ndv = combineIfNonNull(Long::max, this.ndv, other.ndv);
         Long nullCount = combineIfNonNull(Long::sum, this.nullCount, other.nullCount);
         Double avgLen = combineIfNonNull((a1, a2) -> (a1 + a2) / 2, this.avgLen, other.avgLen);
         Integer maxLen = combineIfNonNull(Math::max, this.maxLen, other.maxLen);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/plan/stats/TableStats.java
@@ -81,7 +81,7 @@ public final class TableStats {
      * @return The merged table stats.
      */
     public TableStats merge(TableStats other, @Nullable Set<String> partitionKeys) {
-        if (this == UNKNOWN || other == UNKNOWN) {
+        if (this.rowCount < 0 || other.rowCount < 0) {
             return TableStats.UNKNOWN;
         }
         long rowCount =

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
@@ -55,6 +55,14 @@ class TableStatsTest {
         colStatsMerge3.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
         assertThat(stats1.merge(stats2, new HashSet<>(Collections.singletonList("a"))))
                 .isEqualTo(new TableStats(62, colStatsMerge3));
+
+        // test merge with one side is TableStats.UNKNOWN.
+        stats2 = TableStats.UNKNOWN;
+        assertThat(stats1.merge(stats2, null)).isEqualTo(TableStats.UNKNOWN);
+
+        // test merge with one side have no column stats.
+        stats2 = new TableStats(32);
+        assertThat(stats1.merge(stats2, null)).isEqualTo(new TableStats(62));
     }
 
     @Test
@@ -89,15 +97,15 @@ class TableStatsTest {
     void testMergeUnknownRowCount() {
         TableStats stats1 = new TableStats(-1, new HashMap<>());
         TableStats stats2 = new TableStats(32, new HashMap<>());
-        assertThat(stats1.merge(stats2, null)).isEqualTo(new TableStats(-1, new HashMap<>()));
+        assertThat(stats1.merge(stats2, null)).isEqualTo(TableStats.UNKNOWN);
 
         stats1 = new TableStats(-1, new HashMap<>());
         stats2 = new TableStats(-1, new HashMap<>());
-        assertThat(stats1.merge(stats2, null)).isEqualTo(new TableStats(-1, new HashMap<>()));
+        assertThat(stats1.merge(stats2, null)).isEqualTo(TableStats.UNKNOWN);
 
         stats1 = new TableStats(-3, new HashMap<>());
         stats2 = new TableStats(-2, new HashMap<>());
-        assertThat(stats1.merge(stats2, null)).isEqualTo(new TableStats(-1, new HashMap<>()));
+        assertThat(stats1.merge(stats2, null)).isEqualTo(TableStats.UNKNOWN);
     }
 
     @Test

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
@@ -39,7 +39,7 @@ class TableStatsTest {
         TableStats stats2 = new TableStats(32, colStats2);
 
         Map<String, ColumnStats> colStatsMerge = new HashMap<>();
-        colStatsMerge.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
+        colStatsMerge.put("a", new ColumnStats(4L, 20L, 7D, 23, 35, 2));
         assertThat(stats1.merge(stats2)).isEqualTo(new TableStats(62, colStatsMerge));
     }
 
@@ -55,7 +55,7 @@ class TableStatsTest {
         TableStats stats2 = new TableStats(32, colStats2);
 
         Map<String, ColumnStats> colStatsMerge = new HashMap<>();
-        colStatsMerge.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
+        colStatsMerge.put("a", new ColumnStats(4L, 20L, 7D, 23, 35, 2));
         assertThat(stats1.merge(stats2)).isEqualTo(new TableStats(62, colStatsMerge));
     }
 
@@ -85,18 +85,18 @@ class TableStatsTest {
         ColumnStats columnStats6 = new ColumnStats(4L, 5L, null, 3, 15, 2);
 
         assertThat(columnStats0.merge(columnStats1))
-                .isEqualTo(new ColumnStats(8L, null, 2D, 3, 15, 2));
+                .isEqualTo(new ColumnStats(4L, null, 2D, 3, 15, 2));
         assertThat(columnStats0.merge(columnStats2))
-                .isEqualTo(new ColumnStats(8L, 10L, 2D, null, 15, 2));
+                .isEqualTo(new ColumnStats(4L, 10L, 2D, null, 15, 2));
         assertThat(columnStats0.merge(columnStats3))
                 .isEqualTo(new ColumnStats(null, 10L, 2D, 3, 15, 2));
         assertThat(columnStats0.merge(columnStats4))
-                .isEqualTo(new ColumnStats(8L, 10L, 2D, 3, null, 2));
+                .isEqualTo(new ColumnStats(4L, 10L, 2D, 3, null, 2));
         assertThat(columnStats0.merge(columnStats5))
-                .isEqualTo(new ColumnStats(8L, 10L, 2D, 3, 15, null));
+                .isEqualTo(new ColumnStats(4L, 10L, 2D, 3, 15, null));
         assertThat(columnStats0.merge(columnStats6))
-                .isEqualTo(new ColumnStats(8L, 10L, null, 3, 15, 2));
+                .isEqualTo(new ColumnStats(4L, 10L, null, 3, 15, 2));
         assertThat(columnStats6.merge(columnStats6))
-                .isEqualTo(new ColumnStats(8L, 10L, null, 3, 15, 2));
+                .isEqualTo(new ColumnStats(4L, 10L, null, 3, 15, 2));
     }
 }

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
@@ -56,6 +56,21 @@ class TableStatsTest {
         assertThat(stats1.merge(stats2, new HashSet<>(Collections.singletonList("a"))))
                 .isEqualTo(new TableStats(62, colStatsMerge3));
 
+        Map<String, ColumnStats> colStats3 = new HashMap<>();
+        colStats3.put("a", new ColumnStats(4L, 5L, 2D, 3, 15, 2));
+        colStats3.put("b", new ColumnStats(4L, 5L, 2D, 3, 15, 2));
+        stats1 = new TableStats(30, colStats3);
+        Map<String, ColumnStats> colStats4 = new HashMap<>();
+        colStats4.put("a", new ColumnStats(3L, 15L, 12D, 23, 35, 6));
+        colStats4.put("b", new ColumnStats(3L, 15L, 12D, 23, 35, 6));
+        stats2 = new TableStats(32, colStats4);
+
+        Map<String, ColumnStats> colStatsMerge4 = new HashMap<>();
+        colStatsMerge4.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
+        colStatsMerge4.put("b", new ColumnStats(4L, 20L, 7D, 23, 35, 2));
+        assertThat(stats1.merge(stats2, new HashSet<>(Collections.singletonList("a"))))
+                .isEqualTo(new TableStats(62, colStatsMerge4));
+
         // test merge with one side is TableStats.UNKNOWN.
         stats2 = TableStats.UNKNOWN;
         assertThat(stats1.merge(stats2, null)).isEqualTo(TableStats.UNKNOWN);

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/plan/stats/TableStatsTest.java
@@ -43,12 +43,18 @@ class TableStatsTest {
         Map<String, ColumnStats> colStatsMerge = new HashMap<>();
         colStatsMerge.put("a", new ColumnStats(4L, 20L, 7D, 23, 35, 2));
         assertThat(stats1.merge(stats2, null)).isEqualTo(new TableStats(62, colStatsMerge));
+
+        Map<String, ColumnStats> colStatsMerge2 = new HashMap<>();
+        colStatsMerge2.put("a", new ColumnStats(4L, 20L, 7D, 23, 35, 2));
+        assertThat(stats1.merge(stats2, new HashSet<>()))
+                .isEqualTo(new TableStats(62, colStatsMerge2));
+
         // test column stats merge while column 'a' is partition key. Merged Ndv for columns which
         // are partition keys using sum instead of max.
-        Map<String, ColumnStats> colStatsMerge2 = new HashMap<>();
-        colStatsMerge2.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
+        Map<String, ColumnStats> colStatsMerge3 = new HashMap<>();
+        colStatsMerge3.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
         assertThat(stats1.merge(stats2, new HashSet<>(Collections.singletonList("a"))))
-                .isEqualTo(new TableStats(62, colStatsMerge2));
+                .isEqualTo(new TableStats(62, colStatsMerge3));
     }
 
     @Test
@@ -65,12 +71,18 @@ class TableStatsTest {
         Map<String, ColumnStats> colStatsMerge = new HashMap<>();
         colStatsMerge.put("a", new ColumnStats(4L, 20L, 7D, 23, 35, 2));
         assertThat(stats1.merge(stats2, null)).isEqualTo(new TableStats(62, colStatsMerge));
+
+        Map<String, ColumnStats> colStatsMerge2 = new HashMap<>();
+        colStatsMerge2.put("a", new ColumnStats(4L, 20L, 7D, 23, 35, 2));
+        assertThat(stats1.merge(stats2, new HashSet<>()))
+                .isEqualTo(new TableStats(62, colStatsMerge2));
+
         // test column stats merge while column 'a' is partition key. Merged Ndv for columns which
         // are partition keys using sum instead of max.
-        Map<String, ColumnStats> colStatsMerge2 = new HashMap<>();
-        colStatsMerge2.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
+        Map<String, ColumnStats> colStatsMerge3 = new HashMap<>();
+        colStatsMerge3.put("a", new ColumnStats(7L, 20L, 7D, 23, 35, 2));
         assertThat(stats1.merge(stats2, new HashSet<>(Collections.singletonList("a"))))
-                .isEqualTo(new TableStats(62, colStatsMerge2));
+                .isEqualTo(new TableStats(62, colStatsMerge3));
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/CatalogTableStatisticsConverter.java
@@ -83,15 +83,9 @@ public class CatalogTableStatisticsConverter {
                             catalogTableStatistics, catalogColumnStatistics));
         }
 
-        if (tableStats.isEmpty()) {
-            return TableStats.UNKNOWN;
-        }
-
-        TableStats resultTableStats = tableStats.get(0);
-        for (int i = 1; i < tableStats.size(); i++) {
-            resultTableStats = resultTableStats.merge(tableStats.get(i), partitionKeys);
-        }
-        return resultTableStats;
+        return tableStats.stream()
+                .reduce((s1, s2) -> s1.merge(s2, partitionKeys))
+                .orElse(TableStats.UNKNOWN);
     }
 
     @VisibleForTesting

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
@@ -220,9 +220,7 @@ public class FlinkRecomputeStatisticsProgram implements FlinkOptimizeProgram<Bat
         Set<String> partitionKeys = new HashSet<>();
         for (CatalogPartitionSpec catalogPartitionSpec : catalogPartitionSpecs) {
             Map<String, String> partitionSpec = catalogPartitionSpec.getPartitionSpec();
-            for (Map.Entry<String, String> entry : partitionSpec.entrySet()) {
-                partitionKeys.add(entry.getKey());
-            }
+            partitionKeys.addAll(partitionSpec.keySet());
         }
         return partitionKeys;
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkRecomputeStatisticsProgram.java
@@ -47,9 +47,11 @@ import org.apache.calcite.rel.logical.LogicalTableScan;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.table.api.config.OptimizerConfigOptions.TABLE_OPTIMIZER_SOURCE_REPORT_STATISTICS_ENABLED;
@@ -207,10 +209,22 @@ public class FlinkRecomputeStatisticsProgram implements FlinkOptimizeProgram<Bat
             return Optional.of(
                     convertToAccumulatedTableStates(
                             catalog.bulkGetPartitionStatistics(tablePath, partitionSpecs),
-                            catalog.bulkGetPartitionColumnStatistics(tablePath, partitionSpecs)));
+                            catalog.bulkGetPartitionColumnStatistics(tablePath, partitionSpecs),
+                            getPartitionKeys(partitionSpecs)));
         } catch (PartitionNotExistException e) {
             return Optional.empty();
         }
+    }
+
+    private static Set<String> getPartitionKeys(List<CatalogPartitionSpec> catalogPartitionSpecs) {
+        Set<String> partitionKeys = new HashSet<>();
+        for (CatalogPartitionSpec catalogPartitionSpec : catalogPartitionSpecs) {
+            Map<String, String> partitionSpec = catalogPartitionSpec.getPartitionSpec();
+            for (Map.Entry<String, String> entry : partitionSpec.entrySet()) {
+                partitionKeys.add(entry.getKey());
+            }
+        }
+        return partitionKeys;
     }
 
     @SuppressWarnings({"unchecked", "raw"})

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoLegacyTableSourceScanRule.scala
@@ -40,8 +40,8 @@ import org.apache.calcite.rex.{RexInputRef, RexNode, RexShuttle, RexUtil}
 import java.util
 import java.util.TimeZone
 
+import scala.collection.{mutable, JavaConversions}
 import scala.collection.JavaConversions._
-import scala.collection.mutable
 
 /**
  * Planner rule that tries to push partitions evaluated by filter condition into a
@@ -205,7 +205,9 @@ class PushPartitionIntoLegacyTableSourceScanRule
                   if (stats == null) {
                     stats = currStats
                   } else {
-                    stats = stats.merge(currStats)
+                    stats = stats.merge(
+                      currStats,
+                      JavaConversions.setAsJavaSet(partitionFieldNames.toSet))
                   }
                 case None => return null
               }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemStatisticsReportTest.java
@@ -22,9 +22,15 @@ import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.catalog.CatalogPartitionImpl;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatistics;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataBase;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataLong;
+import org.apache.flink.table.catalog.stats.CatalogColumnStatisticsDataString;
 import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
+import org.apache.flink.table.plan.stats.ColumnStats;
 import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.utils.CatalogTableStatisticsConverter;
 import org.apache.flink.table.planner.utils.StatisticsReportTestBase;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +44,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,6 +74,7 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
         partitionDataPath.mkdirs();
         writeData(new File(partitionDataPath, "b=1"), Arrays.asList("1,1,hi", "2,1,hello"));
         writeData(new File(partitionDataPath, "b=2"), Collections.singletonList("3,2,hello world"));
+        writeData(new File(partitionDataPath, "b=3"), Collections.singletonList("4,3,hello"));
         String ddl2 =
                 String.format(
                         "CREATE TABLE PartTable (\n"
@@ -91,6 +99,13 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
                 .createPartition(
                         new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
                         new CatalogPartitionSpec(Collections.singletonMap("b", "2")),
+                        new CatalogPartitionImpl(new HashMap<>(), ""),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .createPartition(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "3")),
                         new CatalogPartitionImpl(new HashMap<>(), ""),
                         false);
 
@@ -262,6 +277,59 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
     }
 
     @Test
+    public void testPartitionPushDownAndCatalogColumnStatisticsExist() throws Exception {
+        // The purpose of this test case is to test the correctness of stats after partition push
+        // down, and recompute partition table and column stats. For partition table, merged Ndv for
+        // columns which are partition keys using sum instead of max (other columns using max).
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "1")),
+                        new CatalogTableStatistics(6L, 1, 100L, 100L),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "2")),
+                        new CatalogTableStatistics(3L, 1, 100L, 100L),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .alterPartitionStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "3")),
+                        new CatalogTableStatistics(3L, 1, 100L, 100L),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .alterPartitionColumnStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "1")),
+                        createSinglePartitionColumnStats(),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .alterPartitionColumnStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "2")),
+                        createSinglePartitionColumnStats(),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .alterPartitionColumnStatistics(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "PartTable"),
+                        new CatalogPartitionSpec(Collections.singletonMap("b", "3")),
+                        createSinglePartitionColumnStats(),
+                        false);
+        FlinkStatistic statistic =
+                getStatisticsFromOptimizedPlan("select * from PartTable where b < 3");
+        assertThat(statistic.getTableStats())
+                .isEqualTo(new TableStats(9, createMergedPartitionColumnStats()));
+    }
+
+    @Test
     public void testFilterPartitionPushDownPushDownAndCatalogStatisticsExist() throws Exception {
         tEnv.getCatalog(tEnv.getCurrentCatalog())
                 .orElseThrow(Exception::new)
@@ -280,7 +348,8 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
 
         FlinkStatistic statistic =
                 getStatisticsFromOptimizedPlan("select * from PartTable where a > 10 and b = 1");
-        assertThat(statistic.getTableStats()).isEqualTo(new TableStats(6));
+        assertThat(statistic.getTableStats())
+                .isEqualTo(new TableStats(6, createMergedPartitionColumnStats()));
     }
 
     @Test
@@ -315,5 +384,32 @@ public class FileSystemStatisticsReportTest extends StatisticsReportTestBase {
         FlinkStatistic statistic =
                 getStatisticsFromOptimizedPlan("select * from emptyTable limit 1");
         assertThat(statistic.getTableStats()).isEqualTo(new TableStats(1));
+    }
+
+    private CatalogColumnStatistics createSinglePartitionColumnStats() {
+        Map<String, CatalogColumnStatisticsDataBase> colStatsMap = new HashMap<>();
+        CatalogColumnStatisticsDataLong longColStats =
+                new CatalogColumnStatisticsDataLong(1L, 10L, 5L, 5L);
+        colStatsMap.put("a", longColStats);
+        colStatsMap.put("b", longColStats);
+        CatalogColumnStatisticsDataString stringColStats =
+                new CatalogColumnStatisticsDataString(10L, 10D, 5L, 5L);
+        colStatsMap.put("c", stringColStats);
+        return new CatalogColumnStatistics(colStatsMap);
+    }
+
+    private Map<String, ColumnStats> createMergedPartitionColumnStats() {
+        Map<String, CatalogColumnStatisticsDataBase> colStatsMap = new HashMap<>();
+        CatalogColumnStatisticsDataLong longColStats =
+                new CatalogColumnStatisticsDataLong(1L, 10L, 5L, 10L);
+        colStatsMap.put("a", longColStats);
+        // Merged Ndv for columns which are partition keys using sum instead of max.
+        CatalogColumnStatisticsDataLong longColStats2 =
+                new CatalogColumnStatisticsDataLong(1L, 10L, 10L, 10L);
+        colStatsMap.put("b", longColStats2);
+        CatalogColumnStatisticsDataString stringColStats =
+                new CatalogColumnStatisticsDataString(10L, 10D, 5L, 10L);
+        colStatsMap.put("c", stringColStats);
+        return CatalogTableStatisticsConverter.convertToColumnStatsMap(colStatsMap);
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
@@ -167,7 +167,7 @@ public class CatalogStatisticsTest {
         assertThat(mq.getAverageColumnSizes(t1)).isEqualTo(Arrays.asList(8.0, 43.5));
 
         // long type
-        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(0), null)).isEqualTo(46.0);
+        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(0), null)).isEqualTo(23.0);
         assertThat(mq.getColumnNullCount(t1, 0)).isEqualTo(154.0);
         assertThat(mq.getColumnInterval(t1, 0))
                 .isEqualTo(
@@ -178,7 +178,7 @@ public class CatalogStatisticsTest {
                                 true));
 
         // string type
-        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(1), null)).isEqualTo(40.0);
+        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(1), null)).isEqualTo(20.0);
         assertThat(mq.getColumnNullCount(t1, 1)).isEqualTo(0.0);
         assertThat(mq.getColumnInterval(t1, 1)).isNull();
     }
@@ -203,7 +203,7 @@ public class CatalogStatisticsTest {
         assertThat(mq.getAverageColumnSizes(t1)).isEqualTo(Arrays.asList(8.0, 43.5));
 
         // long type
-        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(0), null)).isEqualTo(46.0);
+        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(0), null)).isEqualTo(23.0);
         assertThat(mq.getColumnNullCount(t1, 0)).isEqualTo(154.0);
         assertThat(mq.getColumnInterval(t1, 0))
                 .isEqualTo(
@@ -214,7 +214,7 @@ public class CatalogStatisticsTest {
                                 true));
 
         // string type
-        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(1), null)).isEqualTo(40.0);
+        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(1), null)).isEqualTo(20.0);
         assertThat(mq.getColumnNullCount(t1, 1)).isEqualTo(0.0);
         assertThat(mq.getColumnInterval(t1, 1)).isNull();
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/catalog/CatalogStatisticsTest.java
@@ -200,22 +200,16 @@ public class CatalogStatisticsTest {
         FlinkRelMetadataQuery mq =
                 FlinkRelMetadataQuery.reuseOrCreate(t1.getCluster().getMetadataQuery());
         assertThat(mq.getRowCount(t1)).isEqualTo(100_000_000);
-        assertThat(mq.getAverageColumnSizes(t1)).isEqualTo(Arrays.asList(8.0, 43.5));
+        assertThat(mq.getAverageColumnSizes(t1)).isEqualTo(Arrays.asList(4.0, 12.0));
 
         // long type
-        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(0), null)).isEqualTo(23.0);
-        assertThat(mq.getColumnNullCount(t1, 0)).isEqualTo(154.0);
-        assertThat(mq.getColumnInterval(t1, 0))
-                .isEqualTo(
-                        ValueInterval$.MODULE$.apply(
-                                BigDecimal.valueOf(-123L),
-                                BigDecimal.valueOf(763322L),
-                                true,
-                                true));
+        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(0), null)).isNull();
+        assertThat(mq.getColumnNullCount(t1, 0)).isNull();
+        assertThat(mq.getColumnInterval(t1, 0)).isNull();
 
         // string type
-        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(1), null)).isEqualTo(20.0);
-        assertThat(mq.getColumnNullCount(t1, 1)).isEqualTo(0.0);
+        assertThat(mq.getDistinctRowCount(t1, ImmutableBitSet.of(1), null)).isNull();
+        assertThat(mq.getColumnNullCount(t1, 1)).isNull();
         assertThat(mq.getColumnInterval(t1, 1)).isNull();
     }
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Now, when we obtain column statistics `Ndv` of the partition table, we use the method of taking sum of` Ndv` of all partitions, which will cause the obtained stats to be far from the real stats. So now we take the max value instead of sum of all partitions.


## Brief change log

- Change `Ndv` takes the max value instead of sum of all partitions when getting partition table column stats.
- Modify related test.


## Verifying this change

- Modify related test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
