### PR TITLE
[FLINK-28934][Connector/pulsar] Fix split assignment for different Pulsar subscriptions

### DIFF
--- a/flink-connectors/flink-connector-pulsar/archunit-violations/f4d91193-72ba-4ce4-ad83-98f780dce581
+++ b/flink-connectors/flink-connector-pulsar/archunit-violations/f4d91193-72ba-4ce4-ad83-98f780dce581
@@ -4,3 +4,9 @@ org.apache.flink.connector.pulsar.source.PulsarSourceITCase does not satisfy: on
 * reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
 * reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
  or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule
+org.apache.flink.connector.pulsar.source.PulsarUnorderedSourceITCase does not satisfy: only one of the following predicates match:\
+* reside in a package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type InternalMiniClusterExtension and annotated with @RegisterExtension\
+* reside outside of package 'org.apache.flink.runtime.*' and contain any fields that are static, final, and of type MiniClusterExtension and annotated with @RegisterExtension\
+* reside in a package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class InternalMiniClusterExtension\
+* reside outside of package 'org.apache.flink.runtime.*' and is annotated with @ExtendWith with class MiniClusterExtension\
+ or contain any fields that are public, static, and of type MiniClusterWithClientResource and final and annotated with @ClassRule or contain any fields that is of type MiniClusterWithClientResource and public and final and not static and annotated with @Rule

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.pulsar.common.schema;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.util.IOUtils;
 
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.impl.schema.SchemaInfoImpl;
@@ -52,8 +51,9 @@ import static org.apache.pulsar.client.impl.schema.KeyValueSchemaInfo.encodeKeyV
  * A wrapper for Pulsar {@link Schema}, make it serializable and can be created from {@link
  * SchemaInfo}.
  *
