### PR TITLE
[FLINK-28838] Avoid to notify the elementQueue consumer when the fetc…

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsBySplits.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsBySplits.java
@@ -44,11 +44,20 @@ public class RecordsBySplits<E> implements RecordsWithSplitIds<E> {
 
     @Nullable private Iterator<E> recordsInCurrentSplit;
 
+    private final boolean isEmpty;
+
     public RecordsBySplits(
             final Map<String, Collection<E>> recordsBySplit, final Set<String> finishedSplits) {
-
         this.splitsIterator = checkNotNull(recordsBySplit, "recordsBySplit").entrySet().iterator();
         this.finishedSplits = checkNotNull(finishedSplits, "finishedSplits");
+        boolean isEmpty = true;
+        for (Map.Entry<String, Collection<E>> entry : recordsBySplit.entrySet()) {
+            if (!entry.getValue().isEmpty()) {
+                isEmpty = false;
+                break;
+            }
+        }
+        this.isEmpty = isEmpty;
     }
 
     @Nullable
@@ -76,6 +85,11 @@ public class RecordsBySplits<E> implements RecordsWithSplitIds<E> {
     @Override
     public Set<String> finishedSplits() {
         return finishedSplits;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return isEmpty;
     }
 
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsWithSplitIds.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordsWithSplitIds.java
@@ -57,4 +57,13 @@ public interface RecordsWithSplitIds<E> {
      * large or otherwise heavy to allocate.
      */
     default void recycle() {}
+
+    /**
+     * This indicates whether this fetch result is empty.
+     *
+     * @return whether this fetch result is empty.
+     */
+    default boolean isEmpty() {
+        return false;
+    }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/FetchTask.java
@@ -61,7 +61,7 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
             if (!isWakenUp()) {
                 // The order matters here. We must first put the last records into the queue.
                 // This ensures the handling of the fetched records is atomic to wakeup.
-                if (elementsQueue.put(fetcherIndex, lastRecords)) {
+                if (lastRecords.isEmpty() || elementsQueue.put(fetcherIndex, lastRecords)) {
                     if (!lastRecords.finishedSplits().isEmpty()) {
                         // The callback does not throw InterruptedException.
                         splitFinishedCallback.accept(lastRecords.finishedSplits());
@@ -92,7 +92,7 @@ class FetchTask<E, SplitT extends SourceSplit> implements SplitFetcherTask {
         if (lastRecords == null) {
             // Two possible cases:
             // 1. The splitReader is reading or is about to read the records.
-            // 2. The records has been enqueued and set to null.
+            // 2. The records have been enqueued and set to null.
             // In case 1, we just wakeup the split reader. In case 2, the next run might be skipped.
             // In any case, the records won't be enqueued in the ongoing run().
             splitReader.wakeUp();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileRecords.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileRecords.java
@@ -92,6 +92,11 @@ public final class FileRecords<T> implements RecordsWithSplitIds<RecordAndPositi
         return finishedSplits;
     }
 
+    @Override
+    public boolean isEmpty() {
+        return recordsForSplit == null;
+    }
+
     // ------------------------------------------------------------------------
 
     public static <T> FileRecords<T> forRecords(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -458,10 +458,12 @@ public class KafkaPartitionSplitReader
         private Iterator<ConsumerRecord<byte[], byte[]>> recordIterator;
         private TopicPartition currentTopicPartition;
         private Long currentSplitStoppingOffset;
+        private final boolean isEmpty;
 
         private KafkaPartitionSplitRecords(
                 ConsumerRecords<byte[], byte[]> consumerRecords, KafkaSourceReaderMetrics metrics) {
             this.consumerRecords = consumerRecords;
+            this.isEmpty = consumerRecords.isEmpty();
             this.splitIterator = consumerRecords.partitions().iterator();
             this.metrics = metrics;
         }
@@ -513,6 +515,11 @@ public class KafkaPartitionSplitReader
         @Override
         public Set<String> finishedSplits() {
             return finishedSplits;
+        }
+
+        @Override
+        public boolean isEmpty() {
+            return this.isEmpty;
         }
     }
 }


### PR DESCRIPTION
…h result is empty

## What is the purpose of the change

This PR is meant to avoid to enqueue the empty fetch result into the elementQueue, which may cause the queue frequently notify which brings high cpu sys usage.

## Brief change log

- Add a default interface in the `RecordsWithSplitIds` which return false by default
- Use `isEmpty` result to shortcut the put operation.


## Verifying this change

The existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
