### PR TITLE
[FLINK-29287][tests] Rewrite sql-client packaging tests 

### DIFF
--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -44,6 +44,12 @@ under the License.
 			<artifactId>flink-connector-kafka</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-sql-connector-kafka/src/test/java/org/apache/flink/connectors/kafka/PackagingITCase.java
+++ b/flink-connectors/flink-sql-connector-kafka/src/test/java/org/apache/flink/connectors/kafka/PackagingITCase.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.kafka;
+
+import org.apache.flink.packaging.PackagingTestUtils;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.test.resources.ResourceTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+class PackagingITCase {
+
+    @Test
+    void testPackaging() throws Exception {
+        final Path jar = ResourceTestUtils.getResource(".*/flink-sql-connector-kafka[^/]*\\.jar");
+
+        PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                jar, Arrays.asList("org/apache/flink/", "META-INF/"));
+        PackagingTestUtils.assertJarContainsServiceEntry(jar, Factory.class);
+    }
+}

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -44,6 +44,12 @@ under the License.
 			<artifactId>flink-connector-kinesis</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-sql-connector-kinesis/src/test/java/org/apache/flink/connectors/kinesis/PackagingITCase.java
+++ b/flink-connectors/flink-sql-connector-kinesis/src/test/java/org/apache/flink/connectors/kinesis/PackagingITCase.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.kinesis;
+
+import org.apache.flink.packaging.PackagingTestUtils;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.test.resources.ResourceTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+class PackagingITCase {
+
+    @Test
+    void testPackaging() throws Exception {
+        final Path jar = ResourceTestUtils.getResource(".*/flink-sql-connector-kinesis[^/]*\\.jar");
+
+        PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                jar,
+                Arrays.asList(
+                        "org/apache/flink/",
+                        "META-INF/",
+                        "amazon-kinesis-producer-native-binaries/",
+                        "cacerts/",
+                        "google/"));
+        PackagingTestUtils.assertJarContainsServiceEntry(jar, Factory.class);
+    }
+}

--- a/flink-end-to-end-tests/test-scripts/test_sql_client.sh
+++ b/flink-end-to-end-tests/test-scripts/test_sql_client.sh
@@ -41,47 +41,6 @@ SQL_TOOLBOX_JAR=$END_TO_END_DIR/flink-sql-client-test/target/SqlToolbox.jar
 SQL_JARS_DIR=$END_TO_END_DIR/flink-sql-client-test/target/sql-jars
 
 ################################################################################
-# Verify existing SQL jars
-################################################################################
-
-EXTRACTED_JAR=$TEST_DATA_DIR/extracted
-
-mkdir -p $EXTRACTED_JAR
-
-for SQL_JAR in $SQL_JARS_DIR/*.jar; do
-  echo "Checking SQL JAR: $SQL_JAR"
-  (cd $EXTRACTED_JAR && jar xf $SQL_JAR)
-
-  # check for proper shading
-  for EXTRACTED_FILE in $(find $EXTRACTED_JAR -type f); do
-
-    if ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/org/apache/flink"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/META-INF"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/LICENSE"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/NOTICE"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/org/apache/avro"* ]] && \
-        # Following required by amazon-kinesis-producer in flink-connector-kinesis
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/amazon-kinesis-producer-native-binaries"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/cacerts"* ]] && \
-        ! [[ $EXTRACTED_FILE = "$EXTRACTED_JAR/google"* ]] ; then
-      echo "Bad file in JAR: $EXTRACTED_FILE"
-      exit 1
-    fi
-  done
-
-  # check for table factory
-  if [ ! -f $EXTRACTED_JAR/META-INF/services/org.apache.flink.table.factories.Factory ]; then
-    echo "No table factory found in JAR: $SQL_JAR"
-    exit 1
-  fi
-
-  # clean up
-  rm -r $EXTRACTED_JAR/*
-done
-
-rm -r $EXTRACTED_JAR
-
-################################################################################
 # Prepare connectors
 ################################################################################
 

--- a/flink-formats/flink-sql-avro/pom.xml
+++ b/flink-formats/flink-sql-avro/pom.xml
@@ -43,6 +43,12 @@ under the License.
 			<artifactId>flink-avro</artifactId>
 			<version>${project.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-formats/flink-sql-avro/src/test/java/org/apache/flink/formats/avro/PackagingITCase.java
+++ b/flink-formats/flink-sql-avro/src/test/java/org/apache/flink/formats/avro/PackagingITCase.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.avro;
+
+import org.apache.flink.packaging.PackagingTestUtils;
+import org.apache.flink.table.factories.Factory;
+import org.apache.flink.test.resources.ResourceTestUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+
+class PackagingITCase {
+
+    @Test
+    void testPackaging() throws Exception {
+        final Path jar = ResourceTestUtils.getResource(".*/flink-sql-avro[^/]*\\.jar");
+
+        PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                jar, Arrays.asList("org/apache/flink/", "META-INF/"));
+        PackagingTestUtils.assertJarContainsServiceEntry(jar, Factory.class);
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/packaging/PackagingTestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/packaging/PackagingTestUtils.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.packaging;
+
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test utils around jar packaging. */
+public class PackagingTestUtils {
+
+    /**
+     * Verifies that all files in the jar match one of the provided allow strings.
+     *
+     * <p>An allow item ending on a {@code "/"} is treated as an allowed parent directory.
+     * Otherwise, it is treated as an allowed file.
+     *
+     * <p>For example, given a jar containing a file {@code META-INF/NOTICES}:
+     *
+     * <p>These would pass:
+     *
+     * <ul>
+     *   <li>{@code "META-INF/"}
+     *   <li>{@code "META-INF/NOTICES"}
+     * </ul>
+     *
+     * <p>These would fail:
+     *
+     * <ul>
+     *   <li>{@code "META-INF"}
+     *   <li>{@code "META-INF/NOTICE"}
+     *   <li>{@code "META-INF/NOTICES/"}
+     * </ul>
+     */
+    public static void assertJarContainsOnlyFilesMatching(
+            Path jarPath, Collection<String> allowedPaths) throws Exception {
+        final URI jar = jarPath.toUri();
+
+        try (final FileSystem fileSystem =
+                FileSystems.newFileSystem(
+                        new URI("jar:file", jar.getHost(), jar.getPath(), jar.getFragment()),
+                        Collections.emptyMap())) {
+            try (Stream<Path> walk = Files.walk(fileSystem.getPath("/"))) {
+                walk.filter(file -> !Files.isDirectory(file))
+                        .map(file -> file.toAbsolutePath().toString())
+                        .map(file -> file.startsWith("/") ? file.substring(1) : file)
+                        .forEach(
+                                file ->
+                                        assertThat(allowedPaths)
+                                                .as("Bad file in JAR: %s", file)
+                                                .anySatisfy(
+                                                        allowedPath -> {
+                                                            if (allowedPath.endsWith("/")) {
+                                                                assertThat(file)
+                                                                        .startsWith(allowedPath);
+                                                            } else {
+                                                                assertThat(file)
+                                                                        .isEqualTo(allowedPath);
+                                                            }
+                                                        }));
+            }
+        }
+    }
+
+    /**
+     * Verifies that the given jar contains a service entry file for the given service.
+     *
+     * <p>Caution: This only checks that the file exists; the content is not verified.
+     */
+    public static void assertJarContainsServiceEntry(Path jarPath, Class<?> service)
+            throws Exception {
+        final URI jar = jarPath.toUri();
+
+        try (final FileSystem fileSystem =
+                FileSystems.newFileSystem(
+                        new URI("jar:file", jar.getHost(), jar.getPath(), jar.getFragment()),
+                        Collections.emptyMap())) {
+            assertThat(fileSystem.getPath("META-INF", "services", service.getName())).exists();
+        }
+    }
+}

