### PR TITLE
[FLINK-29123][k8s] Dynamic paramters are not pushed to working with kubernetes

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -117,6 +117,12 @@
             <td>The limit factor of cpu used by job manager. The resources limit cpu will be set to cpu * limit-factor.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.jobmanager.entrypoint.args</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Extra arguments used when starting the job manager.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.jobmanager.labels</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
@@ -229,6 +235,12 @@
             <td style="word-wrap: break-word;">1.0</td>
             <td>Double</td>
             <td>The limit factor of cpu used by task manager. The resources limit cpu will be set to cpu * limit-factor.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.taskmanager.entrypoint.args</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Extra arguments used when starting the task manager.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.taskmanager.labels</h5></td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -331,6 +331,18 @@ public class KubernetesConfigOptions {
                             "The user-specified annotations that are set to the TaskManager pod. The value could be "
                                     + "in the form of a1:v1,a2:v2");
 
+    public static final ConfigOption<String> KUBERNETES_JOBMANAGER_ENTRYPOINT_ARGS =
+            key("kubernetes.jobmanager.entrypoint.args")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Extra arguments used when starting the job manager.");
+
+    public static final ConfigOption<String> KUBERNETES_TASKMANAGER_ENTRYPOINT_ARGS =
+            key("kubernetes.taskmanager.entrypoint.args")
+                    .stringType()
+                    .defaultValue("")
+                    .withDescription("Extra arguments used when starting the task manager.");
+
     public static final ConfigOption<List<Map<String, String>>> JOB_MANAGER_TOLERATIONS =
             key("kubernetes.jobmanager.tolerations")
                     .mapType()

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdJobManagerDecorator.java
@@ -56,6 +56,10 @@ public class CmdJobManagerDecorator extends AbstractKubernetesStepDecorator {
                 KubernetesDeploymentTarget.fromConfig(
                         kubernetesJobManagerParameters.getFlinkConfiguration());
         return KubernetesUtils.getStartCommandWithBashWrapper(
-                Constants.KUBERNETES_JOB_MANAGER_SCRIPT_PATH + " " + deploymentTarget.getName());
+                Constants.KUBERNETES_JOB_MANAGER_SCRIPT_PATH
+                        + " "
+                        + deploymentTarget.getName()
+                        + " "
+                        + kubernetesJobManagerParameters.getEntrypointArgs());
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecorator.java
@@ -73,6 +73,8 @@ public class CmdTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                         + " "
                         + dynamicProperties
                         + " "
-                        + resourceArgs);
+                        + resourceArgs
+                        + " "
+                        + kubernetesTaskManagerParameters.getEntrypointArgs());
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -200,4 +200,8 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
         }
         return replicas;
     }
+
+    public String getEntrypointArgs() {
+        return flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_ENTRYPOINT_ARGS);
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -191,4 +191,9 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
     public String getNodeNameLabel() {
         return checkNotNull(flinkConfig.get(KubernetesConfigOptions.KUBERNETES_NODE_NAME_LABEL));
     }
+
+    public String getEntrypointArgs() {
+        return flinkConfig.getString(
+                KubernetesConfigOptions.KUBERNETES_TASKMANAGER_ENTRYPOINT_ARGS);
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerTestBase.java
@@ -39,6 +39,7 @@ public class KubernetesJobManagerTestBase extends KubernetesPodTestBase {
     protected static final String REST_BIND_PORT = "9082";
     protected static final int RPC_PORT = 7123;
     protected static final int BLOB_SERVER_PORT = 8346;
+    protected static final String ENTRYPOINT_ARGS = "entrypoint args";
 
     protected KubernetesJobManagerParameters kubernetesJobManagerParameters;
 
@@ -65,6 +66,8 @@ public class KubernetesJobManagerTestBase extends KubernetesPodTestBase {
         this.flinkConfig.set(KubernetesConfigOptions.JOB_MANAGER_NODE_SELECTOR, nodeSelector);
         this.flinkConfig.set(
                 JobManagerOptions.TOTAL_PROCESS_MEMORY, MemorySize.ofMebiBytes(JOB_MANAGER_MEMORY));
+        this.flinkConfig.set(
+                KubernetesConfigOptions.KUBERNETES_JOBMANAGER_ENTRYPOINT_ARGS, ENTRYPOINT_ARGS);
     }
 
     @Override

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/KubernetesTaskManagerTestBase.java
@@ -45,6 +45,7 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
     protected static final double TASK_MANAGER_CPU = 2.0;
     protected static final double TASK_MANAGER_CPU_LIMIT_FACTOR = 1.5;
     protected static final double TASK_MANAGER_MEMORY_LIMIT_FACTOR = 2.0;
+    protected static final String ENTRYPOINT_ARGS = "entrypoint args";
 
     protected TaskExecutorProcessSpec taskExecutorProcessSpec;
 
@@ -77,6 +78,8 @@ public class KubernetesTaskManagerTestBase extends KubernetesPodTestBase {
         flinkConfig.set(
                 KubernetesConfigOptions.TASK_MANAGER_MEMORY_LIMIT_FACTOR,
                 TASK_MANAGER_MEMORY_LIMIT_FACTOR);
+        this.flinkConfig.set(
+                KubernetesConfigOptions.KUBERNETES_TASKMANAGER_ENTRYPOINT_ARGS, ENTRYPOINT_ARGS);
     }
 
     @Override

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdJobManagerDecoratorTest.java
@@ -78,7 +78,11 @@ class CmdJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
                 .containsExactlyInAnyOrder(entryCommand);
         List<String> flinkCommands =
                 KubernetesUtils.getStartCommandWithBashWrapper(
-                        Constants.KUBERNETES_JOB_MANAGER_SCRIPT_PATH + " " + target);
+                        Constants.KUBERNETES_JOB_MANAGER_SCRIPT_PATH
+                                + " "
+                                + target
+                                + " "
+                                + ENTRYPOINT_ARGS);
         assertThat(resultFlinkPod.getMainContainer().getArgs())
                 .containsExactlyElementsOf(flinkCommands);
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/CmdTaskManagerDecoratorTest.java
@@ -70,7 +70,9 @@ class CmdTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
                                 + " "
                                 + DYNAMIC_PROPERTIES
                                 + " "
-                                + mainClassArgs);
+                                + mainClassArgs
+                                + " "
+                                + ENTRYPOINT_ARGS);
         assertThat(resultFlinkPod.getMainContainer().getArgs())
                 .containsExactlyElementsOf(flinkCommands);
     }


### PR DESCRIPTION
## What is the purpose of the change

Provide the possibility to push dynamic arguments for the kubernetes Job/TaskManager.

## Brief change log

Added a new configuration key for both Job/TaskManager which is used when creating them

## Verifying this change

Updated the unit tests which cover the relevant code

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

 - Does this pull request introduce a new feature? no
 - If yes, how is the feature documented? Default config descriptions are present
