### PR TITLE
[FLINK-29260][release] Wipe exclusion list when updating reference version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2154,6 +2154,7 @@ under the License.
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
 								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
+								<!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
 								<exclude>org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator#getSideOutput(org.apache.flink.util.OutputTag)</exclude>
 								<exclude>org.apache.flink.streaming.api.datastream.DataStream#DataStream(org.apache.flink.streaming.api.environment.StreamExecutionEnvironment,org.apache.flink.streaming.api.transformations.StreamTransformation)</exclude>
 								<exclude>org.apache.flink.streaming.api.environment.LegacyLocalStreamEnvironment</exclude>
@@ -2174,6 +2175,7 @@ under the License.
 								<exclude>org.apache.flink.metrics.Histogram#getMetricType()</exclude>
 								<exclude>org.apache.flink.api.connector.source.SplitEnumeratorContext#sendEventToSourceReader(int,int,org.apache.flink.api.connector.source.SourceEvent)</exclude>
 								<exclude>org.apache.flink.api.connector.source.SplitEnumeratorContext#registeredReadersOfAttempts()</exclude>
+								<!-- MARKER: end exclusions -->
 							</excludes>
 							<accessModifier>public</accessModifier>
 							<breakBuildOnModifications>false</breakBuildOnModifications>

--- a/tools/releasing/update_japicmp_configuration.sh
+++ b/tools/releasing/update_japicmp_configuration.sh
@@ -59,6 +59,13 @@ function set_japicmp_reference_version() {
   perl -pi -e 's#(<japicmp.referenceVersion>).*(</japicmp.referenceVersion>)#${1}'${version}'${2}#' ${POM}
 }
 
+function clear_exclusions() {
+  exclusion_start=$(($(sed -n '/<!-- MARKER: start exclusions/=' ${POM}) + 1))
+  exclusion_end=$(($(sed -n '/<!-- MARKER: end exclusions/=' ${POM}) - 1))
+
+  sed -i "${exclusion_start},${exclusion_end}d" ${POM}
+}
+
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 
 if [[ ${current_branch} =~ -rc ]]; then
@@ -73,10 +80,12 @@ if [[ ${current_branch} =~ -rc ]]; then
 elif [[ ${current_branch} =~ ^master$ ]]; then
   # master branch
   set_japicmp_reference_version ${NEW_VERSION}
+  clear_exclusions
 elif [[ ${current_branch} =~ ^release- ]]; then
   # snapshot branch
   set_japicmp_reference_version ${NEW_VERSION}
   enable_public_evolving_compatibility_checks
+  clear_exclusions
 else
   echo "Script was called from unexpected branch ${current_branch}; should be rc/snapshot/master branch."
   exit 1

--- a/tools/releasing/update_japicmp_configuration.sh
+++ b/tools/releasing/update_japicmp_configuration.sh
@@ -63,7 +63,9 @@ function clear_exclusions() {
   exclusion_start=$(($(sed -n '/<!-- MARKER: start exclusions/=' ${POM}) + 1))
   exclusion_end=$(($(sed -n '/<!-- MARKER: end exclusions/=' ${POM}) - 1))
 
-  sed -i "${exclusion_start},${exclusion_end}d" ${POM}
+  if [[ $exclusion_start -lt $exclusion_end ]]; then
+    sed -i "${exclusion_start},${exclusion_end}d" ${POM}
+  fi
 }
 
 current_branch=$(git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
Japicmp exclusion denote changes that break source/binary compatibility which we have concluded to accept.
Since we always compare one from version to the immediately next version these exclusions are only required for a single release.

They will now be discarded automatically as part of the release process, when:
* the master branch is updated to compare against the new minor version
* the release branch is updated to compare against the new patch version