### PR TITLE
[FLINK-26666][python] Add support for version comparision of pyflink and flink

### DIFF
--- a/flink-python/pyflink/find_flink_home.py
+++ b/flink-python/pyflink/find_flink_home.py
@@ -19,7 +19,10 @@
 import glob
 import logging
 import os
+import subprocess
 import sys
+
+from pyflink.version import __version__
 
 
 def _is_flink_home(path):
@@ -38,12 +41,53 @@ def _is_apache_flink_libraries_home(path):
         return False
 
 
+def _is_pyflink_and_flink_version_match():
+    pyflink_version = __version__
+    flink_home_env = os.environ['FLINK_HOME']
+    try:
+        output_version = subprocess.check_output([flink_home_env + "/bin/flink", "--version"],
+                                                 stderr=subprocess.PIPE)
+        flink_version_bytes = output_version.decode("utf-8")
+        flink_version = ""
+        for flink_version_byte in flink_version_bytes.split(","):
+            if flink_version_byte.startswith("Version:"):
+                flink_version = flink_version_byte.split("Version:")[1].strip()
+    except Exception:
+        logging.error("Parsing Flink Version error from System Env FLINK_HOME.")
+        return False
+
+    pyflink_version_list = []
+    for subversion in pyflink_version.split("."):
+        if subversion.isdigit():
+            pyflink_version_list.append(subversion)
+
+    flink_version_list = []
+    for f_version in flink_version.split("."):
+        if f_version.isdigit():
+            flink_version_list.append(f_version)
+        elif "-" in f_version:
+            for f_sub_version in f_version.split("-"):
+                if f_sub_version.isdigit():
+                    flink_version_list.append(f_sub_version)
+
+    if pyflink_version_list == flink_version_list:
+        return True
+    err_strs = ["pyflink version: %s and flink version: %s from FLINK_HOME env are "
+                "not matched.\n" % (".".join(pyflink_version_list), ".".join(flink_version_list)),
+                "You have 2 choices to solve this problem:\n",
+                "1. Unset the FLINK_HOME environment variable.\n",
+                "2. Make sure that the flink version of FLINK_HOME is the same as "
+                "the pyflink version.\n"]
+    logging.error("".join(err_strs))
+    return False
+
+
 def _find_flink_home():
     """
     Find the FLINK_HOME.
     """
-    # If the environment has set FLINK_HOME, trust it.
-    if 'FLINK_HOME' in os.environ:
+    # If the environment has set FLINK_HOME, trust it after validation.
+    if 'FLINK_HOME' in os.environ and _is_pyflink_and_flink_version_match():
         return os.environ['FLINK_HOME']
     else:
         try:


### PR DESCRIPTION
This patch adds a validation when user setting the FLINK_HOME env.
If the flink version from FLINK_HOME is the same as the pyflink, we
trust the FLINK_HOME, otherwise will rewrite the FLINK_HOME env anyway.


## What is the purpose of the change

improve the user experience and left a suggestion before exit.


## Brief change log

  - Add a func for comparing the pyflink version and flink version from FLINK_HOME env
  - Don't trust FLINK_HOME if the system env had been setting before validation
  - Even FLINK_HOME env had been setted before running pyflink job. Once the validation is failure, the logic will overwrite the FLINK_HOME.


## Verifying this change

Exec a pyflink job, and try to make sure the pyflink version and the flink version of FLINK_HOME are different.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
