### PR TITLE
[FLINK-28569][table-planner] Fix SinkUpsertMaterializer that should be aware of the input upsertKey if it is not empty to prevent wrong results

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
@@ -71,6 +71,7 @@ public class BatchExecSink extends CommonExecSink implements BatchExecNode<Objec
                 inputTransform,
                 tableSink,
                 -1,
-                false);
+                false,
+                null);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -411,10 +411,13 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                 new EqualiserCodeGenerator(physicalRowType, classLoader)
                         .generateRecordEqualiser("SinkMaterializeEqualiser");
         final GeneratedRecordEqualiser upsertKeyEqualiser =
-                new EqualiserCodeGenerator(
-                                RowTypeUtils.projectRowType(physicalRowType, inputUpsertKey),
-                                classLoader)
-                        .generateRecordEqualiser("SinkMaterializeUpsertKeyEqualiser");
+                inputUpsertKey == null
+                        ? null
+                        : new EqualiserCodeGenerator(
+                                        RowTypeUtils.projectRowType(
+                                                physicalRowType, inputUpsertKey),
+                                        classLoader)
+                                .generateRecordEqualiser("SinkMaterializeUpsertKeyEqualiser");
 
         SinkUpsertMaterializer operator =
                 new SinkUpsertMaterializer(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecSink.java
@@ -61,6 +61,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.TransformationMetadata;
 import org.apache.flink.table.planner.plan.utils.KeySelectorUtil;
+import org.apache.flink.table.planner.typeutils.RowTypeUtils;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
@@ -141,7 +142,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             Transformation<RowData> inputTransform,
             DynamicTableSink tableSink,
             int rowtimeFieldIndex,
-            boolean upsertMaterialize) {
+            boolean upsertMaterialize,
+            int[] inputUpsertKey) {
         final ResolvedSchema schema = tableSinkSpec.getContextResolvedTable().getResolvedSchema();
         final SinkRuntimeProvider runtimeProvider =
                 tableSink.getSinkRuntimeProvider(new SinkRuntimeProviderContext(isBounded));
@@ -193,7 +195,8 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
                             sinkParallelism,
                             config,
                             classLoader,
-                            physicalRowType);
+                            physicalRowType,
+                            inputUpsertKey);
         }
 
         return (Transformation<Object>)
@@ -402,16 +405,25 @@ public abstract class CommonExecSink extends ExecNodeBase<Object>
             int sinkParallelism,
             ExecNodeConfig config,
             ClassLoader classLoader,
-            RowType physicalRowType) {
-        GeneratedRecordEqualiser equaliser =
+            RowType physicalRowType,
+            int[] inputUpsertKey) {
+        final GeneratedRecordEqualiser rowEqualiser =
                 new EqualiserCodeGenerator(physicalRowType, classLoader)
                         .generateRecordEqualiser("SinkMaterializeEqualiser");
+        final GeneratedRecordEqualiser upsertKeyEqualiser =
+                new EqualiserCodeGenerator(
+                                RowTypeUtils.projectRowType(physicalRowType, inputUpsertKey),
+                                classLoader)
+                        .generateRecordEqualiser("SinkMaterializeUpsertKeyEqualiser");
+
         SinkUpsertMaterializer operator =
                 new SinkUpsertMaterializer(
                         StateConfigUtil.createTtlConfig(
                                 config.get(ExecutionConfigOptions.IDLE_STATE_RETENTION).toMillis()),
                         InternalSerializers.create(physicalRowType),
-                        equaliser);
+                        rowEqualiser,
+                        upsertKeyEqualiser,
+                        inputUpsertKey);
         final String[] fieldNames = physicalRowType.getFieldNames().toArray(new String[0]);
         final List<String> pkFieldNames =
                 Arrays.stream(primaryKeys)

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
@@ -74,6 +74,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
 
     public static final String FIELD_NAME_INPUT_CHANGELOG_MODE = "inputChangelogMode";
     public static final String FIELD_NAME_REQUIRE_UPSERT_MATERIALIZE = "requireUpsertMaterialize";
+    public static final String FIELD_NAME_INPUT_UPSERT_KEY = "inputUpsertKey";
 
     @JsonProperty(FIELD_NAME_INPUT_CHANGELOG_MODE)
     private final ChangelogMode inputChangelogMode;
@@ -82,6 +83,10 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
     @JsonInclude(JsonInclude.Include.NON_DEFAULT)
     private final boolean upsertMaterialize;
 
+    @JsonProperty(FIELD_NAME_INPUT_UPSERT_KEY)
+    @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    private final int[] inputUpsertKey;
+
     public StreamExecSink(
             ReadableConfig tableConfig,
             DynamicTableSinkSpec tableSinkSpec,
@@ -89,6 +94,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
             InputProperty inputProperty,
             LogicalType outputType,
             boolean upsertMaterialize,
+            int[] inputUpsertKey,
             String description) {
         this(
                 ExecNodeContext.newNodeId(),
@@ -99,6 +105,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
                 Collections.singletonList(inputProperty),
                 outputType,
                 upsertMaterialize,
+                inputUpsertKey,
                 description);
     }
 
@@ -112,6 +119,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
             @JsonProperty(FIELD_NAME_INPUT_PROPERTIES) List<InputProperty> inputProperties,
             @JsonProperty(FIELD_NAME_OUTPUT_TYPE) LogicalType outputType,
             @JsonProperty(FIELD_NAME_REQUIRE_UPSERT_MATERIALIZE) boolean upsertMaterialize,
+            @JsonProperty(FIELD_NAME_INPUT_UPSERT_KEY) int[] inputUpsertKey,
             @JsonProperty(FIELD_NAME_DESCRIPTION) String description) {
         super(
                 id,
@@ -125,6 +133,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
                 description);
         this.inputChangelogMode = inputChangelogMode;
         this.upsertMaterialize = upsertMaterialize;
+        this.inputUpsertKey = inputUpsertKey;
     }
 
     @SuppressWarnings("unchecked")
