### PR TITLE
[hotfix][build] Use ${flink.shaded.version} for flink-docs and flink-runtime

### DIFF
--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -41,7 +41,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-swagger</artifactId>
-			<version>15.0</version>
+			<version>${flink.shaded.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -88,7 +88,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-swagger</artifactId>
-			<version>15.0</version>
+			<version>${flink.shaded.version}</version>
 			<!-- Only required at compile-time; only flink-docs needs it at runtime -->
 			<optional>true</optional>
 		</dependency>


### PR DESCRIPTION

## What is the purpose of the change

This is a trivial PR making using of `${flink.shaded.version}` in flink-docs and flink-runtime pom files instead of version.

## Brief change log

_flink-docs/pom.xml_
_flink-runtime/pom/xml_


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
