### PR TITLE
[FLINK-29195] Expose lastCompletedCheckpointId metric

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1297,7 +1297,7 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
   </thead>
   <tbody>
     <tr>
-      <th rowspan="8"><strong>Job (only available on JobManager)</strong></th>
+      <th rowspan="10"><strong>Job (only available on JobManager)</strong></th>
       <td>lastCheckpointDuration</td>
       <td>The time it took to complete the last checkpoint (in milliseconds).</td>
       <td>Gauge</td>
@@ -1305,6 +1305,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
     <tr>
       <td>lastCheckpointSize</td>
       <td>The checkpointed size of the last checkpoint (in bytes), this metric could be different from lastCheckpointFullSize if incremental checkpoint or changelog is enabled.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>lastCompletedCheckpointId</td>
+      <td>The identifier of the last completed checkpoint.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1282,7 +1282,7 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
   </thead>
   <tbody>
     <tr>
-      <th rowspan="9"><strong>Job (only available on JobManager)</strong></th>
+      <th rowspan="10"><strong>Job (only available on JobManager)</strong></th>
       <td>lastCheckpointDuration</td>
       <td>The time it took to complete the last checkpoint (in milliseconds).</td>
       <td>Gauge</td>
@@ -1290,6 +1290,11 @@ Note that for failed checkpoints, metrics are updated on a best efforts basis an
     <tr>
       <td>lastCheckpointSize</td>
       <td>The checkpointed size of the last checkpoint (in bytes), this metric could be different from lastCheckpointFullSize if incremental checkpoint or changelog is enabled.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>lastCompletedCheckpointId</td>
+      <td>The identifier of the last completed checkpoint.</td>
       <td>Gauge</td>
     </tr>
     <tr>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTracker.java
