### PR TITLE
[FLINK-29010][planner] fix wrong result check of unit test.

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/DecimalITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/DecimalITCase.scala
@@ -46,7 +46,7 @@ class DecimalITCase extends BatchTestBase {
       tables: Seq[Coll],
       query: String,
       expected: Coll,
-      isSorted: Boolean = false): Unit = {
+      isSorted: Boolean = true): Unit = {
 
     var tableId = 0
     var queryX = query
@@ -71,7 +71,7 @@ class DecimalITCase extends BatchTestBase {
     Assert.assertTrue(ts1.zip(ts2).forall { case (t1, t2) => isInteroperable(t1, t2) })
 
     def prepareResult(isSorted: Boolean, seq: Seq[Row]) = {
-      if (!isSorted) seq.map(_.toString).sortBy(s => s) else seq.map(_.toString)
+      if (isSorted) seq.map(_.toString).sortBy(s => s) else seq.map(_.toString)
     }
     val resultRows = executeQuery(resultTable)
     Assert.assertEquals(prepareResult(isSorted, expected.rows), prepareResult(isSorted, resultRows))
@@ -83,7 +83,7 @@ class DecimalITCase extends BatchTestBase {
       query: String,
       expectedColTypes: Seq[LogicalType],
       expectedRows: Seq[Row],
-      isSorted: Boolean = false): Unit = {
+      isSorted: Boolean = true): Unit = {
     checkQueryX(
       Seq(Coll(sourceColTypes, sourceRows)),
       query,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MiscITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/MiscITCase.scala
@@ -69,7 +69,7 @@ class MiscITCase extends BatchTestBase {
       table1Data: Seq[T],
       sqlQuery: String,
       expected: Seq[_ <: Product],
-      isSorted: Boolean = false): Unit = {
+      isSorted: Boolean = true): Unit = {
     val table2Data: Seq[Tuple1[String]] = null
     checkQuery2(table1Data, table2Data, sqlQuery, expected, isSorted)
   }
@@ -79,7 +79,7 @@ class MiscITCase extends BatchTestBase {
       table2Data: Seq[T2],
       sqlQuery: String,
       expected: Seq[_ <: Product],
-      isSorted: Boolean = false): Unit = {
+      isSorted: Boolean = true): Unit = {
 
     var sqlQueryX: String = sqlQuery
     if (table1Data != null) {

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/DecimalITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/table/DecimalITCase.scala
@@ -45,7 +45,7 @@ class DecimalITCase extends BatchTestBase {
       tableTransfer: Table => Table,
       expectedColTypes: Seq[DataType],
       expectedRows: Seq[Row],
-      isSorted: Boolean = false): Unit = {
+      isSorted: Boolean = true): Unit = {
     val t = tEnv.fromValues(DataTypes.ROW(sourceColTypes: _*), sourceRows: _*)
 
     // check result schema
@@ -56,7 +56,7 @@ class DecimalITCase extends BatchTestBase {
     expectedColTypes.zip(ts2).foreach { case (t1, t2) => assertEquals(t1, t2) }
 
     def prepareResult(isSorted: Boolean, seq: Seq[Row]) = {
-      if (!isSorted) seq.map(_.toString).sortBy(s => s) else seq.map(_.toString)
+      if (isSorted) seq.map(_.toString).sortBy(s => s) else seq.map(_.toString)
     }
 
     val resultRows = executeQuery(resultTable)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
@@ -104,11 +104,11 @@ class BatchTestBase extends BatchAbstractTestBase {
       s"$logicalPlan"
   }
 
-  def checkResult(sqlQuery: String, expectedResult: Seq[Row], isSorted: Boolean = false): Unit = {
+  def checkResult(sqlQuery: String, expectedResult: Seq[Row], isSorted: Boolean = true): Unit = {
     check(sqlQuery, (result: Seq[Row]) => checkSame(expectedResult, result, isSorted))
   }
 
-  def checkTableResult(table: Table, expectedResult: Seq[Row], isSorted: Boolean = false): Unit = {
+  def checkTableResult(table: Table, expectedResult: Seq[Row], isSorted: Boolean = true): Unit = {
     checkTable(table, (result: Seq[Row]) => checkSame(expectedResult, result, isSorted))
   }
 
@@ -314,13 +314,13 @@ class BatchTestBase extends BatchAbstractTestBase {
   }
 
   private def prepareResult(seq: Seq[Row], isSorted: Boolean): Seq[String] = {
-    if (!isSorted) seq.map(_.toString).sortBy(s => s) else seq.map(_.toString)
+    if (isSorted) seq.map(_.toString).sortBy(s => s) else seq.map(_.toString)
   }
 
   def checkSame(
       expectedResult: Seq[Row],
       result: Seq[Row],
-      isSorted: Boolean = false): Option[String] = {
+      isSorted: Boolean = true): Option[String] = {
     if (
       expectedResult.size != result.size
       || !prepareResult(expectedResult, isSorted).equals(prepareResult(result, isSorted))


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
