### PR TITLE
[FLINK-29007][e2e] Fix UsingRemoteJarITCase failed with NPE in hadoop3

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
@@ -201,13 +201,9 @@
     </build>
 
     <profiles>
-        <!-- Activate these profiles with -Phadoop3-tests to build and test against hadoop 3.1.3 -->
+        <!-- This profile adds dependencies needed to execute the tests with Hadoop 3 -->
         <profile>
             <id>hadoop3-tests</id>
-            <properties>
-                <flink.hadoop.version>3.1.3</flink.hadoop.version>
-            </properties>
-
             <dependencies>
                 <dependency>
                     <groupId>org.apache.hadoop</groupId>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
@@ -210,12 +210,6 @@
                     <artifactId>hadoop-hdfs-client</artifactId>
                     <version>${flink.hadoop.version}</version>
                     <scope>test</scope>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>com.fasterxml.jackson.core</groupId>
-                            <artifactId>jackson-annotations</artifactId>
-                        </exclusion>
-                    </exclusions>
                 </dependency>
             </dependencies>
         </profile>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/pom.xml
@@ -199,4 +199,29 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!-- Activate these profiles with -Phadoop3-tests to build and test against hadoop 3.1.3 -->
+        <profile>
+            <id>hadoop3-tests</id>
+            <properties>
+                <flink.hadoop.version>3.1.3</flink.hadoop.version>
+            </properties>
+
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-hdfs-client</artifactId>
+                    <version>${flink.hadoop.version}</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>com.fasterxml.jackson.core</groupId>
+                            <artifactId>jackson-annotations</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## What is the purpose of the change

Fix UsingRemoteJarITCase failed in hadoop3, test passed in local machine.

This change aim to address the ClassNotFoundException of `HdfsConfiguration` when run test with hadoop3, the reason is that hadoop-hdfs module doesn't include transitive dependency of hadoop-hdfs-client, hadoop-hdfs-client is not in classpath, so we need to introduce this dependency explicitly in maven.

## Verifying this change

This change is already covered by existing tests in `UsingRemoteJarITCase`.