### PR TITLE
[FLINK-29059][table-planner] Fix the existing column stats are deleted incorrectly when analyze table for partial columns

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/AnalyzeTableUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/AnalyzeTableUtil.java
@@ -91,7 +91,7 @@ public class AnalyzeTableUtil {
                             catalog.getPartitionColumnStatistics(objectPath, partitionSpec);
                     // merge stats
                     CatalogColumnStatistics mergedColumnStatistics =
-                            mergeColumnStatistics(oldColumnStat.copy(), newColumnStat);
+                            mergeColumnStatistics(oldColumnStat, newColumnStat);
                     catalog.alterPartitionColumnStatistics(
                             objectPath, partitionSpec, mergedColumnStatistics, false);
                 }
@@ -108,7 +108,7 @@ public class AnalyzeTableUtil {
                         catalog.getTableColumnStatistics(objectPath);
                 // merge stats.
                 CatalogColumnStatistics mergedColumnStatistics =
-                        mergeColumnStatistics(oldColumnStat.copy(), newColumnStat);
+                        mergeColumnStatistics(oldColumnStat, newColumnStat);
                 catalog.alterTableColumnStatistics(objectPath, mergedColumnStatistics, false);
             }
         }
@@ -118,10 +118,11 @@ public class AnalyzeTableUtil {
     private static CatalogColumnStatistics mergeColumnStatistics(
             CatalogColumnStatistics oldColumnStatistics,
             CatalogColumnStatistics newColumnStatistics) {
-        oldColumnStatistics
+        CatalogColumnStatistics columnStatistics = oldColumnStatistics.copy();
+        columnStatistics
                 .getColumnStatisticsData()
                 .putAll(newColumnStatistics.getColumnStatisticsData());
-        return oldColumnStatistics;
+        return columnStatistics;
     }
 
     private static Tuple2<CatalogTableStatistics, CatalogColumnStatistics>

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/AnalyzeTableUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/AnalyzeTableUtil.java
@@ -85,10 +85,15 @@ public class AnalyzeTableUtil {
                         executeSqlAndGenerateStatistics(tableEnv, columns, statSql);
                 CatalogTableStatistics tableStat = result.f0;
                 catalog.alterPartitionStatistics(objectPath, partitionSpec, tableStat, false);
-                CatalogColumnStatistics columnStat = result.f1;
-                if (columnStat != null) {
+                CatalogColumnStatistics newColumnStat = result.f1;
+                if (newColumnStat != null) {
+                    CatalogColumnStatistics oldColumnStat =
+                            catalog.getPartitionColumnStatistics(objectPath, partitionSpec);
+                    // merge stats
+                    CatalogColumnStatistics mergedColumnStatistics =
+                            mergeColumnStatistics(oldColumnStat.copy(), newColumnStat);
                     catalog.alterPartitionColumnStatistics(
-                            objectPath, partitionSpec, columnStat, false);
+                            objectPath, partitionSpec, mergedColumnStatistics, false);
                 }
             }
         } else {
@@ -97,12 +102,26 @@ public class AnalyzeTableUtil {
                     executeSqlAndGenerateStatistics(tableEnv, columns, statSql);
             CatalogTableStatistics tableStat = result.f0;
             catalog.alterTableStatistics(objectPath, tableStat, false);
-            CatalogColumnStatistics columnStat = result.f1;
-            if (columnStat != null) {
-                catalog.alterTableColumnStatistics(objectPath, columnStat, false);
+            CatalogColumnStatistics newColumnStat = result.f1;
+            if (newColumnStat != null) {
+                CatalogColumnStatistics oldColumnStat =
+                        catalog.getTableColumnStatistics(objectPath);
+                // merge stats.
+                CatalogColumnStatistics mergedColumnStatistics =
+                        mergeColumnStatistics(oldColumnStat.copy(), newColumnStat);
+                catalog.alterTableColumnStatistics(objectPath, mergedColumnStatistics, false);
             }
         }
         return TableResultImpl.TABLE_RESULT_OK;
+    }
+
+    private static CatalogColumnStatistics mergeColumnStatistics(
+            CatalogColumnStatistics oldColumnStatistics,
+            CatalogColumnStatistics newColumnStatistics) {
+        oldColumnStatistics
+                .getColumnStatisticsData()
+                .putAll(newColumnStatistics.getColumnStatisticsData());
+        return oldColumnStatistics;
     }
 
     private static Tuple2<CatalogTableStatistics, CatalogColumnStatistics>


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

If there are three columns named `a, b, c` with column stats already exists for non partition table,  when user just analyze column `a` using `Analyze table xxx FOR COLUMNS a`, the existing column stats of `b, c` will be reset back to empty. This error also exists for the partition table.


## Brief change log

- Adding the operation of merging column statistics in  `AnalyzeTableUtil`.
- Adding tests to cover this condition.


## Verifying this change

- IT test is added in `AnalyzeTableITCase` to cover this condition.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  no docs.
