### PR TITLE
[FLINK-29030][core] Improve messaging around Kryo & schema evolution

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
@@ -95,16 +95,29 @@ Flink 完全支持 Avro 状态类型的升级，只要数据结构的修改是�
 
 一个例外是如果新的 Avro 数据 schema 生成的类无法被重定位或者使用了不同的命名空间，在作业恢复时状态数据会被认为是不兼容的。
 
-{{< hint warning >}}
-Schema evolution of keys is not supported.
-{{< /hint >}}
+## Schema Migration Limitations
 
-Example: RocksDB state backend relies on binary objects identity, rather than `hashCode` method implementation. Any changes to the keys object structure could lead to non deterministic behaviour.
+Flink's schema migration has some limitations that are required to ensure correctness. For users that need to work
+around these limitations, and understand them to be safe in their specific use-case, consider using
+a [custom serializer]({{< ref "docs/dev/datastream/fault-tolerance/serialization/custom_serialization" >}}) or the
+[state processor api]({{< ref "docs/libs/state_processor_api" >}}).
 
-{{< hint warning >}}
-**Kryo** cannot be used for schema evolution.
-{{< /hint >}}
+### Schema evolution of keys is not supported.
+
+The structure of a key cannot be migrated as this may lead to non-deterministic behavior.
+For example, if a POJO is used as a key and one field is dropped then there may suddenly be
+multiple separate keys that are now identical. Flink has no way to merge the corresponding values.
+
+Additionally, the RocksDB state backend relies on binary object identity, rather than the `hashCode` method. Any change to the keys' object structure can lead to non-deterministic behavior.
+
+### **Kryo** cannot be used for schema evolution.
 
 When Kryo is used, there is no possibility for the framework to verify if any incompatible changes have been made.
+
+{{< hint warning >}}
+This means that if a data-structure containing a given type is serialized via Kryo, then that contained type can **not** undergo schema evolution.
+
+For example, if a POJO contains a `List<SomeOtherPojo>`, then the `List` _and_ its contents are serialized via Kryo and schema evolution is **not** supported for `SomeOtherPojo`.
+{{< /hint >}}
 
 {{< top >}}

--- a/docs/content/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
+++ b/docs/content/docs/dev/datastream/fault-tolerance/serialization/schema_evolution.md
@@ -125,4 +125,10 @@ Additionally, the RocksDB state backend relies on binary object identity, rather
 
 When Kryo is used, there is no possibility for the framework to verify if any incompatible changes have been made.
 