@@ -171,6 +180,7 @@ public class StreamExecSink extends CommonExecSink implements StreamExecNode<Obj
                 inputTransform,
                 tableSink,
                 rowtimeFieldIndex,
-                upsertMaterialize);
+                upsertMaterialize,
+                inputUpsertKey);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/UpsertKeyUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/utils/UpsertKeyUtil.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.calcite.util.ImmutableBitSet;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Set;
+
+/**
+ * Utility for upsertKey which represented as a Set of {@link
+ * org.apache.calcite.util.ImmutableBitSet}.
+ */
+public class UpsertKeyUtil {
+
+    /**
+     * Returns the smallest key of given upsert keys. The rule of 'small' is an upsert key
+     * represented by {@link ImmutableBitSet} has smaller cardinality or has a smaller leading
+     * element when the same cardinality. E.g., '{0,1}' is smaller than '{0,1,2}' and '{0,1}' is
+     * smaller than '{0,2}'.
+     *
+     * @param upsertKeys input upsert keys
+     * @return the smallest key
+     */
+    @Nonnull
+    public static int[] getSmallestKey(@Nullable Set<ImmutableBitSet> upsertKeys) {
+        if (null == upsertKeys || upsertKeys.isEmpty()) {
+            return new int[0];
+        }
+        return upsertKeys.stream()
+                .map(ImmutableBitSet::toArray)
+                .reduce(
+                        (k1, k2) -> {
+                            if (k1.length < k2.length) {
+                                return k1;
+                            }
+                            if (k1.length == k2.length) {
+                                for (int index = 0; index < k1.length; index++) {
+                                    if (k1[index] < k2[index]) {
+                                        return k1;
+                                    }
+                                }
+                            }
+                            return k2;
+                        })
+                .get();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -93,12 +93,6 @@ object AggCodeGenHelper {
       .asInstanceOf[Map[AggregateFunction[_, _], String]]
   }
 
-  /** @deprecated Use [[RowTypeUtils#projectRowType]] instead. */
-  @deprecated
-  def projectRowType(rowType: RowType, mapping: Array[Int]): RowType = {
-    RowType.of(mapping.map(rowType.getTypeAt), mapping.map(rowType.getFieldNames.get(_)))
-  }
-
   /** Add agg handler to class member and open it. */
   private[flink] def addAggsHandler(
       aggsHandler: GeneratedAggsHandleFunction,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/AggCodeGenHelper.scala
@@ -93,6 +93,8 @@ object AggCodeGenHelper {
       .asInstanceOf[Map[AggregateFunction[_, _], String]]
   }
 
+  /** @deprecated Use [[RowTypeUtils#projectRowType]] instead. */
+  @deprecated
   def projectRowType(rowType: RowType, mapping: Array[Int]): RowType = {
     RowType.of(mapping.map(rowType.getTypeAt), mapping.map(rowType.getFieldNames.get(_)))
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/HashAggCodeGenerator.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenUtils, ProjectionCodeGenerator}
 import org.apache.flink.table.planner.functions.aggfunctions.DeclarativeAggregateFunction
 import org.apache.flink.table.planner.plan.utils.{AggregateInfo, AggregateInfoList}
+import org.apache.flink.table.planner.typeutils.RowTypeUtils
 import org.apache.flink.table.runtime.generated.GeneratedOperator
 import org.apache.flink.table.runtime.operators.TableStreamOperator
 import org.apache.flink.table.runtime.operators.aggregate.BytesHashMapSpillMemorySegmentPool
@@ -60,7 +61,7 @@ class HashAggCodeGenerator(
   private lazy val aggBufferTypes: Array[Array[LogicalType]] =
     AggCodeGenHelper.getAggBufferTypes(inputType, auxGrouping, aggInfos)
 
-  private lazy val groupKeyRowType = AggCodeGenHelper.projectRowType(inputType, grouping)
+  private lazy val groupKeyRowType = RowTypeUtils.projectRowType(inputType, grouping)
   private lazy val aggBufferRowType = RowType.of(aggBufferTypes.flatten, aggBufferNames.flatten)
 
   def genWithKeys(): GeneratedOperator[OneInputStreamOperator[RowData, RowData]] = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortAggCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/SortAggCodeGenerator.scala
@@ -25,6 +25,7 @@ import org.apache.flink.table.functions.AggregateFunction
 import org.apache.flink.table.planner.codegen.{CodeGeneratorContext, CodeGenUtils, ProjectionCodeGenerator}
 import org.apache.flink.table.planner.codegen.OperatorCodeGenerator.generateCollect
 import org.apache.flink.table.planner.plan.utils.AggregateInfoList
+import org.apache.flink.table.planner.typeutils.RowTypeUtils
 import org.apache.flink.table.runtime.generated.GeneratedOperator
 import org.apache.flink.table.runtime.operators.TableStreamOperator
 import org.apache.flink.table.types.logical.RowType
@@ -63,7 +64,7 @@ object SortAggCodeGenerator {
     val currentKeyTerm = "currentKey"
     val currentKeyWriterTerm = "currentKeyWriter"
 
-    val groupKeyRowType = AggCodeGenHelper.projectRowType(inputType, grouping)
+    val groupKeyRowType = RowTypeUtils.projectRowType(inputType, grouping)
     val keyProjectionCode = ProjectionCodeGenerator
       .generateProjectionExpression(
         ctx,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/agg/batch/WindowCodeGenerator.scala
@@ -38,6 +38,7 @@ import org.apache.flink.table.planner.expressions.ExpressionBuilder._
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter
 import org.apache.flink.table.planner.plan.logical.{LogicalWindow, SlidingGroupWindow, TumblingGroupWindow}
 import org.apache.flink.table.planner.plan.utils.{AggregateInfo, AggregateInfoList, AggregateUtil}
+import org.apache.flink.table.planner.typeutils.RowTypeUtils
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTypeFactory
 import org.apache.flink.table.runtime.groupwindow.NamedWindowProperty
 import org.apache.flink.table.runtime.operators.window.TimeWindow
@@ -82,7 +83,7 @@ abstract class WindowCodeGenerator(
     AggCodeGenHelper.getAggBufferTypes(inputRowType, auxGrouping, aggInfos)
 
   protected lazy val groupKeyRowType: RowType =
-    AggCodeGenHelper.projectRowType(inputRowType, grouping)
+    RowTypeUtils.projectRowType(inputRowType, grouping)
 
   protected lazy val timestampInternalType: LogicalType =
     if (inputTimeIsDate) new IntType() else new BigIntType()

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -21,11 +21,12 @@ import org.apache.flink.table.catalog.ContextResolvedTable
 import org.apache.flink.table.connector.sink.DynamicTableSink
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory
 import org.apache.flink.table.planner.plan.abilities.sink.SinkAbilitySpec
+import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import org.apache.flink.table.planner.plan.nodes.calcite.Sink
 import org.apache.flink.table.planner.plan.nodes.exec.{ExecNode, InputProperty}
 import org.apache.flink.table.planner.plan.nodes.exec.spec.DynamicTableSinkSpec
 import org.apache.flink.table.planner.plan.nodes.exec.stream.StreamExecSink
-import org.apache.flink.table.planner.plan.utils.ChangelogPlanUtils
+import org.apache.flink.table.planner.plan.utils.{ChangelogPlanUtils, JoinUtil}
 import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 
 import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
@@ -33,6 +34,8 @@ import org.apache.calcite.rel.{RelNode, RelWriter}
 import org.apache.calcite.rel.hint.RelHint
 
 import java.util
+
+import scala.collection.JavaConversions._
 
 /**
  * Stream physical RelNode to to write data into an external sink defined by a [[DynamicTableSink]].
@@ -81,6 +84,18 @@ class StreamPhysicalSink(
     val tableSinkSpec =
       new DynamicTableSinkSpec(contextResolvedTable, util.Arrays.asList(abilitySpecs: _*))
     tableSinkSpec.setTableSink(tableSink)
+    // no need to call getUpsertKeysInKeyGroupRange here because there's no exchange before sink,
+    // and only add exchange in exec sink node.
+    val inputUpsertKeys = FlinkRelMetadataQuery
+      .reuseOrCreate(cluster.getMetadataQuery)
+      .getUpsertKeys(inputRel)
+
+    val usedUpsertKey = if (inputUpsertKeys != null && !inputUpsertKeys.isEmpty) {
+      JoinUtil.getSmallestKey(inputUpsertKeys.map(_.asList.map(_.intValue).toArray).toList)
+    } else {
+      Array.empty[Int]
+    }
+
     new StreamExecSink(
       unwrapTableConfig(this),
       tableSinkSpec,
@@ -88,6 +103,7 @@ class StreamPhysicalSink(
       InputProperty.DEFAULT,
       FlinkTypeFactory.toLogicalRowType(getRowType),
       upsertMaterialize,
+      usedUpsertKey,
       getRelDetailedDescription)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
@@ -189,7 +189,7 @@ object JoinUtil {
     }
   }
 
-  private def getSmallestKey(keys: util.List[Array[Int]]) = {
+  private[flink] def getSmallestKey(keys: util.List[Array[Int]]): Array[Int] = {
     keys.reduce((k1, k2) => if (k1.length <= k2.length) k1 else k2)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
@@ -189,7 +189,7 @@ object JoinUtil {
     }
   }
 
-  private def getSmallestKey(keys: util.List[Array[Int]]): Array[Int] = {
+  private def getSmallestKey(keys: util.List[Array[Int]]) = {
     keys.reduce((k1, k2) => if (k1.length <= k2.length) k1 else k2)
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/JoinUtil.scala
@@ -189,7 +189,7 @@ object JoinUtil {
     }
   }
 
-  private[flink] def getSmallestKey(keys: util.List[Array[Int]]): Array[Int] = {
+  private def getSmallestKey(keys: util.List[Array[Int]]): Array[Int] = {
     keys.reduce((k1, k2) => if (k1.length <= k2.length) k1 else k2)
   }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.stream;
 
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions;
 import org.apache.flink.table.planner.utils.StreamTableTestUtil;
 import org.apache.flink.table.planner.utils.TableTestBase;
 
@@ -90,5 +91,40 @@ public class TableSinkJsonPlanTest extends TableTestBase {
                         + "  'writable-metadata' = 'm:STRING')";
         tEnv.executeSql(sinkTableDdl);
         util.verifyJsonPlan("insert into MySink select * from MyTable");
+    }
+
+    @Test
+    public void testCdcWithNonDeterministicFuncSinkWithDifferentPk() {
+        tEnv.createTemporaryFunction(
+                "ndFunc", new JavaUserDefinedScalarFunctions.NonDeterministicUdf());
+
+        String cdcDdl =
+                "CREATE TABLE users (\n"
+                        + "  user_id STRING,\n"
+                        + "  user_name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  balance DECIMAL(18,2),\n"
+                        + "  primary key (user_id) not enforced\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'changelog-mode' = 'I,UA,UB,D'\n"
+                        + ")";
+
+        String sinkTableDdl =
+                "CREATE TABLE sink (\n"
+                        + "  user_id STRING,\n"
+                        + "  user_name STRING,\n"
+                        + "  email STRING,\n"
+                        + "  balance DECIMAL(18,2),\n"
+                        + "  PRIMARY KEY(email) NOT ENFORCED\n"
+                        + ") WITH(\n"
+                        + "  'connector' = 'values',\n"
+                        + "  'sink-insert-only' = 'false'\n"
+                        + ")";
+        tEnv.executeSql(cdcDdl);
+        tEnv.executeSql(sinkTableDdl);
+
+        util.verifyJsonPlan(
+                "insert into sink select user_id, ndFunc(user_name), email, balance from users");
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/UpsertKeyUtilTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/utils/UpsertKeyUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.utils;
+
+import org.apache.calcite.util.ImmutableBitSet;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link UpsertKeyUtil}. */
+public class UpsertKeyUtilTest {
+    private final int[] emptyKey = new int[0];
+
+    @Test
+    public void testSmallestKey() {
+        assertThat(UpsertKeyUtil.getSmallestKey(null)).isEqualTo(emptyKey);
+        assertThat(UpsertKeyUtil.getSmallestKey(new HashSet<>())).isEqualTo(emptyKey);
+
+        ImmutableBitSet smallestKey = ImmutableBitSet.of(0, 1);
+        ImmutableBitSet middleKey = ImmutableBitSet.of(0, 2);
+        ImmutableBitSet longKey = ImmutableBitSet.of(0, 1, 2);
+
+        Set<ImmutableBitSet> upsertKeys = new HashSet<>();
+        upsertKeys.add(smallestKey);
+        upsertKeys.add(middleKey);
+        assertThat(UpsertKeyUtil.getSmallestKey(upsertKeys)).isEqualTo(smallestKey.toArray());
+
+        upsertKeys.clear();
+        upsertKeys.add(smallestKey);
+        upsertKeys.add(longKey);
+        assertThat(UpsertKeyUtil.getSmallestKey(upsertKeys)).isEqualTo(smallestKey.toArray());
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JavaUserDefinedScalarFunctions.java
@@ -131,6 +131,10 @@ public class JavaUserDefinedScalarFunctions {
             return v + random.nextInt();
         }
 
+        public String eval(String v) {
+            return v + "-" + random.nextInt();
+        }
+
         @Override
         public boolean isDeterministic() {
             return false;

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.typeutils;
 
 import org.apache.flink.table.api.ValidationException;
-import org.apache.flink.table.planner.codegen.agg.batch.AggCodeGenHelper;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -59,14 +58,8 @@ public class RowTypeUtilsTest {
 
     @Test
     public void testProjectRowType() {
-        assertThat(RowTypeUtils.projectRowType(srcType, new int[0]))
-                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[0]));
-
         assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0}))
                 .isEqualTo(RowType.of(new LogicalType[] {new IntType()}, new String[] {"f0"}));
-
-        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0}))
-                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[] {0}));
 
         assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 2}))
                 .isEqualTo(
@@ -74,13 +67,7 @@ public class RowTypeUtilsTest {
                                 new LogicalType[] {new IntType(), new BigIntType()},
                                 new String[] {"f0", "f2"}));
 
-        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 2}))
-                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[] {0, 2}));
-
         assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 1, 2})).isEqualTo(srcType);
-
-        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 1, 2}))
-                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[] {0, 1, 2}));
     }
 
     @Test
@@ -97,6 +84,5 @@ public class RowTypeUtilsTest {
         expectedException.expect(ValidationException.class);
         expectedException.expectMessage("Field names must be unique. Found duplicates");
         RowTypeUtils.projectRowType(srcType, new int[] {0, 0, 0, 0});
-        AggCodeGenHelper.projectRowType(srcType, new int[] {0, 0, 0, 0});
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/typeutils/RowTypeUtilsTest.java
@@ -18,7 +18,17 @@
 
 package org.apache.flink.table.planner.typeutils;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.planner.codegen.agg.batch.AggCodeGenHelper;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 
@@ -26,6 +36,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link RowTypeUtils}. */
 public class RowTypeUtilsTest {
+
+    @Rule public ExpectedException expectedException = ExpectedException.none();
+
+    private final RowType srcType =
+            RowType.of(
+                    new LogicalType[] {new IntType(), new VarCharType(), new BigIntType()},
+                    new String[] {"f0", "f1", "f2"});
 
     @Test
     public void testGetUniqueName() {
@@ -38,5 +55,48 @@ public class RowTypeUtilsTest {
                                 Arrays.asList("Bob", "Bob", "Dave", "Alice"),
                                 Arrays.asList("Alice", "Bob")))
                 .isEqualTo(Arrays.asList("Bob_0", "Bob_1", "Dave", "Alice_0"));
+    }
+
+    @Test
+    public void testProjectRowType() {
+        assertThat(RowTypeUtils.projectRowType(srcType, new int[0]))
+                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[0]));
+
+        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0}))
+                .isEqualTo(RowType.of(new LogicalType[] {new IntType()}, new String[] {"f0"}));
+
+        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0}))
+                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[] {0}));
+
+        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 2}))
+                .isEqualTo(
+                        RowType.of(
+                                new LogicalType[] {new IntType(), new BigIntType()},
+                                new String[] {"f0", "f2"}));
+
+        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 2}))
+                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[] {0, 2}));
+
+        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 1, 2})).isEqualTo(srcType);
+
+        assertThat(RowTypeUtils.projectRowType(srcType, new int[] {0, 1, 2}))
+                .isEqualTo(AggCodeGenHelper.projectRowType(srcType, new int[] {0, 1, 2}));
+    }
+
+    @Test
+    public void testInvalidProjectRowType() {
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid projection index: 3");
+        RowTypeUtils.projectRowType(srcType, new int[] {0, 1, 2, 3});
+
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Invalid projection index: 3");
+        RowTypeUtils.projectRowType(srcType, new int[] {0, 1, 3});
+
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("Field names must be unique. Found duplicates");
+        RowTypeUtils.projectRowType(srcType, new int[] {0, 0, 0, 0});
+        AggCodeGenHelper.projectRowType(srcType, new int[] {0, 0, 0, 0});
     }
 }

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testChangelogSource.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testChangelogSource.out
@@ -133,6 +133,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "inputUpsertKey" : [ 0, 1 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testUpsertSource.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ChangelogSourceJsonPlanTest_jsonplan/testUpsertSource.out
@@ -121,6 +121,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`a` BIGINT NOT NULL, `b` INT NOT NULL>",
+    "inputUpsertKey" : [ 0, 1 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, b])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest_jsonplan/testDeduplication.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/DeduplicationJsonPlanTest_jsonplan/testDeduplication.out
@@ -272,6 +272,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`order_id` BIGINT, `user` VARCHAR(2147483647), `product` VARCHAR(2147483647), `order_time` TIMESTAMP(3)>",
+    "inputUpsertKey" : [ 2 ],
     "description" : "Sink(table=[default_catalog.default_database.sink], fields=[order_id, user, product, order_time])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ExpandJsonPlanTest_jsonplan/testExpand.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/ExpandJsonPlanTest_jsonplan/testExpand.out
