### PR TITLE
[FLINK-29205][connectors/kinesis] Passthrough use config to HTTP clie…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Factory.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/proxy/KinesisProxyV2Factory.java
@@ -23,6 +23,7 @@ import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.connector.kinesis.sink.KinesisStreamsConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.internals.publisher.fanout.FanOutRecordPublisherConfiguration;
 import org.apache.flink.streaming.connectors.kinesis.util.AwsV2Util;
+import org.apache.flink.streaming.connectors.kinesis.util.KinesisConfigUtil;
 import org.apache.flink.util.Preconditions;
 
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -61,15 +62,12 @@ public class KinesisProxyV2Factory {
         final FanOutRecordPublisherConfiguration configuration =
                 new FanOutRecordPublisherConfiguration(configProps, emptyList());
 
-        Properties legacyConfigProps = new Properties(configProps);
-        legacyConfigProps.setProperty(
-                KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX,
-                AWSAsyncSinkUtil.formatFlinkUserAgentPrefix(
-                        KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT));
+        Properties asyncClientProperties =
+                KinesisConfigUtil.getV2ConsumerAsyncClientProperties(configProps);
 
         final KinesisAsyncClient client =
                 AWSAsyncSinkUtil.createAwsAsyncClient(
-                        legacyConfigProps,
+                        asyncClientProperties,
                         httpClient,
                         KinesisAsyncClient.builder(),
                         KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT,

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtil.java
@@ -18,7 +18,9 @@
 package org.apache.flink.streaming.connectors.kinesis.util;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.aws.util.AWSAsyncSinkUtil;
 import org.apache.flink.connector.aws.util.AWSGeneralUtil;
+import org.apache.flink.connector.kinesis.sink.KinesisStreamsConfigConstants;
 import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisConsumer;
 import org.apache.flink.streaming.connectors.kinesis.FlinkKinesisProducer;
 import org.apache.flink.streaming.connectors.kinesis.config.AWSConfigConstants;
@@ -535,6 +537,17 @@ public class KinesisConfigUtil {
         } catch (ParseException exception) {
             return new Date((long) (Double.parseDouble(timestamp) * 1000));
         }
+    }
+
+    public static Properties getV2ConsumerAsyncClientProperties(final Properties configProps) {
+        Properties asyncClientProperties = new Properties();
+        asyncClientProperties.putAll(configProps);
+        asyncClientProperties.setProperty(
+                KinesisStreamsConfigConstants.KINESIS_CLIENT_USER_AGENT_PREFIX,
+                AWSAsyncSinkUtil.formatFlinkUserAgentPrefix(
+                        KinesisStreamsConfigConstants.BASE_KINESIS_USER_AGENT_PREFIX_FORMAT));
+
+        return asyncClientProperties;
     }
 
     private static void validateOptionalPositiveLongProperty(

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/KinesisConfigUtilTest.java
@@ -1010,4 +1010,15 @@ public class KinesisConfigUtilTest {
 
         KinesisConfigUtil.validateConsumerConfiguration(testConfig);
     }
+
+    @Test
+    public void testGetV2ConsumerAsyncClientProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("retained", "property");
+
+        assertThat(KinesisConfigUtil.getV2ConsumerAsyncClientProperties(properties))
+                .containsEntry("retained", "property")
+                .containsKey("aws.kinesis.client.user-agent-prefix")
+                .hasSize(2);
+    }
 }


### PR DESCRIPTION
…nt when constructing Async Client for Kinesis EFO

## What is the purpose of the change

Fix bug introduced in 1.15 where config is not passed through to creation of AWS SDK v2 for EFO, breaking support for custom credential providers.

## Brief change log

* Pass through configuration supplied by user to AWS SDK v2 client

This fix will be applied to 1.15/1.16/1.17:
- 1.15: https://github.com/apache/flink/pull/20768
- 1.16: https://github.com/apache/flink/pull/20770
- 1.17: https://github.com/apache/flink/pull/20769

## Verifying this change

- Unit tested
- Verified using local application

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