--- a/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/packaging/PackagingTestUtilsTest.java
+++ b/flink-test-utils-parent/flink-test-utils/src/test/java/org/apache/flink/packaging/PackagingTestUtilsTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.packaging;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PackagingTestUtilsTest {
+
+    @Test
+    void testAssertJarContainsOnlyFilesMatching(@TempDir Path tmp) throws Exception {
+        Path jar = createJar(tmp, Entry.fileEntry("", Arrays.asList("META-INF", "NOTICES")));
+
+        PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                jar, Collections.singleton("META-INF/"));
+        PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                jar, Collections.singleton("META-INF/NOTICES"));
+
+        assertThatThrownBy(
+                        () ->
+                                PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                                        jar, Collections.singleton("META-INF")))
+                .isInstanceOf(AssertionError.class);
+        assertThatThrownBy(
+                        () ->
+                                PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                                        jar, Collections.singleton("META-INF/NOTICE")))
+                .isInstanceOf(AssertionError.class);
+        assertThatThrownBy(
+                        () ->
+                                PackagingTestUtils.assertJarContainsOnlyFilesMatching(
+                                        jar, Collections.singleton("META-INF/NOTICES/")))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    @Test
+    void testAssertJarContainsServiceEntry(@TempDir Path tmp) throws Exception {
+        final String service = PackagingTestUtilsTest.class.getName();
+        Path jar =
+                createJar(tmp, Entry.fileEntry("", Arrays.asList("META-INF", "services", service)));
+
+        PackagingTestUtils.assertJarContainsServiceEntry(jar, PackagingTestUtilsTest.class);
+
+        assertThatThrownBy(
+                        () ->
+                                PackagingTestUtils.assertJarContainsServiceEntry(
+                                        jar, PackagingTestUtils.class))
+                .isInstanceOf(AssertionError.class);
+    }
+
+    private static class Entry {
+        final String contents;
+        final List<String> path;
+        final boolean isDirectory;
+
+        public static Entry directoryEntry(List<String> path) {
+            return new Entry("", path, true);
+        }
+
+        public static Entry fileEntry(String contents, List<String> path) {
+            return new Entry(contents, path, false);
+        }
+
+        private Entry(String contents, List<String> path, boolean isDirectory) {
+            this.contents = contents;
+            this.path = path;
+            this.isDirectory = isDirectory;
+        }
+    }
+
+    private static Path createJar(Path tempDir, Entry... entries) throws Exception {
+        final Path path = tempDir.resolve(UUID.randomUUID().toString() + ".jar");
+
+        final URI uri = path.toUri();
+
+        final URI jarUri = new URI("jar:file", uri.getHost(), uri.getPath(), uri.getFragment());
+
+        // causes FileSystems#newFileSystem to automatically create a valid zip file
+        // this is easier than manually creating a valid empty zip file manually
+        final Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+
+        try (FileSystem zip = FileSystems.newFileSystem(jarUri, env)) {
+            // shortcut to getting the single root
+            final Path root = zip.getPath("/");
+            for (Entry entry : entries) {
+                final Path zipPath =
+                        root.resolve(
+                                zip.getPath(
+                                        entry.path.get(0),
+                                        entry.path
+                                                .subList(1, entry.path.size())
+                                                .toArray(new String[] {})));
+                if (entry.isDirectory) {
+                    Files.createDirectories(zipPath);
+                } else {
+                    Files.createDirectories(zipPath.getParent());
+                    Files.write(zipPath, entry.contents.getBytes());
+                }
+            }
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
~~Based on #20828.~~

Decouples sql-jar packaging tests from the sql-client e2e tests. The added java utils make it easy to instead write tests directly in the respective module.