### PR TITLE
[FLINK-23020][table-planner] Use FlinkDefaultRelMetadataProvider when accessing FlinkRelMetadataQuery from a different thread

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQuery.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQuery.java
@@ -56,6 +56,13 @@ public class FlinkRelMetadataQuery extends RelMetadataQuery {
      * computing metadata.
      */
     public static FlinkRelMetadataQuery instance() {
+        if (THREAD_PROVIDERS.get() == null) {
+            // RelMetadataProvider is set to FlinkDefaultRelMetadataProvider in
+            // org.apache.flink.table.planner.calcite.FlinkRelOptClusterFactory anyway
+            THREAD_PROVIDERS.set(
+                    JaninoRelMetadataProvider.of(
+                            FlinkDefaultRelMetadataProvider$.MODULE$.INSTANCE()));
+        }
         return new FlinkRelMetadataQuery();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQueryThreadingTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/metadata/FlinkRelMetadataQueryThreadingTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.metadata;
+
+import org.apache.flink.table.planner.utils.PlannerMocks;
+
+import org.apache.calcite.plan.RelOptCluster;
+import org.junit.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.fail;
+
+/** Tests for {@link FlinkRelMetadataQuery} concerning multithreading. */
+public class FlinkRelMetadataQueryThreadingTest {
+    @Test
+    public void testAccessRelMetadataQueryInstanceFromDifferentThreads()
+            throws InterruptedException {
+        PlannerMocks plannerMocks = PlannerMocks.create(true);
+        RelOptCluster relOptCluster = plannerMocks.getPlannerContext().getCluster();
+        relOptCluster.getMetadataQuery();
+
+        Future<?> future =
+                Executors.newSingleThreadExecutor()
+                        .submit(
+                                () -> {
+                                    FlinkRelMetadataQuery instance =
+                                            FlinkRelMetadataQuery.instance();
+                                });
+
+        try {
+            future.get();
+        } catch (ExecutionException e) {
+            if (e.getCause().getClass() == NullPointerException.class) {
+                fail("NullPointerException thrown", e.getCause());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

`FlinkRelMetadataQuery` depends on Apache Calcite `RelMetadataQuery`'s [THREAD_PROVIDERS](https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/metadata/RelMetadataQueryBase.html#THREAD_PROVIDERS) field, which is a `ThreadLocal`. `FlinkRelOptClusterFactory` (implicitly) sets `THREAD_PROVIDERS` to the constant `FlinkDefaultRelMetadataProvider` instance. However, due to the fact that `THREAD_PROVIDERS` is an instance of a `ThreadLocal`, when a different thread tries to access `RelMetadataQuery::instance`, `NullPointerException` gets thrown. This change ensures that `RelMetadataQuery` has a reference to `FlinkDefaultRelMetadataProvider` regardless of the thread it gets accessed by.

## Brief change log

- Use `FlinkDefaultRelMetadataProvider` when accessing `FlinkRelMetadataQuery` from a different thread.

## Verifying this change

This change added tests and can be verified as follows:
- Added multithreaded test `FlinkRelMetadataQueryThreadingTest`
- Manually verified the change by running a simple PyFlink job inside Jupyter notebook, interrupting kernel execution (sending SIGINT to `py4j`/Flink instance), and running the job again (basically running the example described in the [JIRA ticket](https://issues.apache.org/jira/browse/FLINK-23020))

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable