### PR TITLE
[FLINK-29096][table] Add test for json_value, which json path has bla…

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -707,6 +707,9 @@ json:
       `NULL ON EMPTY` or `NULL ON ERROR`, respectively. The default value may be a literal or an
       expression. If the default value itself raises an error, it falls through to the error
       behavior for `ON EMPTY`, and raises an error for `ON ERROR`.
+      
+      For path contains blank characters, should use '[]', which is the grammar of json-path.
+      And path is literal, the character `'` already exists. So you should also use sql escape characters `'`.
 
       ```
       -- "true"
@@ -726,6 +729,9 @@ json:
       -- 0.998D
       JSON_VALUE('{"a.b": [0.998,0.996]}','$.["a.b"][0]' 
           RETURNING DOUBLE)
+      
+      -- "right"
+      JSON_VALUE('{"contains blank": "right"}', 'strict $.[''contains blank'']' NULL ON EMPTY DEFAULT 'wrong' ON ERROR)
       ```
   - sql: JSON_QUERY(jsonValue, path [ { WITHOUT | WITH CONDITIONAL | WITH UNCONDITIONAL } [ ARRAY ] WRAPPER ] [ { NULL | EMPTY ARRAY | EMPTY OBJECT | ERROR } ON EMPTY ] [ { NULL | EMPTY ARRAY | EMPTY OBJECT | ERROR } ON ERROR ])
     table: STRING.jsonQuery(path [, JsonQueryWrapper [, JsonQueryOnEmptyOrError, JsonQueryOnEmptyOrError ] ])

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -812,6 +812,8 @@ json:
       对于空路径表达式或错误，可以将行为定义为返回 `null`、引发错误或返回定义的默认值。当省略时，默认为 `NULL ON EMPTY` 或
       `NULL ON ERROR`。默认值可以是文字或表达式。如果默认值本身引发错误，通过错误就会造成 `ON EMPTY` 的行为，并引发 `ON ERROR` 的错误。
 
+      对于路径表达式中包含空格时,需要使用 '[]', 该语法来自于json-path.同时，path是个常量已经有 `'`字符，因此还需要增加sql转义字符.
+      
       ```
       -- "true"
       JSON_VALUE('{"a": true}', '$.a')
@@ -830,6 +832,9 @@ json:
       -- 0.998D
       JSON_VALUE('{"a.b": [0.998,0.996]}','$.["a.b"][0]'
           RETURNING DOUBLE)
+      
+      -- "right"
+      JSON_VALUE('{"contains blank": "right"}', 'strict $.[''contains blank'']' NULL ON EMPTY DEFAULT 'wrong' ON ERROR)
       ```
   - sql: JSON_QUERY(jsonValue, path [ { WITHOUT | WITH CONDITIONAL | WITH UNCONDITIONAL } [ ARRAY ] WRAPPER ] [ { NULL | EMPTY ARRAY | EMPTY OBJECT | ERROR } ON EMPTY ] [ { NULL | EMPTY ARRAY | EMPTY OBJECT | ERROR } ON ERROR ])
     table: STRING.jsonQuery(path [, JsonQueryWrapper [, JsonQueryOnEmptyOrError, JsonQueryOnEmptyOrError ] ])

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/JsonFunctionsITCase.java
@@ -251,7 +251,20 @@ class JsonFunctionsITCase extends BuiltInFunctionTestBase {
                                         42),
                         "JSON_VALUE(f0, 'strict $.invalid' RETURNING INTEGER NULL ON EMPTY DEFAULT 42 ON ERROR)",
                         42,
-                        INT());
+                        INT())
+
+                // path contains blank characters.
+                .testResult(
+                        $("f0").jsonValue(
+                                        "strict $.['contains blank']",
+                                        STRING(),
+                                        JsonValueOnEmptyOrError.NULL,
+                                        null,
+                                        JsonValueOnEmptyOrError.DEFAULT,
+                                        "wrong"),
+                        "JSON_VALUE(f0, 'strict $.[''contains blank'']' NULL ON EMPTY DEFAULT 'wrong' ON ERROR)",
+                        "right",
+                        STRING());
     }
 
     private static List<TestSetSpec> isJsonSpec() {

--- a/flink-table/flink-table-planner/src/test/resources/json/json-value.json
+++ b/flink-table/flink-table-planner/src/test/resources/json/json-value.json
@@ -6,5 +6,6 @@
     "city": "Munich"
   },
   "roles": ["user", "viewer"],
-  "balance": 13.37
+  "balance": 13.37,
+  "contains blank": "right"
 }


### PR DESCRIPTION
## What is the purpose of the change

*Add test for json_value, which json path has  blank characters*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)
