### PR TITLE
[FLINK-29118][sql-gateway][hive] Remove default GenericInMemoryCatalog in the HiveServer2 Endpoint when openSession

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2Endpoint.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/endpoint/hive/HiveServer2Endpoint.java
@@ -311,7 +311,7 @@ public class HiveServer2Endpoint implements TCLIService.Iface, SqlGatewayEndpoin
             Catalog hiveCatalog =
                     new HiveCatalog(
                             catalogName,
-                            defaultDatabase,
+                            getUsedDefaultDatabase(originSessionConf).orElse(defaultDatabase),
                             conf,
                             HiveShimLoader.getHiveVersion(),
                             allowEmbedded);
@@ -323,8 +323,6 @@ public class HiveServer2Endpoint implements TCLIService.Iface, SqlGatewayEndpoin
                                     .registerCatalog(catalogName, hiveCatalog)
                                     .registerModuleAtHead(moduleName, hiveModule)
                                     .setDefaultCatalog(catalogName)
-                                    .setDefaultDatabase(
-                                            getUsedDefaultDatabase(originSessionConf).orElse(null))
                                     .addSessionConfig(sessionConfig)
                                     .build());
             // response

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
@@ -61,6 +61,7 @@ import org.apache.hive.service.rpc.thrift.TOperationType;
 import org.apache.hive.service.rpc.thrift.TStatusCode;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TTransport;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -107,6 +108,11 @@ public class HiveServer2EndpointITCase extends TestLogger {
     @Order(3)
     public static final HiveServer2EndpointExtension ENDPOINT_EXTENSION =
             new HiveServer2EndpointExtension(SQL_GATEWAY_SERVICE_EXTENSION::getService);
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        initializeEnvironment();
+    }
 
     @Test
     public void testOpenCloseJdbcConnection() throws Exception {
@@ -256,21 +262,19 @@ public class HiveServer2EndpointITCase extends TestLogger {
         runGetObjectTest(
                 connection -> connection.getMetaData().getCatalogs(),
                 ResolvedSchema.of(Column.physical("TABLE_CAT", DataTypes.STRING())),
-                Arrays.asList(
-                        Collections.singletonList("default_catalog"),
-                        Collections.singletonList("hive")));
+                Collections.singletonList(Collections.singletonList("hive")));
     }
 
     @Test
     public void testGetSchemas() throws Exception {
         runGetObjectTest(
-                connection -> connection.getMetaData().getSchemas("default_catalog", null),
+                connection -> connection.getMetaData().getSchemas("hive", null),
                 getExpectedGetSchemasOperationSchema(),
                 Arrays.asList(
-                        Arrays.asList("db_diff", "default_catalog"),
-                        Arrays.asList("db_test1", "default_catalog"),
-                        Arrays.asList("db_test2", "default_catalog"),
-                        Arrays.asList("default_database", "default_catalog")));
+                        Arrays.asList("db_diff", "hive"),
+                        Arrays.asList("db_test1", "hive"),
+                        Arrays.asList("db_test2", "hive"),
+                        Arrays.asList("default", "hive")));
     }
 
     @Test
@@ -279,8 +283,7 @@ public class HiveServer2EndpointITCase extends TestLogger {
                 connection -> connection.getMetaData().getSchemas(null, "db\\_test%"),
                 getExpectedGetSchemasOperationSchema(),
                 Arrays.asList(
-                        Arrays.asList("db_test1", "default_catalog"),
-                        Arrays.asList("db_test2", "default_catalog")));
+                        Arrays.asList("db_test1", "hive"), Arrays.asList("db_test2", "hive")));
     }
 
     @Test
