### PR TITLE
[hotfix][connectors][csv][javadoc] Rename invalid CsvFileSystemFormatFactory to CsvFileFormatFactory

### DIFF
--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemBatchITCase.java
@@ -32,7 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-/** ITCase to test csv format for {@link CsvFileSystemFormatFactory} in batch mode. */
+/** ITCase to test csv format for {@link CsvFileFormatFactory} in batch mode. */
 @RunWith(Enclosed.class)
 public class CsvFilesystemBatchITCase {
 

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamITCase.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.planner.runtime.stream.sql.StreamFileSystemITCaseB
 import java.util.ArrayList;
 import java.util.List;
 
-/** ITCase to test csv format for {@link CsvFileSystemFormatFactory} in stream mode. */
+/** ITCase to test csv format for {@link CsvFileFormatFactory} in stream mode. */
 public class CsvFilesystemStreamITCase extends StreamFileSystemITCaseBase {
 
     @Override

--- a/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamSinkITCase.java
+++ b/flink-formats/flink-csv/src/test/java/org/apache/flink/formats/csv/CsvFilesystemStreamSinkITCase.java
@@ -23,7 +23,7 @@ import org.apache.flink.table.planner.runtime.stream.FsStreamingSinkITCaseBase;
 import java.util.ArrayList;
 import java.util.List;
 
-/** ITCase to test csv format for {@link CsvFileSystemFormatFactory} for streaming sink. */
+/** ITCase to test csv format for {@link CsvFileFormatFactory} for streaming sink. */
 public class CsvFilesystemStreamSinkITCase extends FsStreamingSinkITCaseBase {
     @Override
     public String[] additionalProperties() {


### PR DESCRIPTION

## What is the purpose of the change

At https://github.com/apache/flink/pull/17598 `CsvFileSystemFormatFactory`  was renamed to `CsvFileFormatFactory` however in javadoc there is still invalid name. The PR fixes that

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