@@ -365,6 +365,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`a` BIGINT, `$f1` BIGINT NOT NULL, `$f2` VARCHAR(2147483647)>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, $f1, $f2])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=false].out
@@ -297,6 +297,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`d` BIGINT, `cnt_a1` BIGINT, `cnt_a2` BIGINT, `sum_a` BIGINT, `sum_b` INT, `avg_b` DOUBLE, `cnt_c` BIGINT>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[d, cnt_a1, cnt_a2, sum_a, sum_b, avg_b, cnt_c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testDistinctAggCalls[isMiniBatchEnabled=true].out
@@ -545,6 +545,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`d` BIGINT, `cnt_a1` BIGINT, `cnt_a2` BIGINT, `sum_a` BIGINT, `sum_b` INT, `avg_b` DOUBLE, `cnt_c` BIGINT>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[d, cnt_a1, cnt_a2, sum_a, sum_b, avg_b, cnt_c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=false].out
@@ -240,6 +240,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `cnt_a` BIGINT, `max_b` BIGINT, `min_c` VARCHAR(2147483647)>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, cnt_a, max_b, min_c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testSimpleAggCallsWithGroupBy[isMiniBatchEnabled=true].out
@@ -305,6 +305,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `cnt_a` BIGINT, `max_b` BIGINT, `min_c` VARCHAR(2147483647)>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, cnt_a, max_b, min_c])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=false].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=false].out
@@ -233,6 +233,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, a1, a2, a3, c1])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=true].out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupAggregateJsonPlanTest_jsonplan/testUserDefinedAggCalls[isMiniBatchEnabled=true].out
@@ -249,6 +249,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `a1` BIGINT, `a2` BIGINT, `a3` BIGINT, `c1` BIGINT>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, a1, a2, a3, c1])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -466,6 +466,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$3` BIGINT NOT NULL, `EXPR$4` INT, `EXPR$5` BIGINT NOT NULL, `EXPR$6` VARCHAR(2147483647)>",
+    "inputUpsertKey" : [ 0, 2 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, EXPR$6])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testEventTimeTumbleWindow.out
@@ -466,7 +466,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `window_start` TIMESTAMP(3) NOT NULL, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$3` BIGINT NOT NULL, `EXPR$4` INT, `EXPR$5` BIGINT NOT NULL, `EXPR$6` VARCHAR(2147483647)>",
-    "inputUpsertKey" : [ 0, 2 ],
+    "inputUpsertKey" : [ 0, 1 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, window_start, window_end, EXPR$3, EXPR$4, EXPR$5, EXPR$6])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/GroupWindowAggregateJsonPlanTest_jsonplan/testProcTimeTumbleWindow.out
@@ -451,6 +451,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT, `window_end` TIMESTAMP(3) NOT NULL, `EXPR$2` BIGINT NOT NULL>",
+    "inputUpsertKey" : [ 0, 1 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, window_end, EXPR$2])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregate.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregate.out
@@ -327,6 +327,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`a` BIGINT, `$f1` BIGINT NOT NULL>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a, $f1])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregateWithSumCountDistinctAndRetraction.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/IncrementalAggregateJsonPlanTest_jsonplan/testIncrementalAggregateWithSumCountDistinctAndRetraction.out
@@ -485,6 +485,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`b` BIGINT NOT NULL, `$f1` INT NOT NULL, `$f2` BIGINT NOT NULL, `$f3` BIGINT NOT NULL>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[b, $f1, $f2, $f3])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/JoinJsonPlanTest_jsonplan/testInnerJoinWithEqualPk.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/JoinJsonPlanTest_jsonplan/testInnerJoinWithEqualPk.out
@@ -242,6 +242,7 @@
       "priority" : 0
     } ],
     "outputType" : "ROW<`a1` INT, `b1` INT>",