@@ -296,16 +299,16 @@ public class HiveServer2EndpointITCase extends TestLogger {
                                         new String[] {"MANAGED_TABLE", "VIRTUAL_VIEW"}),
                 getExpectedGetTablesOperationSchema(),
                 Arrays.asList(
-                        Arrays.asList("default_catalog", "db_diff", "tbl_1", "TABLE"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_1", "TABLE"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_2", "TABLE"),
-                        Arrays.asList("default_catalog", "db_test2", "diff_1", "TABLE"),
-                        Arrays.asList("default_catalog", "db_test2", "tbl_1", "TABLE"),
-                        Arrays.asList("default_catalog", "db_diff", "tbl_2", "VIEW"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_3", "VIEW"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_4", "VIEW"),
-                        Arrays.asList("default_catalog", "db_test2", "diff_2", "VIEW"),
-                        Arrays.asList("default_catalog", "db_test2", "tbl_2", "VIEW")));
+                        Arrays.asList("hive", "db_diff", "tbl_1", "TABLE"),
+                        Arrays.asList("hive", "db_test1", "tbl_1", "TABLE"),
+                        Arrays.asList("hive", "db_test1", "tbl_2", "TABLE"),
+                        Arrays.asList("hive", "db_test2", "diff_1", "TABLE"),
+                        Arrays.asList("hive", "db_test2", "tbl_1", "TABLE"),
+                        Arrays.asList("hive", "db_diff", "tbl_2", "VIEW"),
+                        Arrays.asList("hive", "db_test1", "tbl_3", "VIEW"),
+                        Arrays.asList("hive", "db_test1", "tbl_4", "VIEW"),
+                        Arrays.asList("hive", "db_test2", "diff_2", "VIEW"),
+                        Arrays.asList("hive", "db_test2", "tbl_2", "VIEW")));
     }
 
     @Test
@@ -315,15 +318,15 @@ public class HiveServer2EndpointITCase extends TestLogger {
                         connection
                                 .getMetaData()
                                 .getTables(
-                                        "default_catalog",
+                                        "hive",
                                         "db\\_test_",
                                         "tbl%",
                                         new String[] {"VIRTUAL_VIEW"}),
                 getExpectedGetTablesOperationSchema(),
                 Arrays.asList(
-                        Arrays.asList("default_catalog", "db_test1", "tbl_3", "VIEW"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_4", "VIEW"),
-                        Arrays.asList("default_catalog", "db_test2", "tbl_2", "VIEW")));
+                        Arrays.asList("hive", "db_test1", "tbl_3", "VIEW"),
+                        Arrays.asList("hive", "db_test1", "tbl_4", "VIEW"),
+                        Arrays.asList("hive", "db_test2", "tbl_2", "VIEW")));
     }
 
     @Test
