### PR TITLE
[FLINK-29092][tests] Use base path bucket assigner

### DIFF
--- a/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/HadoopPathBasedPartFileWriterTest.java
+++ b/flink-formats/flink-hadoop-bulk/src/test/java/org/apache/flink/formats/hadoop/bulk/HadoopPathBasedPartFileWriterTest.java
@@ -23,7 +23,7 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.filesystem.HadoopPathBasedBulkFormatBuilder;
 import org.apache.flink.streaming.api.functions.sink.filesystem.TestStreamingFileSinkFactory;
-import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.DateTimeBucketAssigner;
+import org.apache.flink.streaming.api.functions.sink.filesystem.bucketassigners.BasePathBucketAssigner;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -79,16 +79,18 @@ public class HadoopPathBasedPartFileWriterTest extends AbstractTestBase {
         env.setParallelism(1);
         env.enableCheckpointing(100);
 
+        // FiniteTestSource will generate two elements with a checkpoint trigger in between the two
+        // elements
         DataStream<String> stream =
                 env.addSource(new FiniteTestSource<>(data), TypeInformation.of(String.class));
         Configuration configuration = new Configuration();
-
+        // Elements from source are going to be assigned to one bucket
         HadoopPathBasedBulkFormatBuilder<String, String, ?> builder =
                 new HadoopPathBasedBulkFormatBuilder<>(
                         basePath,
                         new TestHadoopPathBasedBulkWriterFactory(),
                         configuration,
-                        new DateTimeBucketAssigner<>());
+                        new BasePathBucketAssigner<>());
         TestStreamingFileSinkFactory<String> streamingFileSinkFactory =
                 new TestStreamingFileSinkFactory<>();
         stream.addSink(streamingFileSinkFactory.createSink(builder, 1000));
@@ -102,14 +104,9 @@ public class HadoopPathBasedPartFileWriterTest extends AbstractTestBase {
     private void validateResult(List<String> expected, Configuration config, Path basePath)
             throws IOException {
         FileSystem fileSystem = FileSystem.get(basePath.toUri(), config);
-        FileStatus[] buckets = fileSystem.listStatus(basePath);
-        assertThat(buckets).isNotNull();
-        assertThat(buckets).hasSize(1);
-
-        FileStatus[] partFiles = fileSystem.listStatus(buckets[0].getPath());
+        FileStatus[] partFiles = fileSystem.listStatus(basePath);
         assertThat(partFiles).isNotNull();
         assertThat(partFiles).hasSize(2);
-
         for (FileStatus partFile : partFiles) {
             assertThat(partFile.getLen()).isGreaterThan(0);
 


### PR DESCRIPTION
## What is the purpose of the change

Fix FLINK-29092 in unit test 

## Brief change log

  Use BasePathBucketAssigner


## Verifying this change

  Test case passed

## Does this pull request potentially affect one of the following parts:
   No


## Documentation
   No
