### PR TITLE
[FLINK-29113][table-planner] throw exception when finding at least one invalid table name in join hints

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/JoinHintResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/JoinHintResolver.java
@@ -105,7 +105,6 @@ public class JoinHintResolver extends RelShuttleImpl {
                 assert null != lookupTable;
                 if (rightName.isPresent() && matchIdentifier(lookupTable, rightName.get())) {
                     validHints.add(trimInheritPath(hint));
-                    updateInfoForOptionCheck(hint.hintName, leftName);
                     newHints.add(hint);
                 }
             } else if (JoinStrategy.isJoinStrategy(hint.hintName)) {
@@ -224,10 +223,18 @@ public class JoinHintResolver extends RelShuttleImpl {
             String errorMsg =
                     invalidHints.stream()
                             .map(
-                                    hint ->
-                                            hint.hintName
+                                    hint -> {
+                                        String hintName = hint.hintName;
+                                        if (JoinStrategy.isLookupHint(hintName)) {
+                                            // lookup join
+                                            return hint.hintName;
+                                        } else {
+                                            // join hint
+                                            return hint.hintName
                                                     + ":"
-                                                    + StringUtils.join(hint.listOptions, ", "))
+                                                    + StringUtils.join(hint.listOptions, ", ");
+                                        }
+                                    })
                             .collect(Collectors.joining("\n", "\n", ""));
             throw new ValidationException(String.format(errorPattern, errorMsg));
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/JoinHintResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/JoinHintResolver.java
@@ -206,8 +206,7 @@ public class JoinHintResolver extends RelShuttleImpl {
             errorMsgSb.append("\n");
             errorMsgSb.append(
                     String.format(
-                            "%s:%s",
-                            hintName,
+                            "`%s` in `%s`",
                             optionCheckedStatus.keySet().stream()
                                     .filter(
                                             op -> {
@@ -217,7 +216,8 @@ public class JoinHintResolver extends RelShuttleImpl {
                                                 }
                                                 return checked;
                                             })
-                                    .collect(Collectors.joining(", "))));
+                                    .collect(Collectors.joining(", ")),
+                            hintName));
         }
         if (containsInvalidOptions.get()) {
             throw new ValidationException(String.format(errorPattern, errorMsgSb));
@@ -238,7 +238,7 @@ public class JoinHintResolver extends RelShuttleImpl {
                                         } else {
                                             // join hint
                                             return hint.hintName
-                                                    + ":"
+                                                    + " :"
                                                     + StringUtils.join(hint.listOptions, ", ");
                                         }
                                     })

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/JoinHintResolver.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/JoinHintResolver.java
@@ -34,10 +34,13 @@ import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.singletonList;
@@ -52,6 +55,9 @@ public class JoinHintResolver extends RelShuttleImpl {
     private final Set<RelHint> allHints = new HashSet<>();
     private final Set<RelHint> validHints = new HashSet<>();
 
+    // hintName -> hintOptions -> whether this option has been checked
+    private final Map<String, Map<String, Boolean>> allOptionsInJoinHints = new HashMap<>();
+
     /**
      * Resolves and validates join hints in the given {@link RelNode} list, an {@link
      * ValidationException} will be raised for invalid hints.
@@ -64,7 +70,7 @@ public class JoinHintResolver extends RelShuttleImpl {
      * right side of this join, that means this join hint is invalid and a {@link
      * ValidationException} will be thrown.
      */
-    public List<RelNode> resolve(List<RelNode> roots) {
+    final List<RelNode> resolve(List<RelNode> roots) {
         List<RelNode> resolvedRoots =
                 roots.stream().map(node -> node.accept(this)).collect(Collectors.toList());
         validateHints();
@@ -99,10 +105,14 @@ public class JoinHintResolver extends RelShuttleImpl {
                 assert null != lookupTable;
                 if (rightName.isPresent() && matchIdentifier(lookupTable, rightName.get())) {
                     validHints.add(trimInheritPath(hint));
+                    updateInfoForOptionCheck(hint.hintName, leftName);
                     newHints.add(hint);
                 }
             } else if (JoinStrategy.isJoinStrategy(hint.hintName)) {
                 allHints.add(trimInheritPath(hint));
+                // add options about this hint for finally checking
+                initOptionInfoAboutJoinHintsForCheck(hint);
+
                 // the declared table name or query block name is replaced by
                 // JoinStrategy#LEFT_INPUT or JoinStrategy#RIGHT_INPUT
                 List<String> newOptions =
@@ -143,6 +153,11 @@ public class JoinHintResolver extends RelShuttleImpl {
             Optional<String> rightName,
             List<String> listOptions,
             String hintName) {
+
+        // update info about 'allOptionsInJoinHints' for checking finally
+        updateInfoForOptionCheck(hintName, leftName);
+        updateInfoForOptionCheck(hintName, rightName);
+
         return listOptions.stream()
                 .map(
                         option -> {
@@ -172,21 +187,49 @@ public class JoinHintResolver extends RelShuttleImpl {
     private void validateHints() {
         Set<RelHint> invalidHints = new HashSet<>(allHints);
         invalidHints.removeAll(validHints);
+        String errorPattern;
+
+        // firstly, check the unknown table (view) names in hints
+        errorPattern =
+                "The options of following hints cannot match the name of "
+                        + "input tables or views: %s";
+        StringBuilder errorMsgSb = new StringBuilder();
+        AtomicBoolean containsInvalidOptions = new AtomicBoolean(false);
+        for (String hintName : allOptionsInJoinHints.keySet()) {
+            Map<String, Boolean> optionCheckedStatus = allOptionsInJoinHints.get(hintName);
+            errorMsgSb.append("\n");
+            errorMsgSb.append(
+                    String.format(
+                            "%s:%s",
+                            hintName,
+                            optionCheckedStatus.keySet().stream()
+                                    .filter(
+                                            op -> {
+                                                boolean checked = !optionCheckedStatus.get(op);
+                                                if (checked) {
+                                                    containsInvalidOptions.set(true);
+                                                }
+                                                return checked;
+                                            })
+                                    .collect(Collectors.joining(", "))));
+        }
+        if (containsInvalidOptions.get()) {
+            throw new ValidationException(String.format(errorPattern, errorMsgSb));
+        }
+
+        // secondly, check invalid hints.
+        // see more at JoinStrategy#validOptions
         if (!invalidHints.isEmpty()) {
+            errorPattern = "The options of following hints is invalid: %s";
             String errorMsg =
                     invalidHints.stream()
                             .map(
                                     hint ->
                                             hint.hintName
-                                                    + "("
-                                                    + StringUtils.join(hint.listOptions, ", ")
-                                                    + ")`")
-                            .collect(Collectors.joining("\n`", "\n`", ""));
-            throw new ValidationException(
-                    String.format(
-                            "The options of following hints cannot match the name of "
-                                    + "input tables or views: %s",
-                            errorMsg));
+                                                    + ":"
+                                                    + StringUtils.join(hint.listOptions, ", "))
+                            .collect(Collectors.joining("\n", "\n", ""));
+            throw new ValidationException(String.format(errorPattern, errorMsg));
         }
     }
 
@@ -251,5 +294,39 @@ public class JoinHintResolver extends RelShuttleImpl {
         }
 
         return true;
+    }
+
+    private void initOptionInfoAboutJoinHintsForCheck(RelHint hint) {
+        String hintName = hint.hintName;
+        List<String> options = hint.listOptions;
+        if (allOptionsInJoinHints.containsKey(hintName)) {
+            Map<String, Boolean> optionCheckedStatus = allOptionsInJoinHints.get(hintName);
+            options.forEach(
+                    option -> {
+                        if (!optionCheckedStatus.containsKey(option)) {
+                            // all options are not checked when init
+                            optionCheckedStatus.put(option, false);
+                        }
+                    });
+        } else {
+            allOptionsInJoinHints.put(
+                    hintName,
+                    new HashSet<>(options)
+                            .stream()
+                                    // all options are not checked when init
+                                    .collect(Collectors.toMap(option -> option, option -> false)));
+        }
+    }
+
+    private void updateInfoForOptionCheck(String hintName, Optional<String> tableName) {
+        if (tableName.isPresent()) {
+            Map<String, Boolean> optionMapper = allOptionsInJoinHints.get(hintName);
+            for (String option : optionMapper.keySet()) {
+                if (matchIdentifier(option, tableName.get())) {
+                    // if the hint has not been checked before, update it
+                    allOptionsInJoinHints.get(hintName).put(option, true);
+                }
+            }
+        }
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
@@ -188,8 +188,46 @@ public abstract class JoinHintTestBase extends TableTestBase {
     public void testJoinHintWithUnknownTable() {
         thrown().expect(ValidationException.class);
         thrown().expectMessage(
-                        "The options of following hints cannot match the name of input tables or views:");
+                        String.format(
+                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
+                                getTestSingleJoinHint(), "T99"));
         String sql = "select /*+ %s(T99) */* from T1 join T2 on T1.a1 = T2.a2";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithUnknownTableNameMixedWithValidTableNames1() {
+        thrown().expect(ValidationException.class);
+        thrown().expectMessage(
+                        String.format(
+                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
+                                getTestSingleJoinHint(), "T99"));
+        String sql = "select /*+ %s(T1, T99) */* from T1 join T2 on T1.a1 = T2.a2";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithUnknownTableNameMixedWithValidTableNames2() {
+        thrown().expect(ValidationException.class);
+        thrown().expectMessage(
+                        String.format(
+                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
+                                getTestSingleJoinHint(), "T99"));
+        String sql = "select /*+ %s(T1, T99, T2) */* from T1 join T2 on T1.a1 = T2.a2";
+
+        verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
+    }
+
+    @Test
+    public void testJoinHintWithMultiUnknownTableNamesMixedWithValidTableNames() {
+        thrown().expect(ValidationException.class);
+        thrown().expectMessage(
+                        String.format(
+                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
+                                getTestSingleJoinHint(), "T98, T99"));
+        String sql = "select /*+ %s(T1, T99, T98) */* from T1 join T2 on T1.a1 = T2.a2";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
     }
@@ -207,7 +245,7 @@ public abstract class JoinHintTestBase extends TableTestBase {
         thrown().expectMessage(
                         String.format(
                                 "The options of following hints cannot match the name of input tables or views: \n"
-                                        + "`%s(V99)`",
+                                        + "%s:V99",
                                 getTestSingleJoinHint()));
         String sql = "select /*+ %s(V99) */* from T1 join V4 on T1.a1 = V4.a4";
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/hints/batch/JoinHintTestBase.java
@@ -189,8 +189,8 @@ public abstract class JoinHintTestBase extends TableTestBase {
         thrown().expect(ValidationException.class);
         thrown().expectMessage(
                         String.format(
-                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
-                                getTestSingleJoinHint(), "T99"));
+                                "The options of following hints cannot match the name of input tables or views: \n`%s` in `%s`",
+                                "T99", getTestSingleJoinHint()));
         String sql = "select /*+ %s(T99) */* from T1 join T2 on T1.a1 = T2.a2";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
@@ -201,8 +201,8 @@ public abstract class JoinHintTestBase extends TableTestBase {
         thrown().expect(ValidationException.class);
         thrown().expectMessage(
                         String.format(
-                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
-                                getTestSingleJoinHint(), "T99"));
+                                "The options of following hints cannot match the name of input tables or views: \n`%s` in `%s`",
+                                "T99", getTestSingleJoinHint()));
         String sql = "select /*+ %s(T1, T99) */* from T1 join T2 on T1.a1 = T2.a2";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
@@ -213,8 +213,8 @@ public abstract class JoinHintTestBase extends TableTestBase {
         thrown().expect(ValidationException.class);
         thrown().expectMessage(
                         String.format(
-                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
-                                getTestSingleJoinHint(), "T99"));
+                                "The options of following hints cannot match the name of input tables or views: \n`%s` in `%s`",
+                                "T99", getTestSingleJoinHint()));
         String sql = "select /*+ %s(T1, T99, T2) */* from T1 join T2 on T1.a1 = T2.a2";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
@@ -225,8 +225,8 @@ public abstract class JoinHintTestBase extends TableTestBase {
         thrown().expect(ValidationException.class);
         thrown().expectMessage(
                         String.format(
-                                "The options of following hints cannot match the name of input tables or views: \n%s:%s",
-                                getTestSingleJoinHint(), "T98, T99"));
+                                "The options of following hints cannot match the name of input tables or views: \n`%s` in `%s`",
+                                "T98, T99", getTestSingleJoinHint()));
         String sql = "select /*+ %s(T1, T99, T98) */* from T1 join T2 on T1.a1 = T2.a2";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));
@@ -244,9 +244,8 @@ public abstract class JoinHintTestBase extends TableTestBase {
         thrown().expect(ValidationException.class);
         thrown().expectMessage(
                         String.format(
-                                "The options of following hints cannot match the name of input tables or views: \n"
-                                        + "%s:V99",
-                                getTestSingleJoinHint()));
+                                "The options of following hints cannot match the name of input tables or views: \n`%s` in `%s`",
+                                "V99", getTestSingleJoinHint()));
         String sql = "select /*+ %s(V99) */* from T1 join V4 on T1.a1 = V4.a4";
 
         verifyRelPlanByCustom(String.format(sql, getTestSingleJoinHint()));

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -751,7 +751,9 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
   @Test
   def testJoinHintWithTableAlias(): Unit = {
     // TODO to be supported in FLINK-28850 (to make LogicalSnapshot Hintable)
-    thrown.expectMessage("The options of following hints is invalid: \nLOOKUP")
+    thrown.expectMessage(
+      "The options of following hints cannot match the name of input tables or" +
+        " views: \nLOOKUP:D")
     thrown.expect(classOf[ValidationException])
     val sql = "SELECT /*+ LOOKUP('table'='D') */ * FROM MyTable AS T JOIN LookupTable " +
       "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -753,7 +753,7 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
     // TODO to be supported in FLINK-28850 (to make LogicalSnapshot Hintable)
     thrown.expectMessage(
       "The options of following hints cannot match the name of input tables or" +
-        " views: \nLOOKUP:D")
+        " views: \n`D` in `LOOKUP`")
     thrown.expect(classOf[ValidationException])
     val sql = "SELECT /*+ LOOKUP('table'='D') */ * FROM MyTable AS T JOIN LookupTable " +
       "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id"

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/join/LookupJoinTest.scala
@@ -751,8 +751,7 @@ class LookupJoinTest(legacyTableSource: Boolean) extends TableTestBase with Seri
   @Test
   def testJoinHintWithTableAlias(): Unit = {
     // TODO to be supported in FLINK-28850 (to make LogicalSnapshot Hintable)
-    thrown.expectMessage(
-      "The options of following hints cannot match the name of input tables or views")
+    thrown.expectMessage("The options of following hints is invalid: \nLOOKUP")
     thrown.expect(classOf[ValidationException])
     val sql = "SELECT /*+ LOOKUP('table'='D') */ * FROM MyTable AS T JOIN LookupTable " +
       "FOR SYSTEM_TIME AS OF T.proctime AS D ON T.a = D.id"


### PR DESCRIPTION
## What is the purpose of the change

Currently, join hint with invalid table name mixed with valid names will not raise an error. This pr is try to fix this bug.

## Brief change log

  - validate all options in join hints to throw exception when there is one invalid table names
  - add tests to verify this pr


## Verifying this change

Some tests are added to verify this pr.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
