### PR TITLE
[FLINK-29004]PyFlink supports specifying index-url when installing third-party dependencies

### DIFF
--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -105,6 +105,12 @@
             <td>Specify a requirements.txt file which defines the third-party dependencies. These dependencies will be installed and added to the PYTHONPATH of the python UDF worker. A directory which contains the installation packages of these dependencies could be specified optionally. Use '#' as the separator if the optional parameter exists. The option is equivalent to the command line option "-pyreq".</td>
         </tr>
         <tr>
+            <td><h5>python.requirements.index-url</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Base URL of Python Package Index (default https://pypi.python.org/simple). This should point to a repository compliant with PEP 503 (the simple repository API)</td>
+        </tr>
+        <tr>
             <td><h5>python.state.cache-size</h5></td>
             <td style="word-wrap: break-word;">1000</td>
             <td>Integer</td>

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -114,6 +114,14 @@ public class PythonOptions {
                                     + "optional parameter exists. The option is equivalent to the command line option "
                                     + "\"-pyreq\".");
 
+    public static final ConfigOption<String> PYTHON_REQUIREMENTS_INDEX_URL =
+            ConfigOptions.key("python.requirements.index-url")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Base URL of Python Package Index (default https://pypi.python.org/simple). "
+                                    + "This should point to a repository compliant with PEP 503 (the simple repository API).");
+
     public static final ConfigOption<String> PYTHON_ARCHIVES =
             ConfigOptions.key("python.archives")
                     .stringType()

--- a/flink-python/src/main/java/org/apache/flink/python/env/AbstractPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/AbstractPythonEnvironmentManager.java
@@ -215,6 +215,7 @@ public abstract class AbstractPythonEnvironmentManager implements PythonEnvironm
             PythonEnvironmentManagerUtils.pipInstallRequirements(
                     dependencyInfo.getRequirementsFilePath().get(),
                     dependencyInfo.getRequirementsCacheDir().orElse(null),
+                    dependencyInfo.getRequirementsIndexUrl().orElse(null),
                     requirementsDirectory,
                     dependencyInfo.getPythonExec(),
                     env);

--- a/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
@@ -38,6 +38,7 @@ import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTION_MODE;
 import static org.apache.flink.python.PythonOptions.PYTHON_FILES_DISTRIBUTED_CACHE_INFO;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS_FILE_DISTRIBUTED_CACHE_INFO;
+import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS_INDEX_URL;
 
 /** PythonDependencyInfo contains the information of third-party dependencies. */
 @Internal
@@ -64,6 +65,12 @@ public final class PythonDependencyInfo {
     @Nullable private final String requirementsCacheDir;
 
     /**
+     * Base URL of Python Package Index (default https://pypi.python.org/simple). This should point
+     * to a repository compliant with PEP 503 (the simple repository API).
+     */
+    @Nullable private final String requirementsIndexUrl;
+
+    /**
      * The python archives uploaded by TableEnvironment#add_python_archive() or command line option
      * "-pyarch". The key is the path of the archive file and the value is the name of the directory
      * to extract to.
@@ -83,12 +90,14 @@ public final class PythonDependencyInfo {
             @Nonnull Map<String, String> pythonFiles,
             @Nullable String requirementsFilePath,
             @Nullable String requirementsCacheDir,
+            @Nullable String requirementsIndexUrl,
             @Nonnull Map<String, String> archives,
             @Nonnull String pythonExec) {
         this(
                 pythonFiles,
                 requirementsFilePath,
                 requirementsCacheDir,
+                requirementsIndexUrl,
                 archives,
                 pythonExec,
                 PYTHON_EXECUTION_MODE.defaultValue());
@@ -98,12 +107,14 @@ public final class PythonDependencyInfo {
             @Nonnull Map<String, String> pythonFiles,
             @Nullable String requirementsFilePath,
             @Nullable String requirementsCacheDir,
+            @Nullable String requirementsIndexUrl,
             @Nonnull Map<String, String> archives,
             @Nonnull String pythonExec,
             @Nonnull String executionMode) {
         this.pythonFiles = Objects.requireNonNull(pythonFiles);
         this.requirementsFilePath = requirementsFilePath;
         this.requirementsCacheDir = requirementsCacheDir;
+        this.requirementsIndexUrl = requirementsIndexUrl;
         this.pythonExec = Objects.requireNonNull(pythonExec);
         this.archives = Objects.requireNonNull(archives);
         this.executionMode = Objects.requireNonNull(executionMode);
@@ -115,6 +126,10 @@ public final class PythonDependencyInfo {
 
     public Optional<String> getRequirementsFilePath() {
         return Optional.ofNullable(requirementsFilePath);
+    }
+
+    public Optional<String> getRequirementsIndexUrl() {
+        return Optional.ofNullable(requirementsIndexUrl);
     }
 
     public Optional<String> getRequirementsCacheDir() {
@@ -156,6 +171,8 @@ public final class PythonDependencyInfo {
         String requirementsFilePath = null;
         String requirementsCacheDir = null;
 
+        String requirementsIndexUrl =
+                config.getOptional(PYTHON_REQUIREMENTS_INDEX_URL).orElse(null);
         String requirementsFileName =
                 config.getOptional(PYTHON_REQUIREMENTS_FILE_DISTRIBUTED_CACHE_INFO)
                         .orElse(new HashMap<>())
@@ -188,6 +205,7 @@ public final class PythonDependencyInfo {
                 pythonFiles,
                 requirementsFilePath,
                 requirementsCacheDir,
+                requirementsIndexUrl,
                 archives,
                 pythonExec,
                 config.get(PYTHON_EXECUTION_MODE));

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonEnvironmentManagerUtils.java
@@ -87,6 +87,7 @@ public class PythonEnvironmentManagerUtils {
      *
      * @param requirementsFilePath The path of the requirements file.
      * @param requirementsCacheDir The path of the requirements cached directory.
+     * @param indexUrl Base URL of Python Package Index (default https://pypi.python.org/simple).
      * @param requirementsInstallDir The target directory of the installation.
      * @param pythonExecutable The python interpreter used to launch the pip program.
      * @param environmentVariables The environment variables used to launch the pip program.
@@ -94,6 +95,7 @@ public class PythonEnvironmentManagerUtils {
     public static void pipInstallRequirements(
             String requirementsFilePath,
             @Nullable String requirementsCacheDir,
+            @Nullable String indexUrl,
             String requirementsInstallDir,
             String pythonExecutable,
             Map<String, String> environmentVariables)
@@ -114,6 +116,9 @@ public class PythonEnvironmentManagerUtils {
                                 "--ignore-installed",
                                 "-r",
                                 requirementsFilePath));
+        if (indexUrl != null) {
+            commands.addAll(Arrays.asList("--index-url", indexUrl));
+        }
         if (isPipVersionGreaterEqual("8.0.0", pythonExecutable, environmentVariables)) {
             commands.addAll(Arrays.asList("--prefix", requirementsInstallDir));
         } else {

--- a/flink-python/src/test/java/org/apache/flink/python/env/process/ProcessPythonEnvironmentManagerTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/env/process/ProcessPythonEnvironmentManagerTest.java
@@ -167,7 +167,7 @@ class ProcessPythonEnvironmentManagerTest {
         pythonFiles.put(String.join(File.separator, tmpDir, "file2"), "test_file2.egg");
         pythonFiles.put(String.join(File.separator, tmpDir, "dir0"), "test_dir");
         PythonDependencyInfo dependencyInfo =
-                new PythonDependencyInfo(pythonFiles, null, null, new HashMap<>(), "python");
+                new PythonDependencyInfo(pythonFiles, null, null, null, new HashMap<>(), "python");
 
         try (ProcessPythonEnvironmentManager environmentManager =
                 createBasicPythonEnvironmentManager(dependencyInfo)) {
@@ -236,6 +236,7 @@ class ProcessPythonEnvironmentManagerTest {
                         new HashMap<>(),
                         String.join(File.separator, tmpDir, "file0"),
                         String.join(File.separator, tmpDir, "dir0"),
+                        null,
                         new HashMap<>(),
                         "python");
 
@@ -272,7 +273,7 @@ class ProcessPythonEnvironmentManagerTest {
         archives.put(String.join(File.separator, tmpDir, "zip0"), "py27.zip");
         archives.put(String.join(File.separator, tmpDir, "zip1"), "py37");
         PythonDependencyInfo dependencyInfo =
-                new PythonDependencyInfo(new HashMap<>(), null, null, archives, "python");
+                new PythonDependencyInfo(new HashMap<>(), null, null, null, archives, "python");
 
         try (ProcessPythonEnvironmentManager environmentManager =
                 createBasicPythonEnvironmentManager(dependencyInfo)) {
@@ -299,7 +300,12 @@ class ProcessPythonEnvironmentManagerTest {
     void testPythonExecutable() throws Exception {
         PythonDependencyInfo dependencyInfo =
                 new PythonDependencyInfo(
-                        new HashMap<>(), null, null, new HashMap<>(), "/usr/local/bin/python");
+                        new HashMap<>(),
+                        null,
+                        null,
+                        null,
+                        new HashMap<>(),
+                        "/usr/local/bin/python");
 
         try (ProcessPythonEnvironmentManager environmentManager =
                 createBasicPythonEnvironmentManager(dependencyInfo)) {
@@ -315,7 +321,8 @@ class ProcessPythonEnvironmentManagerTest {
     @Test
     void testCreateRetrievalToken() throws Exception {
         PythonDependencyInfo dependencyInfo =
-                new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), "python");
+                new PythonDependencyInfo(
+                        new HashMap<>(), null, null, null, new HashMap<>(), "python");
         Map<String, String> sysEnv = new HashMap<>();
         sysEnv.put("FLINK_HOME", "/flink");
 
@@ -337,7 +344,8 @@ class ProcessPythonEnvironmentManagerTest {
     @Test
     void testSetLogDirectory() throws Exception {
         PythonDependencyInfo dependencyInfo =
-                new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), "python");
+                new PythonDependencyInfo(
+                        new HashMap<>(), null, null, null, new HashMap<>(), "python");
 
         try (ProcessPythonEnvironmentManager environmentManager =
                 new ProcessPythonEnvironmentManager(
@@ -355,7 +363,8 @@ class ProcessPythonEnvironmentManagerTest {
     @Test
     void testOpenClose() throws Exception {
         PythonDependencyInfo dependencyInfo =
-                new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), "python");
+                new PythonDependencyInfo(
+                        new HashMap<>(), null, null, null, new HashMap<>(), "python");
 
         try (ProcessPythonEnvironmentManager environmentManager =
                 createBasicPythonEnvironmentManager(dependencyInfo)) {

--- a/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PythonTestUtils.java
+++ b/flink-python/src/test/java/org/apache/flink/table/runtime/utils/PythonTestUtils.java
@@ -89,7 +89,8 @@ public final class PythonTestUtils {
         Map<String, String> env = new HashMap<>();
         env.put(PythonEnvironmentManagerUtils.PYFLINK_UDF_RUNNER_DIR, "");
         return new ProcessPythonEnvironmentManager(
-                new PythonDependencyInfo(new HashMap<>(), null, null, new HashMap<>(), "python"),
+                new PythonDependencyInfo(
+                        new HashMap<>(), null, null, null, new HashMap<>(), "python"),
                 new String[] {System.getProperty("java.io.tmpdir")},
                 env,
                 new JobID());


### PR DESCRIPTION
## What is the purpose of the change

PyFlink supports specifying index-url when installing third-party dependencies。
When we use pyflink, if there is a third-party dependency, when using pip to install the package, it is retrieved and obtained from pypi.python.org by default, which is greatly affected by the network, slow download speed and easy to cause connection timeout. At this point, we think we can specify the index-url.


## Brief change log

  - *Supports specifying index-url through the parameter **python.requirements.index-url** when we install third-party dependencies.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
