### PR TITLE
[FLINK-29253][runtime] Removes synchronous close call from DefaultJobManagerRunnerRegistry#localCleanupAsync

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistry.java
@@ -85,11 +85,7 @@ public class DefaultJobManagerRunnerRegistry implements JobManagerRunnerRegistry
     @Override
     public CompletableFuture<Void> localCleanupAsync(JobID jobId, Executor unusedExecutor) {
         if (isRegistered(jobId)) {
-            try {
-                unregister(jobId).close();
-            } catch (Exception e) {
-                return FutureUtils.completedExceptionally(e);
-            }
+            return unregister(jobId).closeAsync();
         }
 
         return FutureUtils.completedVoidFuture();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/dispatcher/DefaultJobManagerRunnerRegistryTest.java
@@ -101,9 +101,9 @@ public class DefaultJobManagerRunnerRegistryTest {
 
     @Test
     public void size() {
-        assertThat(testInstance.size()).isEqualTo(0);
+        assertThat(testInstance.size()).isZero();
         testInstance.register(TestingJobManagerRunner.newBuilder().build());
-        assertThat(testInstance.size()).isEqualTo(1);
+        assertThat(testInstance.size()).isOne();
         testInstance.register(TestingJobManagerRunner.newBuilder().build());
         assertThat(testInstance.size()).isEqualTo(2);
     }
@@ -134,7 +134,7 @@ public class DefaultJobManagerRunnerRegistryTest {
     }
 
     @Test
-    public void testSuccessfulLocalCleanup() throws Throwable {
+    public void testSuccessfulLocalCleanup() {
         final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
 
         assertThat(
@@ -168,7 +168,7 @@ public class DefaultJobManagerRunnerRegistryTest {
     }
 
     @Test
-    public void testSuccessfulLocalCleanupAsync() throws Exception {
+    public void testSuccessfulLocalCleanupAsync() {
         final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
 
         final CompletableFuture<Void> cleanupResult =
@@ -179,7 +179,7 @@ public class DefaultJobManagerRunnerRegistryTest {
     }
 
     @Test
-    public void testFailingLocalCleanupAsync() throws Exception {
+    public void testFailingLocalCleanupAsync() {
         final TestingJobManagerRunner jobManagerRunner = registerTestingJobManagerRunner();
 
         assertThat(testInstance.isRegistered(jobManagerRunner.getJobID())).isTrue();


### PR DESCRIPTION
## What is the purpose of the change

`localCleanupAsync` is meant to be called from the `Dispatcher`'s main thread. Any blocking calls should be avoided here. Instead, we could use `closeAsync` which is implemented by `JobManagerRunner`.

## Brief change log

* Replaced `close` call by the corresponding `closeAsync` call

## Verifying this change

* Adds test for checking the non-blocking behavior
* Adapted two other tests in `DefaultJobManagerRunnerRegistry` since the previously used `close` call resulted in an additional `FlinkException` being added to the Stacktrace in case of failure through `AutoCloseableAsync#close`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
