### PR TITLE
[hotfix][Tests] Replace deprecated AbstractThrowableAssert#getRootCause with AbstractThrowableAssert#rootCause

### DIFF
--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
@@ -58,7 +58,7 @@ public class AsyncSinkBaseITCase {
                 .sinkTo(new ArrayListAsyncSink(1, 1, 2, 10, 1000, 10));
         assertThatThrownBy(() -> env.execute("Integration Test: AsyncSinkBaseITCase"))
                 .isInstanceOf(JobExecutionException.class)
-                .getRootCause()
+                .rootCause()
                 .hasMessageContaining(
                         "Intentional error on persisting 1_000_000 to ArrayListDestination");
     }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDynamicTableFactoryTest.java
@@ -220,7 +220,7 @@ public class HiveDynamicTableFactoryTest {
                         STREAMING_SOURCE_MONITOR_INTERVAL.key(),
                         STREAMING_SOURCE_CONSUME_START_OFFSET.key()));
         assertThatThrownBy(() -> getTableSource("table9"))
-                .getRootCause()
+                .rootCause()
                 .hasMessage(
                         "The 'streaming-source.consume-start-offset' is not supported when "
                                 + "set 'streaming-source.partition.include' to 'latest'");

--- a/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
+++ b/flink-connectors/flink-connector-jdbc/src/test/java/org/apache/flink/connector/jdbc/table/JdbcOutputFormatTest.java
@@ -181,7 +181,7 @@ public class JdbcOutputFormatTest extends JdbcDataTestBase {
                             outputFormat.writeRecord(row);
                             outputFormat.close();
                         })
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(ClassCastException.class);
     }
 
@@ -221,7 +221,7 @@ public class JdbcOutputFormatTest extends JdbcDataTestBase {
                             outputFormat.writeRecord(row);
                             outputFormat.close();
                         })
-                .getRootCause()
+                .rootCause()
                 .isInstanceOf(ClassCastException.class);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcessTest.java
@@ -361,7 +361,7 @@ public class SessionDispatcherLeaderProcessTest {
         terminationFuture.completeExceptionally(expectedFailure);
 
         final Throwable error = fatalErrorHandler.getErrorFuture().join();
-        assertThat(error).getRootCause().isEqualTo(expectedFailure);
+        assertThat(error).rootCause().isEqualTo(expectedFailure);
 
         fatalErrorHandler.clearError();
     }


### PR DESCRIPTION

## What is the purpose of the change

This a trivial PR replacing deprecated `AbstractThrowableAssert#getRootCause` with `AbstractThrowableAssert#rootCause`

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable )
