### PR TITLE
[FLINK-28986][table-planner] Fix UNNEST function with nested filter fails to generate plan

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -116,6 +116,8 @@ object FlinkBatchRuleSets {
         ConvertToNotInOrInRule.INSTANCE,
         // optimize limit 0
         FlinkLimit0RemoveRule.INSTANCE,
+        // fix: FLINK-28986 nested filter pattern causes unnest rule mismatch
+        CoreRules.FILTER_MERGE,
         // unnest rule
         LogicalUnnestRule.INSTANCE,
         // Wrap arguments for JSON aggregate functions

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -122,6 +122,8 @@ object FlinkStreamRuleSets {
           ConvertToNotInOrInRule.INSTANCE,
           // optimize limit 0
           FlinkLimit0RemoveRule.INSTANCE,
+          // fix: FLINK-28986 nested filter pattern causes unnest rule mismatch
+          CoreRules.FILTER_MERGE,
           // unnest rule
           LogicalUnnestRule.INSTANCE,
           // rewrite constant table function scan to correlate

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/UnnestTest.xml
@@ -294,4 +294,40 @@ Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1(
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithNestedFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+   SELECT a, b1, b2 FROM
+       (SELECT a, b FROM MyTable) T
+       CROSS JOIN
+       UNNEST(T.b) AS S(b1, b2)
+       WHERE S.b1 >= 12
+   ) tmp
+WHERE b2 <> 'Hello'
+    ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b1=[$1], b2=[$2])
++- LogicalFilter(condition=[<>($2, _UTF-16LE'Hello')])
+   +- LogicalProject(a=[$0], b1=[$2], b2=[$3])
+      +- LogicalFilter(condition=[>=($2, 12)])
+         +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+            :- LogicalProject(a=[$0], b=[$1])
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+            +- LogicalProject(b1=[$0], b2=[$1])
+               +- Uncollect
+                  +- LogicalProject(b=[$cor0.b])
+                     +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, _1 AS b1, _2 AS b2])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[AND(>=($0, 12), <>($1, _UTF-16LE'Hello'))])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/LogicalUnnestRuleTest.xml
@@ -311,4 +311,46 @@ LogicalProject(a=[$0], b=[$1], _1=[$2], _2=[$3])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithNestedFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+   SELECT a, b1, b2 FROM
+       (SELECT a, b FROM MyTable) T
+       CROSS JOIN
+       UNNEST(T.b) AS S(b1, b2)
+       WHERE S.b1 >= 12
+   ) tmp
+WHERE b2 <> 'Hello'
+    ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b1=[$1], b2=[$2])
++- LogicalFilter(condition=[<>($2, _UTF-16LE'Hello')])
+   +- LogicalProject(a=[$0], b1=[$2], b2=[$3])
+      +- LogicalFilter(condition=[>=($2, 12)])
+         +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+            :- LogicalProject(a=[$0], b=[$1])
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+            +- LogicalProject(b1=[$0], b2=[$1])
+               +- Uncollect
+                  +- LogicalProject(b=[$cor0.b])
+                     +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+LogicalProject(a=[$0], b1=[$1], b2=[$2])
++- LogicalFilter(condition=[<>($2, _UTF-16LE'Hello')])
+   +- LogicalProject(a=[$0], b1=[$2], b2=[$3])
+      +- LogicalFilter(condition=[>=($2, 12)])
+         +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+            :- LogicalProject(a=[$0], b=[$1])
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+            +- LogicalProject(b1=[$0], b2=[$1])
+               +- LogicalTableFunctionScan(invocation=[$UNNEST_ROWS$1($cor0.b)], rowType=[RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2)])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/UnnestTest.xml
@@ -285,4 +285,40 @@ Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1(
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testUnnestWithNestedFilter">
+    <Resource name="sql">
+      <![CDATA[
+SELECT * FROM (
+   SELECT a, b1, b2 FROM
+       (SELECT a, b FROM MyTable) T
+       CROSS JOIN
+       UNNEST(T.b) AS S(b1, b2)
+       WHERE S.b1 >= 12
+   ) tmp
+WHERE b2 <> 'Hello'
+    ]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b1=[$1], b2=[$2])
++- LogicalFilter(condition=[<>($2, _UTF-16LE'Hello')])
+   +- LogicalProject(a=[$0], b1=[$2], b2=[$3])
+      +- LogicalFilter(condition=[>=($2, 12)])
+         +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1}])
+            :- LogicalProject(a=[$0], b=[$1])
+            :  +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]])
+            +- LogicalProject(b1=[$0], b2=[$1])
+               +- Uncollect
+                  +- LogicalProject(b=[$cor0.b])
+                     +- LogicalValues(tuples=[[{ 0 }]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, _1 AS b1, _2 AS b2])
++- Correlate(invocation=[$UNNEST_ROWS$1($cor0.b)], correlate=[table($UNNEST_ROWS$1($cor0.b))], select=[a,b,_1,_2], rowType=[RecordType(INTEGER a, RecordType:peek_no_expand(INTEGER _1, VARCHAR(2147483647) _2) ARRAY b, INTEGER _1, VARCHAR(2147483647) _2)], joinType=[INNER], condition=[AND(>=($0, 12), <>($1, _UTF-16LE'Hello'))])
+   +- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b)]]], fields=[a, b])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/common/UnnestTestBase.scala
@@ -121,6 +121,23 @@ abstract class UnnestTestBase(withExecPlan: Boolean) extends TableTestBase {
     verifyPlan("SELECT a, b, A._1, A._2 FROM MyTable, UNNEST(MyTable.b) AS A where A._1 > 1")
   }
 
+  @Test
+  def testUnnestWithNestedFilter(): Unit = {
+    util.addTableSource[(Int, Array[(Int, String)])]("MyTable", 'a, 'b)
+    val sqlQuery =
+      """
+        |SELECT * FROM (
+        |   SELECT a, b1, b2 FROM
+        |       (SELECT a, b FROM MyTable) T
+        |       CROSS JOIN
+        |       UNNEST(T.b) AS S(b1, b2)
+        |       WHERE S.b1 >= 12
+        |   ) tmp
+        |WHERE b2 <> 'Hello'
+    """.stripMargin
+    verifyPlan(sqlQuery)
+  }
+
   private def verifyPlan(sql: String): Unit = {
     if (withExecPlan) {
       util.verifyExecPlan(sql)


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to fix the issue that the `UNNEST` function with multiple filter predicates in the different subquery fails to generate a plan. The reason is that the optimizer pushes down the filter predicate too early during the decorrelate rewrite phase, which produces a pattern in which two(or more) `LogicalFilter` rel nodes are nested together on top the of `Uncollect` rel node. This leads `LogicalUnnestRule` not to match the rel.


## Brief change log

  - Add `CoreRules.FILTER_MERGE` to `FlinkBatchRuleSets#DEFAULT_REWRITE_RULES` and `FlinkStreamRuleSets#DEFAULT_REWRITE_RULES` before `LogicalUnnestRule.INSTANCE`.

## Verifying this change

This change added tests and can be verified as follows:

  - Added test cases in `UnnestTestBase` and `UnnestITCase`; please comment the source code to run the newly added cases to verify the fix.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
