### PR TITLE
[FLINK-29238][runtime] Wrong index information will be obtained after the downstream failover in hybrid full mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndex.java
@@ -39,10 +39,12 @@ public interface HsFileDataIndex {
      *
      * @param subpartitionId that the readable region belongs to
      * @param bufferIndex that the readable region starts with
+     * @param consumingOffset of the downstream
      * @return a {@link ReadableRegion} for the given subpartition that starts with the given buffer
      *     index, if exist; otherwise, {@link Optional#empty()}.
      */
-    Optional<ReadableRegion> getReadableRegion(int subpartitionId, int bufferIndex);
+    Optional<ReadableRegion> getReadableRegion(
+            int subpartitionId, int bufferIndex, int consumingOffset);
 
     /**
      * Add buffers to the index.
@@ -55,12 +57,12 @@ public interface HsFileDataIndex {
     void addBuffers(List<SpilledBuffer> spilledBuffers);
 
     /**
-     * Mark a buffer as READABLE.
+     * Mark a buffer as RELEASED.
      *
      * @param subpartitionId that the buffer belongs to
      * @param bufferIndex of the buffer within the subpartition
      */
-    void markBufferReadable(int subpartitionId, int bufferIndex);
+    void markBufferReleased(int subpartitionId, int bufferIndex);
 
     /**
      * Represents a series of physically continuous buffers in the file, which are readable, from

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -216,8 +216,8 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
     // ------------------------------------
 
     @Override
-    public void markBufferReadableFromFile(int subpartitionId, int bufferIndex) {
-        fileDataIndex.markBufferReadable(subpartitionId, bufferIndex);
+    public void markBufferReleasedFromFile(int subpartitionId, int bufferIndex) {
+        fileDataIndex.markBufferReleased(subpartitionId, bufferIndex);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerOperation.java
@@ -33,12 +33,12 @@ public interface HsMemoryDataManagerOperation {
     BufferBuilder requestBufferFromPool() throws InterruptedException;
 
     /**
-     * This method is called when buffer should mark as readable in {@link HsFileDataIndex}.
+     * This method is called when buffer should mark as released in {@link HsFileDataIndex}.
      *
      * @param subpartitionId the subpartition that target buffer belong to.
-     * @param bufferIndex index of buffer to mark as readable.
+     * @param bufferIndex index of buffer to mark as released.
      */
-    void markBufferReadableFromFile(int subpartitionId, int bufferIndex);
+    void markBufferReleasedFromFile(int subpartitionId, int bufferIndex);
 
     /**
      * This method is called when buffer is consumed.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -188,7 +188,9 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
     public void prepareForScheduling() {
         // Access the consuming offset with lock, to prevent loading any buffer released from the
         // memory data manager that is already consumed.
-        bufferIndexManager.updateLastConsumed(operations.getConsumingOffset(true));
+        int consumingOffset = operations.getConsumingOffset(true);
+        bufferIndexManager.updateLastConsumed(consumingOffset);
+        cachedRegionManager.updateConsumingOffset(consumingOffset);
     }
 
     /** Provides priority calculation logic for io scheduler. */
@@ -379,6 +381,8 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         private final int subpartitionId;
         private final HsFileDataIndex dataIndex;
 
+        private int consumingOffset = -1;
+
         private int currentBufferIndex;
         private int numSkip;
         private int numReadable;
@@ -392,6 +396,10 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         // ------------------------------------------------------------------------
         //  Called by HsSubpartitionFileReader
         // ------------------------------------------------------------------------
+
+        public void updateConsumingOffset(int consumingOffset) {
+            this.consumingOffset = consumingOffset;
+        }
 
         /** Return Long.MAX_VALUE if region does not exist to giving the lowest priority. */
         private long getFileOffset(int bufferIndex) {
@@ -448,7 +456,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
             }
 
             Optional<HsFileDataIndex.ReadableRegion> lookupResultOpt =
-                    dataIndex.getReadableRegion(subpartitionId, bufferIndex);
+                    dataIndex.getReadableRegion(subpartitionId, bufferIndex, consumingOffset);
             if (!lookupResultOpt.isPresent()) {
                 currentBufferIndex = -1;
                 numReadable = 0;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManager.java
@@ -459,8 +459,8 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
 
     @GuardedBy("subpartitionLock")
     private void checkAndMarkBufferReadable(HsBufferContext bufferContext) {
-        // only spill and not consumed buffer needs to be marked as readable.
-        if (isBufferSatisfyStatus(bufferContext, SpillStatus.SPILL, ConsumeStatus.NOT_CONSUMED)) {
+        // only spill buffer needs to be marked as released.
+        if (isBufferSatisfyStatus(bufferContext, SpillStatus.SPILL, ConsumeStatus.ALL)) {
             bufferContext
                     .getSpilledFuture()
                     .orElseThrow(
@@ -471,7 +471,7 @@ public class HsSubpartitionMemoryDataManager implements HsDataView {
                             () -> {
                                 BufferIndexAndChannel bufferIndexAndChannel =
                                         bufferContext.getBufferIndexAndChannel();
-                                memoryDataManagerOperation.markBufferReadableFromFile(
+                                memoryDataManagerOperation.markBufferReleasedFromFile(
                                         bufferIndexAndChannel.getChannel(),
                                         bufferIndexAndChannel.getBufferIndex());
                             });

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImplTest.java
@@ -68,6 +68,7 @@ class HsFileDataIndexImplTest {
     @Test
     void testGetReadableRegionNotReadable() {
         hsDataIndex.addBuffers(createSpilledBuffers(0, Collections.singletonList(0)));
+        hsDataIndex.markBufferReleased(0, 0);
 
         // 0-0 is not readable as consuming offset is bigger than 0.
         assertThat(hsDataIndex.getReadableRegion(0, 0, 1)).isNotPresent();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingMemoryDataManagerOperation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingMemoryDataManagerOperation.java
@@ -57,7 +57,7 @@ public class TestingMemoryDataManagerOperation implements HsMemoryDataManagerOpe
     }
 
     @Override
-    public void markBufferReadableFromFile(int subpartitionId, int bufferIndex) {
+    public void markBufferReleasedFromFile(int subpartitionId, int bufferIndex) {
         markBufferReadableConsumer.accept(subpartitionId, bufferIndex);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Hybrid shuffle relies on the index to read the disk data. Since the spilled data may be consumed from memory, the readable status is introduced. For the readable buffer, FileDataManager does not pre-load it. However, when the downstream fails, the previous readable status will be used incorrectly, resulting in that some buffer cannot be read correctly.*


## Brief change log

  - *Change the logical of compute readable region to support subpartitionReader register multiple times.*
  - *Avoid possible deadlock in SubpartitionView and FileDataManager.*


## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
