### PR TITLE
[FLINK-29211][hive][legal] Update 2.3.9 NOTICE

### DIFF
--- a/flink-connectors/flink-sql-connector-hive-2.3.9/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hive-2.3.9/src/main/resources/META-INF/NOTICE
@@ -16,6 +16,9 @@ See bundled license files for details.
 The bundled Apache Hive org.apache.hive:hive-exec dependency bundles the following dependencies under
 the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- com.fasterxml.jackson.core:jackson-annotations:2.6.3
+- com.fasterxml.jackson.core:jackson-core:2.6.3
+- com.fasterxml.jackson.core:jackson-databind:2.6.3
 - com.google.guava:guava:14.0.1
 - com.googlecode.javaewah:JavaEWAH:0.3.2
 - com.tdunning:json:1.8
@@ -24,8 +27,15 @@ the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - javax.jdo:jdo-api:3.0.1
 - joda-time:joda-time:2.8.1
 - net.sf.opencsv:opencsv:2.3
-- org.apache.avro:avro-mapred:1.7.7
-- org.apache.avro:avro:1.7.7
+- org.apache.avro:avro-guava-dependencies:1.8.2
+- org.apache.avro:avro-mapred:1.8.2
+- org.apache.avro:avro:1.8.2
+- org.apache.calcite:calcite-core:1.10.0
+- org.apache.calcite:calcite-druid:1.10.0
+- org.apache.calcite:calcite-linq4j:1.10.0
+- org.apache.calcite.avatica:avatica:1.8.0
+- org.apache.calcite.avatica:avatica-metrics:1.8.0
+- org.apache.commons:commons-lang:2.6
 - org.apache.commons:commons-lang3:3.1
 - org.apache.hive.shims:hive-shims-0.23:2.3.9
 - org.apache.hive.shims:hive-shims-common:2.3.9
@@ -40,9 +50,12 @@ the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - org.apache.orc:orc-core:1.3.4
 - org.apache.orc:orc-tools:1.3.4
 - org.apache.parquet:parquet-hadoop-bundle:1.8.1
-- org.apache.parquet:parquet-jackson:1.8.1
+- org.apache.thrift:libthrift:0.7.0
 - org.apache.thrift:libthrift:0.9.3
+- org.apache.thrift:libfb303:0.9.3
+- org.codehaus.jackson:jackson-core-asl:1.9.11
 - org.codehaus.jackson:jackson-core-asl:1.9.13
+- org.codehaus.jackson:jackson-mapper-asl:1.9.11
 - org.codehaus.jackson:jackson-mapper-asl:1.9.13
 - org.objenesis:objenesis:2.1
 
@@ -59,4 +72,4 @@ See bundled license files for details.
 The bundled Apache Hive org.apache.hive:hive-exec dependency bundles the following dependencies under the MIT/X11 license.
 See bundled license files for details.
 
-- org.slf4j:slf4j-api:1.7.10
+- org.slf4j:slf4j-api:1.7.2

--- a/flink-connectors/flink-sql-connector-hive-2.3.9/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hive-2.3.9/src/main/resources/META-INF/NOTICE
@@ -34,7 +34,6 @@ the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - org.apache.calcite:calcite-druid:1.10.0
 - org.apache.calcite:calcite-linq4j:1.10.0
 - org.apache.calcite.avatica:avatica:1.8.0
-- org.apache.calcite.avatica:avatica-metrics:1.8.0
 - org.apache.commons:commons-lang:2.6
 - org.apache.commons:commons-lang3:3.1
 - org.apache.hive.shims:hive-shims-0.23:2.3.9


### PR DESCRIPTION
This got rather complicated because hive-exec bundles parquet-hadoop-bundle which again bundles stuff, like another version of thrift/jackson.
There's also a bunch of missing dependencies bundled directly by hive-exec.
The changes are derived from the pom contents and the original hive-exec pom.