### PR TITLE
[FLINK-29217][tests] Guarantee checkpoint order in OC test

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase.java
@@ -666,6 +666,14 @@ public class CoordinatorEventsToStreamOperatorRecipientExactlyOnceITCase
 
             if (!isEventSentAfterSecondCheckpoint && isCoordinatorSecondCheckpointCompleted) {
                 isEventSentAfterSecondCheckpoint = true;
+            }
+
+            // If the checkpoint coordinator receives the completion message of checkpoint 1 and
+            // checkpoint 2 at the same time, checkpoint 2 might be completed before checkpoint 1
+            // due to the async mechanism in the checkpoint process, which would cause checkpoint 1
+            // to be accidentally aborted. In order to avoid this situation, the following code is
+            // required to make sure that checkpoint 2 is not completed until checkpoint 1 finishes.
+            if (isEventSentAfterSecondCheckpoint && isJobFirstCheckpointCompleted) {
                 EventReceivingOperator.shouldUnblockAllCheckpoint = true;
             }
         }


### PR DESCRIPTION
## What is the purpose of the change

#20752 and #20754 have added test cases to verify that the operator coordinator can work correctly in case of concurrent checkpoints. However, when the checkpoint coordinator receives the completion message of checkpoint 1 and 2 at the same time, checkpoint 2 might be completed in advance due to the async mechanism in the checkpointing process, causing the accidental abortion of checkpoint 1 and failure of the added test case. This PR resolves the problem by further guaranteeing the completion order of the checkpoints received by test operators and coordinators.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)

  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)

  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)