@@ -356,67 +359,64 @@ public class HiveServer2EndpointITCase extends TestLogger {
                                 .isEqualTo(
                                         Arrays.asList(
                                                 Arrays.asList(
-                                                        "default_catalog",
-                                                        "db_diff",
-                                                        "tbl_2",
-                                                        "EXPR$0",
+                                                        "hive", "db_diff", "tbl_2", "EXPR$0",
                                                         "INT"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_1",
                                                         "user",
                                                         "BIGINT"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_1",
                                                         "product",
                                                         "STRING"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_1",
                                                         "amount",
                                                         "INT"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_2",
                                                         "user",
                                                         "STRING"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_2",
                                                         "id",
                                                         "BIGINT"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_2",
                                                         "timestamp",
                                                         "TIMESTAMP"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_3",
                                                         "EXPR$0",
                                                         "INT"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test1",
                                                         "tbl_4",
                                                         "EXPR$0",
                                                         "INT"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test2",
                                                         "diff_2",
                                                         "EXPR$0",
                                                         "INT"),
                                                 Arrays.asList(
-                                                        "default_catalog",
+                                                        "hive",
                                                         "db_test2",
                                                         "tbl_2",
                                                         "EXPR$0",
@@ -429,11 +429,11 @@ public class HiveServer2EndpointITCase extends TestLogger {
                 connection ->
                         connection
                                 .getMetaData()
-                                .getColumns("default_catalog", "db\\_test_", "tbl\\_1", "user"),
+                                .getColumns("hive", "db\\_test_", "tbl\\_1", "user"),
                 getExpectedGetColumnsOperationSchema(),
                 Collections.singletonList(
                         Arrays.asList(
-                                "default_catalog",
+                                "hive",
                                 "db_test1",
                                 "tbl_1",
                                 "user",
@@ -454,9 +454,9 @@ public class HiveServer2EndpointITCase extends TestLogger {
                 connection -> connection.getMetaData().getPrimaryKeys(null, null, null),
                 getExpectedGetPrimaryKeysOperationSchema(),
                 Arrays.asList(
-                        Arrays.asList("default_catalog", "db_test1", "tbl_1", "user", 1, "pk"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_2", "user", 1, "pk"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_2", "id", 2, "pk")));
+                        Arrays.asList("hive", "db_test1", "tbl_1", "user", 1, "pk"),
+                        Arrays.asList("hive", "db_test1", "tbl_2", "user", 1, "pk"),
+                        Arrays.asList("hive", "db_test1", "tbl_2", "id", 2, "pk")));
     }
 
     @Test
@@ -465,8 +465,8 @@ public class HiveServer2EndpointITCase extends TestLogger {
                 connection -> connection.getMetaData().getPrimaryKeys(null, null, "tbl_2"),
                 getExpectedGetPrimaryKeysOperationSchema(),
                 Arrays.asList(
-                        Arrays.asList("default_catalog", "db_test1", "tbl_2", "user", 1, "pk"),
-                        Arrays.asList("default_catalog", "db_test1", "tbl_2", "id", 2, "pk")));
+                        Arrays.asList("hive", "db_test1", "tbl_2", "user", 1, "pk"),
+                        Arrays.asList("hive", "db_test1", "tbl_2", "id", 2, "pk")));
     }
 
     @Test
@@ -541,14 +541,14 @@ public class HiveServer2EndpointITCase extends TestLogger {
                     try (Statement statement = connection.createStatement()) {
                         statement.execute(
                                 String.format(
-                                        "CREATE FUNCTION `default_catalog`.`db_test2`.`my_abs` as '%s'",
+                                        "CREATE FUNCTION `hive`.`db_test2`.`my_abs` as '%s'",
                                         JavaFunc0.class.getName()));
                         statement.execute(
                                 String.format(
-                                        "CREATE FUNCTION `default_catalog`.`db_diff`.`your_abs` as '%s'",
+                                        "CREATE FUNCTION `hive`.`db_diff`.`your_abs` as '%s'",
                                         JavaFunc0.class.getName()));
                     }
-                    return connection.getMetaData().getFunctions("default_catalog", "db.*", "my.*");
+                    return connection.getMetaData().getFunctions("hive", "db.*", "my.*");
                 },
                 ResolvedSchema.of(
                         Column.physical("FUNCTION_CAT", DataTypes.STRING()),
@@ -559,12 +559,7 @@ public class HiveServer2EndpointITCase extends TestLogger {
                         Column.physical("SPECIFIC_NAME", DataTypes.STRING())),
                 Collections.singletonList(
                         Arrays.asList(
-                                "default_catalog",
-                                "db_test2",
-                                "my_abs",
-                                "",
-                                0,
-                                JavaFunc0.class.getName())));
+                                "hive", "db_test2", "my_abs", "", 0, JavaFunc0.class.getName())));
     }
 
     @Test
