### PR TITLE
[FLINK-25868][build] Enable japicmp for all modules 

### DIFF
--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -115,11 +115,6 @@ under the License.
 					</scala>
 				</configuration>
 			</plugin>
-			<!-- activate API compatibility checks -->
-			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 			<!-- Scala Compiler -->
 			<plugin>
 				<groupId>net.alchim31.maven</groupId>

--- a/flink-connectors/flink-hadoop-compatibility/pom.xml
+++ b/flink-connectors/flink-hadoop-compatibility/pom.xml
@@ -117,7 +117,7 @@ under the License.
 			</plugin>
 			<!-- activate API compatibility checks -->
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
+				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
 			<!-- Scala Compiler -->

--- a/flink-connectors/flink-sql-connector-aws-kinesis-firehose/pom.xml
+++ b/flink-connectors/flink-sql-connector-aws-kinesis-firehose/pom.xml
@@ -30,6 +30,10 @@
 	<artifactId>flink-sql-connector-aws-kinesis-firehose</artifactId>
 	<name>Flink : Connectors : SQL : Amazon Kinesis Data Firehose</name>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-aws-kinesis-streams/pom.xml
+++ b/flink-connectors/flink-sql-connector-aws-kinesis-streams/pom.xml
@@ -30,6 +30,10 @@
 	<artifactId>flink-sql-connector-aws-kinesis-streams</artifactId>
 	<name>Flink : Connectors : SQL : Amazon Kinesis Data Streams</name>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
@@ -32,6 +32,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
@@ -32,6 +32,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-hive-2.3.9/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.9/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.2/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-sql-connector-pulsar/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-sql-connector-rabbitmq/pom.xml
+++ b/flink-connectors/flink-sql-connector-rabbitmq/pom.xml
@@ -34,6 +34,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -139,12 +139,6 @@ under the License.
 				</configuration>
 			</plugin>
 
-			<!-- activate API compatibility checks -->
-			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-
 			<!-- publish some test base classes -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -141,7 +141,7 @@ under the License.
 
 			<!-- activate API compatibility checks -->
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
+				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
 

--- a/flink-dist-scala/pom.xml
+++ b/flink-dist-scala/pom.xml
@@ -31,6 +31,10 @@ under the License.
 	<artifactId>flink-dist-scala_${scala.binary.version}</artifactId>
 	<name>Flink : Dist-Scala</name>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -34,6 +34,7 @@ under the License.
 
 	<properties>
 		<zookeeper.optional.version>3.6.3</zookeeper.optional.version>
+		<japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<dependencies>

--- a/flink-docs/pom.xml
+++ b/flink-docs/pom.xml
@@ -34,6 +34,7 @@ under the License.
 	<properties>
 		<generated.docs.dir>./docs/layouts/shortcodes/generated</generated.docs.dir>
 		<generated.static.dir>./docs/static/generated</generated.static.dir>
+		<japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<dependencies>

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -35,6 +35,7 @@ under the License.
 
 	<properties>
 		<excludeE2E/>
+		<japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<modules>

--- a/flink-examples/pom.xml
+++ b/flink-examples/pom.xml
@@ -31,6 +31,10 @@ under the License.
 	<name>Flink : Examples : </name>
 	<packaging>pom</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<modules>
 		<module>flink-examples-batch</module>
 		<module>flink-examples-streaming</module>

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -31,6 +31,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencyManagement>
 		<dependencies>
 			<dependency>

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -32,6 +32,7 @@ under the License.
 
 	<properties>
 		<fs.s3.aws.version>1.11.951</fs.s3.aws.version>
+		<japicmp.skip>true</japicmp.skip>
 	</properties>
 
 	<dependencies>

--- a/flink-formats/flink-sql-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-sql-avro-confluent-registry/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<repositories>
 		<repository>
 			<id>confluent</id>

--- a/flink-formats/flink-sql-avro/pom.xml
+++ b/flink-formats/flink-sql-avro/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-sql-csv/pom.xml
+++ b/flink-formats/flink-sql-csv/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-sql-json/pom.xml
+++ b/flink-formats/flink-sql-json/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-sql-orc/pom.xml
+++ b/flink-formats/flink-sql-orc/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-sql-protobuf/pom.xml
+++ b/flink-formats/flink-sql-protobuf/pom.xml
@@ -33,6 +33,10 @@ under the License.
 
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -71,7 +71,7 @@ under the License.
 		<plugins>
 			<!-- activate API compatibility checks -->
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
+				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
 

--- a/flink-java/pom.xml
+++ b/flink-java/pom.xml
@@ -69,12 +69,6 @@ under the License.
 
 	<build>
 		<plugins>
-			<!-- activate API compatibility checks -->
-			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-
 			<!-- Because flink-scala, flink-avro and flink-hadoop-compatibility uses it in tests -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -50,7 +50,7 @@ under the License.
 		<plugins>
 			<!-- activate API compatibility checks -->
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
+				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
 			<plugin>

--- a/flink-metrics/flink-metrics-core/pom.xml
+++ b/flink-metrics/flink-metrics-core/pom.xml
@@ -48,11 +48,6 @@ under the License.
 
 	<build>
 		<plugins>
