### PR TITLE
Remove POD_IP from Taskmanager arguments in kubernetes session mode deployment

### DIFF
--- a/docs/content/docs/deployment/resource-providers/standalone/kubernetes.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/kubernetes.md
@@ -529,13 +529,7 @@ spec:
       - name: jobmanager
         image: apache/flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
         env:
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        # The following args overwrite the value of jobmanager.rpc.address configured in the configuration config map to POD_IP.
-        args: ["jobmanager", "$(POD_IP)"]
+        args: ["jobmanager"]
         ports:
         - containerPort: 6123
           name: rpc


### PR DESCRIPTION
I just deployed a flink cluster in Kubernetes as stated in the documentation, but I had errors in the taskmanagers and the jobmanager about dropping akka.tcp requests because the request-address and the inbound address did not match:

`dropping message [class akka.actor.ActorSelectionMessage] for non-local recipient [Actor[akka.tcp://flink@flink-jobmanager:6123/]] arriving at [akka.tcp://flink@flink-jobmanager:6123] inbound addresses are [akka.tcp://flink@100.64.87.222:6123]`

I then tried to figure out what the error was and then found out, that the jobmanager.rpc.address property was overridden with the POD_IP for the Jobmanager. As I removed this, it worked for me.