### PR TITLE
[FLINK-28978][kinesis] Update AWS Regions validation to allow for fut…

### DIFF
--- a/flink-connectors/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
+++ b/flink-connectors/flink-connector-aws-base/src/main/java/org/apache/flink/connector/aws/util/AWSGeneralUtil.java
@@ -48,6 +48,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 /** Some general utilities specific to Amazon Web Service. */
 @Internal
@@ -313,7 +314,8 @@ public class AWSGeneralUtil {
      * @return true if the supplied region is valid, false otherwise
      */
     public static boolean isValidRegion(Region region) {
-        return Region.regions().contains(region);
+        return Pattern.matches(
+                "^[a-z]+-([a-z]+[-]{0,1}[a-z]+-([0-9]|global)|global)$", region.id());
     }
 
     /**

--- a/flink-connectors/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
+++ b/flink-connectors/flink-connector-aws-base/src/test/java/org/apache/flink/connector/aws/util/AWSGeneralUtilTest.java
@@ -684,11 +684,16 @@ class AWSGeneralUtilTest {
     @Test
     void testValidRegion() {
         assertThat(AWSGeneralUtil.isValidRegion(Region.of("us-east-1"))).isTrue();
+        assertThat(AWSGeneralUtil.isValidRegion(Region.of("us-gov-west-1"))).isTrue();
+        assertThat(AWSGeneralUtil.isValidRegion(Region.of("us-isob-east-1"))).isTrue();
+        assertThat(AWSGeneralUtil.isValidRegion(Region.of("aws-global"))).isTrue();
+        assertThat(AWSGeneralUtil.isValidRegion(Region.of("aws-iso-global"))).isTrue();
+        assertThat(AWSGeneralUtil.isValidRegion(Region.of("aws-iso-b-global"))).isTrue();
     }
 
     @Test
     void testInvalidRegion() {
-        assertThat(AWSGeneralUtil.isValidRegion(Region.of("ur-east-1"))).isFalse();
+        assertThat(AWSGeneralUtil.isValidRegion(Region.of("unstructured-string"))).isFalse();
     }
 
     @Test

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtil.java
@@ -38,7 +38,6 @@ import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kinesis.AmazonKinesis;
 import com.amazonaws.services.kinesis.AmazonKinesisClientBuilder;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
@@ -55,6 +54,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.regex.Pattern;
 
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
@@ -216,12 +216,7 @@ public class AWSUtil {
      * @return true if the supplied region ID is valid, false otherwise
      */
     public static boolean isValidRegion(String region) {
-        try {
-            Regions.fromName(region.toLowerCase());
-        } catch (IllegalArgumentException e) {
-            return false;
-        }
-        return true;
+        return Pattern.matches("^[a-z]+-([a-z]+[-]{0,1}[a-z]+-([0-9]|global)|global)$", region);
     }
 
     /** The prefix used for properties that should be applied to {@link ClientConfiguration}. */

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/AWSUtilTest.java
@@ -166,11 +166,16 @@ public class AWSUtilTest {
     @Test
     public void testValidRegion() {
         assertThat(AWSUtil.isValidRegion("us-east-1")).isTrue();
+        assertThat(AWSUtil.isValidRegion("us-gov-west-1")).isTrue();
+        assertThat(AWSUtil.isValidRegion("us-isob-east-1")).isTrue();
+        assertThat(AWSUtil.isValidRegion("aws-global")).isTrue();
+        assertThat(AWSUtil.isValidRegion("aws-iso-global")).isTrue();
+        assertThat(AWSUtil.isValidRegion("aws-iso-b-global")).isTrue();
     }
 
     @Test
     public void testInvalidRegion() {
-        assertThat(AWSUtil.isValidRegion("ur-east-1")).isFalse();
+        assertThat(AWSUtil.isValidRegion("invalid-region")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
…ure AWS regions

## What is the purpose of the change
Make the validation for `AWS Region` string passed into the Kinesis connector more permissive (checks that the shape of the string follows the general AWS Region shape, rather than validating that the Region exists in the `Regions` enum). This allows the Kinesis connector to cover future new AWS Regions as well.

Cherry-picked from https://github.com/apache/flink/pull/20588

## Brief change log
- Make the validation for `isValidRegion` more permissive


## Verifying this change
This change is already covered by existing tests, such as unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
