### PR TITLE
[FLINK-29091][table-planner] Fix the determinism declaration of the rand function to be consistent with current behavior

### DIFF
--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -597,7 +597,7 @@ For more examples of custom type inference, see also the `flink-examples-table` 
 2. **在运行时（即在集群执行）**：如果一个函数被调用时带有非常量表达式或 `isDeterministic()` 返回 `false`。
 
 #### 内置函数的确定性
-系统（内置）函数的确定性是不可改变的。存在两种不具有确定性的函数：动态函数和非确定性函数，根据 Apache Calcite `SqlOperator' 的定义：
+系统（内置）函数的确定性是不可改变的。存在两种不具有确定性的函数：动态函数和非确定性函数，根据 Apache Calcite `SqlOperator` 的定义：
 ```java
   /**
    * Returns whether a call to this operator is guaranteed to always return

--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -618,7 +618,7 @@ For more examples of custom type inference, see also the `flink-examples-table` 
 
 `isDeterministic` 表示函数的确定性，声明返回 `false` 时将在运行时对每个记录进行计算。
 `isDynamicFunction` 声明返回 `true` 时意味着该函数只能在查询开始时被计算，对于批处理模式，它只在生成执行计划期间被执行，
-而对于流模式，它等效于一个非确定性的函数，这是因为查询在逻辑上是连续执行的（流模式对[动态表的连续查询抽象]({{< ref "docs/dev/table/concepts/dynamic_tables" >}}#dynamic-tables-amp-continuous-queries)），所以动态函数在每次查询执行时也会被重新计算。
+而对于流模式，它等效于一个非确定性的函数，这是因为查询在逻辑上是连续执行的（流模式对[动态表的连续查询抽象]({{< ref "docs/dev/table/concepts/dynamic_tables" >}}#dynamic-tables-amp-continuous-queries)），所以动态函数在每次查询执行时也会被重新计算（当前实现下等效于每条记录计算）。
 
 以下内置函数总是非确定性的（批和流模式下，都在运行时对每条记录进行计算）
 - UUID

--- a/docs/content.zh/docs/dev/table/functions/udfs.md
+++ b/docs/content.zh/docs/dev/table/functions/udfs.md
@@ -585,6 +585,59 @@ public static class LiteralFunction extends ScalarFunction {
 For more examples of custom type inference, see also the `flink-examples-table` module with
 {{< gh_link file="flink-examples/flink-examples-table/src/main/java/org/apache/flink/table/examples/java/functions/AdvancedFunctionsExample.java" name="advanced function implementation" >}}.
 
+### 确定性
+
+每个用户自定义函数类都可以通过重写 `isDeterministic()` 方法来声明它是否产生确定性的结果。如果该函数不是纯粹函数式的（如`random()`, `date()`, 或`now()`），该方法必须返回 `false`。默认情况下，`isDeterministic()` 返回 `true`。
+
+此外，重写 `isDeterministic()` 方法也可能影响运行时行为。运行时实现可能会在两个不同的阶段被调用：
+
+1. **在生成执行计划期间**：如果一个函数是通过常量表达式调用的或者常量表达式可以从给定的语句中推导出来，那么一个函数就会被预计算以减少常量表达式，并且可能不再在集群上执行。
+除非 `isDeterministic()` 被重写为 `false` 用来在这种情况下禁用常量表达式简化。比如说，以下对 `ABS` 的调用在生成执行计划期间被执行：`SELECT ABS(-1) FROM t` 和 `SELECT ABS(field) FROM t WHERE field = -1`，而 `SELECT ABS(field) FROM t` 则不执行。
+
+2. **在运行时（即在集群执行）**：如果一个函数被调用时带有非常量表达式或 `isDeterministic()` 返回 `false`。
+
+#### 内置函数的确定性
+系统（内置）函数的确定性是不可改变的。存在两种不具有确定性的函数：动态函数和非确定性函数，根据 Apache Calcite `SqlOperator' 的定义：
+```java
+  /**
+   * Returns whether a call to this operator is guaranteed to always return
+   * the same result given the same operands; true is assumed by default.
+   */
+  public boolean isDeterministic() {
+    return true;
+  }
+
+  /**
+   * Returns whether it is unsafe to cache query plans referencing this
+   * operator; false is assumed by default.
+   */
+  public boolean isDynamicFunction() {
+    return false;
+  }
+```
+
+`isDeterministic` 表示函数的确定性，声明返回 `false` 时将在运行时对每个记录进行计算。
+`isDynamicFunction` 声明返回 `true` 时意味着该函数只能在查询开始时被计算，对于批处理模式，它只在生成执行计划期间被执行，
+而对于流模式，它等效于一个非确定性的函数，这是因为查询在逻辑上是连续执行的（流模式对[动态表的连续查询抽象]({{< ref "docs/dev/table/concepts/dynamic_tables" >}}#dynamic-tables-amp-continuous-queries)），所以动态函数在每次查询执行时也会被重新计算。
+
+以下内置函数总是非确定性的（批和流模式下，都在运行时对每条记录进行计算）
+- UUID
+- RAND
+- RAND_INTEGER
+- CURRENT_DATABASE
+- UNIX_TIMESTAMP
+- CURRENT_ROW_TIMESTAMP
+
+以下内置时间函数是动态的，批处理模式下，将在生成执行计划期间被执行（查询开始），对于流模式，将在运行时对每条记录进行计算
+- CURRENT_DATE
+- CURRENT_TIME
+- CURRENT_TIMESTAMP
+- NOW
+- LOCALTIME
+- LOCALTIMESTAMP
+
+注意：`isDynamicFunction` 仅适用于内置函数
+
 ### 运行时集成
 -------------------
 

--- a/docs/content/docs/dev/table/functions/udfs.md
+++ b/docs/content/docs/dev/table/functions/udfs.md
@@ -639,7 +639,7 @@ dynamic function and non-deterministic function, according to Apache Calcite's `
 `isDynamicFunction` implies the function can only be evaluated at query-start if returns `true`,
 it will be only pre-evaluated during planning for batch mode, while for streaming mode, it is equivalent to a non-deterministic
 function because of the query is continuously being executed logically(the abstraction of [continuous query over the dynamic tables]({{< ref "docs/dev/table/concepts/dynamic_tables" >}}#dynamic-tables-amp-continuous-queries)),
-so the dynamic functions are also re-evaluated for each query execution.
+so the dynamic functions are also re-evaluated for each query execution(equivalent to per record in current implementation).
 
 The following system functions are always non-deterministic(evaluated per record during runtime both in batch and streaming mode):
 - UUID

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -39,6 +39,7 @@ import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlSingleOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
@@ -578,6 +579,11 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     "CURRENT_ROW_TIMESTAMP", SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3) {
 
                 @Override
+                public boolean isDeterministic() {
+                    return false;
+                }
+
+                @Override
                 public SqlSyntax getSyntax() {
                     return SqlSyntax.FUNCTION;
                 }
@@ -876,6 +882,42 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 
     public static final SqlFunction TRY_CAST = new SqlTryCastFunction();
 
+    public static final SqlFunction RAND =
+            new SqlFunction(
+                    "RAND",
+                    SqlKind.OTHER_FUNCTION,
+                    ReturnTypes.DOUBLE,
+                    null,
+                    OperandTypes.or(
+                            new SqlSingleOperandTypeChecker[] {
+                                OperandTypes.NILADIC, OperandTypes.NUMERIC
+                            }),
+                    SqlFunctionCategory.NUMERIC) {
+
+                @Override
+                public boolean isDeterministic() {
+                    return false;
+                }
+            };
+
+    public static final SqlFunction RAND_INTEGER =
+            new SqlFunction(
+                    "RAND_INTEGER",
+                    SqlKind.OTHER_FUNCTION,
+                    ReturnTypes.INTEGER,
+                    null,
+                    OperandTypes.or(
+                            new SqlSingleOperandTypeChecker[] {
+                                OperandTypes.NUMERIC, OperandTypes.NUMERIC_NUMERIC
+                            }),
+                    SqlFunctionCategory.NUMERIC) {
+
+                @Override
+                public boolean isDeterministic() {
+                    return false;
+                }
+            };
+
     /** <code>AUXILIARY_GROUP</code> aggregate function. Only be used in internally. */
     public static final SqlAggFunction AUXILIARY_GROUP = new SqlAuxiliaryGroupAggFunction();
 
@@ -1108,8 +1150,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlFunction RADIANS = SqlStdOperatorTable.RADIANS;
     public static final SqlFunction SIGN = SqlStdOperatorTable.SIGN;
     public static final SqlFunction PI = SqlStdOperatorTable.PI;
-    public static final SqlFunction RAND = SqlStdOperatorTable.RAND;
-    public static final SqlFunction RAND_INTEGER = SqlStdOperatorTable.RAND_INTEGER;
 
     // TIME FUNCTIONS
     public static final SqlFunction YEAR = SqlStdOperatorTable.YEAR;

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.xml
@@ -34,6 +34,23 @@ Calc(select=[f0 AS EXPR$0, CAST(2 AS INTEGER) AS EXPR$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testExpressionReductionWithRand">
+    <Resource name="sql">
+      <![CDATA[SELECT RAND(), RAND(), RAND(1), RAND(1), RAND_INTEGER(3), RAND_INTEGER(3) FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[RAND()], EXPR$1=[RAND()], EXPR$2=[RAND(1)], EXPR$3=[RAND(1)], EXPR$4=[RAND_INTEGER(3)], EXPR$5=[RAND_INTEGER(3)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[RAND() AS EXPR$0, RAND() AS EXPR$1, RAND(1) AS EXPR$2, RAND(1) AS EXPR$3, RAND_INTEGER(3) AS EXPR$4, RAND_INTEGER(3) AS EXPR$5])
++- LegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c)]]], fields=[a, b, c])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testExpressionReductionWithUDF">
     <Resource name="sql">
       <![CDATA[SELECT MyUdf(1) FROM MyTable]]>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/NonDeterministicTests.scala
@@ -178,6 +178,15 @@ class NonDeterministicTests extends ExpressionTestBase {
     testAllApis(uuid().charLength(), "CHARACTER_LENGTH(UUID())", "36")
   }
 
+  @Test
+  def testRand(): Unit = {
+    testSqlApi("RAND() <> RAND() or RAND() = RAND()", "TRUE")
+    testSqlApi("RAND(1) <> RAND(1) or RAND(1) = RAND(1)", "TRUE")
+    testSqlApi(
+      "RAND_INTEGER(10) <> RAND_INTEGER(10) or RAND_INTEGER(10) = RAND_INTEGER(10)",
+      "TRUE")
+  }
+
   // ----------------------------------------------------------------------------------------------
 
   override def testData: Row = new Row(0)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/ExpressionReductionRulesTest.scala
@@ -60,6 +60,12 @@ class ExpressionReductionRulesTest extends TableTestBase {
     util.addFunction("MyUdf", Func1)
     util.verifyExecPlan("SELECT PyUdf(), MyUdf(1) FROM MyTable")
   }
+
+  @Test
+  def testExpressionReductionWithRand(): Unit = {
+    util.verifyExecPlan(
+      "SELECT RAND(), RAND(), RAND(1), RAND(1), RAND_INTEGER(3), RAND_INTEGER(3) FROM MyTable")
+  }
 }
 
 @SerialVersionUID(1L)


