### PR TITLE
[FLINK-29046][Connectors/Hive] Fix HiveTableSourceStatisticsReportTest fails with Hive 3.x

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV310.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/catalog/hive/client/HiveShimV310.java
@@ -363,7 +363,7 @@ public class HiveShimV310 extends HiveShimV239 {
                             boolean.class,
                             boolean.class,
                             boolean.class,
-                            long.class,
+                            Long.class,
                             int.class,
                             boolean.class);
             loadTableMethod.invoke(
@@ -401,12 +401,13 @@ public class HiveShimV310 extends HiveShimV239 {
                             Path.class,
                             org.apache.hadoop.hive.ql.metadata.Table.class,
                             Map.class,
+                            clazzLoadFileType,
                             boolean.class,
                             boolean.class,
                             boolean.class,
                             boolean.class,
                             boolean.class,
-                            long.class,
+                            Long.class,
                             int.class,
                             boolean.class);
             org.apache.hadoop.hive.ql.metadata.Table table = hive.getTable(tableName);

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceStatisticsReportTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.plan.stats.ColumnStats;
 import org.apache.flink.table.plan.stats.TableStats;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
@@ -40,7 +41,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.table.catalog.hive.client.HiveShimLoader.HIVE_VERSION_V2_3_9;
+import static org.apache.flink.table.catalog.hive.client.HiveShimLoader.HIVE_VERSION_V3_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** Test for statistics functionality in {@link HiveTableSource}. */
 public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBase {
@@ -292,20 +296,46 @@ public class HiveTableSourceStatisticsReportTest extends StatisticsReportTestBas
         expectedColumnStatsMap.put(
                 "f_string",
                 new ColumnStats.Builder().setMax("def").setMin("abcd").setNullCount(0L).build());
-        expectedColumnStatsMap.put(
-                "f_decimal5",
-                new ColumnStats.Builder()
-                        .setMax(new BigDecimal("223.45"))
-                        .setMin(new BigDecimal("123.45"))
-                        .setNullCount(0L)
-                        .build());
-        expectedColumnStatsMap.put(
-                "f_decimal14",
-                new ColumnStats.Builder()
-                        .setMax(new BigDecimal("123333333355.33"))
-                        .setMin(new BigDecimal("123333333333.33"))
-                        .setNullCount(0L)
-                        .build());
+        switch (HiveShimLoader.getHiveVersion()) {
+            case HIVE_VERSION_V2_3_9:
+                expectedColumnStatsMap.put(
+                        "f_decimal5",
+                        new ColumnStats.Builder()
+                                .setMax(new BigDecimal("223.45"))
+                                .setMin(new BigDecimal("123.45"))
+                                .setNullCount(0L)
+                                .build());
+                expectedColumnStatsMap.put(
+                        "f_decimal14",
+                        new ColumnStats.Builder()
+                                .setMax(new BigDecimal("123333333355.33"))
+                                .setMin(new BigDecimal("123333333333.33"))
+                                .setNullCount(0L)
+                                .build());
+                break;
+            case HIVE_VERSION_V3_1_1:
+                // TODO For hive 3.x version, Orc format encounter decimal type columns (like
+                // decimal(5, 2), decimal(14, 2)) will write a wrong column stat 'min' or 'max' in
+                // orc metadata footer. This branch will remove after this error is fixed, following
+                // issue HIVE-26492
+                expectedColumnStatsMap.put(
+                        "f_decimal5",
+                        new ColumnStats.Builder()
+                                .setMax(new BigDecimal("223.45"))
+                                .setMin(new BigDecimal("0"))
+                                .setNullCount(0L)
+                                .build());
+                expectedColumnStatsMap.put(
+                        "f_decimal14",
+                        new ColumnStats.Builder()
+                                .setMax(new BigDecimal("123333333355.33"))
+                                .setMin(new BigDecimal("0"))
+                                .setNullCount(0L)
+                                .build());
+                break;
+            default:
+                fail("Unknown test version " + HiveShimLoader.getHiveVersion());
+        }
         expectedColumnStatsMap.put(
                 "f_decimal38",
                 new ColumnStats.Builder()


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

For `Hive 3.x` version,  `HiveTableSourceStatisticsReportTest` will fail because of `Orc` format encounter decimal type columns (like decimal(5, 2), decimal(14, 2)) will write a wrong column stat `min` in orc metadata footer equals 0.  I  tried to reproduce the error of these two failed tests. I found that the problem was not produced by `HiveTableSourceStatisticsReport` itself. It is caused by `orc.apache.orc.impl.writer.StructTreeWriter` in `hive-exec-3.1.1.` In this class,  method `writeFileStatistics` will create a wrong column stats min value when encounter decimal type data. So, in this pr, I add one `TODO` after this issue is fixed in `Hive` and remove this pr's contents.


## Brief change log

- Adding branch to cover `Hive 3.x` version in `HiveTableSourceStatisticsReportTest`.


## Verifying this change

- Adding branch to cover `Hive 3.x` version in `HiveTableSourceStatisticsReportTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no docs.
