### PR TITLE
[hotfix] [docs] Fix Typo in sql_functions/sql_functions_zh dayoofweek/dayofmonth  introduction

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -447,7 +447,9 @@ temporal:
   - sql: DAYOFYEAR(date)
     description:  Returns the day of a year (an integer between 1 and 366) from SQL date date. Equivalent to EXTRACT(DOY FROM date). E.g., DAYOFYEAR(DATE '1994-09-27') returns 270.
   - sql: DAYOFMONTH
-    description: Returns the day of a month (an integer between 1 and 31) from SQL date date. Equivalent to EXTRACT(DAY FROM date). E.g., DAYOFWEEK(DATE '1994-09-27') returns 3.
+    description: Returns the day of a month (an integer between 1 and 31) from SQL date date. Equivalent to EXTRACT(DAY FROM date). E.g., DAYOFMONTH(DATE '1994-09-27') returns 27.
+  - sql: DAYOFWEEK
+    description: Returns the day of a week (an integer between 1 and 7) from SQL date date. Equivalent to EXTRACT(DAY FROM date). E.g., DAYOFWEEK(DATE '1994-09-27') returns 3.
   - sql: HOUR(timestamp)
     description: Returns the hour of a day (an integer between 0 and 23) from SQL timestamp timestamp. Equivalent to EXTRACT(HOUR FROM timestamp). E.g., MINUTE(TIMESTAMP '1994-09-27 13:14:15') returns 14.
   - sql: MINUTE(timestamp)

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -550,6 +550,10 @@ temporal:
   - sql: DAYOFMONTH
     description: |
       从 SQL 日期 date 返回一个月中的第几天（1 到 31 之间的整数）。相当于 EXTRACT(DAY FROM date)。
+      例如 `DAYOFMONTH(DATE '1994-09-27')` 返回 27。
+  - sql: DAYOFWEEK
+    description: |
+      从 SQL 日期 date 返回一个星期中的第几天（1 到 31 之间的整数）。相当于 EXTRACT(DAY FROM date)。
       例如 `DAYOFWEEK(DATE '1994-09-27')` 返回 3。
   - sql: HOUR(timestamp)
     description: |


### PR DESCRIPTION
## What is the purpose of the change

The built-in functions dayofmonth and dayofweek of Flink SQL are incorrectly described,It appears that this error exists in other versions as well


## Brief change log
Describe the two wrong functions separately