### PR TITLE
[hotfix] Add TaskManager id in the exception message

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -760,7 +760,9 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
                 disconnectTaskManager(
                         taskManagerId,
                         new FlinkException(
-                                "A registered TaskManager re-registered with a new session id. This indicates a restart of the TaskManager. Closing the old connection."));
+                                String.format(
+                                        "A registered TaskManager %s re-registered with a new session id. This indicates a restart of the TaskManager. Closing the old connection.",
+                                        taskManagerId)));
             }
         }
 


### PR DESCRIPTION
This PR is meant to add the tm id in the exception message to make it clear in the exception history.