### PR TITLE
[FLINK-28893][table] Add built-in conv function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -228,6 +228,13 @@ arithmetic:
   - sql: UUID()
     table: uuid()
     description: Returns an UUID (Universally Unique Identifier) string (e.g., "3d3c68f7-f608-473f-b60c-b0c44ad4cc4e") according to RFC 4122 type 4 (pseudo randomly generated) UUID. The UUID is generated using a cryptographically strong pseudo random number generator.
+  - sql: |
+      CONV(numeric, numeric1, numeric2)
+      CONV(string, numeric1, numeric2)
+    table: |
+      NUMERIC.conv(numeric1, numeric2)
+      STRING.conv(numeric1, numeric2)
+    description: Returns a string representation of an integer NUMERIC value or a STRING converted from base numeric1 to base numeric2. Returns NULL if the argument is NULL. E.g. 'a'.conv(16,2) leads to "1010", 100.conv(10, -8) leads to "144".
   - sql: BIN(INT)
     table: INT.bin()
     description: Returns a string representation of INTEGER in binary format. Returns NULL if INTEGER is NULL. E.g., 4.bin() returns "100" and 12.bin() returns "1100".

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -282,6 +282,15 @@ arithmetic:
     description: |
       根据 RFC 4122 类型 4（伪随机生成）UUID，返回 UUID（通用唯一标识符）字符串。
       例如“3d3c68f7-f608-473f-b60c-b0c44ad4cc4e”，UUID 是使用加密强的伪随机数生成器生成的。
+  - sql: |
+      CONV(numeric, numeric1, numeric2)
+      CONV(string, numeric1, numeric2)
+    table: |
+      NUMERIC.conv(numeric1, numeric2)
+      STRING.conv(numeric1, numeric2)
+    description: |
+      返回从numeric1进制转换成numeric2进制的字符串形式。如果 numeric1 或 numeric2 为 `NULL`，则返回 `NULL`。
+      例如'a'.conv(16,2) 为 ”1010”, 100.conv(10, -8) 为 ”144”.
   - sql: BIN(INT)
     table: INT.bin()
     description: |

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -967,6 +967,15 @@ class Expression(Generic[T]):
         """
         return _unary_op("end")(self)
 
+    def conv(self,
+             from_base: Union[int, 'Expression[int]'],
+             to_base: Union[int, 'Expression[int]']) -> 'Expression[str]':
+        """
+        Converts numbers between different number bases. Returns NULL if any argument is NULL.
+        E.g. conv('a', 16, 2) leads to '1010', conv(100, 10, -8) leads to "144".
+        """
+        return _ternary_op("conv")(self, from_base, to_base)
+
     @property
     def bin(self) -> 'Expression[str]':
         """

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -68,6 +68,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CEIL;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CHAR_LENGTH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CHR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COLLECT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CONV;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COSH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COT;
@@ -720,6 +721,23 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Rounds the given number to integer places right to the decimal point. */
     public OutType round(InType places) {
         return toApiSpecificExpression(unresolvedCall(ROUND, toExpr(), objectToExpression(places)));
+    }
+
+    /**
+     * Converts numbers between different number bases.
+     *
+     * <p>Returns a string representation of the number N, converted from base `fromBase` to base
+     * `toBase`. Returns NULL if any argument is NULL. The argument N is interpreted as an integer,
+     * but may be specified as an integer or a string. The minimum base is 2 and the maximum base is
+     * 36. If fromBase is a negative number, N is regarded as a signed number. Otherwise, N is
+     * treated as unsigned. CONV() works with 64-bit precision.
+     *
+     * <p>E.g. 'a'.conv(16, 2) leads to '1010', 100.conv(10, -8) leads to "144".
+     */
+    public OutType conv(InType fromBase, InType toBase) {
+        return toApiSpecificExpression(
+                unresolvedCall(
+                        CONV, toExpr(), objectToExpression(fromBase), objectToExpression(toBase)));
     }
 
     /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1387,6 +1387,30 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(explicit(INT().notNull()))
                     .build();
 
