### PR TITLE
[FLINK-28831][k8s]Support pluginable decorators mechanism - part 1st

### DIFF
--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -176,6 +176,26 @@ under the License.
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>create-ext-decorator-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>ext-decorator</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-ext-decorator-assembly.xml</descriptor>
+							</descriptors>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/** The flink-kubernetes decorator plugins loading class. */
+public class ExtStepDecoratorUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(ExtStepDecoratorUtils.class);
+
+    public static List<ExtPluginDecorator> loadExtStepDecorators(
+            AbstractKubernetesParameters kubernetesComponentConf) {
+        List<ExtPluginDecorator> extendedStepDecorators = new ArrayList<>();
+        Map<String, ExtPluginDecorator> decoratorFactories = new HashMap<>();
+        PluginManager pluginManager =
+                PluginUtils.createPluginManagerFromRootFolder(
+                        kubernetesComponentConf.getFlinkConfiguration());
+
+        // get all factories
+        Iterator<ExtPluginDecorator> factoryIteratorSPI =
+                ServiceLoader.load(ExtPluginDecorator.class).iterator();
+        Iterator<ExtPluginDecorator> factoryIteratorPlugins =
+                pluginManager != null
+                        ? pluginManager.load(ExtPluginDecorator.class)
+                        : Collections.emptyIterator();
+        Iterator<ExtPluginDecorator> factoryIterator =
+                Iterators.concat(factoryIteratorPlugins, factoryIteratorSPI);
+        while (factoryIterator.hasNext()) {
+            try {
+                ExtPluginDecorator factory = factoryIterator.next();
+                factory.configure(kubernetesComponentConf);
+                String factoryClassName = factory.getClass().getName();
+                ExtPluginDecorator existingFactory = decoratorFactories.get(factoryClassName);
+                if (existingFactory == null) {
+                    decoratorFactories.put(factoryClassName, factory);
+                    Collections.addAll(extendedStepDecorators, factory);
+                    LOG.info("Load ext plugin step decorator: {}.", factoryClassName);
+                }
+            } catch (Exception e) {
+                LOG.error("Loading ext plugin step decorator failed: {}", e.getMessage(), e);
+                return Collections.emptyList();
+            }
+        }
+        return extendedStepDecorators;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtPluginDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtPluginDecorator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators.extended;
+
+import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+
+/** The interface class which should be implemented by plugin decorators. */
+public interface ExtPluginDecorator extends KubernetesStepDecorator {
+    void configure(AbstractKubernetesParameters kubernetesComponentConf);
+}

--- a/flink-kubernetes/src/test/assembly/test-ext-decorator-assembly.xml
+++ b/flink-kubernetes/src/test/assembly/test-ext-decorator-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!-- the service impl -->
+			<includes>
+				<include>org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtTestDecorator.class</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<!-- declaring the service impl -->
+			<directory>${project.basedir}/src/test/resources/META-INF/services/org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator</directory>
+			<outputDirectory>/META-INF/services</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtilsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtTestDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** The test class for {@link ExtStepDecoratorUtils}. */
+public class ExtStepDecoratorUtilsTest {
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String EXT_DECORATOR_NAME = "ext-decorator";
+    private static final String EXT_JAR = EXT_DECORATOR_NAME + "-test-jar.jar";
+
+    @Test
+    public void testLoadExtStepDecorators() throws IOException {
+        File testRootFolder = temporaryFolder.newFolder();
+        File testPluginFolder = new File(testRootFolder, EXT_DECORATOR_NAME);
+        assertTrue(testPluginFolder.mkdirs());
+        File testPluginJar = new File("target", EXT_JAR);
+        assertTrue(testPluginJar.exists());
+        Files.copy(testPluginJar.toPath(), Paths.get(testPluginFolder.toString(), EXT_JAR));
+        Map<String, String> origEnv = System.getenv();
+        try {
+            HashMap<String, String> currentEnv = new HashMap<>(origEnv);
+            currentEnv.put(ConfigConstants.ENV_FLINK_PLUGINS_DIR, testRootFolder.getPath());
+            CommonTestUtils.setEnv(currentEnv);
+            final Configuration flinkConfig = new Configuration();
+            final ClusterSpecification clusterSpecification =
+                    new ClusterSpecification.ClusterSpecificationBuilder()
+                            .setMasterMemoryMB(1024)
+                            .setTaskManagerMemoryMB(1024)
+                            .setSlotsPerTaskManager(3)
+                            .createClusterSpecification();
+            KubernetesJobManagerParameters kubernetesJobManagerParameters =
+                    new KubernetesJobManagerParameters(flinkConfig, clusterSpecification);
+            assertEquals(
+                    ExtTestDecorator.class,
+                    ExtStepDecoratorUtils.loadExtStepDecorators(kubernetesJobManagerParameters)
+                            .get(0)
+                            .getClass());
+        } finally {
+            CommonTestUtils.setEnv(origEnv);
+        }
+    }
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtTestDecorator.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtTestDecorator.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators.extended;
+
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.io.IOException;
+import java.util.List;
+
+/** The test class for testing the plugin decorators. */
+public class ExtTestDecorator implements ExtPluginDecorator {
+    @Override
+    public FlinkPod decorateFlinkPod(FlinkPod flinkPod) {
+        return null;
+    }
+
+    @Override
+    public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
+        return null;
+    }
+
+    @Override
+    public void configure(AbstractKubernetesParameters kubernetesComponentConf) {
+        return;
+    }
+}

--- a/flink-kubernetes/src/test/resources/META-INF/services/org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator
+++ b/flink-kubernetes/src/test/resources/META-INF/services/org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtTestDecorator


### PR DESCRIPTION
We introduce a pluginable decoarators mechanism into Flink JobManager and TaskManager.
For 1st part, we relies on the existing flink plugin mechanism and make the KubernetesStepDecorator
as the SPI. And load the extended plugins from plugins directory.
And notice the 1st part only introduces the basic mechanism and doesn't affect the major process login.
There will be another follow up PRs for introduce this mechanism one by one.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change


We introduce the basic plugin mechanism for supporting add more pluginable K8S step decorators in Flink Kubernetes. So in PR introduce the its 1st part.

## Brief change log

- Relied on the Flink existing plugin mechanism to load the plugins from `flink-dist/plugins/` directory.
- Introduce a new Interface class `ExtPluginDecorator ` which is extended from `KubernetesStepDecorator`, and introduce a new interface function for initialize the upcoming StepDecorators if necessary.
- Introduce the basic UTs for plugin mechanism.

## Verifying this change

Run the UTs, or package a sample jar which implement the interface class `ExtPluginDecorator `, then verify the said implement class is loaded in Flink by LOG. Notice that this is the first part of plugin mechanism, and it doen't affect the major Flink Kubernetes process yet. So we can only verify the said functionality via LOG now. Once the following PRs are ready and merged, we will introduce a full insight e2e tests. 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
