### PR TITLE
[FLINK-29309][streaming-java] Relax allow-client-job-configurations for Table API and parameters

### DIFF
--- a/docs/layouts/shortcodes/generated/deployment_configuration.html
+++ b/docs/layouts/shortcodes/generated/deployment_configuration.html
@@ -9,12 +9,6 @@
     </thead>
     <tbody>
         <tr>
-            <td><h5>execution.allow-client-job-configurations</h5></td>
-            <td style="word-wrap: break-word;">true</td>
-            <td>Boolean</td>
-            <td>Determines whether configurations in the user program are allowed. Depending on your deployment mode failing the job might have different affects. Either your client that is trying to submit the job to an external cluster (session cluster deployment) throws the exception or the Job manager (application mode deployment).</td>
-        </tr>
-        <tr>
             <td><h5>execution.attached</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
@@ -25,6 +19,18 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>List&lt;String&gt;</td>
             <td>Custom JobListeners to be registered with the execution environment. The registered listeners cannot have constructors with arguments.</td>
+        </tr>
+        <tr>
+            <td><h5>execution.program-config.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Determines whether configurations in the user program are allowed. By default, configuration can be set both on a cluster-level (via options) or within the user program (i.e. programmatic via environment setters). If disabled, all configuration must be defined on a cluster-level and programmatic setters in the user program are prohibited.<br /><br />Depending on your deployment mode failing the job might have different implications. Either your client that is trying to submit the job to an external cluster (session cluster deployment) throws the exception or the job manager (application mode deployment).<br /><br />The 'execution.program-config.wildcards' option lists configuration keys that are allowed to be set in user programs regardless of this setting.</td>
+        </tr>
+        <tr>
+            <td><h5>execution.program-config.wildcards</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>List&lt;String&gt;</td>
+            <td>List of configuration keys that are allowed to be set in a user program regardless whether program configuration is enabled or not.<br /><br />Currently, this list is limited to 'pipeline.global-job-parameters' only.</td>
         </tr>
         <tr>
             <td><h5>execution.shutdown-on-application-finish</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/MutatedConfigurationException.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MutatedConfigurationException.java
