### PR TITLE
[FLINK-29132][rest] Cleanup subtask attempt metrics to avoid memory leak.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandler.java
@@ -82,23 +82,23 @@ public class JobVertexBackPressureHandler
                 metricFetcher
                         .getMetricStore()
                         .getTaskMetricStore(jobId.toString(), jobVertexId.toString());
-        Map<String, Map<Integer, Integer>> jobCurrentExecutions =
-                metricFetcher.getMetricStore().getCurrentExecutionAttempts().get(jobId.toString());
-        Map<Integer, Integer> currentExecutionAttempts =
-                jobCurrentExecutions != null
-                        ? jobCurrentExecutions.get(jobVertexId.toString())
+        Map<String, Map<Integer, Integer>> jobRepresentativeExecutions =
+                metricFetcher.getMetricStore().getRepresentativeAttempts().get(jobId.toString());
+        Map<Integer, Integer> representativeAttempts =
+                jobRepresentativeExecutions != null
+                        ? jobRepresentativeExecutions.get(jobVertexId.toString())
                         : null;
 
         return CompletableFuture.completedFuture(
                 taskMetricStore != null
-                        ? createJobVertexBackPressureInfo(taskMetricStore, currentExecutionAttempts)
+                        ? createJobVertexBackPressureInfo(taskMetricStore, representativeAttempts)
                         : JobVertexBackPressureInfo.deprecated());
     }
 
     private JobVertexBackPressureInfo createJobVertexBackPressureInfo(
-            TaskMetricStore taskMetricStore, Map<Integer, Integer> currentExecutionAttempts) {
+            TaskMetricStore taskMetricStore, Map<Integer, Integer> representativeAttempts) {
         List<SubtaskBackPressureInfo> subtaskBackPressureInfos =
-                createSubtaskBackPressureInfo(taskMetricStore, currentExecutionAttempts);
+                createSubtaskBackPressureInfo(taskMetricStore, representativeAttempts);
         return new JobVertexBackPressureInfo(
                 JobVertexBackPressureInfo.VertexBackPressureStatus.OK,
                 getBackPressureLevel(getMaxBackPressureRatio(subtaskBackPressureInfos)),
@@ -107,7 +107,7 @@ public class JobVertexBackPressureHandler
     }
 
     private List<SubtaskBackPressureInfo> createSubtaskBackPressureInfo(
-            TaskMetricStore taskMetricStore, Map<Integer, Integer> currentExecutionAttempts) {
+            TaskMetricStore taskMetricStore, Map<Integer, Integer> representativeAttempts) {
         Map<Integer, SubtaskMetricStore> subtaskMetricStores =
                 taskMetricStore.getAllSubtaskMetricStores();
         List<SubtaskBackPressureInfo> result = new ArrayList<>(subtaskMetricStores.size());
@@ -121,19 +121,19 @@ public class JobVertexBackPressureHandler
                         createSubtaskAttemptBackpressureInfo(
                                 subtaskIndex, null, subtaskMetricStore, null));
             } else {
-                int currentAttempt =
-                        currentExecutionAttempts == null
+                int representativeAttempt =
+                        representativeAttempts == null
                                 ? -1
-                                : currentExecutionAttempts.getOrDefault(subtaskIndex, -1);
-                if (!allAttemptsMetricStores.containsKey(currentAttempt)) {
+                                : representativeAttempts.getOrDefault(subtaskIndex, -1);
+                if (!allAttemptsMetricStores.containsKey(representativeAttempt)) {
                     // allAttemptsMetricStores is not empty here
-                    currentAttempt = allAttemptsMetricStores.keySet().iterator().next();
+                    representativeAttempt = allAttemptsMetricStores.keySet().iterator().next();
                 }
                 List<SubtaskBackPressureInfo> otherConcurrentAttempts =
                         new ArrayList<>(allAttemptsMetricStores.size() - 1);
                 for (Map.Entry<Integer, ComponentMetricStore> attemptStore :
                         allAttemptsMetricStores.entrySet()) {
-                    if (attemptStore.getKey() == currentAttempt) {
+                    if (attemptStore.getKey() == representativeAttempt) {
                         continue;
                     }
                     otherConcurrentAttempts.add(
@@ -146,8 +146,8 @@ public class JobVertexBackPressureHandler
                 result.add(
                         createSubtaskAttemptBackpressureInfo(
                                 subtaskIndex,
-                                currentAttempt,
-                                allAttemptsMetricStores.get(currentAttempt),
+                                representativeAttempt,
+                                allAttemptsMetricStores.get(representativeAttempt),
                                 otherConcurrentAttempts));
             }
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/JobDetailsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/messages/webmonitor/JobDetailsTest.java
@@ -29,8 +29,6 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMap
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -101,35 +99,6 @@ class JobDetailsTest {
 
         final JobDetails unmarshalled =
                 objectMapper.readValue(COMPATIBLE_JOB_DETAILS, JobDetails.class);
-
-        assertThat(unmarshalled).isEqualTo(expected);
-    }
-
-    @Test
-    void testJobDetailsWithExecutionAttemptsMarshalling() throws JsonProcessingException {
-        Map<String, Map<Integer, Integer>> currentExecutionAttempts = new HashMap<>();
-        currentExecutionAttempts.computeIfAbsent("a", k -> new HashMap<>()).put(1, 2);
-        currentExecutionAttempts.computeIfAbsent("a", k -> new HashMap<>()).put(2, 4);
-        currentExecutionAttempts.computeIfAbsent("b", k -> new HashMap<>()).put(3, 1);
-
-        final JobDetails expected =
-                new JobDetails(
-                        new JobID(),
-                        "foobar",
-                        1L,
-                        10L,
-                        9L,
-                        JobStatus.RUNNING,
-                        8L,
-                        new int[] {1, 3, 3, 4, 7, 4, 2, 7, 3, 3},
-                        42,
-                        currentExecutionAttempts);
-
-        final ObjectMapper objectMapper = RestMapperUtils.getStrictObjectMapper();
-
-        final JsonNode marshalled = objectMapper.valueToTree(expected);
-
-        final JobDetails unmarshalled = objectMapper.treeToValue(marshalled, JobDetails.class);
 
         assertThat(unmarshalled).isEqualTo(expected);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexBackPressureHandlerTest.java
@@ -285,16 +285,16 @@ class JobVertexBackPressureHandlerTest {
         for (MetricDump metricDump : getMultipleAttemptsMetricDumps()) {
             multipleAttemptsMetricStore.add(metricDump);
         }
-        // Update currentExecutionAttempts directly without JobDetails.
-        Map<Integer, Integer> currentExecutionAttempts = new HashMap<>();
-        currentExecutionAttempts.put(0, 1);
-        currentExecutionAttempts.put(1, 0);
+        // Update representativeAttempts directly without JobDetails.
+        Map<Integer, Integer> representativeAttempts = new HashMap<>();
+        representativeAttempts.put(0, 1);
+        representativeAttempts.put(1, 0);
         multipleAttemptsMetricStore
-                .getCurrentExecutionAttempts()
+                .getRepresentativeAttempts()
                 .put(
                         TEST_JOB_ID_BACK_PRESSURE_STATS_AVAILABLE.toString(),
                         Collections.singletonMap(
-                                TEST_JOB_VERTEX_ID.toString(), currentExecutionAttempts));
+                                TEST_JOB_VERTEX_ID.toString(), representativeAttempts));
 
         JobVertexBackPressureHandler jobVertexBackPressureHandler =
                 new JobVertexBackPressureHandler(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
@@ -18,20 +18,29 @@
 
 package org.apache.flink.runtime.rest.handler.legacy.metrics;
 
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails;
+import org.apache.flink.runtime.messages.webmonitor.JobDetails.CurrentAttempts;
 import org.apache.flink.runtime.metrics.dump.MetricDump;
 import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the MetricStore. */
 class MetricStoreTest {
+
+    private static final JobID JOB_ID = new JobID();
 
     @Test
     void testAdd() throws IOException {
@@ -40,49 +49,55 @@ class MetricStoreTest {
         assertThat(store.getJobManagerMetricStore().getMetric("abc.metric1", "-1")).isEqualTo("0");
         assertThat(store.getTaskManagerMetricStore("tmid").getMetric("abc.metric2", "-1"))
                 .isEqualTo("1");
-        assertThat(store.getJobMetricStore("jobid").getMetric("abc.metric3", "-1")).isEqualTo("2");
-        assertThat(store.getJobMetricStore("jobid").getMetric("abc.metric4", "-1")).isEqualTo("3");
+        assertThat(store.getJobMetricStore(JOB_ID.toString()).getMetric("abc.metric3", "-1"))
+                .isEqualTo("2");
+        assertThat(store.getJobMetricStore(JOB_ID.toString()).getMetric("abc.metric4", "-1"))
+                .isEqualTo("3");
 
-        assertThat(store.getTaskMetricStore("jobid", "taskid").getMetric("8.abc.metric5", "-1"))
-                .isEqualTo("14");
-        assertThat(store.getSubtaskMetricStore("jobid", "taskid", 8).getMetric("abc.metric5", "-1"))
+        assertThat(
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
+                                .getMetric("8.abc.metric5", "-1"))
                 .isEqualTo("14");
         assertThat(
-                        store.getSubtaskAttemptMetricStore("jobid", "taskid", 8, 1)
+                        store.getSubtaskMetricStore(JOB_ID.toString(), "taskid", 8)
+                                .getMetric("abc.metric5", "-1"))
+                .isEqualTo("14");
+        assertThat(
+                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 1)
                                 .getMetric("abc.metric5", "-1"))
                 .isEqualTo("4");
         assertThat(
-                        store.getSubtaskAttemptMetricStore("jobid", "taskid", 8, 2)
+                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 2)
                                 .getMetric("abc.metric5", "-1"))
                 .isEqualTo("14");
 
         assertThat(
-                        store.getTaskMetricStore("jobid", "taskid")
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
                                 .getMetric("8.opname.abc.metric6", "-1"))
                 .isEqualTo("5");
         assertThat(
-                        store.getTaskMetricStore("jobid", "taskid")
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
                                 .getMetric("8.opname.abc.metric7", "-1"))
                 .isEqualTo("6");
         assertThat(
-                        store.getTaskMetricStore("jobid", "taskid")
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
                                 .getMetric("1.opname.abc.metric7", "-1"))
                 .isEqualTo("6");
         assertThat(
-                        store.getSubtaskMetricStore("jobid", "taskid", 1)
+                        store.getSubtaskMetricStore(JOB_ID.toString(), "taskid", 1)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("6");
-        assertThat(store.getSubtaskAttemptMetricStore("jobid", "taskid", 1, 2)).isNull();
+        assertThat(store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 1, 2)).isNull();
         assertThat(
-                        store.getSubtaskAttemptMetricStore("jobid", "taskid", 1, 3)
-                                .getMetric("opname.abc.metric7", "-1"))
-                .isEqualTo("6");
-        assertThat(
-                        store.getSubtaskAttemptMetricStore("jobid", "taskid", 8, 2)
+                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 1, 3)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("6");
         assertThat(
-                        store.getSubtaskAttemptMetricStore("jobid", "taskid", 8, 4)
+                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 2)
+                                .getMetric("opname.abc.metric7", "-1"))
+                .isEqualTo("6");
+        assertThat(
+                        store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 4)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("16");
     }
@@ -106,11 +121,48 @@ class MetricStoreTest {
         assertThat(store.getJobs()).isEmpty();
     }
 
+    @Test
+    void testSubtaskMetricStoreCleanup() {
+        MetricStore store = setupStore(new MetricStore());
+        assertThat(
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
+                                .getSubtaskMetricStore(8)
+                                .getAllAttemptsMetricStores()
+                                .keySet())
+                .containsExactlyInAnyOrderElementsOf(Arrays.asList(1, 2, 4, 5));
+
+        Set<Integer> currentAttempts = new HashSet<>(Arrays.asList(1, 4));
+        Map<String, Map<Integer, CurrentAttempts>> currentExecutionAttempts =
+                Collections.singletonMap(
+                        "taskid",
+                        Collections.singletonMap(8, new CurrentAttempts(1, currentAttempts)));
+        JobDetails jobDetail =
+                new JobDetails(
+                        JOB_ID,
+                        "jobname",
+                        0,
+                        0,
+                        0,
+                        JobStatus.RUNNING,
+                        0,
+                        new int[10],
+                        1,
+                        currentExecutionAttempts);
+        store.updateCurrentExecutionAttempts(Collections.singleton(jobDetail));
+
+        assertThat(
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
+                                .getSubtaskMetricStore(8)
+                                .getAllAttemptsMetricStores()
+                                .keySet())
+                .containsExactlyInAnyOrderElementsOf(Arrays.asList(1, 4, 5));
+    }
+
     static MetricStore setupStore(MetricStore store) {
-        Map<Integer, Integer> currentExecutionAttempts = new HashMap<>();
-        currentExecutionAttempts.put(8, 2);
-        store.getCurrentExecutionAttempts()
-                .put("jobid", Collections.singletonMap("taskid", currentExecutionAttempts));
+        Map<Integer, Integer> representativeAttempts = new HashMap<>();
+        representativeAttempts.put(8, 2);
+        store.getRepresentativeAttempts()
+                .put(JOB_ID.toString(), Collections.singletonMap("taskid", representativeAttempts));
 
         QueryScopeInfo.JobManagerQueryScopeInfo jm =
                 new QueryScopeInfo.JobManagerQueryScopeInfo("abc");
@@ -126,7 +178,8 @@ class MetricStoreTest {
         MetricDump.CounterDump cd22 = new MetricDump.CounterDump(tm2, "metric2", 10);
         MetricDump.CounterDump cd22a = new MetricDump.CounterDump(tm2, "metric2b", 10);
 
-        QueryScopeInfo.JobQueryScopeInfo job = new QueryScopeInfo.JobQueryScopeInfo("jobid", "abc");
+        QueryScopeInfo.JobQueryScopeInfo job =
+                new QueryScopeInfo.JobQueryScopeInfo(JOB_ID.toString(), "abc");
         MetricDump.CounterDump cd3 = new MetricDump.CounterDump(job, "metric3", 2);
         MetricDump.CounterDump cd4 = new MetricDump.CounterDump(job, "metric4", 3);
 
@@ -136,29 +189,40 @@ class MetricStoreTest {
         MetricDump.CounterDump cd42 = new MetricDump.CounterDump(job2, "metric4", 3);
 
         QueryScopeInfo.TaskQueryScopeInfo task =
-                new QueryScopeInfo.TaskQueryScopeInfo("jobid", "taskid", 8, 1, "abc");
+                new QueryScopeInfo.TaskQueryScopeInfo(JOB_ID.toString(), "taskid", 8, 1, "abc");
         MetricDump.CounterDump cd5 = new MetricDump.CounterDump(task, "metric5", 4);
 
         QueryScopeInfo.TaskQueryScopeInfo speculativeTask =
-                new QueryScopeInfo.TaskQueryScopeInfo("jobid", "taskid", 8, 2, "abc");
+                new QueryScopeInfo.TaskQueryScopeInfo(JOB_ID.toString(), "taskid", 8, 2, "abc");
         MetricDump.CounterDump cd52 = new MetricDump.CounterDump(speculativeTask, "metric5", 14);
 
         QueryScopeInfo.OperatorQueryScopeInfo operator =
-                new QueryScopeInfo.OperatorQueryScopeInfo("jobid", "taskid", 8, 2, "opname", "abc");
+                new QueryScopeInfo.OperatorQueryScopeInfo(
+                        JOB_ID.toString(), "taskid", 8, 2, "opname", "abc");
         MetricDump.CounterDump cd6 = new MetricDump.CounterDump(operator, "metric6", 5);
         MetricDump.CounterDump cd7 = new MetricDump.CounterDump(operator, "metric7", 6);
 
         QueryScopeInfo.OperatorQueryScopeInfo operator2 =
-                new QueryScopeInfo.OperatorQueryScopeInfo("jobid", "taskid", 1, 3, "opname", "abc");
+                new QueryScopeInfo.OperatorQueryScopeInfo(
+                        JOB_ID.toString(), "taskid", 1, 3, "opname", "abc");
         MetricDump.CounterDump cd62 = new MetricDump.CounterDump(operator2, "metric6", 5);
         MetricDump.CounterDump cd72 = new MetricDump.CounterDump(operator2, "metric7", 6);
 
         QueryScopeInfo.OperatorQueryScopeInfo speculativeOperator2 =
-                new QueryScopeInfo.OperatorQueryScopeInfo("jobid", "taskid", 8, 4, "opname", "abc");
+                new QueryScopeInfo.OperatorQueryScopeInfo(
+                        JOB_ID.toString(), "taskid", 8, 4, "opname", "abc");
         MetricDump.CounterDump cd63 =
                 new MetricDump.CounterDump(speculativeOperator2, "metric6", 15);
         MetricDump.CounterDump cd73 =
                 new MetricDump.CounterDump(speculativeOperator2, "metric7", 16);
+
+        QueryScopeInfo.OperatorQueryScopeInfo speculativeOperator3 =
+                new QueryScopeInfo.OperatorQueryScopeInfo(
+                        JOB_ID.toString(), "taskid", 8, 5, "opname", "abc");
+        MetricDump.CounterDump cd64 =
+                new MetricDump.CounterDump(speculativeOperator3, "metric6", 17);
+        MetricDump.CounterDump cd74 =
+                new MetricDump.CounterDump(speculativeOperator3, "metric7", 18);
 
         store.add(cd1);
         store.add(cd2);
@@ -179,6 +243,8 @@ class MetricStoreTest {
         store.add(cd52);
         store.add(cd63);
         store.add(cd73);
+        store.add(cd64);
+        store.add(cd74);
 
         return store;
     }


### PR DESCRIPTION
## What is the purpose of the change

In [FLINK-28588](https://issues.apache.org/jira/browse/FLINK-28588), MetricStore supports multiple attempts of a subtask. However, `SubtaskMetricStore` doesn't have a clean mechanism.  In failover scenario, `attempts` pile up and cause OOM.

This PR cleans up the SubtaskMetricStore when the current execution attempts are updated. SubtaskMetricStore will retain only the current execution attempts and the attempts that has a greater attempt number than all current execution attempts, which means they are potentially the current execution attempts, but not updated to the job manager yet. 

We should not simply limit the subtask attempt metrics by the execution history size, since when speculative execution is enabled, a running execution attempt may be not one of the latest execution attempts, but a much earlier one.


## Brief change log

  - Enrich JobDetails.currentExecutionAttempts with all current execution attempts for each subtask, and make the first of the attempt list to be the representative attempt. The currentExecutionAttempts now contains all subtasks no matter whether the subtask contains more than one current attempt, so it is excluded from the jsonized JobDetails.
  -SubtaskMetricStore retains metrics of the potentially currentExecutionAttempts according to the JobDetails when updating.
  - MetricStore.currentExecutionAttempts is now renamed as representativeAttempts.


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
 
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
