### PR TITLE
[FLINK-29223][coordination] Add missing output info for jobs already reached terminal state

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/JobDispatcherLeaderProcessFactoryFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/JobDispatcherLeaderProcessFactoryFactory.java
@@ -131,8 +131,12 @@ public class JobDispatcherLeaderProcessFactoryFactory
             JobGraph jobGraph, Collection<JobResult> dirtyJobResults) {
         final Set<JobID> jobIdsOfFinishedJobs =
                 dirtyJobResults.stream().map(JobResult::getJobId).collect(Collectors.toSet());
-        return jobIdsOfFinishedJobs.contains(jobGraph.getJobID())
-                ? Optional.empty()
-                : Optional.of(jobGraph);
+        if (jobIdsOfFinishedJobs.contains(jobGraph.getJobID())) {
+            LOG.info(
+                    "Skipping recovery of a job with job id {}, because it already reached a globally terminal state",
+                    jobGraph.getJobID());
+            return Optional.empty();
+        }
+        return Optional.of(jobGraph);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java
@@ -148,6 +148,10 @@ public class SessionDispatcherLeaderProcess extends AbstractDispatcherLeaderProc
         for (JobID jobId : jobIds) {
             if (!recoveredDirtyJobResults.contains(jobId)) {
                 tryRecoverJob(jobId).ifPresent(recoveredJobGraphs::add);
+            } else {
+                log.info(
+                        "Skipping recovery of a job with job id {}, because it already reached a globally terminal state",
+                        jobId);
             }
         }
 


### PR DESCRIPTION
## What is the purpose of the change

The PR adds logging for jobs already reached their terminal state

## Brief change log

_flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/runner/SessionDispatcherLeaderProcess.java_


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