### PR DESCRIPTION
## What is the purpose of the change
RAND, RAND_INTEGER and CURRENT_ROW_TIMESTAMP are declared as dynamic function (isDynamicFuntion returns true), as the declaration it should only evaluate once at query-level (not per record) for batch mode, [FLINK-21713](https://issues.apache.org/jira/browse/FLINK-21713) did the similar fix for temporal functions.

But current behavior is completely a non-deterministic function which evaluated per record for both batch and streaming mode, it's not a good choice to break current behavior,  and the determinism of RAND function are also different across vendors:

[1] evaluated at query-level though it is treated as non-deterministic function [https://docs.microsoft.com/en-us/sql/relational-databases/user-defined-functions/deterministic-and-nondeterministic-functions?view=sql-server-ver16#built-in-function-determinism](https://docs.microsoft.com/en-us/sql/relational-databases/user-defined-functions/deterministic-and-nondeterministic-functions?view=sql-server-ver16#built-in-function-determinism))

[2][ evaluated at row level:  https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_rand|https://dev.mysql.com/doc/refman/5.7/en/mathematical-functions.html#function_rand)]

[3] evaluated at row level if not specifies a seed,  e.g., DBMS_RANDOM.normal, DBMS_RANDOM.value(1,10)  [https://docs.oracle.com/database/timesten-18.1/TTPLP/d_random.htm#TTPLP71231](https://docs.oracle.com/database/timesten-18.1/TTPLP/d_random.htm#TTPLP71231))

So just fix the determinism declaration of the rand function to be consistent with the current behavior and make it clear in the documentation.

## Brief change log
does not change any process logic 
only update function definition rand/ rand_integer 

## Verifying this change
ExpressionReductionRulesTest NonDeterministicTests

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
