### PR TITLE
[FLINK-28915] Flink Native k8s mode jar localtion support s3 schema.

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
@@ -123,7 +123,7 @@ Now, The jar package supports reading from the [flink filesystem]({{< ref "docs/
 The jar package will be downloaded from filesystem to
 [kubernetes.user.artifacts.base.dir]({{< ref "docs/deployment/config" >}}#kubernetes-user-artifacts-base-dir)/[kubernetes.namespace]({{< ref "docs/deployment/config" >}}#kubernetes-namespace)/[kubernetes.cluster-id]({{< ref "docs/deployment/config" >}}#kubernetes-cluster-id) path in image.
 {{< /hint >}}
-<span class="label label-info">Note</span> `local` schema is also supported .
+<span class="label label-info">Note</span> `local` schema is still supported. If you use `local` schema,  the jar must be provided in the image or download by a init container like [Example]({{< ref "docs/deployment/resource-providers/native_kubernetes" >}}#example-of-pod-template).
 
 
 The `kubernetes.cluster-id` option specifies the cluster name and must be unique.

--- a/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content.zh/docs/deployment/resource-providers/native_kubernetes.md
@@ -97,14 +97,34 @@ COPY /path/of/my-flink-job.jar $FLINK_HOME/usrlib/my-flink-job.jar
 After creating and publishing the Docker image under `custom-image-name`, you can start an Application cluster with the following command:
 
 ```bash
+# Local Schema
 $ ./bin/flink run-application \
     --target kubernetes-application \
     -Dkubernetes.cluster-id=my-first-application-cluster \
     -Dkubernetes.container.image=custom-image-name \
     local:///opt/flink/usrlib/my-flink-job.jar
-```
 
-<span class="label label-info">Note</span> `local` is the only supported scheme in Application Mode.
+# FileSystem
+$ ./bin/flink run-application \
+    --target kubernetes-application \
+    -Dkubernetes.cluster-id=my-first-application-cluster \
+    -Dkubernetes.container.image=custom-image-name \
+    s3://my-bucket/my-flink-job.jar
+
+# Http/Https Schema
+$ ./bin/flink run-application \
+    --target kubernetes-application \
+    -Dkubernetes.cluster-id=my-first-application-cluster \
+    -Dkubernetes.container.image=custom-image-name \
+    http://ip:port/my-flink-job.jar
+```
+{{< hint info >}}
+Now, The jar package supports reading from the [flink filesystem]({{< ref "docs/deployment/filesystems/overview" >}}#docker-hub-flink-images) or Http/Https in Application Mode.  
+The jar package will be downloaded from filesystem to
+[kubernetes.user.artifacts.base.dir]({{< ref "docs/deployment/config" >}}#kubernetes-user-artifacts-base-dir)/[kubernetes.namespace]({{< ref "docs/deployment/config" >}}#kubernetes-namespace)/[kubernetes.cluster-id]({{< ref "docs/deployment/config" >}}#kubernetes-cluster-id) path in image.
+{{< /hint >}}
+<span class="label label-info">Note</span> `local` schema is also supported .
+
 
 The `kubernetes.cluster-id` option specifies the cluster name and must be unique.
 If you do not specify this option, then Flink will generate a random name.

--- a/docs/content/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/native_kubernetes.md
@@ -101,14 +101,33 @@ COPY /path/of/my-flink-job.jar $FLINK_HOME/usrlib/my-flink-job.jar
 After creating and publishing the Docker image under `custom-image-name`, you can start an Application cluster with the following command:
 
 ```bash
+# Local Schema
 $ ./bin/flink run-application \
     --target kubernetes-application \
     -Dkubernetes.cluster-id=my-first-application-cluster \
     -Dkubernetes.container.image=custom-image-name \
     local:///opt/flink/usrlib/my-flink-job.jar
-```
 
-<span class="label label-info">Note</span> `local` is the only supported scheme in Application Mode.
+# FileSystem
+$ ./bin/flink run-application \
+    --target kubernetes-application \
+    -Dkubernetes.cluster-id=my-first-application-cluster \
+    -Dkubernetes.container.image=custom-image-name \
+    s3://my-bucket/my-flink-job.jar
+
+# Http/Https Schema
+$ ./bin/flink run-application \
+    --target kubernetes-application \
+    -Dkubernetes.cluster-id=my-first-application-cluster \
+    -Dkubernetes.container.image=custom-image-name \
+    http://ip:port/my-flink-job.jar
+```
+{{< hint info >}}
+ Now, The jar package supports reading from the [flink filesystem]({{< ref "docs/deployment/filesystems/overview" >}}#docker-hub-flink-images) or Http/Https in Application Mode.  
+The jar package will be downloaded from filesystem to
+[kubernetes.user.artifacts.base.dir]({{< ref "docs/deployment/config" >}}#kubernetes-user-artifacts-base-dir)/[kubernetes.namespace]({{< ref "docs/deployment/config" >}}#kubernetes-namespace)/[kubernetes.cluster-id]({{< ref "docs/deployment/config" >}}#kubernetes-cluster-id) path in image.
+{{< /hint >}}
+ <span class="label label-info">Note</span> `local` schema is also supported .
 
 The `kubernetes.cluster-id` option specifies the cluster name and must be unique.
 If you do not specify this option, then Flink will generate a random name.

--- a/docs/content/docs/deployment/resource-providers/native_kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/native_kubernetes.md
@@ -127,7 +127,7 @@ $ ./bin/flink run-application \
 The jar package will be downloaded from filesystem to
 [kubernetes.user.artifacts.base.dir]({{< ref "docs/deployment/config" >}}#kubernetes-user-artifacts-base-dir)/[kubernetes.namespace]({{< ref "docs/deployment/config" >}}#kubernetes-namespace)/[kubernetes.cluster-id]({{< ref "docs/deployment/config" >}}#kubernetes-cluster-id) path in image.
 {{< /hint >}}
- <span class="label label-info">Note</span> `local` schema is also supported .
+ <span class="label label-info">Note</span> `local` schema is still supported. If you use `local` schema,  the jar must be provided in the image or download by a init container like [Example]({{< ref "docs/deployment/resource-providers/native_kubernetes" >}}#example-of-pod-template).
 
 The `kubernetes.cluster-id` option specifies the cluster name and must be unique.
 If you do not specify this option, then Flink will generate a random name.

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -267,7 +267,13 @@
             <td>The base dir to put the application job artifacts.</td>
         </tr>
         <tr>
-            <td><h5>kubernetes.operator.user.artifacts.http.header</h5></td>
+            <td><h5>kubernetes.user.artifacts.emptyDir.enable</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable create mount an empty dir for <code class="highlighter-rouge">kubernetes.user.artifacts.base.dir</code> to keep user artifacts if container restart.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.user.artifacts.http.header</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
             <td>Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the application job artifacts. Expected format: headerKey1:headerValue1,headerKey2:headerValue2.</td>

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -260,5 +260,17 @@
             <td>Integer</td>
             <td>Defines the number of Kubernetes transactional operation retries before the client gives up. For example, <code class="highlighter-rouge">FlinkKubeClient#checkAndUpdateConfigMap</code>.</td>
         </tr>
+        <tr>
+            <td><h5>kubernetes.user.artifacts.base.dir</h5></td>
+            <td style="word-wrap: break-word;">"/opt/flink/artifacts"</td>
+            <td>String</td>
+            <td>The base dir to put the application job artifacts.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.operator.user.artifacts.http.header</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>Map</td>
+            <td>Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the application job artifacts. Expected format: headerKey1:headerValue1,headerKey2:headerValue2.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesClusterDescriptor.java
@@ -59,7 +59,7 @@ import org.apache.flink.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -202,7 +202,7 @@ public class KubernetesClusterDescriptor implements ClusterDescriptor<String> {
         // No need to do pipelineJars validation if it is a PyFlink job.
         if (!(PackagedProgramUtils.isPython(applicationConfiguration.getApplicationClassName())
                 || PackagedProgramUtils.isPython(applicationConfiguration.getProgramArguments()))) {
-            final List<File> pipelineJars =
+            final List<URI> pipelineJars =
                     KubernetesUtils.checkJarFileForApplicationMode(flinkConfig);
             Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
         }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/ArtifactFetcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/ArtifactFetcher.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.artifact;
+
+import org.apache.flink.configuration.Configuration;
+
+import java.io.File;
+
+/** The artifact fetcher. */
+public interface ArtifactFetcher {
+
+    /**
+     * Fetch the resource from the uri to the targetDir.
+     *
+     * @param uri The artifact to be fetched.
+     * @param flinkConfiguration Flink configuration.
+     * @param targetDir The target dir to put the artifact.
+     * @return The path of the fetched artifact.
+     * @throws Exception Error during fetching the artifact.
+     */
+    File fetch(String uri, Configuration flinkConfiguration, File targetDir) throws Exception;
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/ArtifactUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/ArtifactUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.artifact;
+
+import org.apache.flink.client.program.PackagedProgramUtils;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URI;
+
+/** Manage the user artifacts. */
+public class ArtifactUtils {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ArtifactUtils.class);
+
+    private static synchronized void createIfNotExists(File targetDir) {
+        if (!targetDir.exists()) {
+            try {
+                FileUtils.forceMkdirParent(targetDir);
+                LOG.info("Created dir: {}", targetDir);
+            } catch (Exception e) {
+                throw new FlinkRuntimeException(
+                        String.format("Failed to create the dir: %s", targetDir), e);
+            }
+        }
+    }
+
+    public static File fetch(String jarURI, Configuration flinkConfiguration, String targetDirStr)
+            throws Exception {
+        File targetDir = new File(targetDirStr);
+        createIfNotExists(targetDir);
+        URI uri = PackagedProgramUtils.resolveURI(jarURI);
+        if ("local".equals(uri.getScheme()) && uri.isAbsolute()) {
+            return new File(uri.getPath());
+        } else if ("http".equals(uri.getScheme()) || "https".equals(uri.getScheme())) {
+            return HttpArtifactFetcher.INSTANCE.fetch(jarURI, flinkConfiguration, targetDir);
+        } else {
+            return FileSystemBasedArtifactFetcher.INSTANCE.fetch(
+                    jarURI, flinkConfiguration, targetDir);
+        }
+    }
+
+    public static String generateJarDir(Configuration configuration) {
+        return String.join(
+                File.separator,
+                new String[] {
+                    new File(
+                                    configuration.get(
+                                            KubernetesConfigOptions
+                                                    .KUBERNETES_USER_ARTIFACTS_BASE_DIR))
+                            .getAbsolutePath(),
+                    configuration.get(KubernetesConfigOptions.NAMESPACE),
+                    configuration.get(KubernetesConfigOptions.CLUSTER_ID)
+                });
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/FileSystemBasedArtifactFetcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/FileSystemBasedArtifactFetcher.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.artifact;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.core.fs.FileSystem;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+/** Leverage the flink filesystem plugin to fetch the artifact. */
+public class FileSystemBasedArtifactFetcher implements ArtifactFetcher {
+
+    public static final Logger LOG = LoggerFactory.getLogger(FileSystemBasedArtifactFetcher.class);
+    public static final FileSystemBasedArtifactFetcher INSTANCE =
+            new FileSystemBasedArtifactFetcher();
+
+    @Override
+    public File fetch(String uri, Configuration flinkConfiguration, File targetDir)
+            throws Exception {
+        org.apache.flink.core.fs.Path source = new org.apache.flink.core.fs.Path(uri);
+        long start = System.currentTimeMillis();
+        FileSystem fileSystem = source.getFileSystem();
+        String fileName = source.getName();
+        File targetFile = new File(targetDir, fileName);
+        try (FSDataInputStream inputStream = fileSystem.open(source)) {
+            FileUtils.copyToFile(inputStream, targetFile);
+        }
+        LOG.debug(
+                "Copied file from {} to {}, cost {} ms",
+                source,
+                targetFile,
+                System.currentTimeMillis() - start);
+        return targetFile;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/HttpArtifactFetcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/HttpArtifactFetcher.java
@@ -43,12 +43,9 @@ public class HttpArtifactFetcher implements ArtifactFetcher {
         long start = System.currentTimeMillis();
         URL url = new URL(uri);
         HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-
-        // merged session job level header and cluster level header, session job level header take
-        // precedence.
         Map<String, String> headers =
                 flinkConfiguration.get(
-                        KubernetesConfigOptions.KUBERNETES_USER_JAR_ARTIFACT_HTTP_HEADER);
+                        KubernetesConfigOptions.KUBERNETES_USER_ARTIFACT_HTTP_HEADER);
 
         if (headers != null) {
             headers.forEach(conn::setRequestProperty);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/HttpArtifactFetcher.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/artifact/HttpArtifactFetcher.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.artifact;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+/** Download the jar from the http resource. */
+public class HttpArtifactFetcher implements ArtifactFetcher {
+
+    public static final Logger LOG = LoggerFactory.getLogger(HttpArtifactFetcher.class);
+    public static final HttpArtifactFetcher INSTANCE = new HttpArtifactFetcher();
+
+    @Override
+    public File fetch(String uri, Configuration flinkConfiguration, File targetDir)
+            throws Exception {
+        long start = System.currentTimeMillis();
+        URL url = new URL(uri);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+
+        // merged session job level header and cluster level header, session job level header take
+        // precedence.
+        Map<String, String> headers =
+                flinkConfiguration.get(
+                        KubernetesConfigOptions.KUBERNETES_USER_JAR_ARTIFACT_HTTP_HEADER);
+
+        if (headers != null) {
+            headers.forEach(conn::setRequestProperty);
+        }
+
+        conn.setRequestMethod("GET");
+
+        String fileName = FilenameUtils.getName(url.getPath());
+        File targetFile = new File(targetDir, fileName);
+        try (InputStream inputStream = conn.getInputStream()) {
+            FileUtils.copyToFile(inputStream, targetFile);
+        }
+        LOG.debug(
+                "Copied file from {} to {}, cost {} ms",
+                uri,
+                targetFile,
+                System.currentTimeMillis() - start);
+        return targetFile;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -498,6 +498,20 @@ public class KubernetesConfigOptions {
                             "Whether to enable HostNetwork mode. "
                                     + "The HostNetwork allows the pod could use the node network namespace instead of the individual pod network namespace. Please note that the JobManager service account should have the permission to update Kubernetes service.");
 
+    public static final ConfigOption<Map<String, String>> KUBERNETES_USER_JAR_ARTIFACT_HTTP_HEADER =
+            ConfigOptions.key("kubernetes.user.artifacts.http.header")
+                    .mapType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Custom HTTP header for HttpArtifactFetcher. The header will be applied when getting the application job artifacts. "
+                                    + "Expected format: headerKey1:headerValue1,headerKey2:headerValue2.");
+
+    public static final ConfigOption<String> KUBERNETES_USER_ARTIFACTS_BASE_DIR =
+            ConfigOptions.key("kubernetes.user.artifacts.base.dir")
+                    .stringType()
+                    .defaultValue("/opt/flink/artifacts")
+                    .withDescription("The base dir to put the application job artifacts.");
+
     private static String getDefaultFlinkImage() {
         // The default container image that ties to the exact needed versions of both Flink and
         // Scala.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -498,7 +498,7 @@ public class KubernetesConfigOptions {
                             "Whether to enable HostNetwork mode. "
                                     + "The HostNetwork allows the pod could use the node network namespace instead of the individual pod network namespace. Please note that the JobManager service account should have the permission to update Kubernetes service.");
 
-    public static final ConfigOption<Map<String, String>> KUBERNETES_USER_JAR_ARTIFACT_HTTP_HEADER =
+    public static final ConfigOption<Map<String, String>> KUBERNETES_USER_ARTIFACT_HTTP_HEADER =
             ConfigOptions.key("kubernetes.user.artifacts.http.header")
                     .mapType()
                     .noDefaultValue()
@@ -511,6 +511,17 @@ public class KubernetesConfigOptions {
                     .stringType()
                     .defaultValue("/opt/flink/artifacts")
                     .withDescription("The base dir to put the application job artifacts.");
+
+    public static final ConfigOption<Boolean> KUBERNETES_USER_ARTIFACTS_EMPTYDIR_ENABLE =
+            ConfigOptions.key("kubernetes.user.artifacts.emptyDir.enable")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Whether to enable create mount an empty dir for %s to keep user artifacts if container restart.",
+                                            code(KUBERNETES_USER_ARTIFACTS_BASE_DIR.key()))
+                                    .build());
 
     private static String getDefaultFlinkImage() {
         // The default container image that ties to the exact needed versions of both Flink and

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
@@ -71,11 +71,12 @@ public final class KubernetesApplicationClusterEntrypoint extends ApplicationClu
         final Configuration configuration =
                 KubernetesEntrypointUtils.loadConfiguration(dynamicParameters);
 
-        PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
-        LOG.info("Install default filesystem in Kubernetes Application Mode.");
-        FileSystem.initialize(configuration, pluginManager);
         PackagedProgram program = null;
         try {
+            PluginManager pluginManager =
+                    PluginUtils.createPluginManagerFromRootFolder(configuration);
+            LOG.info("Install default filesystem for fetching user artifacts in Kubernetes Application Mode.");
+            FileSystem.initialize(configuration, pluginManager);
             SecurityContext securityContext = installSecurityContext(configuration);
             program = securityContext.runSecured(() -> getPackagedProgram(configuration));
         } catch (Exception e) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
@@ -75,7 +75,8 @@ public final class KubernetesApplicationClusterEntrypoint extends ApplicationClu
         try {
             PluginManager pluginManager =
                     PluginUtils.createPluginManagerFromRootFolder(configuration);
-            LOG.info("Install default filesystem for fetching user artifacts in Kubernetes Application Mode.");
+            LOG.info(
+                    "Install default filesystem for fetching user artifacts in Kubernetes Application Mode.");
             FileSystem.initialize(configuration, pluginManager);
             SecurityContext securityContext = installSecurityContext(configuration);
             program = securityContext.runSecured(() -> getPackagedProgram(configuration));

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/entrypoint/KubernetesApplicationClusterEntrypoint.java
@@ -26,10 +26,16 @@ import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.PackagedProgramRetriever;
 import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
 import org.apache.flink.kubernetes.utils.KubernetesUtils;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypoint;
 import org.apache.flink.runtime.entrypoint.ClusterEntrypointUtils;
 import org.apache.flink.runtime.entrypoint.DynamicParametersConfigurationParserFactory;
+import org.apache.flink.runtime.security.SecurityConfiguration;
+import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.contexts.SecurityContext;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.JvmShutdownSafeguard;
 import org.apache.flink.runtime.util.SignalHandler;
@@ -65,9 +71,13 @@ public final class KubernetesApplicationClusterEntrypoint extends ApplicationClu
         final Configuration configuration =
                 KubernetesEntrypointUtils.loadConfiguration(dynamicParameters);
 
+        PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
+        LOG.info("Install default filesystem in Kubernetes Application Mode.");
+        FileSystem.initialize(configuration, pluginManager);
         PackagedProgram program = null;
         try {
-            program = getPackagedProgram(configuration);
+            SecurityContext securityContext = installSecurityContext(configuration);
+            program = securityContext.runSecured(() -> getPackagedProgram(configuration));
         } catch (Exception e) {
             LOG.error("Could not create application program.", e);
             System.exit(1);
@@ -111,14 +121,27 @@ public final class KubernetesApplicationClusterEntrypoint extends ApplicationClu
         // No need to do pipelineJars validation if it is a PyFlink job.
         if (!(PackagedProgramUtils.isPython(jobClassName)
                 || PackagedProgramUtils.isPython(programArguments))) {
-            final List<File> pipelineJars =
-                    KubernetesUtils.checkJarFileForApplicationMode(configuration);
-            Preconditions.checkArgument(pipelineJars.size() == 1, "Should only have one jar");
+            final List<File> pipelineJarFiles =
+                    KubernetesUtils.fetchJarFileForApplicationMode(configuration);
+            Preconditions.checkArgument(pipelineJarFiles.size() == 1, "Should only have one jar");
             return DefaultPackagedProgramRetriever.create(
-                    userLibDir, pipelineJars.get(0), jobClassName, programArguments, configuration);
+                    userLibDir,
+                    pipelineJarFiles.get(0),
+                    jobClassName,
+                    programArguments,
+                    configuration);
         }
 
         return DefaultPackagedProgramRetriever.create(
                 userLibDir, jobClassName, programArguments, configuration);
+    }
+
+    private static SecurityContext installSecurityContext(Configuration configuration)
+            throws Exception {
+        LOG.info("Kubernetes Application Mode Install security context.");
+
+        SecurityUtils.install(new SecurityConfiguration(configuration));
+
+        return SecurityUtils.getInstalledContext();
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -105,6 +105,17 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                 .endSpec();
 
         final Container basicMainContainer = decorateMainContainer(flinkPod.getMainContainer());
+        if (flinkConfig.getBoolean(
+                KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_EMPTYDIR_ENABLE)) {
+            basicPodBuilder
+                    .editOrNewSpec()
+                    .addNewVolume()
+                    .withName(Constants.USER_ARTIFACTS_VOLUME)
+                    .withNewEmptyDir()
+                    .endEmptyDir()
+                    .endVolume()
+                    .endSpec();
+        }
 
         return new FlinkPod.Builder(flinkPod)
                 .withPod(basicPodBuilder.build())
@@ -159,6 +170,15 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                                 .withNewFieldRef(API_VERSION, POD_IP_FIELD_PATH)
                                 .build())
                 .endEnv();
+        if (flinkConfig.getBoolean(
+                KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_EMPTYDIR_ENABLE)) {
+            mainContainerBuilder
+                    .addNewVolumeMount()
+                    .withName(Constants.USER_ARTIFACTS_VOLUME)
+                    .withMountPath(kubernetesJobManagerParameters.getUserArtifactsBaseDir())
+                    .endVolumeMount();
+        }
+
         getFlinkLogDirEnv().ifPresent(mainContainerBuilder::addToEnv);
         return mainContainerBuilder.build();
     }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -200,4 +200,8 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
         }
         return replicas;
     }
+
+    public String getUserArtifactsBaseDir() {
+        return flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_BASE_DIR);
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -111,4 +111,6 @@ public class Constants {
     public static final String KUBERNETES_TASK_MANAGER_SCRIPT_PATH = "kubernetes-taskmanager.sh";
 
     public static final String ENV_TM_JVM_MEM_OPTS = "FLINK_TM_JVM_MEM_OPTS";
+
+    public static final String USER_ARTIFACTS_VOLUME = "user-artifacts-volume";
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.program.PackagedProgramUtils;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.kubernetes.artifact.ArtifactUtils;
 import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.highavailability.KubernetesCheckpointStoreUtil;
 import org.apache.flink.kubernetes.highavailability.KubernetesJobGraphStoreUtil;
@@ -396,20 +397,24 @@ public class KubernetesUtils {
         return Arrays.asList("bash", "-c", command);
     }
 
-    public static List<File> checkJarFileForApplicationMode(Configuration configuration) {
+    public static List<URI> checkJarFileForApplicationMode(Configuration configuration) {
+        return configuration.get(PipelineOptions.JARS).stream()
+                .map(FunctionUtils.uncheckedFunction(PackagedProgramUtils::resolveURI))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Fetch the user jar from path.
+     *
+     * @param configuration Flink Configuration
+     * @return User jar File
+     */
+    public static List<File> fetchJarFileForApplicationMode(Configuration configuration) {
+        String targetDir = ArtifactUtils.generateJarDir(configuration);
         return configuration.get(PipelineOptions.JARS).stream()
                 .map(
                         FunctionUtils.uncheckedFunction(
-                                uri -> {
-                                    final URI jarURI = PackagedProgramUtils.resolveURI(uri);
-                                    if (jarURI.getScheme().equals("local") && jarURI.isAbsolute()) {
-                                        return new File(jarURI.getPath());
-                                    }
-                                    throw new IllegalArgumentException(
-                                            "Only \"local\" is supported as schema for application mode."
-                                                    + " This assumes that the jar is located in the image, not the Flink client."
-                                                    + " An example of such path is: local:///opt/flink/examples/streaming/WindowJoin.jar");
-                                }))
+                                uri -> ArtifactUtils.fetch(uri, configuration, targetDir)))
                 .collect(Collectors.toList());
     }
 

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesClusterDescriptorTest.java
@@ -148,17 +148,6 @@ public class KubernetesClusterDescriptorTest extends KubernetesClientTestBase {
     }
 
     @Test
-    public void testDeployApplicationClusterWithNonLocalSchema() {
-        flinkConfig.set(
-                PipelineOptions.JARS, Collections.singletonList("file:///path/of/user.jar"));
-        flinkConfig.set(DeploymentOptions.TARGET, KubernetesDeploymentTarget.APPLICATION.getName());
-        assertThrows(
-                "Only \"local\" is supported as schema for application mode.",
-                IllegalArgumentException.class,
-                () -> descriptor.deployApplicationCluster(clusterSpecification, appConfig));
-    }
-
-    @Test
     public void testDeployApplicationClusterWithClusterAlreadyExists() {
         flinkConfig.set(
                 PipelineOptions.JARS, Collections.singletonList("local:///path/of/user.jar"));

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/ArtifactUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/ArtifactUtilsTest.java
@@ -99,7 +99,7 @@ public class ArtifactUtilsTest {
                             new Configuration()
                                     .set(
                                             KubernetesConfigOptions
-                                                    .KUBERNETES_USER_JAR_ARTIFACT_HTTP_HEADER,
+                                                    .KUBERNETES_USER_ARTIFACT_HTTP_HEADER,
                                             new HashMap<String, String>() {
                                                 {
                                                     put("k1", "v1");

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/ArtifactUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/artifact/ArtifactUtilsTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.artifact;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
+import org.apache.flink.util.Preconditions;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.BindException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.nio.file.Path;
+import java.util.HashMap;
+
+/** Test for {@link ArtifactUtils}. */
+public class ArtifactUtilsTest {
+    private static final Logger LOG = LoggerFactory.getLogger(ArtifactUtilsTest.class);
+    public static final String TEST_NAMESPACE = "flink-artifact-namespace-test";
+    public static final String TEST_CLUSTER_ID = "flink-artifact-cluster-id-test";
+    private Configuration configuration;
+    @TempDir Path tempDir;
+
+    @BeforeEach
+    public void setup() {
+        configuration = new Configuration();
+        configuration.setString(
+                KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_BASE_DIR,
+                tempDir.toAbsolutePath().toString());
+        configuration.setString(KubernetesConfigOptions.NAMESPACE, TEST_NAMESPACE);
+        configuration.setString(KubernetesConfigOptions.CLUSTER_ID, TEST_CLUSTER_ID);
+    }
+
+    @Test
+    public void testGenerateJarDir() {
+        String baseDir = ArtifactUtils.generateJarDir(configuration);
+        String expectedDir =
+                String.join(
+                        File.separator,
+                        new String[] {tempDir.toString(), TEST_NAMESPACE, TEST_CLUSTER_ID});
+        Assertions.assertEquals(expectedDir, baseDir);
+    }
+
+    @Test
+    public void testFilesystemFetch() throws Exception {
+        File sourceFile = mockTheJarFile();
+        File file =
+                ArtifactUtils.fetch(
+                        String.format("file://%s", sourceFile.toURI().getPath()),
+                        configuration,
+                        tempDir.toString());
+        Assertions.assertTrue(file.exists());
+        Assertions.assertEquals(tempDir.toString(), file.getParentFile().toString());
+    }
+
+    @Test
+    public void testHttpFetch() throws Exception {
+        HttpServer httpServer = null;
+        try {
+            httpServer = startHttpServer();
+            File sourceFile = mockTheJarFile();
+            httpServer.createContext(
+                    "/download/major.jar", new DownloadFileHttpHandler(sourceFile));
+
+            File file =
+                    ArtifactUtils.fetch(
+                            String.format(
+                                    "http://127.0.0.1:%d/download/major.jar",
+                                    httpServer.getAddress().getPort()),
+                            new Configuration()
+                                    .set(
+                                            KubernetesConfigOptions
+                                                    .KUBERNETES_USER_JAR_ARTIFACT_HTTP_HEADER,
+                                            new HashMap<String, String>() {
+                                                {
+                                                    put("k1", "v1");
+                                                }
+                                            }),
+                            tempDir.toString());
+            Assertions.assertTrue(file.exists());
+            Assertions.assertEquals(tempDir.toString(), file.getParent());
+            Assertions.assertEquals("major.jar", file.getName());
+        } finally {
+            if (httpServer != null) {
+                httpServer.stop(0);
+            }
+        }
+    }
+
+    private HttpServer startHttpServer() throws IOException {
+        int port = RandomUtils.nextInt(2000, 3000);
+        HttpServer httpServer = null;
+        while (httpServer == null && port <= 65536) {
+            try {
+                httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+                httpServer.setExecutor(null);
+                httpServer.start();
+            } catch (BindException e) {
+                LOG.warn("Failed to start http server", e);
+                port++;
+            }
+        }
+        return httpServer;
+    }
+
+    private File mockTheJarFile() {
+        String className = String.format("%s.class", ArtifactUtilsTest.class.getSimpleName());
+        URL url = ArtifactUtilsTest.class.getResource(className);
+        Assertions.assertNotNull(url);
+        return new File(url.getPath());
+    }
+
+    /** Handler to mock download file. */
+    public static class DownloadFileHttpHandler implements HttpHandler {
+
+        private final File file;
+        private final String contentType = "application/octet-stream";
+
+        public DownloadFileHttpHandler(File fileToDownload) {
+            Preconditions.checkArgument(
+                    fileToDownload.exists(), "The file to be download not exists!");
+            this.file = fileToDownload;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            exchange.getResponseHeaders().add("Content-Type", contentType);
+            exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, file.length());
+            FileUtils.copyFile(this.file, exchange.getResponseBody());
+            exchange.close();
+        }
+    }
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -188,7 +188,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
 
         assertEquals(1, resultPodSpec.getContainers().size());
         assertEquals(SERVICE_ACCOUNT_NAME, resultPodSpec.getServiceAccountName());
-        assertEquals(3, resultPodSpec.getVolumes().size());
+        assertEquals(4, resultPodSpec.getVolumes().size());
 
         final Container resultedMainContainer = resultPodSpec.getContainers().get(0);
         assertEquals(Constants.MAIN_CONTAINER_NAME, resultedMainContainer.getName());
@@ -211,7 +211,7 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
         // The args list is [bash, -c, 'java -classpath $FLINK_CLASSPATH ...'].
         assertEquals(3, resultedMainContainer.getArgs().size());
 
-        assertEquals(3, resultedMainContainer.getVolumeMounts().size());
+        assertEquals(4, resultedMainContainer.getVolumeMounts().size());
     }
 
     @Test
@@ -422,9 +422,10 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
                 podSpec.getVolumes().stream()
                         .anyMatch(
                                 volume ->
-                                        volume.getConfigMap()
-                                                .getName()
-                                                .equals(EXISTING_HADOOP_CONF_CONFIG_MAP)));
+                                        volume.getConfigMap() != null
+                                                && volume.getConfigMap()
+                                                        .getName()
+                                                        .equals(EXISTING_HADOOP_CONF_CONFIG_MAP)));
     }
 
     @Test
@@ -490,5 +491,60 @@ public class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBas
         assertThat(
                 kubernetesJobManagerSpecification.getDeployment().getSpec().getReplicas(),
                 is(JOBMANAGER_REPLICAS));
+    }
+
+    @Test
+    public void testArtifactsEmptyDirVolume() throws IOException {
+        flinkConfig.set(
+                KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_BASE_DIR, "/opt/artifacts");
+        kubernetesJobManagerSpecification =
+                KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(
+                        flinkPod, kubernetesJobManagerParameters);
+        final PodSpec podSpec =
+                kubernetesJobManagerSpecification.getDeployment().getSpec().getTemplate().getSpec();
+        assertTrue(
+                podSpec.getVolumes().stream()
+                        .anyMatch(
+                                resource ->
+                                        resource.getName()
+                                                .equals(Constants.USER_ARTIFACTS_VOLUME)));
+        final Container container = podSpec.getContainers().get(0);
+        assertTrue(
+                container.getVolumeMounts().stream()
+                        .anyMatch(
+                                resouce ->
+                                        resouce.getName().equals(Constants.USER_ARTIFACTS_VOLUME)
+                                                && resouce.getMountPath()
+                                                        .equals(
+                                                                kubernetesJobManagerParameters
+                                                                        .getUserArtifactsBaseDir())));
+    }
+
+    @Test
+    public void testTurnOffArtifactsEmptyDirVolume() throws IOException {
+        flinkConfig.set(KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_EMPTYDIR_ENABLE, false);
+        flinkConfig.set(
+                KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_BASE_DIR, "/opt/artifacts");
+        kubernetesJobManagerSpecification =
+                KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(
+                        flinkPod, kubernetesJobManagerParameters);
+        final PodSpec podSpec =
+                kubernetesJobManagerSpecification.getDeployment().getSpec().getTemplate().getSpec();
+        assertFalse(
+                podSpec.getVolumes().stream()
+                        .anyMatch(
+                                resource ->
+                                        resource.getName()
+                                                .equals(Constants.USER_ARTIFACTS_VOLUME)));
+        final Container container = podSpec.getContainers().get(0);
+        assertFalse(
+                container.getVolumeMounts().stream()
+                        .anyMatch(
+                                resouce ->
+                                        resouce.getName().equals(Constants.USER_ARTIFACTS_VOLUME)
+                                                && resouce.getMountPath()
+                                                        .equals(
+                                                                kubernetesJobManagerParameters
+                                                                        .getUserArtifactsBaseDir())));
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
@@ -260,4 +260,12 @@ public class KubernetesJobManagerParametersTest extends KubernetesTestBase {
         flinkConfig.set(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_REPLICAS, 2);
         assertThat(kubernetesJobManagerParameters.getReplicas(), is(2));
     }
+
+    @Test
+    public void testGetUserArtifactsBaseDir() {
+        flinkConfig.set(
+                KubernetesConfigOptions.KUBERNETES_USER_ARTIFACTS_BASE_DIR, "/opt/job/artifacts");
+        assertEquals(
+                kubernetesJobManagerParameters.getUserArtifactsBaseDir(), "/opt/job/artifacts");
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
Flink On Kerbernetes Native K8s Application Mode supports fetching jar from DFS schema(S3, OSS, HDFS, etc.).


## Brief change log
  - Fetch jar from DFS(S3, OSS, HDFS, etc.) before starting flink cluster.

## Verifying this change
This change added tests and can be verified as follows:
  - Remove `testDeployApplicationClusterWithNonLocalSchema` test
  - Added tests that fetch jar from http schema
  - Added tests that fetch jar from file schema
  -  Manually verify the local, file, oss, HDFS with Kerberos, S3 resource.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: Native Kubernetes Application Mode:  yes
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