- * <p>General pulsar schema info (avro, json, protobuf and keyvalue) don't contain the require class
- * info. We have to urge user to provide the related type class and encoded it into schema info.
+ * <p>General pulsar schema info (avro, json, protobuf and keyvalue) don't contain the required
+ * class info. We have to urge users to provide the related type class and encode it into schema
+ * info.
  */
 @Internal
 public final class PulsarSchema<T> implements Serializable {
@@ -164,7 +164,7 @@ public final class PulsarSchema<T> implements Serializable {
         // Schema
         int byteLen = ois.readInt();
         byte[] schemaBytes = new byte[byteLen];
-        IOUtils.readFully(ois, schemaBytes, 0, byteLen);
+        ois.readFully(schemaBytes);
 
         // Type
         int typeIdx = ois.readInt();
@@ -210,8 +210,8 @@ public final class PulsarSchema<T> implements Serializable {
     }
 
     /**
-     * We would throw exception if schema type is protobuf and user don't provide protobuf-java in
-     * class path.
+     * We would throw exception if the schema type is protobuf and users don't provide protobuf-java
+     * in the class path.
      */
     private void validateSchemaInfo(SchemaInfo info) {
         SchemaType type = info.getType();

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarSerdeUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/utils/PulsarSerdeUtils.java
@@ -50,10 +50,7 @@ public final class PulsarSerdeUtils {
     public static byte[] deserializeBytes(DataInputStream in) throws IOException {
         int size = in.readInt();
         byte[] bytes = new byte[size];
-        int result = in.read(bytes);
-        if (result < 0) {
-            throw new IOException("Couldn't deserialize the object, wrong byte buffer.");
-        }
+        in.readFully(bytes);
 
         return bytes;
     }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListener.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListener.java
@@ -43,8 +43,8 @@ import static java.util.Collections.emptyList;
 import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createAdmin;
 import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyAdmin;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.isPartition;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicName;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
-import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithoutPartition;
 import static org.apache.pulsar.common.partition.PartitionedTopicMetadata.NON_PARTITIONED;
 
 /**
@@ -120,7 +120,7 @@ public class TopicMetadataListener implements Serializable, Closeable {
                 int partitionNums = entry.getValue();
                 // Get all topics from partitioned and non-partitioned topic names
                 if (partitionNums == NON_PARTITIONED) {
-                    results.add(topicNameWithoutPartition(entry.getKey()));
+                    results.add(topicName(entry.getKey()));
                 } else {
                     for (int i = 0; i < partitionNums; i++) {
                         results.add(topicNameWithPartition(entry.getKey(), i));

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
@@ -32,8 +32,6 @@ import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumStateSerializer;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumerator;
-import org.apache.flink.connector.pulsar.source.enumerator.assigner.SplitAssigner;
-import org.apache.flink.connector.pulsar.source.enumerator.assigner.SplitAssignerFactory;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
@@ -143,14 +141,13 @@ public final class PulsarSource<OUT>
     @Override
     public SplitEnumerator<PulsarPartitionSplit, PulsarSourceEnumState> createEnumerator(
             SplitEnumeratorContext<PulsarPartitionSplit> enumContext) {
-        SplitAssigner splitAssigner = SplitAssignerFactory.create(stopCursor, sourceConfiguration);
         return new PulsarSourceEnumerator(
                 subscriber,
                 startCursor,
+                stopCursor,
                 rangeGenerator,
                 sourceConfiguration,
-                enumContext,
-                splitAssigner);
+                enumContext);
     }
 
     @Internal
@@ -158,15 +155,14 @@ public final class PulsarSource<OUT>
     public SplitEnumerator<PulsarPartitionSplit, PulsarSourceEnumState> restoreEnumerator(
             SplitEnumeratorContext<PulsarPartitionSplit> enumContext,
             PulsarSourceEnumState checkpoint) {
-        SplitAssigner splitAssigner =
-                SplitAssignerFactory.create(stopCursor, sourceConfiguration, checkpoint);
         return new PulsarSourceEnumerator(
                 subscriber,
                 startCursor,
+                stopCursor,
                 rangeGenerator,
                 sourceConfiguration,
                 enumContext,
-                splitAssigner);
+                checkpoint);
     }
 
     @Internal

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumState.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumState.java
@@ -20,11 +20,8 @@ package org.apache.flink.connector.pulsar.source.enumerator;
 
 import org.apache.flink.connector.pulsar.source.enumerator.assigner.SplitAssigner;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
-import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -36,63 +33,16 @@ public class PulsarSourceEnumState {
     /** The topic partitions that have been appended to this source. */
     private final Set<TopicPartition> appendedPartitions;
 
-    /**
-     * We convert the topic partition into a split and add to this pending list for assigning to a
-     * reader. It is used for Key_Shared, Failover, Exclusive subscription.
-     */
-    private final Set<PulsarPartitionSplit> pendingPartitionSplits;
-
-    /**
-     * It is used for Shared subscription. When a reader is crashed in Shared subscription, its
-     * splits would be put in here.
-     */
-    private final Map<Integer, Set<PulsarPartitionSplit>> sharedPendingPartitionSplits;
-
-    /**
-     * It is used for Shared subscription. Every {@link PulsarPartitionSplit} should be assigned for
-     * all flink readers. Using this map for recording assign status.
-     */
-    private final Map<Integer, Set<String>> readerAssignedSplits;
-
-    /** The pipeline has been triggered and topic partitions have been assigned to readers. */
-    private final boolean initialized;
-
-    public PulsarSourceEnumState(
-            Set<TopicPartition> appendedPartitions,
-            Set<PulsarPartitionSplit> pendingPartitionSplits,
-            Map<Integer, Set<PulsarPartitionSplit>> pendingSharedPartitionSplits,
-            Map<Integer, Set<String>> readerAssignedSplits,
-            boolean initialized) {
+    public PulsarSourceEnumState(Set<TopicPartition> appendedPartitions) {
         this.appendedPartitions = appendedPartitions;
-        this.pendingPartitionSplits = pendingPartitionSplits;
-        this.sharedPendingPartitionSplits = pendingSharedPartitionSplits;
-        this.readerAssignedSplits = readerAssignedSplits;
-        this.initialized = initialized;
     }
 
     public Set<TopicPartition> getAppendedPartitions() {
         return appendedPartitions;
     }
 
-    public Set<PulsarPartitionSplit> getPendingPartitionSplits() {
-        return pendingPartitionSplits;
-    }
-
-    public Map<Integer, Set<PulsarPartitionSplit>> getSharedPendingPartitionSplits() {
-        return sharedPendingPartitionSplits;
-    }
-
-    public Map<Integer, Set<String>> getReaderAssignedSplits() {
-        return readerAssignedSplits;
-    }
-
-    public boolean isInitialized() {
-        return initialized;
-    }
-
     /** The initial assignment state for Pulsar. */
     public static PulsarSourceEnumState initialState() {
-        return new PulsarSourceEnumState(
-                new HashSet<>(), new HashSet<>(), new HashMap<>(), new HashMap<>(), false);
+        return new PulsarSourceEnumState(new HashSet<>());
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumerator.java
@@ -25,6 +25,7 @@ import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.connector.pulsar.source.enumerator.assigner.SplitAssigner;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.CursorPosition;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
@@ -45,8 +46,10 @@ import java.util.Set;
 import static java.util.Collections.singletonList;
 import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createAdmin;
 import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyAdmin;
+import static org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState.initialState;
+import static org.apache.flink.connector.pulsar.source.enumerator.assigner.SplitAssignerFactory.createAssigner;
 
-/** The enumerator class for pulsar source. */
+/** The enumerator class for the pulsar source. */
 @Internal
 public class PulsarSourceEnumerator
         implements SplitEnumerator<PulsarPartitionSplit, PulsarSourceEnumState> {
@@ -64,17 +67,35 @@ public class PulsarSourceEnumerator
     public PulsarSourceEnumerator(
             PulsarSubscriber subscriber,
             StartCursor startCursor,
+            StopCursor stopCursor,
+            RangeGenerator rangeGenerator,
+            SourceConfiguration sourceConfiguration,
+            SplitEnumeratorContext<PulsarPartitionSplit> context) {
+        this(
+                subscriber,
+                startCursor,
+                stopCursor,
+                rangeGenerator,
+                sourceConfiguration,
+                context,
+                initialState());
+    }
+
+    public PulsarSourceEnumerator(
+            PulsarSubscriber subscriber,
+            StartCursor startCursor,
+            StopCursor stopCursor,
             RangeGenerator rangeGenerator,
             SourceConfiguration sourceConfiguration,
             SplitEnumeratorContext<PulsarPartitionSplit> context,
-            SplitAssigner splitAssigner) {
+            PulsarSourceEnumState enumState) {
         this.pulsarAdmin = createAdmin(sourceConfiguration);
         this.subscriber = subscriber;
         this.startCursor = startCursor;
         this.rangeGenerator = rangeGenerator;
         this.sourceConfiguration = sourceConfiguration;
         this.context = context;
-        this.splitAssigner = splitAssigner;
+        this.splitAssigner = createAssigner(stopCursor, sourceConfiguration, context, enumState);
     }
 
     @Override
@@ -114,7 +135,12 @@ public class PulsarSourceEnumerator
 
         // If the failed subtask has already restarted, we need to assign pending splits to it.
         if (context.registeredReaders().containsKey(subtaskId)) {
-            assignPendingPartitionSplits(singletonList(subtaskId));
+            LOG.debug(
+                    "Reader {} has been restarted after crashing, we will put splits back to it.",
+                    subtaskId);
+            // Reassign for all readers in case of adding splits after scale up/down.
+            List<Integer> readers = new ArrayList<>(context.registeredReaders().keySet());
+            assignPendingPartitionSplits(readers);
         }
     }
 
@@ -155,8 +181,8 @@ public class PulsarSourceEnumerator
     }
 
     /**
-     * Check if there's any partition changes within subscribed topic partitions fetched by worker
-     * thread, and convert them to splits the assign them to pulsar readers.
+     * Check if there are any partition changes within subscribed topic partitions fetched by worker
+     * thread, and convert them to splits, then assign them to pulsar readers.
      *
      * <p>NOTE: This method should only be invoked in the coordinator executor thread.
      *
@@ -230,9 +256,17 @@ public class PulsarSourceEnumerator
                 });
 
         // Assign splits to downstream readers.
-        splitAssigner.createAssignment(pendingReaders).ifPresent(context::assignSplits);
+        splitAssigner
+                .createAssignment(pendingReaders)
+                .ifPresent(
+                        assignments -> {
+                            LOG.info(
+                                    "The split assignment results are: {}",
+                                    assignments.assignment());
+                            context.assignSplits(assignments);
+                        });
 
-        // If periodically partition discovery is disabled and the initializing discovery has done,
+        // If periodically partition discovery is turned off and the initializing discovery has done
         // signal NoMoreSplitsEvent to pending readers.
         for (Integer reader : pendingReaders) {
             if (splitAssigner.noMoreSplits(reader)) {

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/NonSharedSplitAssigner.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/NonSharedSplitAssigner.java
@@ -19,8 +19,8 @@
 package org.apache.flink.connector.pulsar.source.enumerator.assigner;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.connector.source.SplitsAssignment;
-import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
@@ -29,10 +29,7 @@ import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 import org.apache.pulsar.client.api.SubscriptionType;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -40,27 +37,14 @@ import java.util.Set;
  * and {@link SubscriptionType#Key_Shared} subscriptions.
  */
 @Internal
-public class NonSharedSplitAssigner implements SplitAssigner {
-    private static final long serialVersionUID = 8412586087991597092L;
-
-    private final StopCursor stopCursor;
-    private final boolean enablePartitionDiscovery;
-
-    // These fields would be saved into checkpoint.
-
-    private final Set<TopicPartition> appendedPartitions;
-    private final Set<PulsarPartitionSplit> pendingPartitionSplits;
-    private boolean initialized;
+class NonSharedSplitAssigner extends SplitAssignerBase {
 
     public NonSharedSplitAssigner(
             StopCursor stopCursor,
-            SourceConfiguration sourceConfiguration,
-            PulsarSourceEnumState sourceEnumState) {
-        this.stopCursor = stopCursor;
-        this.enablePartitionDiscovery = sourceConfiguration.isEnablePartitionDiscovery();
-        this.appendedPartitions = sourceEnumState.getAppendedPartitions();
-        this.pendingPartitionSplits = sourceEnumState.getPendingPartitionSplits();
-        this.initialized = sourceEnumState.isInitialized();
+            boolean enablePartitionDiscovery,
+            SplitEnumeratorContext<PulsarPartitionSplit> context,
+            PulsarSourceEnumState enumState) {
+        super(stopCursor, enablePartitionDiscovery, context, enumState);
     }
 
     @Override
@@ -69,9 +53,13 @@ public class NonSharedSplitAssigner implements SplitAssigner {
 
         for (TopicPartition partition : fetchedPartitions) {
             if (!appendedPartitions.contains(partition)) {
-                pendingPartitionSplits.add(new PulsarPartitionSplit(partition, stopCursor));
                 appendedPartitions.add(partition);
                 newPartitions.add(partition);
+
+                // Calculate the reader id by the current parallelism.
+                int readerId = partitionOwner(partition);
+                PulsarPartitionSplit split = new PulsarPartitionSplit(partition, stopCursor);
+                addSplitToPendingList(readerId, split);
             }
         }
 
@@ -84,43 +72,41 @@ public class NonSharedSplitAssigner implements SplitAssigner {
 
     @Override
     public void addSplitsBack(List<PulsarPartitionSplit> splits, int subtaskId) {
-        pendingPartitionSplits.addAll(splits);
-    }
-
-    @Override
-    public Optional<SplitsAssignment<PulsarPartitionSplit>> createAssignment(
-            List<Integer> readers) {
-        if (pendingPartitionSplits.isEmpty() || readers.isEmpty()) {
-            return Optional.empty();
+        for (PulsarPartitionSplit split : splits) {
+            int readerId = partitionOwner(split.getPartition());
+            addSplitToPendingList(readerId, split);
         }
-
-        Map<Integer, List<PulsarPartitionSplit>> assignMap = new HashMap<>();
-
-        List<PulsarPartitionSplit> partitionSplits = new ArrayList<>(pendingPartitionSplits);
-        int readerCount = readers.size();
-        for (int i = 0; i < partitionSplits.size(); i++) {
-            int index = i % readerCount;
-            Integer readerId = readers.get(index);
-            PulsarPartitionSplit split = partitionSplits.get(i);
-            assignMap.computeIfAbsent(readerId, id -> new ArrayList<>()).add(split);
-        }
-        pendingPartitionSplits.clear();
-
-        return Optional.of(new SplitsAssignment<>(assignMap));
     }
 
-    @Override
-    public boolean noMoreSplits(Integer reader) {
-        return !enablePartitionDiscovery && initialized && pendingPartitionSplits.isEmpty();
+    /**
+     * Returns the index of the target subtask that a specific partition should be assigned to. It's
+     * inspired by the {@code KafkaSourceEnumerator.getSplitOwner()}
+     *
+     * <p>The resulting distribution of partition has the following contract:
+     *
+     * <ul>
+     *   <li>1. Uniformly distributed across subtasks.
+     *   <li>2. Partitions are round-robin distributed (strictly clockwise w.r.t. ascending subtask
+     *       indices) by using the partition id as the offset from a starting index (i.e., the index
+     *       of the subtask which partition 0 of the topic will be assigned to, determined using the
+     *       topic name).
+     * </ul>
+     *
+     * @param partition The Pulsar partition to assign.
+     * @return The id of the reader that owns this partition.
+     */
+    private int partitionOwner(TopicPartition partition) {
+        return calculatePartitionOwner(
+                partition.getTopic(), partition.getPartitionId(), context.currentParallelism());
     }
 
-    @Override
-    public PulsarSourceEnumState snapshotState() {
-        return new PulsarSourceEnumState(
-                appendedPartitions,
-                pendingPartitionSplits,
-                new HashMap<>(),
-                new HashMap<>(),
-                initialized);
+    @VisibleForTesting
+    static int calculatePartitionOwner(String topic, int partitionId, int parallelism) {
+        int startIndex = ((topic.hashCode() * 31) & 0x7FFFFFFF) % parallelism;
+        /*
+         * Here, the assumption is that the id of Pulsar partitions are always ascending starting from
+         * 0. Therefore, can be used directly as the offset clockwise from the start index.
+         */
+        return (startIndex + partitionId) % parallelism;
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssigner.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssigner.java
@@ -24,7 +24,6 @@ import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 
-import java.io.Serializable;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -34,7 +33,7 @@ import java.util.Set;
  * readers and store all the state into checkpoint.
  */
 @Internal
-public interface SplitAssigner extends Serializable {
+public interface SplitAssigner {
 
     /**
      * Add the current available partitions into assigner.
@@ -54,8 +53,8 @@ public interface SplitAssigner extends Serializable {
     Optional<SplitsAssignment<PulsarPartitionSplit>> createAssignment(List<Integer> readers);
 
     /**
-     * It would return true only if periodically partition discovery is disabled, the initializing
-     * partition discovery has finished AND there is no pending splits for assignment.
+     * It would return true only if periodically partition discovery is turned off, the initializing
+     * partition discovery has finished, AND there are no pending splits for assignment.
      */
     boolean noMoreSplits(Integer reader);
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssignerBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssignerBase.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source.enumerator.assigner;
+
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
+import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/** Common abstraction for split assigner. */
+abstract class SplitAssignerBase implements SplitAssigner {
+
+    protected final StopCursor stopCursor;
+    protected final boolean enablePartitionDiscovery;
+    protected final SplitEnumeratorContext<PulsarPartitionSplit> context;
+    protected final Set<TopicPartition> appendedPartitions;
+    protected final Map<Integer, Set<PulsarPartitionSplit>> pendingPartitionSplits;
+
+    protected boolean initialized;
+
+    protected SplitAssignerBase(
+            StopCursor stopCursor,
+            boolean enablePartitionDiscovery,
+            SplitEnumeratorContext<PulsarPartitionSplit> context,
+            PulsarSourceEnumState enumState) {
+        this.stopCursor = stopCursor;
+        this.enablePartitionDiscovery = enablePartitionDiscovery;
+        this.context = context;
+        this.appendedPartitions = enumState.getAppendedPartitions();
+        this.pendingPartitionSplits = new HashMap<>(context.currentParallelism());
+        this.initialized = false;
+    }
+
+    @Override
+    public Optional<SplitsAssignment<PulsarPartitionSplit>> createAssignment(
+            List<Integer> readers) {
+        if (pendingPartitionSplits.isEmpty() || readers.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Map<Integer, List<PulsarPartitionSplit>> assignMap =
+                new HashMap<>(pendingPartitionSplits.size());
+
+        for (Integer reader : readers) {
+            Set<PulsarPartitionSplit> splits = pendingPartitionSplits.remove(reader);
+            if (splits != null && !splits.isEmpty()) {
+                assignMap.put(reader, new ArrayList<>(splits));
+            }
+        }
+
+        if (assignMap.isEmpty()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new SplitsAssignment<>(assignMap));
+        }
+    }
+
+    @Override
+    public boolean noMoreSplits(Integer reader) {
+        return !enablePartitionDiscovery
+                && initialized
+                && !pendingPartitionSplits.containsKey(reader);
+    }
+
+    @Override
+    public PulsarSourceEnumState snapshotState() {
+        return new PulsarSourceEnumState(appendedPartitions);
+    }
+
+    /** Add split to pending lists. */
+    protected void addSplitToPendingList(int readerId, PulsarPartitionSplit split) {
+        Set<PulsarPartitionSplit> splits =
+                pendingPartitionSplits.computeIfAbsent(readerId, i -> new HashSet<>());
+        splits.add(split);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/CursorPosition.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/CursorPosition.java
@@ -25,6 +25,8 @@ import org.apache.pulsar.client.api.MessageId;
 
 import java.io.Serializable;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
 /**
  * The class for defining the start or stop position. We only expose the constructor for end user.
  */
@@ -39,12 +41,16 @@ public final class CursorPosition implements Serializable {
     private final Long timestamp;
 
     public CursorPosition(MessageId messageId) {
+        checkNotNull(messageId, "Message id couldn't be null.");
+
         this.type = Type.MESSAGE_ID;
         this.messageId = messageId;
         this.timestamp = null;
     }
 
     public CursorPosition(Long timestamp) {
+        checkNotNull(timestamp, "Timestamp couldn't be null.");
+
         this.type = Type.TIMESTAMP;
         this.messageId = null;
         this.timestamp = timestamp;

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/subscriber/impl/TopicPatternSubscriber.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.pulsar.source.enumerator.subscriber.impl;
 
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGenerator;
@@ -35,6 +36,7 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.toSet;
+import static org.apache.flink.shaded.guava30.com.google.common.base.Predicates.not;
 
 /** Subscribe to matching topics based on topic pattern. */
 public class TopicPatternSubscriber extends BasePulsarSubscriber {
@@ -64,6 +66,7 @@ public class TopicPatternSubscriber extends BasePulsarSubscriber {
                     .getTopics(namespace)
                     .parallelStream()
                     .filter(this::matchesSubscriptionMode)
+                    .filter(not(TopicNameUtils::isInternal))
                     .filter(topic -> topicPattern.matcher(topic).find())
                     .map(topic -> queryTopicMetadata(pulsarAdmin, topic))
                     .filter(Objects::nonNull)

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtils.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.pulsar.source.enumerator.topic;
 import org.apache.flink.annotation.Internal;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
 
 import org.apache.pulsar.common.naming.TopicName;
 
@@ -30,12 +31,31 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.pulsar.common.naming.NamespaceName.SYSTEM_NAMESPACE;
+import static org.apache.pulsar.common.naming.TopicDomain.persistent;
 
 /** util for topic name. */
 @Internal
 public final class TopicNameUtils {
+
+    private static final Pattern HEARTBEAT_NAMESPACE_PATTERN =
+            Pattern.compile("pulsar/[^/]+/([^:]+:\\d+)");
+    private static final Pattern HEARTBEAT_NAMESPACE_PATTERN_V2 =
+            Pattern.compile("pulsar/([^:]+:\\d+)");
+    private static final Pattern SLA_NAMESPACE_PATTERN =
+            Pattern.compile("sla-monitor" + "/[^/]+/([^:]+:\\d+)");
+    private static final Set<String> EVENTS_TOPIC_NAMES =
+            ImmutableSet.of("__change_events", "__transaction_buffer_snapshot");
+    private static final String TRANSACTION_COORDINATOR_ASSIGN_PREFIX =
+            TopicName.get(persistent.value(), SYSTEM_NAMESPACE, "transaction_coordinator_assign")
+                    .toString();
+    private static final String TRANSACTION_COORDINATOR_LOG_PREFIX =
+            TopicName.get(persistent.value(), SYSTEM_NAMESPACE, "__transaction_log_").toString();
+    private static final String PENDING_ACK_STORE_SUFFIX = "__transaction_pending_ack";
+    private static final String PENDING_ACK_STORE_CURSOR_SUFFIX = "__pending_ack_state";
 
     private TopicNameUtils() {
         // No public constructor.
@@ -50,11 +70,6 @@ public final class TopicNameUtils {
     public static String topicNameWithPartition(String topic, int partitionId) {
         checkArgument(partitionId >= 0, "Illegal partition id %s", partitionId);
         return TopicName.get(topic).getPartition(partitionId).toString();
-    }
-
-    /** Get a non-partitioned topic name that does not belong to any partitioned topic. */
-    public static String topicNameWithoutPartition(String topic) {
-        return TopicName.get(topic).toString();
     }
 
     public static boolean isPartition(String topic) {
@@ -91,5 +106,32 @@ public final class TopicNameUtils {
         }
 
         return builder.build();
+    }
+
+    /**
+     * This method is refactored from {@code BrokerService} in pulsar-broker which is not available
+     * in the Pulsar client. We have to put it here and self maintained. Since these topic names
+     * would never be changed for backward compatible, we only need to add new topic names after
+     * version bump.
+     *
+     * @see <a
+     *     href="https://github.com/apache/pulsar/blob/7075a5ce0d4a70f52625ac8c3d0c48894442b72a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java#L3024">BrokerService#isSystemTopic</a>
+     */
+    public static boolean isInternal(String topic) {
+        // A topic name instance without partition information.
+        String topicName = topicName(topic);
+        TopicName topicInstance = TopicName.get(topicName);
+        String localName = topicInstance.getLocalName();
+        String namespace = topicInstance.getNamespace();
+
+        return namespace.equals(SYSTEM_NAMESPACE.toString())
+                || SLA_NAMESPACE_PATTERN.matcher(namespace).matches()
+                || HEARTBEAT_NAMESPACE_PATTERN.matcher(namespace).matches()
+                || HEARTBEAT_NAMESPACE_PATTERN_V2.matcher(namespace).matches()
+                || EVENTS_TOPIC_NAMES.contains(localName)
+                || topicName.startsWith(TRANSACTION_COORDINATOR_ASSIGN_PREFIX)
+                || topicName.startsWith(TRANSACTION_COORDINATOR_LOG_PREFIX)
+                || localName.endsWith(PENDING_ACK_STORE_SUFFIX)
+                || localName.endsWith(PENDING_ACK_STORE_CURSOR_SUFFIX);
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarUnorderedFetcherManager.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/fetcher/PulsarUnorderedFetcherManager.java
@@ -53,19 +53,19 @@ public class PulsarUnorderedFetcherManager<T> extends PulsarFetcherManagerBase<T
         super(elementsQueue, splitReaderSupplier);
     }
 
-    public List<PulsarPartitionSplit> snapshotState(long checkpointId) {
+    public List<PulsarPartitionSplit> snapshotState() {
         return fetchers.values().stream()
                 .map(SplitFetcher::getSplitReader)
-                .map(splitReader -> snapshotReader(checkpointId, splitReader))
+                .map(this::snapshotReader)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
                 .collect(toCollection(() -> new ArrayList<>(fetchers.size())));
     }
 
     private Optional<PulsarPartitionSplit> snapshotReader(
-            long checkpointId, SplitReader<PulsarMessage<T>, PulsarPartitionSplit> splitReader) {
+            SplitReader<PulsarMessage<T>, PulsarPartitionSplit> splitReader) {
         return ((PulsarUnorderedPartitionSplitReader<T>) splitReader)
-                .snapshotState(checkpointId)
+                .snapshotState()
                 .map(PulsarPartitionSplitState::toPulsarPartitionSplit);
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
@@ -138,11 +138,10 @@ public class PulsarUnorderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT
     public List<PulsarPartitionSplit> snapshotState(long checkpointId) {
         LOG.debug("Trigger the new transaction for downstream readers.");
         List<PulsarPartitionSplit> splits =
-                ((PulsarUnorderedFetcherManager<OUT>) splitFetcherManager)
-                        .snapshotState(checkpointId);
+                ((PulsarUnorderedFetcherManager<OUT>) splitFetcherManager).snapshotState();
 
         if (coordinatorClient != null) {
-            // Snapshot the transaction status and commit it after checkpoint finished.
+            // Snapshot the transaction status and commit it after checkpoint finishing.
             List<TxnID> txnIDs =
                     transactionsToCommit.computeIfAbsent(checkpointId, id -> new ArrayList<>());
             for (PulsarPartitionSplit split : splits) {

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderBase.java
@@ -160,24 +160,21 @@ abstract class PulsarPartitionSplitReaderBase<OUT>
         List<PulsarPartitionSplit> newSplits = splitsChanges.splits();
         Preconditions.checkArgument(
                 newSplits.size() == 1, "This pulsar split reader only support one split.");
-        PulsarPartitionSplit newSplit = newSplits.get(0);
+        this.registeredSplit = newSplits.get(0);
 
         // Open stop cursor.
-        newSplit.open(pulsarAdmin);
+        registeredSplit.open(pulsarAdmin);
 
         // Before creating the consumer.
-        beforeCreatingConsumer(newSplit);
+        beforeCreatingConsumer(registeredSplit);
 
         // Create pulsar consumer.
-        Consumer<byte[]> consumer = createPulsarConsumer(newSplit);
+        this.pulsarConsumer = createPulsarConsumer(registeredSplit);
 
         // After creating the consumer.
-        afterCreatingConsumer(newSplit, consumer);
+        afterCreatingConsumer(registeredSplit, pulsarConsumer);
 
-        LOG.info("Register split {} consumer for current reader.", newSplit);
-
-        this.registeredSplit = newSplit;
-        this.pulsarConsumer = consumer;
+        LOG.info("Register split {} consumer for current reader.", registeredSplit);
     }
 
     @Override

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
@@ -136,7 +136,7 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
         }
     }
 
-    public Optional<PulsarPartitionSplitState> snapshotState(long checkpointId) {
+    public Optional<PulsarPartitionSplitState> snapshotState() {
         if (registeredSplit == null) {
             return Optional.empty();
         }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
@@ -58,8 +58,6 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
     private static final Logger LOG =
             LoggerFactory.getLogger(PulsarUnorderedPartitionSplitReader.class);
 
-    private static final Duration REDELIVER_TIME = Duration.ofSeconds(3);
-
     private final TransactionCoordinatorClient coordinatorClient;
 
     @Nullable private Transaction uncommittedTransaction;
@@ -98,17 +96,7 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
                         .acknowledgeAsync(message.getMessageId(), uncommittedTransaction)
                         .get();
             } catch (InterruptedException e) {
-                sneakyClient(
-                        () ->
-                                pulsarConsumer.reconsumeLater(
-                                        message, REDELIVER_TIME.toMillis(), TimeUnit.MILLISECONDS));
                 Thread.currentThread().interrupt();
-                throw e;
-            } catch (ExecutionException e) {
-                sneakyClient(
-                        () ->
-                                pulsarConsumer.reconsumeLater(
-                                        message, REDELIVER_TIME.toMillis(), TimeUnit.MILLISECONDS));
                 throw e;
             }
         }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -147,7 +148,11 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
         }
     }
 
-    public PulsarPartitionSplitState snapshotState(long checkpointId) {
+    public Optional<PulsarPartitionSplitState> snapshotState(long checkpointId) {
+        if (registeredSplit == null) {
+            return Optional.empty();
+        }
+
         PulsarPartitionSplitState state = new PulsarPartitionSplitState(registeredSplit);
 
         // Avoiding NP problem when Pulsar don't get the message before Flink checkpoint.
@@ -157,7 +162,7 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
             state.setUncommittedTransactionId(txnID);
         }
 
-        return state;
+        return Optional.of(state);
     }
 
     private Transaction newTransaction() {

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListenerTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicMetadataListenerTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.IntStream;
 
@@ -34,8 +33,8 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_TOPIC_METADATA_REFRESH_INTERVAL;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicName;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
-import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithoutPartition;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -130,8 +129,7 @@ class TopicMetadataListenerTest extends PulsarTestSuiteBase {
     void fetchNonPartitionTopic() {
         String topic = randomAlphabetic(10);
         operator().createTopic(topic, 0);
-        List<String> nonPartitionTopic =
-                Collections.singletonList(topicNameWithoutPartition(topic));
+        List<String> nonPartitionTopic = singletonList(topicName(topic));
 
         TopicMetadataListener listener = new TopicMetadataListener(nonPartitionTopic);
         long interval = Duration.ofMinutes(15).toMillis();

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
@@ -32,9 +32,13 @@ import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.testutils.junit.FailsOnJava11;
 
+import org.apache.pulsar.client.api.SubscriptionType;
 import org.junit.experimental.categories.Category;
 
-/** Unite test class for {@link PulsarSource}. */
+/**
+ * Unit test class for {@link PulsarSource}. Used for {@link SubscriptionType#Exclusive}
+ * subscription.
+ */
 @Category(value = {FailsOnJava11.class})
 class PulsarSourceITCase extends SourceTestSuiteBase<String> {
     // Defines test environment on Flink MiniCluster
@@ -48,7 +52,7 @@ class PulsarSourceITCase extends SourceTestSuiteBase<String> {
     CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
 
     // Defines an external context Factories,
-    // so test cases will be invoked using this external contexts.
+    // so test cases will be invoked using these external contexts.
     @TestContext
     PulsarTestContextFactory<String, SingleTopicConsumingContext> singleTopic =
             new PulsarTestContextFactory<>(pulsar, SingleTopicConsumingContext::new);

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarUnorderedSourceITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarUnorderedSourceITCase.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source;
+
+import org.apache.flink.connector.pulsar.testutils.PulsarTestContextFactory;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
+import org.apache.flink.connector.pulsar.testutils.cases.SharedSubscriptionConsumingContext;
+import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntime;
+import org.apache.flink.connector.testframe.environment.MiniClusterTestEnvironment;
+import org.apache.flink.connector.testframe.environment.TestEnvironment;
+import org.apache.flink.connector.testframe.external.source.DataStreamSourceExternalContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
+import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem;
+import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
+import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.testutils.junit.FailsOnJava11;
+import org.apache.flink.util.CloseableIterator;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Disabled;
+
+import java.util.List;
+
+import static java.util.concurrent.CompletableFuture.runAsync;
+import static org.apache.flink.connector.testframe.utils.CollectIteratorAssertions.assertUnordered;
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.DEFAULT_COLLECT_DATA_TIMEOUT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Unit test class for {@link PulsarSource}. Used for {@link SubscriptionType#Shared} subscription.
+ */
+@Category(value = {FailsOnJava11.class})
+public class PulsarUnorderedSourceITCase extends SourceTestSuiteBase<String> {
+    // Defines test environment on Flink MiniCluster
+    @TestEnv MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
+
+    // Defines pulsar running environment
+    @TestExternalSystem
+    PulsarTestEnvironment pulsar = new PulsarTestEnvironment(PulsarRuntime.mock());
+
+    @TestSemantics
+    CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
+
+    @TestContext
+    PulsarTestContextFactory<String, SharedSubscriptionConsumingContext> singleTopic =
+            new PulsarTestContextFactory<>(pulsar, SharedSubscriptionConsumingContext::new);
+
+    @Override
+    protected void checkResultWithSemantic(
+            CloseableIterator<String> resultIterator,
+            List<List<String>> testData,
+            CheckpointingMode semantic,
+            Integer limit) {
+        Runnable runnable =
+                () ->
+                        assertUnordered(resultIterator)
+                                .withNumRecordsLimit(getExpectedSize(testData, limit))
+                                .matchesRecordsFromSource(testData, semantic);
+
+        assertThat(runAsync(runnable)).succeedsWithin(DEFAULT_COLLECT_DATA_TIMEOUT);
+    }
+
+    /**
+     * Shared subscription will have multiple readers on same partition, this would make hard to
+     * automatically stop like a bounded source.
+     */
+    private static int getExpectedSize(List<List<String>> testData, Integer limit) {
+        if (limit == null) {
+            return testData.stream().mapToInt(List::size).sum();
+        } else {
+            return limit;
+        }
+    }
+
+    @Override
+    @Disabled("We don't have any idle readers in Pulsar's shared subscription.")
+    public void testIdleReader(
+            TestEnvironment testEnv,
+            DataStreamSourceExternalContext<String> externalContext,
+            CheckpointingMode semantic)
+            throws Exception {
+        super.testIdleReader(testEnv, externalContext, semantic);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumStateSerializerTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumStateSerializerTest.java
@@ -18,23 +18,17 @@
 
 package org.apache.flink.connector.pulsar.source.enumerator;
 
-import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
-import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumStateSerializer.INSTANCE;
-import static org.apache.flink.connector.pulsar.source.enumerator.cursor.MessageIdUtils.newMessageId;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -48,29 +42,13 @@ class PulsarSourceEnumStateSerializerTest {
                 Sets.newHashSet(
                         new TopicPartition(randomAlphabetic(10), 2, new TopicRange(1, 30)),
                         new TopicPartition(randomAlphabetic(10), 1, createFullRange()));
-        Set<PulsarPartitionSplit> splits =
-                Collections.singleton(
-                        new PulsarPartitionSplit(
-                                new TopicPartition(randomAlphabetic(10), 10, createFullRange()),
-                                StopCursor.defaultStopCursor(),
-                                newMessageId(100L, 23L, 44),
-                                null));
-        Map<Integer, Set<PulsarPartitionSplit>> shared = Collections.singletonMap(5, splits);
-        Map<Integer, Set<String>> mapping =
-                ImmutableMap.of(
-                        1, Sets.newHashSet(randomAlphabetic(10), randomAlphabetic(10)),
-                        2, Sets.newHashSet(randomAlphabetic(10), randomAlphabetic(10)));
 
-        PulsarSourceEnumState state =
-                new PulsarSourceEnumState(partitions, splits, shared, mapping, true);
+        PulsarSourceEnumState state = new PulsarSourceEnumState(partitions);
 
         byte[] bytes = INSTANCE.serialize(state);
         PulsarSourceEnumState state1 = INSTANCE.deserialize(INSTANCE.getVersion(), bytes);
 
         assertEquals(state.getAppendedPartitions(), state1.getAppendedPartitions());
-        assertEquals(state.getPendingPartitionSplits(), state1.getPendingPartitionSplits());
-        assertEquals(state.getReaderAssignedSplits(), state1.getReaderAssignedSplits());
-        assertEquals(state.isInitialized(), state1.isInitialized());
 
         assertNotSame(state, state1);
     }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumeratorTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/PulsarSourceEnumeratorTest.java
@@ -19,29 +19,25 @@
 package org.apache.flink.connector.pulsar.source.enumerator;
 
 import org.apache.flink.api.connector.source.ReaderInfo;
+import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
-import org.apache.flink.connector.pulsar.source.enumerator.assigner.SplitAssigner;
-import org.apache.flink.connector.pulsar.source.enumerator.assigner.SplitAssignerFactory;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
-import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.FullRangeGenerator;
 import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
-import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntimeOperator;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
-import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
 
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -49,14 +45,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toSet;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_NAME;
 import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_SUBSCRIPTION_TYPE;
-import static org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor.latest;
+import static org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState.initialState;
 import static org.apache.flink.connector.pulsar.source.enumerator.subscriber.PulsarSubscriber.getTopicPatternSubscriber;
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
+import static org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntimeOperator.DEFAULT_PARTITIONS;
 import static org.apache.flink.shaded.guava30.com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -66,6 +64,7 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
     private static final int NUM_SUBTASKS = 3;
     private static final int READER0 = 0;
     private static final int READER1 = 1;
+    private static final int READER2 = 2;
     private static final int PARTITION_DISCOVERY_CALLABLE_INDEX = 0;
     private static final boolean ENABLE_PERIODIC_PARTITION_DISCOVERY = true;
     private static final boolean DISABLE_PERIODIC_PARTITION_DISCOVERY = false;
@@ -75,13 +74,13 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             value = SubscriptionType.class,
             names = {"Failover", "Shared"})
     void startWithDiscoverPartitionsOnce(SubscriptionType subscriptionType) throws Exception {
-        Set<String> prexistingTopics = setupPreexistingTopics();
+        Set<String> preexistingTopics = setupPreexistingTopics();
         try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 PulsarSourceEnumerator enumerator =
                         createEnumerator(
                                 subscriptionType,
-                                prexistingTopics,
+                                preexistingTopics,
                                 context,
                                 DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
@@ -100,13 +99,13 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             value = SubscriptionType.class,
             names = {"Failover", "Shared"})
     void startWithPeriodicPartitionDiscovery(SubscriptionType subscriptionType) throws Exception {
-        Set<String> prexistingTopics = setupPreexistingTopics();
+        Set<String> preexistingTopics = setupPreexistingTopics();
         try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 PulsarSourceEnumerator enumerator =
                         createEnumerator(
                                 subscriptionType,
-                                prexistingTopics,
+                                preexistingTopics,
                                 context,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
@@ -123,26 +122,27 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             value = SubscriptionType.class,
             names = {"Failover", "Shared"})
     void discoverPartitionsTriggersAssignments(SubscriptionType subscriptionType) throws Throwable {
-        Set<String> prexistingTopics = setupPreexistingTopics();
+        Set<String> preexistingTopics = setupPreexistingTopics();
         try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 PulsarSourceEnumerator enumerator =
                         createEnumerator(
                                 subscriptionType,
-                                prexistingTopics,
+                                preexistingTopics,
                                 context,
                                 DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             enumerator.start();
 
-            // register reader 0, 1
+            // register reader 0, 1, 2
             registerReader(context, enumerator, READER0);
             registerReader(context, enumerator, READER1);
+            registerReader(context, enumerator, READER2);
             assertThat(context.getSplitsAssignmentSequence()).isEmpty();
 
             // Run the partition discover callable and check the partition assignment.
             runOneTimePartitionDiscovery(context);
-            verifyLastReadersAssignments(subscriptionType, context, prexistingTopics, 1);
+            verifyAllReaderAssignments(subscriptionType, context, preexistingTopics, 1);
         }
     }
 
@@ -151,9 +151,9 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             value = SubscriptionType.class,
             names = {"Failover", "Shared"})
     void discoverPartitionsPeriodically(SubscriptionType subscriptionType) throws Throwable {
-        String dynamicTopic = randomAlphabetic(10);
-        Set<String> prexistingTopics = setupPreexistingTopics();
-        Set<String> topicsToSubscribe = new HashSet<>(prexistingTopics);
+        String dynamicTopic = "topic3-" + randomAlphabetic(10);
+        Set<String> preexistingTopics = setupPreexistingTopics();
+        Set<String> topicsToSubscribe = new HashSet<>(preexistingTopics);
         topicsToSubscribe.add(dynamicTopic);
         try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
@@ -165,35 +165,28 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             testRegisterReadersForPreexistingTopics(
-                    subscriptionType, prexistingTopics, context, enumerator);
+                    subscriptionType, preexistingTopics, context, enumerator);
 
             // invoke partition discovery callable again and there should be no new assignments.
             runPeriodicPartitionDiscovery(context);
 
-            int expectedSplitsAssignmentSequenceSize =
-                    subscriptionType == SubscriptionType.Failover ? 1 : 2;
-
             assertThat(context.getSplitsAssignmentSequence())
                     .as("No new assignments should be made because there is no partition change")
-                    .hasSize(expectedSplitsAssignmentSequenceSize);
+                    .hasSize(3);
 
-            // create the dynamic topic.
-            operator().createTopic(dynamicTopic, PulsarRuntimeOperator.DEFAULT_PARTITIONS);
+            // Create the dynamic topic.
+            operator().createTopic(dynamicTopic, DEFAULT_PARTITIONS);
 
-            // invoke partition discovery callable again.
+            // Invoke partition discovery callable again.
             while (true) {
                 runPeriodicPartitionDiscovery(context);
-                if (context.getSplitsAssignmentSequence().size() < 2) {
+                if (context.getSplitsAssignmentSequence().size() < 4) {
                     sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
                 } else {
                     break;
                 }
             }
-            verifyLastReadersAssignments(
-                    subscriptionType,
-                    context,
-                    Collections.singleton(dynamicTopic),
-                    expectedSplitsAssignmentSequenceSize + 1);
+            verifyAllReaderAssignments(subscriptionType, context, topicsToSubscribe, 4);
         }
     }
 
@@ -202,57 +195,51 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             value = SubscriptionType.class,
             names = {"Failover", "Shared"})
     void addSplitsBack(SubscriptionType subscriptionType) throws Throwable {
-        Set<String> prexistingTopics = setupPreexistingTopics();
+        Set<String> preexistingTopics = setupPreexistingTopics();
         try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 PulsarSourceEnumerator enumerator =
                         createEnumerator(
                                 subscriptionType,
-                                prexistingTopics,
+                                preexistingTopics,
                                 context,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
 
             testRegisterReadersForPreexistingTopics(
-                    subscriptionType, prexistingTopics, context, enumerator);
+                    subscriptionType, preexistingTopics, context, enumerator);
 
             // Simulate a reader failure.
             context.unregisterReader(READER0);
             enumerator.addSplitsBack(
                     context.getSplitsAssignmentSequence().get(0).assignment().get(READER0),
                     READER0);
-            int expectedSplitsAssignmentSequenceSize =
-                    subscriptionType == SubscriptionType.Failover ? 1 : 2;
             assertThat(context.getSplitsAssignmentSequence())
                     .as("The added back splits should have not been assigned")
-                    .hasSize(expectedSplitsAssignmentSequenceSize);
+                    .hasSize(3);
 
             // Simulate a reader recovery.
             registerReader(context, enumerator, READER0);
-            verifyLastReadersAssignments(
-                    subscriptionType,
-                    context,
-                    prexistingTopics,
-                    expectedSplitsAssignmentSequenceSize + 1);
+            verifyAllReaderAssignments(subscriptionType, context, preexistingTopics, 3 + 1);
         }
     }
 
     @ParameterizedTest
     @EnumSource(
             value = SubscriptionType.class,
-            names = {"Failover"})
+            names = {"Failover", "Shared"})
     void workWithPreexistingAssignments(SubscriptionType subscriptionType) throws Throwable {
-        Set<String> prexistingTopics = setupPreexistingTopics();
+        Set<String> preexistingTopics = setupPreexistingTopics();
         PulsarSourceEnumState preexistingAssignments;
         try (MockSplitEnumeratorContext<PulsarPartitionSplit> context1 =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 PulsarSourceEnumerator enumerator =
                         createEnumerator(
                                 subscriptionType,
-                                prexistingTopics,
+                                preexistingTopics,
                                 context1,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
             testRegisterReadersForPreexistingTopics(
-                    subscriptionType, prexistingTopics, context1, enumerator);
+                    subscriptionType, preexistingTopics, context1, enumerator);
             preexistingAssignments =
                     asEnumState(context1.getSplitsAssignmentSequence().get(0).assignment());
         }
@@ -262,7 +249,7 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
                 PulsarSourceEnumerator enumerator =
                         createEnumerator(
                                 subscriptionType,
-                                prexistingTopics,
+                                preexistingTopics,
                                 context2,
                                 ENABLE_PERIODIC_PARTITION_DISCOVERY,
                                 preexistingAssignments)) {
@@ -270,7 +257,11 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             runPeriodicPartitionDiscovery(context2);
 
             registerReader(context2, enumerator, READER0);
-            verifyLastReadersAssignments(subscriptionType, context2, prexistingTopics, 1);
+            if (subscriptionType == SubscriptionType.Shared) {
+                verifyAllReaderAssignments(subscriptionType, context2, preexistingTopics, 1);
+            } else {
+                assertThat(context2.getSplitsAssignmentSequence()).isEmpty();
+            }
         }
     }
 
@@ -279,11 +270,11 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             value = SubscriptionType.class,
             names = {"Failover", "Shared"})
     void snapshotState(SubscriptionType subscriptionType) throws Throwable {
-        Set<String> prexistingTopics = setupPreexistingTopics();
+        Set<String> preexistingTopics = setupPreexistingTopics();
         try (MockSplitEnumeratorContext<PulsarPartitionSplit> context =
                         new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
                 PulsarSourceEnumerator enumerator =
-                        createEnumerator(subscriptionType, prexistingTopics, context, false)) {
+                        createEnumerator(subscriptionType, preexistingTopics, context, false)) {
             enumerator.start();
 
             // No reader is registered, so the state should be empty
@@ -297,19 +288,18 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             // The state should contain splits assigned to READER0 and READER1
             final PulsarSourceEnumState state2 = enumerator.snapshotState(1L);
             verifySplitAssignmentWithPartitions(
-                    getExpectedTopicPartitions(prexistingTopics), state2.getAppendedPartitions());
+                    getExpectedTopicPartitions(preexistingTopics), state2.getAppendedPartitions());
         }
     }
 
     private Set<String> setupPreexistingTopics() {
-        String topic1 = randomAlphabetic(10);
-        String topic2 = randomAlphabetic(10);
+        String topic1 = "topic1-" + randomAlphabetic(10);
+        String topic2 = "topic2-" + randomAlphabetic(10);
+
         operator().setupTopic(topic1);
         operator().setupTopic(topic2);
-        Set<String> preexistingTopics = new HashSet<>();
-        preexistingTopics.add(topic1);
-        preexistingTopics.add(topic2);
-        return preexistingTopics;
+
+        return ImmutableSet.of(topic1, topic2);
     }
 
     private void testRegisterReadersForPreexistingTopics(
@@ -326,14 +316,14 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
 
         // Run the partition discover callable and check the partition assignment.
         runPeriodicPartitionDiscovery(context);
-        verifyLastReadersAssignments(subscriptionType, context, topics, 1);
+        if (subscriptionType == SubscriptionType.Shared) {
+            verifyAllReaderAssignments(subscriptionType, context, topics, 1);
+        }
 
         registerReader(context, enumerator, READER1);
+        registerReader(context, enumerator, READER2);
 
-        int expectedSplitsAssignmentSequenceSize =
-                subscriptionType == SubscriptionType.Failover ? 1 : 2;
-        verifyLastReadersAssignments(
-                subscriptionType, context, topics, expectedSplitsAssignmentSequenceSize);
+        verifyAllReaderAssignments(subscriptionType, context, topics, 3);
     }
 
     private PulsarSourceEnumerator createEnumerator(
@@ -341,19 +331,12 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
             Set<String> topics,
             MockSplitEnumeratorContext<PulsarPartitionSplit> enumContext,
             boolean enablePeriodicPartitionDiscovery) {
-        PulsarSourceEnumState sourceEnumState =
-                new PulsarSourceEnumState(
-                        Sets.newHashSet(),
-                        Sets.newHashSet(),
-                        Maps.newHashMap(),
-                        Maps.newHashMap(),
-                        false);
         return createEnumerator(
                 subscriptionType,
                 topics,
                 enumContext,
                 enablePeriodicPartitionDiscovery,
-                sourceEnumState);
+                initialState());
     }
 
     private PulsarSourceEnumerator createEnumerator(
@@ -377,50 +360,50 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
         } else {
             configuration.set(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, -1L);
         }
-        SourceConfiguration sourceConfiguration = new SourceConfiguration(configuration);
 
-        SplitAssigner assigner =
-                SplitAssignerFactory.create(latest(), sourceConfiguration, sourceEnumState);
         return new PulsarSourceEnumerator(
                 subscriber,
                 StartCursor.earliest(),
+                StopCursor.latest(),
                 new FullRangeGenerator(),
-                sourceConfiguration,
+                new SourceConfiguration(configuration),
                 enumContext,
-                assigner);
+                sourceEnumState);
     }
 
     private void registerReader(
             MockSplitEnumeratorContext<PulsarPartitionSplit> context,
             PulsarSourceEnumerator enumerator,
             int reader) {
-        context.registerReader(new ReaderInfo(reader, "testing location "));
+        context.registerReader(new ReaderInfo(reader, "testing location"));
         enumerator.addReader(reader);
     }
 
-    private void verifyLastReadersAssignments(
+    private void verifyAllReaderAssignments(
             SubscriptionType subscriptionType,
             MockSplitEnumeratorContext<PulsarPartitionSplit> context,
             Set<String> topics,
             int expectedAssignmentSeqSize) {
         assertThat(context.getSplitsAssignmentSequence()).hasSize(expectedAssignmentSeqSize);
-        verifyAssignments(
-                subscriptionType,
-                getExpectedTopicPartitions(topics),
-                context.getSplitsAssignmentSequence()
-                        .get(expectedAssignmentSeqSize - 1)
-                        .assignment());
-    }
+        // Merge the assignments into one
+        List<SplitsAssignment<PulsarPartitionSplit>> sequence =
+                context.getSplitsAssignmentSequence();
+        Map<Integer, Set<PulsarPartitionSplit>> assignments = new HashMap<>();
 
-    private void verifyAssignments(
-            SubscriptionType subscriptionType,
-            Set<TopicPartition> expectedTopicPartitions,
-            Map<Integer, List<PulsarPartitionSplit>> actualAssignments) {
+        for (int i = 0; i < expectedAssignmentSeqSize; i++) {
+            Map<Integer, List<PulsarPartitionSplit>> assignment = sequence.get(i).assignment();
+            assignment.forEach(
+                    (key, value) ->
+                            assignments.computeIfAbsent(key, k -> new HashSet<>()).addAll(value));
+        }
+
+        // Compare assigned partitions with desired partitions.
+        Set<TopicPartition> expectedTopicPartitions = getExpectedTopicPartitions(topics);
         if (subscriptionType == SubscriptionType.Failover) {
-            int actualSize = actualAssignments.values().stream().mapToInt(List::size).sum();
+            int actualSize = assignments.values().stream().mapToInt(Set::size).sum();
             assertThat(actualSize).isEqualTo(expectedTopicPartitions.size());
         } else if (subscriptionType == SubscriptionType.Shared) {
-            actualAssignments
+            assignments
                     .values()
                     .forEach(
                             (splits) -> assertThat(splits).hasSize(expectedTopicPartitions.size()));
@@ -430,8 +413,8 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
     private Set<TopicPartition> getExpectedTopicPartitions(Set<String> topics) {
         Set<TopicPartition> allPartitions = new HashSet<>();
         for (String topicName : topics) {
-            for (int i = 0; i < PulsarRuntimeOperator.DEFAULT_PARTITIONS; i++) {
-                allPartitions.add(new TopicPartition(topicName, i, TopicRange.createFullRange()));
+            for (int i = 0; i < DEFAULT_PARTITIONS; i++) {
+                allPartitions.add(new TopicPartition(topicName, i, createFullRange()));
             }
         }
         return allPartitions;
@@ -442,32 +425,16 @@ class PulsarSourceEnumeratorTest extends PulsarTestSuiteBase {
         assertThat(actualTopicPartitions).isEqualTo(expectedAssignment);
     }
 
-    // this method only works for non Shared Mode
+    // this method only works for non-Shared Mode
     private PulsarSourceEnumState asEnumState(
             Map<Integer, List<PulsarPartitionSplit>> assignments) {
-        Set<TopicPartition> appendedPartitions = new HashSet<>();
-        Set<PulsarPartitionSplit> pendingPartitionSplits = new HashSet<>();
-        Map<Integer, Set<PulsarPartitionSplit>> sharedPendingPartitionSplits = new HashMap<>();
-        Map<Integer, Set<String>> readerAssignedSplits = new HashMap<>();
-        boolean initialized = false;
+        Set<TopicPartition> appendedPartitions =
+                assignments.values().stream()
+                        .flatMap(List::stream)
+                        .map(PulsarPartitionSplit::getPartition)
+                        .collect(toSet());
 
-        assignments
-                .values()
-                .forEach(
-                        splits -> {
-                            appendedPartitions.addAll(
-                                    splits.stream()
-                                            .map(PulsarPartitionSplit::getPartition)
-                                            .collect(Collectors.toList()));
-                            pendingPartitionSplits.addAll(splits);
-                        });
-
-        return new PulsarSourceEnumState(
-                appendedPartitions,
-                pendingPartitionSplits,
-                sharedPendingPartitionSplits,
-                readerAssignedSplits,
-                initialized);
+        return new PulsarSourceEnumState(appendedPartitions);
     }
 
     private void runOneTimePartitionDiscovery(

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/NonSharedSplitAssignerTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/NonSharedSplitAssignerTest.java
@@ -18,47 +18,56 @@
 
 package org.apache.flink.connector.pulsar.source.enumerator.assigner;
 
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
-import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
+import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Collections.singletonList;
+import static org.apache.flink.connector.pulsar.source.enumerator.assigner.NonSharedSplitAssigner.calculatePartitionOwner;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit tests for {@link NonSharedSplitAssigner}. */
-class NonSharedSplitAssignerTest extends SplitAssignerTestBase<NonSharedSplitAssigner> {
+class NonSharedSplitAssignerTest extends SplitAssignerTestBase {
 
     @Test
     void noMoreSplits() {
-        NonSharedSplitAssigner assigner = splitAssigner(true);
+        SplitAssigner assigner = splitAssigner(true, 4);
         assertFalse(assigner.noMoreSplits(3));
 
-        assigner = splitAssigner(false);
+        assigner = splitAssigner(false, 4);
         assertFalse(assigner.noMoreSplits(3));
 
-        assigner.registerTopicPartitions(createPartitions("f", 8));
-        assertFalse(assigner.noMoreSplits(3));
+        Set<TopicPartition> partitions = createPartitions("persistent://public/default/f", 8);
+        int owner = calculatePartitionOwner("persistent://public/default/f", 8, 4);
 
-        assigner.createAssignment(singletonList(1));
-        assertTrue(assigner.noMoreSplits(1));
-        assertTrue(assigner.noMoreSplits(3));
+        assigner.registerTopicPartitions(partitions);
+        assertFalse(assigner.noMoreSplits(owner));
+
+        assigner.createAssignment(singletonList(owner));
+        assertTrue(assigner.noMoreSplits(owner));
     }
 
     @Test
     void partitionsAssignment() {
-        NonSharedSplitAssigner assigner = splitAssigner(true);
-        assigner.registerTopicPartitions(createPartitions("d", 4));
-        List<Integer> readers = Arrays.asList(1, 3, 5, 7);
+        SplitAssigner assigner = splitAssigner(true, 4);
+        assigner.registerTopicPartitions(createPartitions("persistent://public/default/d", 4));
+        int owner = calculatePartitionOwner("persistent://public/default/d", 4, 4);
+        List<Integer> readers = Arrays.asList(owner, owner + 1);
 
         // Assignment with initial states.
         Optional<SplitsAssignment<PulsarPartitionSplit>> assignment =
@@ -66,30 +75,39 @@ class NonSharedSplitAssignerTest extends SplitAssignerTestBase<NonSharedSplitAss
         assertThat(assignment).isPresent();
         assertThat(assignment.get().assignment()).hasSize(1);
 
-        // Reassignment with same readers.
+        // Reassignment with the same readers.
         assignment = assigner.createAssignment(readers);
         assertThat(assignment).isNotPresent();
 
         // Register new partition and assign.
-        assigner.registerTopicPartitions(createPartitions("e", 5));
-        assigner.registerTopicPartitions(createPartitions("f", 1));
-        assigner.registerTopicPartitions(createPartitions("g", 3));
-        assigner.registerTopicPartitions(createPartitions("h", 4));
+        assigner.registerTopicPartitions(createPartitions("persistent://public/default/e", 5));
+        assigner.registerTopicPartitions(createPartitions("persistent://public/default/f", 1));
+        assigner.registerTopicPartitions(createPartitions("persistent://public/default/g", 3));
+        assigner.registerTopicPartitions(createPartitions("persistent://public/default/h", 4));
+
+        Set<Integer> owners = new HashSet<>();
+        owners.add(calculatePartitionOwner("persistent://public/default/e", 5, 4));
+        owners.add(calculatePartitionOwner("persistent://public/default/f", 1, 4));
+        owners.add(calculatePartitionOwner("persistent://public/default/g", 3, 4));
+        owners.add(calculatePartitionOwner("persistent://public/default/h", 4, 4));
+        readers = new ArrayList<>(owners);
+
         assignment = assigner.createAssignment(readers);
         assertThat(assignment).isPresent();
-        assertThat(assignment.get().assignment()).hasSize(4);
+        assertThat(assignment.get().assignment()).hasSize(readers.size());
 
         // Assign to new readers.
-        readers = Arrays.asList(2, 4, 6, 8);
+        readers = Collections.singletonList(5);
         assignment = assigner.createAssignment(readers);
         assertThat(assignment).isNotPresent();
     }
 
     @Override
-    protected NonSharedSplitAssigner createAssigner(
+    protected SplitAssigner createAssigner(
             StopCursor stopCursor,
-            SourceConfiguration sourceConfiguration,
-            PulsarSourceEnumState sourceEnumState) {
-        return new NonSharedSplitAssigner(stopCursor, sourceConfiguration, sourceEnumState);
+            boolean enablePartitionDiscovery,
+            SplitEnumeratorContext<PulsarPartitionSplit> context,
+            PulsarSourceEnumState enumState) {
+        return new NonSharedSplitAssigner(stopCursor, enablePartitionDiscovery, context, enumState);
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssignerTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/assigner/SplitAssignerTestBase.java
@@ -18,17 +18,19 @@
 
 package org.apache.flink.connector.pulsar.source.enumerator.assigner;
 
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
+import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.TopicPartition;
 import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -36,18 +38,20 @@ import java.util.Set;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
-import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_PARTITION_DISCOVERY_INTERVAL_MS;
 import static org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState.initialState;
 import static org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor.defaultStopCursor;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicRange.createFullRange;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test utils for split assigners. */
-abstract class SplitAssignerTestBase<T extends SplitAssigner> extends TestLogger {
+abstract class SplitAssignerTestBase extends TestLogger {
+
+    private static final List<MockSplitEnumeratorContext<PulsarPartitionSplit>> enumeratorContexts =
+            new ArrayList<>();
 
     @Test
     void registerTopicPartitionsWillOnlyReturnNewPartitions() {
-        T assigner = splitAssigner(true);
+        SplitAssigner assigner = splitAssigner(true, 4);
 
         Set<TopicPartition> partitions = createPartitions("persistent://public/default/a", 1);
         List<TopicPartition> newPartitions = assigner.registerTopicPartitions(partitions);
@@ -72,7 +76,7 @@ abstract class SplitAssignerTestBase<T extends SplitAssigner> extends TestLogger
 
     @Test
     void noReadersProvideForAssignment() {
-        T assigner = splitAssigner(false);
+        SplitAssigner assigner = splitAssigner(false, 4);
         assigner.registerTopicPartitions(createPartitions("c", 5));
 
         Optional<SplitsAssignment<PulsarPartitionSplit>> assignment =
@@ -82,7 +86,7 @@ abstract class SplitAssignerTestBase<T extends SplitAssigner> extends TestLogger
 
     @Test
     void noPartitionsProvideForAssignment() {
-        T assigner = splitAssigner(true);
+        SplitAssigner assigner = splitAssigner(true, 4);
         Optional<SplitsAssignment<PulsarPartitionSplit>> assignment =
                 assigner.createAssignment(singletonList(4));
         assertThat(assignment).isNotPresent();
@@ -93,21 +97,32 @@ abstract class SplitAssignerTestBase<T extends SplitAssigner> extends TestLogger
         return singleton(p1);
     }
 
-    protected T splitAssigner(boolean discovery) {
-        Configuration configuration = new Configuration();
-
-        if (discovery) {
-            configuration.set(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, 1000L);
-        } else {
-            configuration.set(PULSAR_PARTITION_DISCOVERY_INTERVAL_MS, -1L);
-        }
-
-        SourceConfiguration sourceConfiguration = new SourceConfiguration(configuration);
-        return createAssigner(defaultStopCursor(), sourceConfiguration, initialState());
+    protected SplitAssigner splitAssigner(boolean discovery, int parallelism) {
+        MockSplitEnumeratorContext<PulsarPartitionSplit> context =
+                new MockSplitEnumeratorContext<>(parallelism);
+        enumeratorContexts.add(context);
+        return createAssigner(defaultStopCursor(), discovery, context, initialState());
     }
 
-    protected abstract T createAssigner(
+    protected SplitAssigner splitAssigner(
+            boolean discovery, int parallelism, Set<TopicPartition> partitions) {
+        MockSplitEnumeratorContext<PulsarPartitionSplit> context =
+                new MockSplitEnumeratorContext<>(parallelism);
+        enumeratorContexts.add(context);
+        return createAssigner(
+                defaultStopCursor(), discovery, context, new PulsarSourceEnumState(partitions));
+    }
+
+    protected abstract SplitAssigner createAssigner(
             StopCursor stopCursor,
-            SourceConfiguration sourceConfiguration,
-            PulsarSourceEnumState sourceEnumState);
+            boolean enablePartitionDiscovery,
+            SplitEnumeratorContext<PulsarPartitionSplit> context,
+            PulsarSourceEnumState enumState);
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        for (MockSplitEnumeratorContext<PulsarPartitionSplit> context : enumeratorContexts) {
+            context.close();
+        }
+    }
 }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtilsTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/topic/TopicNameUtilsTest.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Unit tests for {@link TopicNameUtils}. */
 class TopicNameUtilsTest {
@@ -83,5 +84,13 @@ class TopicNameUtilsTest {
                 .containsExactlyInAnyOrder(
                         "persistent://public/default/short-topic",
                         "persistent://public/default/long-topic-partition-1");
+    }
+
+    @Test
+    void internalTopicAssertion() {
+        boolean internal =
+                TopicNameUtils.isInternal(
+                        "persistent://public/default/topic__transaction_pending_ack");
+        assertTrue(internal);
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/cases/SharedSubscriptionConsumingContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/cases/SharedSubscriptionConsumingContext.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils.cases;
+
+import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
+
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A consuming context with {@link SubscriptionType#Shared}, it's almost the same as {@link
+ * MultipleTopicConsumingContext}.
+ */
+public class SharedSubscriptionConsumingContext extends MultipleTopicTemplateContext {
+
+    public SharedSubscriptionConsumingContext(PulsarTestEnvironment environment) {
+        this(environment, Collections.emptyList());
+    }
+
+    public SharedSubscriptionConsumingContext(
+            PulsarTestEnvironment environment, List<URL> connectorJarPaths) {
+        super(environment, connectorJarPaths);
+    }
+
+    @Override
+    protected String displayName() {
+        return "consuming message with shared subscription";
+    }
+
+    @Override
+    protected String subscriptionName() {
+        return "flink-shared-subscription-test";
+    }
+
+    @Override
+    protected SubscriptionType subscriptionType() {
+        return SubscriptionType.Shared;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/PulsarRuntimeOperator.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/PulsarRuntimeOperator.java
@@ -29,6 +29,7 @@ import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
 import org.apache.pulsar.client.admin.PulsarAdminException.NotFoundException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
@@ -53,7 +54,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -76,7 +76,8 @@ import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_WR
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicName;
 import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.pulsar.client.api.SubscriptionInitialPosition.Earliest;
+import static org.apache.pulsar.client.api.MessageId.earliest;
+import static org.apache.pulsar.client.api.ProducerAccessMode.Shared;
 import static org.apache.pulsar.client.api.SubscriptionMode.Durable;
 import static org.apache.pulsar.client.api.SubscriptionType.Exclusive;
 import static org.apache.pulsar.common.partition.PartitionedTopicMetadata.NON_PARTITIONED;
@@ -95,8 +96,6 @@ public class PulsarRuntimeOperator implements Closeable {
     private final String adminUrl;
     private final PulsarClient client;
     private final PulsarAdmin admin;
-    private final ConcurrentHashMap<String, ConcurrentHashMap<Integer, Producer<?>>> producers;
-    private final ConcurrentHashMap<String, ConcurrentHashMap<Integer, Consumer<?>>> consumers;
 
     public PulsarRuntimeOperator(String serviceUrl, String adminUrl) {
         this(serviceUrl, serviceUrl, adminUrl, adminUrl);
@@ -117,8 +116,6 @@ public class PulsarRuntimeOperator implements Closeable {
                                         .enableTransaction(true)
                                         .build());
         this.admin = sneakyClient(() -> PulsarAdmin.builder().serviceHttpUrl(adminUrl).build());
-        this.producers = new ConcurrentHashMap<>();
-        this.consumers = new ConcurrentHashMap<>();
     }
 
     /**
@@ -169,7 +166,8 @@ public class PulsarRuntimeOperator implements Closeable {
     }
 
     /**
-     * Create a pulsar topic with given partition number.
+     * Create a pulsar topic with given partition number if the topic doesn't exist. We won't do
+     * anything for the existing topic. Make sure correctly used in the testing code.
      *
      * @param topic The name of the topic.
      * @param numberOfPartitions The number of partitions. We would create a non-partitioned topic
@@ -218,10 +216,6 @@ public class PulsarRuntimeOperator implements Closeable {
             sneakyThrow(e);
             return;
         }
-
-        // Close all the available consumers and producers.
-        removeConsumers(topic);
-        removeProducers(topic);
 
         if (metadata.partitions == NON_PARTITIONED) {
             sneakyAdmin(() -> admin().topics().delete(topicName));
@@ -305,8 +299,8 @@ public class PulsarRuntimeOperator implements Closeable {
      */
     public <T> List<MessageId> sendMessages(
             String topic, Schema<T> schema, String key, Collection<T> messages) {
+        Producer<T> producer = createProducer(topic, schema);
         try {
-            Producer<T> producer = createProducer(topic, schema);
             List<MessageId> messageIds = new ArrayList<>(messages.size());
 
             for (T message : messages) {
@@ -322,6 +316,15 @@ public class PulsarRuntimeOperator implements Closeable {
         } catch (PulsarClientException e) {
             sneakyThrow(e);
             return emptyList();
+        } finally {
+            try {
+                // Waiting for all the pending messages be sent to the Pulsar.
+                producer.flush();
+                // Directly close without the flush will drop all the pending messages.
+                producer.close();
+            } catch (PulsarClientException e) {
+                // Just ignore the exception here.
+            }
         }
     }
 
@@ -330,9 +333,10 @@ public class PulsarRuntimeOperator implements Closeable {
      * message from this topic.
      */
     public <T> Message<T> receiveMessage(String topic, Schema<T> schema) {
-        try {
-            Consumer<T> consumer = createConsumer(topic, schema);
-            return drainOneMessage(consumer);
+        try (Consumer<T> consumer = createConsumer(topic, schema)) {
+            Message<T> message = consumer.receive();
+            consumer.acknowledge(message.getMessageId());
+            return message;
         } catch (PulsarClientException e) {
             sneakyThrow(e);
             return null;
@@ -344,10 +348,10 @@ public class PulsarRuntimeOperator implements Closeable {
      * timeout. A null message would be returned if no message has been consumed from Pulsar.
      */
     public <T> Message<T> receiveMessage(String topic, Schema<T> schema, Duration timeout) {
-        try {
-            Consumer<T> consumer = createConsumer(topic, schema);
-            Message<T> message = consumer.receiveAsync().get(timeout.toMillis(), MILLISECONDS);
-            consumer.acknowledgeCumulative(message.getMessageId());
+        try (Consumer<T> consumer = createConsumer(topic, schema)) {
+            Message<T> message =
+                    consumer.receive(Math.toIntExact(timeout.toMillis()), MILLISECONDS);
+            consumer.acknowledge(message.getMessageId());
 
             return message;
         } catch (Exception e) {
@@ -371,12 +375,12 @@ public class PulsarRuntimeOperator implements Closeable {
             return singletonList(message);
         } else {
             // Drain a fixed number of messages.
-            try {
-                Consumer<T> consumer = createConsumer(topic, schema);
+            try (Consumer<T> consumer = createConsumer(topic, schema)) {
                 List<Message<T>> messages = new ArrayList<>(counts);
                 for (int i = 0; i < counts; i++) {
-                    Message<T> message = drainOneMessage(consumer);
+                    Message<T> message = consumer.receive();
                     messages.add(message);
+                    consumer.acknowledge(message.getMessageId());
                 }
                 return messages;
             } catch (PulsarClientException e) {
@@ -459,9 +463,6 @@ public class PulsarRuntimeOperator implements Closeable {
     /** This method is used for test framework. You can't close this operator manually. */
     @Override
     public void close() throws IOException {
-        producers.clear();
-        consumers.clear();
-
         if (admin != null) {
             admin.close();
         }
@@ -474,93 +475,53 @@ public class PulsarRuntimeOperator implements Closeable {
 
     private void createNonPartitionedTopic(String topic) {
         try {
-            admin().lookups().lookupTopic(topic);
-            sneakyAdmin(() -> admin().topics().expireMessagesForAllSubscriptions(topic, 0));
+            admin().topics().createNonPartitionedTopic(topic);
         } catch (PulsarAdminException e) {
-            sneakyAdmin(() -> admin().topics().createNonPartitionedTopic(topic));
+            if (!(e instanceof ConflictException
+                    && e.getMessage().equals("This topic already exists"))) {
+                sneakyThrow(e);
+            }
         }
     }
 
     private void createPartitionedTopic(String topic, int numberOfPartitions) {
         try {
-            admin().lookups().lookupPartitionedTopic(topic);
-            sneakyAdmin(() -> admin().topics().expireMessagesForAllSubscriptions(topic, 0));
+            admin().topics().createPartitionedTopic(topic, numberOfPartitions);
         } catch (PulsarAdminException e) {
-            sneakyAdmin(() -> admin().topics().createPartitionedTopic(topic, numberOfPartitions));
-        }
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> Producer<T> createProducer(String topic, Schema<T> schema)
-            throws PulsarClientException {
-        TopicName topicName = TopicName.get(topic);
-        String name = topicName.getPartitionedTopicName();
-        int index = topicName.getPartitionIndex();
-        ConcurrentHashMap<Integer, Producer<?>> topicProducers =
-                producers.computeIfAbsent(name, d -> new ConcurrentHashMap<>());
-
-        return (Producer<T>)
-                topicProducers.computeIfAbsent(
-                        index,
-                        i -> {
-                            ProducerBuilder<T> builder =
-                                    client().newProducer(schema)
-                                            .topic(topic)
-                                            .enableBatching(false)
-                                            .enableMultiSchema(true);
-
-                            return sneakyClient(builder::create);
-                        });
-    }
-
-    @SuppressWarnings("unchecked")
-    private <T> Consumer<T> createConsumer(String topic, Schema<T> schema)
-            throws PulsarClientException {
-        TopicName topicName = TopicName.get(topic);
-        String name = topicName.getPartitionedTopicName();
-        int index = topicName.getPartitionIndex();
-        ConcurrentHashMap<Integer, Consumer<?>> topicConsumers =
-                consumers.computeIfAbsent(name, d -> new ConcurrentHashMap<>());
-
-        return (Consumer<T>)
-                topicConsumers.computeIfAbsent(
-                        index,
-                        i -> {
-                            ConsumerBuilder<T> builder =
-                                    client().newConsumer(schema)
-                                            .topic(topic)
-                                            .subscriptionName(SUBSCRIPTION_NAME)
-                                            .subscriptionMode(Durable)
-                                            .subscriptionType(Exclusive)
-                                            .subscriptionInitialPosition(Earliest);
-
-                            return sneakyClient(builder::subscribe);
-                        });
-    }
-
-    private void removeProducers(String topic) {
-        String topicName = topicName(topic);
-        ConcurrentHashMap<Integer, Producer<?>> integerProducers = producers.remove(topicName);
-        if (integerProducers != null) {
-            for (Producer<?> producer : integerProducers.values()) {
-                sneakyClient(producer::close);
+            if (!(e instanceof ConflictException
+                    && e.getMessage().equals("This topic already exists"))) {
+                sneakyThrow(e);
             }
         }
     }
 
-    private void removeConsumers(String topic) {
-        String topicName = topicName(topic);
-        ConcurrentHashMap<Integer, Consumer<?>> integerConsumers = consumers.remove(topicName);
-        if (integerConsumers != null) {
-            for (Consumer<?> consumer : integerConsumers.values()) {
-                sneakyClient(consumer::close);
-            }
-        }
+    private synchronized <T> Producer<T> createProducer(String topic, Schema<T> schema) {
+        ProducerBuilder<T> builder =
+                client().newProducer(schema)
+                        .topic(topic)
+                        .enableBatching(false)
+                        .enableMultiSchema(true)
+                        .accessMode(Shared);
+
+        return sneakyClient(builder::create);
     }
 
-    private <T> Message<T> drainOneMessage(Consumer<T> consumer) throws PulsarClientException {
-        Message<T> message = consumer.receive();
-        consumer.acknowledgeCumulative(message.getMessageId());
-        return message;
+    private synchronized <T> Consumer<T> createConsumer(String topic, Schema<T> schema) {
+        // Create the earliest subscription if it's not existed.
+        List<String> subscriptions = sneakyAdmin(() -> admin().topics().getSubscriptions(topic));
+        if (!subscriptions.contains(SUBSCRIPTION_NAME)) {
+            sneakyAdmin(
+                    () -> admin().topics().createSubscription(topic, SUBSCRIPTION_NAME, earliest));
+        }
+
+        // Create the consumer without the initial position.
+        ConsumerBuilder<T> builder =
+                client().newConsumer(schema)
+                        .topic(topic)
+                        .subscriptionName(SUBSCRIPTION_NAME)
+                        .subscriptionMode(Durable)
+                        .subscriptionType(Exclusive);
+
+        return sneakyClient(builder::subscribe);
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/container/PulsarContainerRuntime.java
@@ -124,7 +124,6 @@ public class PulsarContainerRuntime implements PulsarRuntime {
         try {
             if (operator != null) {
                 operator.close();
-                this.operator = null;
             }
             container.stop();
             started.compareAndSet(true, false);

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/embedded/PulsarEmbeddedRuntime.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/embedded/PulsarEmbeddedRuntime.java
@@ -86,7 +86,6 @@ public class PulsarEmbeddedRuntime implements PulsarRuntime {
         try {
             if (operator != null) {
                 operator.close();
-                this.operator = null;
             }
             if (pulsarService != null) {
                 pulsarService.close();

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/mock/PulsarMockRuntime.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/mock/PulsarMockRuntime.java
@@ -65,8 +65,9 @@ public class PulsarMockRuntime implements PulsarRuntime {
     public void tearDown() {
         try {
             pulsarService.close();
-            operator.close();
-            this.operator = null;
+            if (operator != null) {
+                operator.close();
+            }
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/testsuites/SourceTestSuiteBase.java
@@ -64,17 +64,16 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.singletonList;
+import static java.util.concurrent.CompletableFuture.runAsync;
 import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.DEFAULT_COLLECT_DATA_TIMEOUT;
 import static org.apache.flink.connector.testframe.utils.MetricQuerier.getJobDetails;
 import static org.apache.flink.runtime.testutils.CommonTestUtils.terminateJob;
@@ -153,11 +152,11 @@ public abstract class SourceTestSuiteBase<T> {
         try (CollectResultIterator<T> resultIterator = iteratorBuilder.build(jobClient)) {
             // Check test result
             LOG.info("Checking test results");
-            checkResultWithSemantic(resultIterator, Arrays.asList(testRecords), semantic, null);
+            checkResultWithSemantic(resultIterator, singletonList(testRecords), semantic, null);
         }
 
         // Step 5: Clean up
-        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.FINISHED));
+        waitForJobStatus(jobClient, singletonList(JobStatus.FINISHED));
     }
 
     /**
@@ -341,7 +340,7 @@ public abstract class SourceTestSuiteBase<T> {
                         .stopWithSavepoint(
                                 true, testEnv.getCheckpointUri(), SavepointFormatType.CANONICAL)
                         .get(30, TimeUnit.SECONDS);
-        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.FINISHED));
+        waitForJobStatus(jobClient, singletonList(JobStatus.FINISHED));
 
         // Step 5: Generate new test data
         final List<List<T>> newTestRecordCollections = new ArrayList<>();
@@ -372,7 +371,7 @@ public abstract class SourceTestSuiteBase<T> {
 
         final JobClient restartJobClient = restartEnv.executeAsync("Restart Test");
 
-        waitForJobStatus(restartJobClient, Collections.singletonList(JobStatus.RUNNING));
+        waitForJobStatus(restartJobClient, singletonList(JobStatus.RUNNING));
 
         try {
             iterator.setJobClient(restartJobClient);
@@ -526,7 +525,7 @@ public abstract class SourceTestSuiteBase<T> {
         }
 
         // Step 5: Clean up
-        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.FINISHED));
+        waitForJobStatus(jobClient, singletonList(JobStatus.FINISHED));
     }
 
     /**
@@ -589,7 +588,7 @@ public abstract class SourceTestSuiteBase<T> {
         LOG.info("Checking records before killing TaskManagers");
         checkResultWithSemantic(
                 iterator,
-                Arrays.asList(testRecordsBeforeFailure),
+                singletonList(testRecordsBeforeFailure),
                 semantic,
                 testRecordsBeforeFailure.size());
 
@@ -598,7 +597,7 @@ public abstract class SourceTestSuiteBase<T> {
         controller.triggerTaskManagerFailover(jobClient, () -> {});
 
         LOG.info("Waiting for job recovering from failure");
-        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.RUNNING));
+        waitForJobStatus(jobClient, singletonList(JobStatus.RUNNING));
 
         // Step 6: Write test data again to external system
         List<T> testRecordsAfterFailure =
@@ -614,13 +613,13 @@ public abstract class SourceTestSuiteBase<T> {
         LOG.info("Checking records after job failover");
         checkResultWithSemantic(
                 iterator,
-                Arrays.asList(testRecordsAfterFailure),
+                singletonList(testRecordsAfterFailure),
                 semantic,
                 testRecordsAfterFailure.size());
 
         // Step 8: Clean up
         terminateJob(jobClient);
-        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.CANCELED));
+        waitForJobStatus(jobClient, singletonList(JobStatus.CANCELED));
         iterator.close();
     }
 
@@ -727,21 +726,19 @@ public abstract class SourceTestSuiteBase<T> {
      * @param semantic the supported semantic, see {@link CheckpointingMode}
      * @param limit expected number of the data to read from the job
      */
-    private void checkResultWithSemantic(
+    protected void checkResultWithSemantic(
             CloseableIterator<T> resultIterator,
             List<List<T>> testData,
             CheckpointingMode semantic,
             Integer limit) {
         if (limit != null) {
-            assertThat(
-                            CompletableFuture.supplyAsync(
-                                    () -> {
-                                        CollectIteratorAssertions.assertThat(resultIterator)
-                                                .withNumRecordsLimit(limit)
-                                                .matchesRecordsFromSource(testData, semantic);
-                                        return true;
-                                    }))
-                    .succeedsWithin(DEFAULT_COLLECT_DATA_TIMEOUT);
+            Runnable runnable =
+                    () ->
+                            CollectIteratorAssertions.assertThat(resultIterator)
+                                    .withNumRecordsLimit(limit)
+                                    .matchesRecordsFromSource(testData, semantic);
+
+            assertThat(runAsync(runnable)).succeedsWithin(DEFAULT_COLLECT_DATA_TIMEOUT);
         } else {
             CollectIteratorAssertions.assertThat(resultIterator)
                     .matchesRecordsFromSource(testData, semantic);
@@ -768,7 +765,7 @@ public abstract class SourceTestSuiteBase<T> {
 
     private void killJob(JobClient jobClient) throws Exception {
         terminateJob(jobClient);
-        waitForJobStatus(jobClient, Collections.singletonList(JobStatus.CANCELED));
+        waitForJobStatus(jobClient, singletonList(JobStatus.CANCELED));
     }
 
     /** Builder class for constructing {@link CollectResultIterator} of collect sink. */

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/CollectIteratorAssertions.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/CollectIteratorAssertions.java
@@ -24,8 +24,17 @@ import java.util.Iterator;
  * Entry point for assertion methods for {@link CollectIteratorAssert}. Each method in this class is
  * a static factory.
  */
-public class CollectIteratorAssertions {
+public final class CollectIteratorAssertions {
+
+    private CollectIteratorAssertions() {
+        // no constructor.
+    }
+
     public static <T> CollectIteratorAssert<T> assertThat(Iterator<T> actual) {
         return new CollectIteratorAssert<>(actual);
+    }
+
+    public static <T> UnorderedCollectIteratorAssert<T> assertUnordered(Iterator<T> actual) {
+        return new UnorderedCollectIteratorAssert<>(actual);
     }
 }

--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/UnorderedCollectIteratorAssert.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/utils/UnorderedCollectIteratorAssert.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.testframe.utils;
+
+import org.apache.flink.streaming.api.CheckpointingMode;
+
+import org.assertj.core.api.AbstractAssert;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toSet;
+import static org.apache.flink.shaded.guava30.com.google.common.base.Predicates.not;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This assertion used to compare records in the collect iterator to the target test data with
+ * different semantics (AT_LEAST_ONCE, EXACTLY_ONCE) for unordered messages.
+ *
+ * @param <T> The type of records in the test data and collect iterator
+ */
+public class UnorderedCollectIteratorAssert<T>
+        extends AbstractAssert<UnorderedCollectIteratorAssert<T>, Iterator<T>> {
+
+    private final Iterator<T> collectorIterator;
+    private final Set<T> allRecords;
+    private final Set<T> matchedRecords;
+
+    private Integer limit = null;
+
+    protected UnorderedCollectIteratorAssert(Iterator<T> collectorIterator) {
+        super(collectorIterator, UnorderedCollectIteratorAssert.class);
+        this.collectorIterator = collectorIterator;
+        this.allRecords = new HashSet<>();
+        this.matchedRecords = new HashSet<>();
+    }
+
+    public UnorderedCollectIteratorAssert<T> withNumRecordsLimit(int limit) {
+        this.limit = limit;
+        return this;
+    }
+
+    public void matchesRecordsFromSource(
+            List<List<T>> recordsBySplitsFromSource, CheckpointingMode semantic) {
+        for (List<T> list : recordsBySplitsFromSource) {
+            for (T t : list) {
+                assertTrue(allRecords.add(t), "All the records should be unique.");
+            }
+        }
+
+        if (limit != null && limit > allRecords.size()) {
+            throw new IllegalArgumentException(
+                    "Limit validation size should be less than or equal to total number of records from source");
+        }
+
+        switch (semantic) {
+            case AT_LEAST_ONCE:
+                compareWithAtLeastOnceSemantic();
+                break;
+            case EXACTLY_ONCE:
+                compareWithExactlyOnceSemantic();
+                break;
+            default:
+                throw new IllegalArgumentException("Unrecognized semantic \"" + semantic + "\"");
+        }
+    }
+
+    private void compareWithAtLeastOnceSemantic() {
+        int recordCounter = 0;
+        while (collectorIterator.hasNext()) {
+            final T record = collectorIterator.next();
+            if (allRecords.contains(record)) {
+                if (matchedRecords.add(record)) {
+                    recordCounter++;
+                }
+            } else {
+                throw new IllegalArgumentException("Record " + record + " is not expected.");
+            }
+
+            if (limit != null && recordCounter >= limit) {
+                break;
+            }
+        }
+
+        verifyMatchedRecords();
+    }
+
+    private void compareWithExactlyOnceSemantic() {
+        int recordCounter = 0;
+        while (collectorIterator.hasNext()) {
+            final T record = collectorIterator.next();
+            if (allRecords.contains(record)) {
+                assertTrue(
+                        matchedRecords.add(record),
+                        "Record " + record + " is duplicated in exactly-once.");
+                recordCounter++;
+            } else {
+                throw new IllegalArgumentException("Record " + record + " is not expected.");
+            }
+
+            if (limit != null && recordCounter >= limit) {
+                break;
+            }
+        }
+
+        verifyMatchedRecords();
+    }
+
+    private void verifyMatchedRecords() {
+        if (limit == null && allRecords.size() > matchedRecords.size()) {
+            Set<T> missingResults =
+                    allRecords.stream().filter(not(matchedRecords::contains)).collect(toSet());
+            if (!missingResults.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "Expected to have "
+                                + allRecords.size()
+                                + " elements. But we missing: "
+                                + missingResults);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Pulsar Source put all the splits to only one parallelism when using Exclusive subscription. This is because we misunderstand the lifecycle of the `SourceEnumerator`. All the splits should be preassigned according to the parallelism. Shared subscription would meet state share issue on the meantime.

So we have rewrite the split assign logic in Pulsar connector, fix the issues mentioned above.

## Brief change log

  - Fix the split assign logic in `NonSharedSplitAssigner` and `SharedSplitAssigner`.
  - Fix the state scale up/down issues in `PulsarUnorderedSourceReader`.
  - Change the `PulsarSourceEnumState` and bump its version and serializer.
  
Fix related issues for getting the new test class `PulsarUnorderedSourceITCase` passed:

 - FLINK-27400
 - FLINK-27611
 - FLINK-28084
 - FLINK-27388

## Verifying this change

This change is already covered by existing tests, such as `PulsarSourceEnumeratorTest`, `NonSharedSplitAssignerTest` and 
`SharedSplitAssignerTest`

We also add new test class `PulsarUnorderedSourceITCase` which is based on the flink connector source testing tool.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
