### PR TITLE
[FLINK-29271]Change to byte array from bytebuffer to improve performance and compatible direct byte buffers

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/RunLengthDecoder.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/reader/RunLengthDecoder.java
@@ -265,8 +265,17 @@ final class RunLengthDecoder {
                     while (valueIndex < this.currentCount) {
                         // values are bit packed 8 at a time, so reading bitWidth will always work
                         ByteBuffer buffer = in.slice(bitWidth);
-                        this.packer.unpack8Values(
-                                buffer, buffer.position(), this.currentBuffer, valueIndex);
+                        if (buffer.hasArray()) {
+                            // byte array has better performance than ByteBuffer
+                            this.packer.unpack8Values(
+                                    buffer.array(),
+                                    buffer.arrayOffset() + buffer.position(),
+                                    this.currentBuffer,
+                                    valueIndex);
+                        } else {
+                            this.packer.unpack8Values(
+                                    buffer, buffer.position(), this.currentBuffer, valueIndex);
+                        }
                         valueIndex += 8;
                     }
                     return;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
The PR uses byte array api instead of ByteBuffer api to improve performance  and compatible with DirectByteBuffer which does not have byte array backed  when reading parquet DataPage V2

## Brief change log
  - Use the byte array api instead of ByteBuffer api.

## Verifying this change
I have done a test to compare byte array api and ByteBuffer api on parquet-mr project.
The result is:
[Unpack8ValuesByteArray spent time] 80 ms
[Unpack8ValuesByteBuffer spent time] 133 ms

The test code is:
package org.apache.parquet.column.values.bitpacking;

import java.nio.ByteBuffer;

public class ByteBufferTest {
  private static final BytePacker bytePacker = Packer.LITTLE_ENDIAN.newBytePacker(7);

  private static final int COUNT = 100000;

  public static void main(String[] args) {
    byte  [] in  = new byte[1008];
    int [] out = new int[1152];
    int [] out1 = new int[1152];
    int [] out2 = new int[1152];

    int res = 0;

    for(int i = 0; i < in.length; i++) {
      in[i] = (byte) i;
    }

    for(int i = 0; i < COUNT; i++) {
      res += unpack8ValuesBytes(in, out, i % out.length);
    }

    res = 0;
    long t1 = System.currentTimeMillis();
    for(int i = 0; i < COUNT; i++) {
      res += unpack8ValuesBytes(in, out1, i % out.length);
    }
    long t2 = System.currentTimeMillis();
    System.out.println("[Unpack8ValuesByteArray spent time] " + (t2-t1) + " ms");

    ByteBuffer byteBuffer = ByteBuffer.wrap(in);

    for(int i = 0; i < COUNT; i++) {
      res += unpack8ValuesByteBuffer(byteBuffer, out, i % out.length);
    }

    res = 0;
    long t3 = System.currentTimeMillis();
    for(int i = 0; i < COUNT; i++) {
      res += unpack8ValuesByteBuffer(byteBuffer, out2, i % out.length);
    }
    long t4 = System.currentTimeMillis();
    System.out.println("[Unpack8ValuesByteBuffer spent time] " + (t4-t3) + " ms");

    for (int i=0; i<out1.length; i++) {
      if(out1[i] != out2[i]) {
        System.out.println("diff: " + out1[i] + " " + out2[i]);
      }
    }
  }

  private static int unpack8ValuesBytes(byte [] in, int [] out, int ctr) {
    for(int i = 0, j = 0; i < in.length; i+=7, j+=8) {
      bytePacker.unpack8Values(in, i, out, j);
    }
    return out[ctr];
  }
  private static int unpack8ValuesByteBuffer(ByteBuffer in, int [] out, int ctr) {
    for(int i = 0, j = 0; i < in.capacity(); i+=7, j+=8) {
      bytePacker.unpack8Values(in, i, out, j);
    }
    return out[ctr];
  }
}



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
