### PR TITLE
[FLINK-29120][table-planner] avoid join hint propagating into view

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/calcite/FlinkPlannerImpl.scala
@@ -199,10 +199,8 @@ class FlinkPlannerImpl(
       val sqlToRelConverter: SqlToRelConverter = if (checkContainJoinHintShuttle.containsJoinHint) {
         val converter = createSqlToRelConverter(
           sqlValidator,
-          // disable project merge
-          // if the project can merge, when the join hints exist, the join hints
-          // can be attached into the current project which maybe has a query block hint
-          // when parsing 'select', and cause join hints propagating into the query block
+          // disable project merge during sql to rel phase to prevent
+          // incorrect propagation of join hints into child query block
           sqlToRelConverterConfig.addRelBuilderConfigTransform(c => c.withBloat(-1))
         )
         // TODO currently, it is a relatively hacked way to tell converter

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
@@ -95,6 +95,9 @@ public abstract class JoinHintTestBase extends TableTestBase {
                                 + ")");
 
         util.tableEnv().executeSql("CREATE View V4 as select a3 as a4, b3 as b4 from T3");
+
+        util.tableEnv()
+                .executeSql("create view V5 as select T1.* from T1 join T2 on T1.a1 = T2.a2");
     }
 
     protected abstract String getTestSingleJoinHint();
@@ -372,33 +375,27 @@ public abstract class JoinHintTestBase extends TableTestBase {
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInView1() {
+    public void testJoinHintWithoutAffectingJoinInViewWhileArgsCanBeFoundInOuterJoin() {
         // the join in V2 will use the planner's default join strategy,
-        // and the join between T1 and V2 will use BROADCAST
-        util.tableEnv()
-                .executeSql("create view V2 as select T1.* from T1 join T2 on T1.a1 = T2.a2");
-
-        String sql = "select /*+ %s(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1";
+        // and the join between T1 and V5 will use the tested join hint
+        String sql = "select /*+ %s(T1)*/T1.* from T1 join V5 on T1.a1 = V5.a1";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInView2() {
+    public void testJoinHintWithoutAffectingJoinInViewWhileOuterQueryIsNotJoin() {
         // the join in V2 will use the planner's default join strategy,
-        // and the join between T1 and V2 will use BROADCAST
-        util.tableEnv()
-                .executeSql("create view V2 as select T1.* from T1 join T2 on T1.a1 = T2.a2");
-
-        String sql = "select /*+ %s(T1)*/* from V2";
+        // and the join between T1 and V5 will use the tested join hint
+        String sql = "select /*+ %s(T1)*/* from V5";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInView3() {
+    public void testJoinHintWithoutAffectingJoinInViewWhileRootOfViewIsFilter() {
         // the join in V2 will use the planner's default join strategy,
-        // and the join between T1 and V2 will use BROADCAST
+        // and the join between T1 and V2 will use the tested join hint
         util.tableEnv()
                 .executeSql(
                         "create view V2 as select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc'");
@@ -409,9 +406,25 @@ public abstract class JoinHintTestBase extends TableTestBase {
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInSubQuery1() {
+    public void testJoinHintWithSimpleSumInSelectList() {
+        String sql =
+                "select /*+ %s(T1)*/T1.b1, sum(T1.a1) from T1 join T2 on T1.b1 = T2.b2 group by T1.b1";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithCastInSelectList() {
+        String sql =
+                "select /*+ %s(T1)*/T1.b1, cast(T1.a1 as int) from T1 join T2 on T1.b1 = T2.b2";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithoutAffectingJoinInSubQueryWhileArgsCanBeFoundInOuterJoin() {
         // the join in sub-query will use the planner's default join strategy,
-        // and the join outside will use BROADCAST
+        // and the join outside will use the tested join hint
         String sql =
                 "select /*+ %s(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1";
 
@@ -419,14 +432,14 @@ public abstract class JoinHintTestBase extends TableTestBase {
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInSubQuery2() {
+    public void testJoinHintWithoutAffectingJoinInSubQueryWhileOuterQueryIsNotJoin() {
         String sql = "select /*+ %s(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInSubQuery3() {
+    public void testJoinHintWithoutAffectingJoinInSubQueryWhileRootOfSubQueryIsFilter() {
         String sql =
                 "select /*+ %s(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')";
 
@@ -434,9 +447,33 @@ public abstract class JoinHintTestBase extends TableTestBase {
     }
 
     @Test
+    public void testJoinHintWithoutAffectingJoinInSubQueryWhileContainsSumInQueryBlock() {
+        String sql =
+                "select /*+ %s(T1)*/T4.a1, (select count(*) from T1 join T3 on T1.a1 = T3.a3) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc') T4";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectList() {
+        String sql =
+                "select /*+ %s(T1)*/T4.a1, (select count(*) from T1 join ((select T1.a1 as a3 from T1) union (select a3 from T3)) T3 on T1.a1 = T3.a3 where T3.a3 = 1) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2) T4";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectFrom() {
+        String sql =
+                "select /*+ %s(T1)*/T4.a1 from (select T1.* from T1 join ((select T1.a1 as a2 from T1) union (select a2 from T2)) T2 on T1.a1 = T2.a2) T4";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
     public void testJoinHintWithTableAlias() {
         // the join in sub-query will use the planner's default join strategy,
-        // and the join between T1 and alias V2 will use BROADCAST
+        // and the join between T1 and alias V2 will use the tested join hint
         String sql =
                 "select /*+ %s(V2)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1";
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
@@ -372,7 +372,7 @@ public abstract class JoinHintTestBase extends TableTestBase {
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInView() {
+    public void testJoinHintWithoutAffectingJoinInView1() {
         // the join in V2 will use the planner's default join strategy,
         // and the join between T1 and V2 will use BROADCAST
         util.tableEnv()
@@ -384,11 +384,51 @@ public abstract class JoinHintTestBase extends TableTestBase {
     }
 
     @Test
-    public void testJoinHintWithoutAffectingJoinInSubQuery() {
+    public void testJoinHintWithoutAffectingJoinInView2() {
+        // the join in V2 will use the planner's default join strategy,
+        // and the join between T1 and V2 will use BROADCAST
+        util.tableEnv()
+                .executeSql("create view V2 as select T1.* from T1 join T2 on T1.a1 = T2.a2");
+
+        String sql = "select /*+ %s(T1)*/* from V2";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithoutAffectingJoinInView3() {
+        // the join in V2 will use the planner's default join strategy,
+        // and the join between T1 and V2 will use BROADCAST
+        util.tableEnv()
+                .executeSql(
+                        "create view V2 as select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc'");
+
+        String sql = "select /*+ %s(T1)*/* from V2";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithoutAffectingJoinInSubQuery1() {
         // the join in sub-query will use the planner's default join strategy,
         // and the join outside will use BROADCAST
         String sql =
                 "select /*+ %s(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithoutAffectingJoinInSubQuery2() {
+        String sql = "select /*+ %s(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithoutAffectingJoinInSubQuery3() {
+        String sql =
+                "select /*+ %s(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
     }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/BroadcastJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/BroadcastJoinHintTest.xml
@@ -838,7 +838,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -868,7 +868,78 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[EXPR$0]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[EXPR$0]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -898,6 +969,56 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[V2]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithoutCaseSensitive">
     <Resource name="sql">
       <![CDATA[select /*+ BrOaDcAsT(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -913,27 +1034,6 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2], isBroadcast=[true], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
-    <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
 :- Exchange(distribution=[broadcast])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/BroadcastJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/BroadcastJoinHintTest.xml
@@ -437,6 +437,28 @@ NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithCastInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.b1, cast(T1.a1 as int) from T1 join T2 on T1.b1 = T2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b1=[$1], EXPR$1=[CAST($0):INTEGER])
++- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[b1, CAST(a1 AS INTEGER) AS EXPR$1])
++- HashJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2], isBroadcast=[true], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithDisabledOperator">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -838,7 +860,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -868,7 +890,138 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsSumInQueryBlock">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1, (select count(*) from T1 join T3 on T1.a1 = T3.a3) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc') T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[T4]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], build=[right], singleRowJoin=[true])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+      +- Exchange(distribution=[single])
+         +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+            +- Calc(select=[0 AS $f0])
+               +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[right])
+                  :- Exchange(distribution=[hash[a1]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  +- Exchange(distribution=[hash[a3]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectFrom">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1 from (select T1.* from T1 join ((select T1.a1 as a2 from T1) union (select a2 from T2)) T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T2]]]])
+         :- LogicalProject(a2=[$0])
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalProject(a2=[$0])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a10)], select=[a1, a10], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+   +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
+      +- Exchange(distribution=[hash[a1]])
+         +- LocalHashAggregate(groupBy=[a1], select=[a1])
+            +- Union(all=[true], union=[a1])
+               :- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1, (select count(*) from T1 join ((select T1.a1 as a3 from T1) union (select a3 from T3)) T3 on T1.a1 = T3.a3 where T3.a3 = 1) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalFilter(condition=[=($2, 1)])
+      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+        LogicalUnion(all=[false])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[right])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[right])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- Calc(select=[*(EXPR$0, EXPR$00) AS $f2])
+      +- NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[EXPR$0, EXPR$00], build=[left], singleRowJoin=[true])
+         :- Exchange(distribution=[broadcast])
+         :  +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+         :     +- Exchange(distribution=[single])
+         :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+         :           +- Calc(select=[a1], where=[=(a1, 1)])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- HashAggregate(isMerge=[true], groupBy=[a3], select=[a3])
+                     +- Exchange(distribution=[hash[a3]])
+                        +- LocalHashAggregate(groupBy=[a3], select=[a3])
+                           +- Union(all=[true], union=[a3])
+                              :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileOuterQueryIsNotJoin">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
     </Resource>
@@ -892,7 +1045,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileRootOfSubQueryIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
     </Resource>
@@ -918,38 +1071,17 @@ Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
-    <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V5 on T1.a1 = V5.a1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0] options:[T1]]]])
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
          :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
          +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -969,15 +1101,15 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileOuterQueryIsNotJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V5]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
-+- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
       :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -993,7 +1125,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileRootOfViewIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
     </Resource>
@@ -1034,6 +1166,27 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2], isBroadcast=[true], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
 :- Exchange(distribution=[broadcast])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
@@ -1128,6 +1281,32 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithSimpleSumInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.b1, sum(T1.a1) from T1 join T2 on T1.b1 = T2.b2 group by T1.b1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
++- LogicalProject(b1=[$1], a1=[$0])
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[BROADCAST inheritPath:[0, 0] options:[T1]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[b1], select=[b1, Final_SUM(sum$0) AS EXPR$1])
++- Exchange(distribution=[hash[b1]])
+   +- LocalHashAggregate(groupBy=[b1], select=[b1, Partial_SUM(a1) AS sum$0])
+      +- Calc(select=[b1, a1])
+         +- HashJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2], isBroadcast=[true], build=[left])
+            :- Exchange(distribution=[broadcast])
+            :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+            +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/NestLoopJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/NestLoopJoinHintTest.xml
@@ -835,7 +835,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
     <Resource name="sql">
       <![CDATA[select /*+ NEST_LOOP(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -865,7 +865,78 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[EXPR$0]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[EXPR$0]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[NEST_LOOP inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
     <Resource name="sql">
       <![CDATA[select /*+ NEST_LOOP(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -895,6 +966,56 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[V2]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithoutCaseSensitive">
     <Resource name="sql">
       <![CDATA[select /*+ NeSt_lOoP(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -910,27 +1031,6 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 NestedLoopJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
-    <Resource name="sql">
-      <![CDATA[select /*+ NEST_LOOP(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[NEST_LOOP inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
 :- Exchange(distribution=[broadcast])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/NestLoopJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/NestLoopJoinHintTest.xml
@@ -436,6 +436,28 @@ NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithCastInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/T1.b1, cast(T1.a1 as int) from T1 join T2 on T1.b1 = T2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b1=[$1], EXPR$1=[CAST($0):INTEGER])
++- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[NEST_LOOP inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[b1, CAST(a1 AS INTEGER) AS EXPR$1])
++- NestedLoopJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2], build=[left])
+   :- Exchange(distribution=[broadcast])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithDisabledOperator">
     <Resource name="sql">
       <![CDATA[select /*+ NEST_LOOP(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -835,7 +857,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
       <![CDATA[select /*+ NEST_LOOP(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -865,7 +887,138 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsSumInQueryBlock">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/T4.a1, (select count(*) from T1 join T3 on T1.a1 = T3.a3) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc') T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[T4]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], build=[right])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+      +- Exchange(distribution=[single])
+         +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+            +- Calc(select=[0 AS $f0])
+               +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[right])
+                  :- Exchange(distribution=[hash[a1]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  +- Exchange(distribution=[hash[a3]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectFrom">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/T4.a1 from (select T1.* from T1 join ((select T1.a1 as a2 from T1) union (select a2 from T2)) T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T2]]]])
+         :- LogicalProject(a2=[$0])
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalProject(a2=[$0])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a10)], select=[a1, a10], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+   +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
+      +- Exchange(distribution=[hash[a1]])
+         +- LocalHashAggregate(groupBy=[a1], select=[a1])
+            +- Union(all=[true], union=[a1])
+               :- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/T4.a1, (select count(*) from T1 join ((select T1.a1 as a3 from T1) union (select a3 from T3)) T3 on T1.a1 = T3.a3 where T3.a3 = 1) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalFilter(condition=[=($2, 1)])
+      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+        LogicalUnion(all=[false])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[right])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[right])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- Calc(select=[*(EXPR$0, EXPR$00) AS $f2])
+      +- NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[EXPR$0, EXPR$00], build=[left], singleRowJoin=[true])
+         :- Exchange(distribution=[broadcast])
+         :  +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+         :     +- Exchange(distribution=[single])
+         :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+         :           +- Calc(select=[a1], where=[=(a1, 1)])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- HashAggregate(isMerge=[true], groupBy=[a3], select=[a3])
+                     +- Exchange(distribution=[hash[a3]])
+                        +- LocalHashAggregate(groupBy=[a3], select=[a3])
+                           +- Union(all=[true], union=[a3])
+                              :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileOuterQueryIsNotJoin">
     <Resource name="sql">
       <![CDATA[select /*+ NEST_LOOP(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
     </Resource>
@@ -889,7 +1042,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileRootOfSubQueryIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ NEST_LOOP(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
     </Resource>
@@ -915,38 +1068,17 @@ Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ NEST_LOOP(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[NEST_LOOP inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
-    <Resource name="sql">
-      <![CDATA[select /*+ NEST_LOOP(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
+      <![CDATA[select /*+ NEST_LOOP(T1)*/T1.* from T1 join V5 on T1.a1 = V5.a1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[NEST_LOOP inheritPath:[0] options:[T1]]]])
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
          :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
          +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -966,15 +1098,15 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileOuterQueryIsNotJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ NEST_LOOP(T1)*/* from V2]]>
+      <![CDATA[select /*+ NEST_LOOP(T1)*/* from V5]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
-+- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
       :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -990,7 +1122,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileRootOfViewIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ NEST_LOOP(T1)*/* from V2]]>
     </Resource>
@@ -1031,6 +1163,27 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
     <Resource name="optimized rel plan">
       <![CDATA[
 NestedLoopJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[NEST_LOOP inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
 :- Exchange(distribution=[broadcast])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
@@ -1124,6 +1277,32 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithSimpleSumInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ NEST_LOOP(T1)*/T1.b1, sum(T1.a1) from T1 join T2 on T1.b1 = T2.b2 group by T1.b1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
++- LogicalProject(b1=[$1], a1=[$0])
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[NEST_LOOP inheritPath:[0, 0] options:[T1]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashAggregate(isMerge=[true], groupBy=[b1], select=[b1, Final_SUM(sum$0) AS EXPR$1])
++- Exchange(distribution=[hash[b1]])
+   +- LocalHashAggregate(groupBy=[b1], select=[b1, Partial_SUM(a1) AS sum$0])
+      +- Calc(select=[b1, a1])
+         +- NestedLoopJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2], build=[left])
+            :- Exchange(distribution=[broadcast])
+            :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+            +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleHashJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleHashJoinHintTest.xml
@@ -452,6 +452,29 @@ NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithCastInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T1.b1, cast(T1.a1 as int) from T1 join T2 on T1.b1 = T2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b1=[$1], EXPR$1=[CAST($0):INTEGER])
++- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[SHUFFLE_HASH inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[b1, CAST(a1 AS INTEGER) AS EXPR$1])
++- HashJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2], build=[left])
+   :- Exchange(distribution=[hash[b1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithDisabledOperator">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_HASH(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -867,7 +890,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -897,7 +920,138 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsSumInQueryBlock">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T4.a1, (select count(*) from T1 join T3 on T1.a1 = T3.a3) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc') T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[T4]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], build=[right], singleRowJoin=[true])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+      +- Exchange(distribution=[single])
+         +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+            +- Calc(select=[0 AS $f0])
+               +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[right])
+                  :- Exchange(distribution=[hash[a1]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  +- Exchange(distribution=[hash[a3]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectFrom">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T4.a1 from (select T1.* from T1 join ((select T1.a1 as a2 from T1) union (select a2 from T2)) T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T2]]]])
+         :- LogicalProject(a2=[$0])
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalProject(a2=[$0])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a10)], select=[a1, a10], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+   +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
+      +- Exchange(distribution=[hash[a1]])
+         +- LocalHashAggregate(groupBy=[a1], select=[a1])
+            +- Union(all=[true], union=[a1])
+               :- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T4.a1, (select count(*) from T1 join ((select T1.a1 as a3 from T1) union (select a3 from T3)) T3 on T1.a1 = T3.a3 where T3.a3 = 1) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalFilter(condition=[=($2, 1)])
+      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+        LogicalUnion(all=[false])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[right])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[right])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- Calc(select=[*(EXPR$0, EXPR$00) AS $f2])
+      +- NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[EXPR$0, EXPR$00], build=[left], singleRowJoin=[true])
+         :- Exchange(distribution=[broadcast])
+         :  +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+         :     +- Exchange(distribution=[single])
+         :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+         :           +- Calc(select=[a1], where=[=(a1, 1)])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- HashAggregate(isMerge=[true], groupBy=[a3], select=[a3])
+                     +- Exchange(distribution=[hash[a3]])
+                        +- LocalHashAggregate(groupBy=[a3], select=[a3])
+                           +- Union(all=[true], union=[a3])
+                              :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileOuterQueryIsNotJoin">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
     </Resource>
@@ -921,7 +1075,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileRootOfSubQueryIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
     </Resource>
@@ -947,38 +1101,17 @@ Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_HASH(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_HASH inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
-    <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T1.* from T1 join V5 on T1.a1 = V5.a1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[SHUFFLE_HASH inheritPath:[0] options:[T1]]]])
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
          :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
          +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -998,15 +1131,15 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileOuterQueryIsNotJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from V2]]>
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from V5]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
-+- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
       :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -1022,7 +1155,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileRootOfViewIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from V2]]>
     </Resource>
@@ -1067,6 +1200,27 @@ HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2], build
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_HASH inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
 ]]>
     </Resource>
   </TestCase>
@@ -1159,6 +1313,31 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithSimpleSumInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T1.b1, sum(T1.a1) from T1 join T2 on T1.b1 = T2.b2 group by T1.b1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
++- LogicalProject(b1=[$1], a1=[$0])
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[SHUFFLE_HASH inheritPath:[0, 0] options:[T1]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[b1], select=[b1, SUM(a1) AS EXPR$1])
++- Calc(select=[b1, a1])
+   +- HashJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2], build=[left])
+      :- Exchange(distribution=[hash[b1]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+      +- Exchange(distribution=[hash[b2]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleHashJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleHashJoinHintTest.xml
@@ -867,7 +867,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -897,7 +897,78 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[EXPR$0]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[EXPR$0]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_HASH inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_HASH(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -927,6 +998,56 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_HASH(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[V2]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithoutCaseSensitive">
     <Resource name="sql">
       <![CDATA[select /*+ ShUfFlE_HaSh(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -946,27 +1067,6 @@ HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2], build
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
-    <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_HASH(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_HASH inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleMergeJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleMergeJoinHintTest.xml
@@ -867,7 +867,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -897,7 +897,78 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[EXPR$0]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[EXPR$0]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_MERGE inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -927,6 +998,56 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[V2]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+   :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[a2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithoutCaseSensitive">
     <Resource name="sql">
       <![CDATA[select /*+ ShUfFlE_MeRgE(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -946,27 +1067,6 @@ SortMergeJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
-    <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_MERGE(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_MERGE inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleMergeJoinHintTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/hints/batch/ShuffleMergeJoinHintTest.xml
@@ -452,6 +452,29 @@ NestedLoopJoin(joinType=[LeftAntiJoin], where=[OR(IS NULL(a1), IS NULL(a2), =(a1
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithCastInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T1.b1, cast(T1.a1 as int) from T1 join T2 on T1.b1 = T2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b1=[$1], EXPR$1=[CAST($0):INTEGER])
++- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[SHUFFLE_MERGE inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[b1, CAST(a1 AS INTEGER) AS EXPR$1])
++- SortMergeJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2])
+   :- Exchange(distribution=[hash[b1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+   +- Exchange(distribution=[hash[b2]])
+      +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithDisabledOperator">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_MERGE(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -867,7 +890,7 @@ NestedLoopJoin(joinType=[InnerJoin], where=[>(a1, a2)], select=[a1, b1, a2, b2],
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -897,7 +920,138 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsSumInQueryBlock">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T4.a1, (select count(*) from T1 join T3 on T1.a1 = T3.a3) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc') T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[T4]]]])
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, EXPR$0], build=[right], singleRowJoin=[true])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[left])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- Calc(select=[a1], where=[=(b1, 'abc')])
+:     :     +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[]]], fields=[a1, b1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+      +- Exchange(distribution=[single])
+         +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+            +- Calc(select=[0 AS $f0])
+               +- HashJoin(joinType=[InnerJoin], where=[=(a1, a3)], select=[a1, a3], build=[right])
+                  :- Exchange(distribution=[hash[a1]])
+                  :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                  +- Exchange(distribution=[hash[a3]])
+                     +- TableSourceScan(table=[[default_catalog, default_database, T3, project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectFrom">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T4.a1 from (select T1.* from T1 join ((select T1.a1 as a2 from T1) union (select a2 from T2)) T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T2]]]])
+         :- LogicalProject(a2=[$0])
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+         +- LogicalProject(a2=[$0])
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a1])
++- HashJoin(joinType=[InnerJoin], where=[=(a1, a10)], select=[a1, a10], build=[right])
+   :- Exchange(distribution=[hash[a1]])
+   :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+   +- HashAggregate(isMerge=[true], groupBy=[a1], select=[a1])
+      +- Exchange(distribution=[hash[a1]])
+         +- LocalHashAggregate(groupBy=[a1], select=[a1])
+            +- Union(all=[true], union=[a1])
+               :- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+               +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T4.a1, (select count(*) from T1 join ((select T1.a1 as a3 from T1) union (select a3 from T3)) T3 on T1.a1 = T3.a3 where T3.a3 = 1) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalFilter(condition=[=($2, 1)])
+      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+        LogicalUnion(all=[false])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a1, $f2], build=[right])
+:- Calc(select=[a1])
+:  +- HashJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, a2], build=[right])
+:     :- Exchange(distribution=[hash[a1]])
+:     :  +- TableSourceScan(table=[[default_catalog, default_database, T1, project=[a1], metadata=[]]], fields=[a1])
+:     +- Exchange(distribution=[hash[a2]])
+:        +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2])
++- Exchange(distribution=[broadcast])
+   +- Calc(select=[*(EXPR$0, EXPR$00) AS $f2])
+      +- NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[EXPR$0, EXPR$00], build=[left], singleRowJoin=[true])
+         :- Exchange(distribution=[broadcast])
+         :  +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+         :     +- Exchange(distribution=[single])
+         :        +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+         :           +- Calc(select=[a1], where=[=(a1, 1)])
+         :              +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- HashAggregate(isMerge=[true], groupBy=[a3], select=[a3])
+                     +- Exchange(distribution=[hash[a3]])
+                        +- LocalHashAggregate(groupBy=[a3], select=[a3])
+                           +- Union(all=[true], union=[a3])
+                              :- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a1, 1)])
+                              :  +- TableSourceScan(table=[[default_catalog, default_database, T1, filter=[], project=[a1], metadata=[]]], fields=[a1], hints=[[[ALIAS options:[T1]]]])
+                              +- Calc(select=[CAST(1 AS BIGINT) AS a3], where=[=(a3, 1)])
+                                 +- TableSourceScan(table=[[default_catalog, default_database, T3, filter=[], project=[a3], metadata=[]]], fields=[a3], hints=[[[ALIAS options:[T3]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileOuterQueryIsNotJoin">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
     </Resource>
@@ -921,7 +1075,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileRootOfSubQueryIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
     </Resource>
@@ -947,38 +1101,17 @@ Calc(select=[a1, CAST('abc' AS VARCHAR(2147483647)) AS b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_MERGE(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_MERGE inheritPath:[0] options:[T1]]]])
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
-]]>
-    </Resource>
-    <Resource name="optimized rel plan">
-      <![CDATA[
-NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
-:- Exchange(distribution=[broadcast])
-:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
-+- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
-    <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T1.* from T1 join V5 on T1.a1 = V5.a1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[SHUFFLE_MERGE inheritPath:[0] options:[T1]]]])
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
-   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
+   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
          :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
          +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -998,15 +1131,15 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileOuterQueryIsNotJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from V2]]>
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from V5]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1])
-+- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]])
-   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]])
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]])
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]])
       :- LogicalTableScan(table=[[default_catalog, default_database, T1]])
       +- LogicalTableScan(table=[[default_catalog, default_database, T2]])
 ]]>
@@ -1022,7 +1155,7 @@ Calc(select=[a1, b1])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileRootOfViewIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/* from V2]]>
     </Resource>
@@ -1067,6 +1200,27 @@ SortMergeJoin(joinType=[InnerJoin], where=[=(a1, a2)], select=[a1, b1, a2, b2])
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3])
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[SHUFFLE_MERGE inheritPath:[0] options:[T1]]]])
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+NestedLoopJoin(joinType=[InnerJoin], where=[true], select=[a1, b1, a2, b2], build=[left])
+:- Exchange(distribution=[broadcast])
+:  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
++- TableSourceScan(table=[[default_catalog, default_database, T2]], fields=[a2, b2])
 ]]>
     </Resource>
   </TestCase>
@@ -1159,6 +1313,31 @@ HashJoin(joinType=[LeftSemiJoin], where=[=(a1, a2)], select=[a1, b1], build=[rig
 :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
 +- Exchange(distribution=[hash[a2]])
    +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[a2], metadata=[]]], fields=[a2], hints=[[[ALIAS options:[T2]]]])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithSimpleSumInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ SHUFFLE_MERGE(T1)*/T1.b1, sum(T1.a1) from T1 join T2 on T1.b1 = T2.b2 group by T1.b1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)])
++- LogicalProject(b1=[$1], a1=[$0])
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[SHUFFLE_MERGE inheritPath:[0, 0] options:[T1]]]])
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[false], groupBy=[b1], select=[b1, SUM(a1) AS EXPR$1])
++- Calc(select=[b1, a1])
+   +- SortMergeJoin(joinType=[InnerJoin], where=[=(b1, b2)], select=[a1, b1, b2])
+      :- Exchange(distribution=[hash[b1]])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, T1]], fields=[a1, b1])
+      +- Exchange(distribution=[hash[b2]])
+         +- TableSourceScan(table=[[default_catalog, default_database, T2, project=[b2], metadata=[]]], fields=[b2])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
@@ -240,6 +240,19 @@ LogicalProject(a2=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithCastInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.b1, cast(T1.a1 as int) from T1 join T2 on T1.b1 = T2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b1=[$1], EXPR$1=[CAST($0):INTEGER]), rowType=[RecordType(VARCHAR(2147483647) b1, INTEGER EXPR$1)]
++- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithDisabledOperator">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -478,7 +491,7 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -494,7 +507,71 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsSumInQueryBlock">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1, (select count(*) from T1 join T3 on T1.a1 = T3.a3) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc') T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectFrom">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1 from (select T1.* from T1 join ((select T1.a1 as a2 from T1) union (select a2 from T2)) T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0]), rowType=[RecordType(BIGINT a1)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalUnion(all=[false]), rowType=[RecordType(BIGINT a2)]
+         :- LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1, (select count(*) from T1 join ((select T1.a1 as a3 from T1) union (select a3 from T3)) T3 on T1.a1 = T3.a3 where T3.a3 = 1) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalFilter(condition=[=($2, 1)])
+      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+        LogicalUnion(all=[false])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileOuterQueryIsNotJoin">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
     </Resource>
@@ -508,7 +585,7 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileRootOfSubQueryIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
     </Resource>
@@ -523,22 +600,9 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
-    <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V5 on T1.a1 = V5.a1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -552,9 +616,9 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileOuterQueryIsNotJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V5]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
@@ -566,7 +630,7 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileRootOfViewIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
     </Resource>
@@ -589,6 +653,19 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
@@ -647,6 +724,20 @@ LogicalProject(a2=[$0])
   LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithSimpleSumInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.b1, sum(T1.a1) from T1 join T2 on T1.b1 = T2.b2 group by T1.b1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)]), rowType=[RecordType(VARCHAR(2147483647) b1, BIGINT EXPR$1)]
++- LogicalProject(b1=[$1], a1=[$0]), rowType=[RecordType(VARCHAR(2147483647) b1, BIGINT a1)]
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/ClearQueryBlockAliasResolverTest.xml
@@ -478,7 +478,7 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -494,7 +494,49 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -510,6 +552,35 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithoutCaseSensitive">
     <Resource name="sql">
       <![CDATA[select /*+ BrOaDcAsT(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -518,19 +589,6 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
-    <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/JoinHintResolverTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/JoinHintResolverTest.xml
@@ -240,6 +240,19 @@ LogicalProject(a2=[$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithCastInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.b1, cast(T1.a1 as int) from T1 join T2 on T1.b1 = T2.b2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(b1=[$1], EXPR$1=[CAST($0):INTEGER]), rowType=[RecordType(VARCHAR(2147483647) b1, INTEGER EXPR$1)]
++- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithDisabledOperator">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -478,7 +491,7 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -494,7 +507,71 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsSumInQueryBlock">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1, (select count(*) from T1 join T3 on T1.a1 = T3.a3) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc') T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+      LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+      LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectFrom">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1 from (select T1.* from T1 join ((select T1.a1 as a2 from T1) union (select a2 from T2)) T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0]), rowType=[RecordType(BIGINT a1)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalUnion(all=[false], hints=[[[ALIAS options:[T2]]]]), rowType=[RecordType(BIGINT a2)]
+         :- LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
+         :  +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalProject(a2=[$0]), rowType=[RecordType(BIGINT a2)]
+            +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileContainsUnionAndJoinInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T4.a1, (select count(*) from T1 join ((select T1.a1 as a3 from T1) union (select a3 from T3)) T3 on T1.a1 = T3.a3 where T3.a3 = 1) as cnt from (select T1.* from T1 join T2 on T1.a1 = T2.a2) T4]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], cnt=[$SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalFilter(condition=[=($2, 1)])
+      LogicalJoin(condition=[=($0, $2)], joinType=[inner])
+        LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+        LogicalUnion(all=[false])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]])
+          LogicalProject(a3=[$0])
+            LogicalTableScan(table=[[default_catalog, default_database, T3]], hints=[[[ALIAS inheritPath:[] options:[T3]]]])
+})]), rowType=[RecordType(BIGINT a1, BIGINT cnt)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[T4]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileOuterQueryIsNotJoin">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
     </Resource>
@@ -508,7 +585,7 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQueryWhileRootOfSubQueryIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
     </Resource>
@@ -523,50 +600,37 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileArgsCanBeFoundInOuterJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
-    <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V5 on T1.a1 = V5.a1]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a10, VARCHAR(2147483647) b10)]
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+   +- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
          :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
          +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileOuterQueryIsNotJoin">
     <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V5]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
 LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-+- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V5]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V5]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
       :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
       +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+  <TestCase name="testJoinHintWithoutAffectingJoinInViewWhileRootOfViewIsFilter">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
     </Resource>
@@ -591,6 +655,19 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
     </Resource>
   </TestCase>
@@ -647,6 +724,20 @@ LogicalProject(a2=[$0])
   LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]])
 })]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithSimpleSumInSelectList">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/T1.b1, sum(T1.a1) from T1 join T2 on T1.b1 = T2.b2 group by T1.b1]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0}], EXPR$1=[SUM($1)]), rowType=[RecordType(VARCHAR(2147483647) b1, BIGINT EXPR$1)]
++- LogicalProject(b1=[$1], a1=[$0]), rowType=[RecordType(VARCHAR(2147483647) b1, BIGINT a1)]
+   +- LogicalJoin(condition=[=($1, $3)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/JoinHintResolverTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/optimize/JoinHintResolverTest.xml
@@ -478,7 +478,7 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery1">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join (select T1.* from T1 join T2 on T1.a1 = T2.a2) V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -494,7 +494,49 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testJoinHintWithoutAffectingJoinInView">
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery2">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[EXPR$0]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInSubQuery3">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from (select T1.* from T1 join T2 on T1.a1 = T2.a2 where T1.b1 = 'abc')]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[EXPR$0]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[EXPR$0]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutJoinPred">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
++- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView1">
     <Resource name="sql">
       <![CDATA[select /*+ BROADCAST(T1)*/T1.* from T1 join V2 on T1.a1 = V2.a1]]>
     </Resource>
@@ -510,6 +552,35 @@ LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView2">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0] options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+      +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testJoinHintWithoutAffectingJoinInView3">
+    <Resource name="sql">
+      <![CDATA[select /*+ BROADCAST(T1)*/* from V2]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a1=[$0], b1=[$1]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
++- LogicalProject(a1=[$0], b1=[$1], hints=[[[ALIAS options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'abc')]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+      +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], hints=[[[ALIAS inheritPath:[0, 0] options:[V2]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
+         :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
+         +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testJoinHintWithoutCaseSensitive">
     <Resource name="sql">
       <![CDATA[select /*+ BrOaDcAsT(T1) */* from T1 join T2 on T1.a1 = T2.a2]]>
@@ -520,19 +591,6 @@ LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a
 +- LogicalJoin(condition=[=($0, $2)], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
    :- LogicalTableScan(table=[[default_catalog, default_database, T1]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
    +- LogicalTableScan(table=[[default_catalog, default_database, T2]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
-]]>
-    </Resource>
-  </TestCase>
-  <TestCase name="testJoinHintWithoutJoinPred">
-    <Resource name="sql">
-      <![CDATA[select /*+ BROADCAST(T1) */* from T1, T2]]>
-    </Resource>
-    <Resource name="ast">
-      <![CDATA[
-LogicalProject(a1=[$0], b1=[$1], a2=[$2], b2=[$3]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-+- LogicalJoin(condition=[true], joinType=[inner], joinHints=[[[BROADCAST options:[LEFT]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1, BIGINT a2, VARCHAR(2147483647) b2)]
-   :- LogicalTableScan(table=[[default_catalog, default_database, T1]], hints=[[[ALIAS inheritPath:[] options:[T1]]]]), rowType=[RecordType(BIGINT a1, VARCHAR(2147483647) b1)]
-   +- LogicalTableScan(table=[[default_catalog, default_database, T2]], hints=[[[ALIAS inheritPath:[] options:[T2]]]]), rowType=[RecordType(BIGINT a2, VARCHAR(2147483647) b2)]
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
## What is the purpose of the change

The join hints are forbidden propagating into a view. However, in the sql like "SELECT /*+ SHUFFLE_MERGE(part)  */ * from v1;", the join hint will be propagated into the view with an unexpected behavior.

## Brief change log

  - when join hints exist, disable project merge
  - add tests to verify this pr


## Verifying this change

Some tests are added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? 
