### PR TITLE
[FLINK-29034] HYBRID_FULL result partition type is not yet reConsumable

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
@@ -293,8 +293,8 @@ public class RestartPipelinedRegionFailoverStrategy implements FailoverStrategy 
                     && resultPartitionAvailabilityChecker.isAvailable(resultPartitionID)
                     // If the result partition is available in the partition tracker and does not
                     // fail, it will be available if it can be re-consumption, and it may also be
-                    // available for PIPELINED_APPROXIMATE type.
-                    && isResultPartitionIsReConsumableOrPipelinedApproximate(resultPartitionID);
+                    // available for PIPELINED_APPROXIMATE and HYBRID_FULL type.
+                    && isResultPartitionCanBeConsumedRepeatedly(resultPartitionID);
         }
 
         public void markResultPartitionFailed(IntermediateResultPartitionID resultPartitionID) {
@@ -306,12 +306,14 @@ public class RestartPipelinedRegionFailoverStrategy implements FailoverStrategy 
             failedPartitions.remove(resultPartitionID);
         }
 
-        private boolean isResultPartitionIsReConsumableOrPipelinedApproximate(
+        private boolean isResultPartitionCanBeConsumedRepeatedly(
                 IntermediateResultPartitionID resultPartitionID) {
             ResultPartitionType resultPartitionType =
                     resultPartitionTypeRetriever.apply(resultPartitionID);
             return resultPartitionType.isReconsumable()
-                    || resultPartitionType == ResultPartitionType.PIPELINED_APPROXIMATE;
+                    || resultPartitionType == ResultPartitionType.PIPELINED_APPROXIMATE
+                    // TODO support re-consumable for HYBRID_FULL resultPartitionType.
+                    || resultPartitionType == ResultPartitionType.HYBRID_FULL;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -91,14 +91,16 @@ public enum ResultPartitionType {
      *
      * <p>Hybrid partitions can be consumed any time, whether fully produced or not.
      *
-     * <p>HYBRID_FULL partitions is re-consumable, so double calculation can be avoided during
+     * <p>HYBRID_FULL partitions can be consumed repeatedly, but it does not support concurrent
+     * consumption. So re-consumable is false, but double calculation can be avoided during
      * failover.
      */
-    HYBRID_FULL(true, false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER),
+    // TODO support re-consumable for HYBRID_FULL resultPartitionType.
+    HYBRID_FULL(false, false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER),
 
     /**
-     * HYBRID_SELECTIVE partitions are similar to {@link #HYBRID_FULL} partitions, but it is not
-     * re-consumable.
+     * HYBRID_SELECTIVE partitions are similar to {@link #HYBRID_FULL} partitions, but it cannot be
+     * consumed repeatedly.
      */
     HYBRID_SELECTIVE(
             false, false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
@@ -39,14 +39,14 @@ public enum StreamExchangeMode {
     /**
      * The consumer can start consuming data anytime as long as the producer has started producing.
      *
-     * <p>This exchange mode is re-consumable.
+     * <p>This exchange mode can be consumed repeatedly.
      */
     HYBRID_FULL,
 
     /**
      * The consumer can start consuming data anytime as long as the producer has started producing.
      *
-     * <p>This exchange mode is not re-consumable.
+     * <p>This exchange mode can not be consumed repeatedly.
      */
     HYBRID_SELECTIVE,
 


### PR DESCRIPTION
## What is the purpose of the change

*HYBRID_FULL partitions can be consumed repeatedly, but it does not support concurrent consumption. So re-consumable is false, but double calculation can be avoided during failover. If we regard it as re-consumable, there will be problems when the partition is reused. Therefore, we temporarily set this field false, and reset it to true when HsResultPartition supports downstream concurrent consumption of multiple identical subpartitions.*


## Brief change log

  - *Set `isReconsumable = false` for HYBRID_FULL `ResultPartitionType`.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
