### PR TITLE
[FLINK-28941][Runtime/Checkpointing] Add concurrent checkpoint support in Operator Coordinator

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/CoordinatorEventsExactlyOnceITCase.java
@@ -312,7 +312,7 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
         protected int nextNumber;
 
         protected CompletableFuture<byte[]> nextToComplete;
-        private CompletableFuture<byte[]> requestedCheckpoint;
+        protected CompletableFuture<byte[]> requestedCheckpoint;
 
         private SubtaskGateway subtaskGateway;
         private boolean workLoopRunning;
@@ -683,7 +683,7 @@ public class CoordinatorEventsExactlyOnceITCase extends TestLogger {
             return MAP_FOR_OPERATOR.computeIfAbsent(operatorName, (key) -> new TestScript());
         }
 
-        static void reset() {
+        public static void reset() {
             MAP_FOR_OPERATOR.clear();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/SubtaskGatewayImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/SubtaskGatewayImplTest.java
@@ -139,7 +139,7 @@ public class SubtaskGatewayImplTest {
         final CompletableFuture<Acknowledge> future1 = gateway3.sendEvent(event1);
         final CompletableFuture<Acknowledge> future2 = gateway0.sendEvent(event2);
 
-        gateways.forEach(SubtaskGatewayImpl::openGatewayAndUnmarkCheckpoint);
+        gateways.forEach(SubtaskGatewayImpl::openGatewayAndUnmarkAllCheckpoint);
 
         assertThat(receiver.events)
                 .containsExactly(new EventWithSubtask(event1, 3), new EventWithSubtask(event2, 0));
@@ -161,7 +161,7 @@ public class SubtaskGatewayImplTest {
         gateway.tryCloseGateway(17L);
 
         final CompletableFuture<Acknowledge> future = gateway.sendEvent(new TestOperatorEvent());
-        gateway.openGatewayAndUnmarkCheckpoint();
+        gateway.openGatewayAndUnmarkAllCheckpoint();
 
         assertThat(future).isCompletedExceptionally();
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase.java
@@ -114,7 +114,12 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
         env.setParallelism(1);
         env.enableCheckpointing(100);
         ManuallyClosedSourceFunction.shouldCloseSource = false;
-        EventSendingCoordinatorWithGuaranteedCheckpoint.isEventSentAfterFirstCheckpoint = false;
+        EventReceivingOperator.shouldUnblockAllCheckpoint = false;
+        EventReceivingOperator.shouldUnblockNextCheckpoint = false;
+        EventSendingCoordinatorWithGuaranteedConcurrentCheckpoint
+                        .isCheckpointAbortedBeforeScriptFailure =
+                false;
+        TestScript.reset();
     }
 
     @Test
@@ -155,6 +160,19 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
                 .isTrue();
     }
 
+    @Test
+    public void testConcurrentCheckpoint() throws Exception {
+        env.getCheckpointConfig().setMaxConcurrentCheckpoints(2);
+        executeAndVerifyResults(
+                env,
+                new EventReceivingOperatorFactoryWithGuaranteedConcurrentCheckpoint<>(
+                        "eventReceiving", NUM_EVENTS, DELAY));
+        assertThat(
+                        EventSendingCoordinatorWithGuaranteedConcurrentCheckpoint
+                                .isCheckpointAbortedBeforeScriptFailure)
+                .isFalse();
+    }
+
     private void executeAndVerifyResults(
             StreamExecutionEnvironment env, EventReceivingOperatorFactory<Long, Long> factory)
             throws Exception {
@@ -162,10 +180,6 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
         // when checkpoint barriers are injected into sources, the event receiving operator has not
         // started checkpoint yet.
         env.addSource(new ManuallyClosedSourceFunction<>(), TypeInformation.of(Long.class))
-                .transform(
-                        "blockCheckpointBarrier",
-                        TypeInformation.of(Long.class),
-                        new BlockCheckpointBarrierOperator<>())
                 .disableChaining()
                 .transform(factory.name, TypeInformation.of(Long.class), factory)
                 .addSink(new DiscardingSink<>());
@@ -198,29 +212,6 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
     }
 
     /**
-     * A stream operator that blocks the checkpoint barrier until the coordinator has sent events to
-     * its subtask. It helps to guarantee that there are events being sent when the coordinator has
-     * completed the first checkpoint while the subtask has not yet.
-     */
-    private static class BlockCheckpointBarrierOperator<T> extends AbstractStreamOperator<T>
-            implements OneInputStreamOperator<T, T> {
-
-        @Override
-        public void processElement(StreamRecord<T> element) throws Exception {
-            output.collect(element);
-        }
-
-        @Override
-        public void snapshotState(StateSnapshotContext context) throws Exception {
-            super.snapshotState(context);
-            while (!EventSendingCoordinatorWithGuaranteedCheckpoint
-                    .isEventSentAfterFirstCheckpoint) {
-                Thread.sleep(100);
-            }
-        }
-    }
-
-    /**
      * A wrapper operator factory for {@link EventSendingCoordinatorWithGuaranteedCheckpoint} and
      * {@link EventReceivingOperator}.
      */
@@ -232,7 +223,7 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
 
         protected final int numEvents;
 
-        private final int delay;
+        protected final int delay;
 
         public EventReceivingOperatorFactory(String name, int numEvents, int delay) {
             this.name = name;
@@ -293,14 +284,14 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
     private static class EventSendingCoordinatorWithGuaranteedCheckpoint
             extends EventSendingCoordinator {
 
-        /** Whether the coordinator has sent any event to its subtask after any checkpoint. */
-        private static boolean isEventSentAfterFirstCheckpoint;
-
         /**
          * The max number that the coordinator might send out before it completes the first
          * checkpoint.
          */
         private final int maxNumberBeforeFirstCheckpoint;
+
+        /** Whether the coordinator has sent any event to its subtask after any checkpoint. */
+        private boolean isEventSentAfterFirstCheckpoint;
 
         /** Whether the coordinator has completed the first checkpoint. */
         private boolean isCoordinatorFirstCheckpointCompleted;
@@ -312,6 +303,7 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
                 Context context, String name, int numEvents, int delay) {
             super(context, name, numEvents, delay);
             this.maxNumberBeforeFirstCheckpoint = new Random().nextInt(numEvents / 6);
+            this.isEventSentAfterFirstCheckpoint = false;
             this.isCoordinatorFirstCheckpointCompleted = false;
             this.isJobFirstCheckpointCompleted = false;
         }
@@ -331,6 +323,7 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
 
             if (!isEventSentAfterFirstCheckpoint && isCoordinatorFirstCheckpointCompleted) {
                 isEventSentAfterFirstCheckpoint = true;
+                EventReceivingOperator.shouldUnblockAllCheckpoint = true;
             }
         }
 
@@ -382,11 +375,22 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
     /**
      * The stream operator that receives the events and accumulates the numbers. The task is
      * stateful and checkpoints the accumulator.
+     *
+     * <p>The operator also supports blocking the checkpoint process until certain signal is invoked
+     * (See {@link #shouldUnblockAllCheckpoint} and {@link #shouldUnblockNextCheckpoint}). It helps
+     * to guarantee that there are events being sent when the coordinator has completed a checkpoint
+     * while the subtask has not yet.
      */
     private static class EventReceivingOperator<T> extends AbstractStreamOperator<T>
             implements OneInputStreamOperator<T, T>, OperatorEventHandler {
 
         protected static final String ACCUMULATOR_NAME = "receivedIntegers";
+
+        /** Whether to unblock all the following checkpoints. */
+        private static boolean shouldUnblockAllCheckpoint;
+
+        /** Whether to unblock the next checkpoint. */
+        private static boolean shouldUnblockNextCheckpoint;
 
         protected final ListAccumulator<Integer> accumulator = new ListAccumulator<>();
 
@@ -426,6 +430,14 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
         @Override
         public void snapshotState(StateSnapshotContext context) throws Exception {
             super.snapshotState(context);
+            while (!shouldUnblockAllCheckpoint && !shouldUnblockNextCheckpoint) {
+                Thread.sleep(100);
+            }
+
+            if (shouldUnblockNextCheckpoint) {
+                shouldUnblockNextCheckpoint = false;
+            }
+
             state.update(accumulator.getLocalValue());
         }
 
@@ -548,6 +560,166 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
                     .getOperatorCoordinatorEventGateway()
                     .sendOperatorEventToCoordinator(
                             getOperatorID(), new SerializedValue<>(new StartEvent(lastValue)));
+        }
+    }
+
+    /**
+     * A wrapper operator factory for {@link
+     * EventSendingCoordinatorWithGuaranteedConcurrentCheckpoint} and {@link
+     * EventReceivingOperator}.
+     */
+    private static class EventReceivingOperatorFactoryWithGuaranteedConcurrentCheckpoint<IN, OUT>
+            extends EventReceivingOperatorFactory<IN, OUT> {
+
+        public EventReceivingOperatorFactoryWithGuaranteedConcurrentCheckpoint(
+                String name, int numEvents, int delay) {
+            super(name, numEvents, delay);
+        }
+
+        @Override
+        public OperatorCoordinator.Provider getCoordinatorProvider(
+                String operatorName, OperatorID operatorID) {
+            return new OperatorCoordinator.Provider() {
+
+                @Override
+                public OperatorID getOperatorId() {
+                    return operatorID;
+                }
+
+                @Override
+                public OperatorCoordinator create(OperatorCoordinator.Context context) {
+                    return new EventSendingCoordinatorWithGuaranteedConcurrentCheckpoint(
+                            context, name, numEvents, delay);
+                }
+            };
+        }
+    }
+
+    /**
+     * A subclass of {@link EventSendingCoordinator} that additionally guarantees the following
+     * behavior around checkpoint.
+     *
+     * <ul>
+     *   <li>The job must have completed two checkpoints before the coordinator injects the failure.
+     *   <li>The two checkpoints must have an overlapping period. i.e. The second checkpoint must
+     *       have started before the first checkpoint finishes.
+     *   <li>The failure must be injected after the coordinator has completed its second checkpoint
+     *       and before it completes the third.
+     *   <li>There must be events being sent when the coordinator has completed the second
+     *       checkpoint while the subtask has not.
+     * </ul>
+     *
+     * <p>In order for this class to work correctly, make sure to invoke {@link
+     * org.apache.flink.streaming.api.environment.CheckpointConfig#setMaxConcurrentCheckpoints(int)}
+     * method with a parameter value larger than 1.
+     */
+    private static class EventSendingCoordinatorWithGuaranteedConcurrentCheckpoint
+            extends EventSendingCoordinator {
+
+        /** Whether there is a checkpoint aborted before the test script failure is triggered. */
+        private static boolean isCheckpointAbortedBeforeScriptFailure;
+
+        /**
+         * The max number that the coordinator might send out before it completes the second
+         * checkpoint.
+         */
+        private final int maxNumberBeforeSecondCheckpoint;
+
+        /** Whether the coordinator has sent out any event after the second checkpoint. */
+        private boolean isEventSentAfterSecondCheckpoint;
+
+        /** Whether the coordinator has completed the first checkpoint. */
+        private boolean isCoordinatorFirstCheckpointCompleted;
+
+        /** Whether the job (both coordinator and operator) has completed the first checkpoint. */
+        private boolean isJobFirstCheckpointCompleted;
+
+        /** Whether the coordinator has completed the second checkpoint. */
+        private boolean isCoordinatorSecondCheckpointCompleted;
+
+        /** Whether the job (both coordinator and operator) has completed the second checkpoint. */
+        private boolean isJobSecondCheckpointCompleted;
+
+        public EventSendingCoordinatorWithGuaranteedConcurrentCheckpoint(
+                Context context, String name, int numEvents, int delay) {
+            super(context, name, numEvents, delay);
+            this.maxNumberBeforeSecondCheckpoint = new Random().nextInt(numEvents / 6);
+            this.isEventSentAfterSecondCheckpoint = false;
+            this.isCoordinatorFirstCheckpointCompleted = false;
+            this.isJobFirstCheckpointCompleted = false;
+            this.isCoordinatorSecondCheckpointCompleted = false;
+            this.isJobSecondCheckpointCompleted = false;
+        }
+
+        @Override
+        protected void sendNextEvent() {
+            if (!isCoordinatorSecondCheckpointCompleted
+                    && nextNumber > maxNumberBeforeSecondCheckpoint) {
+                return;
+            }
+
+            if (!isJobSecondCheckpointCompleted && nextNumber >= maxNumberBeforeFailure) {
+                return;
+            }
+
+            super.sendNextEvent();
+
+            if (!isEventSentAfterSecondCheckpoint && isCoordinatorSecondCheckpointCompleted) {
+                isEventSentAfterSecondCheckpoint = true;
+                EventReceivingOperator.shouldUnblockAllCheckpoint = true;
+            }
+        }
+
+        @Override
+        protected void handleCheckpoint() {
+            if (nextToComplete != null) {
+                if (!isCoordinatorFirstCheckpointCompleted) {
+                    isCoordinatorFirstCheckpointCompleted = true;
+                } else if (!isCoordinatorSecondCheckpointCompleted) {
+                    isCoordinatorSecondCheckpointCompleted = true;
+                    EventReceivingOperator.shouldUnblockNextCheckpoint = true;
+                }
+            }
+
+            super.handleCheckpoint();
+
+            if (nextToComplete != null
+                    && isEventSentAfterSecondCheckpoint
+                    && !testScript.hasAlreadyFailed()) {
+                testScript.recordHasFailed();
+                context.failJob(new Exception("test failure"));
+            }
+        }
+
+        @Override
+        public void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData)
+                throws Exception {
+            super.resetToCheckpoint(checkpointId, checkpointData);
+            runInMailbox(
+                    () -> {
+                        isCoordinatorFirstCheckpointCompleted = true;
+                        isJobFirstCheckpointCompleted = true;
+                    });
+        }
+
+        @Override
+        public void notifyCheckpointAborted(long checkpointId) {
+            if (!testScript.hasAlreadyFailed()) {
+                isCheckpointAbortedBeforeScriptFailure = true;
+            }
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) {
+            super.notifyCheckpointComplete(checkpointId);
+            runInMailbox(
+                    () -> {
+                        if (!isJobFirstCheckpointCompleted) {
+                            isJobFirstCheckpointCompleted = true;
+                        } else if (!isJobSecondCheckpointCompleted) {
+                            isJobSecondCheckpointCompleted = true;
+                        }
+                    });
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

#20275 has improved the checkpoint behavior of `OperatorCoordinator`, guaranteeing the distributed consistency of operator events sent from the coordinator to its subtasks. However, while the previous implementation only requires that there is no concurrent "triggering phase" of checkpoints, the implementation in #20275 requires that before the previous checkpoint is fully completed or aborted, the next checkpoint should not be started. This has limited the usage of coordinators in cases when savepoints are triggered or the maximum allowed concurrent checkpoints is larger than 1.

This PR solves the problem above by adding concurrent checkpoint support in the coordinator's implementation.

## Brief change log

- The subtask gateway can cache events for multiple ongoing checkpoints.

## Verifying this change

This change added tests and can be verified as follows:

- Added integration tests to verify that coordinator can work correctly without message loss when the concurrent checkpoint is enforced.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
    - This PR affects the behavior of the coordinator in case of concurrent checkpoints, as described above.

  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)