### PR TITLE
[FLINK-29035][table-planner] Fix bug of ExpressionReducer does not work with jar resources

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExpressionReducer.scala
@@ -94,7 +94,7 @@ class ExpressionReducer(
       EMPTY_ROW_TYPE
     )
 
-    val function = generatedFunction.newInstance(Thread.currentThread().getContextClassLoader)
+    val function = generatedFunction.newInstance(classLoader)
     val richMapFunction = function match {
       case r: RichMapFunction[GenericRowData, GenericRowData] => r
       case _ =>

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
@@ -159,6 +159,22 @@ public class FunctionITCase extends BatchTestBase {
                 "drop function lowerUdf");
     }
 
+    @Test
+    public void testExpressionReducerByUsingJar() {
+        String functionDDL =
+                String.format(
+                        "create temporary function lowerUdf as '%s' using jar '%s'",
+                        udfClassName, jarPath);
+        tEnv().executeSql(functionDDL);
+
+        TableResult tableResult = tEnv().executeSql("SELECT lowerUdf('HELLO')");
+
+        List<Row> actualRows = CollectionUtil.iteratorToList(tableResult.collect());
+        assertThat(actualRows).isEqualTo(Arrays.asList(Row.of("hello")));
+
+        tEnv().executeSql("drop temporary function lowerUdf");
+    }
+
     private void testUserDefinedFunctionByUsingJar(String createFunctionDDL, String dropFunctionDDL)
             throws Exception {
         List<Row> sourceData =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/FunctionITCase.java
@@ -18,20 +18,16 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql;
 
-import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.api.Table;
-import org.apache.flink.table.api.TableResult;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
 import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
 import org.apache.flink.types.Row;
-import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.UserClassLoaderJarTestUtils;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.UUID;
@@ -89,32 +85,6 @@ public class FunctionITCase extends BatchTestBase {
     }
 
     @Test
-    public void testCreateCatalogFunctionByUsingJar() {
-        String ddl =
-                String.format(
-                        "CREATE FUNCTION default_database.f11 AS '%s' USING JAR '%s'",
-                        udfClassName, jarPath);
-        tEnv().executeSql(ddl);
-        assertThat(Arrays.asList(tEnv().listFunctions())).contains("f11");
-
-        tEnv().executeSql("DROP FUNCTION default_database.f11");
-        assertThat(Arrays.asList(tEnv().listFunctions())).doesNotContain("f11");
-    }
-
-    @Test
-    public void testCreateTemporaryCatalogFunctionByUsingJar() {
-        String ddl =
-                String.format(
-                        "CREATE TEMPORARY FUNCTION default_database.f12 AS '%s' USING JAR '%s'",
-                        udfClassName, jarPath);
-        tEnv().executeSql(ddl);
-        assertThat(Arrays.asList(tEnv().listFunctions())).contains("f12");
-
-        tEnv().executeSql("DROP TEMPORARY FUNCTION default_database.f12");
-        assertThat(Arrays.asList(tEnv().listFunctions())).doesNotContain("f12");
-    }
-
-    @Test
     public void testUserDefinedTemporarySystemFunctionByUsingJar() throws Exception {
         String functionDDL =
                 String.format(
@@ -123,56 +93,6 @@ public class FunctionITCase extends BatchTestBase {
 
         String dropFunctionDDL = "drop temporary system function lowerUdf";
         testUserDefinedFunctionByUsingJar(functionDDL, dropFunctionDDL);
-    }
-
-    @Test
-    public void testUserDefinedRegularCatalogFunctionByUsingJar() throws Exception {
-        String functionDDL =
-                String.format(
-                        "create function lowerUdf as '%s' using jar '%s'", udfClassName, jarPath);
-
-        String dropFunctionDDL = "drop function lowerUdf";
-        testUserDefinedFunctionByUsingJar(functionDDL, dropFunctionDDL);
-    }
-
-    @Test
-    public void testUserDefinedTemporaryCatalogFunctionByUsingJar() throws Exception {
-        String functionDDL =
-                String.format(
-                        "create temporary function lowerUdf as '%s' using jar '%s'",
-                        udfClassName, jarPath);
-
-        String dropFunctionDDL = "drop temporary function lowerUdf";
-        testUserDefinedFunctionByUsingJar(functionDDL, dropFunctionDDL);
-    }
-
-    @Test
-    public void testUsingAddJar() throws Exception {
-        tEnv().executeSql(String.format("ADD JAR '%s'", jarPath));
-
-        TableResult tableResult = tEnv().executeSql("SHOW JARS");
-        assertThat(CollectionUtil.iteratorToList(tableResult.collect()))
-                .isEqualTo(Collections.singletonList(Row.of(new Path(jarPath).getPath())));
-
-        testUserDefinedFunctionByUsingJar(
-                String.format("create function lowerUdf as '%s' LANGUAGE JAVA", udfClassName),
-                "drop function lowerUdf");
-    }
-
-    @Test
-    public void testExpressionReducerByUsingJar() {
-        String functionDDL =
-                String.format(
-                        "create temporary function lowerUdf as '%s' using jar '%s'",
-                        udfClassName, jarPath);
-        tEnv().executeSql(functionDDL);
-
-        TableResult tableResult = tEnv().executeSql("SELECT lowerUdf('HELLO')");
-
-        List<Row> actualRows = CollectionUtil.iteratorToList(tableResult.collect());
-        assertThat(actualRows).isEqualTo(Arrays.asList(Row.of("hello")));
-
-        tEnv().executeSql("drop temporary function lowerUdf");
     }
 
     private void testUserDefinedFunctionByUsingJar(String createFunctionDDL, String dropFunctionDDL)

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/FunctionITCase.java
@@ -474,6 +474,22 @@ public class FunctionITCase extends StreamingTestBase {
         tEnv().executeSql(dropFunctionDDL);
     }
 
+    @Test
+    public void testExpressionReducerByUsingJar() {
+        String functionDDL =
+                String.format(
+                        "create temporary function lowerUdf as '%s' using jar '%s'",
+                        udfClassName, jarPath);
+        tEnv().executeSql(functionDDL);
+
+        TableResult tableResult = tEnv().executeSql("SELECT lowerUdf('HELLO')");
+
+        List<Row> actualRows = CollectionUtil.iteratorToList(tableResult.collect());
+        assertThat(actualRows).isEqualTo(Arrays.asList(Row.of("hello")));
+
+        tEnv().executeSql("drop temporary function lowerUdf");
+    }
+
     /** Test udf class. */
     public static class TestUDF extends ScalarFunction {
 


### PR DESCRIPTION
## What is the purpose of the change

Fix bug of ExpressionReducer does not work with jar resources

## Brief change log

  - *Fix bug of ExpressionReducer does not work with jar resources*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests in FunctionITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
