### PR TITLE
[FLINK-29099][connectors/kinesis] Update global watermark for idle subtask

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -404,9 +404,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
     public static final long DEFAULT_WATERMARK_SYNC_MILLIS = 30_000;
 
-    public static final Duration DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT = Duration.ofMinutes(6);
+    public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY = 10_000;
 
-    //    public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY = 10_000;
+    public static final Duration DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT = Duration.ofMinutes(6);
 
     /**
      * To avoid shard iterator expires in {@link ShardConsumer}s, the value for the configured

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -404,7 +404,7 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
     public static final long DEFAULT_WATERMARK_SYNC_MILLIS = 30_000;
 
-    public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY = 10_000;
+    public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONCURRENCY = 10_000;
 
     public static final Duration DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT = Duration.ofMinutes(6);
 

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/config/ConsumerConfigConstants.java
@@ -404,9 +404,9 @@ public class ConsumerConfigConstants extends AWSConfigConstants {
 
     public static final long DEFAULT_WATERMARK_SYNC_MILLIS = 30_000;
 
-    public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONCURRENCY = 10_000;
-
     public static final Duration DEFAULT_EFO_HTTP_CLIENT_READ_TIMEOUT = Duration.ofMinutes(6);
+
+    //    public static final int DEFAULT_EFO_HTTP_CLIENT_MAX_CONURRENCY = 10_000;
 
     /**
      * To avoid shard iterator expires in {@link ShardConsumer}s, the value for the configured

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/KinesisDataFetcher.java
@@ -1174,6 +1174,14 @@ public class KinesisDataFetcher<T> {
             }
         }
 
+        LOG.debug(
+                "WatermarkEmitter subtask: {}, last watermark: {}, potential watermark: {}"
+                        + ", potential next watermark: {}",
+                indexOfThisConsumerSubtask,
+                lastWatermark,
+                potentialWatermark,
+                potentialNextWatermark);
+
         // advance watermark if possible (watermarks can only be ascending)
         if (potentialWatermark == Long.MAX_VALUE) {
             if (shardWatermarks.isEmpty() || shardIdleIntervalMillis > 0) {
@@ -1265,11 +1273,11 @@ public class KinesisDataFetcher<T> {
         public void onProcessingTime(long timestamp) {
             if (nextWatermark != Long.MIN_VALUE) {
                 long globalWatermark = lastGlobalWatermark;
-                // TODO: refresh watermark while idle
                 if (!(isIdle && nextWatermark == propagatedLocalWatermark)) {
                     globalWatermark = watermarkTracker.updateWatermark(nextWatermark);
                     propagatedLocalWatermark = nextWatermark;
                 } else {
+                    globalWatermark = watermarkTracker.getWatermark();
                     LOG.info(
                             "WatermarkSyncCallback subtask: {} is idle",
                             indexOfThisConsumerSubtask);
@@ -1279,12 +1287,14 @@ public class KinesisDataFetcher<T> {
                     lastLogged = System.currentTimeMillis();
                     LOG.info(
                             "WatermarkSyncCallback subtask: {} local watermark: {}"
-                                    + ", global watermark: {}, delta: {} timeouts: {}, emitter: {}",
+                                    + ", global watermark: {}, delta: {} timeouts: {}, idle: {}"
+                                    + ", emitter: {}",
                             indexOfThisConsumerSubtask,
                             nextWatermark,
                             globalWatermark,
                             nextWatermark - globalWatermark,
                             watermarkTracker.getUpdateTimeoutCount(),
+                            isIdle,
                             recordEmitter.printInfo());
 
                     // Following is for debugging non-reproducible issue with stalled watermark

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTracker.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTracker.java
@@ -95,6 +95,8 @@ public abstract class WatermarkTracker implements Closeable, Serializable {
      */
     public abstract long updateWatermark(final long localWatermark);
 
+    public abstract long getWatermark();
+
     protected long getCurrentTime() {
         return System.currentTimeMillis();
     }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -1243,6 +1243,11 @@ public class FlinkKinesisConsumerTest extends TestLogger {
             return localWatermark;
         }
 
+        @Override
+        public long getWatermark() {
+            return WATERMARK.get();
+        }
+
         static void assertGlobalWatermark(long expected) {
             assertThat(WATERMARK.get()).isEqualTo(expected);
         }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
