### PR TITLE
[FLINK-28917][table-runtime] Add sql test for adaptive hash join

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/LongHashJoinGenerator.scala
@@ -319,6 +319,7 @@ object LongHashJoinGenerator {
     ctx.addReusableMember(s"""
                              |private void fallbackSMJProcessPartition() throws Exception {
                              |  if(!table.getPartitionsPendingForSMJ().isEmpty()) {
+                             |    table.releaseMemoryCacheForSMJ();
                              |    LOG.info(
                              |    "Fallback to sort merge join to process spilled partitions.");
                              |    initialSortMergeJoinFunction();
@@ -353,6 +354,7 @@ object LongHashJoinGenerator {
     ctx.addReusableMember(s"""
                              |private void initialSortMergeJoinFunction() throws Exception {
                              |  sortMergeJoinFunction.open(
+                             |    true,
                              |    this.getContainingTask(),
                              |    this.getOperatorConfig(),
                              |    new $collector<$ROW_DATA>(output),

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/join/AdaptiveHashJoinITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/join/AdaptiveHashJoinITCase.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql.join;
+
+import org.apache.flink.api.common.BatchShuffleMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.TaskManagerOptions;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.utils.TestingTableEnvironment;
+import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.TestLogger;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for adaptive hash join. */
+public class AdaptiveHashJoinITCase extends TestLogger {
+
+    public static final int DEFAULT_PARALLELISM = 3;
+
+    @ClassRule
+    public static MiniClusterWithClientResource miniClusterResource =
+            new MiniClusterWithClientResource(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setConfiguration(getConfiguration())
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
+                            .build());
+
+    private static Configuration getConfiguration() {
+        Configuration config = new Configuration();
+        config.set(TaskManagerOptions.MANAGED_MEMORY_SIZE, MemorySize.parse("6m"));
+        return config;
+    }
+
+    private final TableEnvironment tEnv =
+            TestingTableEnvironment.create(
+                    EnvironmentSettings.newInstance().inBatchMode().build(),
+                    null,
+                    TableConfig.getDefault());
+
+    @Before
+    public void before() throws Exception {
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 1);
+        tEnv.getConfig()
+                .set(ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_PIPELINED);
+
+        JoinITCaseHelper.disableOtherJoinOpForJoin(tEnv, JoinType.HashJoin());
+
+        // prepare data
+        List<Row> data1 = new ArrayList<>();
+        data1.addAll(getRepeatedRow(2, 100000));
+        data1.addAll(getRepeatedRow(5, 100000));
+        data1.addAll(getRepeatedRow(10, 100000));
+        String dataId1 = TestValuesTableFactory.registerData(data1);
+
+        List<Row> data2 = new ArrayList<>();
+        data2.addAll(getRepeatedRow(5, 10));
+        data2.addAll(getRepeatedRow(10, 10));
+        data2.addAll(getRepeatedRow(20, 10));
+        String dataId2 = TestValuesTableFactory.registerData(data2);
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE t1 (\n"
+                                + "  x INT,\n"
+                                + "  y BIGINT,\n"
+                                + "  z VARCHAR\n"
+                                + ")  WITH (\n"
+                                + " 'connector' = 'values',\n"
+                                + " 'data-id' = '%s',\n"
+                                + " 'bounded' = 'true'\n"
+                                + ")",
+                        dataId1));
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE t2 (\n"
+                                + "  a INT,\n"
+                                + "  b BIGINT,\n"
+                                + "  c VARCHAR\n"
+                                + ")  WITH (\n"
+                                + " 'connector' = 'values',\n"
+                                + " 'data-id' = '%s',\n"
+                                + " 'bounded' = 'true'\n"
+                                + ")",
+                        dataId2));
+
+        tEnv.executeSql(
+                "CREATE TABLE sink (\n"
+                        + "  x INT,\n"
+                        + "  z VARCHAR,\n"
+                        + "  a INT,\n"
+                        + "  b BIGINT,\n"
+                        + "  c VARCHAR\n"
+                        + ")  WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")");
+    }
+
+    @After
+    public void after() {
+        TestValuesTableFactory.clearAllData();
+    }
+
+    @Test
+    public void testBuildLeftIntKeyAdaptiveHashJoin() {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t1 JOIN t2 ON t1.x=t2.a");
+        List<String> result = TestValuesTableFactory.getResults("sink");
+        assertThat(result.size()).isEqualTo(2000000);
+    }
+
+    @Test
+    public void testBuildRightIntKeyAdaptiveHashJoin() {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t2 JOIN t1 ON t1.x=t2.a");
+        List<String> result = TestValuesTableFactory.getResults("sink");
+        assertThat(result.size()).isEqualTo(2000000);
+    }
+
+    @Test
+    public void testBuildLeftStringKeyAdaptiveHashJoin() {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t1 JOIN t2 ON t1.z=t2.c");
+        List<String> result = TestValuesTableFactory.getResults("sink");
+        assertThat(result.size()).isEqualTo(2000000);
+    }
+
+    @Test
+    public void testBuildRightStringKeyAdaptiveHashJoin() {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t2 JOIN t1 ON t1.z=t2.c");
+        List<String> result = TestValuesTableFactory.getResults("sink");
+        assertThat(result.size()).isEqualTo(2000000);
+    }
+
+    private List<Row> getRepeatedRow(int key, int nums) {
+        List<Row> rows = new ArrayList<>();
+        for (int i = 0; i < nums; i++) {
+            rows.add(Row.of(key, (long) key, String.valueOf(key)));
+        }
+        return rows;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/join/AdaptiveHashJoinITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/join/AdaptiveHashJoinITCase.java
@@ -41,6 +41,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -138,31 +139,41 @@ public class AdaptiveHashJoinITCase extends TestLogger {
     }
 
     @Test
-    public void testBuildLeftIntKeyAdaptiveHashJoin() {
-        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t1 JOIN t2 ON t1.x=t2.a");
-        List<String> result = TestValuesTableFactory.getResults("sink");
-        assertThat(result.size()).isEqualTo(2000000);
+    public void testBuildLeftIntKeyAdaptiveHashJoin() throws Exception {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t1 JOIN t2 ON t1.x=t2.a")
+                .await(60, TimeUnit.SECONDS);
+
+        asserResult("sink", 2000000);
     }
 
     @Test
-    public void testBuildRightIntKeyAdaptiveHashJoin() {
-        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t2 JOIN t1 ON t1.x=t2.a");
-        List<String> result = TestValuesTableFactory.getResults("sink");
-        assertThat(result.size()).isEqualTo(2000000);
+    public void testBuildRightIntKeyAdaptiveHashJoin() throws Exception {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t2 JOIN t1 ON t1.x=t2.a")
+                .await(60, TimeUnit.SECONDS);
+
+        asserResult("sink", 2000000);
     }
 
     @Test
-    public void testBuildLeftStringKeyAdaptiveHashJoin() {
-        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t1 JOIN t2 ON t1.z=t2.c");
-        List<String> result = TestValuesTableFactory.getResults("sink");
-        assertThat(result.size()).isEqualTo(2000000);
+    public void testBuildLeftStringKeyAdaptiveHashJoin() throws Exception {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t1 JOIN t2 ON t1.z=t2.c")
+                .await(60, TimeUnit.SECONDS);
+
+        asserResult("sink", 2000000);
     }
 
     @Test
-    public void testBuildRightStringKeyAdaptiveHashJoin() {
-        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t2 JOIN t1 ON t1.z=t2.c");
-        List<String> result = TestValuesTableFactory.getResults("sink");
-        assertThat(result.size()).isEqualTo(2000000);
+    public void testBuildRightStringKeyAdaptiveHashJoin() throws Exception {
+        tEnv.executeSql("INSERT INTO sink SELECT x, z, a, b, c FROM t2 JOIN t1 ON t1.z=t2.c")
+                .await(60, TimeUnit.SECONDS);
+
+        asserResult("sink", 2000000);
+    }
+
+    private void asserResult(String sinkTableName, int resultSize) {
+        // Due to concern OOM and record value is same, here just assert result size
+        List<String> result = TestValuesTableFactory.getResults(sinkTableName);
+        assertThat(result.size()).isEqualTo(resultSize);
     }
 
     private List<Row> getRepeatedRow(int key, int nums) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BaseHybridHashTable.java
@@ -264,15 +264,19 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
             this.buildSpillRetBufferNumbers--;
 
             // grab as many more buffers as are available directly
-            MemorySegment currBuff;
-            while (this.buildSpillRetBufferNumbers > 0
-                    && (currBuff = this.buildSpillReturnBuffers.poll()) != null) {
-                returnPage(currBuff);
-                this.buildSpillRetBufferNumbers--;
-            }
+            returnSpillBuffers();
             return toReturn;
         } else {
             return null;
+        }
+    }
+
+    private void returnSpillBuffers() {
+        MemorySegment currBuff;
+        while (this.buildSpillRetBufferNumbers > 0
+                && (currBuff = this.buildSpillReturnBuffers.poll()) != null) {
+            returnPage(currBuff);
+            this.buildSpillRetBufferNumbers--;
         }
     }
 
@@ -437,6 +441,19 @@ public abstract class BaseHybridHashTable implements MemorySegmentPool {
     /** Free the memory not used. */
     public void freeCurrent() {
         internalPool.cleanCache();
+    }
+
+    /**
+     * Due to adaptive hash join is introduced, the cached memory segments should be released to
+     * {@link MemoryManager} before switch to sort merge join. Otherwise, open sort merge join
+     * operator maybe fail because of insufficient memory.
+     *
+     * <p>Note: this method should only be invoked for sort merge join.
+     */
+    public void releaseMemoryCacheForSMJ() {
+        // return build spill buffer memory first
+        returnSpillBuffers();
+        freeCurrent();
     }
 
     LazyMemorySegmentPool getInternalPool() {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashBucketArea.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashBucketArea.java
@@ -508,7 +508,7 @@ public class BinaryHashBucketArea {
         int posInSegment = bucketInSegmentOffset + BUCKET_HEADER_LENGTH;
         int countInBucket = bucket.getShort(bucketInSegmentOffset + HEADER_COUNT_OFFSET);
         int numInBucket = 0;
-        RandomAccessInputView view = partition.getBuildStateInputView();
+        RandomAccessInputView view = partition.getBuildStageInputView();
         while (countInBucket != 0) {
             while (numInBucket < countInBucket) {
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
@@ -215,7 +215,7 @@ public class BinaryHashPartition extends AbstractPagedInputView implements Seeka
                 : this.partitionBuffers.length;
     }
 
-    RandomAccessInputView getBuildStateInputView() {
+    RandomAccessInputView getBuildStageInputView() {
         return this.buildSideWriteBuffer.getBuildStageInputView();
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/HashJoinOperator.java
@@ -259,6 +259,8 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
      */
     private void fallbackSMJProcessPartition() throws Exception {
         if (!table.getPartitionsPendingForSMJ().isEmpty()) {
+            // release memory to MemoryManager first that is used to sort merge join operator
+            table.releaseMemoryCacheForSMJ();
             // initialize sort merge join operator
             LOG.info("Fallback to sort merge join to process spilled partitions.");
             initialSortMergeJoinFunction();
@@ -292,6 +294,7 @@ public abstract class HashJoinOperator extends TableStreamOperator<RowData>
 
     private void initialSortMergeJoinFunction() throws Exception {
         sortMergeJoinFunction.open(
+                true,
                 this.getContainingTask(),
                 this.getOperatorConfig(),
                 (StreamRecordCollector) this.collector,

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinOperator.java
@@ -48,6 +48,7 @@ public class SortMergeJoinOperator extends TableStreamOperator<RowData>
 
         // initialize sort merge join function
         this.sortMergeJoinFunction.open(
+                false,
                 this.getContainingTask(),
                 this.getOperatorConfig(),
                 new StreamRecordCollector(output),


### PR DESCRIPTION
## What is the purpose of the change

Add sql test for adaptive hash join and fix bug of memory segment insufficient when fallback to sort merge join.

## Brief change log
  - Add sql test for adaptive hash join
  - *fix bug of memory segment insufficient when fallback to sort merge join*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added ITCase in  AdaptiveHashJoinITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (now)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? ( not documented)