@@ -327,6 +327,9 @@ public class CheckpointStatsTracker {
     static final String LATEST_COMPLETED_CHECKPOINT_EXTERNAL_PATH_METRIC =
             "lastCheckpointExternalPath";
 
+    @VisibleForTesting
+    static final String LATEST_COMPLETED_CHECKPOINT_ID_METRIC = "lastCompletedCheckpointId";
+
     /**
      * Register the exposed metrics.
      *
@@ -359,6 +362,8 @@ public class CheckpointStatsTracker {
         metricGroup.gauge(
                 LATEST_COMPLETED_CHECKPOINT_EXTERNAL_PATH_METRIC,
                 new LatestCompletedCheckpointExternalPathGauge());
+        metricGroup.gauge(
+                LATEST_COMPLETED_CHECKPOINT_ID_METRIC, new LatestCompletedCheckpointIdGauge());
     }
 
     private class CheckpointsCounter implements Gauge<Long> {
@@ -469,6 +474,18 @@ public class CheckpointStatsTracker {
                 return completed.getExternalPath();
             } else {
                 return "n/a";
+            }
+        }
+    }
+
+    private class LatestCompletedCheckpointIdGauge implements Gauge<Long> {
+        @Override
+        public Long getValue() {
+            CompletedCheckpointStats completed = latestCompletedCheckpoint;
+            if (completed != null) {
+                return completed.getCheckpointId();
+            } else {
+                return -1L;
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointStatsTrackerTest.java
@@ -313,8 +313,9 @@ public class CheckpointStatsTrackerTest {
                                 CheckpointStatsTracker
                                         .LATEST_COMPLETED_CHECKPOINT_PERSISTED_DATA_METRIC,
                                 CheckpointStatsTracker
-                                        .LATEST_COMPLETED_CHECKPOINT_EXTERNAL_PATH_METRIC)));
-        assertEquals(11, registeredGaugeNames.size());
+                                        .LATEST_COMPLETED_CHECKPOINT_EXTERNAL_PATH_METRIC,
+                                CheckpointStatsTracker.LATEST_COMPLETED_CHECKPOINT_ID_METRIC)));
+        assertEquals(12, registeredGaugeNames.size());
     }
 
     /**
@@ -345,7 +346,7 @@ public class CheckpointStatsTrackerTest {
         CheckpointStatsTracker stats = new CheckpointStatsTracker(0, metricGroup);
 
         // Make sure to adjust this test if metrics are added/removed
-        assertEquals(11, registeredGauges.size());
+        assertEquals(12, registeredGauges.size());
 
         // Check initial values
         Gauge<Long> numCheckpoints =
@@ -395,6 +396,10 @@ public class CheckpointStatsTrackerTest {
                         registeredGauges.get(
                                 CheckpointStatsTracker
                                         .LATEST_COMPLETED_CHECKPOINT_EXTERNAL_PATH_METRIC);
+        Gauge<Long> latestCompletedId =
+                (Gauge<Long>)
+                        registeredGauges.get(
+                                CheckpointStatsTracker.LATEST_COMPLETED_CHECKPOINT_ID_METRIC);
 
         assertEquals(Long.valueOf(0), numCheckpoints.getValue());
         assertEquals(Integer.valueOf(0), numInProgressCheckpoints.getValue());
@@ -407,6 +412,7 @@ public class CheckpointStatsTrackerTest {
         assertEquals(Long.valueOf(-1), latestProcessedData.getValue());
         assertEquals(Long.valueOf(-1), latestPersistedData.getValue());
         assertEquals("n/a", latestCompletedExternalPath.getValue());
+        assertEquals(Long.valueOf(-1), latestCompletedId.getValue());
 
         PendingCheckpointStats pending =
                 stats.reportPendingCheckpoint(
@@ -461,6 +467,7 @@ public class CheckpointStatsTrackerTest {
         assertEquals(Long.valueOf(persistedData), latestPersistedData.getValue());
         assertEquals(Long.valueOf(ackTimestamp), latestCompletedDuration.getValue());
         assertEquals(externalPath, latestCompletedExternalPath.getValue());
+        assertEquals(Long.valueOf(0), latestCompletedId.getValue());
 
         // Check failed
         PendingCheckpointStats nextPending =
@@ -479,6 +486,7 @@ public class CheckpointStatsTrackerTest {
         assertEquals(Integer.valueOf(0), numInProgressCheckpoints.getValue());
         assertEquals(Long.valueOf(1), numCompletedCheckpoints.getValue());
         assertEquals(Long.valueOf(1), numFailedCheckpoints.getValue()); // one failed now
+        assertEquals(Long.valueOf(0), latestCompletedId.getValue());
 
         // Check restore
         long restoreTimestamp = 183419283L;
@@ -495,6 +503,7 @@ public class CheckpointStatsTrackerTest {
         assertEquals(Integer.valueOf(0), numInProgressCheckpoints.getValue());
         assertEquals(Long.valueOf(1), numCompletedCheckpoints.getValue());
         assertEquals(Long.valueOf(1), numFailedCheckpoints.getValue());
+        assertEquals(Long.valueOf(0), latestCompletedId.getValue());
 
         assertEquals(Long.valueOf(restoreTimestamp), latestRestoreTimestamp.getValue());
 
@@ -509,6 +518,7 @@ public class CheckpointStatsTrackerTest {
 
         thirdPending.reportSubtaskStats(jobVertexID, subtaskStats);
         stats.reportCompletedCheckpoint(thirdPending.toCompletedCheckpointStats(null));
+        assertEquals(Long.valueOf(2), latestCompletedId.getValue());
 
         // Verify external path is "n/a", because internal checkpoint won't generate external path.
         assertEquals("n/a", latestCompletedExternalPath.getValue());


### PR DESCRIPTION


## What is the purpose of the change

*Expose the lastCheckpointId metric.*


## Brief change log

  - *Register  `LatestCompletedCheckpointIdGauge` named "lastCheckpointId"  to `CheckpointStatsTracker`*



## Verifying this change


This change is already covered by existing tests, such as *CheckpointStatsTrackerTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