+    public static final BuiltInFunctionDefinition CONV =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("CONV")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    sequence(
+                                            new String[] {"number", "fromBase", "toBase"},
+                                            new ArgumentTypeStrategy[] {
+                                                logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                                logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                                logical(LogicalTypeFamily.INTEGER_NUMERIC)
+                                            }),
+                                    sequence(
+                                            new String[] {"number", "fromBase", "toBase"},
+                                            new ArgumentTypeStrategy[] {
+                                                logical(LogicalTypeFamily.CHARACTER_STRING),
+                                                logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                                logical(LogicalTypeFamily.INTEGER_NUMERIC)
+                                            })))
+                    .outputTypeStrategy(explicit(DataTypes.STRING()))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.ConvFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition BIN =
             BuiltInFunctionDefinition.newBuilder()
                     .name("bin")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ConvFunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/ConvFunctionITCase.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions;
+
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.DataTypes.BIGINT;
+import static org.apache.flink.table.api.DataTypes.SMALLINT;
+import static org.apache.flink.table.api.DataTypes.STRING;
+import static org.apache.flink.table.api.DataTypes.TINYINT;
+import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.call;
+
+/** Test {@link BuiltInFunctionDefinitions#CONV} and its return type. */
+class ConvFunctionITCase extends BuiltInFunctionTestBase {
+
+    @Override
+    Stream<TestSetSpec> getTestSetSpecs() {
+        return Stream.of(
+                TestSetSpec.forFunction(BuiltInFunctionDefinitions.CONV)
+                        .onFieldsWithData(null, 44, 43, 100, -1, "facebook")
+                        .andDataTypes(
+                                BIGINT().nullable(),
+                                TINYINT().notNull(),
+                                SMALLINT().notNull(),
+                                BIGINT().notNull(),
+                                BIGINT().notNull(),
+                                STRING().notNull())
+                        // test for all LogicalTypeFamily.INTEGER_NUMERIC type.
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f1"), 10, 16),
+                                        "conv(f1, 10, 16)",
+                                        "2C",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f2"), 10, 16),
+                                        "conv(f2, 10, 16)",
+                                        "2B",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f3"), 10, -8),
+                                        "conv(f3, 10, -8)",
+                                        "144",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f3"), 10, -8),
+                                        "conv(f3, 10, -8)",
+                                        "144",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f4"), 10, 16),
+                                        "conv(f4, 10, 16)",
+                                        "FFFFFFFFFFFFFFFF",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f4"), 10, -16),
+                                        "conv(f4, 10, -16)",
+                                        "-1",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f5"), 36, 16),
+                                        "conv(f5, 36, 16)",
+                                        "116ED2B2FB4",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", 1111, 2, 10),
+                                        "conv(1111, 2, 10)",
+                                        "15",
+                                        STRING().nullable()))
+
+                        // 2^64 - 1
+                        .testResult(
+                                resultSpec(
+                                        call("conv", "18446744073709551615", 10, 10),
+                                        "conv('18446744073709551615', 10, 10)",
+                                        "18446744073709551615",
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", "18446744073709551615", 10, -10),
+                                        "conv('18446744073709551615', 10, -10)",
+                                        "-1",
+                                        STRING().nullable()))
+                        // overflow, return maximum (2^64 - 1), which is consistent with
+                        // Mysql.
+                        .testResult(
+                                resultSpec(
+                                        call("conv", "38446744073709551615", 10, 10),
+                                        "conv('38446744073709551615', 10, 10)",
+                                        "18446744073709551615",
+                                        STRING().nullable()))
+
+                        // args is null
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f0"), 10, 2),
+                                        "conv(f0, 10, 2)",
+                                        null,
+                                        STRING().nullable()))
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f0"), null, 2),
+                                        "conv(f0, null, 2)",
+                                        null,
+                                        STRING().nullable()))
+
+                        // the input is not a decimal number.
+                        .testResult(
+                                resultSpec(
+                                        call("conv", "This is a test String.", 10, 16),
+                                        "conv('This is a test String.', 10, 16)",
+                                        null,
+                                        STRING().nullable()))
+
+                        // fromBase cannot be negative.
+                        .testResult(
+                                resultSpec(
+                                        call("conv", $("f2"), -10, 16),
+                                        "conv(f2, -10, 16)",
+                                        null,
+                                        STRING().nullable())));
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/BaseConversionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/BaseConversionUtils.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions;
+
+import java.util.Arrays;
+
+/**
+ * This is ported from Hive: org.apache.hadoop.hive.ql.udf.UDFConv.java. Just modify conv function
+ * return type to prevent codec overhead.
+ */
+public class BaseConversionUtils {
+    /**
+     * Divide x by m as if x is an unsigned 64-bit integer. Examples: unsignedLongDiv(-1, 2) ==
+     * Long.MAX_VALUE unsignedLongDiv(6, 3) == 2 unsignedLongDiv(0, 5) == 0
+     *
+     * @param x is treated as unsigned
+     * @param m is treated as signed
+     */
+    private static long unsignedLongDiv(long x, int m) {
+        if (x >= 0) {
+            return x / m;
+        }
+
+        // Let uval be the value of the unsigned long with the same bits as x
+        // Two's complement => x = uval - 2*MAX - 2
+        // => uval = x + 2*MAX + 2
+        // Now, use the fact: (a+b)/c = a/c + b/c + (a%c+b%c)/c
+        return x / m
+                + 2 * (Long.MAX_VALUE / m)
+                + 2 / m
+                + (x % m + 2 * (Long.MAX_VALUE % m) + 2 % m) / m;
+    }
+
+    /**
+     * Decode val into value[].
+     *
+     * @param val is treated as an unsigned 64-bit integer
+     * @param radix must be between MIN_RADIX and MAX_RADIX
+     */
+    private static void decode(byte[] value, long val, int radix) {
+        Arrays.fill(value, (byte) 0);
+        for (int i = value.length - 1; val != 0; i--) {
+            long q = unsignedLongDiv(val, radix);
+            value[i] = (byte) (val - q * radix);
+            val = q;
+        }
+    }
+
+    /**
+     * Convert value[] into a long. On overflow, return -1 (as mySQL does). If a negative digit is
+     * found, ignore the suffix starting there.
+     *
+     * @param radix must be between MIN_RADIX and MAX_RADIX
+     * @param fromPos is the first element that should be conisdered
+     * @return the result should be treated as an unsigned 64-bit integer.
+     */
+    private static long encode(byte[] value, int radix, int fromPos) {
+        long val = 0;
+        long bound = unsignedLongDiv(-1 - radix, radix); // Possible overflow once
+        // val
+        // exceeds this value
+        for (int i = fromPos; i < value.length && value[i] >= 0; i++) {
+            if (val >= bound) {
+                // Check for overflow
+                if (unsignedLongDiv(-1 - value[i], radix) < val) {
+                    return -1;
+                }
+            }
+            val = val * radix + value[i];
+        }
+        return val;
+    }
+
+    /**
+     * Convert the bytes in value[] to the corresponding chars.
+     *
+     * @param radix must be between MIN_RADIX and MAX_RADIX
+     * @param fromPos is the first nonzero element
+     */
+    private static void byte2char(byte[] value, int radix, int fromPos) {
+        for (int i = fromPos; i < value.length; i++) {
+            value[i] = (byte) Character.toUpperCase(Character.forDigit(value[i], radix));
+        }
+    }
+
+    /**
+     * Convert the chars in value[] to the corresponding integers. Convert invalid characters to -1.
+     *
+     * @param radix must be between MIN_RADIX and MAX_RADIX
+     * @param fromPos is the first nonzero element
+     */
+    private static boolean char2byte(byte[] value, int radix, int fromPos) {
+        for (int i = fromPos; i < value.length; i++) {
+            value[i] = (byte) Character.digit(value[i], radix);
+            if (value[i] == -1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Convert numbers between different number bases. If toBase&gt;0 the result is unsigned,
+     * otherwise it is signed.
+     */
+    public static byte[] conv(byte[] n, int fromBase, int toBase) {
+        byte[] value = new byte[64];
+        if (n == null || n.length < 1) {
+            return null;
+        }
+
+        if (fromBase < Character.MIN_RADIX
+                || fromBase > Character.MAX_RADIX
+                || Math.abs(toBase) < Character.MIN_RADIX
+                || Math.abs(toBase) > Character.MAX_RADIX) {
+            return null;
+        }
+
+        boolean negative = (n[0] == '-');
+        int first = 0;
+        if (negative) {
+            first = 1;
+        }
+
+        // Copy the digits in the right side of the array
+        for (int i = 1; i <= n.length - first; i++) {
+            value[value.length - i] = n[n.length - i];
+        }
+        if (!char2byte(value, fromBase, value.length - n.length + first)) {
+            return null;
+        }
+
+        // Do the conversion by going through a 64 bit integer
+        long val = encode(value, fromBase, value.length - n.length + first);
+        if (negative && toBase > 0) {
+            if (val < 0) {
+                val = -1;
+            } else {
+                val = -val;
+            }
+        }
+        if (toBase < 0 && val < 0) {
+            val = -val;
+            negative = true;
+        }
+        decode(value, val, Math.abs(toBase));
+
+        // Find the first non-zero digit or the last digits if all are zero.
+        for (first = 0; first < value.length - 1 && value[first] == 0; first++) {}
+
+        byte2char(value, Math.abs(toBase), first);
+
+        if (negative && toBase < 0) {
+            value[--first] = '-';
+        }
+
+        return Arrays.copyOfRange(value, first, value.length);
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ConvFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ConvFunction.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+import org.apache.flink.table.runtime.functions.BaseConversionUtils;
+
+import java.nio.charset.StandardCharsets;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#CONV}. */
+@Internal
+public class ConvFunction extends BuiltInScalarFunction {
+
+    public ConvFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.CONV, context);
+    }
+
+    public static StringData eval(StringData input, Number fromBase, Number toBase) {
+        if (input == null || fromBase == null || toBase == null) {
+            return null;
+        }
+        byte[] bytes =
+                BaseConversionUtils.conv(input.toBytes(), fromBase.intValue(), toBase.intValue());
+        // fromBase cannot be negative, orElse it will return null.
+        return bytes == null ? null : StringData.fromBytes(bytes);
+    }
+
+    public static StringData eval(Number input, Number fromBase, Number toBase) {
+        if (input == null || fromBase == null || toBase == null) {
+            return null;
+        }
+        byte[] bytes =
+                BaseConversionUtils.conv(
+                        String.valueOf(input.longValue()).getBytes(StandardCharsets.UTF_8),
+                        fromBase.intValue(),
+                        toBase.intValue());
+        // fromBase cannot be negative, orElse it will return null.
+        return bytes == null ? null : StringData.fromBytes(bytes);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Add built-in conv function*


## Brief change log
- *Converts numbers between different number bases. Returns a string representation of the number N, converted from base from_base to base to_base. Returns NULL if any argument is NULL. The argument N is interpreted as an integer, but may be specified as an integer or a string. The minimum base is 2 and the maximum base is 36. If from_base is a negative number, N is regarded as a signed number. Otherwise, N is treated as unsigned. [CONV()](https://dev.mysql.com/doc/refman/8.0/en/mathematical-functions.html#function_conv) works with 64-bit precision.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
