### PR TITLE
[FLINK-29337][hive] Fix fail to query non-hive table in Hive dialect 

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParser.java
@@ -380,7 +380,10 @@ public class HiveParser extends ParserImpl {
         if (isLoadData(input)) {
             HiveParserLoadSemanticAnalyzer loadSemanticAnalyzer =
                     new HiveParserLoadSemanticAnalyzer(
-                            hiveConf, frameworkConfig, plannerContext.getCluster());
+                            hiveConf,
+                            frameworkConfig,
+                            plannerContext.getCluster(),
+                            getCatalogManager());
             return loadSemanticAnalyzer.convertToOperation(input);
         }
         if (isMultiDestQuery(input)) {
@@ -447,16 +450,14 @@ public class HiveParser extends ParserImpl {
     }
 
     public HiveParserCalcitePlanner createCalcitePlanner(
-            HiveParserContext context, HiveParserQueryState queryState, HiveShim hiveShim)
-            throws SemanticException {
+            HiveParserContext context, HiveParserQueryState queryState) throws SemanticException {
         HiveParserCalcitePlanner calciteAnalyzer =
                 new HiveParserCalcitePlanner(
                         queryState,
                         plannerContext,
                         catalogReader,
                         frameworkConfig,
-                        getCatalogManager(),
-                        hiveShim);
+                        getCatalogManager());
         calciteAnalyzer.initCtx(context);
         calciteAnalyzer.init(false);
         return calciteAnalyzer;
@@ -465,11 +466,9 @@ public class HiveParser extends ParserImpl {
     public void analyzeCreateView(
             HiveParserCreateViewInfo createViewInfo,
             HiveParserContext context,
-            HiveParserQueryState queryState,
-            HiveShim hiveShim)
+            HiveParserQueryState queryState)
             throws SemanticException {
-        HiveParserCalcitePlanner calciteAnalyzer =
-                createCalcitePlanner(context, queryState, hiveShim);
+        HiveParserCalcitePlanner calciteAnalyzer = createCalcitePlanner(context, queryState);
         calciteAnalyzer.setCreatViewInfo(createViewInfo);
         calciteAnalyzer.genLogicalPlan(createViewInfo.getQuery());
     }
@@ -478,7 +477,7 @@ public class HiveParser extends ParserImpl {
             HiveParserContext context, HiveConf hiveConf, HiveShim hiveShim, HiveParserASTNode node)
             throws SemanticException {
         HiveParserCalcitePlanner analyzer =
-                createCalcitePlanner(context, new HiveParserQueryState(hiveConf), hiveShim);
+                createCalcitePlanner(context, new HiveParserQueryState(hiveConf));
         RelNode relNode = analyzer.genLogicalPlan(node);
         if (relNode == null) {
             return new NopOperation();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
@@ -18,8 +18,11 @@
 
 package org.apache.flink.table.planner.delegation.hive;
 
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.CatalogManager;
-import org.apache.flink.table.catalog.hive.client.HiveShim;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
 import org.apache.flink.table.functions.hive.conversion.HiveInspectors;
 import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
@@ -30,7 +33,6 @@ import org.apache.flink.table.planner.delegation.hive.copy.HiveParserASTBuilder;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserASTNode;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.AggInfo;
-import org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.TableType;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserContext;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserJoinTypeCheckCtx;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserNamedJoinInfo;
@@ -110,7 +112,6 @@ import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.lib.Node;
-import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelOptUtil;
 import org.apache.hadoop.hive.ql.parse.ColumnAccessInfo;
@@ -145,6 +146,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -168,7 +170,6 @@ import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBase
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.getPartitionKeys;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.getWindowSpecIndx;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.initPhase1Ctx;
-import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.obtainTableType;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.processPositionAlias;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.removeOBInSubQuery;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.topLevelConjunctCheck;
@@ -205,8 +206,7 @@ public class HiveParserCalcitePlanner {
             PlannerContext plannerContext,
             FlinkCalciteCatalogReader catalogReader,
             FrameworkConfig frameworkConfig,
-            CatalogManager catalogManager,
-            HiveShim hiveShim)
+            CatalogManager catalogManager)
             throws SemanticException {
         this.catalogManager = catalogManager;
         this.catalogReader = catalogReader;
@@ -216,7 +216,7 @@ public class HiveParserCalcitePlanner {
         this.hiveConf = queryState.getConf();
         this.semanticAnalyzer =
                 new HiveParserSemanticAnalyzer(
-                        queryState, hiveShim, frameworkConfig, plannerContext.getCluster());
+                        queryState, frameworkConfig, plannerContext.getCluster(), catalogManager);
         this.cluster = plannerContext.getCluster();
         this.funcConverter =
                 new SqlFunctionConverter(
@@ -801,66 +801,59 @@ public class HiveParserCalcitePlanner {
             }
 
             // 2. Get Table Metadata
-            Table table = qb.getMetaData().getSrcForAlias(tableAlias);
-            if (table.isTemporary()) {
-                // Hive creates a temp table for VALUES, we need to convert it to LogicalValues
+            if (qb.getValuesTableToData().containsKey(tableAlias)) {
+                // a temp table has been created for VALUES, we need to convert it to LogicalValues
+                Tuple2<CatalogTable, List<List<String>>> tableValueTuple =
+                        qb.getValuesTableToData().get(tableAlias);
                 RelNode values =
                         genValues(
                                 tableAlias,
-                                table,
+                                tableValueTuple.f0,
                                 rowResolver,
                                 cluster,
-                                getQB().getValuesTableToData().get(tableAlias));
+                                tableValueTuple.f1);
                 relToRowResolver.put(values, rowResolver);
                 relToHiveColNameCalcitePosMap.put(values, buildHiveToCalciteColumnMap(rowResolver));
                 return values;
             } else {
                 // 3. Get Table Logical Schema (Row Type)
                 // NOTE: Table logical schema = Non Partition Cols + Partition Cols + Virtual Cols
-
-                // 3.1 Add Column info for non partition cols (Object Inspector fields)
-                StructObjectInspector rowObjectInspector =
-                        (StructObjectInspector) table.getDeserializer().getObjectInspector();
-                List<? extends StructField> fields = rowObjectInspector.getAllStructFieldRefs();
+                Tuple2<String, CatalogTable> nameAndTableTuple =
+                        qb.getMetaData().getSrcForAlias(tableAlias);
+                String tableName = nameAndTableTuple.f0;
+                CatalogTable catalogTable = nameAndTableTuple.f1;
+                TableSchema schema =
+                        HiveParserUtils.fromUnresolvedSchema(catalogTable.getUnresolvedSchema());
+                String[] fieldNames = schema.getFieldNames();
                 ColumnInfo colInfo;
-                String colName;
-                for (StructField field : fields) {
-                    colName = field.getFieldName();
-                    colInfo =
-                            new ColumnInfo(
-                                    field.getFieldName(),
-                                    TypeInfoUtils.getTypeInfoFromObjectInspector(
-                                            field.getFieldObjectInspector()),
-                                    tableAlias,
+                // 3.1 Add Column info
+                for (String fieldName : fieldNames) {
+                    Optional<DataType> dataType = schema.getFieldDataType(fieldName);
+                    TypeInfo hiveType =
+                            HiveTypeUtil.toHiveTypeInfo(
+                                    dataType.orElseThrow(
+                                            () ->
+                                                    new SemanticException(
+                                                            String.format(
+                                                                    "Can't get data type for column %s of table %s.",
+                                                                    fieldName, tableName))),
                                     false);
-                    colInfo.setSkewedCol(HiveParserUtils.isSkewedCol(tableAlias, qb, colName));
-                    rowResolver.put(tableAlias, colName, colInfo);
+                    colInfo = new ColumnInfo(fieldName, hiveType, tableAlias, false);
+                    colInfo.setSkewedCol(HiveParserUtils.isSkewedCol(tableAlias, qb, fieldName));
+                    rowResolver.put(tableAlias, fieldName, colInfo);
                 }
 
-                // 3.2 Add column info corresponding to partition columns
-                for (FieldSchema partCol : table.getPartCols()) {
-                    colName = partCol.getName();
-                    colInfo =
-                            new ColumnInfo(
-                                    colName,
-                                    TypeInfoFactory.getPrimitiveTypeInfo(partCol.getType()),
-                                    tableAlias,
-                                    true);
-                    rowResolver.put(tableAlias, colName, colInfo);
-                }
-
-                final TableType tableType = obtainTableType(table);
-                Preconditions.checkArgument(
-                        tableType == TableType.NATIVE, "Only native tables are supported");
+                ObjectIdentifier tableIdentifier =
+                        HiveParserBaseSemanticAnalyzer.parseCompoundName(catalogManager, tableName);
 
                 // Build Hive Table Scan Rel
                 RelNode tableRel =
                         catalogReader
                                 .getTable(
                                         Arrays.asList(
-                                                catalogManager.getCurrentCatalog(),
-                                                table.getDbName(),
-                                                table.getTableName()))
+                                                tableIdentifier.getCatalogName(),
+                                                tableIdentifier.getDatabaseName(),
+                                                tableIdentifier.getObjectName()))
                                 .toRel(
                                         ViewExpanders.toRelContext(
                                                 flinkPlanner.createToRelContext(), cluster));
@@ -1029,7 +1022,7 @@ public class HiveParserCalcitePlanner {
                     HiveParserBaseSemanticAnalyzer.Phase1Ctx ctx1 = initPhase1Ctx();
                     semanticAnalyzer.doPhase1(
                             (HiveParserASTNode) next.getChild(1), subQB, ctx1, null);
-                    semanticAnalyzer.getMetaData(subQB);
+                    semanticAnalyzer.getMetaData(subQB, false);
                     RelNode subQueryRelNode =
                             genLogicalPlan(
                                     subQB,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserQBMetaData.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserQBMetaData.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.delegation.hive;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.tuple.Tuple3;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogTable;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Counterpart of hive's org.apache.hadoop.hive.ql.parse.QBMetaData. */
+public class HiveParserQBMetaData {
+    public static final int DEST_TABLE = 1;
+    // alias -> <tableName, CatalogBaseTable>
+    private final Map<String, Tuple2<String, CatalogTable>> aliasToTable = new LinkedHashMap<>();
+    private final Map<String, Tuple2<String, CatalogTable>> nameToDestTable = new HashMap<>();
+    private final Map<String, Tuple3<String, CatalogTable, CatalogPartitionSpec>>
+            nameToDestPartition = new HashMap<>();
+    private final Map<String, String> nameToDestFile = new HashMap<>();
+    private final Map<String, Integer> nameToDestType = new HashMap<>();
+    private final Map<String, Map<String, String>> aliasToPartSpec = new LinkedHashMap<>();
+
+    public HiveParserQBMetaData() {}
+
+    public void setSrcForAlias(String alias, String tabName, CatalogTable tab) {
+        this.aliasToTable.put(alias, Tuple2.of(tabName, tab));
+    }
+
+    public void setDestForAlias(String alias, String tabName, CatalogTable tab) {
+        this.nameToDestType.put(alias, 1);
+        this.nameToDestTable.put(alias, Tuple2.of(tabName, tab));
+    }
+
+    public void setDestForAlias(
+            String alias, String tabName, CatalogTable tab, CatalogPartitionSpec part) {
+        this.nameToDestType.put(alias, 2);
+        this.nameToDestPartition.put(alias, Tuple3.of(tabName, tab, part));
+    }
+
+    public void setDestForAlias(String alias, String fname, boolean isDfsFile) {
+        this.nameToDestType.put(alias, isDfsFile ? 3 : 5);
+        this.nameToDestFile.put(alias, fname);
+    }
+
+    public Map<String, Tuple2<String, CatalogTable>> getNameToDestTable() {
+        return this.nameToDestTable;
+    }
+
+    public String getDestFileForAlias(String alias) {
+        return nameToDestFile.get(alias.toLowerCase());
+    }
+
+    public CatalogPartitionSpec getDestPartitionForAlias(String alias) {
+        return this.nameToDestPartition.get(alias.toLowerCase()).f2;
+    }
+
+    public Map<String, Tuple3<String, CatalogTable, CatalogPartitionSpec>>
+            getNameToDestPartition() {
+        return this.nameToDestPartition;
+    }
+
+    public Tuple2<String, CatalogTable> getSrcForAlias(String alias) {
+        return this.aliasToTable.get(alias.toLowerCase());
+    }
+
+    public Map<String, String> getPartSpecForAlias(String alias) {
+        return this.aliasToPartSpec.get(alias);
+    }
+
+    public void setPartSpecForAlias(String alias, Map<String, String> partSpec) {
+        this.aliasToPartSpec.put(alias, partSpec);
+    }
+
+    public Integer getDestTypeForAlias(String alias) {
+        return nameToDestType.get(alias.toLowerCase());
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserUtils.java
@@ -19,12 +19,17 @@
 package org.apache.flink.table.planner.delegation.hive;
 
 import org.apache.flink.connectors.hive.FlinkHiveException;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableColumn;
+import org.apache.flink.table.api.TableSchema;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientWrapper;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.factories.HiveCatalogFactoryOptions;
 import org.apache.flink.table.catalog.hive.util.HiveReflectionUtils;
 import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
+import org.apache.flink.table.expressions.SqlCallExpression;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.functions.hive.HiveGenericUDAF;
 import org.apache.flink.table.module.hive.udf.generic.GenericUDFLegacyGroupingID;
@@ -1688,5 +1693,62 @@ public class HiveParserUtils {
     public static boolean isFromTimeStampToDecimal(RelDataType srcType, RelDataType targetType) {
         return srcType.getSqlTypeName().equals(SqlTypeName.TIMESTAMP)
                 && targetType.getSqlTypeName().equals(SqlTypeName.DECIMAL);
+    }
+
+    /**
+     * Helps to migrate the new {@link Schema} to old API methods. HiveCatalog use deprecated {@link
+     * TableSchema}, other catalogs may use the new {@link Schema}. Currently, we use it to unify to
+     * {@link TableSchema}. It should be dropped after dropping {@link TableSchema}.
+     */
+    public static TableSchema fromUnresolvedSchema(Schema schema) {
+        final TableSchema.Builder builder = TableSchema.builder();
+
+        final DataType unresolvedType = DataTypes.TIMESTAMP(3);
+        schema.getColumns().stream()
+                .map(
+                        column -> {
+                            if (column instanceof Schema.UnresolvedPhysicalColumn) {
+                                final Schema.UnresolvedPhysicalColumn c =
+                                        (Schema.UnresolvedPhysicalColumn) column;
+                                return TableColumn.physical(
+                                        c.getName(), (DataType) c.getDataType());
+                            } else if (column instanceof Schema.UnresolvedMetadataColumn) {
+                                final Schema.UnresolvedMetadataColumn c =
+                                        (Schema.UnresolvedMetadataColumn) column;
+                                return TableColumn.metadata(
+                                        c.getName(),
+                                        (DataType) c.getDataType(),
+                                        c.getMetadataKey(),
+                                        c.isVirtual());
+                            } else if (column instanceof Schema.UnresolvedComputedColumn) {
+                                final Schema.UnresolvedComputedColumn c =
+                                        (Schema.UnresolvedComputedColumn) column;
+                                return TableColumn.computed(
+                                        c.getName(),
+                                        unresolvedType,
+                                        ((SqlCallExpression) c.getExpression()).getSqlExpression());
+                            }
+                            throw new IllegalArgumentException(
+                                    "Unsupported column type: " + column);
+                        })
+                .forEach(builder::add);
+
+        schema.getWatermarkSpecs()
+                .forEach(
+                        spec ->
+                                builder.watermark(
+                                        spec.getColumnName(),
+                                        ((SqlCallExpression) spec.getWatermarkExpression())
+                                                .getSqlExpression(),
+                                        unresolvedType));
+
+        schema.getPrimaryKey()
+                .ifPresent(
+                        pk ->
+                                builder.primaryKey(
+                                        pk.getConstraintName(),
+                                        pk.getColumnNames().toArray(new String[0])));
+
+        return builder.build();
     }
 }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
@@ -106,6 +106,8 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.io.Serializable;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
@@ -532,7 +534,9 @@ public class HiveParserBaseSemanticAnalyzer {
     }
 
     public static String getUnescapedName(
-            HiveParserASTNode tableOrColumnNode, String currentCatalog, String currentDatabase)
+            HiveParserASTNode tableOrColumnNode,
+            @Nullable String currentCatalog,
+            @Nullable String currentDatabase)
             throws SemanticException {
         int tokenType = tableOrColumnNode.getToken().getType();
         if (tokenType == HiveASTParser.TOK_TABNAME) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
@@ -19,6 +19,13 @@
 package org.apache.flink.table.planner.delegation.hive.copy;
 
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
+import org.apache.flink.table.catalog.hive.util.HiveTypeUtil;
 import org.apache.flink.table.planner.delegation.hive.HiveParserConstants;
 import org.apache.flink.table.planner.delegation.hive.HiveParserRexNodeConverter;
 import org.apache.flink.table.planner.delegation.hive.HiveParserTypeCheckProcFactory;
@@ -32,6 +39,7 @@ import org.apache.flink.table.planner.delegation.hive.copy.HiveParserPTFInvocati
 import org.apache.flink.table.planner.delegation.hive.parse.HiveASTParser;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserDDLSemanticAnalyzer;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserErrorMsg;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import org.antlr.runtime.tree.Tree;
@@ -63,7 +71,6 @@ import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeUtil;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.util.ImmutableBitSet;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.common.ObjectPair;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -73,10 +80,6 @@ import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.lib.Node;
-import org.apache.hadoop.hive.ql.metadata.Hive;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.metadata.InvalidTableException;
-import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
@@ -117,9 +120,12 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.apache.flink.table.planner.delegation.hive.HiveParserUtils.removeASTChild;
 import static org.apache.flink.table.planner.delegation.hive.parse.HiveParserDDLSemanticAnalyzer.encodeRowFormat;
@@ -218,7 +224,6 @@ public class HiveParserBaseSemanticAnalyzer {
         int numCh = ast.getChildCount();
         List<PKInfo> pkInfos = new ArrayList<>();
         Map<String, FieldSchema> nametoFS = new HashMap<>();
-        Tree parent = ast.getParent();
 
         for (int i = 0; i < numCh; i++) {
             FieldSchema col = new FieldSchema();
@@ -255,16 +260,9 @@ public class HiveParserBaseSemanticAnalyzer {
                         constraintChild = (HiveParserASTNode) child.getChild(2);
                     }
                     if (constraintChild != null) {
-                        String[] qualifiedTabName =
-                                getQualifiedTableName((HiveParserASTNode) parent.getChild(0));
                         switch (constraintChild.getToken().getType()) {
                             case HiveASTParser.TOK_NOT_NULL:
-                                notNulls.add(
-                                        processNotNull(
-                                                constraintChild,
-                                                qualifiedTabName[0],
-                                                qualifiedTabName[1],
-                                                col.getName()));
+                                notNulls.add(processNotNull(constraintChild, col.getName()));
                                 break;
                             default:
                                 throw new SemanticException(
@@ -277,13 +275,12 @@ public class HiveParserBaseSemanticAnalyzer {
             }
         }
         if (!pkInfos.isEmpty()) {
-            processPrimaryKeys((HiveParserASTNode) parent, pkInfos, primaryKeys, nametoFS);
+            processPrimaryKeys(pkInfos, primaryKeys, nametoFS);
         }
         return colList;
     }
 
-    private static NotNullConstraint processNotNull(
-            HiveParserASTNode nnNode, String dbName, String tblName, String colName)
+    private static NotNullConstraint processNotNull(HiveParserASTNode nnNode, String colName)
             throws SemanticException {
         boolean enable = true;
         boolean validate = false;
@@ -309,30 +306,17 @@ public class HiveParserBaseSemanticAnalyzer {
                             "Unexpected node for NOT NULL constraint: " + child);
             }
         }
-        return new NotNullConstraint(dbName, tblName, colName, null, enable, validate, rely);
+        return new NotNullConstraint(colName, null, enable, validate, rely);
     }
 
     private static void processPrimaryKeys(
-            HiveParserASTNode parent,
-            List<PKInfo> pkInfos,
-            List<PrimaryKey> primaryKeys,
-            Map<String, FieldSchema> nametoFS)
+            List<PKInfo> pkInfos, List<PrimaryKey> primaryKeys, Map<String, FieldSchema> nametoFS)
             throws SemanticException {
-        int cnt = 1;
-        String[] qualifiedTabName = getQualifiedTableName((HiveParserASTNode) parent.getChild(0));
-
         for (PKInfo pkInfo : pkInfos) {
             String pk = pkInfo.colName;
             if (nametoFS.containsKey(pk)) {
                 PrimaryKey currPrimaryKey =
-                        new PrimaryKey(
-                                qualifiedTabName[0],
-                                qualifiedTabName[1],
-                                pk,
-                                pkInfo.constraintName,
-                                false,
-                                false,
-                                pkInfo.rely);
+                        new PrimaryKey(pk, pkInfo.constraintName, false, false, pkInfo.rely);
                 primaryKeys.add(currPrimaryKey);
             } else {
                 throw new SemanticException(ErrorMsg.INVALID_COLUMN.getMsg(pk));
@@ -403,12 +387,8 @@ public class HiveParserBaseSemanticAnalyzer {
         }
     }
 
-    public static String getDotName(String[] qname) throws SemanticException {
-        String genericName = StringUtils.join(qname, ".");
-        if (qname.length != 2) {
-            throw new SemanticException(ErrorMsg.INVALID_TABLE_NAME, genericName);
-        }
-        return genericName;
+    public static String getDotName(String... names) {
+        return Stream.of(names).filter(Objects::nonNull).collect(Collectors.joining("."));
     }
 
     /**
@@ -429,20 +409,44 @@ public class HiveParserBaseSemanticAnalyzer {
         }
     }
 
-    public static String[] getQualifiedTableName(HiveParserASTNode tabNameNode)
+    public static ObjectIdentifier getObjectIdentifier(
+            CatalogManager catalogManager, HiveParserASTNode tabNameNode) throws SemanticException {
+        UnresolvedIdentifier qualifiedTableName = getQualifiedTableName(tabNameNode);
+        return catalogManager.qualifyIdentifier(qualifiedTableName);
+    }
+
+    public static ObjectIdentifier parseCompoundName(
+            CatalogManager catalogManager, String compoundName) {
+        String[] names = compoundName.split("\\.");
+        return catalogManager.qualifyIdentifier(UnresolvedIdentifier.of(names));
+    }
+
+    public static UnresolvedIdentifier getQualifiedTableName(HiveParserASTNode tabNameNode)
             throws SemanticException {
-        if (tabNameNode.getType() != HiveASTParser.TOK_TABNAME
-                || (tabNameNode.getChildCount() != 1 && tabNameNode.getChildCount() != 2)) {
+        if (tabNameNode.getType() != HiveASTParser.TOK_TABNAME) {
             throw new SemanticException(
                     HiveParserErrorMsg.getMsg(ErrorMsg.INVALID_TABLE_NAME, tabNameNode));
         }
-        if (tabNameNode.getChildCount() == 2) {
-            String dbName = unescapeIdentifier(tabNameNode.getChild(0).getText());
-            String tableName = unescapeIdentifier(tabNameNode.getChild(1).getText());
-            return new String[] {dbName, tableName};
+        String catalogName;
+        String dbName;
+        String tableName;
+        switch (tabNameNode.getChildCount()) {
+            case 1:
+                tableName = unescapeIdentifier(tabNameNode.getChild(0).getText());
+                return UnresolvedIdentifier.of(tableName);
+            case 2:
+                dbName = unescapeIdentifier(tabNameNode.getChild(0).getText());
+                tableName = unescapeIdentifier(tabNameNode.getChild(1).getText());
+                return UnresolvedIdentifier.of(dbName, tableName);
+            case 3:
+                catalogName = unescapeIdentifier(tabNameNode.getChild(0).getText());
+                dbName = unescapeIdentifier(tabNameNode.getChild(1).getText());
+                tableName = unescapeIdentifier(tabNameNode.getChild(2).getText());
+                return UnresolvedIdentifier.of(catalogName, dbName, tableName);
+            default:
+                throw new SemanticException(
+                        HiveParserErrorMsg.getMsg(ErrorMsg.INVALID_TABLE_NAME, tabNameNode));
         }
-        String tableName = unescapeIdentifier(tabNameNode.getChild(0).getText());
-        return Utilities.getDbTableName(tableName);
     }
 
     public static Tuple2<String, String> charSetString(String charSetName, String charSetString)
@@ -499,19 +503,18 @@ public class HiveParserBaseSemanticAnalyzer {
 
     /**
      * Get the unqualified name from a table node. This method works for table names qualified with
-     * their schema (e.g., "db.table") and table names without schema qualification. In both cases,
-     * it returns the table name without the schema.
+     * their schema (e.g., "catalog.db.table") and table names without schema qualification. In both
+     * cases, it returns the table name without the schema.
      *
      * @param node the table node
-     * @return the table name without schema qualification (i.e., if name is "db.table" or "table",
-     *     returns "table")
+     * @return the table name without schema qualification (i.e., if name is "catalog.db.table" or
+     *     "table", returns "table")
      */
-    public static String getUnescapedUnqualifiedTableName(HiveParserASTNode node) {
-        assert node.getChildCount() <= 2;
+    public static String getUnescapedUnqualifiedTableName(HiveParserASTNode node)
+            throws SemanticException {
+        assert node.getChildCount() <= 3;
 
-        if (node.getChildCount() == 2) {
-            node = (HiveParserASTNode) node.getChild(1);
-        }
+        node = (HiveParserASTNode) node.getChild(node.getChildCount() - 1);
 
         return getUnescapedName(node);
     }
@@ -520,10 +523,46 @@ public class HiveParserBaseSemanticAnalyzer {
      * Get dequoted name from a table/column node.
      *
      * @param tableOrColumnNode the table or column node
-     * @return for table node, db.tab or tab. for column node column.
+     * @return for table node, return the table that users specific like catalog.db.tab, db.tab or
+     *     tab. For column node column, return col.
      */
-    public static String getUnescapedName(HiveParserASTNode tableOrColumnNode) {
-        return getUnescapedName(tableOrColumnNode, null);
+    public static String getUnescapedName(HiveParserASTNode tableOrColumnNode)
+            throws SemanticException {
+        return getUnescapedName(tableOrColumnNode, null, null);
+    }
+
+    public static String getUnescapedName(
+            HiveParserASTNode tableOrColumnNode, String currentCatalog, String currentDatabase)
+            throws SemanticException {
+        int tokenType = tableOrColumnNode.getToken().getType();
+        if (tokenType == HiveASTParser.TOK_TABNAME) {
+            // table node
+            UnresolvedIdentifier tableIdentifier = getQualifiedTableName(tableOrColumnNode);
+            return getDotName(
+                    tableIdentifier.getCatalogName().orElse(currentCatalog),
+                    tableIdentifier.getDatabaseName().orElse(currentDatabase),
+                    tableIdentifier.getObjectName());
+        } else if (tokenType == HiveASTParser.StringLiteral) {
+            return unescapeSQLString(tableOrColumnNode.getText());
+        }
+        // column node
+        return unescapeIdentifier(tableOrColumnNode.getText());
+    }
+
+    /**
+     * Get the unescaped origin table name for the table node. This method returns
+     * "catalog.db.table","db.table" or "table" according to what the table node actually specifies
+     *
+     * @param node the table node
+     * @return "catalog.db.table", "db.table" or "table"
+     */
+    public static String getUnescapedOriginTableName(HiveParserASTNode node)
+            throws SemanticException {
+        UnresolvedIdentifier tableIdentifier = getQualifiedTableName(node);
+        return getDotName(
+                tableIdentifier.getCatalogName().orElse(null),
+                tableIdentifier.getDatabaseName().orElse(null),
+                tableIdentifier.getObjectName());
     }
 
     public static String getUnescapedName(
@@ -662,19 +701,6 @@ public class HiveParserBaseSemanticAnalyzer {
         return sb.toString();
     }
 
-    public static void validatePartSpec(
-            Table tbl,
-            Map<String, String> partSpec,
-            HiveParserASTNode astNode,
-            HiveConf conf,
-            boolean shouldBeFull,
-            FrameworkConfig frameworkConfig,
-            RelOptCluster cluster)
-            throws SemanticException {
-        tbl.validatePartColumnNames(partSpec, shouldBeFull);
-        validatePartColumnType(tbl, partSpec, astNode, conf, frameworkConfig, cluster);
-    }
-
     private static boolean getPartExprNodeDesc(
             HiveParserASTNode astNode,
             HiveConf conf,
@@ -743,7 +769,8 @@ public class HiveParserBaseSemanticAnalyzer {
         return exprs;
     }
 
-    static String findSimpleTableName(HiveParserASTNode tabref, int aliasIndex) {
+    static String findSimpleTableName(HiveParserASTNode tabref, int aliasIndex)
+            throws SemanticException {
         assert tabref.getType() == HiveASTParser.TOK_TABREF;
         HiveParserASTNode tableTree = (HiveParserASTNode) (tabref.getChild(0));
 
@@ -1770,14 +1797,15 @@ public class HiveParserBaseSemanticAnalyzer {
 
     public static RelNode genValues(
             String tabAlias,
-            Table tmpTable,
+            CatalogTable catalogTable,
             HiveParserRowResolver rowResolver,
             RelOptCluster cluster,
             List<List<String>> values) {
-        List<TypeInfo> tmpTableTypes =
-                tmpTable.getCols().stream()
-                        .map(f -> TypeInfoUtils.getTypeInfoFromTypeString(f.getType()))
-                        .collect(Collectors.toList());
+        List<TypeInfo> tmpTableTypes = new ArrayList<>();
+        DataType[] dataTypes = catalogTable.getSchema().getFieldDataTypes();
+        for (DataType dataType : dataTypes) {
+            tmpTableTypes.add(HiveTypeUtil.toHiveTypeInfo(dataType, false));
+        }
 
         RexBuilder rexBuilder = cluster.getRexBuilder();
         // calcite types for each field
@@ -1935,8 +1963,8 @@ public class HiveParserBaseSemanticAnalyzer {
         return allVars;
     }
 
-    private static void validatePartColumnType(
-            Table tbl,
+    public static void validatePartColumnType(
+            CatalogTable catalogTable,
             Map<String, String> partSpec,
             HiveParserASTNode astNode,
             HiveConf conf,
@@ -1959,10 +1987,22 @@ public class HiveParserBaseSemanticAnalyzer {
             return; // All columns are dynamic, nothing to do.
         }
 
-        List<FieldSchema> parts = tbl.getPartitionKeys();
-        Map<String, String> partCols = new HashMap<>(parts.size());
-        for (FieldSchema col : parts) {
-            partCols.put(col.getName(), col.getType().toLowerCase());
+        List<String> parts = catalogTable.getPartitionKeys();
+        Map<String, TypeInfo> partColsTypes = new HashMap<>(parts.size());
+        for (String col : parts) {
+            Optional<DataType> dataType =
+                    HiveParserUtils.fromUnresolvedSchema(catalogTable.getUnresolvedSchema())
+                            .getFieldDataType(col);
+            TypeInfo hiveType =
+                    HiveTypeUtil.toHiveTypeInfo(
+                            dataType.orElseThrow(
+                                    () ->
+                                            new SemanticException(
+                                                    String.format(
+                                                            "Can't get data type for column %s.",
+                                                            col))),
+                            false);
+            partColsTypes.put(col, hiveType);
         }
         for (Map.Entry<HiveParserASTNode, ExprNodeDesc> astExprNodePair :
                 astExprNodeMap.entrySet()) {
@@ -1970,12 +2010,11 @@ public class HiveParserBaseSemanticAnalyzer {
             if (astExprNodePair.getKey().getType() == HiveASTParser.Identifier) {
                 astKeyName = stripIdentifierQuotes(astKeyName);
             }
-            String colType = partCols.get(astKeyName);
+
+            TypeInfo expectedType = partColsTypes.get(astKeyName);
             ObjectInspector inputOI =
                     TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(
                             astExprNodePair.getValue().getTypeInfo());
-
-            TypeInfo expectedType = TypeInfoUtils.getTypeInfoFromTypeString(colType);
             ObjectInspector outputOI =
                     TypeInfoUtils.getStandardJavaObjectInspectorFromTypeInfo(expectedType);
             //  Since partVal is a constant, it is safe to cast ExprNodeDesc to
@@ -2006,9 +2045,9 @@ public class HiveParserBaseSemanticAnalyzer {
                                     + " but input value is in type "
                                     + inputOI.getTypeName()
                                     + ". Convert "
-                                    + value.toString()
+                                    + value
                                     + " to "
-                                    + convertedValue.toString());
+                                    + convertedValue);
                 }
             }
 
@@ -2021,17 +2060,17 @@ public class HiveParserBaseSemanticAnalyzer {
                                 + " has been changed to "
                                 + astKeyName
                                 + "="
-                                + convertedValue.toString());
+                                + convertedValue);
             }
             partSpec.put(astKeyName, convertedValue.toString());
         }
     }
 
-    private static void errorPartSpec(Map<String, String> partSpec, List<FieldSchema> parts)
+    private static void errorPartSpec(Map<String, String> partSpec, List<String> parts)
             throws SemanticException {
         StringBuilder sb = new StringBuilder("Partition columns in the table schema are: (");
-        for (FieldSchema fs : parts) {
-            sb.append(fs.getName()).append(", ");
+        for (String part : parts) {
+            sb.append(part).append(", ");
         }
         sb.setLength(sb.length() - 2); // remove the last ", "
         sb.append("), while the partitions specified in the query are: (");
@@ -2045,15 +2084,27 @@ public class HiveParserBaseSemanticAnalyzer {
         throw new SemanticException(ErrorMsg.PARTSPEC_DIFFER_FROM_SCHEMA.getMsg(sb.toString()));
     }
 
+    public static CatalogBaseTable getCatalogBaseTable(
+            CatalogManager catalogManager, ObjectIdentifier tableIdentifier) {
+        return catalogManager
+                .getTable(tableIdentifier)
+                .orElseThrow(
+                        () ->
+                                new IllegalArgumentException(
+                                        String.format(
+                                                "Table %s doesn't exist.",
+                                                tableIdentifier.asSummaryString())))
+                .getTable();
+    }
+
     /** Counterpart of hive's BaseSemanticAnalyzer.TableSpec. */
     public static class TableSpec {
+        public ObjectIdentifier tableIdentifier;
         public String tableName;
-        public Table tableHandle;
-        public Map<String, String> partSpec; // has to use LinkedHashMap to enforce order
-        public Partition partHandle;
+        public CatalogBaseTable table;
+        public Map<String, String> partSpec = new HashMap<>();
+        public CatalogPartitionSpec partHandle;
         public int numDynParts; // number of dynamic partition columns
-        public List<Partition>
-                partitions; // involved partitions in TableScanOperator/FileSinkOperator
 
         /** SpecType. */
         public enum SpecType {
@@ -2065,21 +2116,9 @@ public class HiveParserBaseSemanticAnalyzer {
         public TableSpec.SpecType specType;
 
         public TableSpec(
-                Hive db,
+                CatalogManager catalogManager,
                 HiveConf conf,
                 HiveParserASTNode ast,
-                FrameworkConfig frameworkConfig,
-                RelOptCluster cluster)
-                throws SemanticException {
-            this(db, conf, ast, true, false, frameworkConfig, cluster);
-        }
-
-        public TableSpec(
-                Hive db,
-                HiveConf conf,
-                HiveParserASTNode ast,
-                boolean allowDynamicPartitionsSpec,
-                boolean allowPartialPartitionsSpec,
                 FrameworkConfig frameworkConfig,
                 RelOptCluster cluster)
                 throws SemanticException {
@@ -2091,22 +2130,12 @@ public class HiveParserBaseSemanticAnalyzer {
             int childIndex = 0;
             numDynParts = 0;
 
-            try {
-                // get table metadata
-                tableName = getUnescapedName((HiveParserASTNode) ast.getChild(0));
-                boolean testMode = conf.getBoolVar(HiveConf.ConfVars.HIVETESTMODE);
-                if (testMode) {
-                    tableName = conf.getVar(HiveConf.ConfVars.HIVETESTMODEPREFIX) + tableName;
-                }
-                if (ast.getToken().getType() != HiveASTParser.TOK_CREATETABLE
-                        && ast.getToken().getType() != HiveASTParser.TOK_CREATE_MATERIALIZED_VIEW) {
-                    tableHandle = db.getTable(tableName);
-                }
-            } catch (InvalidTableException ite) {
-                throw new SemanticException(
-                        HiveParserErrorMsg.getMsg(ErrorMsg.INVALID_TABLE, ast.getChild(0)), ite);
-            } catch (HiveException e) {
-                throw new SemanticException("Error while retrieving table metadata", e);
+            // get table metadata
+            tableIdentifier =
+                    getObjectIdentifier(catalogManager, (HiveParserASTNode) ast.getChild(0));
+            if (ast.getToken().getType() != HiveASTParser.TOK_CREATETABLE
+                    && ast.getToken().getType() != HiveASTParser.TOK_CREATE_MATERIALIZED_VIEW) {
+                table = getCatalogBaseTable(catalogManager, tableIdentifier);
             }
 
             // get partition metadata if partition specified
@@ -2115,7 +2144,6 @@ public class HiveParserBaseSemanticAnalyzer {
                     && ast.getToken().getType() != HiveASTParser.TOK_CREATE_MATERIALIZED_VIEW) {
                 childIndex = 1;
                 HiveParserASTNode partspec = (HiveParserASTNode) ast.getChild(1);
-                partitions = new ArrayList<Partition>();
                 // partSpec is a mapping from partition column name to its value.
                 Map<String, String> tmpPartSpec = new HashMap<>(partspec.getChildCount());
                 for (int i = 0; i < partspec.getChildCount(); ++i) {
@@ -2124,28 +2152,27 @@ public class HiveParserBaseSemanticAnalyzer {
                     String colName =
                             unescapeIdentifier(partspecVal.getChild(0).getText().toLowerCase());
                     if (partspecVal.getChildCount() < 2) { // DP in the form of T partition (ds, hr)
-                        if (allowDynamicPartitionsSpec) {
-                            ++numDynParts;
-                        } else {
-                            throw new SemanticException(
-                                    ErrorMsg.INVALID_PARTITION.getMsg(
-                                            " - Dynamic partitions not allowed"));
-                        }
+                        ++numDynParts;
                     } else { // in the form of T partition (ds="2010-03-03")
                         val = stripQuotes(partspecVal.getChild(1).getText());
                     }
                     tmpPartSpec.put(colName, val);
                 }
 
-                // check if the columns, as well as value types in the partition() clause are valid
-                validatePartSpec(
-                        tableHandle, tmpPartSpec, ast, conf, false, frameworkConfig, cluster);
+                if (!(table instanceof CatalogTable)) {
+                    throw new IllegalArgumentException(
+                            tableIdentifier.asSummaryString()
+                                    + " is not a table, partition is only allowed for table.");
+                }
 
-                List<FieldSchema> parts = tableHandle.getPartitionKeys();
-                partSpec = new LinkedHashMap<String, String>(partspec.getChildCount());
-                for (FieldSchema fs : parts) {
-                    String partKey = fs.getName();
-                    partSpec.put(partKey, tmpPartSpec.get(partKey));
+                // check if the columns value type in the partition() clause are valid
+                validatePartColumnType(
+                        (CatalogTable) table, tmpPartSpec, ast, conf, frameworkConfig, cluster);
+
+                List<String> parts = ((CatalogTable) table).getPartitionKeys();
+                partSpec = new LinkedHashMap<>(partspec.getChildCount());
+                for (String part : parts) {
+                    partSpec.put(part, tmpPartSpec.get(part));
                 }
 
                 // check if the partition spec is valid
@@ -2163,15 +2190,15 @@ public class HiveParserBaseSemanticAnalyzer {
                         errorPartSpec(partSpec, parts);
                     }
                     Iterator<String> itrPsKeys = partSpec.keySet().iterator();
-                    for (FieldSchema fs : parts) {
-                        if (!itrPsKeys.next().toLowerCase().equals(fs.getName().toLowerCase())) {
+                    for (String part : parts) {
+                        if (!itrPsKeys.next().equalsIgnoreCase(part)) {
                             errorPartSpec(partSpec, parts);
                         }
                     }
 
                     // check if static partition appear after dynamic partitions
-                    for (FieldSchema fs : parts) {
-                        if (partSpec.get(fs.getName().toLowerCase()) == null) {
+                    for (String part : parts) {
+                        if (partSpec.get(part.toLowerCase()) == null) {
                             if (numStaPart > 0) { // found a DP, but there exists ST as subpartition
                                 throw new SemanticException(
                                         HiveParserErrorMsg.getMsg(
@@ -2186,26 +2213,7 @@ public class HiveParserBaseSemanticAnalyzer {
                     partHandle = null;
                     specType = TableSpec.SpecType.DYNAMIC_PARTITION;
                 } else {
-                    try {
-                        if (allowPartialPartitionsSpec) {
-                            partitions = db.getPartitions(tableHandle, partSpec);
-                        } else {
-                            // this doesn't create partition.
-                            partHandle = db.getPartition(tableHandle, partSpec, false);
-                            if (partHandle == null) {
-                                // if partSpec doesn't exists in DB, return a delegate one
-                                // and the actual partition is created in MoveTask
-                                partHandle = new Partition(tableHandle, partSpec, null);
-                            } else {
-                                partitions.add(partHandle);
-                            }
-                        }
-                    } catch (HiveException e) {
-                        throw new SemanticException(
-                                HiveParserErrorMsg.getMsg(
-                                        ErrorMsg.INVALID_PARTITION, ast.getChild(childIndex)),
-                                e);
-                    }
+                    partHandle = new CatalogPartitionSpec(partSpec);
                     specType = TableSpec.SpecType.STATIC_PARTITION;
                 }
             } else {
@@ -2226,7 +2234,11 @@ public class HiveParserBaseSemanticAnalyzer {
             if (partHandle != null) {
                 return partHandle.toString();
             } else {
-                return tableHandle.toString();
+                return String.format(
+                        "Table kind: %s, table schema: %s, table options: %s",
+                        table.getTableKind(),
+                        HiveParserUtils.fromUnresolvedSchema(table.getUnresolvedSchema()),
+                        table.getOptions());
             }
         }
     }
@@ -2280,12 +2292,6 @@ public class HiveParserBaseSemanticAnalyzer {
 
         public PKInfo(String colName) {
             this.colName = colName;
-        }
-
-        public PKInfo(String colName, String constraintName, boolean rely) {
-            this.colName = colName;
-            this.constraintName = constraintName;
-            this.rely = rely;
         }
     }
 
@@ -2453,10 +2459,8 @@ public class HiveParserBaseSemanticAnalyzer {
     /** Counterpart of hive's SQLPrimaryKey. */
     public static class PrimaryKey implements Serializable {
 
-        private static final long serialVersionUID = 3036210046732750293L;
+        private static final long serialVersionUID = 1L;
 
-        private final String dbName;
-        private final String tblName;
         private final String pk;
         private final String constraintName;
         private final boolean enable;
@@ -2464,28 +2468,12 @@ public class HiveParserBaseSemanticAnalyzer {
         private final boolean rely;
 
         public PrimaryKey(
-                String dbName,
-                String tblName,
-                String pk,
-                String constraintName,
-                boolean enable,
-                boolean validate,
-                boolean rely) {
-            this.dbName = dbName;
-            this.tblName = tblName;
+                String pk, String constraintName, boolean enable, boolean validate, boolean rely) {
             this.pk = pk;
             this.constraintName = constraintName;
             this.enable = enable;
             this.validate = validate;
             this.rely = rely;
-        }
-
-        public String getDbName() {
-            return dbName;
-        }
-
-        public String getTblName() {
-            return tblName;
         }
 
         public String getPk() {
@@ -2512,10 +2500,8 @@ public class HiveParserBaseSemanticAnalyzer {
     /** Counterpart of hive's SQLNotNullConstraint. */
     public static class NotNullConstraint implements Serializable {
 
-        private static final long serialVersionUID = 7642343368203203950L;
+        private static final long serialVersionUID = 1L;
 
-        private final String dbName;
-        private final String tblName;
         private final String colName;
         private final String constraintName;
         private final boolean enable;
@@ -2523,28 +2509,16 @@ public class HiveParserBaseSemanticAnalyzer {
         private final boolean rely;
 
         public NotNullConstraint(
-                String dbName,
-                String tblName,
                 String colName,
                 String constraintName,
                 boolean enable,
                 boolean validate,
                 boolean rely) {
-            this.dbName = dbName;
-            this.tblName = tblName;
             this.colName = colName;
             this.constraintName = constraintName;
             this.enable = enable;
             this.validate = validate;
             this.rely = rely;
-        }
-
-        public String getDbName() {
-            return dbName;
-        }
-
-        public String getTblName() {
-            return tblName;
         }
 
         public String getColName() {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserQBParseInfo.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserQBParseInfo.java
@@ -158,8 +158,7 @@ public class HiveParserQBParseInfo {
     }
 
     // See also {@link #getInsertOverwriteTables()}
-    public boolean isInsertIntoTable(String dbName, String table) {
-        String fullName = dbName + "." + table;
+    public boolean isInsertIntoTable(String fullName) {
         return insertIntoTables.containsKey(fullName.toLowerCase());
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
@@ -89,6 +89,8 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -2078,6 +2080,7 @@ public class HiveParserSemanticAnalyzer {
         return getCatalogBaseTable(tableName, qb, true);
     }
 
+    @Nullable
     public CatalogBaseTable getCatalogBaseTable(
             String tableName, HiveParserQB qb, boolean throwException) {
         // first try to get the table from QB, temp table will be stored in here.

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
@@ -18,8 +18,19 @@
 
 package org.apache.flink.table.planner.delegation.hive.copy;
 
-import org.apache.flink.table.catalog.hive.client.HiveShim;
-import org.apache.flink.table.catalog.hive.util.HiveTableUtil;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.CatalogPartition;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.CatalogTableImpl;
+import org.apache.flink.table.catalog.CatalogView;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.UnresolvedIdentifier;
 import org.apache.flink.table.planner.delegation.hive.HiveParserTypeCheckProcFactory;
 import org.apache.flink.table.planner.delegation.hive.HiveParserUtils;
 import org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.TableSpec;
@@ -32,6 +43,7 @@ import org.apache.flink.table.planner.delegation.hive.copy.HiveParserWindowingSp
 import org.apache.flink.table.planner.delegation.hive.parse.HiveASTParser;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserDDLSemanticAnalyzer;
 import org.apache.flink.table.planner.delegation.hive.parse.HiveParserErrorMsg;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import org.antlr.runtime.ClassicToken;
@@ -41,10 +53,8 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.tools.FrameworkConfig;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.common.ObjectPair;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -56,17 +66,12 @@ import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
-import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
-import org.apache.hadoop.hive.ql.io.RCFileInputFormat;
-import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
 import org.apache.hadoop.hive.ql.lib.Dispatcher;
 import org.apache.hadoop.hive.ql.lib.GraphWalker;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
-import org.apache.hadoop.hive.ql.metadata.Partition;
-import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ColumnAccessInfo;
 import org.apache.hadoop.hive.ql.parse.GlobalLimitCtx;
 import org.apache.hadoop.hive.ql.parse.JoinType;
@@ -80,14 +85,10 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
 import org.apache.hadoop.hive.ql.plan.ExprNodeFieldDesc;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
-import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.mapred.InputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -97,6 +98,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
@@ -107,9 +109,12 @@ import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBase
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.findTabRefIdxs;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.getAliasId;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.getColumnInternalName;
+import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.getObjectIdentifier;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.getUnescapedName;
+import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.getUnescapedOriginTableName;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.handleQueryWindowClauses;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.initPhase1Ctx;
+import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.parseCompoundName;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.processPTFPartitionSpec;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.processWindowFunction;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.readProps;
@@ -117,7 +122,7 @@ import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBase
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.unescapeIdentifier;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.unescapeSQLString;
 import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.unparseExprForValuesClause;
-import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.validatePartSpec;
+import static org.apache.flink.table.planner.delegation.hive.copy.HiveParserBaseSemanticAnalyzer.validatePartColumnType;
 
 /**
  * Counterpart of hive's org.apache.hadoop.hive.ql.parse.SemanticAnalyzer and adapted to our needs.
@@ -152,13 +157,6 @@ public class HiveParserSemanticAnalyzer {
     private final String autogenColAliasPrfxLbl;
     private final boolean autogenColAliasPrfxIncludeFuncName;
 
-    // Keep track of view alias to read entity corresponding to the view
-    // For eg: for a query like 'select * from V3', where V3 -> V2, V2 -> V1, V1 -> T
-    // keeps track of aliases for V3, V3:V2, V3:V2:V1.
-    // This is used when T is added as an input for the query, the parents of T is
-    // derived from the alias V3:V2:V1:T
-    private final Map<String, ReadEntity> viewAliasToInput;
-
     // need merge isDirect flag to input even if the newInput does not have a parent
     private boolean mergeIsDirect;
 
@@ -179,9 +177,6 @@ public class HiveParserSemanticAnalyzer {
 
     protected HiveParserBaseSemanticAnalyzer.AnalyzeRewriteContext analyzeRewrite;
 
-    // A mapping from a tableName to a table object in metastore.
-    Map<String, Table> tabNameToTabObject;
-
     public ColumnAccessInfo columnAccessInfo;
 
     private final HiveConf conf;
@@ -189,10 +184,7 @@ public class HiveParserSemanticAnalyzer {
     public HiveParserContext ctx;
 
     QueryProperties queryProperties;
-
-    private final HiveShim hiveShim;
-
-    private final Hive db;
+    private Hive db;
 
     // ReadEntities that are passed to the hooks.
     protected HashSet<ReadEntity> inputs = new LinkedHashSet<>();
@@ -202,23 +194,19 @@ public class HiveParserSemanticAnalyzer {
     private final FrameworkConfig frameworkConfig;
     private final RelOptCluster cluster;
 
+    private final CatalogManager catalogManager;
+
     public HiveParserSemanticAnalyzer(
             HiveParserQueryState queryState,
-            HiveShim hiveShim,
             FrameworkConfig frameworkConfig,
-            RelOptCluster cluster)
+            RelOptCluster cluster,
+            CatalogManager catalogManager)
             throws SemanticException {
         this.queryState = queryState;
         this.conf = queryState.getConf();
-        this.hiveShim = hiveShim;
-        try {
-            this.db = Hive.get(conf);
-        } catch (HiveException e) {
-            throw new SemanticException(e);
-        }
+        this.catalogManager = catalogManager;
         nameToSplitSample = new HashMap<>();
         prunedPartitions = new HashMap<>();
-        tabNameToTabObject = new HashMap<>();
         unparseTranslator = new HiveParserUnparseTranslator(conf);
         autogenColAliasPrfxLbl =
                 HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_AUTOGEN_COLUMNALIAS_PREFIX_LABEL);
@@ -228,10 +216,8 @@ public class HiveParserSemanticAnalyzer {
         queryProperties = new QueryProperties();
         aliasToCTEs = new HashMap<>();
         globalLimitCtx = new GlobalLimitCtx();
-        viewAliasToInput = new HashMap<>();
         mergeIsDirect = true;
         noscan = partialscan = false;
-        tabNameToTabObject = new HashMap<>();
         defaultJoinMerge = !Boolean.parseBoolean(conf.get("hive.merge.nway.joins", "true"));
         disableJoinMerge = defaultJoinMerge;
         this.frameworkConfig = frameworkConfig;
@@ -262,7 +248,6 @@ public class HiveParserSemanticAnalyzer {
         } else {
             mergeIsDirect = false;
         }
-        tabNameToTabObject.clear();
         qb = null;
         ast = null;
         disableJoinMerge = defaultJoinMerge;
@@ -274,7 +259,6 @@ public class HiveParserSemanticAnalyzer {
         viewSelect = null;
         ctesExpanded = null;
         globalLimitCtx.disableOpt();
-        viewAliasToInput.clear();
         unparseTranslator.clear();
         queryProperties.clear();
     }
@@ -486,7 +470,13 @@ public class HiveParserSemanticAnalyzer {
 
         HiveParserASTNode tableTree = (HiveParserASTNode) (tabref.getChild(0));
 
-        String tabIdName = getUnescapedName(tableTree).toLowerCase();
+        String qualifiedTableName =
+                getUnescapedName(
+                                tableTree,
+                                catalogManager.getCurrentCatalog(),
+                                catalogManager.getCurrentDatabase())
+                        .toLowerCase();
+        String originTableName = getUnescapedOriginTableName(tableTree);
 
         String alias = findSimpleTableName(tabref, aliasIndex);
 
@@ -569,7 +559,7 @@ public class HiveParserSemanticAnalyzer {
             nameToSplitSample.put(aliasId, sample);
         }
         // Insert this map into the stats
-        qb.setTabAlias(alias, tabIdName);
+        qb.setTabAlias(alias, originTableName, qualifiedTableName);
         if (qb.isInsideView()) {
             qb.getAliasInsideView().add(alias.toLowerCase());
         }
@@ -579,9 +569,11 @@ public class HiveParserSemanticAnalyzer {
 
         // if alias to CTE contains the table name, we do not do the translation because
         // cte is actually a subquery.
-        if (!this.aliasToCTEs.containsKey(tabIdName)) {
+        if (!this.aliasToCTEs.containsKey(qualifiedTableName)) {
             unparseTranslator.addTableNameTranslation(
-                    tableTree, SessionState.get().getCurrentDatabase());
+                    tableTree,
+                    catalogManager.getCurrentCatalog(),
+                    catalogManager.getCurrentDatabase());
             if (aliasIndex != 0) {
                 unparseTranslator.addIdentifierTranslation(
                         (HiveParserASTNode) tabref.getChild(aliasIndex));
@@ -636,9 +628,9 @@ public class HiveParserSemanticAnalyzer {
 
         List<? extends Node> rows = valuesTable.getChildren();
         List<List<String>> valuesData = new ArrayList<>(rows.size());
+        List<String> fieldsName = new ArrayList<>();
+        List<DataType> fieldsDataType = new ArrayList<>();
         try {
-            List<FieldSchema> fields = new ArrayList<>();
-
             boolean firstRow = true;
             for (Node n : rows) {
                 // Each of the children of TOK_VALUES_TABLE will be a TOK_VALUE_ROW
@@ -654,7 +646,8 @@ public class HiveParserSemanticAnalyzer {
                 for (Node n1 : columns) {
                     HiveParserASTNode column = (HiveParserASTNode) n1;
                     if (firstRow) {
-                        fields.add(new FieldSchema("tmp_values_col" + nextColNum++, "string", ""));
+                        fieldsName.add("tmp_values_col" + nextColNum++);
+                        fieldsDataType.add(DataTypes.STRING());
                     }
                     data.add(unparseExprForValuesClause(column));
                 }
@@ -662,23 +655,18 @@ public class HiveParserSemanticAnalyzer {
                 valuesData.add(data);
             }
 
-            // Step 2, create a temp table
-            Table table = db.newTable(tableName);
-            table.setSerializationLib(conf.getVar(HiveConf.ConfVars.HIVEDEFAULTSERDE));
-            HiveTableUtil.setStorageFormat(table.getSd(), "TextFile", conf);
-            table.setFields(fields);
-            // make up a path for this table
-            File dataLocation = Files.createTempDirectory(tableName).toFile();
-            try {
-                table.setDataLocation(new Path(dataLocation.toURI().toString(), tableName));
-                table.getTTable().setTemporary(true);
-                table.setStoredAsSubDirectories(false);
-                db.createTable(table, false);
-            } finally {
-                FileUtils.deleteQuietly(dataLocation);
-            }
+            // Step 2, create a temp table to maintain table schema
+            CatalogTable tempTable =
+                    new CatalogTableImpl(
+                            TableSchema.builder()
+                                    .fields(
+                                            fieldsName.toArray(new String[0]),
+                                            fieldsDataType.toArray(new DataType[0]))
+                                    .build(),
+                            Collections.emptyMap(),
+                            "values temp table");
             // remember the data for this table
-            qb.getValuesTableToData().put(tableName, valuesData);
+            qb.getValuesTableToData().put(tableName, Tuple2.of(tempTable, valuesData));
         } catch (Exception e) {
             throw new SemanticException("Failed to create temp table for VALUES", e);
         }
@@ -958,11 +946,11 @@ public class HiveParserSemanticAnalyzer {
                     break;
 
                 case HiveASTParser.TOK_INSERT_INTO:
-                    String currentDatabase = SessionState.get().getCurrentDatabase();
                     String tabName =
                             getUnescapedName(
                                     (HiveParserASTNode) ast.getChild(0).getChild(0),
-                                    currentDatabase);
+                                    catalogManager.getCurrentCatalog(),
+                                    catalogManager.getCurrentDatabase());
                     qbp.addInsertIntoTable(tabName, ast);
                     // TODO: hive doesn't break here, so we copy what's below here
                     handleTokDestination(ctx1, ast, qbp, plannerCtx);
@@ -1119,8 +1107,11 @@ public class HiveParserSemanticAnalyzer {
                     String tableName =
                             getUnescapedName((HiveParserASTNode) ast.getChild(0).getChild(0))
                                     .toLowerCase();
+                    String originTableName =
+                            getUnescapedOriginTableName(
+                                    (HiveParserASTNode) ast.getChild(0).getChild(0));
 
-                    qb.setTabAlias(tableName, tableName);
+                    qb.setTabAlias(tableName, originTableName, tableName);
                     qb.addAlias(tableName);
                     qb.getParseInfo().setIsAnalyzeCommand(true);
                     qb.getParseInfo().setNoScanAnalyzeCommand(this.noscan);
@@ -1150,8 +1141,9 @@ public class HiveParserSemanticAnalyzer {
                     if (destination.getChildCount() == 2
                             && tab.getChildCount() == 2
                             && destination.getChild(1).getType() == HiveASTParser.TOK_IFNOTEXISTS) {
-                        String name =
-                                getUnescapedName((HiveParserASTNode) tab.getChild(0)).toLowerCase();
+                        ObjectIdentifier tableIdentifier =
+                                getObjectIdentifier(
+                                        catalogManager, (HiveParserASTNode) tab.getChild(0));
 
                         Tree partitions = tab.getChild(1);
                         int numChildren = partitions.getChildCount();
@@ -1171,33 +1163,26 @@ public class HiveParserSemanticAnalyzer {
                                     ErrorMsg.INSERT_INTO_DYNAMICPARTITION_IFNOTEXISTS.getMsg(
                                             partition.toString()));
                         }
-                        Table table;
-                        try {
-                            table = getTableObjectByName(name);
-                        } catch (HiveException ex) {
-                            throw new SemanticException(ex);
+                        Optional<CatalogPartition> catalogPartition =
+                                catalogManager.getPartition(
+                                        tableIdentifier, new CatalogPartitionSpec(partition));
+                        // Check partition exists if it exists skip the overwrite
+                        if (catalogPartition.isPresent()) {
+                            phase1Result = false;
+                            skipRecursion = true;
+                            LOG.info(
+                                    "Partition already exists so insert into overwrite "
+                                            + "skipped for partition : "
+                                            + partition);
+                            break;
                         }
-                        try {
-                            Partition parMetaData = db.getPartition(table, partition, false);
-                            // Check partition exists if it exists skip the overwrite
-                            if (parMetaData != null) {
-                                phase1Result = false;
-                                skipRecursion = true;
-                                LOG.info(
-                                        "Partition already exists so insert into overwrite "
-                                                + "skipped for partition : "
-                                                + parMetaData.toString());
-                                break;
-                            }
-                        } catch (HiveException e) {
-                            LOG.info("Error while getting metadata : ", e);
-                        }
-                        validatePartSpec(
-                                table,
+                        CatalogTable catalogTable =
+                                getCatalogTable(tableIdentifier.asSummaryString(), qb);
+                        validatePartColumnType(
+                                catalogTable,
                                 partition,
                                 (HiveParserASTNode) tab,
                                 conf,
-                                false,
                                 frameworkConfig,
                                 cluster);
                     }
@@ -1251,7 +1236,8 @@ public class HiveParserSemanticAnalyzer {
                     String fullTableName =
                             getUnescapedName(
                                     (HiveParserASTNode) ast.getChild(0).getChild(0),
-                                    SessionState.get().getCurrentDatabase());
+                                    catalogManager.getCurrentCatalog(),
+                                    catalogManager.getCurrentDatabase());
                     qbp.getInsertOverwriteTables().put(fullTableName, ast);
                 }
             }
@@ -1315,7 +1301,8 @@ public class HiveParserSemanticAnalyzer {
             String fullTableName =
                     getUnescapedName(
                             (HiveParserASTNode) ast.getChild(0).getChild(0),
-                            SessionState.get().getCurrentDatabase());
+                            catalogManager.getCurrentCatalog(),
+                            catalogManager.getCurrentDatabase());
             qbp.setDestSchemaForClause(ctx1.dest, targetColNames);
             Set<String> targetColumns = new HashSet<>(targetColNames);
             if (targetColNames.size() != targetColumns.size()) {
@@ -1326,21 +1313,16 @@ public class HiveParserSemanticAnalyzer {
                                         + fullTableName
                                         + " table schema specification"));
             }
-            Table targetTable;
-            try {
-                targetTable = db.getTable(fullTableName, false);
-            } catch (HiveException ex) {
-                LOG.error("Error processing HiveASTParser.TOK_DESTINATION: " + ex.getMessage(), ex);
-                throw new SemanticException(ex);
-            }
-            if (targetTable == null) {
-                throw new SemanticException(
-                        HiveParserUtils.generateErrorMessage(
-                                ast, "Unable to access metadata for table " + fullTableName));
-            }
-            for (FieldSchema f : targetTable.getCols()) {
+            CatalogTable targetTable = getCatalogTable(fullTableName, qb);
+            Set<String> partitionColumns = new HashSet<>(targetTable.getPartitionKeys());
+            TableSchema tableSchema =
+                    HiveParserUtils.fromUnresolvedSchema(targetTable.getUnresolvedSchema());
+            for (String column : tableSchema.getFieldNames()) {
                 // parser only allows foo(a,b), not foo(foo.a, foo.b)
-                targetColumns.remove(f.getName());
+                // only consider non-partition col
+                if (!partitionColumns.contains(column)) {
+                    targetColumns.remove(column);
+                }
             }
             // here we need to see if remaining columns are dynamic partition columns
             if (!targetColumns.isEmpty()) {
@@ -1441,8 +1423,8 @@ public class HiveParserSemanticAnalyzer {
             HiveParserQB qb, HiveParserBaseSemanticAnalyzer.CTEClause current)
             throws HiveException {
         for (String alias : qb.getTabAliases()) {
-            String tabName = qb.getTabNameForAlias(alias);
-            String cteName = tabName.toLowerCase();
+            String originTabName = qb.getOriginTabNameForAlias(alias);
+            String cteName = originTabName.toLowerCase();
 
             HiveParserBaseSemanticAnalyzer.CTEClause cte = findCTEFromName(qb, cteName);
             if (cte != null) {
@@ -1474,17 +1456,13 @@ public class HiveParserSemanticAnalyzer {
         }
     }
 
-    public void getMetaData(HiveParserQB qb) throws SemanticException {
-        getMetaData(qb, false);
-    }
-
     public void getMetaData(HiveParserQB qb, boolean enableMaterialization)
             throws SemanticException {
         try {
             if (enableMaterialization) {
                 getMaterializationMetadata(qb);
             }
-            getMetaData(qb, null);
+            getMetaData(qb);
         } catch (HiveException e) {
             LOG.error(org.apache.hadoop.util.StringUtils.stringifyException(e));
             if (e instanceof SemanticException) {
@@ -1494,17 +1472,17 @@ public class HiveParserSemanticAnalyzer {
         }
     }
 
-    private void getMetaData(HiveParserQBExpr qbexpr, ReadEntity parentInput) throws HiveException {
+    private void getMetaData(HiveParserQBExpr qbexpr) throws HiveException {
         if (qbexpr.getOpcode() == HiveParserQBExpr.Opcode.NULLOP) {
-            getMetaData(qbexpr.getQB(), parentInput);
+            getMetaData(qbexpr.getQB());
         } else {
-            getMetaData(qbexpr.getQBExpr1(), parentInput);
-            getMetaData(qbexpr.getQBExpr2(), parentInput);
+            getMetaData(qbexpr.getQBExpr1());
+            getMetaData(qbexpr.getQBExpr2());
         }
     }
 
     @SuppressWarnings("nls")
-    private void getMetaData(HiveParserQB qb, ReadEntity parentInput) throws HiveException {
+    private void getMetaData(HiveParserQB qb) throws HiveException {
         LOG.info("Get metadata for source tables");
 
         // Go over the tables and populate the related structures. We have to materialize the table
@@ -1512,22 +1490,29 @@ public class HiveParserSemanticAnalyzer {
         // modify it in the middle for view rewrite.
         List<String> tabAliases = new ArrayList<>(qb.getTabAliases());
 
-        // Keep track of view alias to view name and read entity
+        // Keep track of view alias to view name
         // For eg: for a query like 'select * from V3', where V3 -> V2, V2 -> V1, V1 -> T
-        // keeps track of full view name and read entity corresponding to alias V3, V3:V2, V3:V2:V1.
-        // This is needed for tracking the dependencies for inputs, along with their parents.
-        Map<String, ObjectPair<String, ReadEntity>> aliasToViewInfo = new HashMap<>();
+        // keeps track of full view name corresponding to alias V3, V3:V2, V3:V2:V1.
+        Map<String, String> aliasToViewInfo = new HashMap<>();
 
         // used to capture view to SQ conversions. This is used to check for recursive CTE
         // invocations.
         Map<String, String> sqAliasToCTEName = new HashMap<>();
 
         for (String alias : tabAliases) {
+            // tabName will always be "catalog.db.table"
             String tabName = qb.getTabNameForAlias(alias);
-            String cteName = tabName.toLowerCase();
+            ObjectIdentifier tableIdentifier = parseCompoundName(catalogManager, tabName);
+            // get the origin table name like "table", "db.table", "catalog.db.table" that user
+            // specifies
+            String originTabName = qb.getOriginTabNameForAlias(alias);
+            String cteName = originTabName.toLowerCase();
 
-            Table tab = db.getTable(tabName, false);
-            if (tab == null || tab.getDbName().equals(SessionState.get().getCurrentDatabase())) {
+            CatalogBaseTable tab = getCatalogBaseTable(tabName, qb, false);
+            if (tab == null
+                    || tableIdentifier
+                            .getDatabaseName()
+                            .equals(catalogManager.getCurrentDatabase())) {
                 // we first look for this alias from CTE, and then from catalog.
                 HiveParserBaseSemanticAnalyzer.CTEClause cte = findCTEFromName(qb, cteName);
                 if (cte != null) {
@@ -1549,106 +1534,27 @@ public class HiveParserSemanticAnalyzer {
                     throw new SemanticException(ErrorMsg.INVALID_TABLE.getMsg(alias));
                 }
             }
-            if (tab.isView()) {
+            if (tab instanceof CatalogView) {
                 if (qb.getParseInfo().isAnalyzeCommand()) {
                     throw new SemanticException(ErrorMsg.ANALYZE_VIEW.getMsg());
                 }
-                String fullViewName = tab.getDbName() + "." + tab.getTableName();
                 // Prevent view cycles
-                if (viewsExpanded.contains(fullViewName)) {
+                if (viewsExpanded.contains(tabName)) {
                     throw new SemanticException(
                             "Recursive view "
-                                    + fullViewName
+                                    + tabName
                                     + " detected (cycle: "
                                     + StringUtils.join(viewsExpanded, " -> ")
                                     + " -> "
-                                    + fullViewName
+                                    + tabName
                                     + ").");
                 }
-                replaceViewReferenceWithDefinition(qb, tab, tabName, alias);
-                // This is the last time we'll see the Table objects for views, so add it to the
-                // inputs now. isInsideView will tell if this view is embedded in another view.
-                // If the view is Inside another view, it should have at least one parent
-                if (qb.isInsideView() && parentInput == null) {
-                    parentInput =
-                            PlanUtils.getParentViewInfo(getAliasId(alias, qb), viewAliasToInput);
-                }
-                ReadEntity viewInput = new ReadEntity(tab, parentInput, !qb.isInsideView());
-                viewInput = PlanUtils.addInput(inputs, viewInput);
-                aliasToViewInfo.put(alias, new ObjectPair<>(fullViewName, viewInput));
-                String aliasId = getAliasId(alias, qb);
-                if (aliasId != null) {
-                    aliasId = aliasId.replace(SUBQUERY_TAG_1, "").replace(SUBQUERY_TAG_2, "");
-                }
-                viewAliasToInput.put(aliasId, viewInput);
+                replaceViewReferenceWithDefinition(qb, (CatalogView) tab, tabName, alias);
+                aliasToViewInfo.put(alias, tabName);
                 continue;
             }
 
-            if (!InputFormat.class.isAssignableFrom(tab.getInputFormatClass())) {
-                throw new SemanticException(
-                        HiveParserUtils.generateErrorMessage(
-                                qb.getParseInfo().getSrcForAlias(alias),
-                                ErrorMsg.INVALID_INPUT_FORMAT_TYPE.getMsg()));
-            }
-
-            qb.getMetaData().setSrcForAlias(alias, tab);
-
-            if (qb.getParseInfo().isAnalyzeCommand()) {
-                // allow partial partition specification for nonscan since noscan is fast.
-                TableSpec ts =
-                        new TableSpec(
-                                db,
-                                conf,
-                                (HiveParserASTNode) ast.getChild(0),
-                                true,
-                                this.noscan,
-                                frameworkConfig,
-                                cluster);
-                if (ts.specType == SpecType.DYNAMIC_PARTITION) { // dynamic partitions
-                    try {
-                        ts.partitions = db.getPartitionsByNames(ts.tableHandle, ts.partSpec);
-                    } catch (HiveException e) {
-                        throw new SemanticException(
-                                HiveParserUtils.generateErrorMessage(
-                                        qb.getParseInfo().getSrcForAlias(alias),
-                                        "Cannot get partitions for " + ts.partSpec),
-                                e);
-                    }
-                }
-                // validate partial scan command
-                HiveParserQBParseInfo qbpi = qb.getParseInfo();
-                if (qbpi.isPartialScanAnalyzeCommand()) {
-                    Class<? extends InputFormat> inputFormatClass = null;
-                    switch (ts.specType) {
-                        case TABLE_ONLY:
-                        case DYNAMIC_PARTITION:
-                            inputFormatClass = ts.tableHandle.getInputFormatClass();
-                            break;
-                        case STATIC_PARTITION:
-                            inputFormatClass = ts.partHandle.getInputFormatClass();
-                            break;
-                        default:
-                            assert false;
-                    }
-                    if (!(inputFormatClass.equals(RCFileInputFormat.class)
-                            || inputFormatClass.equals(OrcInputFormat.class))) {
-                        throw new SemanticException(
-                                "ANALYZE TABLE PARTIALSCAN doesn't support non-RCfile.");
-                    }
-                }
-
-                qb.getParseInfo().addTableSpec(alias, ts);
-            }
-
-            ReadEntity parentViewInfo =
-                    PlanUtils.getParentViewInfo(getAliasId(alias, qb), viewAliasToInput);
-            // Temporary tables created during the execution are not the input sources
-            if (!HiveParserUtils.isValuesTempTable(alias)) {
-                HiveParserUtils.addInput(
-                        inputs,
-                        new ReadEntity(tab, parentViewInfo, parentViewInfo == null),
-                        mergeIsDirect);
-            }
+            qb.getMetaData().setSrcForAlias(alias, tabName, (CatalogTable) tab);
         }
 
         LOG.info("Get metadata for subqueries");
@@ -1656,15 +1562,13 @@ public class HiveParserSemanticAnalyzer {
         for (String alias : qb.getSubqAliases()) {
             boolean wasView = aliasToViewInfo.containsKey(alias);
             boolean wasCTE = sqAliasToCTEName.containsKey(alias);
-            ReadEntity newParentInput = null;
             if (wasView) {
-                viewsExpanded.add(aliasToViewInfo.get(alias).getFirst());
-                newParentInput = aliasToViewInfo.get(alias).getSecond();
+                viewsExpanded.add(aliasToViewInfo.get(alias));
             } else if (wasCTE) {
                 ctesExpanded.add(sqAliasToCTEName.get(alias));
             }
             HiveParserQBExpr qbexpr = qb.getSubqForAlias(alias);
-            getMetaData(qbexpr, newParentInput);
+            getMetaData(qbexpr);
             if (wasView) {
                 viewsExpanded.remove(viewsExpanded.size() - 1);
             } else if (wasCTE) {
@@ -1685,38 +1589,28 @@ public class HiveParserSemanticAnalyzer {
             switch (ast.getToken().getType()) {
                 case HiveASTParser.TOK_TAB:
                     {
-                        TableSpec ts = new TableSpec(db, conf, ast, frameworkConfig, cluster);
-                        if (ts.tableHandle.isView()
-                                || hiveShim.isMaterializedView(ts.tableHandle)) {
+                        TableSpec ts =
+                                new TableSpec(catalogManager, conf, ast, frameworkConfig, cluster);
+                        if (ts.table instanceof CatalogView) {
                             throw new SemanticException(ErrorMsg.DML_AGAINST_VIEW.getMsg());
-                        }
-
-                        Class<?> outputFormatClass = ts.tableHandle.getOutputFormatClass();
-                        if (!ts.tableHandle.isNonNative()
-                                && !HiveOutputFormat.class.isAssignableFrom(outputFormatClass)) {
-                            throw new SemanticException(
-                                    HiveParserErrorMsg.getMsg(
-                                            ErrorMsg.INVALID_OUTPUT_FORMAT_TYPE,
-                                            ast,
-                                            "The class is " + outputFormatClass.toString()));
                         }
 
                         boolean isTableWrittenTo =
                                 qb.getParseInfo()
-                                        .isInsertIntoTable(
-                                                ts.tableHandle.getDbName(),
-                                                ts.tableHandle.getTableName());
+                                        .isInsertIntoTable(ts.tableIdentifier.asSummaryString());
                         isTableWrittenTo |=
                                 (qb.getParseInfo()
                                                 .getInsertOverwriteTables()
                                                 .get(
                                                         getUnescapedName(
                                                                 (HiveParserASTNode) ast.getChild(0),
-                                                                ts.tableHandle.getDbName()))
+                                                                ts.tableIdentifier.getCatalogName(),
+                                                                ts.tableIdentifier
+                                                                        .getDatabaseName()))
                                         != null);
                         assert isTableWrittenTo
                                 : "Inconsistent data structure detected: we are writing to "
-                                        + ts.tableHandle
+                                        + ts.tableIdentifier.asSummaryString()
                                         + " in "
                                         + name
                                         + " but it's not in isInsertIntoTable() or getInsertOverwriteTables()";
@@ -1725,18 +1619,30 @@ public class HiveParserSemanticAnalyzer {
                         // but whether the table itself is partitioned is not know.
                         if (ts.specType != SpecType.STATIC_PARTITION) {
                             // This is a table or dynamic partition
-                            qb.getMetaData().setDestForAlias(name, ts.tableHandle);
+                            qb.getMetaData()
+                                    .setDestForAlias(
+                                            name,
+                                            ts.tableIdentifier.asSummaryString(),
+                                            (CatalogTable) ts.table);
                             // has dynamic as well as static partitions
                             if (ts.partSpec != null && ts.partSpec.size() > 0) {
                                 qb.getMetaData().setPartSpecForAlias(name, ts.partSpec);
                             }
                         } else {
+                            // rewrite QBMetaData
                             // This is a partition
-                            qb.getMetaData().setDestForAlias(name, ts.partHandle);
+                            qb.getMetaData()
+                                    .setDestForAlias(
+                                            name,
+                                            ts.tableIdentifier.asSummaryString(),
+                                            (CatalogTable) ts.table,
+                                            ts.partHandle);
                         }
                         if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVESTATSAUTOGATHER)) {
                             // Add the table spec for the destination table.
-                            qb.getParseInfo().addTableSpec(ts.tableName.toLowerCase(), ts);
+                            qb.getParseInfo()
+                                    .addTableSpec(
+                                            ts.tableIdentifier.asSummaryString().toLowerCase(), ts);
                         }
                         break;
                     }
@@ -1781,9 +1687,18 @@ public class HiveParserSemanticAnalyzer {
                                         conf, HiveConf.ConfVars.HIVESTATSAUTOGATHER)) {
                                     TableSpec ts =
                                             new TableSpec(
-                                                    db, conf, this.ast, frameworkConfig, cluster);
+                                                    catalogManager,
+                                                    conf,
+                                                    this.ast,
+                                                    frameworkConfig,
+                                                    cluster);
                                     // Add the table spec for the destination table.
-                                    qb.getParseInfo().addTableSpec(ts.tableName.toLowerCase(), ts);
+                                    qb.getParseInfo()
+                                            .addTableSpec(
+                                                    ts.tableIdentifier
+                                                            .asSummaryString()
+                                                            .toLowerCase(),
+                                                    ts);
                                 }
                             } else {
                                 // This is the only place where isQuery is set to true; it defaults
@@ -1840,20 +1755,21 @@ public class HiveParserSemanticAnalyzer {
     }
 
     private void replaceViewReferenceWithDefinition(
-            HiveParserQB qb, Table tab, String tabName, String alias) throws SemanticException {
+            HiveParserQB qb, CatalogView catalogView, String viewName, String alias)
+            throws SemanticException {
         HiveParserASTNode viewTree;
         final HiveParserASTNodeOrigin viewOrigin =
                 new HiveParserASTNodeOrigin(
                         "VIEW",
-                        tab.getTableName(),
-                        tab.getViewExpandedText(),
+                        viewName,
+                        catalogView.getExpandedQuery(),
                         alias,
                         qb.getParseInfo().getSrcForAlias(alias));
         try {
             // Reparse text, passing null for context to avoid clobbering
             // the top-level token stream.
-            String viewText = tab.getViewExpandedText();
-            viewTree = HiveASTParseUtils.parse(viewText, ctx, tab.getCompleteName());
+            String viewText = catalogView.getExpandedQuery();
+            viewTree = HiveASTParseUtils.parse(viewText, ctx, viewName);
 
             Dispatcher nodeOriginDispatcher =
                     (nd, stack, nodeOutputs) -> {
@@ -1880,9 +1796,9 @@ public class HiveParserSemanticAnalyzer {
                         && !qb.isInsideView()
                         && HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_AUTHORIZATION_ENABLED))
                 || HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_STATS_COLLECT_SCANCOLS)) {
-            qb.rewriteViewToSubq(alias, tabName, qbexpr, tab);
+            qb.rewriteViewToSubq(alias, viewName, qbexpr, catalogView);
         } else {
-            qb.rewriteViewToSubq(alias, tabName, qbexpr, null);
+            qb.rewriteViewToSubq(alias, viewName, qbexpr, null);
         }
     }
 
@@ -2158,6 +2074,44 @@ public class HiveParserSemanticAnalyzer {
         return this.autogenColAliasPrfxLbl;
     }
 
+    public CatalogBaseTable getCatalogBaseTable(String tableName, HiveParserQB qb) {
+        return getCatalogBaseTable(tableName, qb, true);
+    }
+
+    public CatalogBaseTable getCatalogBaseTable(
+            String tableName, HiveParserQB qb, boolean throwException) {
+        // first try to get the table from QB, temp table will be stored in here.
+        // the tableName passed is resolved as 'catalog.db.table', but the temp table is stored as
+        // unresolved which only contains table name, so we need to get the actual table name from
+        // the passed 'tableName'
+        String tempTableName = parseCompoundName(catalogManager, tableName).getObjectName();
+        if (qb.getValuesTableToData().containsKey(tempTableName)) {
+            return qb.getValuesTableToData().get(tempTableName).f0;
+        }
+        // then get the table from catalogs
+        ObjectIdentifier tableIdentifier =
+                catalogManager.qualifyIdentifier(UnresolvedIdentifier.of(tableName.split("\\.")));
+        Optional<ContextResolvedTable> optionalTab = catalogManager.getTable(tableIdentifier);
+        if (!optionalTab.isPresent()) {
+            if (throwException) {
+                throw new IllegalArgumentException(
+                        String.format("Table %s doesn't exist.", tableName));
+            } else {
+                return null;
+            }
+        } else {
+            return optionalTab.get().getTable();
+        }
+    }
+
+    public CatalogTable getCatalogTable(String tableName, HiveParserQB qb) {
+        CatalogBaseTable catalogBaseTable = getCatalogBaseTable(tableName, qb);
+        if (!(catalogBaseTable instanceof CatalogTable)) {
+            throw new IllegalArgumentException(tableName + " isn't a table.");
+        }
+        return (CatalogTable) catalogBaseTable;
+    }
+
     public boolean autogenColAliasPrfxIncludeFuncName() {
         return this.autogenColAliasPrfxIncludeFuncName;
     }
@@ -2224,16 +2178,6 @@ public class HiveParserSemanticAnalyzer {
 
         // init
         this.qb = new HiveParserQB(null, null, false);
-    }
-
-    private Table getTableObjectByName(String tableName) throws HiveException {
-        if (!tabNameToTabObject.containsKey(tableName)) {
-            Table table = db.getTable(tableName);
-            tabNameToTabObject.put(tableName, table);
-            return table;
-        } else {
-            return tabNameToTabObject.get(tableName);
-        }
     }
 
     public boolean genResolvedParseTree(HiveParserASTNode ast, HiveParserPlannerContext plannerCtx)

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/FromClauseASTParser.g
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/FromClauseASTParser.g
@@ -216,6 +216,9 @@ tableName
 @init { gParent.pushMsg("table name", state); }
 @after { gParent.popMsg(state); }
     :
+    (identifier DOT identifier DOT identifier) => cat=identifier DOT db=identifier DOT tab=identifier
+    -> ^(TOK_TABNAME $cat $db $tab)
+    |
     db=identifier DOT tab=identifier
     -> ^(TOK_TABNAME $db $tab)
     |
@@ -227,8 +230,14 @@ viewName
 @init { gParent.pushMsg("view name", state); }
 @after { gParent.popMsg(state); }
     :
-    (db=identifier DOT)? view=identifier
-    -> ^(TOK_TABNAME $db? $view)
+    (identifier DOT identifier DOT identifier) => cat=identifier DOT db=identifier DOT view=identifier
+    -> ^(TOK_TABNAME $cat $db $view)
+    |
+    db=identifier DOT view=identifier
+    -> ^(TOK_TABNAME $db $view)
+    |
+    view=identifier
+    -> ^(TOK_TABNAME $view)
     ;
 
 subQuerySource

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -21,6 +21,8 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.table.HiveVersionTestUtil;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
@@ -45,8 +47,10 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -67,6 +71,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test hive query compatibility. */
 public class HiveDialectQueryITCase {
+
+    @ClassRule public static TemporaryFolder tempFolder = new TemporaryFolder();
 
     private static final String QTEST_DIR =
             Thread.currentThread().getContextClassLoader().getResource("query-test").getPath();
@@ -842,6 +848,65 @@ public class HiveDialectQueryITCase {
                     .hasRootCauseMessage("DISTINCT keyword must be specified");
         } finally {
             tableEnv.executeSql("drop table abcd");
+        }
+    }
+
+    @Test
+    public void testCrossCatalogQueryNoHiveTable() throws Exception {
+        // register a new in-memory catalog
+        Catalog inMemoryCatalog = new GenericInMemoryCatalog("m_catalog", "db");
+        tableEnv.registerCatalog("m_catalog", inMemoryCatalog);
+        tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+        // create a non-hive table
+        tableEnv.executeSql(
+                String.format(
+                        "create table m_catalog.db.t1(x int, y string) "
+                                + "with ('connector' = 'filesystem', 'path' = '%s', 'format'='csv')",
+                        tempFolder.newFolder().toURI()));
+        // create a non-hive partitioned table
+        tableEnv.executeSql(
+                String.format(
+                        "create table m_catalog.db.t2(x int, p1 int,p2 string) partitioned by (p1, p2) "
+                                + "with ('connector' = 'filesystem', 'path' = '%s', 'format'='csv')",
+                        tempFolder.newFolder().toURI()));
+
+        tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
+        // create a hive table
+        tableEnv.executeSql("create table t1(x int, y string)");
+
+        try {
+            // insert data into the non-hive table and hive table
+            tableEnv.executeSql("insert into m_catalog.db.t1 values (1, 'v1'), (2, 'v2')").await();
+            tableEnv.executeSql(
+                            "insert into m_catalog.db.t2 partition (p1=0,p2='static') values (1), (2), (1)")
+                    .await();
+            tableEnv.executeSql("insert into t1 values (1, 'h1'), (4, 'h2')").await();
+            // query a non-hive table
+            List<Row> result =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql("select * from m_catalog.db.t1 sort by x desc")
+                                    .collect());
+            assertThat(result.toString()).isEqualTo("[+I[2, v2], +I[1, v1]]");
+            // query a non-hive partitioned table
+            result =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql("select * from m_catalog.db.t2 cluster by x")
+                                    .collect());
+            assertThat(result.toString())
+                    .isEqualTo("[+I[1, 0, static], +I[1, 0, static], +I[2, 0, static]]");
+            // join a table using a hive table and a non-hive table
+            result =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql(
+                                            "select ht1.x, ht1.y from m_catalog.db.t1 as mt1 join t1 as ht1 using (x)")
+                                    .collect());
+            assertThat(result.toString()).isEqualTo("[+I[1, h1]]");
+        } finally {
+            tableEnv.getConfig().setSqlDialect(SqlDialect.DEFAULT);
+            tableEnv.executeSql("drop table m_catalog.db.t1");
+            tableEnv.executeSql("drop table m_catalog.db.t2");
+            tableEnv.executeSql("drop table t1");
+            tableEnv.getConfig().setSqlDialect(SqlDialect.HIVE);
         }
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
Ti fix the failure for the query with non-hive table in Hive dialect.

## Brief change log
- Modify [FromClauseASTParser.g](https://github.com/apache/flink/pull/20855/files#diff-2c1c44e0dd96a52613a64a23d27f68596207577457d5a0d2cbc9f1447daeba0f) to make table can be `catalog.db.table`.
- Parse table name user specified to `catalog.db.table` intead of `db.table`.
- Replace the Hive's `Table` which only represents `db.table` with Flink's `CatalogTable` which can  represents `catalog.db.table`.


## Verifying this change
Added test in [HiveDialectQueryITCase.java](https://github.com/apache/flink/pull/20855/files#diff-fb5fc4106e27e27f9968e59b643003444fd40af58aa2f147ac301009b53a47ca).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