+    "inputUpsertKey" : [ 0 ],
     "description" : "Sink(table=[default_catalog.default_database.MySink], fields=[a1, b1])"
   } ],
   "edges" : [ {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testCdcWithNonDeterministicFuncSinkWithDifferentPk.out
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/nodes/exec/stream/TableSinkJsonPlanTest_jsonplan/testCdcWithNonDeterministicFuncSinkWithDifferentPk.out
@@ -1,0 +1,147 @@
+{
+  "flinkVersion" : "",
+  "nodes" : [ {
+    "id" : 1,
+    "type" : "stream-exec-table-source-scan_1",
+    "scanTableSource" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`users`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "user_id",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "user_name",
+              "dataType" : "VARCHAR(2147483647)"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647)"
+            }, {
+              "name" : "balance",
+              "dataType" : "DECIMAL(18, 2)"
+            } ],
+            "watermarkSpecs" : [ ],
+            "primaryKey" : {
+              "name" : "PK_-147132882",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "user_id" ]
+            }
+          },
+          "partitionKeys" : [ ],
+          "options" : {
+            "connector" : "values",
+            "changelog-mode" : "I,UA,UB,D"
+          }
+        }
+      }
+    },
+    "outputType" : "ROW<`user_id` VARCHAR(2147483647) NOT NULL, `user_name` VARCHAR(2147483647), `email` VARCHAR(2147483647), `balance` DECIMAL(18, 2)>",
+    "description" : "TableSourceScan(table=[[default_catalog, default_database, users]], fields=[user_id, user_name, email, balance])",
+    "inputProperties" : [ ]
+  }, {
+    "id" : 2,
+    "type" : "stream-exec-calc_1",
+    "projection" : [ {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 0,
+      "type" : "VARCHAR(2147483647) NOT NULL"
+    }, {
+      "kind" : "CALL",
+      "catalogName" : "`default_catalog`.`default_database`.`ndFunc`",
+      "operands" : [ {
+        "kind" : "INPUT_REF",
+        "inputIndex" : 1,
+        "type" : "VARCHAR(2147483647)"
+      } ],
+      "type" : "VARCHAR(2147483647)"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 2,
+      "type" : "VARCHAR(2147483647)"
+    }, {
+      "kind" : "INPUT_REF",
+      "inputIndex" : 3,
+      "type" : "DECIMAL(18, 2)"
+    } ],
+    "condition" : null,
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`user_id` VARCHAR(2147483647) NOT NULL, `EXPR$1` VARCHAR(2147483647), `email` VARCHAR(2147483647), `balance` DECIMAL(18, 2)>",
+    "description" : "Calc(select=[user_id, ndFunc(user_name) AS EXPR$1, email, balance])"
+  }, {
+    "id" : 3,
+    "type" : "stream-exec-sink_1",
+    "configuration" : {
+      "table.exec.sink.keyed-shuffle" : "AUTO",
+      "table.exec.sink.not-null-enforcer" : "ERROR",
+      "table.exec.sink.type-length-enforcer" : "IGNORE",
+      "table.exec.sink.upsert-materialize" : "AUTO"
+    },
+    "dynamicTableSink" : {
+      "table" : {
+        "identifier" : "`default_catalog`.`default_database`.`sink`",
+        "resolvedTable" : {
+          "schema" : {
+            "columns" : [ {
+              "name" : "user_id",
+              "dataType" : "VARCHAR(2147483647)"
+            }, {
+              "name" : "user_name",
+              "dataType" : "VARCHAR(2147483647)"
+            }, {
+              "name" : "email",
+              "dataType" : "VARCHAR(2147483647) NOT NULL"
+            }, {
+              "name" : "balance",
+              "dataType" : "DECIMAL(18, 2)"
+            } ],
+            "watermarkSpecs" : [ ],
+            "primaryKey" : {
+              "name" : "PK_96619451",
+              "type" : "PRIMARY_KEY",
+              "columns" : [ "email" ]
+            }
+          },
+          "partitionKeys" : [ ],
+          "options" : {
+            "sink-insert-only" : "false",
+            "connector" : "values"
+          }
+        }
+      }
+    },
+    "inputChangelogMode" : [ "INSERT", "UPDATE_BEFORE", "UPDATE_AFTER", "DELETE" ],
+    "inputProperties" : [ {
+      "requiredDistribution" : {
+        "type" : "UNKNOWN"
+      },
+      "damBehavior" : "PIPELINED",
+      "priority" : 0
+    } ],
+    "outputType" : "ROW<`user_id` VARCHAR(2147483647) NOT NULL, `EXPR$1` VARCHAR(2147483647), `email` VARCHAR(2147483647), `balance` DECIMAL(18, 2)>",
+    "requireUpsertMaterialize" : true,
+    "inputUpsertKey" : [ 0 ],
+    "description" : "Sink(table=[default_catalog.default_database.sink], fields=[user_id, EXPR$1, email, balance], upsertMaterialize=[true])"
+  } ],
+  "edges" : [ {
+    "source" : 1,
+    "target" : 2,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  }, {
+    "source" : 2,
+    "target" : 3,
+    "shuffle" : {
+      "type" : "FORWARD"
+    },
+    "shuffleMode" : "PIPELINED"
+  } ]
+}

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/utils/userDefinedScalarFunctions.scala
@@ -20,7 +20,8 @@ package org.apache.flink.table.planner.expressions.utils
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.annotation.DataTypeHint
 import org.apache.flink.table.api.Types
