### PR TITLE
[FLINK-29201][docs] Add setting up of maven-wrapper

### DIFF
--- a/docs/content.zh/docs/flinkDev/ide_setup.md
+++ b/docs/content.zh/docs/flinkDev/ide_setup.md
@@ -77,8 +77,9 @@ IntelliJ 提供了插件设置来安装 Scala 插件。如果尚未安装，请�
 4. 保留默认选项，然后依次单击 "Next"，直到到达 SDK 部分。
 5. 如果未列出 SDK，请使用左上角的 "+" 号创建一个。选择 "JDK"，选择 JDK 主目录，然后单击 "OK"。选择最合适的 JDK 版本。注意：一个好的经验法则是选择与活动 Maven 配置文件匹配的 JDK 版本。
 6. 单击 "Next" 继续，直到完成导入。
-7. 右键单击已导入的 Flink 项目 → Maven → Generate Sources and Update Folders。请注意：这会将 Flink 库安装在本地 Maven 存储库中，默认情况下位于 "/home/$USER/.m2/repository/org/apache/flink/"。另外 `mvn clean package -DskipTests` 也可以创建 IDE 运行所需的文件，但无需安装库。
-8. 编译项目（Build → Make Project）。
+7. Set up maven home path to maven-wrapper. Go to "File" → "Settings" → "Build,Execution,Deployment" → "Build Tools" → "Maven". For "Maven home path" select "Use maven-wrapper".
+8. 右键单击已导入的 Flink 项目 → Maven → Generate Sources and Update Folders。请注意：这会将 Flink 库安装在本地 Maven 存储库中，默认情况下位于 "/home/$USER/.m2/repository/org/apache/flink/"。另外 `./mvnw clean package -DskipTests` 也可以创建 IDE 运行所需的文件，但无需安装库。
+9. 译项目（Build → Make Project）。
 
 
 ### 代码格式化

--- a/docs/content/docs/flinkDev/ide_setup.md
+++ b/docs/content/docs/flinkDev/ide_setup.md
@@ -76,10 +76,13 @@ accurately.
    Select the most suitable JDK version. NOTE: A good rule of thumb is to select
    the JDK version matching the active Maven profile.
 6. Continue by clicking "Next" until the import is finished.
-7. Open the "Maven" tab (or right-click on the imported project and find "Maven") and run
+7. Set up maven home path to maven-wrapper. 
+   Go to "File" → "Settings" → "Build,Execution,Deployment" → "Build Tools" → "Maven".
+   For "Maven home path" select "Use maven-wrapper".
+8. Open the "Maven" tab (or right-click on the imported project and find "Maven") and run
    "Generate Sources and Update Folders". Alternatively, you can run
-   `mvn clean package -DskipTests`.
-8. Build the Project ("Build" → "Build Project").
+   `./mvnw clean package -DskipTests`.
+9. Build the Project ("Build" → "Build Project").
 
 ### Copyright Profile
 


### PR DESCRIPTION
## What is the purpose of the change
The PR adds information about setting up of maven-wrapper
Otherwise (in case there is a much higher version than recommended) it could lead to non-compilable within IDE flink-connector-hive and flink-sql-client modules
Similar issue during compile/build from command line was mentioned at https://issues.apache.org/jira/browse/FLINK-27640

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
