### PR TITLE
[FLINK-29087][connector/jdbc] change dependencies order to avoid compile failure while running idea

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -105,6 +105,13 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
 			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
@@ -112,12 +119,6 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-scala-bridge_${scala.binary.version}</artifactId>
-			<version>${project.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>


### PR DESCRIPTION
## What is the purpose of the change

Currently, we rewrite calcite to full its logic on Flink. But in connector-jdbc pom.xml, the wrong order about "flink-table-planner" and "flink-table-planner" (test-jar) will cause idea to fail when running MySqlCatalogITCase. This reason is that the wrong order causes idea to load calcite-1.26 first and then load table-planner, and the rewritten files do not work actually.

BTW, compiling and testing by maven, and other pom.xml will not be affected.

## Brief change log

  - change dependency order about "flink-table-planner" and "flink-table-planner" (test-jar).

## Verifying this change

This change is already covered by existing tests 'MySqlCatalogITCase'

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