-import org.apache.flink.table.functions.{FunctionContext, ScalarFunction}
+import org.apache.flink.table.functions.{AggregateFunction, FunctionContext, ScalarFunction, TableFunction}
+import org.apache.flink.table.planner.utils.CountAccumulator
 import org.apache.flink.types.Row
 
 import org.apache.commons.lang3.StringUtils
@@ -231,4 +232,54 @@ class SplitUDF(deterministic: Boolean) extends ScalarFunction {
   }
   override def isDeterministic: Boolean = deterministic
 
+}
+
+@SerialVersionUID(1L)
+class TestNonDeterministicUdf extends ScalarFunction {
+  val random = new Random()
+
+  def eval(id: JLong): JLong = {
+    id + random.nextInt()
+  }
+
+  def eval(id: Int): Int = {
+    id + random.nextInt()
+  }
+
+  def eval(id: String): String = {
+    s"$id-${random.nextInt()}"
+  }
+
+  override def isDeterministic: Boolean = false
+}
+
+@SerialVersionUID(1L)
+class TestNonDeterministicUdtf extends TableFunction[String] {
+
+  val random = new Random()
+
+  def eval(id: Int): Unit = {
+    collect(s"${id + random.nextInt()}")
+  }
+
+  def eval(id: String): Unit = {
+    id.split(",").foreach(str => collect(s"$str#${random.nextInt()}"))
+  }
+
+  override def isDeterministic: Boolean = false
+}
+
+class TestNonDeterministicUdaf extends AggregateFunction[JLong, CountAccumulator] {
+
+  val random = new Random()
+
+  def accumulate(acc: CountAccumulator, in: JLong): Unit = {
+    acc.f0 += (in + random.nextInt())
+  }
+
+  override def getValue(acc: CountAccumulator): JLong = acc.f0
+
+  override def createAccumulator(): CountAccumulator = new CountAccumulator
+
+  override def isDeterministic: Boolean = false
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -175,7 +175,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
 
   @Test
   def testCdcWithNonDeterministicFuncSinkWithDifferentPk(): Unit = {
-    tEnv.createTemporaryFunction("ndFunc", TestNonDeterministicUdf)
+    tEnv.createTemporaryFunction("ndFunc", new TestNonDeterministicUdf)
     tEnv.executeSql("""
                       |CREATE TABLE sink_with_pk (
                       |  user_id STRING,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TableSinkITCase.scala
@@ -174,7 +174,7 @@ class TableSinkITCase(mode: StateBackendMode) extends StreamingWithStateTestBase
   }
 
   @Test
-  def testCdcWithNonDeterministicFuncSinkWithDifferentPk(): Unit = {
+  def testChangelogSourceWithNonDeterministicFuncSinkWithDifferentPk(): Unit = {
     tEnv.createTemporaryFunction("ndFunc", new TestNonDeterministicUdf)
     tEnv.executeSql("""
                       |CREATE TABLE sink_with_pk (

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.generated.GeneratedRecordEqualiser;
 import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.operators.TableStreamOperator;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +95,7 @@ public class SinkUpsertMaterializer extends TableStreamOperator<RowData>
             StateTtlConfig ttlConfig,
             TypeSerializer<RowData> serializer,
             GeneratedRecordEqualiser generatedRecordEqualiser,
-            GeneratedRecordEqualiser generatedUpsertKeyEqualiser,
+            @Nullable GeneratedRecordEqualiser generatedUpsertKeyEqualiser,
             @Nullable int[] inputUpsertKey) {
         this.ttlConfig = ttlConfig;
         this.serializer = serializer;
@@ -102,6 +103,11 @@ public class SinkUpsertMaterializer extends TableStreamOperator<RowData>
         this.generatedUpsertKeyEqualiser = generatedUpsertKeyEqualiser;
         this.inputUpsertKey = inputUpsertKey;
         this.hasUpsertKey = null != inputUpsertKey && inputUpsertKey.length > 0;
+        if (hasUpsertKey) {
+            Preconditions.checkNotNull(
+                    generatedUpsertKeyEqualiser,
+                    "GeneratedUpsertKeyEqualiser cannot be null when inputUpsertKey is not empty!");
+        }
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializerTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.table.runtime.generated.RecordEqualiser;
 import org.apache.flink.table.runtime.keyselector.RowDataKeySelector;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.flink.table.runtime.util.StateConfigUtil;
+import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -43,16 +44,19 @@ import java.util.List;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.deleteRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.insertRecord;
 import static org.apache.flink.table.runtime.util.StreamRecordUtils.rowOfKind;
+import static org.apache.flink.table.runtime.util.StreamRecordUtils.updateAfterRecord;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link SinkUpsertMaterializer}. */
 public class SinkUpsertMaterializerTest {
 
     private final StateTtlConfig ttlConfig = StateConfigUtil.createTtlConfig(1000);
-    private final LogicalType[] types = new LogicalType[] {new IntType(), new VarCharType()};
+    private final LogicalType[] types =
+            new LogicalType[] {new BigIntType(), new IntType(), new VarCharType()};
     private final RowDataSerializer serializer = new RowDataSerializer(types);
     private final RowDataKeySelector keySelector =
-            HandwrittenSelectorUtil.getRowDataSelector(new int[0], types);
+            HandwrittenSelectorUtil.getRowDataSelector(new int[] {1}, types);
+
     private final GeneratedRecordEqualiser equaliser =
             new GeneratedRecordEqualiser("", "", new Object[0]) {
 
@@ -62,10 +66,20 @@ public class SinkUpsertMaterializerTest {
                 }
             };
 
+    private final GeneratedRecordEqualiser upsertKeyEqualiser =
+            new GeneratedRecordEqualiser("", "", new Object[0]) {
+
+                @Override
+                public RecordEqualiser newInstance(ClassLoader classLoader) {
+                    return new TestUpsertKeyEqualiser();
+                }
+            };
+
     @Test
     public void test() throws Exception {
         SinkUpsertMaterializer materializer =
-                new SinkUpsertMaterializer(ttlConfig, serializer, equaliser);
+                new SinkUpsertMaterializer(
+                        ttlConfig, serializer, equaliser, upsertKeyEqualiser, null);
         KeyedOneInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
                 new KeyedOneInputStreamOperatorTestHarness<>(
                         materializer, keySelector, keySelector.getProducedType());
@@ -74,30 +88,69 @@ public class SinkUpsertMaterializerTest {
 
         testHarness.setStateTtlProcessingTime(1);
 
-        testHarness.processElement(insertRecord(1, "a1"));
-        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1, "a1"));
+        testHarness.processElement(insertRecord(1L, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1L, 1, "a1"));
 
-        testHarness.processElement(insertRecord(1, "a2"));
-        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a2"));
+        testHarness.processElement(insertRecord(2L, 1, "a2"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 2L, 1, "a2"));
 
-        testHarness.processElement(insertRecord(1, "a3"));
-        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a3"));
+        testHarness.processElement(insertRecord(3L, 1, "a3"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 3L, 1, "a3"));
 
-        testHarness.processElement(deleteRecord(1, "a2"));
+        testHarness.processElement(deleteRecord(2L, 1, "a2"));
         shouldEmitNothing(testHarness);
 
-        testHarness.processElement(deleteRecord(1, "a3"));
-        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1, "a1"));
+        testHarness.processElement(deleteRecord(3L, 1, "a3"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1L, 1, "a1"));
 
-        testHarness.processElement(deleteRecord(1, "a1"));
-        shouldEmit(testHarness, rowOfKind(RowKind.DELETE, 1, "a1"));
+        testHarness.processElement(deleteRecord(1L, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.DELETE, 1L, 1, "a1"));
 
-        testHarness.processElement(insertRecord(1, "a4"));
-        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1, "a4"));
+        testHarness.processElement(insertRecord(4L, 1, "a4"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 4L, 1, "a4"));
 
         testHarness.setStateTtlProcessingTime(1002);
 
