### PR TITLE
[FLINK-29285][tests] Move TestUtils#getResource

### DIFF
--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/src/test/java/org/apache/flink/connector/firehose/table/test/KinesisFirehoseTableITTest.java
@@ -22,8 +22,8 @@ import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.connector.aws.testutils.LocalstackContainer;
 import org.apache.flink.connector.testframe.container.FlinkContainers;
 import org.apache.flink.connector.testframe.container.TestcontainersSettings;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.util.DockerImageVersions;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
@@ -84,7 +84,7 @@ public class KinesisFirehoseTableITTest extends TestLogger {
 
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
-    private final Path sqlConnectorFirehoseJar = TestUtils.getResource(".*firehose.jar");
+    private final Path sqlConnectorFirehoseJar = ResourceTestUtils.getResource(".*firehose.jar");
 
     private SdkHttpClient httpClient;
     private S3Client s3Client;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/table/test/KinesisStreamsTableApiIT.java
@@ -24,8 +24,8 @@ import org.apache.flink.connector.aws.util.AWSGeneralUtil;
 import org.apache.flink.connector.testframe.container.FlinkContainers;
 import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.connectors.kinesis.testutils.KinesaliteContainer;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.util.DockerImageVersions;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
 
@@ -84,7 +84,8 @@ public class KinesisStreamsTableApiIT {
     private SdkHttpClient httpClient;
     private KinesisClient kinesisClient;
 
-    private final Path sqlConnectorKinesisJar = TestUtils.getResource(".*kinesis-streams.jar");
+    private final Path sqlConnectorKinesisJar =
+            ResourceTestUtils.getResource(".*kinesis-streams.jar");
     private static final Network network = Network.newNetwork();
 
     @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSinkE2ECase.java
@@ -27,7 +27,7 @@ import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem
 import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
 import org.apache.flink.connector.testframe.testsuites.SinkTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
-import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.testcontainers.containers.KafkaContainer;
@@ -66,15 +66,15 @@ public class KafkaSinkE2ECase extends SinkTestSuiteBase<String> {
             new KafkaSinkExternalContextFactory(
                     kafka.getContainer(),
                     Arrays.asList(
-                            TestUtils.getResource("kafka-connector.jar")
+                            ResourceTestUtils.getResource("kafka-connector.jar")
                                     .toAbsolutePath()
                                     .toUri()
                                     .toURL(),
-                            TestUtils.getResource("kafka-clients.jar")
+                            ResourceTestUtils.getResource("kafka-clients.jar")
                                     .toAbsolutePath()
                                     .toUri()
                                     .toURL(),
-                            TestUtils.getResource("flink-connector-testing.jar")
+                            ResourceTestUtils.getResource("flink-connector-testing.jar")
                                     .toAbsolutePath()
                                     .toUri()
                                     .toURL()));

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSourceE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/KafkaSourceE2ECase.java
@@ -27,7 +27,7 @@ import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem
 import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
 import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
-import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.testcontainers.containers.KafkaContainer;
@@ -66,8 +66,8 @@ public class KafkaSourceE2ECase extends SourceTestSuiteBase<String> {
             new KafkaSourceExternalContextFactory(
                     kafka.getContainer(),
                     Arrays.asList(
-                            TestUtils.getResource("kafka-connector.jar").toUri().toURL(),
-                            TestUtils.getResource("kafka-clients.jar").toUri().toURL()),
+                            ResourceTestUtils.getResource("kafka-connector.jar").toUri().toURL(),
+                            ResourceTestUtils.getResource("kafka-clients.jar").toUri().toURL()),
                     PARTITION);
 
     @SuppressWarnings("unused")
@@ -76,8 +76,8 @@ public class KafkaSourceE2ECase extends SourceTestSuiteBase<String> {
             new KafkaSourceExternalContextFactory(
                     kafka.getContainer(),
                     Arrays.asList(
-                            TestUtils.getResource("kafka-connector.jar").toUri().toURL(),
-                            TestUtils.getResource("kafka-clients.jar").toUri().toURL()),
+                            ResourceTestUtils.getResource("kafka-connector.jar").toUri().toURL(),
+                            ResourceTestUtils.getResource("kafka-clients.jar").toUri().toURL()),
                     TOPIC);
 
     public KafkaSourceE2ECase() throws Exception {}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientKafkaITCase.java
@@ -20,8 +20,8 @@ package org.apache.flink.tests.util.kafka;
 
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.cache.DownloadCache;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.tests.util.flink.FlinkResource;
@@ -101,8 +101,8 @@ public class SQLClientKafkaITCase extends TestLogger {
 
     @ClassRule public static final DownloadCache DOWNLOAD_CACHE = DownloadCache.get();
 
-    private static final Path sqlAvroJar = TestUtils.getResource(".*avro.jar");
-    private static final Path sqlToolBoxJar = TestUtils.getResource(".*SqlToolbox.jar");
+    private static final Path sqlAvroJar = ResourceTestUtils.getResource(".*avro.jar");
+    private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*SqlToolbox.jar");
     private final List<Path> apacheAvroJars = new ArrayList<>();
     private final Path sqlConnectorKafkaJar;
 
@@ -116,7 +116,7 @@ public class SQLClientKafkaITCase extends TestLogger {
         this.kafkaSQLVersion = kafkaSQLVersion;
         this.kafkaIdentifier = kafkaIdentifier;
 
-        this.sqlConnectorKafkaJar = TestUtils.getResource(kafkaSQLJarPattern);
+        this.sqlConnectorKafkaJar = ResourceTestUtils.getResource(kafkaSQLJarPattern);
     }
 
     @Before

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SQLClientSchemaRegistryITCase.java
@@ -21,8 +21,8 @@ package org.apache.flink.tests.util.kafka;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.connector.testframe.container.FlinkContainers;
 import org.apache.flink.connector.testframe.container.TestcontainersSettings;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.kafka.containers.SchemaRegistryContainer;
 import org.apache.flink.util.DockerImageVersions;
 
@@ -65,10 +65,11 @@ public class SQLClientSchemaRegistryITCase {
 
     public static final String INTER_CONTAINER_KAFKA_ALIAS = "kafka";
     public static final String INTER_CONTAINER_REGISTRY_ALIAS = "registry";
-    private static final Path sqlAvroJar = TestUtils.getResource(".*avro.jar");
-    private static final Path sqlAvroRegistryJar = TestUtils.getResource(".*avro-confluent.jar");
-    private static final Path sqlToolBoxJar = TestUtils.getResource(".*SqlToolbox.jar");
-    private final Path sqlConnectorKafkaJar = TestUtils.getResource(".*kafka.jar");
+    private static final Path sqlAvroJar = ResourceTestUtils.getResource(".*avro.jar");
+    private static final Path sqlAvroRegistryJar =
+            ResourceTestUtils.getResource(".*avro-confluent.jar");
+    private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*SqlToolbox.jar");
+    private final Path sqlConnectorKafkaJar = ResourceTestUtils.getResource(".*kafka.jar");
 
     @ClassRule public static final Network NETWORK = Network.newNetwork();
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
@@ -25,8 +25,8 @@ import org.apache.flink.connector.testframe.container.FlinkContainers;
 import org.apache.flink.connector.testframe.container.FlinkContainersSettings;
 import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.streaming.api.environment.ExecutionCheckpointingOptions;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.JobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.util.TestLoggerExtension;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
@@ -129,7 +129,7 @@ public class SmokeKafkaITCase {
 
     @Test
     public void testKafka() throws Exception {
-        final Path kafkaExampleJar = TestUtils.getResource(EXAMPLE_JAR_MATCHER);
+        final Path kafkaExampleJar = ResourceTestUtils.getResource(EXAMPLE_JAR_MATCHER);
 
         final String inputTopic = "test-input-" + "-" + UUID.randomUUID();
         final String outputTopic = "test-output" + "-" + UUID.randomUUID();

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common/src/main/java/org/apache/flink/tests/util/TestUtils.java
@@ -18,79 +18,23 @@
 
 package org.apache.flink.tests.util;
 
-import org.apache.flink.test.parameters.ParameterProperty;
-
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /** General test utilities. */
 public enum TestUtils {
     ;
-
-    private static final ParameterProperty<Path> MODULE_DIRECTORY =
-            new ParameterProperty<>("moduleDir", Paths::get);
-
-    /**
-     * Searches for a resource file matching the given regex in the given directory. This method is
-     * primarily intended to be used for the initialization of static {@link Path} fields for
-     * resource file(i.e. jar, config file) that reside in the modules {@code target} directory.
-     *
-     * @param resourceNameRegex regex pattern to match against
-     * @return Path pointing to the matching jar
-     * @throws RuntimeException if none or multiple resource files could be found
-     */
-    public static Path getResource(final String resourceNameRegex) {
-        // if the property is not set then we are most likely running in the IDE, where the working
-        // directory is the
-        // module of the test that is currently running, which is exactly what we want
-        Path moduleDirectory = MODULE_DIRECTORY.get(Paths.get("").toAbsolutePath());
-
-        try (Stream<Path> dependencyResources = Files.walk(moduleDirectory)) {
-            final List<Path> matchingResources =
-                    dependencyResources
-                            .filter(
-                                    jar ->
-                                            Pattern.compile(resourceNameRegex)
-                                                    .matcher(jar.toAbsolutePath().toString())
-                                                    .find())
-                            .collect(Collectors.toList());
-            switch (matchingResources.size()) {
-                case 0:
-                    throw new RuntimeException(
-                            new FileNotFoundException(
-                                    String.format(
-                                            "No resource file could be found that matches the pattern %s. "
-                                                    + "This could mean that the test module must be rebuilt via maven.",
-                                            resourceNameRegex)));
-                case 1:
-                    return matchingResources.get(0);
-                default:
-                    throw new RuntimeException(
-                            new IOException(
-                                    String.format(
-                                            "Multiple resource files were found matching the pattern %s. Matches=%s",
-                                            resourceNameRegex, matchingResources)));
-            }
-        } catch (final IOException ioe) {
-            throw new RuntimeException("Could not search for resource resource files.", ioe);
-        }
-    }
 
     /**
      * Copy all the files and sub-directories under source directory to destination directory

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6SinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch6/src/test/java/org/apache/flink/streaming/tests/Elasticsearch6SinkE2ECase.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.connector.testframe.junit.annotations.TestContext;
-import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.slf4j.Logger;
@@ -44,15 +44,17 @@ public class Elasticsearch6SinkE2ECase
             new Elasticsearch6SinkExternalContextFactory(
                     elasticsearch.getContainer(),
                     Arrays.asList(
-                            TestUtils.getResource("dependencies/elasticsearch6-end-to-end-test.jar")
+                            ResourceTestUtils.getResource(
+                                            "dependencies/elasticsearch6-end-to-end-test.jar")
                                     .toAbsolutePath()
                                     .toUri()
                                     .toURL(),
-                            TestUtils.getResource("dependencies/flink-connector-test-utils.jar")
+                            ResourceTestUtils.getResource(
+                                            "dependencies/flink-connector-test-utils.jar")
                                     .toAbsolutePath()
                                     .toUri()
                                     .toURL(),
-                            TestUtils.getResource(
+                            ResourceTestUtils.getResource(
                                             "dependencies/flink-connector-elasticsearch-test-utils.jar")
                                     .toAbsolutePath()
                                     .toUri()

--- a/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7SinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-elasticsearch7/src/test/java/org/apache/flink/streaming/tests/Elasticsearch7SinkE2ECase.java
@@ -18,7 +18,7 @@
 package org.apache.flink.streaming.tests;
 
 import org.apache.flink.connector.testframe.junit.annotations.TestContext;
-import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.util.DockerImageVersions;
 
 import org.slf4j.Logger;
@@ -44,15 +44,17 @@ public class Elasticsearch7SinkE2ECase
             new Elasticsearch7SinkExternalContextFactory(
                     elasticsearch.getContainer(),
                     Arrays.asList(
-                            TestUtils.getResource("dependencies/elasticsearch7-end-to-end-test.jar")
+                            ResourceTestUtils.getResource(
+                                            "dependencies/elasticsearch7-end-to-end-test.jar")
                                     .toAbsolutePath()
                                     .toUri()
                                     .toURL(),
-                            TestUtils.getResource("dependencies/flink-connector-test-utils.jar")
+                            ResourceTestUtils.getResource(
+                                            "dependencies/flink-connector-test-utils.jar")
                                     .toAbsolutePath()
                                     .toUri()
                                     .toURL(),
-                            TestUtils.getResource(
+                            ResourceTestUtils.getResource(
                                             "dependencies/flink-connector-elasticsearch-test-utils.jar")
                                     .toAbsolutePath()
                                     .toUri()

--- a/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-hbase/src/test/java/org/apache/flink/tests/util/hbase/SQLClientHBaseITCase.java
@@ -19,8 +19,8 @@
 package org.apache.flink.tests.util.hbase;
 
 import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.cache.DownloadCache;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.tests.util.flink.FlinkResource;
@@ -96,14 +96,15 @@ public class SQLClientHBaseITCase extends TestLogger {
 
     @ClassRule public static final DownloadCache DOWNLOAD_CACHE = DownloadCache.get();
 
-    private static final Path sqlToolBoxJar = TestUtils.getResource(".*SqlToolbox.jar");
-    private static final Path hadoopClasspath = TestUtils.getResource(".*hadoop.classpath");
+    private static final Path sqlToolBoxJar = ResourceTestUtils.getResource(".*SqlToolbox.jar");
+    private static final Path hadoopClasspath = ResourceTestUtils.getResource(".*hadoop.classpath");
     private List<Path> hadoopClasspathJars;
 
     public SQLClientHBaseITCase(String hbaseVersion, String hbaseConnector) {
         this.hbase = HBaseResource.get(hbaseVersion);
         this.hbaseConnector = hbaseConnector;
-        this.sqlConnectorHBaseJar = TestUtils.getResource(".*sql-" + hbaseConnector + ".jar");
+        this.sqlConnectorHBaseJar =
+                ResourceTestUtils.getResource(".*sql-" + hbaseConnector + ".jar");
     }
 
     @Before

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/common/FlinkContainerWithPulsarEnvironment.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.connector.testframe.container.FlinkContainerTestEnvironment;
-import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.test.resources.ResourceTestUtils;
 
 /** A Flink Container which would bundles pulsar connector in its classpath. */
 public class FlinkContainerWithPulsarEnvironment extends FlinkContainerTestEnvironment {
@@ -47,7 +47,7 @@ public class FlinkContainerWithPulsarEnvironment extends FlinkContainerTestEnvir
     }
 
     private static String resourcePath(String jarName) {
-        return TestUtils.getResource(jarName).toAbsolutePath().toString();
+        return ResourceTestUtils.getResource(jarName).toAbsolutePath().toString();
     }
 
     protected static Configuration flinkConfiguration() {

--- a/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/test/java/org/apache/flink/tests/scala/ScalaFreeITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-scala/src/test/java/org/apache/flink/tests/scala/ScalaFreeITCase.java
@@ -17,8 +17,8 @@
 
 package org.apache.flink.tests.scala;
 
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.JobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.tests.util.flink.FlinkResource;
 import org.apache.flink.tests.util.flink.FlinkResourceSetup;
@@ -65,7 +65,8 @@ public class ScalaFreeITCase extends TestLogger {
                         ScalaJob.class.getCanonicalName(),
                         builder ->
                                 builder.addJar(
-                                        TestUtils.getResource("/scala.jar"), JarLocation.LIB)));
+                                        ResourceTestUtils.getResource("/scala.jar"),
+                                        JarLocation.LIB)));
     }
 
     public ScalaFreeITCase(TestParams testParams) {
@@ -79,7 +80,7 @@ public class ScalaFreeITCase extends TestLogger {
 
     @Test
     public void testScalaFreeJobExecution() throws Exception {
-        final Path jobJar = TestUtils.getResource("/jobs.jar");
+        final Path jobJar = ResourceTestUtils.getResource("/jobs.jar");
 
         try (final ClusterController clusterController = flink.startCluster(1)) {
             // if the job fails then this throws an exception

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/SqlITCaseBase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/SqlITCaseBase.java
@@ -20,7 +20,7 @@ package org.apache.flink.table.sql.codegen;
 
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.configuration.Configuration;
-import org.apache.flink.tests.util.TestUtils;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.tests.util.flink.FlinkResource;
 import org.apache.flink.tests.util.flink.FlinkResourceSetup;
@@ -77,7 +77,8 @@ public abstract class SqlITCaseBase extends TestLogger {
 
     private Path result;
 
-    protected static final Path SQL_TOOL_BOX_JAR = TestUtils.getResource(".*SqlToolbox.jar");
+    protected static final Path SQL_TOOL_BOX_JAR =
+            ResourceTestUtils.getResource(".*SqlToolbox.jar");
 
     public SqlITCaseBase(String executionMode) {
         this.executionMode = executionMode;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/UsingRemoteJarITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-sql/src/test/java/org/apache/flink/table/sql/codegen/UsingRemoteJarITCase.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.table.sql.codegen;
 
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.OperatingSystem;
@@ -46,7 +46,8 @@ import java.util.Map;
 
 /** End to End tests for using remote jar. */
 public class UsingRemoteJarITCase extends SqlITCaseBase {
-    private static final Path HADOOP_CLASSPATH = TestUtils.getResource(".*hadoop.classpath");
+    private static final Path HADOOP_CLASSPATH =
+            ResourceTestUtils.getResource(".*hadoop.classpath");
 
     private MiniDFSCluster hdfsCluster;
     private org.apache.hadoop.fs.Path hdPath;

--- a/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/SqlGatewayE2ECase.java
+++ b/flink-end-to-end-tests/flink-sql-gateway-test/src/test/java/org/apache/flink/table/gateway/SqlGatewayE2ECase.java
@@ -23,8 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.endpoint.hive.HiveServer2Endpoint;
 import org.apache.flink.table.gateway.containers.HiveContainer;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.tests.util.flink.ClusterController;
 import org.apache.flink.tests.util.flink.FlinkResource;
 import org.apache.flink.tests.util.flink.FlinkResourceSetup;
@@ -73,8 +73,9 @@ import static org.junit.Assert.assertEquals;
 public class SqlGatewayE2ECase extends TestLogger {
 
     private static final Path HIVE_SQL_CONNECTOR_JAR =
-            TestUtils.getResource(".*dependencies/flink-sql-connector-hive-.*.jar");
-    private static final Path HADOOP_CLASS_PATH = TestUtils.getResource(".*hadoop.classpath");
+            ResourceTestUtils.getResource(".*dependencies/flink-sql-connector-hive-.*.jar");
+    private static final Path HADOOP_CLASS_PATH =
+            ResourceTestUtils.getResource(".*hadoop.classpath");
     private static final String GATEWAY_E2E_SQL = "gateway_e2e.sql";
     private static final Configuration ENDPOINT_CONFIG = new Configuration();
     private static final String RESULT_KEY = "$RESULT";

--- a/flink-end-to-end-tests/flink-streaming-kinesis-test/src/test/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
+++ b/flink-end-to-end-tests/flink-streaming-kinesis-test/src/test/java/org/apache/flink/streaming/kinesis/test/KinesisTableApiITCase.java
@@ -24,8 +24,8 @@ import org.apache.flink.connector.testframe.container.TestcontainersSettings;
 import org.apache.flink.connectors.kinesis.testutils.KinesaliteContainer;
 import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
 import org.apache.flink.streaming.kinesis.test.model.Order;
+import org.apache.flink.test.resources.ResourceTestUtils;
 import org.apache.flink.test.util.SQLJobSubmission;
-import org.apache.flink.tests.util.TestUtils;
 import org.apache.flink.util.DockerImageVersions;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.jackson.JacksonMapperFactory;
@@ -70,7 +70,7 @@ public class KinesisTableApiITCase extends TestLogger {
 
     private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
-    private final Path sqlConnectorKinesisJar = TestUtils.getResource(".*kinesis.jar");
+    private final Path sqlConnectorKinesisJar = ResourceTestUtils.getResource(".*kinesis.jar");
     private static final Network network = Network.newNetwork();
 
     @ClassRule public static final Timeout TIMEOUT = new Timeout(10, TimeUnit.MINUTES);

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/resources/ResourceTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/resources/ResourceTestUtils.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/** Test utils around module resources. */
 public class ResourceTestUtils {
 
     private static final ParameterProperty<Path> MODULE_DIRECTORY =

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/resources/ResourceTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/resources/ResourceTestUtils.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.test.resources;
+
+import org.apache.flink.test.parameters.ParameterProperty;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ResourceTestUtils {
+
+    private static final ParameterProperty<Path> MODULE_DIRECTORY =
+            new ParameterProperty<>("moduleDir", Paths::get);
+
+    /**
+     * Searches for a resource file matching the given regex in the given directory. This method is
+     * primarily intended to be used for the initialization of static {@link Path} fields for
+     * resource file(i.e. jar, config file) that reside in the modules {@code target} directory.
+     *
+     * @param resourceNameRegex regex pattern to match against
+     * @return Path pointing to the matching jar
+     * @throws RuntimeException if none or multiple resource files could be found
+     */
+    public static Path getResource(final String resourceNameRegex) {
+        // if the property is not set then we are most likely running in the IDE, where the working
+        // directory is the
+        // module of the test that is currently running, which is exactly what we want
+        Path moduleDirectory = MODULE_DIRECTORY.get(Paths.get("").toAbsolutePath());
+
+        try (Stream<Path> dependencyResources = Files.walk(moduleDirectory)) {
+            final List<Path> matchingResources =
+                    dependencyResources
+                            .filter(
+                                    jar ->
+                                            Pattern.compile(resourceNameRegex)
+                                                    .matcher(jar.toAbsolutePath().toString())
+                                                    .find())
+                            .collect(Collectors.toList());
+            switch (matchingResources.size()) {
+                case 0:
+                    throw new RuntimeException(
+                            new FileNotFoundException(
+                                    String.format(
+                                            "No resource file could be found that matches the pattern %s. "
+                                                    + "This could mean that the test module must be rebuilt via maven.",
+                                            resourceNameRegex)));
+                case 1:
+                    return matchingResources.get(0);
+                default:
+                    throw new RuntimeException(
+                            new IOException(
+                                    String.format(
+                                            "Multiple resource files were found matching the pattern %s. Matches=%s",
+                                            resourceNameRegex, matchingResources)));
+            }
+        } catch (final IOException ioe) {
+            throw new RuntimeException("Could not search for resource resource files.", ioe);
+        }
+    }
+}


### PR DESCRIPTION
This method is very common in e2e tests and required to be accessible to external connector repos.
Move the class to flink-test-utils which we actually publish (compared to flink-end-to-tests-common which is not because its internal).