### PR TITLE
[BP-1.15][tests] Mitigate likelihood to run into test stability issues caused by CURATOR-645

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperMultipleComponentLeaderElectionDriverTest.java
@@ -262,6 +262,24 @@ class ZooKeeperMultipleComponentLeaderElectionDriverTest {
                                                 ElectionDriver::hasLeadership, Collectors.toSet()));
 
                 assertThat(leaderAndRest.get(true)).hasSize(1);
+
+                // TODO: remove this line after CURATOR-645 is resolved
+                // CURATOR-645 covers a bug in the LeaderLatch implementation that causes a race
+                // condition if a child node, participating in the leader election, is removed too
+                // fast. This results in a different code branch being executed which triggers a
+                // reset of the LeaderLatch instead of re-collecting the children to determine the
+                // next leader.
+                // The issue occurs because LeaderLatch#checkLeadership is not executed
+                // transactionally, i.e. retrieving the children and setting up the watcher for the
+                // predecessor is not done atomically. This leads to the race condition where a
+                // children (the previous leader's node) is removed before setting up the watcher
+                // which results in an invalid handling of the situation using reset.
+                // Adding some sleep here (simulating the leader actually doing something) will
+                // reduce the risk of falling into the race condition because it will give the
+                // concurrently running LeaderLatch instances more time to set up the watchers
+                // properly.
+                Thread.sleep(100);
+
                 Iterables.getOnlyElement(leaderAndRest.get(true)).close();
 
                 electionDrivers = leaderAndRest.get(false);


### PR DESCRIPTION
This is a 1.15 backport of PR #20709 (no conflicts detected during cherry-pick)

[CURATOR-645](https://issues.apache.org/jira/browse/CURATOR-645) covers a bug in the LeaderLatch implementation that causes a race condition if a child node, participating in the leader election, is removed too fast. This results in a different code branch being executed which triggers a reset of the LeaderLatch instead of re-collecting the children to determine the next leader.
The issue occurs because LeaderLatch#checkLeadership is not executed transactionally, i.e. retrieving the children and setting up the watcher for the predecessor is not done atomically. This leads to the race condition where a children (the previous leader's node) is removed before setting up the watcher which results in an invalid handling of the situation using reset.
Adding some sleep here (simulating the leader actually doing something) will reduce the risk of falling into the race condition because it will give the concurrently running LeaderLatch instances more time to set up the watchers properly.

This is only meant as a temporary solution until CURATOR-645 is resolved and the curator dependency on the Flink side is upgraded.