-        testHarness.processElement(deleteRecord(1, "a4"));
+        testHarness.processElement(deleteRecord(4L, 1, "a4"));
+        shouldEmitNothing(testHarness);
+
+        testHarness.close();
+    }
+
+    @Test
+    public void testInputHasUpsertKeyWithNonDeterministicColumn() throws Exception {
+        SinkUpsertMaterializer materializer =
+                new SinkUpsertMaterializer(
+                        ttlConfig, serializer, equaliser, upsertKeyEqualiser, new int[] {0});
+        KeyedOneInputStreamOperatorTestHarness<RowData, RowData, RowData> testHarness =
+                new KeyedOneInputStreamOperatorTestHarness<>(
+                        materializer, keySelector, keySelector.getProducedType());
+
+        testHarness.open();
+
+        testHarness.setStateTtlProcessingTime(1);
+
+        testHarness.processElement(insertRecord(1L, 1, "a1"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 1L, 1, "a1"));
+
+        testHarness.processElement(updateAfterRecord(1L, 1, "a11"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 1L, 1, "a11"));
+
+        testHarness.processElement(insertRecord(3L, 1, "a3"));
+        shouldEmit(testHarness, rowOfKind(RowKind.UPDATE_AFTER, 3L, 1, "a3"));
+
+        testHarness.processElement(deleteRecord(1L, 1, "a111"));
+        shouldEmitNothing(testHarness);
+
+        testHarness.processElement(deleteRecord(3L, 1, "a33"));
+        shouldEmit(testHarness, rowOfKind(RowKind.DELETE, 3L, 1, "a33"));
+
+        testHarness.processElement(insertRecord(4L, 1, "a4"));
+        shouldEmit(testHarness, rowOfKind(RowKind.INSERT, 4L, 1, "a4"));
+
+        testHarness.setStateTtlProcessingTime(1002);
+
+        testHarness.processElement(deleteRecord(4L, 1, "a4"));
         shouldEmitNothing(testHarness);
 
         testHarness.close();
@@ -118,7 +171,8 @@ public class SinkUpsertMaterializerTest {
         Object o;
         while ((o = harness.getOutput().poll()) != null) {
             RowData value = (RowData) ((StreamRecord<?>) o).getValue();
-            GenericRowData newRow = GenericRowData.of(value.getInt(0), value.getString(1));
+            GenericRowData newRow =
+                    GenericRowData.of(value.getLong(0), value.getInt(1), value.getString(2));
             newRow.setRowKind(value.getRowKind());
             rows.add(newRow);
         }
@@ -129,8 +183,16 @@ public class SinkUpsertMaterializerTest {
         @Override
         public boolean equals(RowData row1, RowData row2) {
             return row1.getRowKind() == row2.getRowKind()
-                    && row1.getInt(0) == row2.getInt(0)
-                    && row1.getString(1).equals(row2.getString(1));
+                    && row1.getLong(0) == row2.getLong(0)
+                    && row1.getInt(1) == row2.getInt(1)
+                    && row1.getString(2).equals(row2.getString(2));
+        }
+    }
+
+    private static class TestUpsertKeyEqualiser implements RecordEqualiser {
+        @Override
+        public boolean equals(RowData row1, RowData row2) {
+            return row1.getRowKind() == row2.getRowKind() && row1.getLong(0) == row2.getLong(0);
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Currently SinkUpsertMaterializer only update row by comparing the complete row in anycase, but this may cause wrong result if input has upsertKey and also non-deterministic column values, see such a case:

```java
@Test
public void testCdcWithNonDeterministicFuncSinkWithDifferentPk() {
tEnv.createTemporaryFunction(
"ndFunc", new JavaUserDefinedScalarFunctions.NonDeterministicUdf());

String cdcDdl =
"CREATE TABLE users (\n"
+ " user_id STRING,\n"
+ " user_name STRING,\n"
+ " email STRING,\n"
+ " balance DECIMAL(18,2),\n"
+ " primary key (user_id) not enforced\n"
+ ") WITH (\n"
+ " 'connector' = 'values',\n"
+ " 'changelog-mode' = 'I,UA,UB,D'\n"
+ ")";

String sinkTableDdl =
"CREATE TABLE sink (\n"
+ " user_id STRING,\n"
+ " user_name STRING,\n"
+ " email STRING,\n"
+ " balance DECIMAL(18,2),\n"
+ " PRIMARY KEY(email) NOT ENFORCED\n"
+ ") WITH(\n"
+ " 'connector' = 'values',\n"
+ " 'sink-insert-only' = 'false'\n"
+ ")";
tEnv.executeSql(cdcDdl);
tEnv.executeSql(sinkTableDdl);

util.verifyJsonPlan(
"insert into sink select user_id, ndFunc(user_name), email, balance from users");
}
```

for original cdc source records:

```gittext
+I[user1, Tom, tom@gmail.com, 10.02],
-D[user1, Tom, tom@gmail.com, 10.02],
```

the above query cannot correctly delete the former insertion row because of the non-deterministic column value 'ndFunc(user_name)'

this canbe solved by letting the SinkUpsertMaterializer be aware of input upsertKey and update by it. This pr aims to address it.

## Brief change log
* Add projectRowType to RowTypeUtils and deprecate AggCodeGenHelper#projectRowType
* Move non-deterministic test functions to userDefinedScalarFunctions
* Add upsertKey info for SinkUpsertMaterializer and do update via upsertKey if has one (if no upsertKey,  code path keeps unchanged)

## Verifying this change
add more related ut & it

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)

