### PR TITLE
[FLINK-28735][scripts] Deprecate jobmanager.sh host/port parameters

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/overview.md
@@ -157,7 +157,7 @@ bin/start-cluster.sh
 #### 添加 JobManager
 
 ```bash
-bin/jobmanager.sh ((start|start-foreground) [host] [webui-port])|stop|stop-all
+bin/jobmanager.sh ((start|start-foreground) [args] [webui-port])|stop|stop-all
 ```
 
 <a name="adding-a-taskmanager"></a>

--- a/flink-dist/src/main/flink-bin/bin/jobmanager.sh
+++ b/flink-dist/src/main/flink-bin/bin/jobmanager.sh
@@ -18,7 +18,7 @@
 ################################################################################
 
 # Start/stop a Flink JobManager.
-USAGE="Usage: jobmanager.sh ((start|start-foreground) [host] [webui-port] [args])|stop|stop-all"
+USAGE="Usage: jobmanager.sh ((start|start-foreground) [args])|stop|stop-all"
 
 STARTSTOP=$1
 
@@ -26,11 +26,11 @@ if [ -z $2 ] || [[ $2 == "-D" ]]; then
     # start [-D ...]
     args=("${@:2}")
 elif [ -z $3 ] || [[ $3 == "-D" ]]; then
-    # start <host> [-D ...]
+    # legacy path: start <host> [-D ...]
     HOST=$2
     args=("${@:3}")
 else
-    # start <host> <port> [-D ...]
+    # legacy path: start <host> <port> [-D ...]
     HOST=$2
     WEBUIPORT=$3
     args=("${@:4}")

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -700,12 +700,18 @@ public abstract class ClusterEntrypoint implements AutoCloseableAsync, FatalErro
         final int restPort = entrypointClusterConfiguration.getRestPort();
 
         if (restPort >= 0) {
+            LOG.warn(
+                    "The 'webui-port' parameter of 'jobmanager.sh' has been deprecated. Please use '-D {}=<port> instead.",
+                    RestOptions.PORT);
             configuration.setInteger(RestOptions.PORT, restPort);
         }
 
         final String hostname = entrypointClusterConfiguration.getHostname();
 
         if (hostname != null) {
+            LOG.warn(
+                    "The 'host' parameter of 'jobmanager.sh' has been deprecated. Please use '-D {}=<host> instead.",
+                    JobManagerOptions.ADDRESS);
             configuration.setString(JobManagerOptions.ADDRESS, hostname);
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/parser/CommandLineOptions.java
@@ -32,6 +32,8 @@ public class CommandLineOptions {
                     .desc("Directory which contains the configuration file flink-conf.yml.")
                     .build();
 
+    /** @deprecated subsumed by dynamic properties */
+    @Deprecated
     public static final Option REST_PORT_OPTION =
             Option.builder("r")
                     .longOpt("webui-port")
@@ -49,6 +51,8 @@ public class CommandLineOptions {
                     .desc("use value for given property")
                     .build();
 
+    /** @deprecated subsumed by dynamic properties */
+    @Deprecated
     public static final Option HOST_OPTION =
             Option.builder("h")
                     .longOpt("host")


### PR DESCRIPTION
Deprecates the host/port options of the `jobmanager.sh` script in favor of dynamic properties. These are more flexible and are less likely to be misinterpreted (FLINK-21038).