### PR TITLE
[FLINK-29013][hive] Fix fail to use BinaryRecordReader in "transform using" syntax with Hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/runtime/operators/hive/script/HiveScriptTransformOperator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/runtime/operators/hive/script/HiveScriptTransformOperator.java
@@ -302,15 +302,12 @@ public class HiveScriptTransformOperator extends TableStreamOperator<RowData>
     private void initScriptOutPutReadThread() throws Exception {
         StructObjectInspector outputStructObjectInspector =
                 (StructObjectInspector) outputSerDe.getObjectInspector();
-        Writable reusedWritableObject =
-                outputSerDe.getSerializedClass().getConstructor().newInstance();
         outReadThread =
                 new HiveScriptTransformOutReadThread(
                         recordReader,
                         outputType,
                         outputSerDe,
                         outputStructObjectInspector,
-                        reusedWritableObject,
                         collector);
         outReadThread.start();
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/runtime/operators/hive/script/HiveScriptTransformOutReadThread.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/runtime/operators/hive/script/HiveScriptTransformOutReadThread.java
@@ -52,14 +52,12 @@ public class HiveScriptTransformOutReadThread extends Thread {
     private final HiveShim hiveShim;
     private final StructObjectInspector outputStructObjectInspector;
     private final List<? extends StructField> structFields;
-    private final Writable reusedWritableObject;
 
     public HiveScriptTransformOutReadThread(
             RecordReader recordReader,
             LogicalType outputType,
             AbstractSerDe outSerDe,
             StructObjectInspector structObjectInspector,
-            Writable reusedWritableObject,
             StreamRecordCollector<RowData> collector) {
         this.recordReader = recordReader;
         this.outSerDe = outSerDe;
@@ -71,7 +69,6 @@ public class HiveScriptTransformOutReadThread extends Thread {
         }
         this.hiveShim = HiveShimLoader.loadHiveShim(HiveShimLoader.getHiveVersion());
         this.outputStructObjectInspector = structObjectInspector;
-        this.reusedWritableObject = reusedWritableObject;
         this.structFields = outputStructObjectInspector.getAllStructFieldRefs();
         this.collector = collector;
         setDaemon(true);
@@ -81,6 +78,7 @@ public class HiveScriptTransformOutReadThread extends Thread {
     @Override
     public void run() {
         try {
+            Writable reusedWritableObject = recordReader.createRow();
             while (true) {
                 long bytes = recordReader.next(reusedWritableObject);
                 if (bytes <= 0) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -587,6 +587,15 @@ public class HiveDialectQueryITCase {
                                     defaultPartitionName,
                                     defaultPartitionName,
                                     defaultPartitionName));
+
+            // test use binary record reader
+            result =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql(
+                                            "select transform(key) using 'cat' as (tkey)"
+                                                    + " RECORDREADER 'org.apache.hadoop.hive.ql.exec.BinaryRecordReader' from src")
+                                    .collect());
+            assertThat(result.toString()).isEqualTo("[+I[1\n2\n3\n]]");
         } finally {
             tableEnv.executeSql("drop table dest1");
             tableEnv.executeSql("drop table destp1");


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To fix fail to use  BinaryRecordReader in "transform using" syntax with Hive dialect.


## Brief change log
  -  While reading the data with `BinaryRecordReader`, first to call `BinaryRecordReader#createRow` to get the reused WritableObject  just like what [Hive does](https://github.com/apache/hive/blob/a6ef9dc903f1e7c4ec53f925ab823f20f9331db8/ql/src/java/org/apache/hadoop/hive/ql/exec/ScriptOperator.java#L696).

## Verifying this change
Added sql in `HiveDialectQueryITCase#testScriptTransform`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
