### PR TITLE
[FLINK-29227][build] package disruptor for log4j async logger.

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -181,6 +181,13 @@ under the License.
 			<scope>compile</scope>
 		</dependency>
 
+		<dependency>
+			<!-- Asynchronous Loggers -->
+			<groupId>com.lmax</groupId>
+			<artifactId>disruptor</artifactId>
+			<scope>compile</scope>
+		</dependency>
+
 		<!-- Table dependencies -->
 
 		<dependency>
@@ -720,8 +727,9 @@ under the License.
 							</filters>
 							<artifactSet>
 								<excludes>
-									<!-- log4j 2 is bundled separately from the flink-dist jar -->
+									<!-- log4j 2 and disruptor are bundled separately from the flink-dist jar -->
 									<exclude>org.apache.logging.log4j:*</exclude>
+									<exclude>com.lmax:disruptor</exclude>
 									<!-- Bundled separately so that users can easily switch between ZK 3.4/3.5-->
 									<exclude>org.apache.flink:flink-shaded-zookeeper-3</exclude>
 								</excludes>

--- a/flink-dist/src/main/assemblies/bin.xml
+++ b/flink-dist/src/main/assemblies/bin.xml
@@ -42,6 +42,7 @@ under the License.
 				<include>org.apache.logging.log4j:log4j-core</include>
 				<include>org.apache.logging.log4j:log4j-slf4j-impl</include>
 				<include>org.apache.logging.log4j:log4j-1.2-api</include>
+				<include>com.lmax:disruptor</include>
 			</includes>
 		</dependencySet>
 		<dependencySet>


### PR DESCRIPTION
## What is the purpose of the change

*package disruptor for log4j async logger*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