@@ -19,12 +19,13 @@
 package org.apache.flink.client.program;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.DeploymentOptions;
 
 import java.util.Collection;
 
 /**
- * If {@link org.apache.flink.configuration.DeploymentOptions#ALLOW_CLIENT_JOB_CONFIGURATIONS} is
- * disabled configurations in the user jar will throw this exception.
+ * If {@link DeploymentOptions#PROGRAM_CONFIG_ENABLED} is disabled, configurations in the user jar
+ * will throw this exception.
  */
 @Internal
 public class MutatedConfigurationException extends Exception {

--- a/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/ClientTest.java
@@ -378,7 +378,7 @@ class ClientTest {
                             .build();
 
             final Configuration configuration = fromPackagedProgram(program, 1, false);
-            configuration.set(DeploymentOptions.ALLOW_CLIENT_JOB_CONFIGURATIONS, false);
+            configuration.set(DeploymentOptions.PROGRAM_CONFIG_ENABLED, false);
 
             assertThatThrownBy(
                             () ->

--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -73,6 +73,15 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 @Public
 public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecutionConfig> {
 
+    // NOTE TO IMPLEMENTERS:
+    // Please do not add further fields to this class. Use the ConfigOption stack instead!
+    // It is currently very tricky to keep this kind of POJO classes in sync with instances of
+    // org.apache.flink.configuration.Configuration. Instances of Configuration are way easier to
+    // pass, layer, merge, restrict, copy, filter, etc.
+    // See ExecutionOptions.RUNTIME_MODE for a reference implementation. If the option is very
+    // crucial for the API, we can add a dedicated setter to StreamExecutionEnvironment. Otherwise,
+    // introducing a ConfigOption should be enough.
+
     private static final long serialVersionUID = 1L;
 
     /**

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -106,15 +106,50 @@ public class DeploymentOptions {
                                     .build());
 
     @Experimental
-    public static final ConfigOption<Boolean> ALLOW_CLIENT_JOB_CONFIGURATIONS =
-            ConfigOptions.key("execution.allow-client-job-configurations")
+    public static final ConfigOption<List<String>> PROGRAM_CONFIG_WILDCARDS =
+            ConfigOptions.key("execution.program-config.wildcards")
+                    .stringType()
+                    .asList()
+                    .defaultValues()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "List of configuration keys that are allowed to be set in a user program "
+                                                    + "regardless whether program configuration is enabled or not.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text(
+                                            "Currently, this list is limited to '%s' only.",
+                                            TextElement.text(
+                                                    PipelineOptions.GLOBAL_JOB_PARAMETERS.key()))
+                                    .build());
+
+    @Experimental
+    public static final ConfigOption<Boolean> PROGRAM_CONFIG_ENABLED =
+            ConfigOptions.key("execution.program-config.enabled")
                     .booleanType()
                     .defaultValue(true)
+                    .withDeprecatedKeys("execution.allow-client-job-configurations")
                     .withDescription(
-                            "Determines whether configurations in the user program are "
-                                    + "allowed. Depending on your deployment mode failing the job "
-                                    + "might have different affects. Either your client that is "
-                                    + "trying to submit the job to an external cluster (session "
-                                    + "cluster deployment) throws the exception or the Job "
-                                    + "manager (application mode deployment).");
+                            Description.builder()
+                                    .text(
+                                            "Determines whether configurations in the user program are allowed. By default, "
+                                                    + "configuration can be set both on a cluster-level (via options) or "
+                                                    + "within the user program (i.e. programmatic via environment setters). "
+                                                    + "If disabled, all configuration must be defined on a cluster-level and "
+                                                    + "programmatic setters in the user program are prohibited.")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text(
+                                            "Depending on your deployment mode failing the job might have different implications. "
+                                                    + "Either your client that is trying to submit the job to an external "
+                                                    + "cluster (session cluster deployment) throws the exception or the "
+                                                    + "job manager (application mode deployment).")
+                                    .linebreak()
+                                    .linebreak()
+                                    .text(
+                                            "The '%s' option lists configuration keys that are allowed to be set in user programs "
+                                                    + "regardless of this setting.",
+                                            TextElement.text(PROGRAM_CONFIG_WILDCARDS.key()))
+                                    .build());
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
@@ -19,12 +19,13 @@
 package org.apache.flink.runtime.dispatcher;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.DeploymentOptions;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.MapDifference;
 
 /**
- * If {@link org.apache.flink.configuration.DeploymentOptions#ALLOW_CLIENT_JOB_CONFIGURATIONS} is
- * disabled this error denotes the not allowed configuration.
+ * If {@link DeploymentOptions#PROGRAM_CONFIG_ENABLED} is disabled, this error denotes the not
+ * allowed configuration.
  */
 @Internal
 public class ConfigurationNotAllowedMessage {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -52,6 +52,15 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Public
 public class CheckpointConfig implements java.io.Serializable {
 
+    // NOTE TO IMPLEMENTERS:
+    // Please do not add further fields to this class. Use the ConfigOption stack instead!
+    // It is currently very tricky to keep this kind of POJO classes in sync with instances of
+    // org.apache.flink.configuration.Configuration. Instances of Configuration are way easier to
+    // pass, layer, merge, restrict, copy, filter, etc.
+    // See ExecutionOptions.RUNTIME_MODE for a reference implementation. If the option is very
+    // crucial for the API, we can add a dedicated setter to StreamExecutionEnvironment. Otherwise,
+    // introducing a ConfigOption should be enough.
+
     private static final long serialVersionUID = -750378776078908147L;
 
     private static final Logger LOG = LoggerFactory.getLogger(CheckpointConfig.class);


### PR DESCRIPTION
## What is the purpose of the change

This is the second and hopefully last iteration on the `allow-client-job-configurations` feature. This PR makes sure that both Table API and DataStream API work as expected. It also provide infrastructure to allow certain options nevertheless. Currently, only global job parameters but this is most likely also the most important option.

## Brief change log

- Relax constraint and allow `StreamExecutionEnvironment.getEnvironment(Configuration)`
- Allow global job parameters and infra for more in the future
- Add more documentation

## Verifying this change

This change added tests and can be verified as follows: `StreamContextEnvironmentTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
