### PR TITLE
[FLINK-29198][test] Fail after maximum RetryOnException

### DIFF
--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/retry/strategy/RetryOnExceptionStrategy.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/retry/strategy/RetryOnExceptionStrategy.java
@@ -22,7 +22,10 @@ import org.opentest4j.TestAbortedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** Retry strategy that retry fixed times, and will not fail with some kind of exception. */
+/**
+ * A retry strategy that will ignore a specific type of exception and retry a test if it occurs, up
+ * to a fixed number of times.
+ */
 public class RetryOnExceptionStrategy extends AbstractRetryStrategy {
     private static final Logger LOG = LoggerFactory.getLogger(RetryOnExceptionStrategy.class);
 
@@ -37,6 +40,12 @@ public class RetryOnExceptionStrategy extends AbstractRetryStrategy {
     @Override
     public void handleException(String testName, int attemptIndex, Throwable throwable)
             throws Throwable {
+        // Failed when reach the total retry times
+        if (attemptIndex >= totalTimes) {
+            LOG.error("Test Failed at the last retry.", throwable);
+            throw throwable;
+        }
+
         if (repeatableException.isAssignableFrom(throwable.getClass())) {
             // continue retrying when get some repeatable exceptions
             String retryMsg =

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/retry/strategy/RetryStrategy.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/testutils/junit/extensions/retry/strategy/RetryStrategy.java
@@ -27,11 +27,17 @@ public interface RetryStrategy {
     void stopFollowingAttempts();
 
     /**
-     * Handle the exception after the test execution.
+     * Handle an exception that occurred during the annotated test attempt.
+     *
+     * <p>This method can swallow the exception to pass the test.
      *
      * @param testName the test name
      * @param attemptIndex test attempt index that starts from 1
      * @param throwable the throwable that the test case throws
+     * @throws org.opentest4j.TestAbortedException When handling a test attempt failure, throwing
+     *     this exception indicates another attempt should be made.
+     * @throws Throwable Propagating the original exception, or throwing any other exception
+     *     indicates that the test has definitively failed and no further attempts should be made.
      */
     void handleException(String testName, int attemptIndex, Throwable throwable) throws Throwable;
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionExtensionTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionExtensionTest.java
@@ -19,14 +19,21 @@
 package org.apache.flink.testutils.junit;
 
 import org.apache.flink.testutils.junit.extensions.retry.RetryExtension;
+import org.apache.flink.testutils.junit.extensions.retry.strategy.RetryOnExceptionStrategy;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opentest4j.TestAbortedException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import java.util.stream.Stream;
 
-/** Tests for the RetryOnException annotation. */
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for the {@link RetryOnException} annotation on JUnit5 {@link RetryExtension}. */
 @ExtendWith(RetryExtension.class)
 class RetryOnExceptionExtensionTest {
 
@@ -42,10 +49,10 @@ class RetryOnExceptionExtensionTest {
 
     @AfterAll
     static void verify() {
-        assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithMatchingException);
-        assertEquals(NUMBER_OF_RUNS + 1, runsForTestWithSubclassException);
-        assertEquals(1, runsForSuccessfulTest);
-        assertEquals(2, runsForPassAfterOneFailure);
+        assertThat(runsForTestWithMatchingException).isEqualTo(NUMBER_OF_RUNS + 1);
+        assertThat(runsForTestWithSubclassException).isEqualTo(NUMBER_OF_RUNS + 1);
+        assertThat(runsForSuccessfulTest).isOne();
+        assertThat(runsForPassAfterOneFailure).isEqualTo(2);
     }
 
     @TestTemplate
@@ -79,5 +86,43 @@ class RetryOnExceptionExtensionTest {
         if (runsForPassAfterOneFailure == 1) {
             throw new IllegalArgumentException();
         }
+    }
+
+    @ParameterizedTest(name = "Retrying with {0}")
+    @MethodSource("retryTestProvider")
+    void testRetryFailsWithExpectedExceptionAfterNumberOfRetries(
+            final Throwable expectedException) {
+        final int numberOfRetries = 1;
+        RetryOnExceptionStrategy retryOnExceptionStrategy =
+                new RetryOnExceptionStrategy(numberOfRetries, expectedException.getClass());
+        // All attempts that permit a retry should be a TestAbortedException.  When retries are no
+        // longer permitted, the handled exception should be propagated.
+        for (int j = 0; j <= numberOfRetries; j++) {
+            final int attemptIndex = j;
+            assertThatThrownBy(
+                            () ->
+                                    retryOnExceptionStrategy.handleException(
+                                            "Any test name", attemptIndex, expectedException))
+                    .isInstanceOf(
+                            j == numberOfRetries
+                                    ? expectedException.getClass()
+                                    : TestAbortedException.class);
+        }
+    }
+
+    static class RetryTestError extends Error {}
+
+    static class RetryTestException extends Exception {}
+
+    static class RetryTestRuntimeException extends RuntimeException {}
+
+    static class RetryTestThrowable extends Throwable {}
+
+    static Stream<Throwable> retryTestProvider() {
+        return Stream.of(
+                new RetryTestError(),
+                new RetryTestException(),
+                new RetryTestRuntimeException(),
+                new RetryTestThrowable());
     }
 }

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnExceptionTest.java
@@ -18,17 +18,16 @@
 
 package org.apache.flink.testutils.junit;
 
-import org.apache.flink.testutils.junit.extensions.retry.RetryExtension;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for the RetryOnException annotation. */
-@ExtendWith(RetryExtension.class)
-class RetryOnExceptionTest {
+/** Tests for the {@link RetryOnException} annotation on JUnit4 {@link RetryRule}. */
+public class RetryOnExceptionTest {
+
+    @Rule public RetryRule retryRule = new RetryRule();
 
     private static final int NUMBER_OF_RUNS = 3;
 
@@ -40,41 +39,41 @@ class RetryOnExceptionTest {
 
     private static int runsForPassAfterOneFailure = 0;
 
-    @AfterAll
+    @AfterClass
     public static void verify() {
         assertThat(runsForTestWithMatchingException).isEqualTo(NUMBER_OF_RUNS + 1);
         assertThat(runsForTestWithSubclassException).isEqualTo(NUMBER_OF_RUNS + 1);
-        assertThat(runsForSuccessfulTest).isEqualTo(1);
+        assertThat(runsForSuccessfulTest).isOne();
         assertThat(runsForPassAfterOneFailure).isEqualTo(2);
     }
 
-    @TestTemplate
+    @Test
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    void testSuccessfulTest() {
+    public void testSuccessfulTest() {
         runsForSuccessfulTest++;
     }
 
-    @TestTemplate
+    @Test
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    void testMatchingException() {
+    public void testMatchingException() {
         runsForTestWithMatchingException++;
         if (runsForTestWithMatchingException <= NUMBER_OF_RUNS) {
             throw new IllegalArgumentException();
         }
     }
 
-    @TestTemplate
+    @Test
     @RetryOnException(times = NUMBER_OF_RUNS, exception = RuntimeException.class)
-    void testSubclassException() {
+    public void testSubclassException() {
         runsForTestWithSubclassException++;
         if (runsForTestWithSubclassException <= NUMBER_OF_RUNS) {
             throw new IllegalArgumentException();
         }
     }
 
-    @TestTemplate
+    @Test
     @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
-    void testPassAfterOneFailure() {
+    public void testPassAfterOneFailure() {
         runsForPassAfterOneFailure++;
         if (runsForPassAfterOneFailure == 1) {
             throw new IllegalArgumentException();

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureExtensionTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureExtensionTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-/** Tests for the RetryOnFailure annotation. */
+/** Tests for the {@link RetryOnFailure} annotation on JUnit5 {@link RetryExtension}. */
 @ExtendWith(RetryExtension.class)
 class RetryOnFailureExtensionTest {
 

--- a/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureTest.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/test/java/org/apache/flink/testutils/junit/RetryOnFailureTest.java
@@ -18,17 +18,16 @@
 
 package org.apache.flink.testutils.junit;
 
-import org.apache.flink.testutils.junit.extensions.retry.RetryExtension;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for the RetryOnFailure annotation. */
-@ExtendWith(RetryExtension.class)
-class RetryOnFailureTest {
+/** Tests for the {@link RetryOnFailure} annotation on JUnit4 {@link RetryRule}. */
+public class RetryOnFailureTest {
+
+    @Rule public RetryRule retryRule = new RetryRule();
 
     private static final int NUMBER_OF_RUNS = 5;
 
@@ -38,15 +37,15 @@ class RetryOnFailureTest {
 
     private static boolean firstRun = true;
 
-    @AfterAll
-    static void verify() {
+    @AfterClass
+    public static void verify() throws Exception {
         assertThat(numberOfFailedRuns).isEqualTo(NUMBER_OF_RUNS + 1);
         assertThat(numberOfSuccessfulRuns).isEqualTo(3);
     }
 
-    @TestTemplate
+    @Test
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    void testRetryOnFailure() {
+    public void testRetryOnFailure() throws Exception {
         // All but the (expected) last run should be successful
         if (numberOfFailedRuns < NUMBER_OF_RUNS) {
             numberOfFailedRuns++;
@@ -56,9 +55,9 @@ class RetryOnFailureTest {
         }
     }
 
-    @TestTemplate
+    @Test
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    void testRetryOnceOnFailure() {
+    public void testRetryOnceOnFailure() throws Exception {
         if (firstRun) {
             numberOfFailedRuns++;
             firstRun = false;
@@ -68,9 +67,9 @@ class RetryOnFailureTest {
         }
     }
 
-    @TestTemplate
+    @Test
     @RetryOnFailure(times = NUMBER_OF_RUNS)
-    void testDontRetryOnSuccess() {
+    public void testDontRetryOnSuccess() throws Exception {
         numberOfSuccessfulRuns++;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request causes tests annotated with `@RetryOnException` to fail after the given number of retries when used with the JUnit5 `RetryExtension`.  This is the old behaviour we saw with the JUnit4 `RetryRule`.

Currently, the test is retried for the maximum number of executions, but the "expected" exception is never thrown even on the last try.  This causes the test to appear skipped instead of failed.

## Brief change log

- If the test doesn't succeed on the last possible retry, the exception is propagated as a test failure.
- I reverted some overeager JUnit5 migration on test cases for the JUnit4 `RetryRule`.  This code is appropriately duplicated for `RetryExtension`.

## Verifying this change

This change is already covered by existing tests, such as `RetryOnExceptionExtensionTest`.

I've manually tested that the following test now fails after the expected number of retries (instead of being skipped):

```
    @TestTemplate
    @RetryOnException(times = NUMBER_OF_RUNS, exception = IllegalArgumentException.class)
    void testThrowExceptionForever() {
        throw new IllegalArgumentException();
    }
```

**In JUnit5, it's very tricky to specify that a test is supposed to fail, but it's possible.**  I started down this route with a technique similar to [ExpectToFail](https://github.com/junit-team/junit5/blob/main/documentation/src/test/java/extensions/ExpectToFail.java) but it ends up needing to be very aware of the internals of our RetryExtension.  I'm not sure it's worth adding test extension code to test extension code, but I can continue down that route!

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
