### PR TITLE
[FLINK-29019][doc][parquet] Updating parquet format document that support read complex type

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/parquet.md
+++ b/docs/content.zh/docs/connectors/table/formats/parquet.md
@@ -176,20 +176,18 @@ Parquet 格式也支持 [ParquetOutputFormat](https://www.javadoc.io/doc/org.apa
     </tr>
     <tr>
       <td>ARRAY</td>
-      <td></td>
+      <td>-</td>
       <td>LIST</td>
     </tr>
     <tr>
       <td>MAP</td>
-      <td></td>
+      <td>-</td>
       <td>MAP</td>
     </tr>
     <tr>
       <td>ROW</td>
-      <td></td>
+      <td>-</td>
       <td>STRUCT</td>
     </tr>
     </tbody>
 </table>
-
-<span class="label label-danger">注意</span> 复合数据类型暂只支持写不支持读（Array、Map 与 Row）。

--- a/docs/content/docs/connectors/table/formats/parquet.md
+++ b/docs/content/docs/connectors/table/formats/parquet.md
@@ -176,22 +176,18 @@ The following table lists the type mapping from Flink type to Parquet type.
     </tr>
     <tr>
       <td>ARRAY</td>
-      <td></td>
+      <td>-</td>
       <td>LIST</td>
     </tr>
     <tr>
       <td>MAP</td>
-      <td></td>
+      <td>-</td>
       <td>MAP</td>
     </tr>
     <tr>
       <td>ROW</td>
-      <td></td>
+      <td>-</td>
       <td>STRUCT</td>
     </tr>
     </tbody>
 </table>
-
-{{< hint warning >}}
-Composite data type: Array, Map and Row are currently only supported when writing, not reading.
-{{< /hint >}}


### PR DESCRIPTION
## What is the purpose of the change

Updating parquet format document that support read complex type


## Brief change log

Updating parquet format document that support read complex type


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
