### PR TITLE
[FLINK-29325][documentation]Fix documentation bug on how to enable ba…

### DIFF
--- a/docs/content.zh/docs/dev/datastream/execution_mode.md
+++ b/docs/content.zh/docs/dev/datastream/execution_mode.md
@@ -60,7 +60,7 @@ Apache Flink 对流处理和批处理统一方法，意味着无论配置何种�
 下面是如何通过命令行配置执行模式：
 
 ```bash
-$ bin/flink run -Dexecution.runtime-mode=BATCH examples/streaming/WordCount.jar
+$ bin/flink run examples/streaming/WordCount.jar --execution-mode BATCH
 ```
 
 这个例子展示了如何在代码中配置执行模式：

--- a/docs/content.zh/docs/dev/datastream/execution_mode.md
+++ b/docs/content.zh/docs/dev/datastream/execution_mode.md
@@ -60,7 +60,7 @@ Apache Flink 对流处理和批处理统一方法，意味着无论配置何种�
 下面是如何通过命令行配置执行模式：
 
 ```bash
-$ bin/flink run examples/streaming/WordCount.jar --execution-mode BATCH
+$ bin/flink run -Dexecution.runtime-mode=BATCH <jarFile>
 ```
 
 这个例子展示了如何在代码中配置执行模式：

--- a/docs/content/docs/dev/datastream/execution_mode.md
+++ b/docs/content/docs/dev/datastream/execution_mode.md
@@ -96,7 +96,7 @@ programmatically when creating/configuring the `StreamExecutionEnvironment`.
 Here's how you can configure the execution mode via the command line:
 
 ```bash
-$ bin/flink run -Dexecution.runtime-mode=BATCH examples/streaming/WordCount.jar
+$ bin/flink run examples/streaming/WordCount.jar --execution-mode BATCH
 ```
 
 This example shows how you can configure the execution mode in code:

--- a/docs/content/docs/dev/datastream/execution_mode.md
+++ b/docs/content/docs/dev/datastream/execution_mode.md
@@ -96,7 +96,7 @@ programmatically when creating/configuring the `StreamExecutionEnvironment`.
 Here's how you can configure the execution mode via the command line:
 
 ```bash
-$ bin/flink run examples/streaming/WordCount.jar --execution-mode BATCH
+$ bin/flink run -Dexecution.runtime-mode=BATCH <jarFile>
 ```
 
 This example shows how you can configure the execution mode in code:


### PR DESCRIPTION

## What is the purpose of the change

Fix documentation error on how to enable batch mode for streaming examples.


## Brief change log

use *--execution-mode BATCH* instead of *-Dexecution.runtime-mode=BATCH*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
