### PR TITLE
[FLINK-29056] Throw PartitionNotFoundException if the partition file is not readable for hybrid shuffle

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/IOUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.util;
 
 import org.slf4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -294,6 +295,22 @@ public final class IOUtils {
                 closeable.close();
             }
         } catch (Throwable ignored) {
+        }
+    }
+
+    /** Delete the given directory or file recursively. */
+    public static void deleteFilesRecursively(Path path) throws Exception {
+        File[] files = path.toFile().listFiles();
+        if (files == null || files.length == 0) {
+            return;
+        }
+
+        for (File file : files) {
+            if (!file.isDirectory()) {
+                Files.deleteIfExists(file.toPath());
+            } else {
+                deleteFilesRecursively(file.toPath());
+            }
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*If data file is not readable especially data loss, throw PartitionNotFoundException to mark this result partition failed. Otherwise, the partition data is not regenerated, so failover can not recover the job.*


## Brief change log

  - *Throw PartitionNotFoundException instead of IOException if the partition file is not readable for hybrid shuffle*

## Verifying this change

This change added tests and can be verified by `HsResultPartitionTest#testCreateSubpartitionViewLostData`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