+{{< hint warning >}}
+This means that if a data-structure containing a given type is serialized via Kryo, then that contained type can **not** undergo schema evolution.
+
+For example, if a POJO contains a `List<SomeOtherPojo>`, then the `List` _and_ its contents are serialized via Kryo and schema evolution is **not** supported for `SomeOtherPojo`.
+{{< /hint >}}
+
 {{< top >}}

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -127,7 +127,7 @@ public class TypeExtractor {
     private static final Logger LOG = LoggerFactory.getLogger(TypeExtractor.class);
 
     private static final String GENERIC_TYPE_DOC_HINT =
-            "Please read the Flink documentation on \"Data Types & Serialization\" for details of the effect on performance.";
+            "Please read the Flink documentation on \"Data Types & Serialization\" for details of the effect on performance and schema evolution.";
 
     public static final int[] NO_INDEX = new int[] {};
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -897,6 +897,15 @@ public class TypeExtractor {
             if (subTypesInfo == null) {
                 return analyzePojo(t, new ArrayList<>(typeHierarchy), in1Type, in2Type);
             }
+            for (int i = 0; i < subTypesInfo.length; i++) {
+                if (subTypesInfo[i] instanceof GenericTypeInfo) {
+                    LOG.info(
+                            "Tuple field #{} of type '{}' will be processed as GenericType. {}",
+                            i + 1,
+                            subTypesInfo[i].getTypeClass().getSimpleName(),
+                            GENERIC_TYPE_DOC_HINT);
+                }
+            }
             // return tuple info
             return new TupleTypeInfo(typeToClass(t), subTypesInfo);
 
@@ -2093,6 +2102,13 @@ public class TypeExtractor {
                     typeInfo =
                             createTypeInfoWithTypeHierarchy(
                                     fieldTypeHierarchy, fieldType, in1Type, in2Type);
+                }
+                if (typeInfo instanceof GenericTypeInfo) {
+                    LOG.info(
+                            "Field {}#{} will be processed as GenericType. {}",
+                            clazz.getSimpleName(),
+                            field.getName(),
+                            GENERIC_TYPE_DOC_HINT);
                 }
                 pojoFields.add(new PojoField(field, typeInfo));
             } catch (InvalidTypesException e) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -126,6 +126,9 @@ public class TypeExtractor {
 
     private static final Logger LOG = LoggerFactory.getLogger(TypeExtractor.class);
 
+    private static final String GENERIC_TYPE_DOC_HINT =
+            "Please read the Flink documentation on \"Data Types & Serialization\" for details of the effect on performance.";
+
     public static final int[] NO_INDEX = new int[] {};
 
     protected TypeExtractor() {
@@ -2041,8 +2044,8 @@ public class TypeExtractor {
                     "Class "
                             + clazz.getName()
                             + " is not public so it cannot be used as a POJO type "
-                            + "and must be processed as GenericType. Please read the Flink documentation "
-                            + "on \"Data Types & Serialization\" for details of the effect on performance.");
+                            + "and must be processed as GenericType. {}",
+                    GENERIC_TYPE_DOC_HINT);
             return new GenericTypeInfo<>(clazz);
         }
 
@@ -2055,8 +2058,8 @@ public class TypeExtractor {
                     "No fields were detected for "
                             + clazz
                             + " so it cannot be used as a POJO type "
-                            + "and must be processed as GenericType. Please read the Flink documentation "
-                            + "on \"Data Types & Serialization\" for details of the effect on performance.");
+                            + "and must be processed as GenericType. {}",
+                    GENERIC_TYPE_DOC_HINT);
             return new GenericTypeInfo<>(clazz);
         }
 
@@ -2068,8 +2071,8 @@ public class TypeExtractor {
                         "Class "
                                 + clazz
                                 + " cannot be used as a POJO type because not all fields are valid POJO fields, "
-                                + "and must be processed as GenericType. Please read the Flink documentation "
-                                + "on \"Data Types & Serialization\" for details of the effect on performance.");
+                                + "and must be processed as GenericType. {}",
+                        GENERIC_TYPE_DOC_HINT);
                 return null;
             }
             try {
@@ -2115,8 +2118,8 @@ public class TypeExtractor {
                         "Class "
                                 + clazz
                                 + " contains custom serialization methods we do not call, so it cannot be used as a POJO type "
-                                + "and must be processed as GenericType. Please read the Flink documentation "
-                                + "on \"Data Types & Serialization\" for details of the effect on performance.");
+                                + "and must be processed as GenericType. {}",
+                        GENERIC_TYPE_DOC_HINT);
                 return null;
             }
         }
@@ -2136,8 +2139,8 @@ public class TypeExtractor {
                 LOG.info(
                         clazz
                                 + " is missing a default constructor so it cannot be used as a POJO type "
-                                + "and must be processed as GenericType. Please read the Flink documentation "
-                                + "on \"Data Types & Serialization\" for details of the effect on performance.");
+                                + "and must be processed as GenericType. {}",
+                        GENERIC_TYPE_DOC_HINT);
                 return null;
             }
         }
@@ -2146,8 +2149,8 @@ public class TypeExtractor {
                     "The default constructor of "
                             + clazz
                             + " is not Public so it cannot be used as a POJO type "
-                            + "and must be processed as GenericType. Please read the Flink documentation "
-                            + "on \"Data Types & Serialization\" for details of the effect on performance.");
+                            + "and must be processed as GenericType. {}",
+                    GENERIC_TYPE_DOC_HINT);
             return null;
         }
 


### PR DESCRIPTION
The type extractors will now _always_ log a message if a tuple/pojo contains a generic type. Additionally we now also give a hint that schema evolution may be affected, and finally clarify the schema evolution docs about Kryo blocking it for types contained in serialized data structures.