### PR TITLE
[FLINK-29347] [runtime] Fix ByteStreamStateHandle#read return -1 when read count is 0

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java
@@ -148,7 +148,7 @@ public class ByteStreamStateHandle implements StreamStateHandle {
                 index += bytesToCopy;
                 return bytesToCopy;
             } else {
-                return -1;
+                return len == 0 ? 0 : -1;
             }
         }
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
@@ -172,4 +172,15 @@ public class ByteStreamStateHandleTest {
             // expected
         }
     }
+
+    @Test
+    public void testStreamWithEmptyByteArray() throws IOException {
+        final byte[] data = new byte[0];
+        final ByteStreamStateHandle handle = new ByteStreamStateHandle("name", data);
+
+        FSDataInputStream in = handle.openInputStream();
+        in.seek(0);
+        byte[] dataGot = new byte[1];
+        assertEquals(0, in.read(dataGot, 0, 0));
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
@@ -178,7 +178,7 @@ public class ByteStreamStateHandleTest {
         final byte[] data = new byte[0];
         final ByteStreamStateHandle handle = new ByteStreamStateHandle("name", data);
 
-        try(FSDataInputStream in = handle.openInputStream()) {
+        try (FSDataInputStream in = handle.openInputStream()) {
             byte[] dataGot = new byte[1];
             assertEquals(0, in.read(dataGot, 0, 0)); // got return 0 because len == 0.
             assertEquals(-1, in.read()); // got -1 because of EOF.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandleTest.java
@@ -178,9 +178,10 @@ public class ByteStreamStateHandleTest {
         final byte[] data = new byte[0];
         final ByteStreamStateHandle handle = new ByteStreamStateHandle("name", data);
 
-        FSDataInputStream in = handle.openInputStream();
-        in.seek(0);
-        byte[] dataGot = new byte[1];
-        assertEquals(0, in.read(dataGot, 0, 0));
+        try(FSDataInputStream in = handle.openInputStream()) {
+            byte[] dataGot = new byte[1];
+            assertEquals(0, in.read(dataGot, 0, 0)); // got return 0 because len == 0.
+            assertEquals(-1, in.read()); // got -1 because of EOF.
+        }
     }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
When protobuf serializer serializes an object, which is built directly with builder without assign any value to field, the serializer will generate a zero length byte[] and then write it into state with content '\0'（indicates zero length data).

When recovered from checkpoint, protobuf seralizer deserialize the data. It get length 0, and call InputStream#read(byte[] bytes, int offset, int count) with count = 0.

The underlying Input implementation is [NoFetchingInput](https://github.com/apache/flink/blob/9d2ae5572897f3e2d9089414261a250cfc2a2ab8/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NoFetchingInput.java). It will call Inputsteam#read(byte[] bytes, int offset, int count) with count = 0.

The InputStream implementation is [ByteStateHandleInputStream](https://github.com/apache/flink/blob/53d5e1cf9666517bc2fded60b510f2fd13d93f10/flink-runtime/src/main/java/org/apache/flink/runtime/state/memory/ByteStreamStateHandle.java#L140-L153)，It will return -1 as long as no data left in memory, even if count is 0.

Any seralizer/deserializer with implementation like protobuf will encounter problem like this (can not recovery from checkpoint with empty length serialized value).

## Brief change log

Add check before return -1 in ByteStateHandleInputStream#read(byte[] bytes, int offset, int count). If caller reads 0 bytes, it should always return 0 instead of -1.


## Verifying this change

This change added tests and can be verified as follows:

  - Use a protobuf generated class as value in list state. Build object of the class with builder and set no field. Try recovery from checkpoint. Before this fix, recovery should fail.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (don't know)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
