### PR TITLE
[FLINK-29101] PipelinedRegionSchedulingStrategy benchmark shows performance degradation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -250,6 +250,11 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
                         .getOrDefault(currentRegion, Collections.emptySet())
                         .forEach(
                                 (consumedPartitionGroup) -> {
+                                    if (!consumedPartitionGroup
+                                            .getResultPartitionType()
+                                            .canBePipelinedConsumed()) {
+                                        return;
+                                    }
                                     // If this group has been visited, there is no need
                                     // to repeat the determination.
                                     if (visitedConsumedPartitionGroups.contains(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -61,7 +61,8 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     private final Set<ConsumedPartitionGroup> crossRegionConsumedPartitionGroups =
             Collections.newSetFromMap(new IdentityHashMap<>());
 
-    private final Set<SchedulingPipelinedRegion> scheduledRegions = new HashSet<>();
+    private final Set<SchedulingPipelinedRegion> scheduledRegions =
+            Collections.newSetFromMap(new IdentityHashMap<>());
 
     public PipelinedRegionSchedulingStrategy(
             final SchedulerOperations schedulerOperations,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -223,11 +223,10 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
     public void onPartitionConsumable(final IntermediateResultPartitionID resultPartitionId) {}
 
     private void maybeScheduleRegions(final Set<SchedulingPipelinedRegion> regions) {
-        // all regions that need to be tried to be marked as schedulable.
-        Set<SchedulingPipelinedRegion> nextRegions =
+        final Set<SchedulingPipelinedRegion> regionsToSchedule = new LinkedHashSet<>();
+        LinkedHashSet<SchedulingPipelinedRegion> nextRegions =
                 SchedulingStrategyUtils.sortPipelinedRegionsInTopologicalOrder(
                         schedulingTopology, regions);
-        Set<SchedulingPipelinedRegion> regionsToSchedule = new LinkedHashSet<>();
         while (!nextRegions.isEmpty()) {
             nextRegions = addSchedulableAndGetNextRegions(nextRegions, regionsToSchedule);
         }
@@ -235,10 +234,10 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         regionsToSchedule.forEach(this::scheduleRegion);
     }
 
-    private Set<SchedulingPipelinedRegion> addSchedulableAndGetNextRegions(
+    private LinkedHashSet<SchedulingPipelinedRegion> addSchedulableAndGetNextRegions(
             Set<SchedulingPipelinedRegion> currentRegions,
             Set<SchedulingPipelinedRegion> regionsToSchedule) {
-        Set<SchedulingPipelinedRegion> nextRegions = new LinkedHashSet<>();
+        LinkedHashSet<SchedulingPipelinedRegion> nextRegions = new LinkedHashSet<>();
         // cache consumedPartitionGroup's consumable status to avoid compute repeatedly.
         final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache = new HashMap<>();
         final Set<ConsumedPartitionGroup> visitedConsumedPartitionGroups = new HashSet<>();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
@@ -20,7 +20,7 @@ package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.util.IterableUtils;
 
-import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -37,26 +37,22 @@ class SchedulingStrategyUtils {
                 .collect(Collectors.toList());
     }
 
-    /**
-     * Sort pipelined regions in topological order.
-     *
-     * @param topology represent the graph contains all pipelined regions.
-     * @param regions to be sorted in topological order.
-     * @return regions in topological order, the set must preserve this order.
-     */
-    static LinkedHashSet<SchedulingPipelinedRegion> sortPipelinedRegionsInTopologicalOrder(
+    static List<SchedulingPipelinedRegion> sortPipelinedRegionsInTopologicalOrder(
             final SchedulingTopology topology, final Set<SchedulingPipelinedRegion> regions) {
 
         // Avoid the O(V) (V is the number of vertices in the topology) sorting
         // complexity if the given set of regions is small enough
-        if (regions.size() <= 1) {
-            return new LinkedHashSet<>(regions);
+        if (regions.size() == 0) {
+            return Collections.emptyList();
+        } else if (regions.size() == 1) {
+            return Collections.singletonList(regions.iterator().next());
         }
 
         return IterableUtils.toStream(topology.getVertices())
                 .map(SchedulingExecutionVertex::getId)
                 .map(topology::getPipelinedRegionOfVertex)
                 .filter(regions::contains)
-                .collect(Collectors.toCollection(LinkedHashSet::new));
+                .distinct()
+                .collect(Collectors.toList());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/SchedulingStrategyUtils.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.util.IterableUtils;
 
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -45,15 +44,13 @@ class SchedulingStrategyUtils {
      * @param regions to be sorted in topological order.
      * @return regions in topological order, the set must preserve this order.
      */
-    static Set<SchedulingPipelinedRegion> sortPipelinedRegionsInTopologicalOrder(
+    static LinkedHashSet<SchedulingPipelinedRegion> sortPipelinedRegionsInTopologicalOrder(
             final SchedulingTopology topology, final Set<SchedulingPipelinedRegion> regions) {
 
         // Avoid the O(V) (V is the number of vertices in the topology) sorting
         // complexity if the given set of regions is small enough
-        if (regions.size() == 0) {
-            return Collections.emptySet();
-        } else if (regions.size() == 1) {
-            return Collections.singleton(regions.iterator().next());
+        if (regions.size() <= 1) {
+            return new LinkedHashSet<>(regions);
         }
 
         return IterableUtils.toStream(topology.getVertices())

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
 
 /**
@@ -29,9 +28,9 @@ import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStra
  * PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
  */
 public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenchmarkBase {
-
-    private ExecutionVertexID executionVertexID;
     private PipelinedRegionSchedulingStrategy schedulingStrategy;
+
+    private int parallelism;
 
     @Override
     public void setup(JobConfiguration jobConfiguration) throws Exception {
@@ -40,18 +39,21 @@ public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenc
         schedulingStrategy =
                 new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
 
-        executionVertexID =
-                executionGraph
-                        .getJobVertex(jobVertices.get(0).getID())
-                        .getTaskVertices()[0]
-                        .getID();
-        for (ExecutionVertex vertex :
-                executionGraph.getJobVertex(jobVertices.get(0).getID()).getTaskVertices()) {
-            vertex.finishAllBlockingPartitions();
-        }
+        parallelism = jobConfiguration.getParallelism();
     }
 
     public void schedulingDownstreamTasks() {
-        schedulingStrategy.onExecutionStateChange(executionVertexID, ExecutionState.FINISHED);
+        for (int i = 0; i < parallelism - 1; i++) {
+            ExecutionVertex taskVertex =
+                    executionGraph.getJobVertex(jobVertices.get(0).getID()).getTaskVertices()[i];
+            taskVertex.finishAllBlockingPartitions();
+
+            schedulingStrategy.onExecutionStateChange(taskVertex.getID(), ExecutionState.FINISHED);
+        }
+        ExecutionVertex lastVertex =
+                executionGraph.getJobVertex(jobVertices.get(0).getID())
+                        .getTaskVertices()[parallelism - 1];
+        lastVertex.finishAllBlockingPartitions();
+        schedulingStrategy.onExecutionStateChange(lastVertex.getID(), ExecutionState.FINISHED);
     }
 }


### PR DESCRIPTION





## What is the purpose of the change

*Fix the problem introduced by FLINK-28799 which may cause PipelinedRegionSchedulingStrategy performance degradation.*


## Brief change log

  - *Filter the the execution vertex finished event for non-finished `ConsumedPartitionGroup`*
  - *Turns the recursion of `maybeScheduleRegions` a into a loop  to avoid `stackoverflow`*


## Verifying this change

This change is already covered by existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
