### PR TITLE
[Hotfix][Build] Remove scala suffix in japicmp

### DIFF
--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -103,18 +103,6 @@ under the License.
 			<plugin>
 				<groupId>com.github.siom79.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
-				<configuration>
-					<oldVersion>
-						<!-- Previous version had a scala suffix -->
-						<!-- Remove this in 1.16 -->
-						<dependency>
-							<groupId>${project.groupId}</groupId>
-							<artifactId>${project.artifactId}_2.11</artifactId>
-							<version>${japicmp.referenceVersion}</version>
-							<type>jar</type>
-						</dependency>
-					</oldVersion>
-				</configuration>
 			</plugin>
 
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -2154,6 +2154,7 @@ under the License.
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
 								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
+								<exclude>org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator#getSideOutput(org.apache.flink.util.OutputTag)</exclude>
 								<exclude>org.apache.flink.streaming.api.datastream.DataStream#DataStream(org.apache.flink.streaming.api.environment.StreamExecutionEnvironment,org.apache.flink.streaming.api.transformations.StreamTransformation)</exclude>
 								<exclude>org.apache.flink.streaming.api.environment.LegacyLocalStreamEnvironment</exclude>
 								<exclude>org.apache.flink.streaming.api.functions.sink.RichSinkFunction#invoke(java.lang.Object)</exclude>


### PR DESCRIPTION
## What is the purpose of the change

Remove temporary scala suffix settings for 1.15 in japicmp.

## Brief change log

Remove temporary scala suffix settings for 1.15 in japicmp.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive): no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
