### PR TITLE
[FLINK-29130][state] Correct the description of state.backend.local-recovery

### DIFF
--- a/docs/content.zh/docs/ops/state/large_state_tuning.md
+++ b/docs/content.zh/docs/ops/state/large_state_tuning.md
@@ -241,9 +241,9 @@ Task 本地恢复 *默认禁用*，可以通过 Flink 的 CheckpointingOptions.L
 
 以下 state backends 可以支持 task 本地恢复。
 
-- FsStateBackend: keyed state 支持 task 本地恢复。 该实现会将状态复制到本地文件。 这会引入额外的写入成本并占用本地磁盘空间。 将来，我们可能还会提供一种将 task 本地状态保存在内存中的实现。
+- **HashMapStateBackend**: keyed state 支持 task 本地恢复。 该实现会将状态复制到本地文件。 这会引入额外的写入成本并占用本地磁盘空间。 将来，我们可能还会提供一种将 task 本地状态保存在内存中的实现。
 
-- RocksDBStateBackend: 支持 keyed state 的 task 本地恢复。对于*全量 checkpoints*，状态被复制到本地文件。这会引入额外的写入成本并占用本地磁盘空间。对于*增量快照*，本地状态基于 RocksDB 的原生 checkpointing 机制。
+- **EmbeddedRocksDBStateBackend**: 支持 keyed state 的 task 本地恢复。对于*全量 checkpoints*，状态被复制到本地文件。这会引入额外的写入成本并占用本地磁盘空间。对于*增量快照*，本地状态基于 RocksDB 的原生 checkpointing 机制。
   这种机制也被用作创建主副本的第一步，这意味着在这种情况下，创建次要副本不会引入额外的成本。我们只是保留本地 checkpoint 目录，
   而不是在上传到分布式存储后将其删除。这个本地副本可以与 RocksDB 的工作目录共享现有文件（通过硬链接），因此对于现有文件，增量快照的 task 本地恢复也不会消耗额外的磁盘空间。
   使用硬链接还意味着 RocksDB 目录必须与所有可用于存储本地状态和本地恢复目录位于同一节点上，否则建立硬链接可能会失败（参见 FLINK-10954）。

--- a/docs/layouts/shortcodes/generated/checkpointing_configuration.html
+++ b/docs/layouts/shortcodes/generated/checkpointing_configuration.html
@@ -18,7 +18,7 @@
             <td><h5>state.backend.local-recovery</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Currently, the MemoryStateBackend does not support local recovery and ignores this option.</td>
+            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).</td>
         </tr>
         <tr>
             <td><h5>state.checkpoint-storage</h5></td>
@@ -60,7 +60,7 @@
             <td><h5>taskmanager.state.local.root-dirs</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignores this option. If not configured it will default to &lt;WORKING_DIR&gt;/localState. The &lt;WORKING_DIR&gt; can be configured via <code class="highlighter-rouge">process.taskmanager.working-dir</code></td>
+            <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. If not configured it will default to &lt;WORKING_DIR&gt;/localState. The &lt;WORKING_DIR&gt; can be configured via <code class="highlighter-rouge">process.taskmanager.working-dir</code></td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/common_state_backends_section.html
+++ b/docs/layouts/shortcodes/generated/common_state_backends_section.html
@@ -42,7 +42,7 @@
             <td><h5>state.backend.local-recovery</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
-            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends. Currently, the MemoryStateBackend does not support local recovery and ignores this option.</td>
+            <td>This option configures local recovery for this state backend. By default, local recovery is deactivated. Local recovery currently only covers keyed state backends (including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).</td>
         </tr>
         <tr>
             <td><h5>state.checkpoints.num-retained</h5></td>
@@ -54,7 +54,7 @@
             <td><h5>taskmanager.state.local.root-dirs</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>
-            <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend does not support local recovery and ignores this option. If not configured it will default to &lt;WORKING_DIR&gt;/localState. The &lt;WORKING_DIR&gt; can be configured via <code class="highlighter-rouge">process.taskmanager.working-dir</code></td>
+            <td>The config parameter defining the root directories for storing file-based state for local recovery. Local recovery currently only covers keyed state backends. If not configured it will default to &lt;WORKING_DIR&gt;/localState. The &lt;WORKING_DIR&gt; can be configured via <code class="highlighter-rouge">process.taskmanager.working-dir</code></td>
         </tr>
     </tbody>
 </table>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CheckpointingOptions.java
@@ -142,8 +142,8 @@ public class CheckpointingOptions {
      * This option configures local recovery for this state backend. By default, local recovery is
      * deactivated.
      *
-     * <p>Local recovery currently only covers keyed state backends. Currently, MemoryStateBackend
-     * and HashMapStateBackend do not support local recovery and ignore this option.
+     * <p>Local recovery currently only covers keyed state backends (including both the
+     * EmbeddedRocksDBStateBackend and the HashMapStateBackend).
      */
     @Documentation.Section(Documentation.Sections.COMMON_STATE_BACKENDS)
     public static final ConfigOption<Boolean> LOCAL_RECOVERY =
@@ -152,8 +152,8 @@ public class CheckpointingOptions {
                     .defaultValue(false)
                     .withDescription(
                             "This option configures local recovery for this state backend. By default, local recovery is "
-                                    + "deactivated. Local recovery currently only covers keyed state backends. Currently, the MemoryStateBackend "
-                                    + "does not support local recovery and ignores this option.");
+                                    + "deactivated. Local recovery currently only covers keyed state backends "
+                                    + "(including both the EmbeddedRocksDBStateBackend and the HashMapStateBackend).");
 
     /**
      * The config parameter defining the root directories for storing file-based state for local
@@ -172,9 +172,8 @@ public class CheckpointingOptions {
                                     .text(
                                             "The config parameter defining the root directories for storing file-based "
                                                     + "state for local recovery. Local recovery currently only covers keyed "
-                                                    + "state backends. Currently, MemoryStateBackend does not support local "
-                                                    + "recovery and ignores this option. If not configured it will default "
-                                                    + "to <WORKING_DIR>/localState. The <WORKING_DIR> can be configured via %s",
+                                                    + "state backends. If not configured it will default to <WORKING_DIR>/localState. "
+                                                    + "The <WORKING_DIR> can be configured via %s",
                                             TextElement.code(
                                                     ClusterOptions
                                                             .TASK_MANAGER_PROCESS_WORKING_DIR_BASE


### PR DESCRIPTION
## What is the purpose of the change

Currently, the docs of configuration state.backend.local-recovery said wrongly on the active scope of this configuration. MemoryStateBackend and HashMapStateBackend actually support this feature.


## Brief change log

Change the related docs to the correct descriptions.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable 