@@ -579,13 +574,12 @@ public class HiveServer2EndpointITCase extends TestLogger {
 
     // --------------------------------------------------------------------------------------------
 
-    private Connection getInitializedConnection() throws Exception {
-        Connection connection = ENDPOINT_EXTENSION.getConnection();
-        try (Statement statement = connection.createStatement()) {
+    private static void initializeEnvironment() throws Exception {
+        try (Connection connection = ENDPOINT_EXTENSION.getConnection();
+                Statement statement = connection.createStatement()) {
             statement.execute("SET table.sql-dialect=default");
-            statement.execute("USE CATALOG `default_catalog`");
 
-            // default_catalog: db_test1 | db_test2 | db_diff | default
+            // hive: db_test1 | db_test2 | db_diff | default
             //     db_test1: temporary table tbl_1, table tbl_2, temporary view tbl_3, view tbl_4
             //     db_test2: table tbl_1, table diff_1, view tbl_2, view diff_2
             //     db_diff:  table tbl_1, view tbl_2
@@ -595,7 +589,7 @@ public class HiveServer2EndpointITCase extends TestLogger {
             statement.execute("CREATE DATABASE db_diff");
 
             statement.execute(
-                    "CREATE TEMPORARY TABLE db_test1.tbl_1(\n"
+                    "CREATE TABLE db_test1.tbl_1(\n"
                             + "`user` BIGINT CONSTRAINT `pk` PRIMARY KEY COMMENT 'user id.',\n"
                             + "`product` STRING NOT NULL,\n"
                             + "`amount`  INT) COMMENT 'temporary table tbl_1'");
@@ -606,7 +600,7 @@ public class HiveServer2EndpointITCase extends TestLogger {
                             + "`timestamp` TIMESTAMP,"
                             + "CONSTRAINT `pk` PRIMARY KEY(`user`, `id`) NOT ENFORCED) COMMENT 'table tbl_2'");
             statement.execute(
-                    "CREATE TEMPORARY VIEW db_test1.tbl_3 COMMENT 'temporary view tbl_3' AS SELECT 1");
+                    "CREATE VIEW db_test1.tbl_3 COMMENT 'temporary view tbl_3' AS SELECT 1");
             statement.execute("CREATE VIEW db_test1.tbl_4 COMMENT 'view tbl_4' AS SELECT 1");
 
             statement.execute("CREATE TABLE db_test2.tbl_1 COMMENT 'table tbl_1'");
@@ -617,7 +611,6 @@ public class HiveServer2EndpointITCase extends TestLogger {
             statement.execute("CREATE TABLE db_diff.tbl_1 COMMENT 'table tbl_1'");
             statement.execute("CREATE VIEW db_diff.tbl_2 COMMENT 'view tbl_2' AS SELECT 1");
         }
-        return connection;
     }
 
     private void runGetObjectTest(
@@ -636,7 +629,7 @@ public class HiveServer2EndpointITCase extends TestLogger {
             ResolvedSchema expectedSchema,
             Consumer<List<List<Object>>> validator)
             throws Exception {
-        try (Connection connection = getInitializedConnection();
+        try (Connection connection = ENDPOINT_EXTENSION.getConnection();
                 java.sql.ResultSet result = resultSetSupplier.apply(connection)) {
             assertSchemaEquals(expectedSchema, result.getMetaData());
             validator.accept(collectAndCompact(result, expectedSchema.getColumnCount()));

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointStatementITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointStatementITCase.java
@@ -155,6 +155,10 @@ public class HiveServer2EndpointStatementITCase extends AbstractSqlGatewayStatem
         for (String sql :
                 Arrays.asList(
                         "RESET",
+                        "CREATE CATALOG `default_catalog` \n"
+                                + "WITH (\n"
+                                + "'type' = 'generic_in_memory',\n"
+                                + "'default-database' = 'default_database')",
                         "USE CATALOG `default_catalog`",
                         "DROP CATALOG hive",
                         "UNLOAD MODULE hive")) {

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/SessionContext.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/context/SessionContext.java
@@ -39,6 +39,7 @@ import org.apache.flink.util.TemporaryClassLoaderContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.Map;
 import java.util.Set;
@@ -168,6 +169,11 @@ public class SessionContext {
             }
         }
         classLoader.close();
+        try {
+            sessionState.resourceManager.close();
+        } catch (IOException e) {
+            LOG.error("Failed to close the resource manager.", e);
+        }
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
+++ b/flink-table/flink-sql-gateway-api/src/main/java/org/apache/flink/table/gateway/api/session/SessionEnvironment.java
@@ -43,7 +43,6 @@ public class SessionEnvironment {
     private final Map<String, Catalog> registeredCatalogs;
     private final Map<String, Module> registeredModules;
     private final @Nullable String defaultCatalog;
-    private final @Nullable String defaultDatabase;
     private final Map<String, String> sessionConfig;
 
     @VisibleForTesting
@@ -53,14 +52,12 @@ public class SessionEnvironment {
             Map<String, Catalog> registeredCatalogs,
             Map<String, Module> registeredModules,
             @Nullable String defaultCatalog,
-            @Nullable String defaultDatabase,
             Map<String, String> sessionConfig) {
         this.sessionName = sessionName;
         this.version = version;
         this.registeredCatalogs = registeredCatalogs;
         this.registeredModules = registeredModules;
         this.defaultCatalog = defaultCatalog;
-        this.defaultDatabase = defaultDatabase;
         this.sessionConfig = sessionConfig;
     }
 
@@ -92,10 +89,6 @@ public class SessionEnvironment {
         return Optional.ofNullable(defaultCatalog);
     }
 
-    public Optional<String> getDefaultDatabase() {
-        return Optional.ofNullable(defaultDatabase);
-    }
-
     // -------------------------------------------------------------------------------------------
 
     @Override
@@ -112,7 +105,6 @@ public class SessionEnvironment {
                 && Objects.equals(registeredCatalogs, that.registeredCatalogs)
                 && Objects.equals(registeredModules, that.registeredModules)
                 && Objects.equals(defaultCatalog, that.defaultCatalog)
-                && Objects.equals(defaultDatabase, that.defaultDatabase)
                 && Objects.equals(sessionConfig, that.sessionConfig);
     }
 
@@ -124,7 +116,6 @@ public class SessionEnvironment {
                 registeredCatalogs,
                 registeredModules,
                 defaultCatalog,
-                defaultDatabase,
                 sessionConfig);
     }
 
@@ -145,7 +136,6 @@ public class SessionEnvironment {
         private final Map<String, Catalog> registeredCatalogs = new HashMap<>();
         private final Map<String, Module> registeredModules = new HashMap<>();
         private @Nullable String defaultCatalog;
-        private @Nullable String defaultDatabase;
 
         public Builder setSessionName(String sessionName) {
             this.sessionName = sessionName;
@@ -164,11 +154,6 @@ public class SessionEnvironment {
 
         public Builder setDefaultCatalog(@Nullable String defaultCatalog) {
             this.defaultCatalog = defaultCatalog;
-            return this;
-        }
-
-        public Builder setDefaultDatabase(@Nullable String defaultDatabase) {
-            this.defaultDatabase = defaultDatabase;
             return this;
         }
 
@@ -198,7 +183,6 @@ public class SessionEnvironment {
                     registeredCatalogs,
                     registeredModules,
                     defaultCatalog,
-                    defaultDatabase,
                     sessionConfig);
         }
     }

--- a/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/session/SessionEnvironmentTest.java
+++ b/flink-table/flink-sql-gateway-api/src/test/java/org/apache/flink/table/gateway/api/session/SessionEnvironmentTest.java
@@ -45,7 +45,6 @@ public class SessionEnvironmentTest {
                         new HashMap<>(),
                         new HashMap<>(),
                         "default",
-                        "default_db",
                         configMap);
 
         SessionEnvironment actualEnvironment =
@@ -54,7 +53,6 @@ public class SessionEnvironmentTest {
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
                         .addSessionConfig(configMap)
                         .setDefaultCatalog("default")
-                        .setDefaultDatabase("default_db")
                         .build();
         assertEquals(expectedEnvironment, actualEnvironment);
     }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/context/SessionContext.java
@@ -171,13 +171,27 @@ public class SessionContext {
             try {
                 sessionState.catalogManager.getCatalog(name).ifPresent(Catalog::close);
             } catch (Throwable t) {
-                LOG.error("Failed to close catalog %s.", t);
+                LOG.error(
+                        String.format(
+                                "Failed to close catalog %s for the session %s.", name, sessionId),
+                        t);
             }
         }
         try {
             userClassloader.close();
         } catch (IOException e) {
-            LOG.debug("Error while closing class loader.", e);
+            LOG.error(
+                    String.format(
+                            "Error while closing class loader for the session %s.", sessionId),
+                    e);
+        }
+        try {
+            sessionState.resourceManager.close();
+        } catch (IOException e) {
+            LOG.error(
+                    String.format(
+                            "Failed to close the resource manager for the session %s.", sessionId),
+                    e);
         }
     }
 

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/SessionManager.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/session/SessionManager.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.gateway.service.session;
 
 import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.gateway.api.session.SessionEnvironment;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
@@ -149,16 +148,7 @@ public class SessionManager {
 
         SessionContext sessionContext =
                 SessionContext.create(
-                        defaultContext,
-                        sessionId,
-                        environment.getSessionEndpointVersion(),
-                        Configuration.fromMap(environment.getSessionConfig()),
-                        operationExecutorService);
-
-        environment.getRegisteredCatalogs().forEach(sessionContext::registerCatalog);
-        environment.getRegisteredModules().forEach(sessionContext::registerModuleAtHead);
-        environment.getDefaultCatalog().ifPresent(sessionContext::setCurrentCatalog);
-        environment.getDefaultDatabase().ifPresent(sessionContext::setCurrentDatabase);
+                        defaultContext, sessionId, environment, operationExecutorService);
 
         session = new Session(sessionContext);
         sessions.put(sessionId, session);

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -24,7 +24,6 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
-import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -138,16 +137,14 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
         String catalogName = "default";
         String databaseName = "testDb";
         String moduleName = "testModule";
-        GenericInMemoryCatalog defaultCatalog = new GenericInMemoryCatalog(catalogName);
-        defaultCatalog.createDatabase(
-                databaseName, new CatalogDatabaseImpl(Collections.emptyMap(), null), true);
+        GenericInMemoryCatalog defaultCatalog =
+                new GenericInMemoryCatalog(catalogName, databaseName);
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
                         .registerCatalog(catalogName, defaultCatalog)
                         .registerModuleAtHead(moduleName, new TestModule())
                         .setDefaultCatalog(catalogName)
-                        .setDefaultDatabase(databaseName)
                         .build();
 
         SessionHandle sessionHandle = service.openSession(environment);

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.gateway.service.context;
 import org.apache.flink.client.cli.DefaultCLI;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.table.gateway.api.session.SessionEnvironment;
 import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
 import org.apache.flink.table.gateway.api.utils.ThreadUtils;
@@ -134,12 +135,13 @@ class SessionContextTest {
         flinkConfig.set(MAX_PARALLELISM, 16);
         DefaultContext defaultContext =
                 new DefaultContext(flinkConfig, Collections.singletonList(new DefaultCLI()));
+        SessionEnvironment environment =
+                SessionEnvironment.newBuilder()
+                        .setSessionEndpointVersion(MockedEndpointVersion.V1)
+                        .addSessionConfig(flinkConfig.toMap())
+                        .build();
         return SessionContext.create(
-                defaultContext,
-                SessionHandle.create(),
-                MockedEndpointVersion.V1,
-                flinkConfig,
-                EXECUTOR_SERVICE);
+                defaultContext, SessionHandle.create(), environment, EXECUTOR_SERVICE);
     }
 
     private ReadableConfig getConfiguration() {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
 import org.apache.flink.table.gateway.api.utils.ThreadUtils;
 
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -51,8 +52,13 @@ class SessionContextTest {
         sessionContext = createSessionContext();
     }
 
+    @AfterEach
+    public void cleanUp() {
+        sessionContext.close();
+    }
+
     @AfterAll
-    public static void cleanUp() {
+    public static void closeResources() {
         EXECUTOR_SERVICE.shutdown();
     }
 


### PR DESCRIPTION
Cherry pick the fix #20714 to the release-1.16