### PR TITLE
[FLINK-28929][table] Add built-in datediff function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -485,6 +485,9 @@ temporal:
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)
     description: 'Returns the (signed) number of timepointunit between timepoint1 and timepoint2. The unit for the interval is given by the first argument, which should be one of the following values: SECOND, MINUTE, HOUR, DAY, MONTH, or YEAR.'
+  - sql: DATEDIFF(datetime1, datetime2)
+    table: dateDiff(datetime1, datetime2)
+    description: Returns the (signed) number of days between datetime1 and datetime2.
   - sql: CONVERT_TZ(string1, string2, string3)
     description: Converts a datetime string1 (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time zone string2 to time zone string3. The format of time zone should be either an abbreviation such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00". E.g., CONVERT_TZ('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31 16:00:00'.
   - sql: FROM_UNIXTIME(numeric[, string])

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -604,6 +604,10 @@ temporal:
     description: |
       返回 timepoint1 和 timepoint2 之间时间间隔。间隔的单位由第一个参数给出，它应该是以下值之一：
       SECOND，MINUTE，HOUR，DAY，MONTH 或 YEAR。
+  - sql: DATEDIFF(datetime1, datetime2)
+    table: dateDiff(datetime1, datetime2)
+    description: |
+      返回 datetime1 和 datetime2 之间的天数.
   - sql: CONVERT_TZ(string1, string2, string3)
     description: |
       将日期时间 string1（具有默认 ISO 时间戳格式 'yyyy-MM-dd HH:mm:ss'）从时区 string2 转换为时区 string3 的值。

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -329,6 +329,21 @@ def date_format(timestamp, format) -> Expression:
     return _binary_op("dateFormat", timestamp, format)
 
 
+def date_diff(datetime1, datetime2) -> Expression:
+    """
+    Returns the (signed) number of days between datetime1 and datetime2.
+
+    For example,
+    `date_diff(lit("2007-12-31 23:59:59").to_timestamp, lit("2007-12-30").to_date`
+    leads to 1.
+
+    :param datetime1: The first date in time.
+    :param datetime2: The second date in time.
+    :return: The number of intervals as integer value.
+    """
+    return _binary_op("dateDiff", datetime1, datetime2)
+
+
 def timestamp_diff(time_point_unit: TimePointUnit, time_point1, time_point2) -> Expression:
     """
     Returns the (signed) number of :class:`~pyflink.table.expression.TimePointUnit` between

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -370,6 +370,20 @@ public final class Expressions {
     }
 
     /**
+     * Returns the (signed) number of days between datetime1 and datetime2.
+     *
+     * <p>For example, {@code dateDiff(lit("2007-12-31 23:59:59").toTimestamp(),
+     * lit("2007-12-30").toDate())} leads to 1.
+     *
+     * @param datetime1 The first date in time.
+     * @param datetime2 The second date in time.
+     * @return The number of intervals as integer value.
+     */
+    public static ApiExpression dateDiff(Object datetime1, Object datetime2) {
+        return apiCall(BuiltInFunctionDefinitions.DATEDIFF, datetime1, datetime2);
+    }
+
+    /**
      * Returns the (signed) number of {@link TimePointUnit} between timePoint1 and timePoint2.
      *
      * <p>For example, {@code timestampDiff(TimePointUnit.DAY, lit("2016-06-15").toDate(),

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -527,6 +527,23 @@ trait ImplicitExpressionConversions {
   }
 
   /**
+   * Returns the (signed) number of days between datetime1 and datetime2.
+   *
+   * <p>For example, {@code dateDiff(lit("2007-12-31 23:59:59").toTimestamp(),
+   * lit("2007-12-30").toDate())} leads to 1.
+   *
+   * @param datetime1
+   *   The first date in time.
+   * @param datetime2
+   *   The second date in time.
+   * @return
+   *   The number of intervals as integer value.
+   */
+  def dateDiff(datetime1: Expression, datetime2: Expression): Expression = {
+    Expressions.dateDiff(datetime1, datetime2)
+  }
+
+  /**
    * Returns the (signed) number of [[TimePointUnit]] between timePoint1 and timePoint2.
    *
    * For example, timestampDiff(TimePointUnit.DAY, '2016-06-15'.toDate, '2016-06-18'.toDate leads to

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1507,6 +1507,19 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition DATEDIFF =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("DATEDIFF")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeFamily.DATETIME),
+                                    logical(LogicalTypeFamily.DATETIME)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(INT())))
+                    .runtimeClass(
+                            "org.apache.flink.table.runtime.functions.scalar.DateDiffFunction")
+                    .build();
+
     public static final BuiltInFunctionDefinition TIMESTAMP_DIFF =
             BuiltInFunctionDefinition.newBuilder()
                     .name("timestampDiff")

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateDiffFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/DateDiffFunction.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.table.utils.DateTimeUtils.timestampMillisToDate;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#DATEDIFF}. */
+@Internal
+public class DateDiffFunction extends BuiltInScalarFunction {
+
+    public DateDiffFunction(SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.DATEDIFF, context);
+    }
+
+    public @Nullable Object eval(TimestampData time1, TimestampData time2) {
+        if (time1 == null || time2 == null) {
+            return null;
+        }
+        return timestampMillisToDate(time1.getMillisecond())
+                - timestampMillisToDate(time2.getMillisecond());
+    }
+
+    public @Nullable Object eval(TimestampData time1, Integer time2) {
+        if (time1 == null || time2 == null) {
+            return null;
+        }
+        return timestampMillisToDate(time1.getMillisecond()) - time2;
+    }
+
+    public @Nullable Object eval(Integer time1, TimestampData time2) {
+        if (time1 == null || time2 == null) {
+            return null;
+        }
+        return time1 - timestampMillisToDate(time2.getMillisecond());
+    }
+
+    public @Nullable Object eval(Integer time1, Integer time2) {
+        if (time1 == null || time2 == null) {
+            return null;
+        }
+        return time1 - time2;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*Add built-in datediff function*


## Brief change log
- Syntax:
  - DATEDIFF(expr1,expr2)
- Returns:
  - returns expr1 − expr2 expressed as a value in days from one date to the other. expr1 and expr2 are date or date-and-time expressions. Only the date parts of the values are used in the calculation.
  - This function returns NULL if expr1 or expr2 is NULL.

See more:
- mysql: https://dev.mysql.com/doc/refman/8.0/en/date-and-time-functions.html#function_datediff

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

![image](https://user-images.githubusercontent.com/6316753/188366335-4b58fec8-cf87-4eae-b943-e3e5aa0fa55f.png)
