### PR TITLE
[FLINK-28998] Translate "Fine-Grained Resource Management" page into Chinese.

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/select-distinct.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/select-distinct.md
@@ -31,9 +31,6 @@ under the License.
 ```sql
 SELECT DISTINCT id FROM Orders
 ```
-
-对于流式查询,计算查询结果所需要的状态可能会源源不断地增长,而状态大小又依赖不同行的数量.此时,可以通过配置文件为状态设置合适的存活时间(TTL),
-
-以防止过大的状态可能对查询结果的正确性的影响. 具体配置可参考:[查询相关的配置]({{< ref "docs/dev/table/config" >}}#table-exec-state-ttl).
+对于流式查询, 计算查询结果所需要的状态可能会源源不断地增长,而状态大小又依赖不同行的数量.此时,可以通过配置文件为状态设置合适的存活时间(TTL),以防止过大的状态可能对查询结果的正确性的影响.具体配置可参考:[查询相关的配置]({{< ref "docs/dev/table/config" >}}#table-exec-state-ttl).
 
 {{< top >}}

--- a/docs/content.zh/docs/dev/table/sql/queries/select-distinct.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/select-distinct.md
@@ -26,13 +26,14 @@ under the License.
 
 {{< label Batch >}} {{< label Streaming >}}
 
-If `SELECT DISTINCT` is specified, all duplicate rows are removed from the result set (one row is kept from each group of duplicates).
+如果使用”SELECT DISTINCT“查询,所有的复制行都会从结果集(每个分组只会保留一行)中被删除.
 
 ```sql
 SELECT DISTINCT id FROM Orders
 ```
 
-For streaming queries, the required state for computing the query result might grow infinitely. State size depends on number of distinct rows. You can provide a query configuration with an appropriate state time-to-live (TTL) to prevent excessive state size. Note that this might affect the correctness of the query result. See [query configuration]({{< ref "docs/dev/table/config" >}}#table-exec-state-ttl) for details
+对于流式查询,计算查询结果所需要的状态可能会源源不断地增长,而状态大小又依赖不同行的数量.此时,可以通过配置文件为状态设置合适的存活时间(TTL),
 
+以防止过大的状态可能对查询结果的正确性的影响. 具体配置可参考:[查询相关的配置]({{< ref "docs/dev/table/config" >}}#table-exec-state-ttl).
 
 {{< top >}}


### PR DESCRIPTION
[FLINK-28998] Translate "Fine-Grained Resource Management" page into Chinese.

Translate "Fine-Grained Resource Management" page into Chinese:https://nightlies.apache.org/flink/flink-docs-master/zh/docs/deployment/finegrained_resource/
The markdown file location: flink/docs/content.zh/docs/deployment/finegrained_resource.md, most of them have been translated, but some part has not been translated into Chinese.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
