### PR TITLE
[FLINK-22900]fix fileSystem source table read fileSystem sink table path multi-partition error

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTempFileManager.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionTempFileManager.java
@@ -121,7 +121,7 @@ public class PartitionTempFileManager {
 
     /** Collect all partitioned paths, aggregate according to partition spec. */
     static Map<LinkedHashMap<String, String>, List<Path>> collectPartSpecToPaths(
-            FileSystem fs, List<Path> taskPaths, int partColSize) {
+            FileSystem fs, List<Path> taskPaths, int partColSize) throws IOException {
         Map<LinkedHashMap<String, String>, List<Path>> specToPaths = new HashMap<>();
         for (Path taskPath : taskPaths) {
             searchPartSpecAndPaths(fs, taskPath, partColSize)


### PR DESCRIPTION
## What is the purpose of the change

Fix the problem of partition matching error caused by the parent directory is a hidden file in the case of multiple partitions.

## Brief change log

  - *When judging whether a file is a hidden file, recursively judge whether the parent path is a hidden file*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
