### PR TITLE
[FLINK-29207][connector/pulsar] release-1.15 Fix Pulsar message eventTime may be incorrectly set to a negative number

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -212,7 +212,7 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
         } else {
             // Set default message timestamp if flink has provided one.
             Long timestamp = context.timestamp();
-            if (timestamp != null) {
+            if (timestamp != null && timestamp > 0L) {
                 builder.eventTime(timestamp);
             }
         }


### PR DESCRIPTION
## What is the purpose of the change
We'd better judge that the `timestamp` is greater than 0, we should skip setting eventTime when timestamp less than or equal to 0, otherwise the pulsar client will throw an exception.

## Brief change log
check the `timestamp` is greater than 0

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
