### PR TITLE
[FLINK-6573][connectors/mongodb] Flink MongoDB Connector

### DIFF
--- a/flink-connectors/flink-connector-mongodb/archunit-violations/stored.rules
+++ b/flink-connectors/flink-connector-mongodb/archunit-violations/stored.rules
@@ -1,0 +1,4 @@
+#
+#Tue Sep 13 11:09:41 CST 2022
+Tests\ inheriting\ from\ AbstractTestBase\ should\ have\ name\ ending\ with\ ITCase=e1d0c13b-3488-4098-b43c-926d7608882f
+ITCASE\ tests\ should\ use\ a\ MiniCluster\ resource\ or\ extension=659b32e6-c4f4-4158-b5a0-b95ae4467c3f

--- a/flink-connectors/flink-connector-mongodb/pom.xml
+++ b/flink-connectors/flink-connector-mongodb/pom.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<artifactId>flink-connectors</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.17-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-connector-mongodb</artifactId>
+	<name>Flink : Connectors : MongoDB</name>
+
+	<packaging>jar</packaging>
+
+	<properties>
+		<mongodb.version>4.7.1</mongodb.version>
+	</properties>
+
+	<dependencies>
+
+		<!-- Core -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- MongoDB -->
+
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-sync</artifactId>
+			<version>${mongodb.version}</version>
+		</dependency>
+
+		<!-- Table ecosystem -->
+
+		<!-- Projects depending on this project won't depend on flink-table-*. -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-api-java-bridge</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<!-- Tests -->
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mongodb</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- Table API integration tests -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<!-- ArchUit test dependencies -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-architecture-tests-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+</project>

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/config/MongoConnectionOptions.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/config/MongoConnectionOptions.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.common.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import com.mongodb.ConnectionString;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The connection configuration class for MongoDB. */
+@PublicEvolving
+public class MongoConnectionOptions implements Serializable {
+
+    private final String uri;
+    private final String database;
+    private final String collection;
+
+    private MongoConnectionOptions(String uri, String database, String collection) {
+        this.uri = checkNotNull(uri);
+        this.database = checkNotNull(database);
+        this.collection = checkNotNull(collection);
+    }
+
+    public String getUri() {
+        return uri;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MongoConnectionOptions that = (MongoConnectionOptions) o;
+        return Objects.equals(uri, that.uri)
+                && Objects.equals(database, that.database)
+                && Objects.equals(collection, that.collection);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(uri, database, collection);
+    }
+
+    public static MongoConnectionOptionsBuilder builder() {
+        return new MongoConnectionOptionsBuilder();
+    }
+
+    /** Builder for {@link MongoConnectionOptions}. */
+    public static class MongoConnectionOptionsBuilder {
+        private String uri;
+        private String database;
+        private String collection;
+
+        /**
+         * Sets the connection string of MongoDB.
+         *
+         * @param uri connection string of MongoDB
+         * @return this builder
+         */
+        public MongoConnectionOptionsBuilder setUri(String uri) {
+            this.uri = new ConnectionString(uri).getConnectionString();
+            return this;
+        }
+
+        /**
+         * Sets the database of MongoDB.
+         *
+         * @param database the database to sink of MongoDB.
+         * @return this builder
+         */
+        public MongoConnectionOptionsBuilder setDatabase(String database) {
+            this.database = checkNotNull(database, "The database of MongoDB must not be null");
+            return this;
+        }
+
+        /**
+         * Sets the collection of MongoDB.
+         *
+         * @param collection the collection to sink of MongoDB.
+         * @return this builder
+         */
+        public MongoConnectionOptionsBuilder setCollection(String collection) {
+            this.collection =
+                    checkNotNull(collection, "The collection of MongoDB must not be null");
+            return this;
+        }
+
+        /**
+         * Build the {@link MongoConnectionOptions}.
+         *
+         * @return a MongoConnectionOptions with the settings made for this builder.
+         */
+        public MongoConnectionOptions build() {
+            return new MongoConnectionOptions(uri, database, collection);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoConstants.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoConstants.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.common.utils;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonMaxKey;
+import org.bson.BsonMinKey;
+import org.bson.BsonValue;
+
+/** Constants for MongoDB. */
+@PublicEvolving
+public class MongoConstants {
+
+    public static final String ID_FIELD = "_id";
+
+    public static final String NAMESPACE_FIELD = "ns";
+
+    public static final String KEY_FIELD = "key";
+
+    public static final String MAX_FIELD = "max";
+
+    public static final String MIN_FIELD = "min";
+
+    public static final String UUID_FIELD = "uuid";
+
+    public static final String SPLIT_KEYS_FIELD = "splitKeys";
+
+    public static final String SHARD_FIELD = "shard";
+
+    public static final String SHARDED_FIELD = "sharded";
+
+    public static final String COUNT_FIELD = "count";
+
+    public static final String SIZE_FIELD = "size";
+
+    public static final String AVG_OBJ_SIZE_FIELD = "avgObjSize";
+
+    public static final String DROPPED_FIELD = "dropped";
+
+    public static final String ERROR_MESSAGE_FIELD = "errmsg";
+
+    public static final String OK_FIELD = "ok";
+
+    public static final BsonValue BSON_MIN_KEY = new BsonMinKey();
+
+    public static final BsonValue BSON_MAX_KEY = new BsonMaxKey();
+
+    public static final BsonDocument ID_HINT = new BsonDocument(ID_FIELD, new BsonInt32(1));
+
+    private MongoConstants() {}
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoSerdeUtils.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoSerdeUtils.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.common.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.util.function.BiConsumerWithException;
+import org.apache.flink.util.function.FunctionWithException;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** A util class with some helper method for serde in the MongoDB source. */
+@Internal
+public class MongoSerdeUtils {
+
+    /** Private constructor for util class. */
+    private MongoSerdeUtils() {}
+
+    public static <T> void serializeList(
+            DataOutputStream out,
+            List<T> list,
+            BiConsumerWithException<DataOutputStream, T, IOException> serializer)
+            throws IOException {
+        out.writeInt(list.size());
+        for (T t : list) {
+            serializer.accept(out, t);
+        }
+    }
+
+    public static <T> List<T> deserializeList(
+            DataInputStream in, FunctionWithException<DataInputStream, T, IOException> deserializer)
+            throws IOException {
+        int size = in.readInt();
+        List<T> list = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            T t = deserializer.apply(in);
+            list.add(t);
+        }
+
+        return list;
+    }
+
+    public static <K, V> void serializeMap(
+            DataOutputStream out,
+            Map<K, V> map,
+            BiConsumerWithException<DataOutputStream, K, IOException> keySerializer,
+            BiConsumerWithException<DataOutputStream, V, IOException> valueSerializer)
+            throws IOException {
+        out.writeInt(map.size());
+        for (Map.Entry<K, V> entry : map.entrySet()) {
+            keySerializer.accept(out, entry.getKey());
+            valueSerializer.accept(out, entry.getValue());
+        }
+    }
+
+    public static <K, V> Map<K, V> deserializeMap(
+            DataInputStream in,
+            FunctionWithException<DataInputStream, K, IOException> keyDeserializer,
+            FunctionWithException<DataInputStream, V, IOException> valueDeserializer)
+            throws IOException {
+        int size = in.readInt();
+        Map<K, V> result = new HashMap<>(size);
+        for (int i = 0; i < size; i++) {
+            K key = keyDeserializer.apply(in);
+            V value = valueDeserializer.apply(in);
+            result.put(key, value);
+        }
+        return result;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoUtils.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoUtils.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.common.utils;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.conversions.Bson;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.or;
+import static com.mongodb.client.model.Projections.excludeId;
+import static com.mongodb.client.model.Projections.fields;
+import static com.mongodb.client.model.Projections.include;
+import static com.mongodb.client.model.Sorts.ascending;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.DROPPED_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.KEY_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.MAX_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.MIN_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.NAMESPACE_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.OK_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.SHARD_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.UUID_FIELD;
+
+/** A util class with some helper method for MongoDB commands. */
+public class MongoUtils {
+
+    public static final int UNAUTHORIZED_ERROR = 13;
+
+    public static final String COLL_STATS_COMMAND = "collStats";
+    public static final String SPLIT_VECTOR_COMMAND = "splitVector";
+    public static final String KEY_PATTERN_OPTION = "keyPattern";
+    public static final String MAX_CHUNK_SIZE_OPTION = "maxChunkSize";
+
+    public static final String CONFIG_DATABASE = "config";
+    public static final String COLLECTIONS_COLLECTION = "collections";
+    public static final String CHUNKS_COLLECTION = "chunks";
+
+    private MongoUtils() {}
+
+    public static BsonDocument collStats(MongoClient mongoClient, MongoNamespace namespace) {
+        BsonDocument collStatsCommand =
+                new BsonDocument(COLL_STATS_COMMAND, new BsonString(namespace.getCollectionName()));
+        return mongoClient
+                .getDatabase(namespace.getDatabaseName())
+                .runCommand(collStatsCommand, BsonDocument.class);
+    }
+
+    public static BsonDocument splitVector(
+            MongoClient mongoClient,
+            MongoNamespace namespace,
+            BsonDocument keyPattern,
+            int maxChunkSizeMB) {
+        return splitVector(mongoClient, namespace, keyPattern, maxChunkSizeMB, null, null);
+    }
+
+    public static BsonDocument splitVector(
+            MongoClient mongoClient,
+            MongoNamespace namespace,
+            BsonDocument keyPattern,
+            int maxChunkSizeMB,
+            @Nullable BsonDocument min,
+            @Nullable BsonDocument max) {
+        BsonDocument splitVectorCommand =
+                new BsonDocument(SPLIT_VECTOR_COMMAND, new BsonString(namespace.getFullName()))
+                        .append(KEY_PATTERN_OPTION, keyPattern)
+                        .append(MAX_CHUNK_SIZE_OPTION, new BsonInt32(maxChunkSizeMB));
+        Optional.ofNullable(min).ifPresent(v -> splitVectorCommand.append(MIN_FIELD, v));
+        Optional.ofNullable(max).ifPresent(v -> splitVectorCommand.append(MAX_FIELD, v));
+        return mongoClient
+                .getDatabase(namespace.getDatabaseName())
+                .runCommand(splitVectorCommand, BsonDocument.class);
+    }
+
+    @Nullable
+    public static BsonDocument readCollectionMetadata(
+            MongoClient mongoClient, MongoNamespace namespace) {
+        MongoCollection<BsonDocument> collection =
+                mongoClient
+                        .getDatabase(CONFIG_DATABASE)
+                        .getCollection(COLLECTIONS_COLLECTION)
+                        .withDocumentClass(BsonDocument.class);
+
+        return collection
+                .find(eq(ID_FIELD, namespace.getFullName()))
+                .projection(include(ID_FIELD, UUID_FIELD, DROPPED_FIELD, KEY_FIELD))
+                .first();
+    }
+
+    public static boolean isValidShardedCollection(BsonDocument collectionMetadata) {
+        return collectionMetadata != null
+                && !collectionMetadata.getBoolean(DROPPED_FIELD, BsonBoolean.FALSE).getValue();
+    }
+
+    public static List<BsonDocument> readChunks(
+            MongoClient mongoClient, BsonDocument collectionMetadata) {
+        MongoCollection<BsonDocument> chunks =
+                mongoClient
+                        .getDatabase(CONFIG_DATABASE)
+                        .getCollection(CHUNKS_COLLECTION)
+                        .withDocumentClass(BsonDocument.class);
+
+        Bson filter =
+                or(
+                        new BsonDocument(NAMESPACE_FIELD, collectionMetadata.get(ID_FIELD)),
+                        // MongoDB 4.9.0 removed ns field of config.chunks collection, using
+                        // collection's uuid instead.
+                        // See: https://jira.mongodb.org/browse/SERVER-53105
+                        new BsonDocument(UUID_FIELD, collectionMetadata.get(UUID_FIELD)));
+
+        return chunks.find(filter)
+                .projection(include(MIN_FIELD, MAX_FIELD, SHARD_FIELD))
+                .sort(ascending(MIN_FIELD))
+                .into(new ArrayList<>());
+    }
+
+    public static boolean isCommandSucceed(BsonDocument commandResult) {
+        return commandResult != null
+                && commandResult.getDouble(OK_FIELD) != null
+                && commandResult.getDouble(OK_FIELD).doubleValue() > 0.0d;
+    }
+
+    public static Bson project(List<String> projectedFields) {
+        if (projectedFields.contains(ID_FIELD)) {
+            return include(projectedFields);
+        } else {
+            // Creates a projection that excludes the _id field.
+            // This suppresses the automatic inclusion of _id that is default.
+            return fields(include(projectedFields), excludeId());
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoValidationUtils.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/common/utils/MongoValidationUtils.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.common.utils;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.DistinctType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** Utility methods for validating MongoDB properties. */
+@Internal
+public class MongoValidationUtils {
+    private static final Set<LogicalTypeRoot> ALLOWED_PRIMARY_KEY_TYPES = new LinkedHashSet<>();
+
+    static {
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.CHAR);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.VARCHAR);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.BOOLEAN);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.DECIMAL);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.TINYINT);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.SMALLINT);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.INTEGER);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.BIGINT);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.FLOAT);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.DOUBLE);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.INTERVAL_YEAR_MONTH);
+        ALLOWED_PRIMARY_KEY_TYPES.add(LogicalTypeRoot.INTERVAL_DAY_TIME);
+    }
+
+    /**
+     * Checks that the table does not have a primary key defined on illegal types. In MongoDB the
+     * primary key is used to calculate the MongoDB document id, which is a string of up to 1024
+     * bytes. It cannot have whitespaces. As of now it is calculated by concatenating the fields.
+     * Certain types do not have a good string representation to be used in this scenario. The
+     * illegal types are mostly {@link LogicalTypeFamily#COLLECTION} types and {@link
+     * LogicalTypeRoot#RAW} type.
+     */
+    public static void validatePrimaryKey(DataType primaryKeyDataType) {
+        List<DataType> fieldDataTypes = DataType.getFieldDataTypes(primaryKeyDataType);
+        List<LogicalTypeRoot> illegalTypes =
+                fieldDataTypes.stream()
+                        .map(DataType::getLogicalType)
+                        .map(
+                                logicalType -> {
+                                    if (logicalType.is(LogicalTypeRoot.DISTINCT_TYPE)) {
+                                        return ((DistinctType) logicalType)
+                                                .getSourceType()
+                                                .getTypeRoot();
+                                    } else {
+                                        return logicalType.getTypeRoot();
+                                    }
+                                })
+                        .filter(t -> !ALLOWED_PRIMARY_KEY_TYPES.contains(t))
+                        .collect(Collectors.toList());
+        if (!illegalTypes.isEmpty()) {
+            throw new ValidationException(
+                    String.format(
+                            "The table has a primary key on columns of illegal types: %s.",
+                            illegalTypes));
+        }
+    }
+
+    private MongoValidationUtils() {}
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/MongoSink.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/MongoSink.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.sink.writer.MongoWriter;
+import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializationSchema;
+
+import com.mongodb.client.model.WriteModel;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * MongoDB sink that requests multiple {@link WriteModel bulkRequests} against a cluster for each
+ * incoming element. The following example shows how to create a MongoSink receiving records of
+ * {@code Document} type.
+ *
+ * <pre>{@code
+ * MongoSink<Document> sink = MongoSink.<Document>builder()
+ *     .setUri("mongodb://user:password@127.0.0.1:27017")
+ *     .setDatabase("db")
+ *     .setCollection("coll")
+ *     .setBulkFlushMaxActions(5)
+ *     .setSerializationSchema(
+ *         (doc, context) -> new InsertOneModel<>(doc.toBsonDocument()))
+ *     .build();
+ * }</pre>
+ *
+ * @param <IN> Type of the elements handled by this sink
+ */
+@PublicEvolving
+public class MongoSink<IN> implements Sink<IN> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final MongoConnectionOptions connectionOptions;
+    private final MongoWriteOptions writeOptions;
+    private final MongoSerializationSchema<IN> serializationSchema;
+
+    MongoSink(
+            MongoConnectionOptions connectionOptions,
+            MongoWriteOptions writeOptions,
+            MongoSerializationSchema<IN> serializationSchema) {
+        this.connectionOptions = checkNotNull(connectionOptions);
+        this.writeOptions = checkNotNull(writeOptions);
+        this.serializationSchema = checkNotNull(serializationSchema);
+    }
+
+    public static <IN> MongoSinkBuilder<IN> builder() {
+        return new MongoSinkBuilder<>();
+    }
+
+    @Override
+    public SinkWriter<IN> createWriter(InitContext context) {
+        return new MongoWriter<>(
+                connectionOptions,
+                writeOptions,
+                writeOptions.getDeliveryGuarantee() == DeliveryGuarantee.AT_LEAST_ONCE,
+                context,
+                serializationSchema);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/MongoSinkBuilder.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/MongoSinkBuilder.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializationSchema;
+import org.apache.flink.util.InstantiationUtil;
+
+import com.mongodb.client.model.WriteModel;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Base builder to construct a {@link MongoSink}.
+ *
+ * @param <IN> type of the records converted to MongoDB bulk request
+ */
+@PublicEvolving
+public class MongoSinkBuilder<IN> {
+
+    private final MongoConnectionOptions.MongoConnectionOptionsBuilder connectionOptionsBuilder;
+    private final MongoWriteOptions.MongoWriteOptionsBuilder writeOptionsBuilder;
+
+    private MongoSerializationSchema<IN> serializationSchema;
+
+    MongoSinkBuilder() {
+        this.connectionOptionsBuilder = MongoConnectionOptions.builder();
+        this.writeOptionsBuilder = MongoWriteOptions.builder();
+    }
+
+    /**
+     * Sets the connection string of MongoDB.
+     *
+     * @param uri connection string of MongoDB
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setUri(String uri) {
+        connectionOptionsBuilder.setUri(uri);
+        return this;
+    }
+
+    /**
+     * Sets the database to sink of MongoDB.
+     *
+     * @param database the database to sink of MongoDB.
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setDatabase(String database) {
+        connectionOptionsBuilder.setDatabase(database);
+        return this;
+    }
+
+    /**
+     * Sets the collection to sink of MongoDB.
+     *
+     * @param collection the collection to sink of MongoDB.
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setCollection(String collection) {
+        connectionOptionsBuilder.setCollection(collection);
+        return this;
+    }
+
+    /**
+     * Sets the maximum number of actions to buffer for each bulk request. You can pass -1 to
+     * disable it. The default flush size 1000.
+     *
+     * @param numMaxActions the maximum number of actions to buffer per bulk request.
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setBulkFlushMaxActions(int numMaxActions) {
+        writeOptionsBuilder.setBulkFlushMaxActions(numMaxActions);
+        return this;
+    }
+
+    /**
+     * Sets the bulk flush interval, in milliseconds. You can pass -1 to disable it.
+     *
+     * @param intervalMillis the bulk flush interval, in milliseconds.
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setBulkFlushIntervalMs(long intervalMillis) {
+        writeOptionsBuilder.setBulkFlushIntervalMs(intervalMillis);
+        return this;
+    }
+
+    /**
+     * Sets the max retry times if writing records failed.
+     *
+     * @param maxRetryTimes the max retry times.
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setMaxRetryTimes(int maxRetryTimes) {
+        writeOptionsBuilder.setMaxRetryTimes(maxRetryTimes);
+        return this;
+    }
+
+    /**
+     * Sets the wanted {@link DeliveryGuarantee}. The default delivery guarantee is {@link
+     * DeliveryGuarantee#NONE}
+     *
+     * @param deliveryGuarantee which describes the record emission behaviour
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee) {
+        writeOptionsBuilder.setDeliveryGuarantee(deliveryGuarantee);
+        return this;
+    }
+
+    /**
+     * Sets the serialization schema which is invoked on every record to convert it to MongoDB bulk
+     * request.
+     *
+     * @param serializationSchema to process records into MongoDB bulk {@link WriteModel}.
+     * @return this builder
+     */
+    public MongoSinkBuilder<IN> setSerializationSchema(
+            MongoSerializationSchema<IN> serializationSchema) {
+        checkNotNull(serializationSchema);
+        checkState(
+                InstantiationUtil.isSerializable(serializationSchema),
+                "The mongo serialization schema must be serializable.");
+        this.serializationSchema = serializationSchema;
+        return this;
+    }
+
+    /**
+     * Constructs the {@link MongoSink} with the properties configured this builder.
+     *
+     * @return {@link MongoSink}
+     */
+    public MongoSink<IN> build() {
+        checkNotNull(serializationSchema, "The serialization schema must be supplied");
+        return new MongoSink<>(
+                connectionOptionsBuilder.build(), writeOptionsBuilder.build(), serializationSchema);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/config/MongoWriteOptions.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/config/MongoWriteOptions.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.BULK_FLUSH_INTERVAL;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.BULK_FLUSH_MAX_ACTIONS;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SINK_MAX_RETRIES;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** The configured class for Mongo sink. */
+@PublicEvolving
+public class MongoWriteOptions implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int bulkFlushMaxActions;
+    private final long bulkFlushIntervalMs;
+    private final int maxRetryTimes;
+    private final DeliveryGuarantee deliveryGuarantee;
+    private final @Nullable Integer parallelism;
+
+    private MongoWriteOptions(
+            int bulkFlushMaxActions,
+            long bulkFlushIntervalMs,
+            int maxRetryTimes,
+            DeliveryGuarantee deliveryGuarantee,
+            @Nullable Integer parallelism) {
+        this.bulkFlushMaxActions = bulkFlushMaxActions;
+        this.bulkFlushIntervalMs = bulkFlushIntervalMs;
+        this.maxRetryTimes = maxRetryTimes;
+        this.deliveryGuarantee = deliveryGuarantee;
+        this.parallelism = parallelism;
+    }
+
+    public int getBulkFlushMaxActions() {
+        return bulkFlushMaxActions;
+    }
+
+    public long getBulkFlushIntervalMs() {
+        return bulkFlushIntervalMs;
+    }
+
+    public int getMaxRetryTimes() {
+        return maxRetryTimes;
+    }
+
+    public DeliveryGuarantee getDeliveryGuarantee() {
+        return deliveryGuarantee;
+    }
+
+    @Nullable
+    public Integer getParallelism() {
+        return parallelism;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MongoWriteOptions that = (MongoWriteOptions) o;
+        return bulkFlushMaxActions == that.bulkFlushMaxActions
+                && bulkFlushIntervalMs == that.bulkFlushIntervalMs
+                && maxRetryTimes == that.maxRetryTimes
+                && deliveryGuarantee == that.deliveryGuarantee
+                && Objects.equals(parallelism, that.parallelism);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                bulkFlushMaxActions,
+                bulkFlushIntervalMs,
+                maxRetryTimes,
+                deliveryGuarantee,
+                parallelism);
+    }
+
+    public static MongoWriteOptionsBuilder builder() {
+        return new MongoWriteOptionsBuilder();
+    }
+
+    /** Builder for {@link MongoWriteOptions}. */
+    public static class MongoWriteOptionsBuilder {
+        private int bulkFlushMaxActions = BULK_FLUSH_MAX_ACTIONS.defaultValue();
+        private long bulkFlushIntervalMs = BULK_FLUSH_INTERVAL.defaultValue().toMillis();
+        private int maxRetryTimes = SINK_MAX_RETRIES.defaultValue();
+        private DeliveryGuarantee deliveryGuarantee = DeliveryGuarantee.AT_LEAST_ONCE;
+        private @Nullable Integer parallelism;
+
+        /**
+         * Sets the maximum number of actions to buffer for each bulk request. You can pass -1 to
+         * disable it. The default flush size 1000.
+         *
+         * @param numMaxActions the maximum number of actions to buffer per bulk request.
+         * @return this builder
+         */
+        public MongoWriteOptionsBuilder setBulkFlushMaxActions(int numMaxActions) {
+            checkState(
+                    numMaxActions == -1 || numMaxActions > 0,
+                    "Max number of buffered actions must be larger than 0.");
+            this.bulkFlushMaxActions = numMaxActions;
+            return this;
+        }
+
+        /**
+         * Sets the bulk flush interval, in milliseconds. You can pass -1 to disable it.
+         *
+         * @param intervalMillis the bulk flush interval, in milliseconds.
+         * @return this builder
+         */
+        public MongoWriteOptionsBuilder setBulkFlushIntervalMs(long intervalMillis) {
+            checkState(
+                    intervalMillis == -1 || intervalMillis >= 0,
+                    "Interval (in milliseconds) between each flush must be larger than "
+                            + "or equal to 0.");
+            this.bulkFlushIntervalMs = intervalMillis;
+            return this;
+        }
+
+        /**
+         * Sets the max retry times if writing records failed.
+         *
+         * @param maxRetryTimes the max retry times.
+         * @return this builder
+         */
+        public MongoWriteOptionsBuilder setMaxRetryTimes(int maxRetryTimes) {
+            checkArgument(
+                    maxRetryTimes >= 0, "The max retry times must be larger than or equal to 0.");
+            this.maxRetryTimes = maxRetryTimes;
+            return this;
+        }
+
+        /**
+         * Sets the wanted {@link DeliveryGuarantee}. The default delivery guarantee is {@link
+         * DeliveryGuarantee#NONE}
+         *
+         * @param deliveryGuarantee which describes the record emission behaviour
+         * @return this builder
+         */
+        public MongoWriteOptionsBuilder setDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee) {
+            checkState(
+                    deliveryGuarantee != DeliveryGuarantee.EXACTLY_ONCE,
+                    "Mongo sink does not support the EXACTLY_ONCE guarantee.");
+            this.deliveryGuarantee = checkNotNull(deliveryGuarantee);
+            return this;
+        }
+
+        /**
+         * Sets the write parallelism.
+         *
+         * @param parallelism the write parallelism
+         * @return this builder
+         */
+        public MongoWriteOptionsBuilder setParallelism(Integer parallelism) {
+            checkArgument(
+                    parallelism == null || parallelism > 0,
+                    "Mongo sink parallelism must be larger than 0.");
+            this.parallelism = parallelism;
+            return this;
+        }
+
+        /**
+         * Build the {@link MongoWriteOptions}.
+         *
+         * @return a MongoWriteOptions with the settings made for this builder.
+         */
+        public MongoWriteOptions build() {
+            return new MongoWriteOptions(
+                    bulkFlushMaxActions,
+                    bulkFlushIntervalMs,
+                    maxRetryTimes,
+                    deliveryGuarantee,
+                    parallelism);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/MongoWriter.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/MongoWriter.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink.writer;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.functions.util.ListCollector;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.sink.writer.context.MongoSinkContext;
+import org.apache.flink.connector.mongodb.sink.writer.context.MongoSinkContextImpl;
+import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializationSchema;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.runtime.operators.util.metrics.CountingCollector;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.model.WriteModel;
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class is responsible to write records in a MongoDB collection.
+ *
+ * @param <IN> The type of the input elements.
+ */
+@Internal
+public class MongoWriter<IN> implements SinkWriter<IN> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoWriter.class);
+
+    private final MongoConnectionOptions connectionOptions;
+    private final MongoWriteOptions writeOptions;
+    private final MongoSerializationSchema<IN> serializationSchema;
+    private final MongoSinkContext sinkContext;
+    private final MailboxExecutor mailboxExecutor;
+    private final boolean flushOnCheckpoint;
+    private final List<WriteModel<BsonDocument>> bulkRequests = new ArrayList<>();
+    private final Collector<WriteModel<BsonDocument>> collector;
+    private final MongoClient mongoClient;
+
+    private boolean checkpointInProgress = false;
+    private volatile long lastSendTime = 0L;
+    private volatile long ackTime = Long.MAX_VALUE;
+
+    public MongoWriter(
+            MongoConnectionOptions connectionOptions,
+            MongoWriteOptions writeOptions,
+            boolean flushOnCheckpoint,
+            Sink.InitContext initContext,
+            MongoSerializationSchema<IN> serializationSchema) {
+        this.connectionOptions = checkNotNull(connectionOptions);
+        this.writeOptions = checkNotNull(writeOptions);
+        this.serializationSchema = checkNotNull(serializationSchema);
+        this.flushOnCheckpoint = flushOnCheckpoint;
+
+        checkNotNull(initContext);
+        this.mailboxExecutor = checkNotNull(initContext.getMailboxExecutor());
+
+        SinkWriterMetricGroup metricGroup = checkNotNull(initContext.metricGroup());
+        metricGroup.setCurrentSendTimeGauge(() -> ackTime - lastSendTime);
+
+        this.collector =
+                new CountingCollector<>(
+                        new ListCollector<>(this.bulkRequests),
+                        metricGroup.getNumRecordsSendCounter());
+
+        // Initialize the serialization schema.
+        this.sinkContext = new MongoSinkContextImpl(initContext, writeOptions);
+        try {
+            SerializationSchema.InitializationContext initializationContext =
+                    initContext.asSerializationSchemaInitializationContext();
+            serializationSchema.open(initializationContext, sinkContext, writeOptions);
+        } catch (Exception e) {
+            throw new FlinkRuntimeException("Failed to open the MongoEmitter", e);
+        }
+
+        // Initialize the mongo client.
+        this.mongoClient = MongoClients.create(connectionOptions.getUri());
+    }
+
+    @Override
+    public void write(IN element, Context context) throws IOException, InterruptedException {
+        // do not allow new bulk writes until all actions are flushed
+        while (checkpointInProgress) {
+            mailboxExecutor.yield();
+        }
+        collector.collect(serializationSchema.serialize(element, sinkContext));
+        if (isOverMaxActionsLimit() || isOverMaxFlushIntervalLimit()) {
+            doBulkWrite();
+        }
+    }
+
+    @Override
+    public void flush(boolean endOfInput) throws IOException {
+        checkpointInProgress = true;
+        while (!bulkRequests.isEmpty() && (flushOnCheckpoint || endOfInput)) {
+            doBulkWrite();
+        }
+        checkpointInProgress = false;
+    }
+
+    @Override
+    public void close() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @VisibleForTesting
+    void doBulkWrite() throws IOException {
+        if (bulkRequests.isEmpty()) {
+            // no records to write
+            return;
+        }
+
+        int maxRetryTimes = writeOptions.getMaxRetryTimes();
+        for (int i = 0; i <= maxRetryTimes; i++) {
+            try {
+                lastSendTime = System.currentTimeMillis();
+                mongoClient
+                        .getDatabase(connectionOptions.getDatabase())
+                        .getCollection(connectionOptions.getCollection(), BsonDocument.class)
+                        .bulkWrite(bulkRequests);
+                ackTime = System.currentTimeMillis();
+                bulkRequests.clear();
+                break;
+            } catch (MongoException e) {
+                LOG.error("Bulk Write to MongoDB failed, retry times = {}", i, e);
+                if (i >= maxRetryTimes) {
+                    throw new IOException(e);
+                }
+                try {
+                    Thread.sleep(1000L * i);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IOException(
+                            "Unable to flush; interrupted while doing another attempt", e);
+                }
+            }
+        }
+    }
+
+    private boolean isOverMaxActionsLimit() {
+        int bulkActions = writeOptions.getBulkFlushMaxActions();
+        return bulkActions != -1 && bulkRequests.size() >= bulkActions;
+    }
+
+    private boolean isOverMaxFlushIntervalLimit() {
+        long bulkFlushInterval = writeOptions.getBulkFlushIntervalMs();
+        long lastSentInterval = System.currentTimeMillis() - lastSendTime;
+        return bulkFlushInterval != -1 && lastSentInterval >= bulkFlushInterval;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/MongoSinkContext.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/MongoSinkContext.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink.writer.context;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializationSchema;
+
+/** This context provides information for {@link MongoSerializationSchema}. */
+@PublicEvolving
+public interface MongoSinkContext {
+
+    /**
+     * Get the number of the subtask that MongoSink is running on. The numbering starts from 0 and
+     * goes up to parallelism-1. (parallelism as returned by {@link #getNumberOfParallelInstances()}
+     *
+     * @return number of subtask
+     */
+    int getParallelInstanceId();
+
+    /** @return number of parallel MongoSink tasks. */
+    int getNumberOfParallelInstances();
+
+    /** Returns the current process time in flink. */
+    long processTime();
+
+    /** Returns the write options of MongoSink. */
+    MongoWriteOptions getWriteOptions();
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/MongoSinkContextImpl.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/context/MongoSinkContextImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink.writer.context;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+
+/** An implementation that would contain all the required context. */
+@Internal
+public class MongoSinkContextImpl implements MongoSinkContext {
+
+    private final int numberOfParallelSubtasks;
+    private final int parallelInstanceId;
+    private final ProcessingTimeService processingTimeService;
+    private final MongoWriteOptions writeOptions;
+
+    public MongoSinkContextImpl(Sink.InitContext initContext, MongoWriteOptions writeOptions) {
+        this.parallelInstanceId = initContext.getSubtaskId();
+        this.numberOfParallelSubtasks = initContext.getNumberOfParallelSubtasks();
+        this.processingTimeService = initContext.getProcessingTimeService();
+        this.writeOptions = writeOptions;
+    }
+
+    @Override
+    public int getParallelInstanceId() {
+        return parallelInstanceId;
+    }
+
+    @Override
+    public int getNumberOfParallelInstances() {
+        return numberOfParallelSubtasks;
+    }
+
+    @Override
+    public long processTime() {
+        return processingTimeService.getCurrentProcessingTime();
+    }
+
+    @Override
+    public MongoWriteOptions getWriteOptions() {
+        return writeOptions;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/serializer/MongoSerializationSchema.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/sink/writer/serializer/MongoSerializationSchema.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink.writer.serializer;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.sink.writer.context.MongoSinkContext;
+
+import com.mongodb.client.model.WriteModel;
+import org.bson.BsonDocument;
+
+import java.io.Serializable;
+
+/**
+ * The serialization schema for how to serialize records into MongoDB.
+ *
+ * @param <IN> The message type send to MongoDB.
+ */
+@PublicEvolving
+public interface MongoSerializationSchema<IN> extends Serializable {
+
+    /**
+     * Initialization method for the schema. It is called before the actual working methods {@link
+     * #serialize(Object, MongoSinkContext)} and thus suitable for one-time setup work.
+     *
+     * <p>The provided {@link SerializationSchema.InitializationContext} can be used to access
+     * additional features such as registering user metrics.
+     *
+     * @param initializationContext Contextual information that can be used during initialization.
+     * @param sinkContext Runtime information i.e. partitions, subtaskId.
+     * @param sinkConfiguration All the configure options for the MongoDB sink. You can add custom
+     *     options.
+     */
+    default void open(
+            SerializationSchema.InitializationContext initializationContext,
+            MongoSinkContext sinkContext,
+            MongoWriteOptions sinkConfiguration)
+            throws Exception {
+        // Nothing to do by default.
+    }
+
+    /**
+     * Serializes the given element into {@link WriteModel}.
+     *
+     * @param element Element to be serialized.
+     * @param sinkContext Context to provide extra information.
+     */
+    WriteModel<BsonDocument> serialize(IN element, MongoSinkContext sinkContext);
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/MongoSource.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/MongoSource.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.enumerator.MongoSourceEnumState;
+import org.apache.flink.connector.mongodb.source.enumerator.MongoSourceEnumStateSerializer;
+import org.apache.flink.connector.mongodb.source.enumerator.MongoSourceEnumerator;
+import org.apache.flink.connector.mongodb.source.enumerator.assigner.MongoScanSplitAssigner;
+import org.apache.flink.connector.mongodb.source.enumerator.assigner.MongoSplitAssigner;
+import org.apache.flink.connector.mongodb.source.reader.MongoSourceReader;
+import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoDeserializationSchema;
+import org.apache.flink.connector.mongodb.source.reader.emitter.MongoRecordEmitter;
+import org.apache.flink.connector.mongodb.source.reader.split.MongoScanSourceSplitReader;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.bson.BsonDocument;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The Source implementation of MongoDB. Please use a {@link MongoSourceBuilder} to construct a
+ * {@link MongoSource}. The following example shows how to create a MongoSource emitting records of
+ * <code>String</code> type.
+ *
+ * <pre>{@code
+ * MongoSource<String> source = MongoSource.<String>builder()
+ *      .setUri("mongodb://user:password@127.0.0.1:27017")
+ *      .setDatabase("db")
+ *      .setCollection("coll")
+ *      .setDeserializationSchema(new MongoJsonDeserializationSchema())
+ *      .build();
+ * }</pre>
+ *
+ * <p>See {@link MongoSourceBuilder} for more details.
+ *
+ * @param <OUT> The output type of the source.
+ */
+@PublicEvolving
+public class MongoSource<OUT>
+        implements Source<OUT, MongoSourceSplit, MongoSourceEnumState>, ResultTypeQueryable<OUT> {
+
+    private static final long serialVersionUID = 1L;
+
+    /** The connection options for MongoDB source. */
+    private final MongoConnectionOptions connectionOptions;
+
+    /** The read options for MongoDB source. */
+    private final MongoReadOptions readOptions;
+
+    /** The projections for MongoDB source. */
+    @Nullable private final List<String> projectedFields;
+
+    /** The limit for MongoDB source. */
+    private final int limit;
+
+    /** The boundedness for MongoDB source. */
+    private final Boundedness boundedness;
+
+    /** The mongo deserialization schema used for deserializing message. */
+    private final MongoDeserializationSchema<OUT> deserializationSchema;
+
+    MongoSource(
+            MongoConnectionOptions connectionOptions,
+            MongoReadOptions readOptions,
+            @Nullable List<String> projectedFields,
+            int limit,
+            MongoDeserializationSchema<OUT> deserializationSchema) {
+        this.connectionOptions = checkNotNull(connectionOptions);
+        this.readOptions = checkNotNull(readOptions);
+        this.projectedFields = projectedFields;
+        this.limit = limit;
+        // Only support bounded mode for now.
+        // We can implement unbounded mode by ChangeStream future.
+        this.boundedness = Boundedness.BOUNDED;
+        this.deserializationSchema = checkNotNull(deserializationSchema);
+    }
+
+    /**
+     * Get a MongoSourceBuilder to builder a {@link MongoSource}.
+     *
+     * @return a Mongo source builder.
+     */
+    public static <OUT> MongoSourceBuilder<OUT> builder() {
+        return new MongoSourceBuilder<>();
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return boundedness;
+    }
+
+    @Override
+    public SourceReader<OUT, MongoSourceSplit> createReader(SourceReaderContext readerContext) {
+        FutureCompletingBlockingQueue<RecordsWithSplitIds<BsonDocument>> elementsQueue =
+                new FutureCompletingBlockingQueue<>();
+
+        Supplier<SplitReader<BsonDocument, MongoSourceSplit>> splitReaderSupplier =
+                () ->
+                        new MongoScanSourceSplitReader(
+                                connectionOptions,
+                                readOptions,
+                                projectedFields,
+                                limit,
+                                readerContext);
+
+        return new MongoSourceReader<>(
+                elementsQueue,
+                splitReaderSupplier,
+                new MongoRecordEmitter<>(deserializationSchema),
+                readerContext);
+    }
+
+    @Override
+    public SplitEnumerator<MongoSourceSplit, MongoSourceEnumState> createEnumerator(
+            SplitEnumeratorContext<MongoSourceSplit> enumContext) {
+        MongoSourceEnumState initialState = MongoSourceEnumState.initialState();
+        MongoSplitAssigner splitAssigner =
+                new MongoScanSplitAssigner(
+                        connectionOptions, readOptions, isLimitPushedDown(), initialState);
+        return new MongoSourceEnumerator(boundedness, enumContext, splitAssigner);
+    }
+
+    @Override
+    public SplitEnumerator<MongoSourceSplit, MongoSourceEnumState> restoreEnumerator(
+            SplitEnumeratorContext<MongoSourceSplit> enumContext, MongoSourceEnumState checkpoint) {
+        MongoSplitAssigner splitAssigner =
+                new MongoScanSplitAssigner(
+                        connectionOptions, readOptions, isLimitPushedDown(), checkpoint);
+        return new MongoSourceEnumerator(boundedness, enumContext, splitAssigner);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<MongoSourceSplit> getSplitSerializer() {
+        return MongoSourceSplitSerializer.INSTANCE;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<MongoSourceEnumState> getEnumeratorCheckpointSerializer() {
+        return MongoSourceEnumStateSerializer.INSTANCE;
+    }
+
+    @Override
+    public TypeInformation<OUT> getProducedType() {
+        return deserializationSchema.getProducedType();
+    }
+
+    private boolean isLimitPushedDown() {
+        return limit > 0;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/MongoSourceBuilder.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/MongoSourceBuilder.java
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
+import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoDeserializationSchema;
+
+import org.bson.BsonDocument;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.util.CollectionUtil.isNullOrEmpty;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * The builder class for {@link MongoSource} to make it easier for the users to construct a {@link
+ * MongoSource}.
+ *
+ * @param <OUT> The output type of the source.
+ */
+@PublicEvolving
+public class MongoSourceBuilder<OUT> {
+
+    private final MongoConnectionOptions.MongoConnectionOptionsBuilder connectionOptionsBuilder;
+    private final MongoReadOptions.MongoReadOptionsBuilder readOptionsBuilder;
+
+    private List<String> projectedFields;
+    private int limit = -1;
+    private MongoDeserializationSchema<OUT> deserializationSchema;
+
+    MongoSourceBuilder() {
+        this.connectionOptionsBuilder = MongoConnectionOptions.builder();
+        this.readOptionsBuilder = MongoReadOptions.builder();
+    }
+
+    /**
+     * Sets the connection string of MongoDB.
+     *
+     * @param uri connection string of MongoDB
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setUri(String uri) {
+        connectionOptionsBuilder.setUri(uri);
+        return this;
+    }
+
+    /**
+     * Sets the database to sink of MongoDB.
+     *
+     * @param database the database to sink of MongoDB.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setDatabase(String database) {
+        connectionOptionsBuilder.setDatabase(database);
+        return this;
+    }
+
+    /**
+     * Sets the collection to sink of MongoDB.
+     *
+     * @param collection the collection to sink of MongoDB.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setCollection(String collection) {
+        connectionOptionsBuilder.setCollection(collection);
+        return this;
+    }
+
+    /**
+     * Sets the number of documents should be fetched per round-trip when reading.
+     *
+     * @param fetchSize the number of documents should be fetched per round-trip when reading.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setFetchSize(int fetchSize) {
+        readOptionsBuilder.setFetchSize(fetchSize);
+        return this;
+    }
+
+    /**
+     * Sets the batch size of MongoDB find cursor.
+     *
+     * @param cursorBatchSize the max batch size of find cursor.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setCursorBatchSize(int cursorBatchSize) {
+        readOptionsBuilder.setCursorBatchSize(cursorBatchSize);
+        return this;
+    }
+
+    /**
+     * Set this option to true to prevent cursor timeout (defaults to 10 minutes).
+     *
+     * @param noCursorTimeout Set this option to true to prevent cursor timeout.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setNoCursorTimeout(boolean noCursorTimeout) {
+        readOptionsBuilder.setNoCursorTimeout(noCursorTimeout);
+        return this;
+    }
+
+    /**
+     * Sets the partition strategy.
+     *
+     * @param partitionStrategy the strategy of a partition.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setPartitionStrategy(PartitionStrategy partitionStrategy) {
+        readOptionsBuilder.setPartitionStrategy(partitionStrategy);
+        return this;
+    }
+
+    /**
+     * Sets the partition size of MongoDB split.
+     *
+     * @param partitionSize the memory size of a partition.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setPartitionSize(MemorySize partitionSize) {
+        readOptionsBuilder.setPartitionSize(partitionSize);
+        return this;
+    }
+
+    /**
+     * Sets the samples size per partition only effective for sample partition strategy.
+     *
+     * @param samplesPerPartition the samples size per partition
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setSamplesPerPartition(int samplesPerPartition) {
+        readOptionsBuilder.setSamplesPerPartition(samplesPerPartition);
+        return this;
+    }
+
+    /**
+     * Sets the limit of documents to read.
+     *
+     * @param limit the limit of documents to read.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setLimit(int limit) {
+        checkArgument(limit == -1 || limit > 0, "The limit must be larger than 0");
+        this.limit = limit;
+        return this;
+    }
+
+    /**
+     * Sets the projection fields of documents to read.
+     *
+     * @param projectedFields the projection fields of documents to read.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setProjectedFields(String... projectedFields) {
+        checkNotNull(projectedFields, "The projected fields must be supplied");
+        return setProjectedFields(Arrays.asList(projectedFields));
+    }
+
+    /**
+     * Sets the projection fields of documents to read.
+     *
+     * @param projectedFields the projection fields of documents to read.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setProjectedFields(List<String> projectedFields) {
+        checkArgument(
+                !isNullOrEmpty(projectedFields), "At least one projected field to be supplied");
+        this.projectedFields = projectedFields;
+        return this;
+    }
+
+    /**
+     * Sets the deserialization schema for MongoDB {@link BsonDocument}.
+     *
+     * @param deserializationSchema the deserialization schema to deserialize {@link BsonDocument}.
+     * @return this builder
+     */
+    public MongoSourceBuilder<OUT> setDeserializationSchema(
+            MongoDeserializationSchema<OUT> deserializationSchema) {
+        checkNotNull(deserializationSchema, "The deserialization schema must not be null");
+        this.deserializationSchema = deserializationSchema;
+        return this;
+    }
+
+    /**
+     * Build the {@link MongoSource}.
+     *
+     * @return a MongoSource with the settings made for this builder.
+     */
+    public MongoSource<OUT> build() {
+        checkNotNull(deserializationSchema, "The deserialization schema must be supplied");
+        return new MongoSource<>(
+                connectionOptionsBuilder.build(),
+                readOptionsBuilder.build(),
+                projectedFields,
+                limit,
+                deserializationSchema);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/config/MongoReadOptions.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/config/MongoReadOptions.java
@@ -1,0 +1,224 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_CURSOR_BATCH_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_FETCH_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_SAMPLES;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_STRATEGY;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The configuration class for MongoDB source. */
+@PublicEvolving
+public class MongoReadOptions implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final int fetchSize;
+
+    private final int cursorBatchSize;
+
+    private final boolean noCursorTimeout;
+
+    private final PartitionStrategy partitionStrategy;
+
+    private final MemorySize partitionSize;
+
+    private final int samplesPerPartition;
+
+    private MongoReadOptions(
+            int fetchSize,
+            int cursorBatchSize,
+            boolean noCursorTimeout,
+            PartitionStrategy partitionStrategy,
+            MemorySize partitionSize,
+            int samplesPerPartition) {
+        this.fetchSize = fetchSize;
+        this.cursorBatchSize = cursorBatchSize;
+        this.noCursorTimeout = noCursorTimeout;
+        this.partitionStrategy = partitionStrategy;
+        this.partitionSize = partitionSize;
+        this.samplesPerPartition = samplesPerPartition;
+    }
+
+    public int getFetchSize() {
+        return fetchSize;
+    }
+
+    public int getCursorBatchSize() {
+        return cursorBatchSize;
+    }
+
+    public boolean isNoCursorTimeout() {
+        return noCursorTimeout;
+    }
+
+    public PartitionStrategy getPartitionStrategy() {
+        return partitionStrategy;
+    }
+
+    public MemorySize getPartitionSize() {
+        return partitionSize;
+    }
+
+    public int getSamplesPerPartition() {
+        return samplesPerPartition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MongoReadOptions that = (MongoReadOptions) o;
+        return cursorBatchSize == that.cursorBatchSize
+                && noCursorTimeout == that.noCursorTimeout
+                && partitionStrategy == that.partitionStrategy
+                && samplesPerPartition == that.samplesPerPartition
+                && Objects.equals(partitionSize, that.partitionSize);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                cursorBatchSize,
+                noCursorTimeout,
+                partitionStrategy,
+                partitionSize,
+                samplesPerPartition);
+    }
+
+    public static MongoReadOptionsBuilder builder() {
+        return new MongoReadOptionsBuilder();
+    }
+
+    /** Builder for {@link MongoReadOptions}. */
+    public static class MongoReadOptionsBuilder {
+        private int fetchSize = SCAN_FETCH_SIZE.defaultValue();
+        private int cursorBatchSize = SCAN_CURSOR_BATCH_SIZE.defaultValue();
+        private boolean noCursorTimeout = SCAN_CURSOR_NO_TIMEOUT.defaultValue();
+        private PartitionStrategy partitionStrategy = SCAN_PARTITION_STRATEGY.defaultValue();
+        private MemorySize partitionSize = SCAN_PARTITION_SIZE.defaultValue();
+        private int samplesPerPartition = SCAN_PARTITION_SAMPLES.defaultValue();
+
+        /**
+         * Sets the number of documents should be fetched per round-trip when reading.
+         *
+         * @param fetchSize the number of documents should be fetched per round-trip when reading.
+         * @return this builder
+         */
+        public MongoReadOptionsBuilder setFetchSize(int fetchSize) {
+            checkArgument(fetchSize > 0, "The fetch size must be larger than 0.");
+            this.fetchSize = fetchSize;
+            return this;
+        }
+
+        /**
+         * Sets the batch size of MongoDB find cursor.
+         *
+         * @param cursorBatchSize the max batch size of find cursor.
+         * @return this builder
+         */
+        public MongoReadOptionsBuilder setCursorBatchSize(int cursorBatchSize) {
+            checkArgument(
+                    cursorBatchSize >= 0,
+                    "The cursor batch size must be larger than or equal to 0.");
+            this.cursorBatchSize = cursorBatchSize;
+            return this;
+        }
+
+        /**
+         * Set this option to true to prevent cursor timeout (10 minutes).
+         *
+         * @param noCursorTimeout Set this option to true to prevent cursor timeout (10 minutes)
+         * @return this builder
+         */
+        public MongoReadOptionsBuilder setNoCursorTimeout(boolean noCursorTimeout) {
+            this.noCursorTimeout = noCursorTimeout;
+            return this;
+        }
+
+        /**
+         * Sets the partition strategy.
+         *
+         * @param partitionStrategy the strategy of a partition.
+         * @return this builder
+         */
+        public MongoReadOptionsBuilder setPartitionStrategy(PartitionStrategy partitionStrategy) {
+            checkNotNull(partitionStrategy, "The partition strategy must not be null.");
+            this.partitionStrategy = partitionStrategy;
+            return this;
+        }
+
+        /**
+         * Sets the partition size of MongoDB split.
+         *
+         * @param partitionSize the memory size of a partition.
+         * @return this builder
+         */
+        public MongoReadOptionsBuilder setPartitionSize(MemorySize partitionSize) {
+            checkNotNull(partitionSize, "The partition size must not be null");
+            checkArgument(
+                    partitionSize.getMebiBytes() >= 1,
+                    "The partition size must be larger than or equals to 1mb.");
+            this.partitionSize = partitionSize;
+            return this;
+        }
+
+        /**
+         * Sets the partition size of MongoDB split.
+         *
+         * @param samplesPerPartition the memory size of a partition.
+         * @return this builder
+         */
+        public MongoReadOptionsBuilder setSamplesPerPartition(int samplesPerPartition) {
+            checkArgument(
+                    samplesPerPartition > 0, "The samples per partition must be larger than 0.");
+            this.samplesPerPartition = samplesPerPartition;
+            return this;
+        }
+
+        /**
+         * Build the {@link MongoReadOptions}.
+         *
+         * @return a MongoReadOptions with the settings made for this builder.
+         */
+        public MongoReadOptions build() {
+            return new MongoReadOptions(
+                    fetchSize,
+                    cursorBatchSize,
+                    noCursorTimeout,
+                    partitionStrategy,
+                    partitionSize,
+                    samplesPerPartition);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumState.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumState.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.enumerator.assigner.MongoSplitAssigner;
+import org.apache.flink.connector.mongodb.source.reader.split.MongoSourceSplitReader;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The state class for MongoDB source enumerator, used for storing the split state. This class is
+ * managed and controlled by {@link MongoSplitAssigner}.
+ */
+@Internal
+public class MongoSourceEnumState {
+
+    /** The Mongo collections remaining. */
+    private final List<String> remainingCollections;
+
+    /**
+     * The paths that are no longer in the enumerator checkpoint, but have been processed before.
+     */
+    private final List<String> alreadyProcessedCollections;
+
+    /** The scan splits in the checkpoint. */
+    private final List<MongoScanSourceSplit> remainingScanSplits;
+
+    /**
+     * The scan splits that the {@link MongoSourceEnumerator} has assigned to {@link
+     * MongoSourceSplitReader}s.
+     */
+    private final Map<String, MongoScanSourceSplit> assignedScanSplits;
+
+    /** The pipeline has been triggered and topic partitions have been assigned to readers. */
+    private final boolean initialized;
+
+    public MongoSourceEnumState(
+            List<String> remainingCollections,
+            List<String> alreadyProcessedCollections,
+            List<MongoScanSourceSplit> remainingScanSplits,
+            Map<String, MongoScanSourceSplit> assignedScanSplits,
+            boolean initialized) {
+        this.remainingCollections = remainingCollections;
+        this.alreadyProcessedCollections = alreadyProcessedCollections;
+        this.remainingScanSplits = remainingScanSplits;
+        this.assignedScanSplits = assignedScanSplits;
+        this.initialized = initialized;
+    }
+
+    public List<String> getRemainingCollections() {
+        return remainingCollections;
+    }
+
+    public List<String> getAlreadyProcessedCollections() {
+        return alreadyProcessedCollections;
+    }
+
+    public List<MongoScanSourceSplit> getRemainingScanSplits() {
+        return remainingScanSplits;
+    }
+
+    public Map<String, MongoScanSourceSplit> getAssignedScanSplits() {
+        return assignedScanSplits;
+    }
+
+    public boolean isInitialized() {
+        return initialized;
+    }
+
+    /** The initial assignment state for Mongo. */
+    public static MongoSourceEnumState initialState() {
+        return new MongoSourceEnumState(
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new HashMap<>(), false);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializer.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializer.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoSerdeUtils.deserializeList;
+import static org.apache.flink.connector.mongodb.common.utils.MongoSerdeUtils.deserializeMap;
+import static org.apache.flink.connector.mongodb.common.utils.MongoSerdeUtils.serializeList;
+import static org.apache.flink.connector.mongodb.common.utils.MongoSerdeUtils.serializeMap;
+
+/** The {@link SimpleVersionedSerializer Serializer} for the enumerator state of Mongo source. */
+@Internal
+public class MongoSourceEnumStateSerializer
+        implements SimpleVersionedSerializer<MongoSourceEnumState> {
+
+    public static final MongoSourceEnumStateSerializer INSTANCE =
+            new MongoSourceEnumStateSerializer();
+
+    private MongoSourceEnumStateSerializer() {
+        // Singleton instance.
+    }
+
+    @Override
+    public int getVersion() {
+        // We use MongoSourceSplitSerializer's version because we use reuse this class.
+        return MongoSourceSplitSerializer.CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(MongoSourceEnumState state) throws IOException {
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            serializeList(out, state.getRemainingCollections(), DataOutputStream::writeUTF);
+
+            serializeList(out, state.getAlreadyProcessedCollections(), DataOutputStream::writeUTF);
+
+            serializeList(
+                    out,
+                    state.getRemainingScanSplits(),
+                    MongoSourceSplitSerializer.INSTANCE::serializeMongoSplit);
+
+            serializeMap(
+                    out,
+                    state.getAssignedScanSplits(),
+                    DataOutputStream::writeUTF,
+                    MongoSourceSplitSerializer.INSTANCE::serializeMongoSplit);
+
+            out.writeBoolean(state.isInitialized());
+
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public MongoSourceEnumState deserialize(int version, byte[] serialized) throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            List<String> remainingCollections = deserializeList(in, DataInput::readUTF);
+            List<String> alreadyProcessedCollections = deserializeList(in, DataInput::readUTF);
+            List<MongoScanSourceSplit> remainingScanSplits =
+                    deserializeList(in, i -> deserializeMongoScanSourceSplit(version, i));
+
+            Map<String, MongoScanSourceSplit> assignedScanSplits =
+                    deserializeMap(
+                            in,
+                            DataInput::readUTF,
+                            i -> deserializeMongoScanSourceSplit(version, i));
+
+            boolean initialized = in.readBoolean();
+
+            return new MongoSourceEnumState(
+                    remainingCollections,
+                    alreadyProcessedCollections,
+                    remainingScanSplits,
+                    assignedScanSplits,
+                    initialized);
+        }
+    }
+
+    private MongoScanSourceSplit deserializeMongoScanSourceSplit(int version, DataInputStream in)
+            throws IOException {
+        return (MongoScanSourceSplit)
+                MongoSourceSplitSerializer.INSTANCE.deserializeMongoSourceSplit(version, in);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumerator.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumerator.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.mongodb.source.MongoSource;
+import org.apache.flink.connector.mongodb.source.enumerator.assigner.MongoSplitAssigner;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeSet;
+
+/** The enumerator class for {@link MongoSource}. */
+@Internal
+public class MongoSourceEnumerator
+        implements SplitEnumerator<MongoSourceSplit, MongoSourceEnumState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSourceEnumerator.class);
+
+    private final Boundedness boundedness;
+    private final SplitEnumeratorContext<MongoSourceSplit> context;
+    private final MongoSplitAssigner splitAssigner;
+    private final TreeSet<Integer> readersAwaitingSplit;
+
+    public MongoSourceEnumerator(
+            Boundedness boundedness,
+            SplitEnumeratorContext<MongoSourceSplit> context,
+            MongoSplitAssigner splitAssigner) {
+        this.boundedness = boundedness;
+        this.context = context;
+        this.splitAssigner = splitAssigner;
+        this.readersAwaitingSplit = new TreeSet<>();
+    }
+
+    @Override
+    public void start() {
+        splitAssigner.open();
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        if (!context.registeredReaders().containsKey(subtaskId)) {
+            // reader failed between sending the request and now. skip this request.
+            return;
+        }
+
+        readersAwaitingSplit.add(subtaskId);
+        assignSplits();
+    }
+
+    @Override
+    public void addSplitsBack(List<MongoSourceSplit> splits, int subtaskId) {
+        LOG.debug("Mongo Source Enumerator adds splits back: {}", splits);
+        splitAssigner.addSplitsBack(splits);
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        LOG.debug("Adding reader {} to MongoSourceEnumerator.", subtaskId);
+    }
+
+    private void assignSplits() {
+        final Iterator<Integer> awaitingReader = readersAwaitingSplit.iterator();
+
+        while (awaitingReader.hasNext()) {
+            int nextAwaiting = awaitingReader.next();
+            // if the reader that requested another split has failed in the meantime, remove
+            // it from the list of waiting readers
+            if (!context.registeredReaders().containsKey(nextAwaiting)) {
+                awaitingReader.remove();
+                continue;
+            }
+
+            Optional<MongoSourceSplit> split = splitAssigner.getNext();
+            if (split.isPresent()) {
+                final MongoSourceSplit mongoSplit = split.get();
+                context.assignSplit(mongoSplit, nextAwaiting);
+                awaitingReader.remove();
+                LOG.info("Assign split {} to subtask {}", mongoSplit, nextAwaiting);
+                break;
+            } else if (splitAssigner.noMoreSplits() && boundedness == Boundedness.BOUNDED) {
+                LOG.info("All splits have been assigned");
+                context.registeredReaders().keySet().forEach(context::signalNoMoreSplits);
+                break;
+            } else {
+                // there is no available splits by now, skip assigning
+                break;
+            }
+        }
+    }
+
+    @Override
+    public MongoSourceEnumState snapshotState(long checkpointId) {
+        return splitAssigner.snapshotState(checkpointId);
+    }
+
+    @Override
+    public void close() throws IOException {
+        splitAssigner.close();
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/assigner/MongoScanSplitAssigner.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/assigner/MongoScanSplitAssigner.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.assigner;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.enumerator.MongoSourceEnumState;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.MongoSplitters;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+
+import com.mongodb.MongoNamespace;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/** The split assigner for {@link MongoScanSourceSplit}. */
+@Internal
+public class MongoScanSplitAssigner implements MongoSplitAssigner {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoScanSplitAssigner.class);
+
+    private final MongoConnectionOptions connectionOptions;
+    private final MongoReadOptions readOptions;
+    private final MongoSplitters mongoSplitters;
+
+    private final LinkedList<String> remainingCollections;
+    private final List<String> alreadyProcessedCollections;
+    private final List<MongoScanSourceSplit> remainingScanSplits;
+    private final Map<String, MongoScanSourceSplit> assignedScanSplits;
+    private boolean initialized;
+
+    public MongoScanSplitAssigner(
+            MongoConnectionOptions connectionOptions,
+            MongoReadOptions readOptions,
+            boolean limitPushedDown,
+            MongoSourceEnumState sourceEnumState) {
+        this.connectionOptions = connectionOptions;
+        this.readOptions = readOptions;
+        this.mongoSplitters = new MongoSplitters(connectionOptions, readOptions, limitPushedDown);
+        this.remainingCollections = new LinkedList<>(sourceEnumState.getRemainingCollections());
+        this.alreadyProcessedCollections = sourceEnumState.getAlreadyProcessedCollections();
+        this.remainingScanSplits = sourceEnumState.getRemainingScanSplits();
+        this.assignedScanSplits = sourceEnumState.getAssignedScanSplits();
+        this.initialized = sourceEnumState.isInitialized();
+    }
+
+    @Override
+    public void open() {
+        LOG.info("Mongo scan split assigner is opening.");
+        if (!initialized) {
+            String collectionId =
+                    String.format(
+                            "%s.%s",
+                            connectionOptions.getDatabase(), connectionOptions.getCollection());
+            remainingCollections.add(collectionId);
+            initialized = true;
+        }
+    }
+
+    @Override
+    public Optional<MongoSourceSplit> getNext() {
+        if (!remainingScanSplits.isEmpty()) {
+            // return remaining splits firstly
+            Iterator<MongoScanSourceSplit> iterator = remainingScanSplits.iterator();
+            MongoScanSourceSplit split = iterator.next();
+            iterator.remove();
+            assignedScanSplits.put(split.splitId(), split);
+            return Optional.of(split);
+        } else {
+            // it's turn for next collection
+            String nextCollection = remainingCollections.pollFirst();
+            if (nextCollection != null) {
+                // split the given collection into chunks (scan splits)
+                Collection<MongoScanSourceSplit> splits =
+                        mongoSplitters.split(new MongoNamespace(nextCollection));
+                remainingScanSplits.addAll(splits);
+                alreadyProcessedCollections.add(nextCollection);
+                return getNext();
+            } else {
+                return Optional.empty();
+            }
+        }
+    }
+
+    @Override
+    public void addSplitsBack(Collection<MongoSourceSplit> splits) {
+        for (MongoSourceSplit split : splits) {
+            if (split instanceof MongoScanSourceSplit) {
+                remainingScanSplits.add((MongoScanSourceSplit) split);
+                // we should remove the add-backed splits from the assigned list,
+                // because they are failed
+                assignedScanSplits.remove(split.splitId());
+            }
+        }
+    }
+
+    @Override
+    public MongoSourceEnumState snapshotState(long checkpointId) {
+        return new MongoSourceEnumState(
+                remainingCollections,
+                alreadyProcessedCollections,
+                remainingScanSplits,
+                assignedScanSplits,
+                initialized);
+    }
+
+    @Override
+    public boolean noMoreSplits() {
+        return initialized && remainingCollections.isEmpty() && remainingScanSplits.isEmpty();
+    }
+
+    @Override
+    public void close() throws IOException {
+        mongoSplitters.close();
+        LOG.info("Mongo scan split assigner is closed.");
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/assigner/MongoSplitAssigner.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/assigner/MongoSplitAssigner.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.assigner;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.enumerator.MongoSourceEnumState;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.Optional;
+
+/** The split assigner for {@link MongoSourceSplit}. */
+@Internal
+public interface MongoSplitAssigner extends Serializable {
+
+    /**
+     * Called to open the assigner to acquire any resources, like threads or network connections.
+     */
+    void open();
+
+    /**
+     * Called to close the assigner, in case it holds on to any resources, like threads or network
+     * connections.
+     */
+    void close() throws IOException;
+
+    /** Gets the next split. */
+    Optional<MongoSourceSplit> getNext();
+
+    /**
+     * Adds a set of splits to this assigner. This happens for example when some split processing
+     * failed and the splits need to be re-added.
+     */
+    void addSplitsBack(Collection<MongoSourceSplit> splits);
+
+    /** Snapshot the current assign state into checkpoint. */
+    MongoSourceEnumState snapshotState(long checkpointId);
+
+    /** Return if there are no more splits. */
+    boolean noMoreSplits();
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSampleSplitter.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSampleSplitter.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.model.Aggregates;
+import com.mongodb.client.model.Projections;
+import com.mongodb.client.model.Sorts;
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
+
+/**
+ * Sample Partitioner
+ *
+ * <p>Samples the collection to generate partitions.
+ *
+ * <p>Uses the average document size to split the collection into average sized chunks
+ *
+ * <p>The partitioner samples the collection, projects and sorts by the partition fields. Then uses
+ * every {@code samplesPerPartition} as the value to use to calculate the partition boundaries.
+ *
+ * <ul>
+ *   <li>scan.partition.size: The average size (MB) for each partition. Note: Uses the average
+ *       document size to determine the number of documents per partition so may not be even.
+ *       Defaults to: 64mb.
+ *   <li>scan.partition.samples: The number of samples to take per partition. Defaults to: 10. The
+ *       total number of samples taken is calculated as: {@code samples per partition * (count /
+ *       number of documents per partition)}.
+ * </ul>
+ */
+@Internal
+public class MongoSampleSplitter implements MongoSplitters.MongoSplitter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSampleSplitter.class);
+
+    public static final MongoSampleSplitter INSTANCE = new MongoSampleSplitter();
+
+    private MongoSampleSplitter() {}
+
+    @Override
+    public Collection<MongoScanSourceSplit> split(MongoSplitContext splitContext) {
+        MongoReadOptions readOptions = splitContext.getReadOptions();
+        MongoNamespace namespace = splitContext.getMongoNamespace();
+
+        long count = splitContext.getCount();
+        long partitionSizeInBytes = readOptions.getPartitionSize().getBytes();
+        int samplesPerPartition = readOptions.getSamplesPerPartition();
+
+        long avgObjSizeInBytes = splitContext.getAvgObjSize();
+        long numDocumentsPerPartition = partitionSizeInBytes / avgObjSizeInBytes;
+
+        if (numDocumentsPerPartition >= count) {
+            LOG.info(
+                    "Fewer documents ({}) than the number of documents per partition ({}), fallback a SingleSplitter.",
+                    count,
+                    numDocumentsPerPartition);
+            return MongoSingleSplitter.INSTANCE.split(splitContext);
+        }
+
+        int numberOfSamples =
+                (int) Math.ceil((samplesPerPartition * count * 1.0d) / numDocumentsPerPartition);
+
+        List<BsonDocument> samples =
+                splitContext
+                        .getMongoCollection()
+                        .aggregate(
+                                Arrays.asList(
+                                        Aggregates.sample(numberOfSamples),
+                                        Aggregates.project(Projections.include(ID_FIELD)),
+                                        Aggregates.sort(Sorts.ascending(ID_FIELD))))
+                        .allowDiskUse(true)
+                        .into(new ArrayList<>());
+
+        List<MongoScanSourceSplit> sourceSplits = new ArrayList<>();
+        BsonDocument min = new BsonDocument(ID_FIELD, BSON_MIN_KEY);
+        int splitNum = 0;
+        for (int i = 0; i < samples.size(); i++) {
+            if (i % samplesPerPartition == 0 || i == samples.size() - 1) {
+                sourceSplits.add(createSplit(namespace, splitNum++, min, samples.get(i)));
+                min = samples.get(i);
+            }
+        }
+
+        // Complete right bound: (upper of last, maxKey)
+        sourceSplits.add(
+                createSplit(namespace, splitNum, min, new BsonDocument(ID_FIELD, BSON_MAX_KEY)));
+
+        return sourceSplits;
+    }
+
+    private MongoScanSourceSplit createSplit(
+            MongoNamespace ns, int index, BsonDocument min, BsonDocument max) {
+        return new MongoScanSourceSplit(
+                String.format("%s_%d", ns, index),
+                ns.getDatabaseName(),
+                ns.getCollectionName(),
+                min,
+                max,
+                ID_HINT);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoShardedSplitter.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoShardedSplitter.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.MongoQueryException;
+import com.mongodb.client.MongoClient;
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.KEY_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.MAX_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.MIN_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.UNAUTHORIZED_ERROR;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.isValidShardedCollection;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.readChunks;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.readCollectionMetadata;
+
+/**
+ * Sharded Partitioner
+ *
+ * <p>Uses the chunks collection and partitions the collection based on the sharded collections
+ * chunk ranges.
+ *
+ * <p>The following config collections' read privilege is required.
+ *
+ * <ul>
+ *   <li>config.collections
+ *   <li>config.chunks
+ * </ul>
+ */
+@Internal
+public class MongoShardedSplitter implements MongoSplitters.MongoSplitter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoShardedSplitter.class);
+
+    public static final MongoShardedSplitter INSTANCE = new MongoShardedSplitter();
+
+    private MongoShardedSplitter() {}
+
+    @Override
+    public Collection<MongoScanSourceSplit> split(MongoSplitContext splitContext) {
+        MongoNamespace namespace = splitContext.getMongoNamespace();
+        MongoClient mongoClient = splitContext.getMongoClient();
+
+        List<BsonDocument> chunks;
+        BsonDocument collectionMetadata;
+        try {
+            collectionMetadata = readCollectionMetadata(mongoClient, namespace);
+            if (!isValidShardedCollection(collectionMetadata)) {
+                LOG.warn(
+                        "Collection {} does not appear to be sharded, fallback to SampleSplitter.",
+                        namespace);
+                return MongoSampleSplitter.INSTANCE.split(splitContext);
+            }
+            chunks = readChunks(mongoClient, collectionMetadata);
+        } catch (MongoQueryException e) {
+            if (e.getErrorCode() == UNAUTHORIZED_ERROR) {
+                LOG.warn(
+                        "Unauthorized to read config.collections or config.chunks: {}, fallback to SampleSplitter.",
+                        e.getErrorMessage());
+            } else {
+                LOG.warn(
+                        "Read config.chunks collection failed: {}, fallback to SampleSplitter",
+                        e.getErrorMessage());
+            }
+            return MongoSampleSplitter.INSTANCE.split(splitContext);
+        }
+
+        if (chunks.isEmpty()) {
+            LOG.warn(
+                    "Collection {} does not appear to be sharded, fallback to SampleSplitter.",
+                    namespace);
+            return MongoSampleSplitter.INSTANCE.split(splitContext);
+        }
+
+        List<MongoScanSourceSplit> sourceSplits = new ArrayList<>(chunks.size());
+        for (int i = 0; i < chunks.size(); i++) {
+            BsonDocument chunk = chunks.get(i);
+            sourceSplits.add(
+                    new MongoScanSourceSplit(
+                            String.format("%s_%d", namespace, i),
+                            namespace.getDatabaseName(),
+                            namespace.getCollectionName(),
+                            chunk.getDocument(MIN_FIELD),
+                            chunk.getDocument(MAX_FIELD),
+                            collectionMetadata.getDocument(KEY_FIELD)));
+        }
+
+        return sourceSplits;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSingleSplitter.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSingleSplitter.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+
+import org.bson.BsonDocument;
+
+import java.util.Collection;
+
+import static java.util.Collections.singletonList;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
+
+/** Mongo Splitter that splits MongoDB collection as a single split. */
+@Internal
+public class MongoSingleSplitter implements MongoSplitters.MongoSplitter {
+
+    public static final MongoSingleSplitter INSTANCE = new MongoSingleSplitter();
+
+    private MongoSingleSplitter() {}
+
+    @Override
+    public Collection<MongoScanSourceSplit> split(MongoSplitContext splitContext) {
+        MongoScanSourceSplit singleSplit =
+                new MongoScanSourceSplit(
+                        splitContext.getMongoNamespace().getFullName(),
+                        splitContext.getDatabaseName(),
+                        splitContext.getCollectionName(),
+                        new BsonDocument(ID_FIELD, BSON_MIN_KEY),
+                        new BsonDocument(ID_FIELD, BSON_MAX_KEY),
+                        ID_HINT);
+
+        return singletonList(singleSplit);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitContext.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitContext.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt64;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.AVG_OBJ_SIZE_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.COUNT_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.SHARDED_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.SIZE_FIELD;
+
+/**
+ * The split context used by {@link MongoSplitters.MongoSplitter} to split collection into a set of
+ * chunks for MongoDB data source.
+ */
+@Internal
+public class MongoSplitContext {
+
+    /** Read options of MongoDB. */
+    private final MongoReadOptions readOptions;
+
+    /** Client of MongoDB. */
+    private final MongoClient mongoClient;
+
+    /** Namespace of MongoDB, eg. db.coll. */
+    private final MongoNamespace namespace;
+
+    /** Is a sharded collection. */
+    private final boolean sharded;
+
+    /** The number of objects or documents in this collection. */
+    private final long count;
+
+    /** The total uncompressed size(bytes) in memory of all records in a collection. */
+    private final long size;
+
+    /** The average size(bytes) of an object in the collection. */
+    private final long avgObjSize;
+
+    public MongoSplitContext(
+            MongoReadOptions readOptions,
+            MongoClient mongoClient,
+            MongoNamespace namespace,
+            boolean sharded,
+            long count,
+            long size,
+            long avgObjSize) {
+        this.readOptions = readOptions;
+        this.mongoClient = mongoClient;
+        this.namespace = namespace;
+        this.sharded = sharded;
+        this.count = count;
+        this.size = size;
+        this.avgObjSize = avgObjSize;
+    }
+
+    public static MongoSplitContext of(
+            MongoReadOptions readOptions,
+            MongoClient mongoClient,
+            MongoNamespace namespace,
+            BsonDocument collStats) {
+        return new MongoSplitContext(
+                readOptions,
+                mongoClient,
+                namespace,
+                collStats.getBoolean(SHARDED_FIELD, BsonBoolean.FALSE).getValue(),
+                collStats.getNumber(COUNT_FIELD, new BsonInt64(0)).longValue(),
+                collStats.getNumber(SIZE_FIELD, new BsonInt64(0)).longValue(),
+                collStats.getNumber(AVG_OBJ_SIZE_FIELD, new BsonInt64(0)).longValue());
+    }
+
+    public MongoClient getMongoClient() {
+        return mongoClient;
+    }
+
+    public MongoReadOptions getReadOptions() {
+        return readOptions;
+    }
+
+    public String getDatabaseName() {
+        return namespace.getDatabaseName();
+    }
+
+    public String getCollectionName() {
+        return namespace.getCollectionName();
+    }
+
+    public MongoNamespace getMongoNamespace() {
+        return namespace;
+    }
+
+    public MongoCollection<BsonDocument> getMongoCollection() {
+        return mongoClient
+                .getDatabase(namespace.getDatabaseName())
+                .getCollection(namespace.getCollectionName())
+                .withDocumentClass(BsonDocument.class);
+    }
+
+    public boolean isSharded() {
+        return sharded;
+    }
+
+    public long getCount() {
+        return count;
+    }
+
+    public long getSize() {
+        return size;
+    }
+
+    public long getAvgObjSize() {
+        return avgObjSize;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitVectorSplitter.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitVectorSplitter.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+
+import com.mongodb.MongoCommandException;
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoClient;
+import org.apache.commons.collections.CollectionUtils;
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MAX_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.BSON_MIN_KEY;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ERROR_MESSAGE_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.SPLIT_KEYS_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.UNAUTHORIZED_ERROR;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.isCommandSucceed;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.splitVector;
+
+/**
+ * SplitVector Partitioner
+ *
+ * <p>Uses the SplitVector command to generate chunks for a collection. eg. <code>
+ * db.runCommand({splitVector:"inventory.products", keyPattern:{_id:1}, maxChunkSize:64})</code>
+ *
+ * <p>Requires splitVector privilege.
+ */
+public class MongoSplitVectorSplitter implements MongoSplitters.MongoSplitter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSplitVectorSplitter.class);
+
+    public static final MongoSplitVectorSplitter INSTANCE = new MongoSplitVectorSplitter();
+
+    private MongoSplitVectorSplitter() {}
+
+    @Override
+    public Collection<MongoScanSourceSplit> split(MongoSplitContext splitContext) {
+        MongoClient mongoClient = splitContext.getMongoClient();
+        MongoNamespace namespace = splitContext.getMongoNamespace();
+        MongoReadOptions readOptions = splitContext.getReadOptions();
+
+        MemorySize chunkSize = readOptions.getPartitionSize();
+        // if partition size < 1mb, use 1 mb as chunk size.
+        int maxChunkSizeMB = Math.max(chunkSize.getMebiBytes(), 1);
+
+        BsonDocument keyPattern = new BsonDocument(ID_FIELD, new BsonInt32(1));
+
+        BsonDocument splitResult;
+        try {
+            splitResult = splitVector(mongoClient, namespace, keyPattern, maxChunkSizeMB);
+        } catch (MongoCommandException e) {
+            if (e.getErrorCode() == UNAUTHORIZED_ERROR) {
+                LOG.warn(
+                        "Unauthorized to execute splitVector command: {}, fallback to SampleSplitter",
+                        e.getErrorMessage());
+            } else {
+                LOG.warn(
+                        "Execute splitVector command failed: {}, fallback to SampleSplitter",
+                        e.getErrorMessage());
+            }
+            return MongoSampleSplitter.INSTANCE.split(splitContext);
+        }
+
+        if (!isCommandSucceed(splitResult)) {
+            LOG.warn(
+                    "Could not calculate standalone splits: {}, fallback to SampleSplitter",
+                    splitResult.getString(ERROR_MESSAGE_FIELD));
+            return MongoSampleSplitter.INSTANCE.split(splitContext);
+        }
+
+        BsonArray splitKeys = splitResult.getArray(SPLIT_KEYS_FIELD);
+        if (CollectionUtils.isEmpty(splitKeys)) {
+            // documents size is less than chunk size, treat the entire collection as single chunk.
+            return MongoSingleSplitter.INSTANCE.split(splitContext);
+        }
+
+        // Complete right bound: (lastKey, maxKey)
+        splitKeys.add(new BsonDocument(ID_FIELD, BSON_MAX_KEY));
+
+        List<MongoScanSourceSplit> sourceSplits = new ArrayList<>(splitKeys.size());
+
+        BsonValue lowerValue = BSON_MIN_KEY;
+        for (int i = 0; i < splitKeys.size(); i++) {
+            BsonValue splitKeyValue = splitKeys.get(i).asDocument().get(ID_FIELD);
+            sourceSplits.add(
+                    new MongoScanSourceSplit(
+                            String.format("%s_%d", namespace, i),
+                            namespace.getDatabaseName(),
+                            namespace.getCollectionName(),
+                            new BsonDocument(ID_FIELD, lowerValue),
+                            new BsonDocument(ID_FIELD, splitKeyValue),
+                            ID_HINT));
+            lowerValue = splitKeyValue;
+        }
+
+        return sourceSplits;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitters.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/MongoSplitters.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.common.utils.MongoUtils;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Collection;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ERROR_MESSAGE_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.isCommandSucceed;
+
+/** To split collections of MongoDB to {@link MongoSourceSplit}s. */
+@Internal
+public class MongoSplitters implements Serializable, Closeable {
+
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSplitters.class);
+
+    private final MongoReadOptions readOptions;
+    private final boolean limitPushedDown;
+    private final MongoClient mongoClient;
+
+    public MongoSplitters(
+            MongoConnectionOptions connectionOptions,
+            MongoReadOptions readOptions,
+            boolean limitPushedDown) {
+        this.readOptions = readOptions;
+        this.limitPushedDown = limitPushedDown;
+        this.mongoClient = MongoClients.create(connectionOptions.getUri());
+    }
+
+    public Collection<MongoScanSourceSplit> split(MongoNamespace namespace) {
+        BsonDocument collStats = MongoUtils.collStats(mongoClient, namespace);
+        if (!isCommandSucceed(collStats)) {
+            LOG.error(
+                    "Execute command collStats failed: {}",
+                    collStats.getString(ERROR_MESSAGE_FIELD));
+            throw new IllegalStateException(String.format("Collection not found %s", namespace));
+        }
+
+        MongoSplitContext splitContext =
+                MongoSplitContext.of(readOptions, mongoClient, namespace, collStats);
+
+        if (limitPushedDown) {
+            LOG.info("Limit {} is applied, using single splitter", limitPushedDown);
+            return MongoSingleSplitter.INSTANCE.split(splitContext);
+        }
+
+        PartitionStrategy strategy = readOptions.getPartitionStrategy();
+        switch (strategy) {
+            case SINGLE:
+                return MongoSingleSplitter.INSTANCE.split(splitContext);
+            case SAMPLE:
+                return MongoSampleSplitter.INSTANCE.split(splitContext);
+            case SPLIT_VECTOR:
+                return MongoSplitVectorSplitter.INSTANCE.split(splitContext);
+            case SHARDED:
+                return MongoShardedSplitter.INSTANCE.split(splitContext);
+            case DEFAULT:
+            default:
+                return splitContext.isSharded()
+                        ? MongoShardedSplitter.INSTANCE.split(splitContext)
+                        : MongoSplitVectorSplitter.INSTANCE.split(splitContext);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    /** Mongo Splitter to split a collection into multiple splits. */
+    public interface MongoSplitter {
+        Collection<MongoScanSourceSplit> split(MongoSplitContext splitContext);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/PartitionStrategy.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/enumerator/splitter/PartitionStrategy.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator.splitter;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.DescribedEnum;
+import org.apache.flink.configuration.description.InlineElement;
+
+import static org.apache.flink.configuration.description.TextElement.text;
+
+/** MongoSplitStrategy that can be chosen. */
+@PublicEvolving
+public enum PartitionStrategy implements DescribedEnum {
+    SINGLE("single", text("Do not split, treat a collection as a single chunk.")),
+
+    SAMPLE("sample", text("Randomly sample the collection, then splits to multiple chunks.")),
+
+    SPLIT_VECTOR(
+            "split-vector",
+            text("Uses the SplitVector command to generate chunks for a collection.")),
+
+    SHARDED(
+            "sharded",
+            text(
+                    "Read the chunk ranges from config.chunks collection and splits to multiple chunks. Only support sharded collections.")),
+
+    DEFAULT(
+            "default",
+            text(
+                    "Using sharded strategy for sharded collections"
+                            + " otherwise using split vector strategy."));
+
+    private final String name;
+    private final InlineElement description;
+
+    PartitionStrategy(String name, InlineElement description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    @Override
+    public InlineElement getDescription() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/MongoSourceReader.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/MongoSourceReader.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.reader;
+
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplitState;
+
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+/**
+ * The common mongo source reader for both ordered & unordered message consuming.
+ *
+ * @param <OUT> The output message type for flink.
+ */
+public class MongoSourceReader<OUT>
+        extends SingleThreadMultiplexSourceReaderBase<
+                BsonDocument, OUT, MongoSourceSplit, MongoSourceSplitState> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSourceReader.class);
+
+    public MongoSourceReader(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<BsonDocument>> elementQueue,
+            Supplier<SplitReader<BsonDocument, MongoSourceSplit>> splitReaderSupplier,
+            RecordEmitter<BsonDocument, OUT, MongoSourceSplitState> recordEmitter,
+            SourceReaderContext readerContext) {
+        super(
+                elementQueue,
+                new SingleThreadFetcherManager<>(
+                        elementQueue, splitReaderSupplier, readerContext.getConfiguration()),
+                recordEmitter,
+                readerContext.getConfiguration(),
+                readerContext);
+    }
+
+    @Override
+    public void start() {
+        if (getNumberOfCurrentlyAssignedSplits() == 0) {
+            context.sendSplitRequest();
+        }
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, MongoSourceSplitState> finishedSplitIds) {
+        for (MongoSourceSplitState splitState : finishedSplitIds.values()) {
+            MongoSourceSplit sourceSplit = splitState.toMongoSourceSplit();
+            LOG.info("Split {} is finished.", sourceSplit.splitId());
+        }
+        context.sendSplitRequest();
+    }
+
+    @Override
+    protected MongoSourceSplitState initializedState(MongoSourceSplit split) {
+        return new MongoSourceSplitState(split);
+    }
+
+    @Override
+    protected MongoSourceSplit toSplitType(String splitId, MongoSourceSplitState splitState) {
+        return splitState.toMongoSourceSplit();
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/deserializer/MongoDeserializationSchema.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/deserializer/MongoDeserializationSchema.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.reader.deserializer;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.util.Collector;
+
+import org.bson.BsonDocument;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * A schema bridge for deserializing the MongoDB's {@code BsonDocument} into a flink managed
+ * instance.
+ *
+ * @param <T> The output message type for sinking to downstream flink operator.
+ */
+@PublicEvolving
+public interface MongoDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+    /**
+     * Deserializes the BSON document.
+     *
+     * @param document The BSON document to deserialize.
+     * @return The deserialized message as an object (null if the message cannot be deserialized).
+     */
+    T deserialize(BsonDocument document) throws IOException;
+
+    /**
+     * Deserializes the BSON document.
+     *
+     * <p>Can output multiple records through the {@link Collector}. Note that number and size of
+     * the produced records should be relatively small. Depending on the source implementation
+     * records can be buffered in memory or collecting records might delay emitting checkpoint
+     * barrier.
+     *
+     * @param document The BSON document to deserialize.
+     * @param out The collector to put the resulting messages.
+     */
+    @PublicEvolving
+    default void deserialize(BsonDocument document, Collector<T> out) throws IOException {
+        T deserialize = deserialize(document);
+        if (deserialize != null) {
+            out.collect(deserialize);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/deserializer/MongoJsonDeserializationSchema.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/deserializer/MongoJsonDeserializationSchema.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.reader.deserializer;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+import org.bson.BsonDocument;
+import org.bson.json.JsonMode;
+
+import java.util.Optional;
+
+/**
+ * A schema bridge for deserializing the MongoDB's {@code BsonDocument} to MongoDB's {@link
+ * JsonMode}'s RELAXED Json string.
+ */
+@PublicEvolving
+public class MongoJsonDeserializationSchema implements MongoDeserializationSchema<String> {
+
+    @Override
+    public String deserialize(BsonDocument document) {
+        return Optional.ofNullable(document).map(BsonDocument::toJson).orElse(null);
+    }
+
+    @Override
+    public TypeInformation<String> getProducedType() {
+        return BasicTypeInfo.STRING_TYPE_INFO;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/emitter/MongoRecordEmitter.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/emitter/MongoRecordEmitter.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.reader.emitter;
+
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.mongodb.source.reader.MongoSourceReader;
+import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoDeserializationSchema;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplitState;
+import org.apache.flink.util.Collector;
+
+import org.bson.BsonDocument;
+
+/**
+ * The {@link RecordEmitter} implementation for {@link MongoSourceReader} . We would always update
+ * the last consumed message id in this emitter.
+ */
+public class MongoRecordEmitter<T>
+        implements RecordEmitter<BsonDocument, T, MongoSourceSplitState> {
+
+    private final MongoDeserializationSchema<T> deserializationSchema;
+    private final SourceOutputWrapper<T> sourceOutputWrapper;
+
+    public MongoRecordEmitter(MongoDeserializationSchema<T> deserializationSchema) {
+        this.deserializationSchema = deserializationSchema;
+        this.sourceOutputWrapper = new SourceOutputWrapper<>();
+    }
+
+    @Override
+    public void emitRecord(
+            BsonDocument document, SourceOutput<T> output, MongoSourceSplitState splitState)
+            throws Exception {
+        // Sink the record to source output.
+        sourceOutputWrapper.setSourceOutput(output);
+        deserializationSchema.deserialize(document, sourceOutputWrapper);
+    }
+
+    private static class SourceOutputWrapper<T> implements Collector<T> {
+        private SourceOutput<T> sourceOutput;
+
+        @Override
+        public void collect(T record) {
+            sourceOutput.collect(record);
+        }
+
+        @Override
+        public void close() {}
+
+        private void setSourceOutput(SourceOutput<T> sourceOutput) {
+            this.sourceOutput = sourceOutput;
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoScanSourceSplitReader.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.reader.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordsBySplits;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsAddition;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+import org.apache.flink.util.CollectionUtil;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.FindIterable;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCursor;
+import org.bson.BsonDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.project;
+
+/** An split reader implements {@link SplitReader} for {@link MongoScanSourceSplit}. */
+@Internal
+public class MongoScanSourceSplitReader implements MongoSourceSplitReader<MongoSourceSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoScanSourceSplitReader.class);
+
+    private final MongoConnectionOptions connectionOptions;
+    private final MongoReadOptions readOptions;
+    private final SourceReaderContext readerContext;
+    @Nullable private final List<String> projectedFields;
+    private final int limit;
+
+    private boolean closed = false;
+    private boolean finished = false;
+    private MongoClient mongoClient;
+    private MongoCursor<BsonDocument> currentCursor;
+    private MongoScanSourceSplit currentSplit;
+
+    public MongoScanSourceSplitReader(
+            MongoConnectionOptions connectionOptions,
+            MongoReadOptions readOptions,
+            @Nullable List<String> projectedFields,
+            int limit,
+            SourceReaderContext context) {
+        this.connectionOptions = connectionOptions;
+        this.readOptions = readOptions;
+        this.projectedFields = projectedFields;
+        this.limit = limit;
+        this.readerContext = context;
+    }
+
+    @Override
+    public RecordsWithSplitIds<BsonDocument> fetch() throws IOException {
+        if (closed) {
+            throw new IllegalStateException("Cannot fetch records from a closed split reader");
+        }
+
+        RecordsBySplits.Builder<BsonDocument> builder = new RecordsBySplits.Builder<>();
+
+        // Return when no split registered to this reader.
+        if (currentSplit == null) {
+            return builder.build();
+        }
+
+        currentCursor = getOrCreateCursor();
+        int fetchSize = readOptions.getFetchSize();
+
+        try {
+            for (int recordNum = 0; recordNum < fetchSize; recordNum++) {
+                if (currentCursor.hasNext()) {
+                    builder.add(currentSplit, currentCursor.next());
+                } else {
+                    builder.addFinishedSplit(currentSplit.splitId());
+                    finished = true;
+                    break;
+                }
+            }
+            return builder.build();
+        } catch (MongoException e) {
+            throw new IOException("Scan records form MongoDB failed", e);
+        } finally {
+            if (finished) {
+                currentSplit = null;
+                releaseCursor();
+            }
+        }
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<MongoSourceSplit> splitsChanges) {
+        LOG.debug("Handle split changes {}", splitsChanges);
+
+        if (!(splitsChanges instanceof SplitsAddition)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "The SplitChange type of %s is not supported.",
+                            splitsChanges.getClass()));
+        }
+
+        MongoSourceSplit sourceSplit = splitsChanges.splits().get(0);
+        if (!(sourceSplit instanceof MongoScanSourceSplit)) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "The SourceSplit type of %s is not supported.",
+                            sourceSplit.getClass()));
+        }
+
+        this.currentSplit = (MongoScanSourceSplit) sourceSplit;
+        this.finished = false;
+    }
+
+    @Override
+    public void wakeUp() {}
+
+    @Override
+    public void close() throws Exception {
+        if (!closed) {
+            closed = true;
+            releaseCursor();
+        }
+    }
+
+    private MongoCursor<BsonDocument> getOrCreateCursor() {
+        if (currentCursor == null) {
+            LOG.debug("Opened cursor for partitionId: {}", currentSplit);
+            mongoClient = MongoClients.create(connectionOptions.getUri());
+
+            // Using MongoDB's cursor.min() and cursor.max() to limit an index bound.
+            // When the index range is the primary key, the bound is (min <= _id < max).
+            // Compound indexes and hash indexes bounds can also be supported in this way.
+            // Please refer to https://www.mongodb.com/docs/manual/reference/method/cursor.min/
+            FindIterable<BsonDocument> findIterable =
+                    mongoClient
+                            .getDatabase(connectionOptions.getDatabase())
+                            .getCollection(connectionOptions.getCollection(), BsonDocument.class)
+                            .find()
+                            .min(currentSplit.getMin())
+                            .max(currentSplit.getMax())
+                            .hint(currentSplit.getHint())
+                            .batchSize(readOptions.getCursorBatchSize())
+                            .noCursorTimeout(readOptions.isNoCursorTimeout());
+
+            // Push limit down
+            if (limit > 0) {
+                findIterable.limit(limit);
+            }
+
+            // Push projection down
+            if (!CollectionUtil.isNullOrEmpty(projectedFields)) {
+                findIterable.projection(project(projectedFields));
+            }
+
+            currentCursor = findIterable.cursor();
+        }
+        return currentCursor;
+    }
+
+    private void releaseCursor() {
+        if (currentCursor != null) {
+            LOG.debug("Closing cursor for split: {}", currentSplit);
+            try {
+                currentCursor.close();
+            } finally {
+                currentCursor = null;
+                try {
+                    mongoClient.close();
+                } finally {
+                    mongoClient = null;
+                }
+            }
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoSourceSplitReader.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/reader/split/MongoSourceSplitReader.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.reader.split;
+
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.mongodb.source.split.MongoSourceSplit;
+
+import org.bson.BsonDocument;
+
+/**
+ * An split reader implements {@link SplitReader} for {@link MongoSourceSplit}.
+ *
+ * @param <T> Mongo source split.
+ */
+public interface MongoSourceSplitReader<T extends MongoSourceSplit>
+        extends SplitReader<BsonDocument, T> {}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoScanSourceSplit.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import org.bson.BsonDocument;
+
+import java.util.Objects;
+
+/** A {@link SourceSplit} implementation for a MongoDB's partition. */
+@Internal
+public class MongoScanSourceSplit extends MongoSourceSplit {
+
+    private static final long serialVersionUID = 1L;
+
+    private final String database;
+
+    private final String collection;
+
+    private final BsonDocument min;
+
+    private final BsonDocument max;
+
+    private final BsonDocument hint;
+
+    public MongoScanSourceSplit(
+            String splitId,
+            String database,
+            String collection,
+            BsonDocument min,
+            BsonDocument max,
+            BsonDocument hint) {
+        super(splitId);
+        this.database = database;
+        this.collection = collection;
+        this.min = min;
+        this.max = max;
+        this.hint = hint;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public String getCollection() {
+        return collection;
+    }
+
+    public BsonDocument getMin() {
+        return min;
+    }
+
+    public BsonDocument getMax() {
+        return max;
+    }
+
+    public BsonDocument getHint() {
+        return hint;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        MongoScanSourceSplit split = (MongoScanSourceSplit) o;
+        return Objects.equals(database, split.database)
+                && Objects.equals(collection, split.collection)
+                && Objects.equals(min, split.min)
+                && Objects.equals(max, split.max)
+                && Objects.equals(hint, split.hint);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), database, collection, min, max, hint);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplit.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplit.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.split;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/** A super class of {@link SourceSplit} implementation for a MongoDB's source split. */
+@Internal
+public abstract class MongoSourceSplit implements SourceSplit, Serializable {
+
+    protected final String splitId;
+
+    protected MongoSourceSplit(String splitId) {
+        this.splitId = splitId;
+    }
+
+    @Override
+    public String splitId() {
+        return splitId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MongoSourceSplit that = (MongoSourceSplit) o;
+        return Objects.equals(splitId, that.splitId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(splitId);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitSerializer.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitSerializer.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.split;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import org.bson.BsonDocument;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+/** The {@link SimpleVersionedSerializer serializer} for {@link MongoSourceSplit}. */
+public class MongoSourceSplitSerializer implements SimpleVersionedSerializer<MongoSourceSplit> {
+
+    public static final MongoSourceSplitSerializer INSTANCE = new MongoSourceSplitSerializer();
+
+    // This version should be bumped after modifying the MongoSourceSplit.
+    public static final int CURRENT_VERSION = 0;
+
+    private static final int SCAN_SPLIT_FLAG = 1;
+
+    private MongoSourceSplitSerializer() {}
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(MongoSourceSplit obj) throws IOException {
+        // VERSION 0 serialization
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputStream out = new DataOutputStream(baos)) {
+            serializeMongoSplit(out, obj);
+            out.flush();
+            return baos.toByteArray();
+        }
+    }
+
+    @Override
+    public MongoSourceSplit deserialize(int version, byte[] serialized) throws IOException {
+        // VERSION 0 deserialization
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            return deserializeMongoSourceSplit(version, in);
+        }
+    }
+
+    public void serializeMongoSplit(DataOutputStream out, MongoSourceSplit obj) throws IOException {
+        if (obj instanceof MongoScanSourceSplit) {
+            MongoScanSourceSplit split = (MongoScanSourceSplit) obj;
+            out.writeInt(SCAN_SPLIT_FLAG);
+            out.writeUTF(split.splitId());
+            out.writeUTF(split.getDatabase());
+            out.writeUTF(split.getCollection());
+            out.writeUTF(split.getMin().toJson());
+            out.writeUTF(split.getMax().toJson());
+            out.writeUTF(split.getHint().toJson());
+        }
+    }
+
+    public MongoSourceSplit deserializeMongoSourceSplit(int version, DataInputStream in)
+            throws IOException {
+        int splitKind = in.readInt();
+        if (splitKind == SCAN_SPLIT_FLAG) {
+            return deserializeMongoScanSourceSplit(version, in);
+        }
+        throw new IOException("Unknown split kind: " + splitKind);
+    }
+
+    public MongoScanSourceSplit deserializeMongoScanSourceSplit(int version, DataInputStream in)
+            throws IOException {
+        switch (version) {
+            case 0:
+                String splitId = in.readUTF();
+                String database = in.readUTF();
+                String collection = in.readUTF();
+                BsonDocument min = BsonDocument.parse(in.readUTF());
+                BsonDocument max = BsonDocument.parse(in.readUTF());
+                BsonDocument hint = BsonDocument.parse(in.readUTF());
+                return new MongoScanSourceSplit(splitId, database, collection, min, max, hint);
+            default:
+                throw new IOException("Unknown version: " + version);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/source/split/MongoSourceSplitState.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.split;
+
+/** MongoDB source split state. */
+public class MongoSourceSplitState {
+
+    private final MongoSourceSplit split;
+
+    public MongoSourceSplitState(MongoSourceSplit split) {
+        this.split = split;
+    }
+
+    public MongoSourceSplit toMongoSourceSplit() {
+        if (split instanceof MongoScanSourceSplit) {
+            MongoScanSourceSplit scanSplit = (MongoScanSourceSplit) split;
+            return new MongoScanSourceSplit(
+                    scanSplit.splitId(),
+                    scanSplit.getDatabase(),
+                    scanSplit.getCollection(),
+                    scanSplit.getMin(),
+                    scanSplit.getMax(),
+                    scanSplit.getHint());
+        } else {
+            throw new IllegalStateException("Unknown split type");
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactory.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.table.config.MongoConfiguration;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.lookup.LookupOptions;
+import org.apache.flink.table.connector.source.lookup.cache.DefaultLookupCache;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.function.SerializableFunction;
+
+import org.bson.BsonValue;
+
+import javax.annotation.Nullable;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.BULK_FLUSH_INTERVAL;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.BULK_FLUSH_MAX_ACTIONS;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.COLLECTION;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.DATABASE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.DELIVERY_GUARANTEE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_CURSOR_BATCH_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_FETCH_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_SAMPLES;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_STRATEGY;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SINK_MAX_RETRIES;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.URI;
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
+
+/**
+ * Factory for creating configured instances of {@link MongoDynamicTableSource} and {@link
+ * MongoDynamicTableSink}.
+ */
+@Internal
+public class MongoDynamicTableFactory
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+    public static final String IDENTIFIER = "mongodb";
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        final Set<ConfigOption<?>> requiredOptions = new HashSet<>();
+        requiredOptions.add(URI);
+        requiredOptions.add(DATABASE);
+        requiredOptions.add(COLLECTION);
+        return requiredOptions;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        final Set<ConfigOption<?>> optionalOptions = new HashSet<>();
+        optionalOptions.add(SCAN_FETCH_SIZE);
+        optionalOptions.add(SCAN_CURSOR_BATCH_SIZE);
+        optionalOptions.add(SCAN_CURSOR_NO_TIMEOUT);
+        optionalOptions.add(SCAN_PARTITION_STRATEGY);
+        optionalOptions.add(SCAN_PARTITION_SIZE);
+        optionalOptions.add(SCAN_PARTITION_SAMPLES);
+        optionalOptions.add(BULK_FLUSH_MAX_ACTIONS);
+        optionalOptions.add(BULK_FLUSH_INTERVAL);
+        optionalOptions.add(DELIVERY_GUARANTEE);
+        optionalOptions.add(SINK_MAX_RETRIES);
+        optionalOptions.add(SINK_PARALLELISM);
+        optionalOptions.add(LookupOptions.CACHE_TYPE);
+        optionalOptions.add(LookupOptions.MAX_RETRIES);
+        optionalOptions.add(LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_ACCESS);
+        optionalOptions.add(LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_WRITE);
+        optionalOptions.add(LookupOptions.PARTIAL_CACHE_MAX_ROWS);
+        optionalOptions.add(LookupOptions.PARTIAL_CACHE_CACHE_MISSING_KEY);
+        return optionalOptions;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> forwardOptions() {
+        final Set<ConfigOption<?>> forwardOptions = new HashSet<>();
+        forwardOptions.add(SCAN_FETCH_SIZE);
+        forwardOptions.add(SCAN_CURSOR_BATCH_SIZE);
+        forwardOptions.add(SCAN_CURSOR_NO_TIMEOUT);
+        forwardOptions.add(BULK_FLUSH_MAX_ACTIONS);
+        forwardOptions.add(BULK_FLUSH_INTERVAL);
+        forwardOptions.add(SINK_MAX_RETRIES);
+        return forwardOptions;
+    }
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+
+        ReadableConfig options = helper.getOptions();
+        MongoConfiguration config = new MongoConfiguration(options);
+        helper.validate();
+
+        return new MongoDynamicTableSource(
+                getConnectionOptions(config),
+                getReadOptions(config),
+                getLookupCache(options),
+                config.getLookupMaxRetryTimes(),
+                context.getPhysicalRowDataType());
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+
+        MongoConfiguration config = new MongoConfiguration(helper.getOptions());
+        helper.validate();
+
+        ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
+        SerializableFunction<RowData, BsonValue> keyExtractor =
+                MongoKeyExtractor.createKeyExtractor(schema);
+
+        return new MongoDynamicTableSink(
+                getConnectionOptions(config),
+                getWriteOptions(config),
+                context.getPhysicalRowDataType(),
+                keyExtractor);
+    }
+
+    @Nullable
+    private LookupCache getLookupCache(ReadableConfig tableOptions) {
+        LookupCache cache = null;
+        if (tableOptions
+                .get(LookupOptions.CACHE_TYPE)
+                .equals(LookupOptions.LookupCacheType.PARTIAL)) {
+            cache = DefaultLookupCache.fromConfig(tableOptions);
+        }
+        return cache;
+    }
+
+    private MongoConnectionOptions getConnectionOptions(MongoConfiguration configuration) {
+        return MongoConnectionOptions.builder()
+                .setUri(configuration.getUri())
+                .setDatabase(configuration.getDatabase())
+                .setCollection(configuration.getCollection())
+                .build();
+    }
+
+    private MongoReadOptions getReadOptions(MongoConfiguration configuration) {
+        return MongoReadOptions.builder()
+                .setFetchSize(configuration.getFetchSize())
+                .setCursorBatchSize(configuration.getCursorBatchSize())
+                .setNoCursorTimeout(configuration.isNoCursorTimeout())
+                .setPartitionStrategy(configuration.getPartitionStrategy())
+                .setPartitionSize(configuration.getPartitionSize())
+                .setSamplesPerPartition(configuration.getSamplesPerPartition())
+                .build();
+    }
+
+    private MongoWriteOptions getWriteOptions(MongoConfiguration configuration) {
+        return MongoWriteOptions.builder()
+                .setBulkFlushMaxActions(configuration.getBulkFlushMaxActions())
+                .setBulkFlushIntervalMs(configuration.getBulkFlushIntervalMs())
+                .setMaxRetryTimes(configuration.getSinkMaxRetryTimes())
+                .setDeliveryGuarantee(configuration.getDeliveryGuarantee())
+                .setParallelism(configuration.getSinkParallelism())
+                .build();
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSink.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSink.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.sink.MongoSink;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters;
+import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters.RowDataToBsonConverter;
+import org.apache.flink.connector.mongodb.table.serialization.MongoRowDataSerializationSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.function.SerializableFunction;
+
+import org.bson.BsonValue;
+
+import java.util.Objects;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A {@link DynamicTableSink} for MongoDB. */
+@Internal
+public class MongoDynamicTableSink implements DynamicTableSink {
+
+    private final MongoConnectionOptions connectionOptions;
+    private final MongoWriteOptions writeOptions;
+    private final DataType physicalRowDataType;
+    private final SerializableFunction<RowData, BsonValue> keyExtractor;
+
+    public MongoDynamicTableSink(
+            MongoConnectionOptions connectionOptions,
+            MongoWriteOptions writeOptions,
+            DataType physicalRowDataType,
+            SerializableFunction<RowData, BsonValue> keyExtractor) {
+        this.connectionOptions = checkNotNull(connectionOptions);
+        this.writeOptions = checkNotNull(writeOptions);
+        this.physicalRowDataType = checkNotNull(physicalRowDataType);
+        this.keyExtractor = checkNotNull(keyExtractor);
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        // UPSERT mode
+        ChangelogMode.Builder builder = ChangelogMode.newBuilder();
+        for (RowKind kind : requestedMode.getContainedKinds()) {
+            if (kind != RowKind.UPDATE_BEFORE) {
+                builder.addContainedKind(kind);
+            }
+        }
+        return builder.build();
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        final RowDataToBsonConverter rowDataToBsonConverter =
+                RowDataToBsonConverters.createNullableConverter(
+                        physicalRowDataType.getLogicalType());
+
+        final MongoRowDataSerializationSchema serializationSchema =
+                new MongoRowDataSerializationSchema(rowDataToBsonConverter, keyExtractor);
+
+        MongoSink<RowData> mongoSink =
+                MongoSink.<RowData>builder()
+                        .setUri(connectionOptions.getUri())
+                        .setDatabase(connectionOptions.getDatabase())
+                        .setCollection(connectionOptions.getCollection())
+                        .setBulkFlushMaxActions(writeOptions.getBulkFlushMaxActions())
+                        .setBulkFlushIntervalMs(writeOptions.getBulkFlushIntervalMs())
+                        .setDeliveryGuarantee(writeOptions.getDeliveryGuarantee())
+                        .setMaxRetryTimes(writeOptions.getMaxRetryTimes())
+                        .setSerializationSchema(serializationSchema)
+                        .build();
+
+        return SinkV2Provider.of(mongoSink, writeOptions.getParallelism());
+    }
+
+    @Override
+    public MongoDynamicTableSink copy() {
+        return new MongoDynamicTableSink(
+                connectionOptions, writeOptions, physicalRowDataType, keyExtractor);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "MongoDB";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MongoDynamicTableSink that = (MongoDynamicTableSink) o;
+        return Objects.equals(connectionOptions, that.connectionOptions)
+                && Objects.equals(writeOptions, that.writeOptions)
+                && Objects.equals(physicalRowDataType, that.physicalRowDataType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(connectionOptions, writeOptions, physicalRowDataType);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSource.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSource.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.source.MongoSource;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoDeserializationSchema;
+import org.apache.flink.connector.mongodb.table.serialization.MongoRowDataDeserializationSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.LookupTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.PartialCachingLookupProvider;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** A {@link DynamicTableSource} for MongoDB. */
+@Internal
+public class MongoDynamicTableSource
+        implements ScanTableSource,
+                LookupTableSource,
+                SupportsProjectionPushDown,
+                SupportsLimitPushDown {
+
+    private final MongoConnectionOptions connectionOptions;
+    private final MongoReadOptions readOptions;
+    @Nullable private final LookupCache lookupCache;
+    private final int lookupRetryTimes;
+    private DataType physicalRowDataType;
+    private int limit = -1;
+
+    public MongoDynamicTableSource(
+            MongoConnectionOptions connectionOptions,
+            MongoReadOptions readOptions,
+            @Nullable LookupCache lookupCache,
+            int lookupRetryTimes,
+            DataType physicalRowDataType) {
+        this.connectionOptions = connectionOptions;
+        this.readOptions = readOptions;
+        this.lookupCache = lookupCache;
+        this.lookupRetryTimes = lookupRetryTimes;
+        this.physicalRowDataType = physicalRowDataType;
+    }
+
+    @Override
+    public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
+        final List<String> keyNames = new ArrayList<>(context.getKeys().length);
+        for (int i = 0; i < context.getKeys().length; i++) {
+            int[] innerKeyArr = context.getKeys()[i];
+            Preconditions.checkArgument(
+                    innerKeyArr.length == 1, "MongoDB only support non-nested look up keys yet");
+            keyNames.add(DataType.getFieldNames(physicalRowDataType).get(innerKeyArr[0]));
+        }
+        final RowType rowType = (RowType) physicalRowDataType.getLogicalType();
+
+        MongoRowDataLookupFunction lookupFunction =
+                new MongoRowDataLookupFunction(
+                        connectionOptions,
+                        lookupRetryTimes,
+                        DataType.getFieldNames(physicalRowDataType),
+                        DataType.getFieldDataTypes(physicalRowDataType),
+                        keyNames,
+                        rowType);
+        if (lookupCache != null) {
+            return PartialCachingLookupProvider.of(lookupFunction, lookupCache);
+        } else {
+            return LookupFunctionProvider.of(lookupFunction);
+        }
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+        final RowType rowType = (RowType) physicalRowDataType.getLogicalType();
+        final TypeInformation<RowData> typeInfo =
+                runtimeProviderContext.createTypeInformation(physicalRowDataType);
+
+        final MongoDeserializationSchema<RowData> deserializationSchema =
+                new MongoRowDataDeserializationSchema(rowType, typeInfo);
+
+        MongoSource<RowData> mongoSource =
+                MongoSource.<RowData>builder()
+                        .setUri(connectionOptions.getUri())
+                        .setDatabase(connectionOptions.getDatabase())
+                        .setCollection(connectionOptions.getCollection())
+                        .setFetchSize(readOptions.getFetchSize())
+                        .setCursorBatchSize(readOptions.getCursorBatchSize())
+                        .setNoCursorTimeout(readOptions.isNoCursorTimeout())
+                        .setPartitionStrategy(readOptions.getPartitionStrategy())
+                        .setPartitionSize(readOptions.getPartitionSize())
+                        .setSamplesPerPartition(readOptions.getSamplesPerPartition())
+                        .setLimit(limit)
+                        .setProjectedFields(DataType.getFieldNames(physicalRowDataType))
+                        .setDeserializationSchema(deserializationSchema)
+                        .build();
+
+        return SourceProvider.of(mongoSource);
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new MongoDynamicTableSource(
+                connectionOptions, readOptions, lookupCache, lookupRetryTimes, physicalRowDataType);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "MongoDB";
+    }
+
+    @Override
+    public void applyLimit(long limit) {
+        this.limit = (int) limit;
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        // planner doesn't support nested projection push down yet.
+        return false;
+    }
+
+    @Override
+    public void applyProjection(int[][] projectedFields, DataType producedDataType) {
+        this.physicalRowDataType = Projection.of(projectedFields).project(physicalRowDataType);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MongoDynamicTableSource)) {
+            return false;
+        }
+        MongoDynamicTableSource that = (MongoDynamicTableSource) o;
+        return Objects.equals(connectionOptions, that.connectionOptions)
+                && Objects.equals(readOptions, that.readOptions)
+                && Objects.equals(physicalRowDataType, that.physicalRowDataType)
+                && Objects.equals(limit, that.limit)
+                && Objects.equals(lookupCache, that.lookupCache)
+                && Objects.equals(lookupRetryTimes, that.lookupRetryTimes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                connectionOptions,
+                readOptions,
+                physicalRowDataType,
+                limit,
+                lookupCache,
+                lookupRetryTimes);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoKeyExtractor.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoKeyExtractor.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.common.utils.MongoValidationUtils;
+import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.utils.ProjectedRowData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.util.function.SerializableFunction;
+
+import org.bson.BsonObjectId;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+
+import java.util.Optional;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** An extractor for a MongoDB key from a {@link RowData}. */
+@Internal
+public class MongoKeyExtractor implements SerializableFunction<RowData, BsonValue> {
+
+    public static final String RESERVED_ID = "_id";
+
+    private final LogicalType primaryKeyType;
+
+    private final int[] primaryKeyIndexes;
+
+    private final RowDataToBsonConverters.RowDataToBsonConverter primaryKeyConverter;
+
+    private MongoKeyExtractor(LogicalType primaryKeyType, int[] primaryKeyIndexes) {
+        this.primaryKeyType = primaryKeyType;
+        this.primaryKeyIndexes = primaryKeyIndexes;
+        this.primaryKeyConverter = RowDataToBsonConverters.createNullableConverter(primaryKeyType);
+    }
+
+    @Override
+    public BsonValue apply(RowData rowData) {
+        BsonValue keyValue;
+        if (isCompoundPrimaryKey(primaryKeyIndexes)) {
+            RowData keyRow = ProjectedRowData.from(primaryKeyIndexes).replaceRow(rowData);
+            keyValue = primaryKeyConverter.convert(keyRow);
+        } else {
+            RowData.FieldGetter fieldGetter =
+                    RowData.createFieldGetter(primaryKeyType, primaryKeyIndexes[0]);
+            keyValue = primaryKeyConverter.convert(fieldGetter.getFieldOrNull(rowData));
+            if (keyValue.isString()) {
+                String keyString = keyValue.asString().getValue();
+                // Try to restore MongoDB's ObjectId from string.
+                if (ObjectId.isValid(keyString)) {
+                    keyValue = new BsonObjectId(new ObjectId(keyString));
+                }
+            }
+        }
+        return checkNotNull(keyValue, "Primary key value is null of RowData: " + rowData);
+    }
+
+    public static SerializableFunction<RowData, BsonValue> createKeyExtractor(
+            ResolvedSchema resolvedSchema) {
+
+        Optional<UniqueConstraint> primaryKey = resolvedSchema.getPrimaryKey();
+        int[] primaryKeyIndexes = resolvedSchema.getPrimaryKeyIndexes();
+        Optional<Column> reversedId = resolvedSchema.getColumn(RESERVED_ID);
+
+        // It behaves as append-only when no primary key is declared and no reversed _id is present.
+        // We use anonymous classes instead of lambdas for a reason here. It is
+        // necessary because the maven shade plugin cannot relocate classes in SerializedLambdas
+        // (MSHADE-260).
+        if (!primaryKey.isPresent() && !reversedId.isPresent()) {
+            return new SerializableFunction<RowData, BsonValue>() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public BsonValue apply(RowData rowData) {
+                    return null;
+                }
+            };
+        }
+
+        if (reversedId.isPresent()) {
+            // Primary key should be declared as (_id) when the mongo reversed _id is present.
+            if (!primaryKey.isPresent()
+                    || isCompoundPrimaryKey(primaryKeyIndexes)
+                    || !primaryKeyContainsReversedId(primaryKey.get())) {
+                throw new IllegalArgumentException(
+                        "The primary key should be declared as (_id) when mongo reversed _id field is present");
+            }
+        }
+
+        DataType primaryKeyType;
+        if (isCompoundPrimaryKey(primaryKeyIndexes)) {
+            DataType physicalRowDataType = resolvedSchema.toPhysicalRowDataType();
+            primaryKeyType = Projection.of(primaryKeyIndexes).project(physicalRowDataType);
+        } else {
+            int primaryKeyIndex = primaryKeyIndexes[0];
+            Optional<Column> column = resolvedSchema.getColumn(primaryKeyIndex);
+            if (!column.isPresent()) {
+                throw new IllegalStateException(
+                        String.format(
+                                "No primary key column found with index '%s'.", primaryKeyIndex));
+            }
+            primaryKeyType = column.get().getDataType();
+        }
+
+        MongoValidationUtils.validatePrimaryKey(primaryKeyType);
+
+        return new MongoKeyExtractor(primaryKeyType.getLogicalType(), primaryKeyIndexes);
+    }
+
+    private static boolean isCompoundPrimaryKey(int[] primaryKeyIndexes) {
+        return primaryKeyIndexes.length > 1;
+    }
+
+    private static boolean primaryKeyContainsReversedId(UniqueConstraint primaryKey) {
+        return primaryKey.getColumns().contains(RESERVED_ID);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoRowDataLookupFunction.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/MongoRowDataLookupFunction.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.table.converter.BsonToRowDataConverters;
+import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.LookupFunction;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+
+import com.mongodb.MongoException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoCursor;
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.mongodb.client.model.Filters.and;
+import static com.mongodb.client.model.Filters.eq;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.project;
+import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** A lookup function for {@link MongoDynamicTableSource}. */
+@Internal
+public class MongoRowDataLookupFunction extends LookupFunction {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoRowDataLookupFunction.class);
+    private static final long serialVersionUID = 1L;
+
+    private final MongoConnectionOptions connectionOptions;
+    private final int maxRetryTimes;
+
+    private final List<String> fieldNames;
+    private final List<String> keyNames;
+
+    private final BsonToRowDataConverters.BsonToRowDataConverter mongoRowConverter;
+    private final RowDataToBsonConverters.RowDataToBsonConverter lookupKeyRowConverter;
+
+    private transient MongoClient mongoClient;
+
+    public MongoRowDataLookupFunction(
+            MongoConnectionOptions connectionOptions,
+            int lookupMaxRetryTimes,
+            List<String> fieldNames,
+            List<DataType> fieldTypes,
+            List<String> keyNames,
+            RowType rowType) {
+        checkNotNull(fieldNames, "No fieldNames supplied.");
+        checkNotNull(fieldTypes, "No fieldTypes supplied.");
+        checkNotNull(keyNames, "No keyNames supplied.");
+        checkArgument(lookupMaxRetryTimes >= 0, "The lookup max retry times must >= 0.");
+
+        this.connectionOptions = checkNotNull(connectionOptions);
+        this.maxRetryTimes = lookupMaxRetryTimes;
+        this.fieldNames = fieldNames;
+        this.mongoRowConverter = BsonToRowDataConverters.createNullableConverter(rowType);
+
+        this.keyNames = keyNames;
+        LogicalType[] keyTypes =
+                this.keyNames.stream()
+                        .map(
+                                s -> {
+                                    checkArgument(
+                                            fieldNames.contains(s),
+                                            "keyName %s can't find in fieldNames %s.",
+                                            s,
+                                            fieldNames);
+                                    return fieldTypes.get(fieldNames.indexOf(s)).getLogicalType();
+                                })
+                        .toArray(LogicalType[]::new);
+
+        this.lookupKeyRowConverter =
+                RowDataToBsonConverters.createNullableConverter(
+                        RowType.of(keyTypes, keyNames.toArray(new String[0])));
+    }
+
+    @Override
+    public void open(FunctionContext context) {
+        this.mongoClient = MongoClients.create(connectionOptions.getUri());
+    }
+
+    /**
+     * This is a lookup method which is called by Flink framework in runtime.
+     *
+     * @param keyRow lookup keys
+     */
+    @Override
+    public Collection<RowData> lookup(RowData keyRow) {
+        for (int retry = 0; retry <= maxRetryTimes; retry++) {
+            try {
+                BsonDocument lookupValues = (BsonDocument) lookupKeyRowConverter.convert(keyRow);
+
+                List<Bson> filters =
+                        keyNames.stream()
+                                .map(name -> eq(name, lookupValues.get(name)))
+                                .collect(Collectors.toList());
+                Bson query = and(filters);
+
+                Bson projection = project(fieldNames);
+
+                try (MongoCursor<BsonDocument> cursor =
+                        getMongoCollection().find(query).projection(projection).cursor()) {
+                    ArrayList<RowData> rows = new ArrayList<>();
+                    while (cursor.hasNext()) {
+                        RowData row = (RowData) mongoRowConverter.convert(cursor.next());
+                        rows.add(row);
+                    }
+                    rows.trimToSize();
+                    return rows;
+                }
+            } catch (MongoException e) {
+                LOG.error(String.format("MongoDB lookup error, retry times = %d", retry), e);
+                if (retry >= maxRetryTimes) {
+                    throw new RuntimeException("Execution of MongoDB lookup failed.", e);
+                }
+                try {
+                    Thread.sleep(1000L * retry);
+                } catch (InterruptedException e1) {
+                    throw new RuntimeException(e1);
+                }
+            }
+        }
+        return Collections.emptyList();
+    }
+
+    private MongoCollection<BsonDocument> getMongoCollection() {
+        return mongoClient
+                .getDatabase(connectionOptions.getDatabase())
+                .getCollection(connectionOptions.getCollection())
+                .withDocumentClass(BsonDocument.class);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConfiguration.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
+import org.apache.flink.table.connector.source.lookup.LookupOptions;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.BULK_FLUSH_INTERVAL;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.BULK_FLUSH_MAX_ACTIONS;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.COLLECTION;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.DATABASE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.DELIVERY_GUARANTEE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_CURSOR_BATCH_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_CURSOR_NO_TIMEOUT;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_FETCH_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_SAMPLES;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_SIZE;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SCAN_PARTITION_STRATEGY;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.SINK_MAX_RETRIES;
+import static org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions.URI;
+import static org.apache.flink.table.factories.FactoryUtil.SINK_PARALLELISM;
+
+/** MongoDB configuration. */
+@PublicEvolving
+public class MongoConfiguration implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final ReadableConfig config;
+
+    public MongoConfiguration(ReadableConfig config) {
+        this.config = config;
+    }
+
+    // -----------------------------------Connection Config----------------------------------------
+    public String getUri() {
+        return config.get(URI);
+    }
+
+    public String getDatabase() {
+        return config.get(DATABASE);
+    }
+
+    public String getCollection() {
+        return config.get(COLLECTION);
+    }
+
+    // -----------------------------------Read Config----------------------------------------
+    public int getFetchSize() {
+        return config.get(SCAN_FETCH_SIZE);
+    }
+
+    public int getCursorBatchSize() {
+        return config.get(SCAN_CURSOR_BATCH_SIZE);
+    }
+
+    public boolean isNoCursorTimeout() {
+        return config.get(SCAN_CURSOR_NO_TIMEOUT);
+    }
+
+    public PartitionStrategy getPartitionStrategy() {
+        return config.get(SCAN_PARTITION_STRATEGY);
+    }
+
+    public MemorySize getPartitionSize() {
+        return config.get(SCAN_PARTITION_SIZE);
+    }
+
+    public int getSamplesPerPartition() {
+        return config.get(SCAN_PARTITION_SAMPLES);
+    }
+
+    // -----------------------------------Lookup Config----------------------------------------
+    public int getLookupMaxRetryTimes() {
+        return config.get(LookupOptions.MAX_RETRIES);
+    }
+
+    // -----------------------------------Write Config------------------------------------------
+    public int getBulkFlushMaxActions() {
+        return config.get(BULK_FLUSH_MAX_ACTIONS);
+    }
+
+    public long getBulkFlushIntervalMs() {
+        return config.get(BULK_FLUSH_INTERVAL).toMillis();
+    }
+
+    public int getSinkMaxRetryTimes() {
+        return config.get(SINK_MAX_RETRIES);
+    }
+
+    public DeliveryGuarantee getDeliveryGuarantee() {
+        return config.get(DELIVERY_GUARANTEE);
+    }
+
+    @Nullable
+    public Integer getSinkParallelism() {
+        return config.getOptional(SINK_PARALLELISM).orElse(null);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        MongoConfiguration that = (MongoConfiguration) o;
+        return Objects.equals(config, that.config);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(config);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConnectorOptions.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/config/MongoConnectorOptions.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table.config;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
+
+import java.time.Duration;
+
+/**
+ * Base options for the MongoDB connector. Needs to be public so that the {@link
+ * org.apache.flink.table.api.TableDescriptor} can access it.
+ */
+@PublicEvolving
+public class MongoConnectorOptions {
+
+    private MongoConnectorOptions() {}
+
+    public static final ConfigOption<String> URI =
+            ConfigOptions.key("uri")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Specifies the connection uri of MongoDB.");
+
+    public static final ConfigOption<String> DATABASE =
+            ConfigOptions.key("database")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Specifies the database to read or write of MongoDB.");
+
+    public static final ConfigOption<String> COLLECTION =
+            ConfigOptions.key("collection")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("Specifies the collection to read or write of MongoDB.");
+
+    public static final ConfigOption<Integer> SCAN_FETCH_SIZE =
+            ConfigOptions.key("scan.fetch-size")
+                    .intType()
+                    .defaultValue(2048)
+                    .withDescription(
+                            "Gives the reader a hint as to the number of documents that should be fetched from the database per round-trip when reading. ");
+
+    public static final ConfigOption<Integer> SCAN_CURSOR_BATCH_SIZE =
+            ConfigOptions.key("scan.cursor.batch-size")
+                    .intType()
+                    .defaultValue(0)
+                    .withDescription(
+                            "Specifies the number of documents to return in each batch of the response from the MongoDB instance. Set to 0 to use server's default.");
+
+    public static final ConfigOption<Boolean> SCAN_CURSOR_NO_TIMEOUT =
+            ConfigOptions.key("scan.cursor.no-timeout")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "The server normally times out idle cursors after an inactivity"
+                                    + " period (10 minutes) to prevent excess memory use. Set this option to true to prevent that."
+                                    + " However, if the application takes longer than 30 minutes to process the current batch of documents,"
+                                    + " the session is marked as expired and closed.");
+
+    public static final ConfigOption<PartitionStrategy> SCAN_PARTITION_STRATEGY =
+            ConfigOptions.key("scan.partition.strategy")
+                    .enumType(PartitionStrategy.class)
+                    .defaultValue(PartitionStrategy.DEFAULT)
+                    .withDescription(
+                            "Specifies the partition strategy. Available strategies are single, sample, split-vector, sharded and default.");
+
+    public static final ConfigOption<MemorySize> SCAN_PARTITION_SIZE =
+            ConfigOptions.key("scan.partition.size")
+                    .memoryType()
+                    .defaultValue(MemorySize.parse("64mb"))
+                    .withDescription("Specifies the partition memory size.");
+
+    public static final ConfigOption<Integer> SCAN_PARTITION_SAMPLES =
+            ConfigOptions.key("scan.partition.samples")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "Specifies the the samples count per partition. It only takes effect when the partition strategy is sample.");
+
+    public static final ConfigOption<Integer> BULK_FLUSH_MAX_ACTIONS =
+            ConfigOptions.key("sink.bulk-flush.max-actions")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription(
+                            "Specifies the maximum number of buffered actions per bulk request.");
+
+    public static final ConfigOption<Duration> BULK_FLUSH_INTERVAL =
+            ConfigOptions.key("sink.bulk-flush.interval")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription("Specifies the bulk flush interval.");
+
+    public static final ConfigOption<DeliveryGuarantee> DELIVERY_GUARANTEE =
+            ConfigOptions.key("sink.delivery-guarantee")
+                    .enumType(DeliveryGuarantee.class)
+                    .defaultValue(DeliveryGuarantee.AT_LEAST_ONCE)
+                    .withDescription("Optional delivery guarantee when committing.");
+
+    public static final ConfigOption<Integer> SINK_MAX_RETRIES =
+            ConfigOptions.key("sink.max-retries")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription(
+                            "Specifies the max retry times if writing records to database failed.");
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/converter/BsonToRowDataConverters.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/converter/BsonToRowDataConverters.java
@@ -1,0 +1,681 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table.converter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeUtils;
+
+import com.mongodb.internal.HexUtils;
+import org.bson.BsonBinary;
+import org.bson.BsonBinarySubType;
+import org.bson.BsonDocument;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonUndefined;
+import org.bson.BsonValue;
+import org.bson.codecs.BsonArrayCodec;
+import org.bson.codecs.EncoderContext;
+import org.bson.json.JsonWriter;
+import org.bson.types.Decimal128;
+
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** Tool class used to convert from {@link BsonValue} to {@link RowData}. * */
+@Internal
+public class BsonToRowDataConverters {
+
+    // -------------------------------------------------------------------------------------
+    // Runtime Converters
+    // -------------------------------------------------------------------------------------
+
+    /**
+     * Runtime converter that converts {@link BsonValue} into objects of Flink Table & SQL internal
+     * data structures.
+     */
+    @FunctionalInterface
+    public interface BsonToRowDataConverter extends Serializable {
+        Object convert(BsonValue bsonValue);
+    }
+
+    // --------------------------------------------------------------------------------
+    // IMPORTANT! We use anonymous classes instead of lambdas for a reason here. It is
+    // necessary because the maven shade plugin cannot relocate classes in
+    // SerializedLambdas (MSHADE-260). On the other hand we want to relocate Bson for
+    // sql-connector uber jars.
+    // --------------------------------------------------------------------------------
+
+    /** Creates a runtime converter which is null safe. */
+    public static BsonToRowDataConverter createNullableConverter(LogicalType type) {
+        return wrapIntoNullableInternalConverter(createConverter(type));
+    }
+
+    private static BsonToRowDataConverter wrapIntoNullableInternalConverter(
+            BsonToRowDataConverter bsonToRowDataConverter) {
+        return new BsonToRowDataConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(BsonValue bsonValue) {
+                if (bsonValue == null || bsonValue.isNull() || bsonValue instanceof BsonUndefined) {
+                    return null;
+                }
+                if (bsonValue.isDecimal128() && bsonValue.asDecimal128().getValue().isNaN()) {
+                    return null;
+                }
+                return bsonToRowDataConverter.convert(bsonValue);
+            }
+        };
+    }
+
+    /** Creates a runtime converter which assuming input object is not null. */
+    private static BsonToRowDataConverter createConverter(LogicalType type) {
+        switch (type.getTypeRoot()) {
+            case NULL:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return null;
+                    }
+                };
+            case BOOLEAN:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToBoolean(bsonValue);
+                    }
+                };
+            case TINYINT:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToTinyInt(bsonValue);
+                    }
+                };
+            case SMALLINT:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToSmallInt(bsonValue);
+                    }
+                };
+            case INTEGER:
+            case INTERVAL_YEAR_MONTH:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToInt(bsonValue);
+                    }
+                };
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToLong(bsonValue);
+                    }
+                };
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return TimestampData.fromLocalDateTime(convertToLocalDateTime(bsonValue));
+                    }
+                };
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return TimestampData.fromInstant(convertToInstant(bsonValue));
+                    }
+                };
+            case FLOAT:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToFloat(bsonValue);
+                    }
+                };
+            case DOUBLE:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToDouble(bsonValue);
+                    }
+                };
+            case CHAR:
+            case VARCHAR:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return StringData.fromString(convertToString(bsonValue));
+                    }
+                };
+            case BINARY:
+            case VARBINARY:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        return convertToBinary(bsonValue);
+                    }
+                };
+            case DECIMAL:
+                return new BsonToRowDataConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public Object convert(BsonValue bsonValue) {
+                        DecimalType decimalType = (DecimalType) type;
+                        BigDecimal decimalValue = convertToBigDecimal(bsonValue);
+                        return DecimalData.fromBigDecimal(
+                                decimalValue, decimalType.getPrecision(), decimalType.getScale());
+                    }
+                };
+            case ROW:
+                return createRowConverter((RowType) type);
+            case ARRAY:
+                return createArrayConverter((ArrayType) type);
+            case MAP:
+                return createMapConverter((MapType) type);
+            case MULTISET:
+            case RAW:
+            default:
+                throw new UnsupportedOperationException("Unsupported type: " + type);
+        }
+    }
+
+    private static BsonToRowDataConverter createRowConverter(RowType rowType) {
+        final BsonToRowDataConverter[] fieldConverters =
+                rowType.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .map(BsonToRowDataConverters::createNullableConverter)
+                        .toArray(BsonToRowDataConverter[]::new);
+        final int arity = rowType.getFieldCount();
+        final String[] fieldNames = rowType.getFieldNames().toArray(new String[0]);
+
+        return new BsonToRowDataConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(BsonValue bsonValue) {
+                if (!bsonValue.isDocument()) {
+                    throw new IllegalArgumentException(
+                            "Unable to convert to rowType from unexpected value '"
+                                    + bsonValue
+                                    + "' of type "
+                                    + bsonValue.getBsonType());
+                }
+
+                BsonDocument document = bsonValue.asDocument();
+                GenericRowData row = new GenericRowData(arity);
+                for (int i = 0; i < arity; i++) {
+                    String fieldName = fieldNames[i];
+                    BsonValue fieldValue = document.get(fieldName);
+                    Object convertedField = fieldConverters[i].convert(fieldValue);
+                    row.setField(i, convertedField);
+                }
+                return row;
+            }
+        };
+    }
+
+    private static BsonToRowDataConverter createArrayConverter(ArrayType arrayType) {
+        final Class<?> elementClass =
+                LogicalTypeUtils.toInternalConversionClass(arrayType.getElementType());
+        final BsonToRowDataConverter elementConverter =
+                createNullableConverter(arrayType.getElementType());
+
+        return new BsonToRowDataConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(BsonValue bsonValue) {
+                if (!bsonValue.isArray()) {
+                    throw new IllegalArgumentException(
+                            "Unable to convert to arrayType from unexpected value '"
+                                    + bsonValue
+                                    + "' of type "
+                                    + bsonValue.getBsonType());
+                }
+
+                List<BsonValue> in = bsonValue.asArray();
+                final Object[] elementArray = (Object[]) Array.newInstance(elementClass, in.size());
+                for (int i = 0; i < in.size(); i++) {
+                    elementArray[i] = elementConverter.convert(in.get(i));
+                }
+                return new GenericArrayData(elementArray);
+            }
+        };
+    }
+
+    private static BsonToRowDataConverter createMapConverter(MapType mapType) {
+        LogicalType keyType = mapType.getKeyType();
+        checkArgument(keyType.supportsInputConversion(String.class));
+
+        LogicalType valueType = mapType.getValueType();
+        BsonToRowDataConverter valueConverter = createNullableConverter(valueType);
+
+        return new BsonToRowDataConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public Object convert(BsonValue bsonValue) {
+                if (!bsonValue.isDocument()) {
+                    throw new IllegalArgumentException(
+                            "Unable to convert to rowType from unexpected value '"
+                                    + bsonValue
+                                    + "' of type "
+                                    + bsonValue.getBsonType());
+                }
+
+                BsonDocument document = bsonValue.asDocument();
+                Map<StringData, Object> map = new HashMap<>();
+                for (String key : document.keySet()) {
+                    map.put(StringData.fromString(key), valueConverter.convert(document.get(key)));
+                }
+                return new GenericMapData(map);
+            }
+        };
+    }
+
+    private static boolean convertToBoolean(BsonValue bsonValue) {
+        if (bsonValue.isBoolean()) {
+            return bsonValue.asBoolean().getValue();
+        }
+        if (bsonValue.isInt32()) {
+            return bsonValue.asInt32().getValue() == 1;
+        }
+        if (bsonValue.isInt64()) {
+            return bsonValue.asInt64().getValue() == 1L;
+        }
+        if (bsonValue.isString()) {
+            return Boolean.parseBoolean(bsonValue.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to boolean from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static byte convertToTinyInt(BsonValue bsonValue) {
+        if (bsonValue.isBoolean()) {
+            return bsonValue.asBoolean().getValue() ? (byte) 1 : (byte) 0;
+        }
+        if (bsonValue.isInt32()) {
+            return (byte) bsonValue.asInt32().getValue();
+        }
+        if (bsonValue.isInt64()) {
+            return (byte) bsonValue.asInt64().getValue();
+        }
+        if (bsonValue.isString()) {
+            return Byte.parseByte(bsonValue.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to tinyint from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static short convertToSmallInt(BsonValue bsonValue) {
+        if (bsonValue.isBoolean()) {
+            return bsonValue.asBoolean().getValue() ? (short) 1 : (short) 0;
+        }
+        if (bsonValue.isInt32()) {
+            return (short) bsonValue.asInt32().getValue();
+        }
+        if (bsonValue.isInt64()) {
+            return (short) bsonValue.asInt64().getValue();
+        }
+        if (bsonValue.isString()) {
+            return Short.parseShort(bsonValue.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to smallint from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static int convertToInt(BsonValue bsonValue) {
+        if (bsonValue.isNumber()) {
+            return bsonValue.asNumber().intValue();
+        }
+        if (bsonValue.isDecimal128()) {
+            Decimal128 decimal128Value = bsonValue.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.intValue();
+            } else if (decimal128Value.isNegative()) {
+                return Integer.MIN_VALUE;
+            } else {
+                return Integer.MAX_VALUE;
+            }
+        }
+        if (bsonValue.isBoolean()) {
+            return bsonValue.asBoolean().getValue() ? 1 : 0;
+        }
+        if (bsonValue.isDateTime()) {
+            return (int) Instant.ofEpochMilli(bsonValue.asDateTime().getValue()).getEpochSecond();
+        }
+        if (bsonValue.isTimestamp()) {
+            return bsonValue.asTimestamp().getTime();
+        }
+        if (bsonValue.isString()) {
+            return Integer.parseInt(bsonValue.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to integer from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static long convertToLong(BsonValue bsonValue) {
+        if (bsonValue.isNumber()) {
+            return bsonValue.asNumber().longValue();
+        }
+        if (bsonValue.isDecimal128()) {
+            Decimal128 decimal128Value = bsonValue.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.longValue();
+            } else if (decimal128Value.isNegative()) {
+                return Long.MIN_VALUE;
+            } else {
+                return Long.MAX_VALUE;
+            }
+        }
+        if (bsonValue.isBoolean()) {
+            return bsonValue.asBoolean().getValue() ? 1L : 0L;
+        }
+        if (bsonValue.isDateTime()) {
+            return bsonValue.asDateTime().getValue();
+        }
+        if (bsonValue.isTimestamp()) {
+            return bsonValue.asTimestamp().getTime() * 1000L;
+        }
+        if (bsonValue.isString()) {
+            return Long.parseLong(bsonValue.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to long from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static double convertToDouble(BsonValue bsonValue) {
+        if (bsonValue.isNumber()) {
+            return bsonValue.asNumber().doubleValue();
+        }
+        if (bsonValue.isDecimal128()) {
+            Decimal128 decimal128Value = bsonValue.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.doubleValue();
+            } else if (decimal128Value.isNegative()) {
+                return -Double.MAX_VALUE;
+            } else {
+                return Double.MAX_VALUE;
+            }
+        }
+        if (bsonValue.isBoolean()) {
+            return bsonValue.asBoolean().getValue() ? 1 : 0;
+        }
+        if (bsonValue.isString()) {
+            return Double.parseDouble(bsonValue.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to double from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static float convertToFloat(BsonValue bsonValue) {
+        if (bsonValue.isInt32()) {
+            return bsonValue.asInt32().getValue();
+        }
+        if (bsonValue.isInt64()) {
+            return bsonValue.asInt64().getValue();
+        }
+        if (bsonValue.isDouble()) {
+            return ((Double) bsonValue.asDouble().getValue()).floatValue();
+        }
+        if (bsonValue.isDecimal128()) {
+            Decimal128 decimal128Value = bsonValue.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                return decimal128Value.floatValue();
+            } else if (decimal128Value.isNegative()) {
+                return -Float.MAX_VALUE;
+            } else {
+                return Float.MAX_VALUE;
+            }
+        }
+        if (bsonValue.isBoolean()) {
+            return bsonValue.asBoolean().getValue() ? 1f : 0f;
+        }
+        if (bsonValue.isString()) {
+            return Float.parseFloat(bsonValue.asString().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to float from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static Instant convertToInstant(BsonValue bsonValue) {
+        if (bsonValue.isTimestamp()) {
+            return Instant.ofEpochSecond(bsonValue.asTimestamp().getTime());
+        }
+        if (bsonValue.isDateTime()) {
+            return Instant.ofEpochMilli(bsonValue.asDateTime().getValue());
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to Instant from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static LocalDateTime convertToLocalDateTime(BsonValue bsonValue) {
+        Instant instant;
+        if (bsonValue.isTimestamp()) {
+            instant = Instant.ofEpochSecond(bsonValue.asTimestamp().getTime());
+        } else if (bsonValue.isDateTime()) {
+            instant = Instant.ofEpochMilli(bsonValue.asDateTime().getValue());
+        } else {
+            throw new IllegalArgumentException(
+                    "Unable to convert to LocalDateTime from unexpected value '"
+                            + bsonValue
+                            + "' of type "
+                            + bsonValue.getBsonType());
+        }
+        return Timestamp.from(instant).toLocalDateTime();
+    }
+
+    private static byte[] convertToBinary(BsonValue bsonValue) {
+        if (bsonValue.isBinary()) {
+            return bsonValue.asBinary().getData();
+        }
+        throw new IllegalArgumentException(
+                "Unsupported BYTES value type: " + bsonValue.getClass().getSimpleName());
+    }
+
+    private static String convertToString(BsonValue bsonValue) {
+        if (bsonValue.isString()) {
+            return bsonValue.asString().getValue();
+        }
+        if (bsonValue.isBinary()) {
+            BsonBinary bsonBinary = bsonValue.asBinary();
+            if (BsonBinarySubType.isUuid(bsonBinary.getType())) {
+                return bsonBinary.asUuid().toString();
+            }
+            return HexUtils.toHex(bsonBinary.getData());
+        }
+        if (bsonValue.isObjectId()) {
+            return bsonValue.asObjectId().getValue().toHexString();
+        }
+        if (bsonValue.isInt32()) {
+            return String.valueOf(bsonValue.asInt32().getValue());
+        }
+        if (bsonValue.isInt64()) {
+            return String.valueOf(bsonValue.asInt64().getValue());
+        }
+        if (bsonValue.isDouble()) {
+            return String.valueOf(bsonValue.asDouble().getValue());
+        }
+        if (bsonValue.isDecimal128()) {
+            return bsonValue.asDecimal128().getValue().toString();
+        }
+        if (bsonValue.isBoolean()) {
+            return String.valueOf(bsonValue.asBoolean().getValue());
+        }
+        if (bsonValue.isDateTime() || bsonValue.isTimestamp()) {
+            Instant instant = convertToInstant(bsonValue);
+            return OffsetDateTime.ofInstant(instant, ZoneOffset.UTC).format(ISO_OFFSET_DATE_TIME);
+        }
+        if (bsonValue.isRegularExpression()) {
+            BsonRegularExpression regex = bsonValue.asRegularExpression();
+            return String.format("/%s/%s", regex.getPattern(), regex.getOptions());
+        }
+        if (bsonValue.isJavaScript()) {
+            return bsonValue.asJavaScript().getCode();
+        }
+        if (bsonValue.isJavaScriptWithScope()) {
+            return bsonValue.asJavaScriptWithScope().getCode();
+        }
+        if (bsonValue.isSymbol()) {
+            return bsonValue.asSymbol().getSymbol();
+        }
+        if (bsonValue.isDBPointer()) {
+            return bsonValue.asDBPointer().getId().toHexString();
+        }
+        if (bsonValue.isDocument()) {
+            // convert document to json string
+            return bsonValue.asDocument().toJson();
+        }
+        if (bsonValue.isArray()) {
+            // convert bson array to json string
+            Writer writer = new StringWriter();
+            JsonWriter jsonArrayWriter =
+                    new JsonWriter(writer) {
+                        private static final long serialVersionUID = 1L;
+
+                        @Override
+                        public void writeStartArray() {
+                            doWriteStartArray();
+                            setState(State.VALUE);
+                        }
+
+                        @Override
+                        public void writeEndArray() {
+                            doWriteEndArray();
+                            setState(getNextState());
+                        }
+                    };
+
+            new BsonArrayCodec()
+                    .encode(jsonArrayWriter, bsonValue.asArray(), EncoderContext.builder().build());
+            return writer.toString();
+        }
+        throw new IllegalArgumentException(
+                "Unable to convert to string from unexpected value '"
+                        + bsonValue
+                        + "' of type "
+                        + bsonValue.getBsonType());
+    }
+
+    private static BigDecimal convertToBigDecimal(BsonValue bsonValue) {
+        BigDecimal decimalValue;
+        if (bsonValue.isString()) {
+            decimalValue = new BigDecimal(bsonValue.asString().getValue());
+        } else if (bsonValue.isDecimal128()) {
+            Decimal128 decimal128Value = bsonValue.asDecimal128().decimal128Value();
+            if (decimal128Value.isFinite()) {
+                decimalValue = bsonValue.asDecimal128().decimal128Value().bigDecimalValue();
+            } else {
+                // DecimalData doesn't have the concept of infinity.
+                throw new IllegalArgumentException(
+                        "Unable to convert infinite bson decimal to Decimal type.");
+            }
+        } else if (bsonValue.isDouble()) {
+            decimalValue = BigDecimal.valueOf(bsonValue.asDouble().doubleValue());
+        } else if (bsonValue.isInt32()) {
+            decimalValue = BigDecimal.valueOf(bsonValue.asInt32().getValue());
+        } else if (bsonValue.isInt64()) {
+            decimalValue = BigDecimal.valueOf(bsonValue.asInt64().getValue());
+        } else {
+            throw new IllegalArgumentException(
+                    "Unable to convert to decimal from unexpected value '"
+                            + bsonValue
+                            + "' of type "
+                            + bsonValue.getBsonType());
+        }
+        return decimalValue;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/converter/RowDataToBsonConverters.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/converter/RowDataToBsonConverters.java
@@ -1,0 +1,320 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table.converter;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeFamily;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.types.Decimal128;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Tool class used to convert from {@link RowData} to {@link BsonValue}. */
+@Internal
+public class RowDataToBsonConverters {
+
+    // --------------------------------------------------------------------------------
+    // Runtime Converters
+    // --------------------------------------------------------------------------------
+
+    /**
+     * Runtime converter that converts objects of Flink Table & SQL internal data structures to
+     * corresponding {@link BsonValue} data structures.
+     */
+    @FunctionalInterface
+    public interface RowDataToBsonConverter extends Serializable {
+        BsonValue convert(Object value);
+    }
+
+    // --------------------------------------------------------------------------------
+    // IMPORTANT! We use anonymous classes instead of lambdas for a reason here. It is
+    // necessary because the maven shade plugin cannot relocate classes in
+    // SerializedLambdas (MSHADE-260). On the other hand we want to relocate Bson for
+    // sql-connector uber jars.
+    // --------------------------------------------------------------------------------
+
+    /** Create a nullable MongoDB {@link RowDataToBsonConverter} from given sql type. */
+    public static RowDataToBsonConverter createNullableConverter(LogicalType type) {
+        return wrapIntoNullableConverter(createConverter(type), type);
+    }
+
+    private static RowDataToBsonConverter wrapIntoNullableConverter(
+            RowDataToBsonConverter rowDataToBsonConverter, LogicalType type) {
+        return new RowDataToBsonConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public BsonValue convert(Object value) {
+                if (value == null || LogicalTypeRoot.NULL.equals(type.getTypeRoot())) {
+                    return BsonNull.VALUE;
+                } else {
+                    return rowDataToBsonConverter.convert(value);
+                }
+            }
+        };
+    }
+
+    private static RowDataToBsonConverter createConverter(LogicalType type) {
+        switch (type.getTypeRoot()) {
+            case NULL:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return null;
+                    }
+                };
+            case BOOLEAN:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonBoolean((boolean) value);
+                    }
+                };
+            case TINYINT:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonInt32(((Byte) value).intValue());
+                    }
+                };
+            case SMALLINT:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonInt32(((Short) value).intValue());
+                    }
+                };
+            case INTEGER:
+            case INTERVAL_YEAR_MONTH:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonInt32((int) value);
+                    }
+                };
+            case BIGINT:
+            case INTERVAL_DAY_TIME:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonInt64((long) value);
+                    }
+                };
+            case FLOAT:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonDouble(Float.valueOf((float) value).doubleValue());
+                    }
+                };
+            case DOUBLE:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonDouble((double) value);
+                    }
+                };
+            case DECIMAL:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        BigDecimal decimalVal = ((DecimalData) value).toBigDecimal();
+                        return new BsonDecimal128(new Decimal128(decimalVal));
+                    }
+                };
+            case CHAR:
+            case VARCHAR:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonString(value.toString());
+                    }
+                };
+            case BINARY:
+            case VARBINARY:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonBinary((byte[]) value);
+                    }
+                };
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonDateTime(((TimestampData) value).toTimestamp().getTime());
+                    }
+                };
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return new RowDataToBsonConverter() {
+                    private static final long serialVersionUID = 1L;
+
+                    @Override
+                    public BsonValue convert(Object value) {
+                        return new BsonDateTime(((TimestampData) value).getMillisecond());
+                    }
+                };
+            case ROW:
+                return createRowConverter((RowType) type);
+            case ARRAY:
+                return createArrayConverter((ArrayType) type);
+            case MAP:
+                return createMapConverter((MapType) type);
+            case MULTISET:
+            case RAW:
+            default:
+                throw new UnsupportedOperationException("Unsupported type:" + type);
+        }
+    }
+
+    private static RowDataToBsonConverter createRowConverter(RowType rowType) {
+        final RowDataToBsonConverter[] fieldConverters =
+                rowType.getChildren().stream()
+                        .map(RowDataToBsonConverters::createNullableConverter)
+                        .toArray(RowDataToBsonConverter[]::new);
+        final LogicalType[] fieldTypes =
+                rowType.getFields().stream()
+                        .map(RowType.RowField::getType)
+                        .toArray(LogicalType[]::new);
+
+        final int fieldCount = rowType.getFieldCount();
+        final RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[fieldCount];
+        for (int i = 0; i < fieldCount; i++) {
+            fieldGetters[i] = RowData.createFieldGetter(fieldTypes[i], i);
+        }
+
+        return new RowDataToBsonConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public BsonValue convert(Object value) {
+                final RowData rowData = (RowData) value;
+                final BsonDocument document = new BsonDocument();
+                for (int i = 0; i < fieldCount; i++) {
+                    String fieldName = rowType.getFieldNames().get(i);
+                    Object fieldValue = fieldGetters[i].getFieldOrNull(rowData);
+                    document.append(fieldName, fieldConverters[i].convert(fieldValue));
+                }
+                return document;
+            }
+        };
+    }
+
+    private static RowDataToBsonConverter createArrayConverter(ArrayType arrayType) {
+        final LogicalType elementType = arrayType.getElementType();
+        final ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(elementType);
+        final RowDataToBsonConverter elementConverter = createNullableConverter(elementType);
+
+        return new RowDataToBsonConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public BsonValue convert(Object value) {
+                final ArrayData arrayData = (ArrayData) value;
+                final List<BsonValue> bsonValues = new ArrayList<>();
+                for (int i = 0; i < arrayData.size(); i++) {
+                    final BsonValue bsonValue =
+                            elementConverter.convert(elementGetter.getElementOrNull(arrayData, i));
+                    bsonValues.add(bsonValue);
+                }
+                return new BsonArray(bsonValues);
+            }
+        };
+    }
+
+    private static RowDataToBsonConverter createMapConverter(MapType mapType) {
+        final LogicalType keyType = mapType.getKeyType();
+        final LogicalType valueType = mapType.getValueType();
+        if (!keyType.is(LogicalTypeFamily.CHARACTER_STRING)) {
+            throw new UnsupportedOperationException(
+                    "MongoDB doesn't support non-string as key type of map. "
+                            + "The type is: "
+                            + keyType.asSummaryString());
+        }
+        final RowDataToBsonConverter valueConverter = createNullableConverter(valueType);
+        final ArrayData.ElementGetter valueGetter = ArrayData.createElementGetter(valueType);
+
+        return new RowDataToBsonConverter() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public BsonValue convert(Object value) {
+                final MapData mapData = (MapData) value;
+                final ArrayData keyArray = mapData.keyArray();
+                final ArrayData valueArray = mapData.valueArray();
+                final BsonDocument document = new BsonDocument();
+                for (int i = 0; i < mapData.size(); i++) {
+                    final String key = keyArray.getString(i).toString();
+                    final BsonValue bsonValue =
+                            valueConverter.convert(valueGetter.getElementOrNull(valueArray, i));
+                    document.append(key, bsonValue);
+                }
+                return document;
+            }
+        };
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/serialization/MongoRowDataDeserializationSchema.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/serialization/MongoRowDataDeserializationSchema.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table.serialization;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoDeserializationSchema;
+import org.apache.flink.connector.mongodb.table.converter.BsonToRowDataConverters;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import org.bson.BsonDocument;
+
+/** Deserializer that {@link BsonDocument} to flink internal {@link RowData}. */
+@Internal
+public class MongoRowDataDeserializationSchema implements MongoDeserializationSchema<RowData> {
+
+    /** Type information describing the result type. */
+    private final TypeInformation<RowData> typeInfo;
+
+    /** Runtime instance that performs the actual work. */
+    private final BsonToRowDataConverters.BsonToRowDataConverter runtimeConverter;
+
+    public MongoRowDataDeserializationSchema(RowType rowType, TypeInformation<RowData> typeInfo) {
+        this.typeInfo = typeInfo;
+        this.runtimeConverter = BsonToRowDataConverters.createNullableConverter(rowType);
+    }
+
+    @Override
+    public RowData deserialize(BsonDocument document) {
+        return (RowData) runtimeConverter.convert(document);
+    }
+
+    @Override
+    public TypeInformation<RowData> getProducedType() {
+        return typeInfo;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/serialization/MongoRowDataSerializationSchema.java
+++ b/flink-connectors/flink-connector-mongodb/src/main/java/org/apache/flink/connector/mongodb/table/serialization/MongoRowDataSerializationSchema.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table.serialization;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.mongodb.sink.writer.context.MongoSinkContext;
+import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializationSchema;
+import org.apache.flink.connector.mongodb.table.converter.RowDataToBsonConverters;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.data.RowData;
+
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+
+import java.util.function.Function;
+
+/** The serialization schema for flink {@link RowData} to serialize records into MongoDB. */
+@Internal
+public class MongoRowDataSerializationSchema implements MongoSerializationSchema<RowData> {
+
+    private final RowDataToBsonConverters.RowDataToBsonConverter rowDataToBsonConverter;
+    private final Function<RowData, BsonValue> createKey;
+
+    public MongoRowDataSerializationSchema(
+            RowDataToBsonConverters.RowDataToBsonConverter rowDataToBsonConverter,
+            Function<RowData, BsonValue> createKey) {
+        this.rowDataToBsonConverter = rowDataToBsonConverter;
+        this.createKey = createKey;
+    }
+
+    @Override
+    public WriteModel<BsonDocument> serialize(RowData element, MongoSinkContext context) {
+        switch (element.getRowKind()) {
+            case INSERT:
+            case UPDATE_AFTER:
+                return processUpsert(element);
+            case UPDATE_BEFORE:
+            case DELETE:
+                return processDelete(element);
+            default:
+                throw new TableException("Unsupported message kind: " + element.getRowKind());
+        }
+    }
+
+    private WriteModel<BsonDocument> processUpsert(RowData row) {
+        final BsonDocument document = (BsonDocument) rowDataToBsonConverter.convert(row);
+        final BsonValue key = createKey.apply(row);
+        if (key != null) {
+            BsonDocument filter = new BsonDocument("_id", key);
+            // _id is immutable so we remove it here to prevent exception.
+            document.remove("_id");
+            BsonDocument update = new BsonDocument("$set", document);
+            return new UpdateOneModel<>(filter, update, new UpdateOptions().upsert(true));
+        } else {
+            return new InsertOneModel<>(document);
+        }
+    }
+
+    private WriteModel<BsonDocument> processDelete(RowData row) {
+        final BsonValue key = createKey.apply(row);
+        BsonDocument filter = new BsonDocument("_id", key);
+        return new DeleteOneModel<>(filter);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connectors/flink-connector-mongodb/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.connector.mongodb.table.MongoDynamicTableFactory

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/architecture/TestCodeArchitectureTest.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/architecture/TestCodeArchitectureTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.architecture;
+
+import org.apache.flink.architecture.common.ImportOptions;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.junit.ArchTests;
+
+/** Architecture tests for test code. */
+@AnalyzeClasses(
+        packages = "org.apache.flink.connector.mongodb",
+        importOptions = {
+            ImportOption.OnlyIncludeTests.class,
+            ImportOptions.ExcludeScalaImportOption.class,
+            ImportOptions.ExcludeShadedImportOption.class
+        })
+public class TestCodeArchitectureTest {
+
+    @ArchTest
+    public static final ArchTests COMMON_TESTS = ArchTests.in(TestCodeArchitectureTestBase.class);
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/MongoTestUtil.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/MongoTestUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb;
+
+import org.apache.flink.annotation.Internal;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+/** Collection of utility methods for MongoDB tests. */
+@Internal
+public class MongoTestUtil {
+
+    private MongoTestUtil() {}
+
+    /**
+     * Creates a preconfigured {@link MongoDBContainer}.
+     *
+     * @param dockerImageVersion describing the MongoDB image
+     * @param logger for test containers
+     * @return configured MongoDB container
+     */
+    public static MongoDBContainer createMongoDBContainer(
+            String dockerImageVersion, Logger logger) {
+        return new MongoDBContainer(DockerImageName.parse(dockerImageVersion))
+                .withLogConsumer(new Slf4jLogConsumer(logger));
+    }
+
+    public static void assertThatIdsAreNotWritten(MongoCollection<Document> coll, Integer... ids) {
+        boolean existOne = coll.find(Filters.in("_id", ids)).first() != null;
+        assertThat(existOne, is(false));
+    }
+
+    public static void assertThatIdsAreWritten(MongoCollection<Document> coll, Integer... ids) {
+        List<Integer> actualIds = new ArrayList<>();
+        coll.find(Filters.in("_id", ids)).map(d -> d.getInteger("_id")).into(actualIds);
+
+        assertThat(actualIds, containsInAnyOrder(ids));
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/MongoSinkITCase.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/MongoSinkITCase.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink;
+
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.mongodb.MongoTestUtil;
+import org.apache.flink.connector.mongodb.sink.writer.context.MongoSinkContext;
+import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializationSchema;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLoggerExtension;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.WriteModel;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.annotation.Nullable;
+
+import static org.apache.flink.connector.mongodb.MongoTestUtil.assertThatIdsAreWritten;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT cases for {@link MongoSink}. */
+@Testcontainers
+@ExtendWith(TestLoggerExtension.class)
+public class MongoSinkITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSinkITCase.class);
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER =
+            MongoTestUtil.createMongoDBContainer(DockerImageVersions.MONGO_4_0, LOG);
+
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setConfiguration(new Configuration())
+                            .build());
+
+    private static final String TEST_DATABASE = "test_sink";
+
+    private static boolean failed;
+
+    private static MongoClient mongoClient;
+
+    @BeforeAll
+    static void setUp() {
+        failed = false;
+        mongoClient = MongoClients.create(MONGO_CONTAINER.getConnectionString());
+    }
+
+    @AfterAll
+    static void tearDown() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(DeliveryGuarantee.class)
+    void testWriteToMongoWithDeliveryGuarantee(DeliveryGuarantee deliveryGuarantee)
+            throws Exception {
+        final String index = "test-sink-with-delivery-" + deliveryGuarantee;
+        boolean failure = false;
+        try {
+            runTest(index, false, deliveryGuarantee, null);
+        } catch (IllegalStateException e) {
+            failure = true;
+            assertThat(deliveryGuarantee).isSameAs(DeliveryGuarantee.EXACTLY_ONCE);
+        } finally {
+            assertThat(failure).isEqualTo(deliveryGuarantee == DeliveryGuarantee.EXACTLY_ONCE);
+        }
+    }
+
+    @Test
+    void testRecovery() throws Exception {
+        final String index = "test-recovery-mongo-sink";
+        runTest(index, true, new FailingMapper());
+        assertThat(failed).isTrue();
+    }
+
+    private void runTest(
+            String collection,
+            boolean allowRestarts,
+            @Nullable MapFunction<Long, Long> additionalMapper)
+            throws Exception {
+        runTest(collection, allowRestarts, DeliveryGuarantee.AT_LEAST_ONCE, additionalMapper);
+    }
+
+    private void runTest(
+            String collection,
+            boolean allowRestarts,
+            DeliveryGuarantee deliveryGuarantee,
+            @Nullable MapFunction<Long, Long> additionalMapper)
+            throws Exception {
+
+        final MongoSink<Document> sink =
+                MongoSink.<Document>builder()
+                        .setUri(MONGO_CONTAINER.getConnectionString())
+                        .setDatabase(TEST_DATABASE)
+                        .setCollection(collection)
+                        .setBulkFlushMaxActions(5)
+                        .setDeliveryGuarantee(deliveryGuarantee)
+                        .setSerializationSchema(new AppendOnlySerializationSchema())
+                        .build();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(100L);
+        if (!allowRestarts) {
+            env.setRestartStrategy(RestartStrategies.noRestart());
+        }
+        DataStream<Long> stream = env.fromSequence(1, 5);
+
+        if (additionalMapper != null) {
+            stream = stream.map(additionalMapper);
+        }
+
+        stream.map(new TestMapFunction()).sinkTo(sink);
+        env.execute();
+        assertThatIdsAreWritten(collectionOf(collection), 1, 2, 3, 4, 5);
+    }
+
+    private MongoCollection<Document> collectionOf(String collection) {
+        return mongoClient.getDatabase(TEST_DATABASE).getCollection(collection);
+    }
+
+    private static Document buildMessage(int id) {
+        return new Document("_id", id).append("f1", "d_" + id);
+    }
+
+    private static class TestMapFunction implements MapFunction<Long, Document> {
+        @Override
+        public Document map(Long value) {
+            return buildMessage(value.intValue());
+        }
+    }
+
+    private static class AppendOnlySerializationSchema
+            implements MongoSerializationSchema<Document> {
+        @Override
+        public WriteModel<BsonDocument> serialize(Document element, MongoSinkContext sinkContext) {
+            return new InsertOneModel<>(element.toBsonDocument());
+        }
+    }
+
+    private static class FailingMapper implements MapFunction<Long, Long>, CheckpointListener {
+
+        private int emittedRecords = 0;
+
+        @Override
+        public Long map(Long value) throws Exception {
+            Thread.sleep(50);
+            emittedRecords++;
+            return value;
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {
+            if (failed || emittedRecords == 0) {
+                return;
+            }
+            failed = true;
+            throw new Exception("Expected failure");
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/writer/MongoWriterITCase.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/sink/writer/MongoWriterITCase.java
@@ -1,0 +1,452 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.sink.writer;
+
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.mongodb.MongoTestUtil;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.sink.writer.context.MongoSinkContext;
+import org.apache.flink.connector.mongodb.sink.writer.serializer.MongoSerializationSchema;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorIOMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
+import org.apache.flink.metrics.testutils.MetricListener;
+import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
+import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLoggerExtension;
+import org.apache.flink.util.UserCodeClassLoader;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.DeleteOneModel;
+import com.mongodb.client.model.InsertOneModel;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.WriteModel;
+import org.bson.BsonDocument;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static org.apache.flink.connector.mongodb.MongoTestUtil.assertThatIdsAreNotWritten;
+import static org.apache.flink.connector.mongodb.MongoTestUtil.assertThatIdsAreWritten;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+/** Tests for {@link MongoWriter}. */
+@Testcontainers
+@ExtendWith(TestLoggerExtension.class)
+public class MongoWriterITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoWriterITCase.class);
+
+    private static final String TEST_DATABASE = "test_writer";
+
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(2)
+                            .setConfiguration(new Configuration())
+                            .build());
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER =
+            MongoTestUtil.createMongoDBContainer(DockerImageVersions.MONGO_4_0, LOG);
+
+    private static final int DEFAULT_SINK_PARALLELISM = 2;
+
+    private static MongoClient mongoClient;
+    private static MetricListener metricListener;
+
+    @BeforeAll
+    static void beforeAll() {
+        mongoClient = MongoClients.create(MONGO_CONTAINER.getConnectionString());
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @BeforeEach
+    void setUp() {
+        metricListener = new MetricListener();
+    }
+
+    @Test
+    void testWriteOnBulkFlush() throws Exception {
+        final String collection = "test-bulk-flush-without-checkpoint";
+        final boolean flushOnCheckpoint = false;
+        final int bulkFlushMaxActions = 5;
+        final int bulkFlushInterval = -1;
+
+        try (final MongoWriter<Document> writer =
+                createWriter(
+                        collection, bulkFlushMaxActions, bulkFlushInterval, flushOnCheckpoint)) {
+            writer.write(buildMessage(1), null);
+            writer.write(buildMessage(2), null);
+            writer.write(buildMessage(3), null);
+            writer.write(buildMessage(4), null);
+
+            // Ignore flush on checkpoint
+            writer.flush(false);
+
+            assertThatIdsAreNotWritten(collectionOf(collection), 1, 2, 3, 4);
+
+            // Trigger flush
+            writer.write(buildMessage(5), null);
+            assertThatIdsAreWritten(collectionOf(collection), 1, 2, 3, 4, 5);
+
+            writer.write(buildMessage(6), null);
+            assertThatIdsAreNotWritten(collectionOf(collection), 6);
+
+            // Force flush
+            writer.doBulkWrite();
+            assertThatIdsAreWritten(collectionOf(collection), 1, 2, 3, 4, 5, 6);
+        }
+    }
+
+    @Test
+    void testWriteOnBulkIntervalFlush() throws Exception {
+        final String collection = "test-bulk-flush-with-interval";
+        final boolean flushOnCheckpoint = false;
+        final int bulkFlushMaxActions = -1;
+        final int bulkFlushInterval = 1000;
+
+        try (final MongoWriter<Document> writer =
+                createWriter(
+                        collection, bulkFlushMaxActions, bulkFlushInterval, flushOnCheckpoint)) {
+            writer.write(buildMessage(1), null);
+            writer.write(buildMessage(2), null);
+            writer.write(buildMessage(3), null);
+            writer.write(buildMessage(4), null);
+            writer.doBulkWrite();
+        }
+
+        assertThatIdsAreWritten(collectionOf(collection), 1, 2, 3, 4);
+    }
+
+    @Test
+    void testWriteOnCheckpoint() throws Exception {
+        final String collection = "test-bulk-flush-with-checkpoint";
+        final boolean flushOnCheckpoint = true;
+        final int bulkFlushMaxActions = -1;
+        final int bulkFlushInterval = -1;
+
+        // Enable flush on checkpoint
+        try (final MongoWriter<Document> writer =
+                createWriter(
+                        collection, bulkFlushMaxActions, bulkFlushInterval, flushOnCheckpoint)) {
+            writer.write(buildMessage(1), null);
+            writer.write(buildMessage(2), null);
+            writer.write(buildMessage(3), null);
+
+            assertThatIdsAreNotWritten(collectionOf(collection), 1, 2, 3);
+
+            // Trigger flush
+            writer.flush(false);
+
+            assertThatIdsAreWritten(collectionOf(collection), 1, 2, 3);
+        }
+    }
+
+    @Test
+    void testIncrementRecordsSendMetric() throws Exception {
+        final String collection = "test-inc-records-send";
+        final boolean flushOnCheckpoint = false;
+        final int bulkFlushMaxActions = 2;
+        final int bulkFlushInterval = -1;
+
+        try (final MongoWriter<Document> writer =
+                createWriter(
+                        collection, bulkFlushMaxActions, bulkFlushInterval, flushOnCheckpoint)) {
+            final Optional<Counter> recordsSend =
+                    metricListener.getCounter(MetricNames.NUM_RECORDS_SEND);
+            writer.write(buildMessage(1), null);
+            // Update existing index
+            writer.write(buildMessage(2, "u"), null);
+            // Delete index
+            writer.write(buildMessage(3, "d"), null);
+
+            writer.doBulkWrite();
+
+            assertThat(recordsSend.isPresent(), is(true));
+            assertThat(recordsSend.get().getCount(), is(3L));
+        }
+    }
+
+    @Test
+    void testCurrentSendTime() throws Exception {
+        final String collection = "test-current-send-time";
+        boolean flushOnCheckpoint = false;
+        final int bulkFlushMaxActions = 2;
+        final int bulkFlushInterval = -1;
+
+        try (final MongoWriter<Document> writer =
+                createWriter(
+                        collection, bulkFlushMaxActions, bulkFlushInterval, flushOnCheckpoint)) {
+            final Optional<Gauge<Long>> currentSendTime =
+                    metricListener.getGauge("currentSendTime");
+
+            writer.write(buildMessage(1), null);
+            writer.write(buildMessage(2), null);
+
+            writer.doBulkWrite();
+
+            assertThat(currentSendTime.isPresent(), is(true));
+            assertThat(currentSendTime.get().getValue(), greaterThan(0L));
+        }
+    }
+
+    @Test
+    void testSinkContext() throws Exception {
+        final String collection = "test-sink-context";
+        boolean flushOnCheckpoint = false;
+        final int bulkFlushMaxActions = 2;
+        final int bulkFlushInterval = -1;
+        final int sinkParallelism = 1;
+
+        MongoWriteOptions expectOptions =
+                MongoWriteOptions.builder()
+                        .setBulkFlushMaxActions(bulkFlushMaxActions)
+                        .setBulkFlushIntervalMs(bulkFlushInterval)
+                        .setMaxRetryTimes(0)
+                        .setParallelism(sinkParallelism)
+                        .build();
+
+        Sink.InitContext initContext = new MockInitContext(metricListener);
+
+        MongoSerializationSchema<Document> testSerializationSchema =
+                (element, context) -> {
+                    assertThat(context.getParallelInstanceId(), equalTo(0));
+                    assertThat(context.getNumberOfParallelInstances(), equalTo(1));
+                    assertThat(context.getWriteOptions(), equalTo(expectOptions));
+                    assertThat(
+                            context.processTime(),
+                            equalTo(
+                                    initContext
+                                            .getProcessingTimeService()
+                                            .getCurrentProcessingTime()));
+                    return new InsertOneModel<>(element.toBsonDocument());
+                };
+
+        try (MongoWriter<Document> writer =
+                createWriter(
+                        collection,
+                        bulkFlushMaxActions,
+                        bulkFlushInterval,
+                        flushOnCheckpoint,
+                        sinkParallelism,
+                        initContext,
+                        testSerializationSchema)) {
+            writer.write(buildMessage(1), null);
+            writer.write(buildMessage(2), null);
+
+            writer.doBulkWrite();
+        }
+    }
+
+    private MongoCollection<Document> collectionOf(String collection) {
+        return mongoClient.getDatabase(TEST_DATABASE).getCollection(collection);
+    }
+
+    private MongoWriter<Document> createWriter(
+            String collection,
+            int bulkFlushMaxActions,
+            long bulkFlushInterval,
+            boolean flushOnCheckpoint) {
+        return createWriter(
+                collection,
+                bulkFlushMaxActions,
+                bulkFlushInterval,
+                flushOnCheckpoint,
+                DEFAULT_SINK_PARALLELISM,
+                new MockInitContext(metricListener),
+                new UpsertSerializationSchema());
+    }
+
+    private MongoWriter<Document> createWriter(
+            String collection,
+            int bulkFlushMaxActions,
+            long bulkFlushInterval,
+            boolean flushOnCheckpoint,
+            @Nullable Integer parallelism,
+            Sink.InitContext initContext,
+            MongoSerializationSchema<Document> serializationSchema) {
+
+        MongoConnectionOptions connectionOptions =
+                MongoConnectionOptions.builder()
+                        .setUri(MONGO_CONTAINER.getConnectionString())
+                        .setDatabase(TEST_DATABASE)
+                        .setCollection(collection)
+                        .build();
+
+        MongoWriteOptions writeOptions =
+                MongoWriteOptions.builder()
+                        .setBulkFlushMaxActions(bulkFlushMaxActions)
+                        .setBulkFlushIntervalMs(bulkFlushInterval)
+                        .setMaxRetryTimes(0)
+                        .setParallelism(parallelism)
+                        .build();
+
+        return new MongoWriter<>(
+                connectionOptions,
+                writeOptions,
+                flushOnCheckpoint,
+                initContext,
+                serializationSchema);
+    }
+
+    private Document buildMessage(int id) {
+        return buildMessage(id, "i");
+    }
+
+    private Document buildMessage(int id, String op) {
+        return new Document("_id", id).append("op", op);
+    }
+
+    private static class UpsertSerializationSchema implements MongoSerializationSchema<Document> {
+
+        @Override
+        public WriteModel<BsonDocument> serialize(Document element, MongoSinkContext sinkContext) {
+            String operation = element.getString("op");
+            switch (operation) {
+                case "i":
+                    return new InsertOneModel<>(element.toBsonDocument());
+                case "u":
+                    {
+                        BsonDocument document = element.toBsonDocument();
+                        BsonDocument filter = new BsonDocument("_id", document.getInt32("_id"));
+                        // _id is immutable so we remove it here to prevent exception.
+                        document.remove("_id");
+                        BsonDocument update = new BsonDocument("$set", document);
+                        return new UpdateOneModel<>(
+                                filter, update, new UpdateOptions().upsert(true));
+                    }
+                case "d":
+                    {
+                        BsonDocument document = element.toBsonDocument();
+                        BsonDocument filter = new BsonDocument("_id", document.getInt32("_id"));
+                        return new DeleteOneModel<>(filter);
+                    }
+                default:
+                    throw new UnsupportedOperationException("op is not supported " + operation);
+            }
+        }
+    }
+
+    private static class MockInitContext implements Sink.InitContext {
+
+        private final OperatorIOMetricGroup ioMetricGroup;
+        private final SinkWriterMetricGroup metricGroup;
+        private final ProcessingTimeService timeService;
+
+        private MockInitContext(MetricListener metricListener) {
+            this.ioMetricGroup =
+                    UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup()
+                            .getIOMetricGroup();
+            MetricGroup metricGroup = metricListener.getMetricGroup();
+            this.metricGroup = InternalSinkWriterMetricGroup.mock(metricGroup, ioMetricGroup);
+            this.timeService = new TestProcessingTimeService();
+        }
+
+        @Override
+        public UserCodeClassLoader getUserCodeClassLoader() {
+            throw new UnsupportedOperationException("Not implemented.");
+        }
+
+        @Override
+        public MailboxExecutor getMailboxExecutor() {
+            return new SyncMailboxExecutor();
+        }
+
+        @Override
+        public ProcessingTimeService getProcessingTimeService() {
+            return timeService;
+        }
+
+        @Override
+        public int getSubtaskId() {
+            return 0;
+        }
+
+        @Override
+        public int getNumberOfParallelSubtasks() {
+            return 1;
+        }
+
+        @Override
+        public SinkWriterMetricGroup metricGroup() {
+            return metricGroup;
+        }
+
+        @Override
+        public OptionalLong getRestoredCheckpointId() {
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public SerializationSchema.InitializationContext
+                asSerializationSchemaInitializationContext() {
+            return new SerializationSchema.InitializationContext() {
+                @Override
+                public MetricGroup getMetricGroup() {
+                    return metricGroup;
+                }
+
+                @Override
+                public UserCodeClassLoader getUserCodeClassLoader() {
+                    return null;
+                }
+            };
+        }
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/MongoSourceITCase.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/MongoSourceITCase.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.mongodb.MongoTestUtil;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
+import org.apache.flink.connector.mongodb.source.reader.deserializer.MongoJsonDeserializationSchema;
+import org.apache.flink.connector.mongodb.table.serialization.MongoRowDataDeserializationSchema;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLoggerExtension;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.Document;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT cases for using Mongo Sink. */
+@Testcontainers
+@ExtendWith(TestLoggerExtension.class)
+public class MongoSourceITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoSourceITCase.class);
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER =
+            MongoTestUtil.createMongoDBContainer(DockerImageVersions.MONGO_4_0, LOG);
+
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(2)
+                            .setConfiguration(new Configuration())
+                            .build());
+
+    private static MongoClient mongoClient;
+
+    private static final String TEST_DATABASE = "test_source";
+
+    public static final String TEST_COLLECTION = "mongo_source";
+
+    @BeforeAll
+    static void beforeAll() {
+        mongoClient = MongoClients.create(MONGO_CONTAINER.getConnectionString());
+
+        MongoCollection<BsonDocument> coll =
+                mongoClient
+                        .getDatabase(TEST_DATABASE)
+                        .getCollection(TEST_COLLECTION)
+                        .withDocumentClass(BsonDocument.class);
+
+        List<BsonDocument> testRecords = new ArrayList<>();
+        for (int i = 1; i <= 30000; i++) {
+            testRecords.add(createTestData(i));
+            if (testRecords.size() >= 10000) {
+                coll.insertMany(testRecords);
+                testRecords.clear();
+            }
+        }
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(PartitionStrategy.class)
+    public void testPartitionStrategy(PartitionStrategy partitionStrategy) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(2);
+
+        MongoSource<RowData> mongoSource =
+                defaultSourceBuilder()
+                        .setPartitionSize(MemorySize.parse("1mb"))
+                        .setSamplesPerPartition(3)
+                        .setPartitionStrategy(partitionStrategy)
+                        .build();
+
+        List<RowData> results =
+                CollectionUtil.iteratorToList(
+                        env.fromSource(
+                                        mongoSource,
+                                        WatermarkStrategy.noWatermarks(),
+                                        "MongoDB-Source")
+                                .executeAndCollect());
+
+        assertThat(results).hasSize(30000);
+    }
+
+    @Test
+    public void testLimit() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(2);
+
+        MongoSource<RowData> mongoSource = defaultSourceBuilder().setLimit(100).build();
+
+        List<RowData> results =
+                CollectionUtil.iteratorToList(
+                        env.fromSource(
+                                        mongoSource,
+                                        WatermarkStrategy.noWatermarks(),
+                                        "MongoDB-Source")
+                                .executeAndCollect());
+
+        assertThat(results).hasSize(100);
+    }
+
+    @Test
+    public void testProject() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(2);
+
+        MongoSource<String> mongoSource =
+                MongoSource.<String>builder()
+                        .setUri(MONGO_CONTAINER.getConnectionString())
+                        .setDatabase(TEST_DATABASE)
+                        .setCollection(TEST_COLLECTION)
+                        .setProjectedFields("f0")
+                        .setDeserializationSchema(new MongoJsonDeserializationSchema())
+                        .build();
+
+        List<String> results =
+                CollectionUtil.iteratorToList(
+                        env.fromSource(
+                                        mongoSource,
+                                        WatermarkStrategy.noWatermarks(),
+                                        "MongoDB-Source")
+                                .executeAndCollect());
+
+        assertThat(results).hasSize(30000);
+        assertThat(Document.parse(results.get(0))).containsOnlyKeys("f0");
+    }
+
+    private MongoSourceBuilder<RowData> defaultSourceBuilder() {
+        ResolvedSchema schema = defaultSourceSchema();
+        RowType rowType = (RowType) schema.toPhysicalRowDataType().getLogicalType();
+        TypeInformation<RowData> typeInfo = InternalTypeInfo.of(rowType);
+
+        return MongoSource.<RowData>builder()
+                .setUri(MONGO_CONTAINER.getConnectionString())
+                .setDatabase(TEST_DATABASE)
+                .setCollection(TEST_COLLECTION)
+                .setDeserializationSchema(new MongoRowDataDeserializationSchema(rowType, typeInfo));
+    }
+
+    private ResolvedSchema defaultSourceSchema() {
+        return ResolvedSchema.of(
+                Column.physical("f0", DataTypes.INT()), Column.physical("f1", DataTypes.STRING()));
+    }
+
+    private static BsonDocument createTestData(int id) {
+        return new BsonDocument("f0", new BsonInt32(id))
+                .append("f1", new BsonString(RandomStringUtils.randomAlphabetic(32)));
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/enumerator/MongoSourceEnumStateSerializerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.enumerator;
+
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonMaxKey;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
+import static org.apache.flink.connector.mongodb.source.enumerator.MongoSourceEnumStateSerializer.INSTANCE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+/** Unit tests for {@link MongoSourceEnumStateSerializer}. */
+@ExtendWith(TestLoggerExtension.class)
+public class MongoSourceEnumStateSerializerTest {
+
+    @Test
+    void serializeAndDeserializeMongoSourceEnumState() throws Exception {
+        boolean initialized = false;
+        List<String> remainingCollections = Arrays.asList("db.remains0", "db.remains1");
+        List<String> alreadyProcessedCollections = Arrays.asList("db.processed0", "db.processed1");
+        List<MongoScanSourceSplit> remainingScanSplits = new ArrayList<>();
+        remainingScanSplits.add(createSourceSplit(0));
+        remainingScanSplits.add(createSourceSplit(1));
+        Map<String, MongoScanSourceSplit> assignedScanSplits = new HashMap<>();
+        assignedScanSplits.put("split2", createSourceSplit(2));
+
+        MongoSourceEnumState state =
+                new MongoSourceEnumState(
+                        remainingCollections,
+                        alreadyProcessedCollections,
+                        remainingScanSplits,
+                        assignedScanSplits,
+                        initialized);
+
+        byte[] bytes = INSTANCE.serialize(state);
+        MongoSourceEnumState state1 = INSTANCE.deserialize(INSTANCE.getVersion(), bytes);
+
+        assertEquals(state.getRemainingCollections(), state1.getRemainingCollections());
+        assertEquals(
+                state.getAlreadyProcessedCollections(), state1.getAlreadyProcessedCollections());
+        assertEquals(state.getRemainingScanSplits(), state1.getRemainingScanSplits());
+        assertEquals(state.getAssignedScanSplits(), state1.getAssignedScanSplits());
+        assertEquals(state.isInitialized(), state1.isInitialized());
+
+        assertNotSame(state, state1);
+    }
+
+    private MongoScanSourceSplit createSourceSplit(int index) {
+        return new MongoScanSourceSplit(
+                "split" + index,
+                "db",
+                "coll",
+                new BsonDocument("_id", new BsonInt32(index)),
+                new BsonDocument("_id", new BsonMaxKey()),
+                ID_HINT);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/splitter/MongoShardedSplitterTest.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/source/splitter/MongoShardedSplitterTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.source.splitter;
+
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.MongoShardedSplitter;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.MongoSplitContext;
+import org.apache.flink.connector.mongodb.source.split.MongoScanSourceSplit;
+
+import com.mongodb.MongoNamespace;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.conversions.Bson;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Filters.or;
+import static com.mongodb.client.model.Projections.include;
+import static com.mongodb.client.model.Sorts.ascending;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.AVG_OBJ_SIZE_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.COUNT_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.DROPPED_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.ID_HINT;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.KEY_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.MAX_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.MIN_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.NAMESPACE_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.SHARD_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.SIZE_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoConstants.UUID_FIELD;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.CHUNKS_COLLECTION;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.COLLECTIONS_COLLECTION;
+import static org.apache.flink.connector.mongodb.common.utils.MongoUtils.CONFIG_DATABASE;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.when;
+
+/** Unit tests for {@link MongoShardedSplitter}. */
+@ExtendWith(MockitoExtension.class)
+public class MongoShardedSplitterTest {
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private MongoClient mongoClient;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private MongoCollection<BsonDocument> collectionsColl;
+
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+    private MongoCollection<BsonDocument> chunksColl;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testShardedSplitter() {
+        MongoNamespace namespace = new MongoNamespace("test_db.test_coll");
+
+        when(mongoClient
+                        .getDatabase(CONFIG_DATABASE)
+                        .getCollection(COLLECTIONS_COLLECTION)
+                        .withDocumentClass(BsonDocument.class))
+                .thenReturn(collectionsColl);
+
+        when(mongoClient
+                        .getDatabase(CONFIG_DATABASE)
+                        .getCollection(CHUNKS_COLLECTION)
+                        .withDocumentClass(BsonDocument.class))
+                .thenReturn(chunksColl);
+
+        BsonDocument mockCollectionMetadata = mockCollectionMetadata();
+        when(collectionsColl
+                        .find(eq(ID_FIELD, namespace.getFullName()))
+                        .projection(include(ID_FIELD, UUID_FIELD, DROPPED_FIELD, KEY_FIELD))
+                        .first())
+                .thenReturn(mockCollectionMetadata);
+
+        Bson chunksFilter =
+                or(
+                        new BsonDocument(NAMESPACE_FIELD, mockCollectionMetadata.get(ID_FIELD)),
+                        new BsonDocument(UUID_FIELD, mockCollectionMetadata.get(UUID_FIELD)));
+
+        ArrayList<BsonDocument> mockChunksData = mockChunksData();
+        when(chunksColl
+                        .find(chunksFilter)
+                        .projection(include(MIN_FIELD, MAX_FIELD, SHARD_FIELD))
+                        .sort(ascending(MIN_FIELD))
+                        .into(new ArrayList<>()))
+                .thenReturn(mockChunksData);
+
+        MongoSplitContext splitContext =
+                MongoSplitContext.of(
+                        MongoReadOptions.builder().build(),
+                        mongoClient,
+                        namespace,
+                        mockCollStats());
+
+        List<MongoScanSourceSplit> expected = new ArrayList<>();
+        for (int i = 0; i < mockChunksData.size(); i++) {
+            BsonDocument mockChunkData = mockChunksData.get(i);
+            expected.add(
+                    new MongoScanSourceSplit(
+                            String.format("%s_%d", namespace, i),
+                            namespace.getDatabaseName(),
+                            namespace.getCollectionName(),
+                            mockChunkData.getDocument(MIN_FIELD),
+                            mockChunkData.getDocument(MAX_FIELD),
+                            mockCollectionMetadata.getDocument(KEY_FIELD)));
+        }
+
+        Collection<MongoScanSourceSplit> actual = MongoShardedSplitter.INSTANCE.split(splitContext);
+        assertThat(actual, equalTo(expected));
+    }
+
+    private BsonDocument mockCollectionMetadata() {
+        return new BsonDocument()
+                .append(ID_FIELD, new BsonObjectId())
+                .append(UUID_FIELD, new BsonBinary(UUID.randomUUID()))
+                .append(DROPPED_FIELD, BsonBoolean.FALSE)
+                .append(KEY_FIELD, ID_HINT);
+    }
+
+    private ArrayList<BsonDocument> mockChunksData() {
+        ArrayList<BsonDocument> chunks = new ArrayList<>();
+        chunks.add(mockChunkData(1));
+        chunks.add(mockChunkData(2));
+        chunks.add(mockChunkData(3));
+        return chunks;
+    }
+
+    private BsonDocument mockChunkData(int index) {
+        return new BsonDocument()
+                .append(MIN_FIELD, new BsonDocument(ID_FIELD, new BsonInt32(index * 100)))
+                .append(MAX_FIELD, new BsonDocument(ID_FIELD, new BsonInt32((index + 1) * 100)))
+                .append(SHARD_FIELD, new BsonString("shard-" + index));
+    }
+
+    private BsonDocument mockCollStats() {
+        return new BsonDocument()
+                .append(SHARD_FIELD, BsonBoolean.TRUE)
+                .append(COUNT_FIELD, new BsonInt64(10000L))
+                .append(SIZE_FIELD, new BsonInt64(10000L))
+                .append(AVG_OBJ_SIZE_FIELD, new BsonInt64(1L));
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableFactoryTest.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.base.DeliveryGuarantee;
+import org.apache.flink.connector.mongodb.common.config.MongoConnectionOptions;
+import org.apache.flink.connector.mongodb.sink.config.MongoWriteOptions;
+import org.apache.flink.connector.mongodb.source.config.MongoReadOptions;
+import org.apache.flink.connector.mongodb.source.enumerator.splitter.PartitionStrategy;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.lookup.LookupOptions;
+import org.apache.flink.table.connector.source.lookup.cache.DefaultLookupCache;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Test for {@link MongoDynamicTableSource} and {@link MongoDynamicTableSink} created by {@link
+ * MongoDynamicTableFactory}.
+ */
+public class MongoDynamicTableFactoryTest {
+
+    private static final ResolvedSchema SCHEMA =
+            new ResolvedSchema(
+                    Arrays.asList(
+                            Column.physical("aaa", DataTypes.INT().notNull()),
+                            Column.physical("bbb", DataTypes.STRING().notNull()),
+                            Column.physical("ccc", DataTypes.DOUBLE()),
+                            Column.physical("ddd", DataTypes.DECIMAL(31, 18)),
+                            Column.physical("eee", DataTypes.TIMESTAMP(3))),
+                    Collections.emptyList(),
+                    UniqueConstraint.primaryKey("name", Arrays.asList("bbb", "aaa")));
+
+    @Test
+    public void testMongoCommonProperties() {
+        Map<String, String> properties = getRequiredOptions();
+
+        // validation for source
+        DynamicTableSource actualSource = createTableSource(SCHEMA, properties);
+
+        MongoConnectionOptions connectionOptions =
+                MongoConnectionOptions.builder()
+                        .setUri("mongodb://127.0.0.1:27017")
+                        .setDatabase("test_db")
+                        .setCollection("test_coll")
+                        .build();
+
+        MongoDynamicTableSource expectedSource =
+                new MongoDynamicTableSource(
+                        connectionOptions,
+                        MongoReadOptions.builder().build(),
+                        null,
+                        LookupOptions.MAX_RETRIES.defaultValue(),
+                        SCHEMA.toPhysicalRowDataType());
+        assertThat(actualSource).isEqualTo(expectedSource);
+
+        // validation for sink
+        DynamicTableSink actualSink = createTableSink(SCHEMA, properties);
+
+        MongoWriteOptions writeOptions = MongoWriteOptions.builder().build();
+        MongoDynamicTableSink expectedSink =
+                new MongoDynamicTableSink(
+                        connectionOptions,
+                        writeOptions,
+                        SCHEMA.toPhysicalRowDataType(),
+                        MongoKeyExtractor.createKeyExtractor(SCHEMA));
+        assertThat(actualSink).isEqualTo(expectedSink);
+    }
+
+    @Test
+    public void testMongoReadProperties() {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put("scan.fetch-size", "1024");
+        properties.put("scan.cursor.batch-size", "2048");
+        properties.put("scan.cursor.no-timeout", "false");
+        properties.put("scan.partition.strategy", "split-vector");
+        properties.put("scan.partition.size", "128m");
+        properties.put("scan.partition.samples", "5");
+
+        DynamicTableSource actual = createTableSource(SCHEMA, properties);
+
+        MongoConnectionOptions connectionOptions =
+                MongoConnectionOptions.builder()
+                        .setUri("mongodb://127.0.0.1:27017")
+                        .setDatabase("test_db")
+                        .setCollection("test_coll")
+                        .build();
+        MongoReadOptions readOptions =
+                MongoReadOptions.builder()
+                        .setFetchSize(1024)
+                        .setCursorBatchSize(2048)
+                        .setNoCursorTimeout(false)
+                        .setPartitionStrategy(PartitionStrategy.SPLIT_VECTOR)
+                        .setPartitionSize(MemorySize.ofMebiBytes(128))
+                        .setSamplesPerPartition(5)
+                        .build();
+
+        MongoDynamicTableSource expected =
+                new MongoDynamicTableSource(
+                        connectionOptions,
+                        readOptions,
+                        null,
+                        LookupOptions.MAX_RETRIES.defaultValue(),
+                        SCHEMA.toPhysicalRowDataType());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testMongoLookupProperties() {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put("lookup.cache", "PARTIAL");
+        properties.put("lookup.partial-cache.expire-after-write", "10s");
+        properties.put("lookup.partial-cache.expire-after-access", "20s");
+        properties.put("lookup.partial-cache.cache-missing-key", "false");
+        properties.put("lookup.partial-cache.max-rows", "15213");
+        properties.put("lookup.max-retries", "10");
+
+        DynamicTableSource actual = createTableSource(SCHEMA, properties);
+
+        MongoConnectionOptions connectionOptions =
+                MongoConnectionOptions.builder()
+                        .setUri("mongodb://127.0.0.1:27017")
+                        .setDatabase("test_db")
+                        .setCollection("test_coll")
+                        .build();
+
+        MongoDynamicTableSource expected =
+                new MongoDynamicTableSource(
+                        connectionOptions,
+                        MongoReadOptions.builder().build(),
+                        DefaultLookupCache.fromConfig(Configuration.fromMap(properties)),
+                        10,
+                        SCHEMA.toPhysicalRowDataType());
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testMongoSinkProperties() {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put("sink.bulk-flush.max-actions", "1001");
+        properties.put("sink.bulk-flush.interval", "2min");
+        properties.put("sink.delivery-guarantee", "at-least-once");
+        properties.put("sink.max-retries", "5");
+
+        DynamicTableSink actual = createTableSink(SCHEMA, properties);
+
+        MongoConnectionOptions connectionOptions =
+                MongoConnectionOptions.builder()
+                        .setUri("mongodb://127.0.0.1:27017")
+                        .setDatabase("test_db")
+                        .setCollection("test_coll")
+                        .build();
+        MongoWriteOptions writeOptions =
+                MongoWriteOptions.builder()
+                        .setBulkFlushMaxActions(1001)
+                        .setBulkFlushIntervalMs(TimeUnit.MINUTES.toMillis(2))
+                        .setDeliveryGuarantee(DeliveryGuarantee.AT_LEAST_ONCE)
+                        .setMaxRetryTimes(5)
+                        .build();
+
+        MongoDynamicTableSink expected =
+                new MongoDynamicTableSink(
+                        connectionOptions,
+                        writeOptions,
+                        SCHEMA.toPhysicalRowDataType(),
+                        MongoKeyExtractor.createKeyExtractor(SCHEMA));
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testMongoSinkWithParallelism() {
+        Map<String, String> properties = getRequiredOptions();
+        properties.put("sink.parallelism", "2");
+
+        DynamicTableSink actual = createTableSink(SCHEMA, properties);
+
+        MongoConnectionOptions connectionOptions =
+                MongoConnectionOptions.builder()
+                        .setUri("mongodb://127.0.0.1:27017")
+                        .setDatabase("test_db")
+                        .setCollection("test_coll")
+                        .build();
+
+        MongoWriteOptions writeOptions = MongoWriteOptions.builder().setParallelism(2).build();
+
+        MongoDynamicTableSink expected =
+                new MongoDynamicTableSink(
+                        connectionOptions,
+                        writeOptions,
+                        SCHEMA.toPhysicalRowDataType(),
+                        MongoKeyExtractor.createKeyExtractor(SCHEMA));
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void testMongoValidation() {
+        // fetch size lower than 1
+        Map<String, String> properties = getRequiredOptions();
+        properties.put("scan.fetch-size", "0");
+
+        Map<String, String> finalProperties1 = properties;
+        assertThatThrownBy(() -> createTableSource(SCHEMA, finalProperties1))
+                .hasStackTraceContaining("The fetch size must be larger than 0.");
+
+        // cursor batch size lower than 0
+        properties = getRequiredOptions();
+        properties.put("scan.cursor.batch-size", "-1");
+
+        Map<String, String> finalProperties2 = properties;
+        assertThatThrownBy(() -> createTableSource(SCHEMA, finalProperties2))
+                .hasStackTraceContaining("The cursor batch size must be larger than or equal to 0");
+
+        // partition memory size lower than 1mb
+        properties = getRequiredOptions();
+        properties.put("scan.partition.size", "900kb");
+
+        Map<String, String> finalProperties3 = properties;
+        assertThatThrownBy(() -> createTableSource(SCHEMA, finalProperties3))
+                .hasStackTraceContaining(
+                        "The partition size must be larger than or equals to 1mb.");
+
+        // samples per partition lower than 1
+        properties = getRequiredOptions();
+        properties.put("scan.partition.samples", "0");
+
+        Map<String, String> finalProperties4 = properties;
+        assertThatThrownBy(() -> createTableSource(SCHEMA, finalProperties4))
+                .hasStackTraceContaining("The samples per partition must be larger than 0.");
+
+        // sink retries shouldn't be negative
+        properties = getRequiredOptions();
+        properties.put("sink.max-retries", "-1");
+        Map<String, String> finalProperties5 = properties;
+        assertThatThrownBy(() -> createTableSink(SCHEMA, finalProperties5))
+                .hasStackTraceContaining("The max retry times must be larger than or equal to 0.");
+
+        // sink buffered actions shouldn't be smaller than 1
+        properties = getRequiredOptions();
+        properties.put("sink.bulk-flush.max-actions", "0");
+        Map<String, String> finalProperties6 = properties;
+        assertThatThrownBy(() -> createTableSink(SCHEMA, finalProperties6))
+                .hasStackTraceContaining("Max number of buffered actions must be larger than 0.");
+    }
+
+    private Map<String, String> getRequiredOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "mongodb");
+        options.put("uri", "mongodb://127.0.0.1:27017");
+        options.put("database", "test_db");
+        options.put("collection", "test_coll");
+        return options;
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSinkITCase.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSinkITCase.java
@@ -1,0 +1,450 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.mongodb.MongoTestUtil;
+import org.apache.flink.connector.mongodb.table.config.MongoConnectorOptions;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.types.Row;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLoggerExtension;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import org.bson.Document;
+import org.bson.types.Binary;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.apache.flink.table.api.Expressions.row;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+
+/** IT tests for {@link MongoDynamicTableSink}. */
+@Testcontainers
+@ExtendWith(TestLoggerExtension.class)
+public class MongoDynamicTableSinkITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDynamicTableSinkITCase.class);
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER =
+            MongoTestUtil.createMongoDBContainer(DockerImageVersions.MONGO_4_0, LOG);
+
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setConfiguration(new Configuration())
+                            .build());
+
+    private MongoClient mongoClient;
+
+    @BeforeEach
+    public void setUp() {
+        mongoClient = MongoClients.create(MONGO_CONTAINER.getConnectionString());
+    }
+
+    @AfterEach
+    public void tearDown() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @Test
+    public void testSinkWithAllSupportedTypes() throws ExecutionException, InterruptedException {
+        String database = "test";
+        String collection = "sink_with_all_supported_types";
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        tEnv.executeSql(
+                String.join(
+                        "\n",
+                        Arrays.asList(
+                                "CREATE TABLE mongo_sink",
+                                "(",
+                                "  _id BIGINT,",
+                                "  f1 STRING,",
+                                "  f2 BOOLEAN,",
+                                "  f3 BINARY,",
+                                "  f4 TINYINT,",
+                                "  f5 SMALLINT,",
+                                "  f6 INTEGER,",
+                                "  f7 TIMESTAMP_LTZ(6),",
+                                "  f8 TIMESTAMP(3),",
+                                "  f9 FLOAT,",
+                                "  f10 DOUBLE,",
+                                "  f11 DECIMAL(10, 2),",
+                                "  f12 MAP<STRING, INTEGER>,",
+                                "  f13 ROW<k INTEGER>,",
+                                "  f14 ARRAY<STRING>,",
+                                "  f15 ARRAY<ROW<k STRING>>,",
+                                "  PRIMARY KEY (_id) NOT ENFORCED",
+                                ") WITH (",
+                                getConnectorSql(database, collection),
+                                ")")));
+
+        Instant now = Instant.now();
+        tEnv.fromValues(
+                        DataTypes.ROW(
+                                DataTypes.FIELD("_id", DataTypes.BIGINT()),
+                                DataTypes.FIELD("f1", DataTypes.STRING()),
+                                DataTypes.FIELD("f2", DataTypes.BOOLEAN()),
+                                DataTypes.FIELD("f3", DataTypes.BINARY(1)),
+                                DataTypes.FIELD("f4", DataTypes.TINYINT()),
+                                DataTypes.FIELD("f5", DataTypes.SMALLINT()),
+                                DataTypes.FIELD("f6", DataTypes.INT()),
+                                DataTypes.FIELD("f7", DataTypes.TIMESTAMP_LTZ(6)),
+                                DataTypes.FIELD("f8", DataTypes.TIMESTAMP(3)),
+                                DataTypes.FIELD("f9", DataTypes.FLOAT()),
+                                DataTypes.FIELD("f10", DataTypes.DOUBLE()),
+                                DataTypes.FIELD("f11", DataTypes.DECIMAL(10, 2)),
+                                DataTypes.FIELD(
+                                        "f12", DataTypes.MAP(DataTypes.STRING(), DataTypes.INT())),
+                                DataTypes.FIELD(
+                                        "f13",
+                                        DataTypes.ROW(DataTypes.FIELD("k", DataTypes.INT()))),
+                                DataTypes.FIELD("f14", DataTypes.ARRAY(DataTypes.STRING())),
+                                DataTypes.FIELD(
+                                        "f15",
+                                        DataTypes.ARRAY(
+                                                DataTypes.ROW(
+                                                        DataTypes.FIELD(
+                                                                "K", DataTypes.STRING()))))),
+                        Row.of(
+                                1L,
+                                "ABCDE",
+                                true,
+                                new byte[] {(byte) 3},
+                                (byte) 4,
+                                (short) 5,
+                                6,
+                                now,
+                                Timestamp.from(now),
+                                9.9f,
+                                10.10d,
+                                new BigDecimal("11.11"),
+                                Collections.singletonMap("k", 12),
+                                Row.of(13),
+                                Arrays.asList("14_1", "14_2"),
+                                Arrays.asList(Row.of("15_1"), Row.of("15_2"))))
+                .executeInsert("mongo_sink")
+                .await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        Document actual = coll.find(Filters.eq("_id", 1L)).first();
+
+        Document expected =
+                new Document("_id", 1L)
+                        .append("f1", "ABCDE")
+                        .append("f2", true)
+                        .append("f3", new Binary(new byte[] {(byte) 3}))
+                        .append("f4", 4)
+                        .append("f5", 5)
+                        .append("f6", 6)
+                        .append("f7", Date.from(now))
+                        .append("f8", Date.from(now))
+                        .append("f9", (double) 9.9f)
+                        .append("f10", 10.10d)
+                        .append("f11", new Decimal128(new BigDecimal("11.11")))
+                        .append("f12", new Document("k", 12))
+                        .append("f13", new Document("k", 13))
+                        .append("f14", Arrays.asList("14_1", "14_2"))
+                        .append(
+                                "f15",
+                                Arrays.asList(
+                                        new Document("k", "15_1"), new Document("k", "15_2")));
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void testSinkWithAllRowKind() throws ExecutionException, InterruptedException {
+        String database = "test";
+        String collection = "test_sink_with_all_row_kind";
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.ofKind(RowKind.INSERT, 1L, "Alice"),
+                                Row.ofKind(RowKind.DELETE, 1L, "Alice"),
+                                Row.ofKind(RowKind.INSERT, 2L, "Bob"),
+                                Row.ofKind(RowKind.UPDATE_BEFORE, 2L, "Bob"),
+                                Row.ofKind(RowKind.UPDATE_AFTER, 2L, "Tom")));
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE value_source (\n"
+                                + "`_id` BIGINT,\n"
+                                + "`name` STRING\n"
+                                + ") WITH (\n"
+                                + "'connector' = 'values', \n"
+                                + "'data-id' = '%s')",
+                        dataId));
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE mongo_sink (\n"
+                                + "`_id` BIGINT,\n"
+                                + "`name` STRING,\n"
+                                + " PRIMARY KEY (_id) NOT ENFORCED\n"
+                                + ") WITH ( %s )",
+                        getConnectorSql(database, collection)));
+
+        tEnv.executeSql("insert into mongo_sink select * from value_source").await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        List<Document> expected =
+                Collections.singletonList(new Document("_id", 2L).append("name", "Tom"));
+
+        List<Document> actual = coll.find().into(new ArrayList<>());
+
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void testSinkWithReversedId() throws Exception {
+        String database = "test";
+        String collection = "sink_with_reversed_id";
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE mongo_sink ("
+                                + "_id STRING NOT NULL,\n"
+                                + "f1 STRING NOT NULL,\n"
+                                + "PRIMARY KEY (_id) NOT ENFORCED\n"
+                                + ")\n"
+                                + "WITH (%s)",
+                        getConnectorSql(database, collection)));
+
+        ObjectId objectId = new ObjectId();
+        tEnv.fromValues(row(objectId.toHexString(), "r1"), row("str", "r2"))
+                .executeInsert("mongo_sink")
+                .await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        List<Document> actual = new ArrayList<>();
+        coll.find(Filters.in("_id", objectId, "str")).into(actual);
+
+        Document[] expected =
+                new Document[] {
+                    new Document("_id", objectId).append("f1", "r1"),
+                    new Document("_id", "str").append("f1", "r2")
+                };
+        assertThat(actual, containsInAnyOrder(expected));
+    }
+
+    @Test
+    public void testSinkWithoutPrimaryKey() throws Exception {
+        String database = "test";
+        String collection = "sink_without_primary_key";
+
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE mongo_sink (" + "f1 STRING NOT NULL\n" + ")\n" + "WITH (%s)",
+                        getConnectorSql(database, collection)));
+
+        tEnv.fromValues(row("d1"), row("d1")).executeInsert("mongo_sink").await();
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        List<Document> actual = new ArrayList<>();
+        coll.find().into(actual);
+
+        assertThat(actual, hasSize(2));
+        for (Document doc : actual) {
+            assertThat(doc.get("f1"), equalTo("d1"));
+        }
+    }
+
+    @Test
+    public void testSinkWithNonCompositePrimaryKey() throws Exception {
+        String database = "test";
+        String collection = "sink_with_non_composite_pk";
+
+        Instant now = Instant.now();
+        List<Expression> testValues =
+                Collections.singletonList(
+                        row(
+                                1L,
+                                true,
+                                "ABCDE",
+                                12.12d,
+                                24.24f,
+                                (byte) 2,
+                                (short) 3,
+                                4,
+                                Timestamp.from(now),
+                                now));
+        List<String> primaryKeys = Collections.singletonList("a");
+
+        testSinkWithoutReversedId(database, collection, primaryKeys, testValues);
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        Document actual = coll.find(Filters.eq("_id", 1L)).first();
+        Document expected = new Document();
+        expected.put("_id", 1L);
+        expected.put("a", 1L);
+        expected.put("b", true);
+        expected.put("c", "ABCDE");
+        expected.put("d", 12.12d);
+        expected.put("e", (double) 24.24f);
+        expected.put("f", 2);
+        expected.put("g", 3);
+        expected.put("h", 4);
+        expected.put("i", Date.from(now));
+        expected.put("j", Date.from(now));
+        assertThat(actual, equalTo(expected));
+    }
+
+    @Test
+    public void testSinkWithCompositePrimaryKey() throws Exception {
+        String database = "test";
+        String collection = "sink_with_composite_pk";
+
+        Instant now = Instant.now();
+        List<Expression> testValues =
+                Collections.singletonList(
+                        row(
+                                1L,
+                                true,
+                                "ABCDE",
+                                12.12d,
+                                24.24f,
+                                (byte) 2,
+                                (short) 3,
+                                4,
+                                Timestamp.from(now),
+                                now));
+        List<String> primaryKeys = Arrays.asList("a", "c");
+
+        testSinkWithoutReversedId(database, collection, primaryKeys, testValues);
+
+        MongoCollection<Document> coll =
+                mongoClient.getDatabase(database).getCollection(collection);
+
+        Document compositeId = new Document();
+        compositeId.put("a", 1L);
+        compositeId.put("c", "ABCDE");
+        Document actual = coll.find(Filters.eq("_id", compositeId)).first();
+
+        Document expected = new Document();
+        expected.put("_id", new Document(compositeId));
+        expected.put("a", 1L);
+        expected.put("b", true);
+        expected.put("c", "ABCDE");
+        expected.put("d", 12.12d);
+        expected.put("e", (double) 24.24f);
+        expected.put("f", 2);
+        expected.put("g", 3);
+        expected.put("h", 4);
+        expected.put("i", Date.from(now));
+        expected.put("j", Date.from(now));
+        assertThat(actual, equalTo(expected));
+    }
+
+    private void testSinkWithoutReversedId(
+            String database, String collection, List<String> primaryKeys, List<Expression> values)
+            throws Exception {
+        TableEnvironment tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE mongo_sink ("
+                                + "a BIGINT NOT NULL,\n"
+                                + "b BOOLEAN,\n"
+                                + "c STRING NOT NULL,\n"
+                                + "d DOUBLE,\n"
+                                + "e FLOAT,\n"
+                                + "f TINYINT NOT NULL,\n"
+                                + "g SMALLINT NOT NULL,\n"
+                                + "h INT NOT NULL,\n"
+                                + "i TIMESTAMP NOT NULL,\n"
+                                + "j TIMESTAMP_LTZ NOT NULL,\n"
+                                + "PRIMARY KEY (%s) NOT ENFORCED\n"
+                                + ")\n"
+                                + "WITH (%s)",
+                        getPrimaryKeys(primaryKeys), getConnectorSql(database, collection)));
+
+        tEnv.fromValues(values).executeInsert("mongo_sink").await();
+    }
+
+    private String getPrimaryKeys(List<String> fieldNames) {
+        return String.join(",", fieldNames);
+    }
+
+    private String getConnectorSql(String database, String collection) {
+        return String.format("'%s'='%s',\n", "connector", "mongodb")
+                + String.format(
+                        "'%s'='%s',\n",
+                        MongoConnectorOptions.URI.key(), MONGO_CONTAINER.getConnectionString())
+                + String.format("'%s'='%s',\n", MongoConnectorOptions.DATABASE.key(), database)
+                + String.format("'%s'='%s'\n", MongoConnectorOptions.COLLECTION.key(), collection);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSourceITCase.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoDynamicTableSourceITCase.java
@@ -1,0 +1,372 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.mongodb.MongoTestUtil;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.table.planner.runtime.utils.StreamTestSink;
+import org.apache.flink.table.runtime.functions.table.lookup.LookupCacheManager;
+import org.apache.flink.table.test.lookup.cache.LookupCacheAssert;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLoggerExtension;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonString;
+import org.bson.BsonTimestamp;
+import org.bson.types.Decimal128;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/** ITCase for {@link MongoDynamicTableSource}. */
+@Testcontainers
+@ExtendWith(TestLoggerExtension.class)
+public class MongoDynamicTableSourceITCase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoDynamicTableSinkITCase.class);
+
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setConfiguration(new Configuration())
+                            .build());
+
+    @Container
+    private static final MongoDBContainer MONGO_CONTAINER =
+            MongoTestUtil.createMongoDBContainer(DockerImageVersions.MONGO_4_0, LOG);
+
+    public static final String DATABASE = "test";
+    public static final String COLLECTION = "mongo_table_source";
+
+    private static MongoClient mongoClient;
+
+    public static StreamExecutionEnvironment env;
+    public static TableEnvironment tEnv;
+
+    @BeforeAll
+    static void beforeAll() {
+        mongoClient = MongoClients.create(MONGO_CONTAINER.getConnectionString());
+
+        MongoCollection<BsonDocument> coll =
+                mongoClient
+                        .getDatabase(DATABASE)
+                        .getCollection(COLLECTION)
+                        .withDocumentClass(BsonDocument.class);
+
+        List<BsonDocument> testRecords = new ArrayList<>();
+        testRecords.add(createTestData(1));
+        testRecords.add(createTestData(2));
+        coll.insertMany(testRecords);
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+        StreamTestSink.clear();
+    }
+
+    @BeforeEach
+    void before() {
+        env = StreamExecutionEnvironment.getExecutionEnvironment();
+        tEnv = StreamTableEnvironment.create(env);
+    }
+
+    @Test
+    public void testSource() {
+        tEnv.executeSql(createTestDDl(null));
+
+        Iterator<Row> collected = tEnv.executeSql("SELECT * FROM mongo_source").collect();
+        List<String> result =
+                CollectionUtil.iteratorToList(collected).stream()
+                        .map(Row::toString)
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        List<String> expected =
+                Stream.of(
+                                "+I[1, 2, false, [3], 4, 5, 6, 2022-09-07T10:25:28.127Z, 2022-09-07T10:25:28Z, 0.9, 1.0, 1.10, {k=12}, +I[13], [14_1, 14_2], [+I[15_1], +I[15_2]]]",
+                                "+I[2, 2, false, [3], 4, 5, 6, 2022-09-07T10:25:28.127Z, 2022-09-07T10:25:28Z, 0.9, 1.0, 1.10, {k=12}, +I[13], [14_1, 14_2], [+I[15_1], +I[15_2]]]")
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test
+    public void testProject() {
+        tEnv.executeSql(createTestDDl(null));
+
+        Iterator<Row> collected = tEnv.executeSql("SELECT f1, f13 FROM mongo_source").collect();
+        List<String> result =
+                CollectionUtil.iteratorToList(collected).stream()
+                        .map(Row::toString)
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        List<String> expected =
+                Stream.of("+I[2, +I[13]]", "+I[2, +I[13]]").sorted().collect(Collectors.toList());
+
+        assertThat(result, equalTo(expected));
+    }
+
+    @Test
+    public void testLimit() {
+        tEnv.executeSql(createTestDDl(null));
+
+        Iterator<Row> collected = tEnv.executeSql("SELECT * FROM mongo_source LIMIT 1").collect();
+        List<String> result =
+                CollectionUtil.iteratorToList(collected).stream()
+                        .map(Row::toString)
+                        .sorted()
+                        .collect(Collectors.toList());
+
+        Set<String> expected = new HashSet<>();
+        expected.add(
+                "+I[1, 2, false, [3], 4, 5, 6, 2022-09-07T10:25:28.127Z, 2022-09-07T10:25:28Z, 0.9, 1.0, 1.10, {k=12}, +I[13], [14_1, 14_2], [+I[15_1], +I[15_2]]]");
+        expected.add(
+                "+I[2, 2, false, [3], 4, 5, 6, 2022-09-07T10:25:28.127Z, 2022-09-07T10:25:28Z, 0.9, 1.0, 1.10, {k=12}, +I[13], [14_1, 14_2], [+I[15_1], +I[15_2]]]");
+
+        assertThat(result.size(), is(1));
+        assertThat(expected, hasItem(result.get(0)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(Caching.class)
+    public void testLookupJoin(Caching caching) throws Exception {
+        // Create MongoDB lookup table
+        Map<String, String> lookupOptions = new HashMap<>();
+        if (caching.equals(Caching.ENABLE_CACHE)) {
+            lookupOptions.put("lookup.cache", "PARTIAL");
+            lookupOptions.put("lookup.partial-cache.expire-after-write", "10min");
+            lookupOptions.put("lookup.partial-cache.expire-after-access", "10min");
+            lookupOptions.put("lookup.partial-cache.max-rows", "100");
+            lookupOptions.put("lookup.max-retries", "10");
+        }
+
+        tEnv.executeSql(createTestDDl(lookupOptions));
+
+        // Create and prepare a value source
+        String dataId =
+                TestValuesTableFactory.registerData(
+                        Arrays.asList(
+                                Row.of(1L, "Alice"),
+                                Row.of(1L, "Alice"),
+                                Row.of(2L, "Bob"),
+                                Row.of(3L, "Charlie")));
+        tEnv.executeSql(
+                String.format(
+                        "CREATE TABLE value_source (\n"
+                                + "`id` BIGINT,\n"
+                                + "`name` STRING,\n"
+                                + "`proctime` AS PROCTIME()\n"
+                                + ") WITH (\n"
+                                + "'connector' = 'values', \n"
+                                + "'data-id' = '%s')",
+                        dataId));
+
+        if (caching == Caching.ENABLE_CACHE) {
+            LookupCacheManager.keepCacheOnRelease(true);
+        }
+
+        // Execute lookup join
+        try (CloseableIterator<Row> iterator =
+                tEnv.executeSql(
+                                "SELECT S.id, S.name, D._id, D.f1, D.f2 FROM value_source"
+                                        + " AS S JOIN mongo_source for system_time as of S.proctime AS D ON S.id = D._id")
+                        .collect()) {
+            List<String> result =
+                    CollectionUtil.iteratorToList(iterator).stream()
+                            .map(Row::toString)
+                            .sorted()
+                            .collect(Collectors.toList());
+            List<String> expected = new ArrayList<>();
+            expected.add("+I[1, Alice, 1, 2, false]");
+            expected.add("+I[1, Alice, 1, 2, false]");
+            expected.add("+I[2, Bob, 2, 2, false]");
+
+            assertThat(result.size(), is(3));
+            assertThat(result, equalTo(expected));
+            if (caching == Caching.ENABLE_CACHE) {
+                // Validate cache
+                Map<String, LookupCacheManager.RefCountedCache> managedCaches =
+                        LookupCacheManager.getInstance().getManagedCaches();
+                assertThat(managedCaches.size(), is(1));
+                LookupCache cache =
+                        managedCaches.get(managedCaches.keySet().iterator().next()).getCache();
+                validateCachedValues(cache);
+            }
+
+        } finally {
+            if (caching == Caching.ENABLE_CACHE) {
+                LookupCacheManager.getInstance().checkAllReleased();
+                LookupCacheManager.getInstance().clear();
+                LookupCacheManager.keepCacheOnRelease(false);
+            }
+        }
+    }
+
+    private void validateCachedValues(LookupCache cache) {
+        // mongo does support project push down, the cached row has been projected
+        RowData key1 = GenericRowData.of(1L);
+        RowData value1 = GenericRowData.of(1L, StringData.fromString("2"), false);
+
+        RowData key2 = GenericRowData.of(2L);
+        RowData value2 = GenericRowData.of(2L, StringData.fromString("2"), false);
+
+        RowData key3 = GenericRowData.of(3L);
+
+        Map<RowData, Collection<RowData>> expectedEntries = new HashMap<>();
+        expectedEntries.put(key1, Collections.singletonList(value1));
+        expectedEntries.put(key2, Collections.singletonList(value2));
+        expectedEntries.put(key3, Collections.emptyList());
+
+        LookupCacheAssert.assertThat(cache).containsExactlyEntriesOf(expectedEntries);
+    }
+
+    private enum Caching {
+        ENABLE_CACHE,
+        DISABLE_CACHE
+    }
+
+    private static String createTestDDl(Map<String, String> extraOptions) {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "mongodb");
+        options.put("uri", MONGO_CONTAINER.getConnectionString());
+        options.put("database", DATABASE);
+        options.put("collection", COLLECTION);
+        if (extraOptions != null) {
+            options.putAll(extraOptions);
+        }
+
+        String optionString =
+                options.entrySet().stream()
+                        .map(e -> String.format("'%s' = '%s'", e.getKey(), e.getValue()))
+                        .collect(Collectors.joining(",\n"));
+
+        return String.join(
+                "\n",
+                Arrays.asList(
+                        "CREATE TABLE mongo_source",
+                        "(",
+                        "  _id BIGINT,",
+                        "  f1 STRING,",
+                        "  f2 BOOLEAN,",
+                        "  f3 BINARY,",
+                        "  f4 TINYINT,",
+                        "  f5 SMALLINT,",
+                        "  f6 INTEGER,",
+                        "  f7 TIMESTAMP_LTZ(6),",
+                        "  f8 TIMESTAMP_LTZ(3),",
+                        "  f9 FLOAT,",
+                        "  f10 DOUBLE,",
+                        "  f11 DECIMAL(10, 2),",
+                        "  f12 MAP<STRING, INTEGER>,",
+                        "  f13 ROW<k INTEGER>,",
+                        "  f14 ARRAY<STRING>,",
+                        "  f15 ARRAY<ROW<k STRING>>",
+                        ") WITH (",
+                        optionString,
+                        ")"));
+    }
+
+    private static BsonDocument createTestData(long id) {
+        return new BsonDocument()
+                .append("_id", new BsonInt64(id))
+                .append("f1", new BsonString("2"))
+                .append("f2", BsonBoolean.FALSE)
+                .append("f3", new BsonBinary(new byte[] {(byte) 3}))
+                .append("f4", new BsonInt32(4))
+                .append("f5", new BsonInt32(5))
+                .append("f6", new BsonInt32(6))
+                // 2022-09-07T10:25:28.127Z
+                .append("f7", new BsonDateTime(1662546328127L))
+                .append("f8", new BsonTimestamp(1662546328, 0))
+                .append("f9", new BsonDouble(0.9d))
+                .append("f10", new BsonDouble(1.0d))
+                .append("f11", new BsonDecimal128(new Decimal128(new BigDecimal("1.10"))))
+                .append("f12", new BsonDocument("k", new BsonInt32(12)))
+                .append("f13", new BsonDocument("k", new BsonInt32(13)))
+                .append(
+                        "f14",
+                        new BsonArray(
+                                Arrays.asList(new BsonString("14_1"), new BsonString("14_2"))))
+                .append(
+                        "f15",
+                        new BsonArray(
+                                Arrays.asList(
+                                        new BsonDocument("k", new BsonString("15_1")),
+                                        new BsonDocument("k", new BsonString("15_2")))));
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoKeyExtractorTest.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/MongoKeyExtractorTest.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonObjectId;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link MongoKeyExtractor}. */
+public class MongoKeyExtractorTest {
+
+    @Test
+    public void testSimpleKey() {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                Column.physical("b", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("a")));
+
+        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+
+        BsonValue key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(key).isEqualTo(new BsonInt64(12L));
+    }
+
+    @Test
+    public void testPrimaryKeyWithReversedId() {
+        ResolvedSchema schema0 =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("_id", DataTypes.STRING().notNull()),
+                                Column.physical("b", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("_id, a")));
+
+        assertThatThrownBy(() -> MongoKeyExtractor.createKeyExtractor(schema0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The primary key should be declared as (_id) when mongo reversed _id field is present");
+
+        ResolvedSchema schema1 =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("_id", DataTypes.STRING().notNull()),
+                                Column.physical("b", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        null);
+
+        assertThatThrownBy(() -> MongoKeyExtractor.createKeyExtractor(schema1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The primary key should be declared as (_id) when mongo reversed _id field is present");
+
+        ResolvedSchema schema2 =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("_id", DataTypes.STRING().notNull()),
+                                Column.physical("b", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Collections.singletonList("_id")));
+
+        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema2);
+
+        ObjectId objectId = new ObjectId();
+        BsonValue key =
+                keyExtractor.apply(
+                        GenericRowData.of(
+                                StringData.fromString(objectId.toHexString()),
+                                StringData.fromString("ABCD")));
+        assertThat(key).isEqualTo(new BsonObjectId(objectId));
+    }
+
+    @Test
+    public void testNoPrimaryKey() {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                Column.physical("b", DataTypes.STRING())),
+                        Collections.emptyList(),
+                        null);
+
+        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+
+        BsonValue key = keyExtractor.apply(GenericRowData.of(12L, StringData.fromString("ABCD")));
+        assertThat(key).isNull();
+    }
+
+    @Test
+    public void testTwoFieldsKey() {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.BIGINT().notNull()),
+                                Column.physical("b", DataTypes.STRING()),
+                                Column.physical("c", DataTypes.TIMESTAMP().notNull())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey("pk", Arrays.asList("a", "b")));
+
+        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+
+        BsonValue key =
+                keyExtractor.apply(
+                        GenericRowData.of(
+                                12L,
+                                StringData.fromString("ABCD"),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.parse("2012-12-12T12:12:12"))));
+
+        BsonDocument expect = new BsonDocument();
+        expect.append("a", new BsonInt64(12L));
+        expect.append("b", new BsonString("ABCD"));
+
+        assertThat(key).isEqualTo(expect);
+    }
+
+    @Test
+    public void testAllTypesKey() {
+        ResolvedSchema schema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("a", DataTypes.TINYINT().notNull()),
+                                Column.physical("b", DataTypes.SMALLINT().notNull()),
+                                Column.physical("c", DataTypes.INT().notNull()),
+                                Column.physical("d", DataTypes.BIGINT().notNull()),
+                                Column.physical("e", DataTypes.BOOLEAN().notNull()),
+                                Column.physical("f", DataTypes.FLOAT().notNull()),
+                                Column.physical("g", DataTypes.DOUBLE().notNull()),
+                                Column.physical("h", DataTypes.STRING().notNull()),
+                                Column.physical("i", DataTypes.TIMESTAMP().notNull()),
+                                Column.physical(
+                                        "j", DataTypes.TIMESTAMP_WITH_LOCAL_TIME_ZONE().notNull())),
+                        Collections.emptyList(),
+                        UniqueConstraint.primaryKey(
+                                "pk",
+                                Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j")));
+
+        Function<RowData, BsonValue> keyExtractor = MongoKeyExtractor.createKeyExtractor(schema);
+
+        BsonValue key =
+                keyExtractor.apply(
+                        GenericRowData.of(
+                                (byte) 1,
+                                (short) 2,
+                                3,
+                                (long) 4,
+                                true,
+                                1.0f,
+                                2.0d,
+                                StringData.fromString("ABCD"),
+                                TimestampData.fromLocalDateTime(
+                                        LocalDateTime.parse("2012-12-12T12:12:12")),
+                                TimestampData.fromInstant(Instant.parse("2013-01-13T13:13:13Z"))));
+
+        BsonDocument expect = new BsonDocument();
+        expect.append("a", new BsonInt32(1));
+        expect.append("b", new BsonInt32(2));
+        expect.append("c", new BsonInt32(3));
+        expect.append("d", new BsonInt64(4L));
+        expect.append("e", new BsonBoolean(true));
+        expect.append("f", new BsonDouble(Float.valueOf("1.0f").doubleValue()));
+        expect.append("g", new BsonDouble(2.0d));
+        expect.append("h", new BsonString("ABCD"));
+        expect.append(
+                "i",
+                new BsonDateTime(
+                        LocalDateTime.parse("2012-12-12T12:12:12")
+                                .atZone(ZoneId.systemDefault())
+                                .toInstant()
+                                .toEpochMilli()));
+        expect.append("j", new BsonDateTime(Instant.parse("2013-01-13T13:13:13Z").toEpochMilli()));
+
+        assertThat(key).isEqualTo(expect);
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/converter/MongoConvertersTest.java
+++ b/flink-connectors/flink-connector-mongodb/src/test/java/org/apache/flink/connector/mongodb/table/converter/MongoConvertersTest.java
@@ -1,0 +1,574 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.mongodb.table.converter;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.bson.BsonArray;
+import org.bson.BsonBinary;
+import org.bson.BsonBoolean;
+import org.bson.BsonDateTime;
+import org.bson.BsonDbPointer;
+import org.bson.BsonDecimal128;
+import org.bson.BsonDocument;
+import org.bson.BsonDouble;
+import org.bson.BsonInt32;
+import org.bson.BsonInt64;
+import org.bson.BsonJavaScript;
+import org.bson.BsonJavaScriptWithScope;
+import org.bson.BsonObjectId;
+import org.bson.BsonRegularExpression;
+import org.bson.BsonString;
+import org.bson.BsonSymbol;
+import org.bson.BsonTimestamp;
+import org.bson.types.Decimal128;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.regex.Pattern;
+
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/** Unit tests for {@link BsonToRowDataConverters} and {@link RowDataToBsonConverters}. */
+@ExtendWith(TestLoggerExtension.class)
+public class MongoConvertersTest {
+
+    @Test
+    public void testConvertBsonToRowData() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("_id", DataTypes.STRING()),
+                        DataTypes.FIELD("f0", DataTypes.STRING()),
+                        DataTypes.FIELD("f1", DataTypes.STRING()),
+                        DataTypes.FIELD("f2", DataTypes.INT()),
+                        DataTypes.FIELD("f3", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f4", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f5", DataTypes.DECIMAL(10, 2)),
+                        DataTypes.FIELD("f6", DataTypes.BOOLEAN()),
+                        DataTypes.FIELD("f7", DataTypes.TIMESTAMP_LTZ(3)),
+                        DataTypes.FIELD("f8", DataTypes.STRING()),
+                        DataTypes.FIELD("f9", DataTypes.STRING()),
+                        DataTypes.FIELD("f10", DataTypes.STRING()),
+                        DataTypes.FIELD("f11", DataTypes.STRING()),
+                        DataTypes.FIELD("f12", DataTypes.STRING()),
+                        DataTypes.FIELD("f13", DataTypes.STRING()),
+                        DataTypes.FIELD(
+                                "f14", DataTypes.ROW(DataTypes.FIELD("f14_k", DataTypes.BIGINT()))),
+                        DataTypes.FIELD("f15", DataTypes.STRING()),
+                        DataTypes.FIELD(
+                                "f16",
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("f16_k", DataTypes.FLOAT())))),
+                        DataTypes.FIELD("f17", DataTypes.STRING()));
+
+        ObjectId oid = new ObjectId();
+        UUID uuid = UUID.randomUUID();
+        Instant now = Instant.now();
+
+        BsonDocument docWithFullTypes =
+                new BsonDocument()
+                        .append("_id", new BsonObjectId(oid))
+                        .append("f0", new BsonString("string"))
+                        .append("f1", new BsonBinary(uuid))
+                        .append("f2", new BsonInt32(2))
+                        .append("f3", new BsonInt64(3L))
+                        .append("f4", new BsonDouble(4.1d))
+                        .append("f5", new BsonDecimal128(new Decimal128(new BigDecimal("5.1"))))
+                        .append("f6", BsonBoolean.FALSE)
+                        .append("f7", new BsonTimestamp((int) now.getEpochSecond(), 0))
+                        .append("f8", new BsonDateTime(now.toEpochMilli()))
+                        .append(
+                                "f9",
+                                new BsonRegularExpression(Pattern.compile("^9$").pattern(), "i"))
+                        .append("f10", new BsonJavaScript("function() { return 10; }"))
+                        .append(
+                                "f11",
+                                new BsonJavaScriptWithScope(
+                                        "function() { return 11; }", new BsonDocument()))
+                        .append("f12", new BsonSymbol("12"))
+                        .append("f13", new BsonDbPointer("db.coll", oid))
+                        .append("f14", new BsonDocument("f14_k", new BsonInt32(14)))
+                        .append("f15", new BsonDocument("f15_k", new BsonInt32(15)))
+                        .append(
+                                "f16",
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonDocument("f16_k", new BsonDouble(16.1d)),
+                                                new BsonDocument("f16_k", new BsonDouble(16.2d)))))
+                        .append(
+                                "f17",
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonDocument("f17_k", new BsonDouble(17.1d)),
+                                                new BsonDocument("f17_k", new BsonDouble(17.2d)))));
+
+        RowData expect =
+                GenericRowData.of(
+                        StringData.fromString(oid.toHexString()),
+                        StringData.fromString("string"),
+                        StringData.fromString(uuid.toString()),
+                        2,
+                        3L,
+                        4.1d,
+                        DecimalData.fromBigDecimal(new BigDecimal("5.1"), 10, 2),
+                        false,
+                        TimestampData.fromEpochMillis(now.getEpochSecond() * 1000),
+                        StringData.fromString(
+                                OffsetDateTime.ofInstant(now, ZoneOffset.UTC)
+                                        .format(ISO_OFFSET_DATE_TIME)),
+                        StringData.fromString("/^9$/i"),
+                        StringData.fromString("function() { return 10; }"),
+                        StringData.fromString("function() { return 11; }"),
+                        StringData.fromString("12"),
+                        StringData.fromString(oid.toHexString()),
+                        GenericRowData.of(14L),
+                        StringData.fromString("{\"f15_k\": 15}"),
+                        new GenericArrayData(
+                                new RowData[] {
+                                    GenericRowData.of((float) 16.1d),
+                                    GenericRowData.of((float) 16.2d)
+                                }),
+                        StringData.fromString("[{\"f17_k\": 17.1}, {\"f17_k\": 17.2}]"));
+
+        // Test convert Bson to RowData
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(docWithFullTypes);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonNumberAndBooleanToSqlString() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.STRING()),
+                        DataTypes.FIELD("f1", DataTypes.STRING()),
+                        DataTypes.FIELD("f2", DataTypes.STRING()),
+                        DataTypes.FIELD("f3", DataTypes.STRING()),
+                        DataTypes.FIELD("f4", DataTypes.STRING()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(127L))
+                        .append("f3", new BsonDouble(127.11d))
+                        .append("f4", new BsonDecimal128(new Decimal128(new BigDecimal("127.11"))));
+
+        RowData expect =
+                GenericRowData.of(
+                        StringData.fromString("false"),
+                        StringData.fromString(String.valueOf(-1)),
+                        StringData.fromString(String.valueOf(127L)),
+                        StringData.fromString(String.valueOf(127.11d)),
+                        StringData.fromString("127.11"));
+
+        // Test for compatible bson number and boolean to string sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlBoolean() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.BOOLEAN()),
+                        DataTypes.FIELD("f1", DataTypes.BOOLEAN()),
+                        DataTypes.FIELD("f2", DataTypes.BOOLEAN()),
+                        DataTypes.FIELD("f3", DataTypes.BOOLEAN()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(1L))
+                        .append("f3", new BsonString("true"));
+
+        RowData expect = GenericRowData.of(false, false, true, true);
+
+        // Test for compatible boolean sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlTinyInt() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.TINYINT()),
+                        DataTypes.FIELD("f1", DataTypes.TINYINT()),
+                        DataTypes.FIELD("f2", DataTypes.TINYINT()),
+                        DataTypes.FIELD("f3", DataTypes.TINYINT()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(127L))
+                        .append("f3", new BsonString("127"));
+
+        RowData expect = GenericRowData.of((byte) 0, (byte) -1, (byte) 127L, (byte) 127);
+
+        // Test for compatible tinyint sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlSmallInt() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.SMALLINT()),
+                        DataTypes.FIELD("f1", DataTypes.SMALLINT()),
+                        DataTypes.FIELD("f2", DataTypes.SMALLINT()),
+                        DataTypes.FIELD("f3", DataTypes.SMALLINT()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(127L))
+                        .append("f3", new BsonString("127"));
+
+        RowData expect = GenericRowData.of((short) 0, (short) -1, (short) 127, (short) 127);
+
+        // Test for compatible smallint sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlInt() {
+        Instant now = Instant.now();
+
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.INT()),
+                        DataTypes.FIELD("f1", DataTypes.INT()),
+                        DataTypes.FIELD("f2", DataTypes.INT()),
+                        DataTypes.FIELD("f3", DataTypes.INT()),
+                        DataTypes.FIELD("f4", DataTypes.INT()),
+                        DataTypes.FIELD("f5", DataTypes.INT()),
+                        DataTypes.FIELD("f6", DataTypes.INT()),
+                        DataTypes.FIELD("f7", DataTypes.INT()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(127L))
+                        .append("f3", new BsonDouble(127.11d))
+                        .append("f4", new BsonDecimal128(new Decimal128(new BigDecimal("127.11"))))
+                        .append("f5", new BsonString("127"))
+                        .append("f6", new BsonDateTime(now.toEpochMilli()))
+                        .append("f7", new BsonTimestamp((int) now.getEpochSecond(), 0));
+
+        RowData expect =
+                GenericRowData.of(
+                        0,
+                        -1,
+                        127,
+                        127,
+                        127,
+                        127,
+                        (int) now.getEpochSecond(),
+                        (int) now.getEpochSecond());
+
+        // Test for compatible int sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlBigInt() {
+        Instant now = Instant.now();
+
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f1", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f2", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f3", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f4", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f5", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f6", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f7", DataTypes.BIGINT()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(127L))
+                        .append("f3", new BsonDouble(127.11d))
+                        .append("f4", new BsonDecimal128(new Decimal128(new BigDecimal("127.11"))))
+                        .append("f5", new BsonString("127"))
+                        .append("f6", new BsonDateTime(now.toEpochMilli()))
+                        .append("f7", new BsonTimestamp((int) now.getEpochSecond(), 0));
+
+        RowData expect =
+                GenericRowData.of(
+                        0L,
+                        -1L,
+                        127L,
+                        127L,
+                        127L,
+                        127L,
+                        now.toEpochMilli(),
+                        now.getEpochSecond() * 1000L);
+
+        // Test for compatible int sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlDouble() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f1", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f2", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f3", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f4", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f5", DataTypes.DOUBLE()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(127L))
+                        .append("f3", new BsonDouble(127.11d))
+                        .append("f4", new BsonDecimal128(new Decimal128(new BigDecimal("127.11"))))
+                        .append("f5", new BsonString("127.11"));
+
+        RowData expect = GenericRowData.of(0d, -1d, 127d, 127.11d, 127.11d, 127.11d);
+
+        // Test for compatible double sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlFloat() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.FLOAT()),
+                        DataTypes.FIELD("f1", DataTypes.FLOAT()),
+                        DataTypes.FIELD("f2", DataTypes.FLOAT()),
+                        DataTypes.FIELD("f3", DataTypes.FLOAT()),
+                        DataTypes.FIELD("f4", DataTypes.FLOAT()),
+                        DataTypes.FIELD("f5", DataTypes.FLOAT()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(-1))
+                        .append("f2", new BsonInt64(127L))
+                        .append("f3", new BsonDouble(127.11d))
+                        .append("f4", new BsonDecimal128(new Decimal128(new BigDecimal("127.11"))))
+                        .append("f5", new BsonString("127.11"));
+
+        RowData expect = GenericRowData.of(0f, -1f, 127f, 127.11f, 127.11f, 127.11f);
+
+        // Test for compatible float sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonToSqlDecimal() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.DECIMAL(10, 2)),
+                        DataTypes.FIELD("f1", DataTypes.DECIMAL(10, 2)),
+                        DataTypes.FIELD("f2", DataTypes.DECIMAL(10, 2)),
+                        DataTypes.FIELD("f3", DataTypes.DECIMAL(10, 2)),
+                        DataTypes.FIELD("f4", DataTypes.DECIMAL(10, 2)));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", new BsonInt32(-1))
+                        .append("f1", new BsonInt64(127L))
+                        .append("f2", new BsonDouble(127.11d))
+                        .append("f3", new BsonDecimal128(new Decimal128(new BigDecimal("127.11"))))
+                        .append("f4", new BsonString("127.11"));
+
+        RowData expect =
+                GenericRowData.of(
+                        DecimalData.fromBigDecimal(new BigDecimal("-1"), 10, 2),
+                        DecimalData.fromBigDecimal(new BigDecimal("127"), 10, 2),
+                        DecimalData.fromBigDecimal(new BigDecimal("127.11"), 10, 2),
+                        DecimalData.fromBigDecimal(new BigDecimal("127.11"), 10, 2),
+                        DecimalData.fromBigDecimal(new BigDecimal("127.11"), 10, 2));
+
+        // Test for compatible float sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertBsonInfiniteDecimalToSqlNumber() {
+        BsonDecimal128 positiveInfinity = new BsonDecimal128(Decimal128.POSITIVE_INFINITY);
+        BsonDecimal128 negativeInfinity = new BsonDecimal128(Decimal128.NEGATIVE_INFINITY);
+
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("f0", DataTypes.INT()),
+                        DataTypes.FIELD("f1", DataTypes.INT()),
+                        DataTypes.FIELD("f2", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f3", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f4", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f5", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f6", DataTypes.FLOAT()),
+                        DataTypes.FIELD("f7", DataTypes.FLOAT()));
+
+        BsonDocument document =
+                new BsonDocument()
+                        .append("f0", positiveInfinity)
+                        .append("f1", negativeInfinity)
+                        .append("f2", positiveInfinity)
+                        .append("f3", negativeInfinity)
+                        .append("f4", positiveInfinity)
+                        .append("f5", negativeInfinity)
+                        .append("f6", positiveInfinity)
+                        .append("f7", negativeInfinity);
+
+        RowData expect =
+                GenericRowData.of(
+                        Integer.MAX_VALUE,
+                        Integer.MIN_VALUE,
+                        Long.MAX_VALUE,
+                        Long.MIN_VALUE,
+                        Double.MAX_VALUE,
+                        -Double.MAX_VALUE,
+                        Float.MAX_VALUE,
+                        -Float.MAX_VALUE);
+
+        // Test for compatible decimal sql type conversions
+        BsonToRowDataConverters.BsonToRowDataConverter bsonToRowDataConverter =
+                BsonToRowDataConverters.createNullableConverter(rowType.getLogicalType());
+        RowData actual = (RowData) bsonToRowDataConverter.convert(document);
+        assertThat(actual, equalTo(expect));
+    }
+
+    @Test
+    public void testConvertRowDataToBson() {
+        DataType rowType =
+                DataTypes.ROW(
+                        DataTypes.FIELD("_id", DataTypes.STRING()),
+                        DataTypes.FIELD("f0", DataTypes.BOOLEAN()),
+                        DataTypes.FIELD("f1", DataTypes.TINYINT()),
+                        DataTypes.FIELD("f2", DataTypes.SMALLINT()),
+                        DataTypes.FIELD("f3", DataTypes.INT()),
+                        DataTypes.FIELD("f4", DataTypes.BIGINT()),
+                        DataTypes.FIELD("f5", DataTypes.FLOAT()),
+                        DataTypes.FIELD("f6", DataTypes.DOUBLE()),
+                        DataTypes.FIELD("f7", DataTypes.DECIMAL(10, 2)),
+                        DataTypes.FIELD("f8", DataTypes.TIMESTAMP_LTZ(6)),
+                        DataTypes.FIELD(
+                                "f9", DataTypes.ROW(DataTypes.FIELD("f9_k", DataTypes.BIGINT()))),
+                        DataTypes.FIELD(
+                                "f10",
+                                DataTypes.ARRAY(
+                                        DataTypes.ROW(
+                                                DataTypes.FIELD("f10_k", DataTypes.FLOAT())))));
+
+        ObjectId oid = new ObjectId();
+        Instant now = Instant.now();
+
+        RowData rowData =
+                GenericRowData.of(
+                        StringData.fromString(oid.toHexString()),
+                        false,
+                        (byte) 1,
+                        (short) 2,
+                        3,
+                        4L,
+                        5.1f,
+                        6.1d,
+                        DecimalData.fromBigDecimal(new BigDecimal("7.1"), 10, 2),
+                        TimestampData.fromEpochMillis(now.toEpochMilli()),
+                        GenericRowData.of(9L),
+                        new GenericArrayData(
+                                new RowData[] {
+                                    GenericRowData.of(10.1f), GenericRowData.of(10.2f)
+                                }));
+
+        BsonDocument expect =
+                new BsonDocument()
+                        .append("_id", new BsonString(oid.toHexString()))
+                        .append("f0", BsonBoolean.FALSE)
+                        .append("f1", new BsonInt32(1))
+                        .append("f2", new BsonInt32(2))
+                        .append("f3", new BsonInt32(3))
+                        .append("f4", new BsonInt64(4))
+                        .append("f5", new BsonDouble(5.1f))
+                        .append("f6", new BsonDouble(6.1d))
+                        .append("f7", new BsonDecimal128(new Decimal128(new BigDecimal("7.10"))))
+                        .append("f8", new BsonDateTime(now.toEpochMilli()))
+                        .append("f9", new BsonDocument("f9_k", new BsonInt64(9L)))
+                        .append(
+                                "f10",
+                                new BsonArray(
+                                        Arrays.asList(
+                                                new BsonDocument("f10_k", new BsonDouble(10.1f)),
+                                                new BsonDocument("f10_k", new BsonDouble(10.2f)))));
+
+        // Test convert RowData to Bson
+        RowDataToBsonConverters.RowDataToBsonConverter rowDataToBsonConverter =
+                RowDataToBsonConverters.createNullableConverter(rowType.getLogicalType());
+        BsonDocument actual = (BsonDocument) rowDataToBsonConverter.convert(rowData);
+        assertThat(actual, equalTo(expect));
+    }
+}

--- a/flink-connectors/flink-connector-mongodb/src/test/resources/archunit.properties
+++ b/flink-connectors/flink-connector-mongodb/src/test/resources/archunit.properties
@@ -1,0 +1,31 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# By default we allow removing existing violations, but fail when new violations are added.
+freeze.store.default.allowStoreUpdate=true
+
+# Enable this if a new (frozen) rule has been added in order to create the initial store and record the existing violations.
+#freeze.store.default.allowStoreCreation=true
+
+# Enable this to add allow new violations to be recorded.
+# NOTE: Adding new violations should be avoided when possible. If the rule was correct to flag a new
+#       violation, please try to avoid creating the violation. If the violation was created due to a
+#       shortcoming of the rule, file a JIRA issue so the rule can be improved.
+#freeze.refreeze=true
+
+freeze.store.default.path=archunit-violations

--- a/flink-connectors/flink-connector-mongodb/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-mongodb/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-connectors/flink-sql-connector-mongodb/pom.xml
+++ b/flink-connectors/flink-sql-connector-mongodb/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-connectors</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.17-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-sql-connector-mongodb</artifactId>
+	<name>Flink : Connectors : SQL : MongoDB</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-mongodb</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>org.apache.flink:flink-connector-base</include>
+									<include>org.apache.flink:flink-connector-mongodb</include>
+									<include>org.mongodb:bson</include>
+									<include>org.mongodb:mongodb-driver-sync</include>
+									<include>org.mongodb:mongodb-driver-core</include>
+								</includes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>org.mongodb:mongodb-driver-core</artifact>
+									<excludes>
+										<exclude>META-INF/native-image/**/**.properties</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<relocations>
+								<!-- Force relocation of all MongoDB dependencies. -->
+								<relocation>
+									<pattern>com.mongodb</pattern>
+									<shadedPattern>org.apache.flink.mongodb.shaded.com.mongodb</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>org.bson</pattern>
+									<shadedPattern>org.apache.flink.mongodb.shaded.org.bson</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-connectors/flink-sql-connector-mongodb/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-mongodb/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,11 @@
+flink-sql-connector-mongodb
+Copyright 2014-2022 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+- org.mongodb:bson:4.7.1
+- org.mongodb:mongodb-driver-core:4.7.1
+- org.mongodb:mongodb-driver-sync:4.7.1

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -54,7 +54,8 @@ under the License.
 		<module>flink-file-sink-common</module>
 		<module>flink-connector-files</module>
 		<module>flink-connector-pulsar</module>
-	</modules>
+		<module>flink-connector-mongodb</module>
+    </modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up
 		in the jars-with-dependencies (uber jars) of connectors and
@@ -100,6 +101,7 @@ under the License.
 				<module>flink-sql-connector-kinesis</module>
 				<module>flink-sql-connector-pulsar</module>
 				<module>flink-sql-connector-rabbitmq</module>
+				<module>flink-sql-connector-mongodb</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>flink-end-to-end-tests</artifactId>
+		<groupId>org.apache.flink</groupId>
+		<version>1.17-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>flink-end-to-end-tests-mongodb</artifactId>
+	<name>Flink : E2E Tests : MongoDB</name>
+
+	<properties>
+		<mongodb.version>4.7.1</mongodb.version>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-end-to-end-tests-common</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<!--using mongodb shade jar to execute end-to-end test-->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-sql-connector-mongodb</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.mongodb</groupId>
+			<artifactId>mongodb-driver-sync</artifactId>
+			<version>${mongodb.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.testcontainers</groupId>
+			<artifactId>mongodb</artifactId>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.apache.flink</groupId>
+									<artifactId>flink-sql-connector-mongodb</artifactId>
+									<version>${project.version}</version>
+									<destFileName>sql-mongodb.jar</destFileName>
+									<type>jar</type>
+									<outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+								</artifactItem>
+							</artifactItems>
+						</configuration>
+					</execution>
+					<execution>
+						<id>store-classpath-in-target-for-tests</id>
+						<phase>package</phase>
+						<goals>
+							<goal>build-classpath</goal>
+						</goals>
+						<configuration>
+							<outputFile>${project.build.directory}/hadoop.classpath</outputFile>
+							<excludeGroupIds>org.apache.flink</excludeGroupIds>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+</project>

--- a/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/src/test/java/org/apache/flink/tests/util/mongodb/MongoTableApiE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/src/test/java/org/apache/flink/tests/util/mongodb/MongoTableApiE2ECase.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.mongodb;
+
+import org.apache.flink.api.common.time.Deadline;
+import org.apache.flink.connector.testframe.container.FlinkContainers;
+import org.apache.flink.connector.testframe.container.FlinkContainersSettings;
+import org.apache.flink.connector.testframe.container.TestcontainersSettings;
+import org.apache.flink.test.resources.ResourceTestUtils;
+import org.apache.flink.test.util.SQLJobSubmission;
+import org.apache.flink.util.DockerImageVersions;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
+
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoDatabase;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+/** End-to-end test for the MongoDB connectors. */
+@Testcontainers
+@ExtendWith({TestLoggerExtension.class})
+public class MongoTableApiE2ECase extends TestLogger {
+
+    private static final Logger LOG = LoggerFactory.getLogger(MongoTableApiE2ECase.class);
+
+    private static final String MONGODB_HOSTNAME = "mongodb";
+
+    private static final Network NETWORK = Network.newNetwork();
+
+    private final Path sqlConnectorMongoDBJar = ResourceTestUtils.getResource(".*mongodb.jar");
+
+    @Container
+    public static final MongoDBContainer MONGO_CONTAINER =
+            new MongoDBContainer(DockerImageVersions.MONGO_4_0)
+                    .withLogConsumer(new Slf4jLogConsumer(LOG))
+                    .withNetwork(NETWORK)
+                    .withNetworkAliases(MONGODB_HOSTNAME);
+
+    public static final TestcontainersSettings TESTCONTAINERS_SETTINGS =
+            TestcontainersSettings.builder()
+                    .logger(LOG)
+                    .network(NETWORK)
+                    .dependsOn(MONGO_CONTAINER)
+                    .build();
+
+    @RegisterExtension
+    public static final FlinkContainers FLINK =
+            FlinkContainers.builder()
+                    .withFlinkContainersSettings(
+                            FlinkContainersSettings.builder().numTaskManagers(2).build())
+                    .withTestcontainersSettings(TESTCONTAINERS_SETTINGS)
+                    .build();
+
+    private static MongoClient mongoClient;
+
+    @BeforeAll
+    private static void setUp() throws Exception {
+        mongoClient = MongoClients.create(MONGO_CONTAINER.getConnectionString());
+    }
+
+    @AfterAll
+    private static void teardown() {
+        if (mongoClient != null) {
+            mongoClient.close();
+        }
+    }
+
+    @Test
+    public void testTableApiSourceAndSink() throws Exception {
+        MongoDatabase db = mongoClient.getDatabase("test");
+
+        int ordersCount = 5;
+        List<Document> orders = mockOrders(ordersCount);
+        db.getCollection("orders").insertMany(orders);
+
+        executeSqlStatements(readSqlFile("mongo_e2e.sql"));
+
+        List<Document> ordersBackup = readAllBackupOrders(db, ordersCount);
+
+        assertThat(ordersBackup, equalTo(orders));
+    }
+
+    private List<Document> readAllBackupOrders(MongoDatabase db, int expect) throws Exception {
+        Deadline deadline = Deadline.fromNow(Duration.ofSeconds(20));
+        List<Document> backupOrders;
+        do {
+            Thread.sleep(1000);
+            backupOrders = db.getCollection("orders_bak").find().into(new ArrayList<>());
+
+            db.getCollection("orders_bak").find().into(new ArrayList<>());
+        } while (deadline.hasTimeLeft() && backupOrders.size() < expect);
+
+        return backupOrders;
+    }
+
+    private List<Document> mockOrders(int ordersCount) {
+        List<Document> orders = new ArrayList<>();
+        for (int i = 1; i <= ordersCount; i++) {
+            orders.add(
+                    new Document("_id", new ObjectId())
+                            .append("code", "ORDER_" + i)
+                            .append("quantity", ordersCount * 10L));
+        }
+        return orders;
+    }
+
+    private List<String> readSqlFile(final String resourceName) throws Exception {
+        return Files.readAllLines(Paths.get(getClass().getResource("/" + resourceName).toURI()));
+    }
+
+    private void executeSqlStatements(final List<String> sqlLines) throws Exception {
+        FLINK.submitSQLJob(
+                new SQLJobSubmission.SQLJobSubmissionBuilder(sqlLines)
+                        .addJars(sqlConnectorMongoDBJar)
+                        .build());
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/src/test/resources/log4j2-test.properties
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+################################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_ERR
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/src/test/resources/mongo_e2e.sql
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-mongodb/src/test/resources/mongo_e2e.sql
@@ -1,0 +1,43 @@
+--/*
+-- * Licensed to the Apache Software Foundation (ASF) under one
+-- * or more contributor license agreements.  See the NOTICE file
+-- * distributed with this work for additional information
+-- * regarding copyright ownership.  The ASF licenses this file
+-- * to you under the Apache License, Version 2.0 (the
+-- * "License"); you may not use this file except in compliance
+-- * with the License.  You may obtain a copy of the License at
+-- *
+-- *     http://www.apache.org/licenses/LICENSE-2.0
+-- *
+-- * Unless required by applicable law or agreed to in writing, software
+-- * distributed under the License is distributed on an "AS IS" BASIS,
+-- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- * See the License for the specific language governing permissions and
+-- * limitations under the License.
+-- */
+
+CREATE TABLE orders (
+  `_id` STRING,
+  `code` STRING,
+  `quantity` BIGINT,
+  PRIMARY KEY (_id) NOT ENFORCED
+) WITH (
+  'connector' = 'mongodb',
+  'uri' = 'mongodb://mongodb:27017',
+  'database' = 'test',
+  'collection' = 'orders'
+);
+
+CREATE TABLE orders_bak (
+  `_id` STRING,
+  `code` STRING,
+  `quantity` BIGINT,
+  PRIMARY KEY (_id) NOT ENFORCED
+) WITH (
+  'connector' = 'mongodb',
+  'uri' = 'mongodb://mongodb:27017',
+  'database' = 'test',
+  'collection' = 'orders_bak'
+);
+
+INSERT INTO orders_bak SELECT * FROM orders;

--- a/flink-end-to-end-tests/pom.xml
+++ b/flink-end-to-end-tests/pom.xml
@@ -83,7 +83,8 @@ under the License.
 		<module>flink-end-to-end-tests-aws-kinesis-streams</module>
 		<module>flink-end-to-end-tests-aws-kinesis-firehose</module>
 		<module>flink-end-to-end-tests-sql</module>
-    </modules>
+		<module>flink-end-to-end-tests-mongodb</module>
+	</modules>
 
 	<dependencyManagement>
 		<dependencies>

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -50,4 +50,6 @@ public class DockerImageVersions {
             "gcr.io/google.com/cloudsdktool/cloud-sdk:379.0.0";
 
     public static final String HIVE2 = "prestodb/hdp2.6-hive:10";
+
+    public static final String MONGO_4_0 = "mongo:4.0.10";
 }


### PR DESCRIPTION
## What is the purpose of the change

Support MongoDB stream and sql connector by new Source and Sink interface.

## Features

  -  Support parallel read and write.
  -  Support lookup table source.
  -  Support scan table source.
  -  Support push limit down.
  -  Support push projection down.

## Documentation

### How to create a MongoDB table
```sql
CREATE TABLE test_source (
  `_id` STRING,
  `idx` INT,
  `code` STRING,
  PRIMARY KEY (_id) NOT ENFORCED
) WITH (
  'connector' = 'mongodb',
  'uri' = 'mongodb://user:password@127.0.0.1:27017',
  'database' = 'test',
  'collection' = 'test_source'
);

CREATE TABLE test_sink (
  `_id` STRING,
  `idx` INT,
  `code` STRING,
  PRIMARY KEY (_id) NOT ENFORCED
) WITH (
  'connector' = 'mongodb',
  'uri' = 'mongodb://user:password@127.0.0.1:27017',
  'database' = 'test',
  'collection' = 'test_sink'
);

INSERT INTO test_sink SELECT * FROM test_source;
```

### How to create MongoDB Source
```java
  StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();

  MongoSource<String> mongoSource =
         MongoSource.<String>builder()
              .setUri("mongodb://user:password@127.0.0.1:27017")
              .setDatabase("test")
              .setCollection("test_source")
              .setDeserializationSchema(new MongoJsonDeserializationSchema())
              .build();

  env.fromSource(mongoSource, WatermarkStrategy.noWatermarks(), "MongoDB Source")
              .setParallelism(4)
              .print()
              .setParallelism(1); 

  env.execute("Print MongoDB records");
```

### How to create MongoDB Sink
```java
  MongoSink<Document> sink =
         MongoSink.<Document>builder()
              .setUri("mongodb://user:password@127.0.0.1:27017")
              .setDatabase("test")
              .setCollection("test_sink")
              .setSerializationSchema((doc, ctx) -> new InsertOneModel<>(doc.toBsonDocument()))
              .build();
```

### Connector Options


Option | Required | Forwarded | Default | Type | Description
-- | -- | -- | -- | -- | --
connector | required |  no  | (none) | String | Specify what connector to use, here should be 'mongodb'.
uri | required |  no  | (none) | String | Specifies the connection uri of MongoDB.
database | required |  no  | (none) | String | Specifies the database to read or write of MongoDB.
collection | required |  no  | (none) | String | Specifies the collection to read or write of MongoDB.
scan.fetch-size | optional |  yes  |  2048 | Integer | Gives the reader a hint as to the number of documents that should be fetched from the database per round-trip when reading.
scan.cursor.batch-size | optional |  yes  | 0 | Integer | Specifies the number of documents to return in each batch of the response from the MongoDB instance. Set to 0 to use server's default.
scan.cursor.no-timeout | optional |  yes  | true | Boolean | The server normally times out idle cursors after an inactivity period (10 minutes) to prevent excess memory use. Set this option to true to prevent that.
scan.partition.strategy | optional |  no  | 'default' | String | Specifies the partition strategy. Available strategies are single, sample, split-vector, sharded and default.
scan.partition.size | optional |  no  | 64mb | MemorySize | Specifies the partition memory size.
scan.partition.samples | optional |  no  | 10 | Integer | Specifies the the samples count per partition. It only takes effect when the partition strategy is sample.
sink.bulk-flush.max-actions | optional |  yes  | 1000 | Integer | Specifies the maximum number of buffered actions per bulk request.
sink.bulk-flush.interval | optional |  yes  | 1s | Integer | Specifies the bulk flush interval.
sink.delivery-guarantee | optional |  no  | 'at-least-once' | String | Optional delivery guarantee when committing.
sink.max-retries | optional |  yes  | 3 | Integer | Specifies the max retry times if writing records to database failed.
sink.parallelism | optional |  no  | (none) | Integer |  Defines the parallelism of the MongoDB sink operator. By default, the parallelism is determined by the framework using the same parallelism of the upstream chained operator.
lookup.max-retries | optional | yes	 | 3 |	Integer | The max retry times if lookup database failed.
lookup.partial-cache.max-rows | optional | yes  | (none)| Integer | The maximum number of rows to store in the cache.
lookup.partial-cache.cache-missing-key | optional | yes  | (none)| Boolean | Whether to store an empty value into the cache if the lookup key doesn't match any rows in the table.
lookup.partial-cache.expire-after-access | optional | yes  | (none)| Duration | Duration to expire an entry in the cache after accessing.
lookup.partial-cache.expire-after-write | optional | yes  | (none)| Duration | Duration to expire an entry in the cache after writing.


### DataType Mapping
Bson Type | Flink SQL type 
-- | -- 
| BsonObjectId | STRING <br> CHAR <br>VARCHAR  |
| BsonBoolean | BOOLEAN |
| BsonBinary | BINARY <br> VARBINARY |
| BsonInt32| TINYINT <br> SMALLINT <br> INT |
| BsonInt64 | BIGINT |
| BsonDouble | FLOAT <br> DOUBLE |
| Decimal128 | DECIMAL |
| BsonDateTime | TIMESTAMP_LTZ(3) |
| BsonTimestamp | TIMESTAMP_LTZ(0) |
| BsonString | STRING |
| BsonSymbol | STRING |
| BsonRegularExpression | STRING |
| BsonJavaScript | STRING |
| BsonDbPointer  | STRING <br> ROW<$ref STRING, $id STRING> |
| BsonDocument | ROW |
| BsonArray | ARRAY |
| [GeoJson](https://www.mongodb.com/docs/manual/reference/geojson/) | Point : ROW<type STRING, coordinates ARRAY<DOUBLE>> <br> Line : ROW<type STRING, coordinates ARRAY<ARRAY< DOUBLE>>> <br>... |
