### PR TITLE
[FLINK-27952][table-planner] Throw error while trying to convert Double.Infinity/NaN to BigDecimal in value literal expression

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/expressions/ValueLiteralExpression.java
@@ -198,6 +198,14 @@ public final class ValueLiteralExpression implements ResolvedExpression {
 
     private @Nullable BigDecimal convertToBigDecimal(Object value) {
         if (Number.class.isAssignableFrom(value.getClass())) {
+            if (value instanceof Double || value instanceof Float) {
+                if (value.toString().equalsIgnoreCase("infinity")
+                        || value.toString().equalsIgnoreCase("-infinity")
+                        || value.toString().equalsIgnoreCase("nan")) {
+                    throw new ExpressionParserException(
+                            "expression parse failed by trying to convert infinity/nan to Decimal");
+                }
+            }
             return new BigDecimal(String.valueOf(value));
         }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/FunctionITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/table/FunctionITCase.java
@@ -18,10 +18,15 @@
 
 package org.apache.flink.table.planner.runtime.stream.table;
 
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.annotation.DataTypeHint;
 import org.apache.flink.table.annotation.FunctionHint;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.ExpressionParserException;
 import org.apache.flink.table.functions.ScalarFunction;
 import org.apache.flink.table.functions.TableFunction;
 import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
@@ -116,9 +121,68 @@ public class FunctionITCase extends StreamingTestBase {
                                 "A lateral join only accepts an expression which defines a table function"));
     }
 
+    @Test
+    public void testTableUdf() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        DataStream<Row> data = env.fromElements(Row.of(1), Row.of(2));
+        StreamTableEnvironment tEnv = StreamTableEnvironment.create(env);
+        Table table = tEnv.fromDataStream(data).as("f0");
+        Double[][] d = new Double[][] {new Double[] {1.0, Double.NaN}};
+        Expression[] expressions = new Expression[2];
+        expressions[0] = org.apache.flink.table.api.Expressions.call(MyUDF.class, $("f0"), d);
+        expressions[1] = org.apache.flink.table.api.Expressions.call(MyUDF.class, $("f0"), d);
+        assertThatThrownBy(
+                        () ->
+                                table.addColumns(expressions)
+                                        .as("f0", "output1", "output2")
+                                        .execute())
+                .satisfies(
+                        anyCauseMatches(
+                                ExpressionParserException.class,
+                                "expression parse failed by trying to convert infinity/nan to Decimal"));
+
+        Double[][] d1 = new Double[][] {new Double[] {1.0, Double.POSITIVE_INFINITY}};
+        expressions[0] = org.apache.flink.table.api.Expressions.call(MyUDF.class, $("f0"), d1);
+        expressions[1] = org.apache.flink.table.api.Expressions.call(MyUDF.class, $("f0"), d1);
+        assertThatThrownBy(
+                        () ->
+                                table.addColumns(expressions)
+                                        .as("f0", "output1", "output2")
+                                        .execute())
+                .satisfies(
+                        anyCauseMatches(
+                                ExpressionParserException.class,
+                                "expression parse failed by trying to convert infinity/nan to Decimal"));
+
+        Float[][] f = new Float[][] {new Float[] {1.0F, Float.NEGATIVE_INFINITY}};
+        expressions[0] = org.apache.flink.table.api.Expressions.call(MyUDF1.class, $("f0"), f);
+        expressions[1] = org.apache.flink.table.api.Expressions.call(MyUDF1.class, $("f0"), f);
+        assertThatThrownBy(
+                        () ->
+                                table.addColumns(expressions)
+                                        .as("f0", "output1", "output2")
+                                        .execute())
+                .satisfies(
+                        anyCauseMatches(
+                                ExpressionParserException.class,
+                                "expression parse failed by trying to convert infinity/nan to Decimal"));
+    }
+
     // --------------------------------------------------------------------------------------------
     // Test functions
     // --------------------------------------------------------------------------------------------
+
+    public static class MyUDF extends ScalarFunction {
+        public Double eval(Double num, Double[][] add) {
+            return num + add[0][0];
+        }
+    }
+
+    public static class MyUDF1 extends ScalarFunction {
+        public Float eval(Float num, Float[][] add) {
+            return num + add[0][0];
+        }
+    }
 
     /** Simple scalar function. */
     public static class SimpleScalarFunction extends ScalarFunction {


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When user use UDF, they may define `Double.Infinity` or `Double.NaN` in `Expression`. For numerical value like Double and Float, it will be converted to and stored as BigDecimal type in value literal expression convert step. However, for `Double.Infinity` or `Double.NaN,` it cannot be converted to BigDecimal. So this pr is aims to throw error when these cases appeared.


## Brief change log

- Throw error while trying to convert Double.Infinity/NaN to BigDecimal in value literal expression.
- Adding UT tests.


## Verifying this change

- Adding UT tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
