### PR TITLE
[FLINK-29299][network] Fix the network memory size calculation issue in fine-grained resource mode

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -106,7 +106,7 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
 
         int numTotalInputChannels =
                 desc.getInputChannelNums().values().stream().mapToInt(Integer::intValue).sum();
-        int numTotalInputGates = desc.getInputChannelNums().size();
+        int numTotalInputGates = desc.getInputGateNums();
 
         int numRequiredNetworkBuffers =
                 NettyShuffleUtils.computeNetworkBuffersForAnnouncing(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/TaskInputsOutputsDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/TaskInputsOutputsDescriptor.java
@@ -29,6 +29,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** Describes inputs and outputs information of a task. */
 public class TaskInputsOutputsDescriptor {
 
+    // Number of input gates
+    private final int inputGateNums;
+
     // Number of input channels per dataSet.
     private final Map<IntermediateDataSetID, Integer> inputChannelNums;
 
@@ -39,6 +42,7 @@ public class TaskInputsOutputsDescriptor {
     private final Map<IntermediateDataSetID, ResultPartitionType> partitionTypes;
 
     private TaskInputsOutputsDescriptor(
+            int inputGateNums,
             Map<IntermediateDataSetID, Integer> inputChannelNums,
             Map<IntermediateDataSetID, Integer> subpartitionNums,
             Map<IntermediateDataSetID, ResultPartitionType> partitionTypes) {
@@ -47,9 +51,14 @@ public class TaskInputsOutputsDescriptor {
         checkNotNull(subpartitionNums);
         checkNotNull(partitionTypes);
 
+        this.inputGateNums = inputGateNums;
         this.inputChannelNums = inputChannelNums;
         this.subpartitionNums = subpartitionNums;
         this.partitionTypes = partitionTypes;
+    }
+
+    public int getInputGateNums() {
+        return inputGateNums;
     }
 
     public Map<IntermediateDataSetID, Integer> getInputChannelNums() {
@@ -65,10 +74,12 @@ public class TaskInputsOutputsDescriptor {
     }
 
     public static TaskInputsOutputsDescriptor from(
+            int inputGateNums,
             Map<IntermediateDataSetID, Integer> inputChannelNums,
             Map<IntermediateDataSetID, Integer> subpartitionNums,
             Map<IntermediateDataSetID, ResultPartitionType> partitionTypes) {
 
-        return new TaskInputsOutputsDescriptor(inputChannelNums, subpartitionNums, partitionTypes);
+        return new TaskInputsOutputsDescriptor(
+                inputGateNums, inputChannelNums, subpartitionNums, partitionTypes);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

After [FLINK-28663](https://issues.apache.org/jira/browse/FLINK-28663), one intermediate dataset can be consumed by multiple consumers, there is a case where one vertex can consume one intermediate dataset multiple times. However, currently in fine-grained resource mode, when computing the required network buffer size, the intermediate dataset is used as key to record the size of network buffer per input gate, which means it may allocate less network buffers than needed if two input gate of the same vertex consumes the same intermediate dataset. This patch tries to fix the issue.

## Brief change log

  - Fix the network memory size calculation issue in fine-grained resource mode
  - Add test case to cover the scenario

## Verifying this change

This change added tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