-			<!-- activate API compatibility checks -->
-			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -157,7 +157,7 @@ under the License.
 
 			<!-- activate API compatibility checks -->
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
+				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
 

--- a/flink-scala/pom.xml
+++ b/flink-scala/pom.xml
@@ -155,12 +155,6 @@ under the License.
 				</configuration>
 			</plugin>
 
-			<!-- activate API compatibility checks -->
-			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -101,7 +101,7 @@ under the License.
 
 			<!-- activate API compatibility checks -->
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
+				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 			</plugin>
 

--- a/flink-streaming-java/pom.xml
+++ b/flink-streaming-java/pom.xml
@@ -98,13 +98,6 @@ under the License.
 
 	<build>
 		<plugins>
-
-			<!-- activate API compatibility checks -->
-			<plugin>
-				<groupId>io.github.zentol.japicmp</groupId>
-				<artifactId>japicmp-maven-plugin</artifactId>
-			</plugin>
-
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -256,7 +256,7 @@ under the License.
 
 			<!-- activate API compatibility checks -->
 			<plugin>
-				<groupId>com.github.siom79.japicmp</groupId>
+				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
 				<configuration>
 					<parameter>

--- a/flink-streaming-scala/pom.xml
+++ b/flink-streaming-scala/pom.xml
@@ -254,7 +254,6 @@ under the License.
 				</executions>
 			</plugin>
 
-			<!-- activate API compatibility checks -->
 			<plugin>
 				<groupId>io.github.zentol.japicmp</groupId>
 				<artifactId>japicmp-maven-plugin</artifactId>
@@ -272,14 +271,6 @@ under the License.
 						</excludes>
 					</parameter>
 				</configuration>
-				<executions>
-					<execution>
-						<phase>verify</phase>
-						<goals>
-							<goal>cmp</goal>
-						</goals>
-					</execution>
-				</executions>
 			</plugin>
 
 			<!-- Generate the test-jar -->

--- a/flink-table/flink-table-planner-loader-bundle/pom.xml
+++ b/flink-table/flink-table-planner-loader-bundle/pom.xml
@@ -34,6 +34,10 @@
 	<packaging>jar</packaging>
 	<description>Intermediate build artifact used by the flink-table-planner-loader.</description>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-yarn-tests/pom.xml
+++ b/flink-yarn-tests/pom.xml
@@ -36,6 +36,10 @@ under the License.
 	<name>Flink : Yarn Tests</name>
 	<packaging>jar</packaging>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		
 		<!-- test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -2185,6 +2185,9 @@ under the License.
 							<skipPomModules>true</skipPomModules>
 							<!-- Don't break build on newly added maven modules -->
 							<ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
+							<packagingSupporteds>
+								<packagingSupported>jar</packagingSupported>
+							</packagingSupporteds>
 						</parameter>
 						<projectBuildDir>${rootDir}/${japicmp.outputDir}/${project.artifactId}</projectBuildDir>
 						<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -964,7 +964,7 @@ under the License.
 							<version>3.2.4</version>
 						</plugin>
 						<plugin>
-							<groupId>com.github.siom79.japicmp</groupId>
+							<groupId>io.github.zentol.japicmp</groupId>
 							<artifactId>japicmp-maven-plugin</artifactId>
 							<dependencies>
 								<dependency>
@@ -1124,7 +1124,7 @@ under the License.
 							</configuration>
 						</plugin>
 						<plugin>
-							<groupId>com.github.siom79.japicmp</groupId>
+							<groupId>io.github.zentol.japicmp</groupId>
 							<artifactId>japicmp-maven-plugin</artifactId>
 							<configuration>
 								<skip>true</skip>
@@ -2125,9 +2125,9 @@ under the License.
 
 				<!-- Configuration for the binary compatibility checker -->
 				<plugin>
-					<groupId>com.github.siom79.japicmp</groupId>
+					<groupId>io.github.zentol.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.11.0</version>
+					<version>0.16.0_m325</version>
 					<configuration>
 						<oldVersion>
 							<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1396,6 +1396,12 @@ under the License.
 			</plugin>
 
 			<plugin>
+				<!-- activate API compatibility checks -->
+				<groupId>io.github.zentol.japicmp</groupId>
+				<artifactId>japicmp-maven-plugin</artifactId>
+			</plugin>
+
+			<plugin>
 				<groupId>org.apache.rat</groupId>
 				<artifactId>apache-rat-plugin</artifactId>
 				<version>0.13</version>

--- a/tools/ci/java-ci-tools/pom.xml
+++ b/tools/ci/java-ci-tools/pom.xml
@@ -33,6 +33,10 @@ under the License.
 	<version>1.17-SNAPSHOT</version>
 	<name>Flink : Tools : CI : Java</name>
 
+	<properties>
+		<japicmp.skip>true</japicmp.skip>
+	</properties>
+
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>


### PR DESCRIPTION
Enables japicmp in all modules, skipping pom/quickstart/packaging modules to reduce noise and build times, using a custom version provided by yours truly.