### PR TITLE
[FLINK-29249][rpc] Drop RpcService#execute/scheduleRunnable

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -38,7 +38,6 @@ import org.apache.flink.util.ExecutorUtils;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
-import org.apache.flink.util.function.FunctionUtils;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
@@ -64,12 +63,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -79,7 +76,6 @@ import scala.reflect.ClassTag$;
 import static org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.guardCompletionWithContextClassLoader;
 import static org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader;
 import static org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.withContextClassLoader;
-import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -462,26 +458,6 @@ public class AkkaRpcService implements RpcService {
     @Override
     public ScheduledExecutor getScheduledExecutor() {
         return internalScheduledExecutor;
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleRunnable(Runnable runnable, long delay, TimeUnit unit) {
-        checkNotNull(runnable, "runnable");
-        checkNotNull(unit, "unit");
-        checkArgument(delay >= 0L, "delay must be zero or larger");
-
-        return internalScheduledExecutor.schedule(runnable, delay, unit);
-    }
-
-    @Override
-    public void execute(Runnable runnable) {
-        getScheduledExecutor().execute(runnable);
-    }
-
-    @Override
-    public <T> CompletableFuture<T> execute(Callable<T> callable) {
-        return CompletableFuture.supplyAsync(
-                FunctionUtils.uncheckedSupplier(callable::call), getScheduledExecutor());
     }
 
     // ---------------------------------------------------------------------------------------

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/AkkaRpcServiceTest.java
@@ -85,7 +85,6 @@ class AkkaRpcServiceTest {
     // ------------------------------------------------------------------------
     //  tests
     // ------------------------------------------------------------------------
-
     @Test
     void testScheduleRunnable() throws Exception {
         final OneShotLatch latch = new OneShotLatch();
@@ -93,7 +92,9 @@ class AkkaRpcServiceTest {
         final long start = System.nanoTime();
 
         ScheduledFuture<?> scheduledFuture =
-                akkaRpcService.scheduleRunnable(latch::trigger, delay, TimeUnit.MILLISECONDS);
+                akkaRpcService
+                        .getScheduledExecutor()
+                        .schedule(latch::trigger, delay, TimeUnit.MILLISECONDS);
 
         scheduledFuture.get();
 
@@ -110,31 +111,9 @@ class AkkaRpcServiceTest {
     void testExecuteRunnable() throws Exception {
         final OneShotLatch latch = new OneShotLatch();
 
-        akkaRpcService.execute(latch::trigger);
+        akkaRpcService.getScheduledExecutor().execute(latch::trigger);
 
         latch.await(30L, TimeUnit.SECONDS);
-    }
-
-    /**
-     * Tests that the {@link AkkaRpcService} can execute callables and returns their result as a
-     * {@link CompletableFuture}.
-     */
-    @Test
-    void testExecuteCallable() throws Exception {
-        final OneShotLatch latch = new OneShotLatch();
-        final int expected = 42;
-
-        CompletableFuture<Integer> result =
-                akkaRpcService.execute(
-                        () -> {
-                            latch.trigger();
-                            return expected;
-                        });
-
-        int actual = result.get(30L, TimeUnit.SECONDS);
-
-        assertThat(actual).isEqualTo(expected);
-        assertThat(latch.isTriggered()).isTrue();
     }
 
     @Test

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -114,7 +114,7 @@ class ContextClassLoadingSettingTest {
                         () ->
                                 contextClassLoader.complete(
                                         Thread.currentThread().getContextClassLoader()));
-        assertIsFlinkClassLoader(contextClassLoader.get());
+        assertThat(contextClassLoader.get()).isSameAs(pretendFlinkClassLoader);
     }
 
     @Test
@@ -128,7 +128,7 @@ class ContextClassLoadingSettingTest {
                                 0,
                                 TimeUnit.MILLISECONDS)
                         .get();
-        assertIsFlinkClassLoader(contextClassLoader);
+        assertThat(contextClassLoader).isSameAs(pretendFlinkClassLoader);
     }
 
     @Test
@@ -148,12 +148,13 @@ class ContextClassLoadingSettingTest {
 
     @Test
     void testAkkaRpcService_ScheduleRunnableWithFixedRateSetsFlinkContextClassLoader() {
-        final List<ClassLoader> contextClassLoaders = new ArrayList<>(2);
+        final int numberOfScheduledRuns = 2;
+        final List<ClassLoader> contextClassLoaders = new ArrayList<>(numberOfScheduledRuns);
         akkaRpcService
                 .getScheduledExecutor()
                 .scheduleAtFixedRate(
                         () -> {
-                            if (contextClassLoaders.size() < 2) {
+                            if (contextClassLoaders.size() < numberOfScheduledRuns) {
                                 contextClassLoaders.add(
                                         Thread.currentThread().getContextClassLoader());
                             } else {
@@ -171,12 +172,13 @@ class ContextClassLoadingSettingTest {
 
     @Test
     void testAkkaRpcService_ScheduleRunnableWithFixedDelaySetsFlinkContextClassLoader() {
-        final List<ClassLoader> contextClassLoaders = new ArrayList<>(2);
+        final int numberOfScheduledRuns = 2;
+        final List<ClassLoader> contextClassLoaders = new ArrayList<>(numberOfScheduledRuns);
         akkaRpcService
                 .getScheduledExecutor()
                 .scheduleWithFixedDelay(
                         () -> {
-                            if (contextClassLoaders.size() < 2) {
+                            if (contextClassLoaders.size() < numberOfScheduledRuns) {
                                 contextClassLoaders.add(
                                         Thread.currentThread().getContextClassLoader());
                             } else {

--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -41,10 +41,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
@@ -101,55 +99,6 @@ class ContextClassLoadingSettingTest {
 
         actorSystem = null;
         akkaRpcService = null;
-    }
-
-    @Test
-    void testAkkaRpcService_ExecuteRunnableSetsFlinkContextClassLoader()
-            throws ExecutionException, InterruptedException {
-        final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
-        akkaRpcService.execute(
-                () -> contextClassLoader.complete(Thread.currentThread().getContextClassLoader()));
-        assertIsFlinkClassLoader(contextClassLoader.get());
-    }
-
-    @Test
-    void testAkkaRpcService_ExecuteCallableSetsFlinkContextClassLoader()
-            throws ExecutionException, InterruptedException {
-        final CompletableFuture<ClassLoader> contextClassLoader =
-                akkaRpcService.execute(() -> Thread.currentThread().getContextClassLoader());
-        assertIsFlinkClassLoader(contextClassLoader.get());
-    }
-
-    @Test
-    void testAkkaRpcService_ExecuteCallableResultCompletedWithFlinkContextClassLoader()
-            throws ExecutionException, InterruptedException {
-
-        final CompletableFuture<Void> blocker = new CompletableFuture<>();
-
-        final CompletableFuture<ClassLoader> contextClassLoader =
-                runWithContextClassLoader(
-                        () ->
-                                akkaRpcService
-                                        .execute((Callable<Void>) blocker::get)
-                                        .thenApply(
-                                                ignored ->
-                                                        Thread.currentThread()
-                                                                .getContextClassLoader()),
-                        testClassLoader);
-        blocker.complete(null);
-
-        assertIsFlinkClassLoader(contextClassLoader.get());
-    }
-
-    @Test
-    void testAkkaRpcService_ScheduleSetsFlinkContextClassLoader()
-            throws ExecutionException, InterruptedException {
-        final CompletableFuture<ClassLoader> contextClassLoader = new CompletableFuture<>();
-        akkaRpcService.scheduleRunnable(
-                () -> contextClassLoader.complete(Thread.currentThread().getContextClassLoader()),
-                5,
-                TimeUnit.MILLISECONDS);
-        assertThat(contextClassLoader.get()).isSameAs(pretendFlinkClassLoader);
     }
 
     @Test

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -22,10 +22,7 @@ import org.apache.flink.runtime.rpc.exceptions.RpcConnectionException;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import java.io.Serializable;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Interface for rpc services. An rpc service is used to start and connect to a {@link RpcEndpoint}.
@@ -121,41 +118,4 @@ public interface RpcService {
      * @return The RPC service provided scheduled executor
      */
     ScheduledExecutor getScheduledExecutor();
-
-    /**
-     * Execute the runnable in the execution context of this RPC Service, as returned by {@link
-     * #getScheduledExecutor()} ()}, after a scheduled delay.
-     *
-     * @param runnable Runnable to be executed
-     * @param delay The delay after which the runnable will be executed
-     */
-    ScheduledFuture<?> scheduleRunnable(Runnable runnable, long delay, TimeUnit unit);
-
-    /**
-     * Execute the given runnable in the executor of the RPC service. This method can be used to run
-     * code outside of the main thread of a {@link RpcEndpoint}.
-     *
-     * <p><b>IMPORTANT:</b> This executor does not isolate the method invocations against any
-     * concurrent invocations and is therefore not suitable to run completion methods of futures
-     * that modify state of an {@link RpcEndpoint}. For such operations, one needs to use the {@link
-     * RpcEndpoint#getMainThreadExecutor() MainThreadExecutionContext} of that {@code RpcEndpoint}.
-     *
-     * @param runnable to execute
-     */
-    void execute(Runnable runnable);
-
-    /**
-     * Execute the given callable and return its result as a {@link CompletableFuture}. This method
-     * can be used to run code outside of the main thread of a {@link RpcEndpoint}.
-     *
-     * <p><b>IMPORTANT:</b> This executor does not isolate the method invocations against any
-     * concurrent invocations and is therefore not suitable to run completion methods of futures
-     * that modify state of an {@link RpcEndpoint}. For such operations, one needs to use the {@link
-     * RpcEndpoint#getMainThreadExecutor() MainThreadExecutionContext} of that {@code RpcEndpoint}.
-     *
-     * @param callable to execute
-     * @param <T> is the return value type
-     * @return Future containing the callable's future result
-     */
-    <T> CompletableFuture<T> execute(Callable<T> callable);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
@@ -332,12 +332,7 @@ public abstract class RetryingRegistration<
         rpcService
                 .getScheduledExecutor()
                 .schedule(
-                        new Runnable() {
-                            @Override
-                            public void run() {
-                                register(gateway, attempt, timeoutMillis);
-                            }
-                        },
+                        () -> register(gateway, attempt, timeoutMillis),
                         delay,
                         TimeUnit.MILLISECONDS);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/registration/RetryingRegistration.java
@@ -329,19 +329,23 @@ public abstract class RetryingRegistration<
 
     private void registerLater(
             final G gateway, final int attempt, final long timeoutMillis, long delay) {
-        rpcService.scheduleRunnable(
-                new Runnable() {
-                    @Override
-                    public void run() {
-                        register(gateway, attempt, timeoutMillis);
-                    }
-                },
-                delay,
-                TimeUnit.MILLISECONDS);
+        rpcService
+                .getScheduledExecutor()
+                .schedule(
+                        new Runnable() {
+                            @Override
+                            public void run() {
+                                register(gateway, attempt, timeoutMillis);
+                            }
+                        },
+                        delay,
+                        TimeUnit.MILLISECONDS);
     }
 
     private void startRegistrationLater(final long delay) {
-        rpcService.scheduleRunnable(this::startRegistration, delay, TimeUnit.MILLISECONDS);
+        rpcService
+                .getScheduledExecutor()
+                .schedule(this::startRegistration, delay, TimeUnit.MILLISECONDS);
     }
 
     static final class RetryingRegistrationResult<G, S, R> {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/util/MetricUtilsTest.java
@@ -49,6 +49,7 @@ import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.metrics.util.MetricUtils.METRIC_GROUP_FLINK;
 import static org.apache.flink.runtime.metrics.util.MetricUtils.METRIC_GROUP_MANAGED_MEMORY;
@@ -84,7 +85,11 @@ public class MetricUtilsTest extends TestLogger {
 
         try {
             final int threadPriority =
-                    rpcService.execute(() -> Thread.currentThread().getPriority()).get();
+                    rpcService
+                            .getScheduledExecutor()
+                            .schedule(
+                                    () -> Thread.currentThread().getPriority(), 0, TimeUnit.SECONDS)
+                            .get();
             assertThat(threadPriority, is(expectedThreadPriority));
         } finally {
             rpcService.stopService().get();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -31,7 +31,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayDeque;
@@ -52,7 +51,6 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -159,6 +157,7 @@ public class RetryingRegistrationTest extends TestLogger {
                 new ManualResponseTestRegistrationGateway(new TestRegistrationSuccess(testId));
 
         try {
+
             // RPC service that fails upon the first connection, but succeeds on the second
             RpcService rpc = mock(RpcService.class);
             when(rpc.connect(anyString(), any(Class.class)))
@@ -171,14 +170,6 @@ public class RetryingRegistrationTest extends TestLogger {
                                     testGateway) // second connection attempt succeeds
                             );
             when(rpc.getScheduledExecutor()).thenReturn(executor);
-            when(rpc.scheduleRunnable(any(Runnable.class), anyLong(), any(TimeUnit.class)))
-                    .thenAnswer(
-                            (InvocationOnMock invocation) -> {
-                                final Runnable runnable = invocation.getArgument(0);
-                                final long delay = invocation.getArgument(1);
-                                final TimeUnit timeUnit = invocation.getArgument(2);
-                                return executor.schedule(runnable, delay, timeUnit);
-                            });
 
             TestRetryingRegistration registration =
                     new TestRetryingRegistration(rpc, "foobar address", leaderId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/registration/RetryingRegistrationTest.java
@@ -157,7 +157,6 @@ public class RetryingRegistrationTest extends TestLogger {
                 new ManualResponseTestRegistrationGateway(new TestRegistrationSuccess(testId));
 
         try {
-
             // RPC service that fails upon the first connection, but succeeds on the second
             RpcService rpc = mock(RpcService.class);
             when(rpc.connect(anyString(), any(Class.class)))

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
@@ -23,11 +23,8 @@ import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import java.io.Serializable;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -210,20 +207,5 @@ public class TestingRpcService implements RpcService {
     @Override
     public ScheduledExecutor getScheduledExecutor() {
         return backingRpcService.getScheduledExecutor();
-    }
-
-    @Override
-    public ScheduledFuture<?> scheduleRunnable(Runnable runnable, long delay, TimeUnit unit) {
-        return backingRpcService.scheduleRunnable(runnable, delay, unit);
-    }
-
-    @Override
-    public void execute(Runnable runnable) {
-        backingRpcService.execute(runnable);
-    }
-
-    @Override
-    public <T> CompletableFuture<T> execute(Callable<T> callable) {
-        return backingRpcService.execute(callable);
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -72,9 +72,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Queue;
 import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -514,21 +512,6 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
         @Override
         public ScheduledExecutor getScheduledExecutor() {
             return rpcService.getScheduledExecutor();
-        }
-
-        @Override
-        public ScheduledFuture<?> scheduleRunnable(Runnable runnable, long delay, TimeUnit unit) {
-            return rpcService.scheduleRunnable(runnable, delay, unit);
-        }
-
-        @Override
-        public void execute(Runnable runnable) {
-            rpcService.execute(runnable);
-        }
-
-        @Override
-        public <T> CompletableFuture<T> execute(Callable<T> callable) {
-            return rpcService.execute(callable);
         }
 
         @SuppressWarnings("unchecked")


### PR DESCRIPTION
These make new implementations more complicated then it needs to be, since `getScheduledExecutor` subsumes all of them.