### PR TITLE
[WIP][FLINK-29055][k8s] add K8S options for excluding the buildin decorators

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -63,6 +63,12 @@
             <td>The desired context from your Kubernetes config file used to configure the Kubernetes client for interacting with the cluster. This could be helpful if one has multiple contexts configured and wants to administrate different Flink clusters on different Kubernetes clusters/contexts.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.decorators.exclude</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>Specify the excluded build-in decorators class name for jobmanager and taskmanager.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.entry.path</h5></td>
             <td style="word-wrap: break-word;">"/docker-entrypoint.sh"</td>
             <td>String</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -450,6 +450,13 @@ public class KubernetesConfigOptions {
                                     + "'. If not explicitly configured, config option '"
                                     + KUBERNETES_POD_TEMPLATE_FILE_KEY
                                     + "' will be used.");
+    public static final ConfigOption<List<String>> BUILD_IN_DECORATORS_EXCLUDE =
+            key("kubernetes.decorators.exclude")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Specify the excluded build-in decorators class name for jobmanager and taskmanager. ");
 
     /**
      * This option is here only for documentation generation, it is the fallback key of

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/BuildInStepDecorators.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/BuildInStepDecorators.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** Return the build-in StepDecorators before create JobManager and TaskManager resources. */
+public class BuildInStepDecorators {
+
+    private static final BuildInStepDecorators INSTANCE = new BuildInStepDecorators();
+    private Map<Integer, Class<KubernetesStepDecorator>> jobManagerStepDecorators;
+    private Map<Integer, Class<KubernetesStepDecorator>> taskManagerStepDecorators;
+
+    public static BuildInStepDecorators getInstance() {
+        return INSTANCE;
+    }
+
+    public BuildInStepDecorators() {
+        this.jobManagerStepDecorators =
+                Stream.of(
+                                new Object[][] {
+                                    {1, InitJobManagerDecorator.class},
+                                    {2, EnvSecretsDecorator.class},
+                                    {3, MountSecretsDecorator.class},
+                                    {4, CmdJobManagerDecorator.class},
+                                    {5, InternalServiceDecorator.class},
+                                    {6, ExternalServiceDecorator.class},
+                                    {7, HadoopConfMountDecorator.class},
+                                    {8, KerberosMountDecorator.class},
+                                    {9, FlinkConfMountDecorator.class},
+                                    {10, PodTemplateMountDecorator.class},
+                                })
+                        .collect(
+                                Collectors.toMap(
+                                        data -> (Integer) data[0],
+                                        data -> (Class<KubernetesStepDecorator>) data[1]));
+
+        this.taskManagerStepDecorators =
+                Stream.of(
+                                new Object[][] {
+                                    {1, InitTaskManagerDecorator.class},
+                                    {2, EnvSecretsDecorator.class},
+                                    {3, MountSecretsDecorator.class},
+                                    {4, CmdTaskManagerDecorator.class},
+                                    {5, HadoopConfMountDecorator.class},
+                                    {6, KerberosMountDecorator.class},
+                                    {7, FlinkConfMountDecorator.class},
+                                })
+                        .collect(
+                                Collectors.toMap(
+                                        data -> (Integer) data[0],
+                                        data -> (Class<KubernetesStepDecorator>) data[1]));
+    }
+
+    public List<KubernetesStepDecorator> loadDecorators(
+            AbstractKubernetesParameters abstractKubernetesParameters) {
+        List<KubernetesStepDecorator> decorators = new ArrayList<>();
+        List<String> kubernetesDecoratorExclude =
+                abstractKubernetesParameters.getKubernetesDecoratorExclude();
+        Map<Integer, Class<KubernetesStepDecorator>> targetMap = null;
+        Class parameterClass = null;
+        if (abstractKubernetesParameters instanceof KubernetesJobManagerParameters) {
+            targetMap = this.jobManagerStepDecorators;
+            parameterClass = KubernetesJobManagerParameters.class;
+        } else if (abstractKubernetesParameters instanceof KubernetesTaskManagerParameters) {
+            targetMap = this.taskManagerStepDecorators;
+            parameterClass = KubernetesTaskManagerParameters.class;
+        }
+        Class finalParameterClass = parameterClass;
+        targetMap.entrySet().stream()
+                .sorted(Map.Entry.<Integer, Class<KubernetesStepDecorator>>comparingByKey())
+                .forEach(
+                        e -> {
+                            if (!kubernetesDecoratorExclude.contains(e.getValue().getName())) {
+                                Class<KubernetesStepDecorator> value = e.getValue();
+                                Constructor<KubernetesStepDecorator> constructor = null;
+                                KubernetesStepDecorator kubernetesStepDecorator = null;
+                                try {
+                                    constructor =
+                                            value.getConstructor(
+                                                    AbstractKubernetesParameters.class);
+                                    kubernetesStepDecorator =
+                                            constructor.newInstance(abstractKubernetesParameters);
+                                } catch (NoSuchMethodException noSuchMethodException) {
+                                    try {
+                                        constructor = value.getConstructor(finalParameterClass);
+                                        kubernetesStepDecorator =
+                                                constructor.newInstance(
+                                                        finalParameterClass.cast(
+                                                                abstractKubernetesParameters));
+                                    } catch (NoSuchMethodException suchMethodException) {
+                                        suchMethodException.printStackTrace();
+                                    } catch (Exception ex) {
+                                        ex.printStackTrace();
+                                    }
+                                } catch (Exception exc) {
+                                    exc.printStackTrace();
+                                }
+                                decorators.add(kubernetesStepDecorator);
+                            }
+                        });
+        return decorators;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -20,17 +20,8 @@ package org.apache.flink.kubernetes.kubeclient.factory;
 
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesJobManagerSpecification;
-import org.apache.flink.kubernetes.kubeclient.decorators.CmdJobManagerDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.EnvSecretsDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.ExternalServiceDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.InitJobManagerDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.InternalServiceDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.KerberosMountDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.BuildInStepDecorators;
 import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.MountSecretsDecorator;
-import org.apache.flink.kubernetes.kubeclient.decorators.PodTemplateMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesOwnerReference;
 import org.apache.flink.kubernetes.utils.Constants;
@@ -61,21 +52,10 @@ public class KubernetesJobManagerFactory {
         FlinkPod flinkPod = Preconditions.checkNotNull(podTemplate).copy();
         List<HasMetadata> accompanyingResources = new ArrayList<>();
 
-        final KubernetesStepDecorator[] stepDecorators =
-                new KubernetesStepDecorator[] {
-                    new InitJobManagerDecorator(kubernetesJobManagerParameters),
-                    new EnvSecretsDecorator(kubernetesJobManagerParameters),
-                    new MountSecretsDecorator(kubernetesJobManagerParameters),
-                    new CmdJobManagerDecorator(kubernetesJobManagerParameters),
-                    new InternalServiceDecorator(kubernetesJobManagerParameters),
-                    new ExternalServiceDecorator(kubernetesJobManagerParameters),
-                    new HadoopConfMountDecorator(kubernetesJobManagerParameters),
-                    new KerberosMountDecorator(kubernetesJobManagerParameters),
-                    new FlinkConfMountDecorator(kubernetesJobManagerParameters),
-                    new PodTemplateMountDecorator(kubernetesJobManagerParameters)
-                };
+        List<KubernetesStepDecorator> jobManagerBuildInStepDecorators =
+                BuildInStepDecorators.getInstance().loadDecorators(kubernetesJobManagerParameters);
 
-        for (KubernetesStepDecorator stepDecorator : stepDecorators) {
+        for (KubernetesStepDecorator stepDecorator : jobManagerBuildInStepDecorators) {
             flinkPod = stepDecorator.decorateFlinkPod(flinkPod);
             accompanyingResources.addAll(stepDecorator.buildAccompanyingKubernetesResources());
         }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -206,4 +206,10 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     public boolean isHostNetworkEnabled() {
         return flinkConfig.getBoolean(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
     }
+
+    public List<String> getKubernetesDecoratorExclude() {
+        return flinkConfig
+                .getOptional(KubernetesConfigOptions.BUILD_IN_DECORATORS_EXCLUDE)
+                .orElse(Collections.emptyList());
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -110,4 +110,7 @@ public interface KubernetesParameters {
      * container(s).
      */
     List<Map<String, String>> getEnvironmentsFromSecrets();
+
+    /** Get the excluded build-in decorators class names. */
+    List<String> getKubernetesDecoratorExclude();
 }


### PR DESCRIPTION
Introduce 2 options for excluding the buildin decorators for jobmanager
and taskmanager.

## What is the purpose of the change

Provide a way to exclude the existing decorators.


## Brief change log

- Introduce 2 options for jobmanager and taskmanager k8s options.
- Maintain a outside Class for generate the said stepDecorators to operate k8s resources.


## Verifying this change
- UTs had been finished.
- Insert several full path classes of existing Decorators to exclude, and verify on the real env whether the associated resources won't be created.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
