### PR TITLE
[hotfix] Fix the problem that BatchShuffleItCase not subject to configuration.

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/BatchShuffleITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/BatchShuffleITCaseBase.java
@@ -69,13 +69,18 @@ class BatchShuffleITCaseBase {
         tmpDir = TempDirUtils.newFolder(path, UUID.randomUUID().toString()).toPath();
     }
 
-    protected JobGraph createJobGraph(int numRecordsToSend, boolean failExecution) {
-        return createJobGraph(numRecordsToSend, failExecution, false);
+    protected JobGraph createJobGraph(
+            int numRecordsToSend, boolean failExecution, Configuration configuration) {
+        return createJobGraph(numRecordsToSend, failExecution, false, configuration);
     }
 
     protected JobGraph createJobGraph(
-            int numRecordsToSend, boolean failExecution, boolean deletePartitionFile) {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            int numRecordsToSend,
+            boolean failExecution,
+            boolean deletePartitionFile,
+            Configuration configuration) {
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
         env.setRestartStrategy(RestartStrategies.fixedDelayRestart(10, 0L));
         env.setParallelism(NUM_SLOTS_PER_TASK_MANAGER);
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/BlockingShuffleITCase.java
@@ -32,23 +32,21 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
     @Test
     public void testBoundedBlockingShuffle() throws Exception {
         final int numRecordsToSend = 1000000;
-        JobGraph jobGraph = createJobGraph(1000000, false, false);
         Configuration configuration = getConfiguration();
         configuration.setInteger(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
                 Integer.MAX_VALUE);
-
+        JobGraph jobGraph = createJobGraph(numRecordsToSend, false, false, configuration);
         executeJob(jobGraph, configuration, numRecordsToSend);
     }
 
     @Test
     public void testBoundedBlockingShuffleWithoutData() throws Exception {
-        JobGraph jobGraph = createJobGraph(0, false, false);
         Configuration configuration = getConfiguration();
         configuration.setInteger(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
                 Integer.MAX_VALUE);
-
+        JobGraph jobGraph = createJobGraph(0, false, false, configuration);
         executeJob(jobGraph, configuration, 0);
     }
 
@@ -59,7 +57,7 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
         configuration.setInteger(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 64);
 
-        JobGraph jobGraph = createJobGraph(1000000, false, false);
+        JobGraph jobGraph = createJobGraph(numRecordsToSend, false, false, configuration);
         executeJob(jobGraph, configuration, numRecordsToSend);
     }
 
@@ -69,7 +67,7 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
         configuration.setInteger(
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_BUFFERS, 64);
 
-        JobGraph jobGraph = createJobGraph(0, false, false);
+        JobGraph jobGraph = createJobGraph(0, false, false, configuration);
         executeJob(jobGraph, configuration, 0);
     }
 
@@ -80,14 +78,14 @@ class BlockingShuffleITCase extends BatchShuffleITCaseBase {
                 NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM,
                 Integer.MAX_VALUE);
 
-        JobGraph jobGraph = createJobGraph(0, false, true);
+        JobGraph jobGraph = createJobGraph(0, false, true, configuration);
         executeJob(jobGraph, configuration, 0);
     }
 
     @Test
     public void testDeletePartitionFileOfSortMergeBlockingShuffle() throws Exception {
         Configuration configuration = getConfiguration();
-        JobGraph jobGraph = createJobGraph(0, false, true);
+        JobGraph jobGraph = createJobGraph(0, false, true, configuration);
         executeJob(jobGraph, configuration, 0);
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/HybridShuffleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/HybridShuffleITCase.java
@@ -34,7 +34,7 @@ class HybridShuffleITCase extends BatchShuffleITCaseBase {
         Configuration configuration = getConfiguration();
         configuration.set(
                 ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_HYBRID_FULL);
-        JobGraph jobGraph = createJobGraph(numRecordsToSend, false);
+        JobGraph jobGraph = createJobGraph(numRecordsToSend, false, configuration);
         executeJob(jobGraph, configuration, numRecordsToSend);
     }
 
@@ -45,7 +45,7 @@ class HybridShuffleITCase extends BatchShuffleITCaseBase {
         configuration.set(
                 ExecutionOptions.BATCH_SHUFFLE_MODE,
                 BatchShuffleMode.ALL_EXCHANGES_HYBRID_SELECTIVE);
-        JobGraph jobGraph = createJobGraph(numRecordsToSend, false);
+        JobGraph jobGraph = createJobGraph(numRecordsToSend, false, configuration);
         executeJob(jobGraph, configuration, numRecordsToSend);
     }
 
@@ -55,7 +55,7 @@ class HybridShuffleITCase extends BatchShuffleITCaseBase {
         Configuration configuration = getConfiguration();
         configuration.set(
                 ExecutionOptions.BATCH_SHUFFLE_MODE, BatchShuffleMode.ALL_EXCHANGES_HYBRID_FULL);
-        JobGraph jobGraph = createJobGraph(numRecordsToSend, true);
+        JobGraph jobGraph = createJobGraph(numRecordsToSend, true, configuration);
         executeJob(jobGraph, configuration, numRecordsToSend);
     }
 
@@ -66,7 +66,7 @@ class HybridShuffleITCase extends BatchShuffleITCaseBase {
         configuration.set(
                 ExecutionOptions.BATCH_SHUFFLE_MODE,
                 BatchShuffleMode.ALL_EXCHANGES_HYBRID_SELECTIVE);
-        JobGraph jobGraph = createJobGraph(numRecordsToSend, true);
+        JobGraph jobGraph = createJobGraph(numRecordsToSend, true, configuration);
         executeJob(jobGraph, configuration, numRecordsToSend);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Fix the problem that `BatchShuffleItCase` not subject to configuration.*


## Brief change log

  - *pass configuration to `StreamExecutionEnvironment.getExecutionEnvironment`*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
