### PR TITLE
[FLINK-29053] Hybrid shuffle has concurrent modification of buffer when compression is enabled

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBuffer.java
@@ -173,7 +173,9 @@ public class NetworkBuffer extends AbstractReferenceCountedByteBuf implements Bu
 
     @Override
     public ReadOnlySlicedNetworkBuffer readOnlySlice(int index, int length) {
-        checkState(!isCompressed, "Unable to slice a compressed buffer.");
+        checkState(
+                !isCompressed || index + length != writerIndex(),
+                "Unable to slice a partial compressed buffer.");
         return new ReadOnlySlicedNetworkBuffer(this, index, length);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/NetworkBuffer.java
@@ -175,8 +175,8 @@ public class NetworkBuffer extends AbstractReferenceCountedByteBuf implements Bu
     public ReadOnlySlicedNetworkBuffer readOnlySlice(int index, int length) {
         checkState(
                 !isCompressed || index + length != writerIndex(),
-                "Unable to slice a partial compressed buffer.");
-        return new ReadOnlySlicedNetworkBuffer(this, index, length);
+                "Unable to partially slice a compressed buffer.");
+        return new ReadOnlySlicedNetworkBuffer(this, index, length, isCompressed);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
@@ -56,11 +56,13 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
      * @param buffer the buffer to derive from
      * @param index the index to start from
      * @param length the length of the slice
+     * @param isCompressed is the buffer compressed
      */
-    ReadOnlySlicedNetworkBuffer(NetworkBuffer buffer, int index, int length) {
+    ReadOnlySlicedNetworkBuffer(NetworkBuffer buffer, int index, int length, boolean isCompressed) {
         super(new SlicedByteBuf(buffer, index, length));
         this.memorySegmentOffset = buffer.getMemorySegmentOffset() + index;
         this.dataType = buffer.getDataType();
+        this.isCompressed = isCompressed;
     }
 
     /**
@@ -143,9 +145,9 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
     public ReadOnlySlicedNetworkBuffer readOnlySlice(int index, int length) {
         checkState(
                 !isCompressed || index + length == writerIndex(),
-                "Unable to slice a partial compressed buffer.");
+                "Unable to partially slice a compressed buffer.");
         return new ReadOnlySlicedNetworkBuffer(
-                super.unwrap(), index, length, memorySegmentOffset, false);
+                super.unwrap(), index, length, memorySegmentOffset, isCompressed);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/buffer/ReadOnlySlicedNetworkBuffer.java
@@ -141,7 +141,9 @@ public final class ReadOnlySlicedNetworkBuffer extends ReadOnlyByteBuf implement
 
     @Override
     public ReadOnlySlicedNetworkBuffer readOnlySlice(int index, int length) {
-        checkState(!isCompressed, "Unable to slice a compressed buffer.");
+        checkState(
+                !isCompressed || index + length == writerIndex(),
+                "Unable to slice a partial compressed buffer.");
         return new ReadOnlySlicedNetworkBuffer(
                 super.unwrap(), index, length, memorySegmentOffset, false);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -82,7 +82,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
             throws IOException {
         this.numSubpartitions = numSubpartitions;
         this.bufferPool = bufferPool;
-        this.spiller = new HsMemoryDataSpiller(dataFilePath, bufferCompressor);
+        this.spiller = new HsMemoryDataSpiller(dataFilePath);
         this.spillStrategy = spillStrategy;
         this.fileDataIndex = fileDataIndex;
         this.subpartitionMemoryDataManagers = new HsSubpartitionMemoryDataManager[numSubpartitions];
@@ -93,7 +93,11 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
         for (int subpartitionId = 0; subpartitionId < numSubpartitions; ++subpartitionId) {
             subpartitionMemoryDataManagers[subpartitionId] =
                     new HsSubpartitionMemoryDataManager(
-                            subpartitionId, bufferSize, readWriteLock.readLock(), this);
+                            subpartitionId,
+                            bufferSize,
+                            readWriteLock.readLock(),
+                            bufferCompressor,
+                            this);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataSpiller.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataSpiller.java
@@ -19,15 +19,12 @@
 package org.apache.flink.runtime.io.network.partition.hybrid;
 
 import org.apache.flink.runtime.io.network.buffer.Buffer;
-import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndex.SpilledBuffer;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FatalExitExceptionHandler;
 
 import org.apache.flink.shaded.guava30.com.google.common.util.concurrent.ThreadFactoryBuilder;
-
-import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -41,9 +38,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
  * This component is responsible for asynchronously writing in-memory data to disk. Each spilling
@@ -66,17 +60,13 @@ public class HsMemoryDataSpiller implements AutoCloseable {
     /** File channel to write data. */
     private final FileChannel dataFileChannel;
 
-    @Nullable private final BufferCompressor bufferCompressor;
-
     /** Records the current writing location. */
     private long totalBytesWritten;
 
-    public HsMemoryDataSpiller(Path dataFilePath, @Nullable BufferCompressor bufferCompressor)
-            throws IOException {
+    public HsMemoryDataSpiller(Path dataFilePath) throws IOException {
         this.dataFileChannel =
                 FileChannel.open(
                         dataFilePath, StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
-        this.bufferCompressor = bufferCompressor;
     }
 
     /**
@@ -98,10 +88,6 @@ public class HsMemoryDataSpiller implements AutoCloseable {
             List<BufferWithIdentity> toWrite,
             CompletableFuture<List<SpilledBuffer>> spilledFuture) {
         try {
-            toWrite =
-                    toWrite.stream()
-                            .map(this::compressBuffersIfPossible)
-                            .collect(Collectors.toList());
             List<SpilledBuffer> spilledBuffers = new ArrayList<>();
             long expectedBytes = createSpilledBuffersAndGetTotalBytes(toWrite, spilledBuffers);
             // write all buffers to file
@@ -191,24 +177,5 @@ public class HsMemoryDataSpiller implements AutoCloseable {
         } catch (Exception e) {
             ExceptionUtils.rethrow(e);
         }
-    }
-
-    private BufferWithIdentity compressBuffersIfPossible(BufferWithIdentity bufferWithIdentity) {
-        Buffer buffer = bufferWithIdentity.getBuffer();
-        if (!canBeCompressed(buffer)) {
-            return bufferWithIdentity;
-        }
-
-        buffer = checkNotNull(bufferCompressor).compressToOriginalBuffer(buffer);
-        return new BufferWithIdentity(
-                buffer, bufferWithIdentity.getBufferIndex(), bufferWithIdentity.getChannelIndex());
-    }
-
-    /**
-     * Whether the buffer can be compressed or not. Note that event is not compressed because it is
-     * usually small and the size can become even larger after compression.
-     */
-    private boolean canBeCompressed(Buffer buffer) {
-        return bufferCompressor != null && buffer.isBuffer() && buffer.readableBytes() > 0;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
@@ -157,7 +157,7 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
         return bufferAndNextDataType.map(
                 tuple ->
                         new BufferAndBacklog(
-                                getSliceBuffer(tuple.f0.getBuffer()),
+                                tuple.f0.getBuffer().readOnlySlice(),
                                 getBacklog(),
                                 tuple.f1,
                                 toConsumeIndex));
@@ -364,7 +364,6 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
         Buffer buffer = bufferConsumer.build();
         currentWritingBuffer.close();
         bufferConsumer.close();
-        // TODO support buffer compression
         HsBufferContext bufferContext =
                 new HsBufferContext(
                         compressBuffersIfPossible(buffer), finishedBufferIndex, targetChannel);
@@ -504,14 +503,6 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
                 break;
         }
         return match;
-    }
-
-    private Buffer getSliceBuffer(Buffer buffer) {
-        Buffer slice = buffer.readOnlySlice();
-        if (buffer.isCompressed()) {
-            slice.setCompressed(true);
-        }
-        return slice;
     }
 
     private void updateStatistics(Buffer buffer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
+import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferConsumer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
@@ -84,17 +85,21 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
     /** DO NOT USE DIRECTLY. Use {@link #runWithLock} or {@link #callWithLock} instead. */
     private final Object subpartitionLock = new Object();
 
+    @Nullable private final BufferCompressor bufferCompressor;
+
     @Nullable private HsOutputMetrics outputMetrics;
 
     HsSubpartitionMemoryDataManager(
             int targetChannel,
             int bufferSize,
             Lock resultPartitionLock,
+            @Nullable BufferCompressor bufferCompressor,
             HsMemoryDataManagerOperation memoryDataManagerOperation) {
         this.targetChannel = targetChannel;
         this.bufferSize = bufferSize;
         this.resultPartitionLock = resultPartitionLock;
         this.memoryDataManagerOperation = memoryDataManagerOperation;
+        this.bufferCompressor = bufferCompressor;
     }
 
     // ------------------------------------------------------------------------
@@ -152,7 +157,7 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
         return bufferAndNextDataType.map(
                 tuple ->
                         new BufferAndBacklog(
-                                tuple.f0.getBuffer().readOnlySlice(),
+                                getSliceBuffer(tuple.f0.getBuffer()),
                                 getBacklog(),
                                 tuple.f1,
                                 toConsumeIndex));
@@ -359,11 +364,27 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
         Buffer buffer = bufferConsumer.build();
         currentWritingBuffer.close();
         bufferConsumer.close();
-
+        // TODO support buffer compression
         HsBufferContext bufferContext =
-                new HsBufferContext(buffer, finishedBufferIndex, targetChannel);
+                new HsBufferContext(
+                        compressBuffersIfPossible(buffer), finishedBufferIndex, targetChannel);
         addFinishedBuffer(bufferContext);
         memoryDataManagerOperation.onBufferFinished();
+    }
+
+    private Buffer compressBuffersIfPossible(Buffer buffer) {
+        if (!canBeCompressed(buffer)) {
+            return buffer;
+        }
+        return checkNotNull(bufferCompressor).compressToOriginalBuffer(buffer);
+    }
+
+    /**
+     * Whether the buffer can be compressed or not. Note that event is not compressed because it is
+     * usually small and the size can become even larger after compression.
+     */
+    private boolean canBeCompressed(Buffer buffer) {
+        return bufferCompressor != null && buffer.isBuffer() && buffer.readableBytes() > 0;
     }
 
     @SuppressWarnings("FieldAccessNotGuarded")
@@ -483,6 +504,14 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
                 break;
         }
         return match;
+    }
+
+    private Buffer getSliceBuffer(Buffer buffer) {
+        Buffer slice = buffer.readOnlySlice();
+        if (buffer.isCompressed()) {
+            slice.setCompressed(true);
+        }
+        return slice;
     }
 
     private void updateStatistics(Buffer buffer) {


### PR DESCRIPTION
## What is the purpose of the change

*When the downstream thread obtains the buffer and consuming it, if the data is compressed in the spilling thread and copied to the original buffer in the same time, since the two threads share the same memory data, the consuming thread will consume incorrect data, causing problems such as deserialize the data disorder. This pr will fix this problem.*


## Brief change log

  - *Move the compression operation to the write thread and store the compressed buffer directly in memory.*


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
