### PR TITLE
[HOTFIX] Change the sample based on current code tree

### DIFF
--- a/flink-python/pyflink/shell.py
+++ b/flink-python/pyflink/shell.py
@@ -79,6 +79,9 @@ import os
 import shutil
 import tempfile
 
+from pyflink.table.expressions import *
+from pyflink.table.schema import Schema
+
 sink_path = tempfile.gettempdir() + '/streaming.csv'
 if os.path.exists(sink_path):
     if os.path.isfile(sink_path):
@@ -101,8 +104,10 @@ st_env.create_temporary_table("stream_sink", TableDescriptor.for_connector("file
                                       .build())
                               .build())
 
-t.select(col('a') + 1, col('b'), col('c')).insert_into("stream_sink")
-st_env.execute("stream_job")
+t.select(col('a') + 1, col('b'), col('c')).execute_insert("stream_sink")
+
+# Execute an sample job via StreamExecutionEnvironment
+s_env.execute("stream_job")
 
 # show the results
 with open(os.path.join(sink_path, os.listdir(sink_path)[0]), 'r') as f:


### PR DESCRIPTION
This is a hotfix for pyflink shell mode.

The output sample has several problems:
1. Need to import the necessary py pkg for avoiding NotDefinitaion
   error.
2. Use the current function for avoiding NoSuchFunction error.


## What is the purpose of the change

Improving the developer experience who using pyflink-shell.sh


## Brief change log

- 1. Need to import the necessary py pkg for avoiding NotDefinitaion
   error.
- 2. Use the current function for avoiding NoSuchFunction error.

## Verifying this change

Exec pyflink-shell.sh and run its sample code.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
