### PR TITLE
[FLINK-29214][Table API/SQL] Remove usages of deprecated Aggregate#indicator

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
@@ -60,6 +60,8 @@ import org.apache.flink.table.planner.plan.nodes.hive.LogicalDistribution;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+
 import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.plan.ViewExpanders;
@@ -1218,7 +1220,8 @@ public class HiveParserCalcitePlanner {
             gbInputRexNodes.add(cluster.getRexBuilder().makeInputRef(srcRel, 0));
         }
 
-        return LogicalAggregate.create(gbInputRel, groupSet, transformedGroupSets, aggregateCalls);
+        return LogicalAggregate.create(
+                gbInputRel, ImmutableList.of(), groupSet, transformedGroupSets, aggregateCalls);
     }
 
     // Generate GB plan.
@@ -2409,7 +2412,11 @@ public class HiveParserCalcitePlanner {
                     ImmutableBitSet.range(res.getRowType().getFieldList().size());
             res =
                     LogicalAggregate.create(
-                            res, groupSet, Collections.emptyList(), Collections.emptyList());
+                            res,
+                            ImmutableList.of(),
+                            groupSet,
+                            Collections.emptyList(),
+                            Collections.emptyList());
             HiveParserRowResolver groupByOutputRowResolver = new HiveParserRowResolver();
             for (int i = 0; i < outRR.getColumnInfos().size(); i++) {
                 ColumnInfo colInfo = outRR.getColumnInfos().get(i);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserRexNodeConverter.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserRexNodeConverter.java
@@ -761,8 +761,7 @@ public class HiveParserRexNodeConverter {
                             .makeNullLiteral(
                                     newChildRexNodeLst
                                             .get(newChildRexNodeLst.size() - 1)
-                                            .getType()
-                                            .getSqlTypeName()));
+                                            .getType()));
         }
         return newChildRexNodeLst;
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlCountAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlCountAggFunction.java
@@ -30,6 +30,7 @@ import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Optionality;
 
 /**
  * Counterpart of hive's
@@ -50,11 +51,15 @@ public class HiveParserSqlCountAggFunction extends SqlAggFunction
             SqlOperandTypeChecker operandTypeChecker) {
         super(
                 "count",
+                null,
                 SqlKind.COUNT,
                 returnTypeInference,
                 operandTypeInference,
                 operandTypeChecker,
-                SqlFunctionCategory.NUMERIC);
+                SqlFunctionCategory.NUMERIC,
+                false,
+                false,
+                Optionality.FORBIDDEN);
         this.isDistinct = isDistinct;
         this.returnTypeInference = returnTypeInference;
         this.operandTypeChecker = operandTypeChecker;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlMinMaxAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlMinMaxAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlSplittableAggFunction;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
 import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.util.Optionality;
 
 /**
  * Counterpart of hive's
@@ -39,11 +40,15 @@ public class HiveParserSqlMinMaxAggFunction extends SqlAggFunction {
             boolean isMin) {
         super(
                 isMin ? "min" : "max",
+                null,
                 isMin ? SqlKind.MIN : SqlKind.MAX,
                 returnTypeInference,
                 operandTypeInference,
                 operandTypeChecker,
-                SqlFunctionCategory.NUMERIC);
+                SqlFunctionCategory.NUMERIC,
+                false,
+                false,
+                Optionality.FORBIDDEN);
     }
 
     @Override

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlSumAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlSumAggFunction.java
@@ -36,6 +36,7 @@ import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.util.ImmutableIntList;
+import org.apache.calcite.util.Optionality;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -62,11 +63,15 @@ public class HiveParserSqlSumAggFunction extends SqlAggFunction
             SqlOperandTypeChecker operandTypeChecker) {
         super(
                 "sum",
+                null,
                 SqlKind.SUM,
                 returnTypeInference,
                 operandTypeInference,
                 operandTypeChecker,
-                SqlFunctionCategory.NUMERIC);
+                SqlFunctionCategory.NUMERIC,
+                false,
+                false,
+                Optionality.FORBIDDEN);
         this.returnTypeInference = returnTypeInference;
         this.operandTypeChecker = operandTypeChecker;
         this.operandTypeInference = operandTypeInference;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
@@ -133,7 +133,8 @@ public class OverConvertRule implements CallExpressionConvertRule {
                                     isPhysical,
                                     true,
                                     false,
-                                    isDistinct));
+                                    isDistinct,
+                                    false));
         }
         return Optional.empty();
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlListAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/SqlListAggFunction.java
@@ -29,6 +29,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Optionality;
 
 import java.util.List;
 
@@ -57,7 +58,8 @@ public class SqlListAggFunction extends SqlAggFunction {
                                 OperandTypes.and(OperandTypes.CHARACTER, OperandTypes.LITERAL))),
                 SqlFunctionCategory.SYSTEM,
                 false,
-                false);
+                false,
+                Optionality.FORBIDDEN);
     }
 
     @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/internal/SqlAuxiliaryGroupAggFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/internal/SqlAuxiliaryGroupAggFunction.java
@@ -25,6 +25,7 @@ import org.apache.calcite.sql.SqlFunctionCategory;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.util.Optionality;
 
 /**
  * An internal [[SqlAggFunction]] to represents auxiliary group keys which will not be computed as
@@ -43,6 +44,7 @@ public class SqlAuxiliaryGroupAggFunction extends SqlAggFunction {
                 OperandTypes.ANY,
                 SqlFunctionCategory.SYSTEM,
                 false,
-                false);
+                false,
+                Optionality.FORBIDDEN);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateExpandDistinctAggregatesRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateExpandDistinctAggregatesRule.java
@@ -470,7 +470,7 @@ public final class FlinkAggregateExpandDistinctAggregatesRule extends RelOptRule
                                 aggCall.left.filterArg,
                                 aggregate.getGroupCount(),
                                 fullGroupSet.cardinality());
-                distinctAggCalls.add(newAggCall.rename(aggCall.right));
+                distinctAggCalls.add(newAggCall.withName(aggCall.right));
             }
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateJoinTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateJoinTransposeRule.java
@@ -488,7 +488,6 @@ public class FlinkAggregateJoinTransposeRule extends RelOptRule {
                     aggregate.copy(
                             aggregate.getTraitSet(),
                             aggregate.getInput(),
-                            aggregate.indicator,
                             newGroupSet,
                             com.google.common.collect.ImmutableList.of(newGroupSet),
                             aggCalls);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateRemoveRule.java
@@ -73,9 +73,7 @@ public class FlinkAggregateRemoveRule extends RelOptRule {
     public boolean matches(RelOptRuleCall call) {
         final Aggregate aggregate = call.rel(0);
         final RelNode input = call.rel(1);
-        if (aggregate.getGroupCount() == 0
-                || aggregate.indicator
-                || aggregate.getGroupType() != Aggregate.Group.SIMPLE) {
+        if (aggregate.getGroupCount() == 0 || aggregate.getGroupType() != Aggregate.Group.SIMPLE) {
             return false;
         }
         for (AggregateCall aggCall : aggregate.getAggCallList()) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkSemiAntiJoinFilterTransposeRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkSemiAntiJoinFilterTransposeRule.java
@@ -17,6 +17,8 @@
 
 package org.apache.flink.table.planner.plan.rules.logical;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
@@ -79,7 +81,7 @@ public class FlinkSemiAntiJoinFilterTransposeRule extends RelOptRule {
                         join.getJoinType());
 
         final RelFactories.FilterFactory factory = RelFactories.DEFAULT_FILTER_FACTORY;
-        RelNode newFilter = factory.createFilter(newJoin, filter.getCondition());
+        RelNode newFilter = factory.createFilter(newJoin, filter.getCondition(), ImmutableSet.of());
 
         call.transformTo(newFilter);
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupAggregateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupAggregateRule.java
@@ -62,7 +62,7 @@ public class StreamPhysicalPythonGroupAggregateRule extends ConverterRule {
         FlinkLogicalAggregate agg = call.rel(0);
 
         // check if we have grouping sets
-        if (agg.getGroupType() != Aggregate.Group.SIMPLE || agg.indicator) {
+        if (agg.getGroupType() != Aggregate.Group.SIMPLE) {
             throw new TableException("GROUPING SETS are currently not supported.");
         }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalPythonGroupWindowAggregateRule.java
@@ -69,7 +69,7 @@ public class StreamPhysicalPythonGroupWindowAggregateRule extends ConverterRule 
         List<AggregateCall> aggCalls = agg.getAggCallList();
 
         // check if we have grouping sets
-        if (agg.getGroupType() != Aggregate.Group.SIMPLE || agg.indicator) {
+        if (agg.getGroupType() != Aggregate.Group.SIMPLE) {
             throw new TableException("GROUPING SETS are currently not supported.");
         }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSize.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSize.scala
@@ -126,7 +126,7 @@ class FlinkRelMdSize private extends MetadataHandler[BuiltInMetadata.Size] {
     // get each column's RexNode (RexLiteral, RexInputRef or null)
     val projectNodes = (0 until fieldCount).map {
       i =>
-        val initNode: RexNode = rel.getCluster.getRexBuilder.constantNull()
+        val initNode: RexNode = rel.getCluster.getRexBuilder.makeNullLiteral(rel.getRowType)
         rel.projects.foldLeft(initNode) {
           (mergeNode, project) =>
             (mergeNode, project.get(i)) match {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/AggregateReduceGroupingRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/AggregateReduceGroupingRule.scala
@@ -44,7 +44,7 @@ class AggregateReduceGroupingRule(relBuilderFactory: RelBuilderFactory)
 
   override def matches(call: RelOptRuleCall): Boolean = {
     val agg: Aggregate = call.rel(0)
-    agg.getGroupCount > 1 && agg.getGroupType == Group.SIMPLE && !agg.indicator
+    agg.getGroupCount > 1 && agg.getGroupType == Group.SIMPLE
   }
 
   override def onMatch(call: RelOptRuleCall): Unit = {
@@ -106,7 +106,6 @@ class AggregateReduceGroupingRule(relBuilderFactory: RelBuilderFactory)
     val newAgg = agg.copy(
       agg.getTraitSet,
       input,
-      agg.indicator, // always false here
       newGrouping,
       ImmutableList.of(newGrouping),
       newAggCalls

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CalcRankTransposeRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/CalcRankTransposeRule.scala
@@ -166,7 +166,7 @@ class CalcRankTransposeRule
     val oldOrderKey = rank.orderKey
     val oldFieldCollations = oldOrderKey.getFieldCollations
     val newFieldCollations = oldFieldCollations.map {
-      fc => fc.copy(fieldMapping(fc.getFieldIndex))
+      fc => fc.withFieldIndex(fieldMapping(fc.getFieldIndex))
     }
     val newOrderKey = if (newFieldCollations.eq(oldFieldCollations)) {
       oldOrderKey

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/DecomposeGroupingSetsRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/DecomposeGroupingSetsRule.scala
@@ -328,7 +328,7 @@ class DecomposeGroupingSetsRule
         val res: Long = call.getArgList.foldLeft(0L)(
           (res, arg) => (res << 1L) + (if (groups.contains(arg)) 0L else 1L))
         builder.makeLiteral(res, call.getType, false)
-      case _ => builder.constantNull()
+      case _ => builder.makeNullLiteral(call.getType)
     }
   }
 }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkRewriteSubQueryRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkRewriteSubQueryRule.scala
@@ -56,7 +56,7 @@ class FlinkRewriteSubQueryRule(
     val filter: Filter = call.rel(0)
     val condition = filter.getCondition
     val newCondition = rewriteScalarQuery(condition)
-    if (RexUtil.eq(condition, newCondition)) {
+    if (condition.equals(newCondition)) {
       return
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkSubQueryRemoveRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/FlinkSubQueryRemoveRule.scala
@@ -304,13 +304,13 @@ class FlinkSubQueryRemoveRule(
       replacement: RexNode): RexNode = {
     condition.accept(new RexShuttle() {
       override def visitSubQuery(subQuery: RexSubQuery): RexNode = {
-        if (RexUtil.eq(subQuery, oldSubQueryCall)) replacement else subQuery
+        if (subQuery.equals(oldSubQueryCall)) replacement else subQuery
       }
 
       override def visitCall(call: RexCall): RexNode = {
         call.getKind match {
           case SqlKind.NOT if call.operands.head.isInstanceOf[RexSubQuery] =>
-            if (RexUtil.eq(call, oldSubQueryCall)) replacement else call
+            if (call.equals(oldSubQueryCall)) replacement else call
           case _ =>
             super.visitCall(call)
         }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalWindowAggregateRuleBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/LogicalWindowAggregateRuleBase.scala
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall, RelFactories}
 import org.apache.calcite.rel.core.Aggregate.Group
+import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.logical.{LogicalAggregate, LogicalProject}
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeUtil
@@ -98,7 +99,7 @@ abstract class LogicalWindowAggregateRuleBase(description: String)
     // we don't use the builder here because it uses RelMetadataQuery which affects the plan
     val newAgg = LogicalAggregate.create(
       newProject,
-      agg.indicator,
+      ImmutableList.of[RelHint](),
       newGroupSet,
       ImmutableList.of(newGroupSet),
       finalCalls)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/ProjectSemiAntiJoinTransposeRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/ProjectSemiAntiJoinTransposeRule.scala
@@ -108,7 +108,7 @@ class ProjectSemiAntiJoinTransposeRule
       inputNeededFields: ImmutableBitSet,
       offset: Int): RelNode = {
     val rexBuilder = originInput.getCluster.getRexBuilder
-    val typeBuilder = new RelDataTypeFactory.FieldInfoBuilder(relBuilder.getTypeFactory)
+    val typeBuilder = relBuilder.getTypeFactory.builder()
     val newProjects: util.List[RexNode] = new util.ArrayList[RexNode]()
     val newFieldNames: util.List[String] = new util.ArrayList[String]()
     inputNeededFields.toList.foreach {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PruneAggregateCallRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/PruneAggregateCallRule.scala
@@ -45,7 +45,7 @@ abstract class PruneAggregateCallRule[T <: RelNode](topClass: Class[T])
     val relOnAgg: T = call.rel(0)
     val agg: Aggregate = call.rel(1)
     if (
-      agg.indicator || agg.getGroupType != Group.SIMPLE || agg.getAggCallList.isEmpty ||
+      agg.getGroupType != Group.SIMPLE || agg.getAggCallList.isEmpty ||
       // at least output one column
       (agg.getGroupCount == 0 && agg.getAggCallList.size() == 1)
     ) {
@@ -91,7 +91,6 @@ abstract class PruneAggregateCallRule[T <: RelNode](topClass: Class[T])
     val newAgg = agg.copy(
       agg.getTraitSet,
       agg.getInput,
-      agg.indicator,
       agg.getGroupSet,
       ImmutableList.of(agg.getGroupSet),
       newAggCalls

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
@@ -384,9 +384,7 @@ class SplitAggregateRule
               FlinkSqlOperatorTable.EQUALS,
               countInputRef,
               relBuilder.getRexBuilder.makeBigintLiteral(JBigDecimal.valueOf(0)))
-            val ifTrue = relBuilder.cast(
-              relBuilder.getRexBuilder.constantNull(),
-              aggCall.`type`.getSqlTypeName)
+            val ifTrue = relBuilder.getRexBuilder.makeNullLiteral(aggCall.`type`)
             val ifFalse = relBuilder.call(FlinkSqlOperatorTable.DIVIDE, sumInputRef, countInputRef)
             relBuilder.call(FlinkSqlOperatorTable.IF, equals, ifTrue, ifFalse)
           } else {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashAggRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalHashAggRule.scala
@@ -79,10 +79,6 @@ class BatchPhysicalHashAggRule
     val input: RelNode = call.rel(1)
     val inputRowType = input.getRowType
 
-    if (agg.indicator) {
-      throw new UnsupportedOperationException("Not support group sets aggregate now.")
-    }
-
     val groupSet = agg.getGroupSet.toArray
     val (auxGroupSet, aggCallsWithoutAuxGroupCalls) = AggregateUtil.checkAndSplitAggCalls(agg)
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/batch/BatchPhysicalWindowAggregateRule.scala
@@ -84,7 +84,7 @@ class BatchPhysicalWindowAggregateRule
 
     // check if we have grouping sets
     val groupSets = agg.getGroupType != Group.SIMPLE
-    if (groupSets || agg.indicator) {
+    if (groupSets) {
       throw new TableException("GROUPING SETS are currently not supported.")
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupAggregateRule.scala
@@ -41,7 +41,7 @@ class StreamPhysicalGroupAggregateRule(config: Config) extends ConverterRule(con
     val agg: FlinkLogicalAggregate = call.rel(0)
 
     // check if we have grouping sets
-    if (agg.getGroupType != Group.SIMPLE || agg.indicator) {
+    if (agg.getGroupType != Group.SIMPLE) {
       throw new TableException("GROUPING SETS are currently not supported.")
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalGroupWindowAggregateRule.scala
@@ -43,8 +43,7 @@ class StreamPhysicalGroupWindowAggregateRule(config: Config) extends ConverterRu
     val agg: FlinkLogicalWindowAggregate = call.rel(0)
 
     // check if we have grouping sets
-    val groupSets = agg.getGroupType != Group.SIMPLE
-    if (groupSets || agg.indicator) {
+    if (agg.getGroupType != Group.SIMPLE) {
       throw new TableException("GROUPING SETS are currently not supported.")
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWindowAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalWindowAggregateRule.scala
@@ -46,7 +46,7 @@ class StreamPhysicalWindowAggregateRule(config: Config) extends ConverterRule(co
     val agg: FlinkLogicalAggregate = call.rel(0)
 
     // check if we have grouping sets
-    if (agg.getGroupType != Group.SIMPLE || agg.indicator) {
+    if (agg.getGroupType != Group.SIMPLE) {
       throw new TableException("GROUPING SETS are currently not supported.")
     }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/trait/FlinkRelDistribution.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/trait/FlinkRelDistribution.scala
@@ -119,7 +119,7 @@ class FlinkRelDistribution private (
           try {
             val i = mapping.getTargetOpt(fieldCollation.getFieldIndex)
             if (i >= 0) {
-              newFieldCollations.add(fieldCollation.copy(i))
+              newFieldCollations.add(fieldCollation.withFieldIndex(i))
             } else {
               return FlinkRelDistribution.ANY
             }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/trait/TraitUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/trait/TraitUtil.scala
@@ -49,7 +49,7 @@ object TraitUtil {
         fieldCollation =>
           try {
             val i = mapping.getTargetOpt(fieldCollation.getFieldIndex)
-            if (i >= 0) newFieldCollations.add(fieldCollation.copy(i))
+            if (i >= 0) newFieldCollations.add(fieldCollation.withFieldIndex(i))
             else return RelCollations.EMPTY
           } catch {
             case _: IndexOutOfBoundsException => return RelCollations.EMPTY

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
@@ -30,6 +30,7 @@ import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall, TableScan}
+import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.rel.logical.LogicalAggregate
 import org.apache.calcite.rel.metadata.{JaninoRelMetadataProvider, RelMetadataQueryBase}
 import org.apache.calcite.rex.{RexInputRef, RexLiteral, RexNode}
@@ -118,6 +119,7 @@ class AggCallSelectivityEstimatorTest {
 
     LogicalAggregate.create(
       scan,
+      ImmutableList.of[RelHint],
       ImmutableBitSet.of(groupSet: _*),
       null,
       ImmutableList.copyOf(aggCalls.toArray))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtilTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtilTest.scala
@@ -206,7 +206,7 @@ class FlinkRexUtilTest {
     assertEquals(RexUtil.toCnf(rexBuilder, predicate).toString, newPredicate3.toString)
 
     val newPredicate4 = FlinkRexUtil.toCnf(rexBuilder, Int.MaxValue, predicate)
-    assertFalse(RexUtil.eq(predicate, newPredicate4))
+    assertFalse(predicate.equals(newPredicate4))
     assertEquals(RexUtil.toCnf(rexBuilder, predicate).toString, newPredicate4.toString)
   }
 


### PR DESCRIPTION
## What is the purpose of the change

In https://issues.apache.org/jira/browse/CALCITE-2944 `Aggregate#indicator` was made always `false` and deprecated.
The PR removes usages of this

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
