### PR TITLE
[FLINK-28488][kafka] Only forward measurable Kafka metrics and ignore others

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/metrics/KafkaMetricWrapper.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/metrics/KafkaMetricWrapper.java
@@ -32,6 +32,11 @@ public class KafkaMetricWrapper implements Gauge<Double> {
 
     @Override
     public Double getValue() {
-        return (Double) kafkaMetric.metricValue();
+        final Object metricValue = kafkaMetric.metricValue();
+        // Previously KafkaMetric supported KafkaMetric#value that always returned a Double value.
+        // Since this method has been deprecated and is removed in future releases we have to
+        // manually check if the returned value is Double. Internally, KafkaMetric#value also
+        // returned 0.0 for all not "measurable" values, so we restored the original behavior.
+        return metricValue instanceof Double ? (Double) metricValue : 0.0;
     }
 }


### PR DESCRIPTION
Backport of https://github.com/apache/flink/pull/19649 for the deprecated producer/consumer.