@@ -65,16 +65,13 @@ public class JobManagerWatermarkTrackerTest {
 
         @Override
         public void run(SourceContext<Integer> ctx) {
-<<<<<<< HEAD
             assertThat(tracker.updateWatermark(998)).isEqualTo(998);
             assertThat(tracker.updateWatermark(999)).isEqualTo(999);
-=======
-            Assert.assertEquals(998, tracker.updateWatermark(998));
-            Assert.assertEquals(999, tracker.updateWatermark(999));
-            Assert.assertEquals(999, tracker.getWatermark());
-            Assert.assertEquals(1000, tracker.updateWatermark(1000));
-            Assert.assertEquals(1000, tracker.getWatermark());
->>>>>>> 8733b7b0314 ([STRMHELP-197] Update Global Watermark When Idle (#61))
+            assertThat(tracker.updateWatermark(998)).isEqualTo(998);
+            assertThat(tracker.updateWatermark(999)).isEqualTo(999);
+            assertThat(tracker.getWatermark()).isEqualTo(999);
+            assertThat(tracker.updateWatermark(1000)).isEqualTo(1000);
+            assertThat(tracker.getWatermark()).isEqualTo(1000);
         }
 
         @Override

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/JobManagerWatermarkTrackerTest.java
@@ -65,8 +65,16 @@ public class JobManagerWatermarkTrackerTest {
 
         @Override
         public void run(SourceContext<Integer> ctx) {
+<<<<<<< HEAD
             assertThat(tracker.updateWatermark(998)).isEqualTo(998);
             assertThat(tracker.updateWatermark(999)).isEqualTo(999);
+=======
+            Assert.assertEquals(998, tracker.updateWatermark(998));
+            Assert.assertEquals(999, tracker.updateWatermark(999));
+            Assert.assertEquals(999, tracker.getWatermark());
+            Assert.assertEquals(1000, tracker.updateWatermark(1000));
+            Assert.assertEquals(1000, tracker.getWatermark());
+>>>>>>> 8733b7b0314 ([STRMHELP-197] Update Global Watermark When Idle (#61))
         }
 
         @Override

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/util/WatermarkTrackerTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +47,15 @@ public class WatermarkTrackerTest {
 
         @Override
         public long updateWatermark(final long localWatermark) {
+            return updateWatermark(Optional.of(localWatermark));
+        }
+
+        @Override
+        public long getWatermark() {
+            return updateWatermark(Optional.empty());
+        }
+
+        private long updateWatermark(Optional<Long> localWatermark) {
             refreshWatermarkSnapshot(this.watermarks);
 
             long currentTime = getCurrentTime();
@@ -55,8 +65,11 @@ public class WatermarkTrackerTest {
             if (ws == null) {
                 watermarks.put(subtaskId, ws = new WatermarkState());
             }
-            ws.lastUpdated = currentTime;
-            ws.watermark = Math.max(ws.watermark, localWatermark);
+            // empty if getting without updating
+            if (localWatermark.isPresent()) {
+                ws.lastUpdated = currentTime;
+                ws.watermark = Math.max(ws.watermark, localWatermark.get());
+            }
             saveWatermark(subtaskId, ws);
 
             long globalWatermark = ws.watermark;


### PR DESCRIPTION
## What is the purpose of the change

This pull request updates the global watermark for subtasks marked idle, rather than waiting until the subtask is no longer idle. That way we avoid a deadlock state where the subtask is idle and unable to emit records due to lookahead.

## Brief change log

 - The WatermarkSyncCallback is now able to get the global watermark without updating it
 - Additional debug logging while emitting the watermark

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Updated tests to add getWatermark without modifying to watermark
  - Manually verified the change by running a 8 node cluster with 2 JobManagers and 8 TaskManagers. I manually introduced a sleep of the ShardConsumer thread for 10 minutes for subtask 0 after 5 minutes had passed. This forced the subtask into an idle state as the subtask was no longer receiving data from Kinesis. I verified the local and global watermarks were updated correctly via logs and metrics. When the subtask's ShardConsumer thread continued after the 10 minute sleep, it continued updating the global watermark as usual.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
