### PR TITLE
[FLINK-29161][tests] Fix the built docker image name

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_docker.sh
+++ b/flink-end-to-end-tests/test-scripts/common_docker.sh
@@ -59,7 +59,7 @@ function build_image() {
     ./add-custom.sh -u ${file_server_address}:9999/flink.tgz -n ${image_name} -j ${java_version}
 
     echo "Building images"
-    run_with_timeout 600 docker build --no-cache --network="host" -t ${image_name} dev/${image_name}-debian
+    run_with_timeout 600 docker build --no-cache --network="host" -t ${image_name} dev/${image_name}-ubuntu
     local build_image_result=$?
     popd
     return $build_image_result


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix the built docker image name since we have switch from debian to ubuntu in https://github.com/apache/flink-docker/pull/130*


## Brief change log

  - *Correct the image name*

## Verifying this change

This change added tests and can be verified as follows:

  - *original e2e tests*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
