### PR TITLE
[FLINK-28965][hive] Not add partition if no data is generated for dynamic partition

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemCommitter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemCommitter.java
@@ -23,9 +23,6 @@ import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,8 +49,6 @@ import static org.apache.flink.connector.file.table.PartitionTempFileManager.lis
  */
 @Internal
 class FileSystemCommitter {
-
-    private static final Logger LOG = LoggerFactory.getLogger(FileSystemCommitter.class);
 
     private final FileSystemFactory factory;
     private final TableMetaStoreFactory metaStoreFactory;
@@ -98,12 +93,6 @@ class FileSystemCommitter {
                 if (taskPaths.isEmpty() && !staticPartitions.isEmpty()) {
                     if (partitionColumnSize == staticPartitions.size()) {
                         loader.loadEmptyPartition(this.staticPartitions);
-                    } else {
-                        LOG.warn(
-                                "{} has {} partition columns, static partition only set {}, and no data is generated, flink will not commit partition!",
-                                identifier,
-                                partitionColumnSize,
-                                staticPartitions);
                     }
                 } else {
                     for (Map.Entry<LinkedHashMap<String, String>, List<Path>> entry :

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSinkITCase.java
@@ -495,6 +495,19 @@ public class HiveTableSinkITCase {
         assertThat(partitions).hasSize(3);
         assertThat(partitions.toString()).contains("dt=2022-07-29");
         assertBatch("target_table", Arrays.asList());
+
+        // test for dynamic partition
+        tEnv.executeSql(
+                "create table partition_table(`name` string) partitioned by (`p_date` string, `p_hour` string)");
+        tEnv.executeSql("create table test_src_table(`name` string, `hour` string, age int)");
+        tEnv.executeSql(
+                        "insert overwrite table partition_table partition(`p_date`='20220816', `p_hour`)"
+                                + " select `name`, `hour` from test_src_table")
+                .await();
+        partitions =
+                CollectionUtil.iteratorToList(
+                        tEnv.executeSql("show partitions partition_table").collect());
+        assertThat(partitions).hasSize(0);
     }
 
     @Test
@@ -574,24 +587,6 @@ public class HiveTableSinkITCase {
         assertThat(new File(changeFileNameTablePath, "dt=2022-08-15/" + successFileName))
                 .doesNotExist();
         assertThat(new File(changeFileNameTablePath, "dt=2022-08-15/_ZM")).exists();
-    }
-
-    @Test
-    public void testInsertBothDynamicAndStaticPartitionWithoutData() throws Exception {
-        TableEnvironment tEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
-        tEnv.registerCatalog(hiveCatalog.getName(), hiveCatalog);
-        tEnv.useCatalog(hiveCatalog.getName());
-        tEnv.executeSql(
-                "create table partition_table(`name` string) partitioned by (`p_date` string, `p_hour` string)");
-        tEnv.executeSql("create table test_src_table(`name` string, `hour` string, age int)");
-        tEnv.executeSql(
-                        "insert overwrite table partition_table partition(`p_date`='20220816', `p_hour`)"
-                                + " select `name`, `hour` from test_src_table")
-                .await();
-        List<Row> partitions =
-                CollectionUtil.iteratorToList(
-                        tEnv.executeSql("show partitions partition_table").collect());
-        assertThat(partitions).hasSize(0);
     }
 
     private static List<String> fetchRows(Iterator<Row> iter, int size) {


### PR DESCRIPTION
## What is the purpose of the change

* When inserting data using dynamic partitioning, no partition is published if no data is written out, consistent with Spark/Hive


## Brief change log

* When no data is written, determine if the number of partition columns in the target table and the number of static partition columns are the same, and if not, do nothing


## Verifying this change

ADD ITCase
* HiveTableSinkITCase#testInsertBothDynamicAndStaticPartitionWithoutData

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
