### PR TITLE
[FLINK-29029][python] Fix the bug of InternalTypeInfo mapping to IdentityConverter in Thread Mode

### DIFF
--- a/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/streaming/api/utils/PythonTypeUtilsTest.java
@@ -41,11 +41,16 @@ import org.apache.flink.api.java.typeutils.runtime.RowSerializer;
 import org.apache.flink.api.java.typeutils.runtime.TupleSerializer;
 import org.apache.flink.fnexecution.v1.FlinkFnApi;
 import org.apache.flink.streaming.api.typeinfo.python.PickledByteArrayTypeInfo;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.runtime.typeutils.serializers.python.BigDecSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.DateSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.StringSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimeSerializer;
 import org.apache.flink.table.runtime.typeutils.serializers.python.TimestampSerializer;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.Test;
@@ -228,5 +233,63 @@ class PythonTypeUtilsTest {
                         new TupleSerializer(
                                 tupleTypeInfo.getTypeClass(),
                                 new TypeSerializer[] {IntSerializer.INSTANCE}));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void testInternalTypeInfoToDataConverter() {
+        RowType rowDataType =
+                (RowType)
+                        DataTypes.ROW(
+                                        DataTypes.BOOLEAN(),
+                                        DataTypes.TINYINT(),
+                                        DataTypes.SMALLINT(),
+                                        DataTypes.INT(),
+                                        DataTypes.BIGINT(),
+                                        DataTypes.FLOAT(),
+                                        DataTypes.DOUBLE(),
+                                        DataTypes.BINARY(10),
+                                        DataTypes.VARCHAR(100),
+                                        DataTypes.CHAR(100),
+                                        DataTypes.VARCHAR(1000),
+                                        DataTypes.DATE(),
+                                        DataTypes.TIME(),
+                                        DataTypes.ARRAY(DataTypes.STRING()),
+                                        DataTypes.MAP(DataTypes.BIGINT(), DataTypes.BYTES()))
+                                .getLogicalType();
+        PythonTypeUtils.DataConverter dataConverter =
+                PythonTypeUtils.TypeInfoToDataConverter.typeInfoDataConverter(
+                        InternalTypeInfo.of(rowDataType));
+
+        PythonTypeUtils.RowDataConverter rowDataConverter =
+                new PythonTypeUtils.RowDataConverter(
+                        new PythonTypeUtils.DataConverter[] {
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.ByteDataConverter.INSTANCE,
+                            PythonTypeUtils.ShortDataConverter.INSTANCE,
+                            PythonTypeUtils.IntDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.FloatDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                            new PythonTypeUtils.ArrayDataConverter<>(
+                                    String.class, PythonTypeUtils.IdentityDataConverter.INSTANCE),
+                            new PythonTypeUtils.MapDataConverter(
+                                    PythonTypeUtils.IdentityDataConverter.INSTANCE,
+                                    PythonTypeUtils.IdentityDataConverter.INSTANCE)
+                        });
+
+        PythonTypeUtils.RowDataDataConverter expectedDataConverter =
+                new PythonTypeUtils.RowDataDataConverter(
+                        rowDataConverter,
+                        DataFormatConverters.getConverterForDataType(
+                                TypeConversions.fromLogicalToDataType(rowDataType)));
+
+        assertThat(dataConverter).isEqualTo(expectedDataConverter);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the bug of InternalTypeInfo mapping to IdentityConverter in Thread Mode*


## Brief change log

  - *Fix the bug of InternalTypeInfo mapping to IdentityConverter in Thread Mode*

## Verifying this change

This change added tests and can be verified as follows:

  - *`EmbeddedFileSourceCsvReaderFormatTests`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
