### PR TITLE
[FLINK-29028][python][doc] Add the missing cache api in Python DataStream API

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/overview.md
+++ b/docs/content.zh/docs/dev/datastream/operators/overview.md
@@ -604,7 +604,16 @@ env.execute()
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
-Python 中尚不支持此特性。
+```python
+data_stream = ... # DataStream
+cached_data_stream = data_stream.cache()
+cached_data_stream.print()
+# ...
+env.execute() # Execute and create cache.
+
+cached_data_stream.print() # Consume cached result.
+env.execute()
+```
 {{< /tab >}}
 {{< /tabs>}}
 

--- a/docs/content/docs/dev/datastream/operators/overview.md
+++ b/docs/content/docs/dev/datastream/operators/overview.md
@@ -609,7 +609,16 @@ env.execute()
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
-This feature is not yet supported in Python
+```python
+data_stream = ... # DataStream
+cached_data_stream = data_stream.cache()
+cached_data_stream.print()
+# ...
+env.execute() # Execute and create cache.
+
+cached_data_stream.print() # Consume cached result.
+env.execute()
+```
 {{< /tab >}}
 {{< /tabs>}}
 

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -895,7 +895,7 @@ class DataStream(object):
         """
         return DataStream(self._j_data_stream.getSideOutput(output_tag.get_java_output_tag()))
 
-    def cache(self) -> 'DataStream':
+    def cache(self) -> 'CachedDataStream':
         """
         Cache the intermediate result of the transformation. Only support bounded streams and
         currently only block mode is supported. The cache is generated lazily at the first time the
@@ -907,7 +907,7 @@ class DataStream(object):
 
         .. versionadded:: 1.16.0
         """
-        return DataStream(self._j_data_stream.cache())
+        return CachedDataStream(self._j_data_stream.cache())
 
     def _apply_chaining_optimization(self):
         """
@@ -1770,8 +1770,62 @@ class KeyedStream(DataStream):
     def slot_sharing_group(self, slot_sharing_group: Union[str, SlotSharingGroup]) -> 'DataStream':
         raise Exception("Setting slot sharing group for KeyedStream is not supported.")
 
-    def cache(self) -> 'DataStream':
+    def cache(self) -> 'CachedDataStream':
         raise Exception("Cache for KeyedStream is not supported.")
+
+
+class CachedDataStream(DataStream):
+    """
+    CachedDataStream represents a DataStream whose intermediate result will be cached at the first
+    time when it is computed. And the cached intermediate result can be used in later job that using
+    the same CachedDataStream to avoid re-computing the intermediate result.
+    """
+
+    def __init__(self, j_data_stream):
+        super(CachedDataStream, self).__init__(j_data_stream)
+
+    def invalidate(self):
+        """
+        Invalidate the cache intermediate result of this DataStream to release the physical
+        resources. Users are not required to invoke this method to release physical resources unless
+        they want to. Cache will be recreated if it is used after invalidated.
+
+        .. versionadded:: 1.16.0
+        """
+        self._j_data_stream.invalidate()
+
+    def set_parallelism(self, parallelism: int):
+        raise Exception("Set parallelism for CachedDataStream is not supported.")
+
+    def name(self, name: str):
+        raise Exception("Set name for CachedDataStream is not supported.")
+
+    def get_name(self) -> str:
+        raise Exception("Get name of CachedDataStream is not supported.")
+
+    def uid(self, uid: str):
+        raise Exception("Set uid for CachedDataStream is not supported.")
+
+    def set_uid_hash(self, uid_hash: str):
+        raise Exception("Set uid hash for CachedDataStream is not supported.")
+
+    def set_max_parallelism(self, max_parallelism: int):
+        raise Exception("Set max parallelism for CachedDataStream is not supported.")
+
+    def force_non_parallel(self):
+        raise Exception("Set force non-parallel for CachedDataStream is not supported.")
+
+    def set_buffer_timeout(self, timeout_millis: int):
+        raise Exception("Set buffer timeout for CachedDataStream is not supported.")
+
+    def start_new_chain(self) -> 'DataStream':
+        raise Exception("Start new chain for CachedDataStream is not supported.")
+
+    def disable_chaining(self) -> 'DataStream':
+        raise Exception("Disable chaining for CachedDataStream is not supported.")
+
+    def slot_sharing_group(self, slot_sharing_group: Union[str, SlotSharingGroup]) -> 'DataStream':
+        raise Exception("Setting slot sharing group for CachedDataStream is not supported.")
 
 
 class WindowedStream(object):

--- a/flink-python/pyflink/datastream/data_stream.py
+++ b/flink-python/pyflink/datastream/data_stream.py
@@ -895,6 +895,20 @@ class DataStream(object):
         """
         return DataStream(self._j_data_stream.getSideOutput(output_tag.get_java_output_tag()))
 
+    def cache(self) -> 'DataStream':
+        """
+        Cache the intermediate result of the transformation. Only support bounded streams and
+        currently only block mode is supported. The cache is generated lazily at the first time the
+        intermediate result is computed. The cache will be clear when the StreamExecutionEnvironment
+        close.
+
+        :return: The cached DataStream that can use in later job to reuse the cached intermediate
+                 result.
+
+        .. versionadded:: 1.16.0
+        """
+        return DataStream(self._j_data_stream.cache())
+
     def _apply_chaining_optimization(self):
         """
         Chain the Python operators if possible.
@@ -1755,6 +1769,9 @@ class KeyedStream(DataStream):
 
     def slot_sharing_group(self, slot_sharing_group: Union[str, SlotSharingGroup]) -> 'DataStream':
         raise Exception("Setting slot sharing group for KeyedStream is not supported.")
+
+    def cache(self) -> 'DataStream':
+        raise Exception("Cache for KeyedStream is not supported.")
 
 
 class WindowedStream(object):

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -1053,3 +1053,12 @@ class StreamExecutionEnvironment(object):
         Returns whether Unaligned Checkpoints are force-enabled.
         """
         return self._j_stream_execution_environment.isForceUnalignedCheckpoints()
+
+    def close(self):
+        """
+        Close and clean up the execution environment. All the cached intermediate results will be
+        released physically.
+
+        .. versionadded:: 1.16.0
+        """
+        self._j_stream_execution_environment.close()


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will add the missing cache api in Python DataStream API*

## Brief change log

  - *Add the missing cache api in Python DataStream API*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
