### PR TITLE
[FLINK-29067][Table SQL/API] Replace deprecated SqlParser#configBuilder with SqlParser#config

### DIFF
--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/package-info.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/package-info.java
@@ -27,13 +27,12 @@
  *
  * <pre>
  *   SqlParser.create(source,
- *   		SqlParser.configBuilder()
- *   			.setParserFactory(new FlinkSqlParserImplFactory(conformance0))
- * 				.setQuoting(Quoting.DOUBLE_QUOTE)
- * 				.setUnquotedCasing(Casing.TO_UPPER)
- * 				.setQuotedCasing(Casing.UNCHANGED)
- * 				.setConformance(conformance0) // the sql conformance you want use.
- * 				.build());
+ *          SqlParser.config()
+ *              .withParserFactory(new FlinkSqlParserImplFactory(conformance0))
+ *              .withQuoting(Quoting.DOUBLE_QUOTE)
+ *              .withUnquotedCasing(Casing.TO_UPPER)
+ *              .withQuotedCasing(Casing.UNCHANGED)
+ *              .withConformance(conformance0); // the sql conformance you want use.
  * </pre>
  *
  * </blockquote>

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/package-info.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/package-info.java
@@ -33,13 +33,12 @@
  *
  * <pre>
  *   SqlParser.create(source,
- *   		SqlParser.configBuilder()
- *   			.setParserFactory(parserImplFactory())
- * 				.setQuoting(Quoting.DOUBLE_QUOTE)
- * 				.setUnquotedCasing(Casing.TO_UPPER)
- * 				.setQuotedCasing(Casing.UNCHANGED)
- * 				.setConformance(conformance0) // the sql conformance you want use.
- * 				.build());
+ *   		SqlParser.config()
+ *   			.withParserFactory(parserImplFactory())
+ * 				.withQuoting(Quoting.DOUBLE_QUOTE)
+ * 				.withUnquotedCasing(Casing.TO_UPPER)
+ * 				.withQuotedCasing(Casing.UNCHANGED)
+ * 				.withConformance(conformance0); // the sql conformance you want use.
  * </pre>
  *
  * </blockquote>

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/CreateTableLikeTest.java
@@ -261,11 +261,10 @@ class CreateTableLikeTest {
 
     private SqlParser createFlinkParser(String expr) {
         SqlParser.Config parserConfig =
-                SqlParser.configBuilder()
-                        .setParserFactory(FlinkSqlParserImpl.FACTORY)
-                        .setLex(Lex.JAVA)
-                        .setIdentifierMaxLength(256)
-                        .build();
+                SqlParser.config()
+                        .withParserFactory(FlinkSqlParserImpl.FACTORY)
+                        .withLex(Lex.JAVA)
+                        .withIdentifierMaxLength(256);
 
         return SqlParser.create(expr, parserConfig);
     }

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkDDLDataTypeTest.java
@@ -600,14 +600,13 @@ class FlinkDDLDataTypeTest {
         }
 
         private static SqlParser.Config createParserConfig(Map<String, Object> options) {
-            return SqlParser.configBuilder()
-                    .setQuoting((Quoting) options.get("quoting"))
-                    .setUnquotedCasing((Casing) options.get("unquotedCasing"))
-                    .setQuotedCasing((Casing) options.get("quotedCasing"))
-                    .setConformance((SqlConformance) options.get("conformance"))
-                    .setCaseSensitive((boolean) options.get("caseSensitive"))
-                    .setParserFactory((SqlParserImplFactory) options.get("parserFactory"))
-                    .build();
+            return SqlParser.config()
+                    .withQuoting((Quoting) options.get("quoting"))
+                    .withUnquotedCasing((Casing) options.get("unquotedCasing"))
+                    .withQuotedCasing((Casing) options.get("quotedCasing"))
+                    .withConformance((SqlConformance) options.get("conformance"))
+                    .withCaseSensitive((boolean) options.get("caseSensitive"))
+                    .withParserFactory((SqlParserImplFactory) options.get("parserFactory"));
         }
 
         private static TestRelDataTypeFactory createTypeFactory(SqlConformance conformance) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -187,7 +187,7 @@ public class PlannerContext {
         }
 
         final SqlParser.Config newSqlParserConfig =
-                SqlParser.configBuilder(sqlParserConfig).setCaseSensitive(caseSensitive).build();
+                sqlParserConfig.withCaseSensitive(caseSensitive);
 
         final SchemaPlus finalRootSchema = getRootSchema(rootSchema.plus());
 


### PR DESCRIPTION

## What is the purpose of the change

Since `SqlParser#configBuilder` is deprecated and probably will be removed in future versions. It is better to replace it with `SqlParser#config` This PR makes this change


## Verifying this change

This change is already covered by existing tests, such as *(please describe tests)*.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
