### PR TITLE
[FLINK-14896][connectors/kinesis] Shade and relocate Jackson dependen…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -325,6 +325,8 @@ under the License.
 									<include>org.reactivestreams:*</include>
 									<include>io.netty:*</include>
 									<include>com.typesafe.netty:*</include>
+									<include>com.fasterxml.jackson.core:*</include>
+									<include>com.fasterxml.jackson.dataformat:*</include>
 								</includes>
 							</artifactSet>
 							<relocations combine.children="override">
@@ -365,6 +367,10 @@ under the License.
 								<relocation>
 									<pattern>org.reactivestreams</pattern>
 									<shadedPattern>org.apache.flink.kinesis.shaded.org.reactivestreams</shadedPattern>
+								</relocation>
+								<relocation>
+									<pattern>com.fasterxml.jackson</pattern>
+									<shadedPattern>org.apache.flink.kinesis.shaded.com.fasterxml.jackson</shadedPattern>
 								</relocation>
 							</relocations>
 							<filters>

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -17,6 +17,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-cloudwatch:1.12.276
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.3
 - com.amazonaws:jmespath-java:1.12.276
+- com.fasterxml.jackson.core:jackson-annotations:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.2
+- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - software.amazon.ion:ion-java:1.0.2

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -69,10 +69,6 @@ under the License.
 								<includes>
 									<include>org.apache.flink:flink-connector-base</include>
 									<include>org.apache.flink:flink-connector-kinesis</include>
-									<include>com.fasterxml.jackson.core:jackson-core</include>
-									<include>com.fasterxml.jackson.core:jackson-databind</include>
-									<include>com.fasterxml.jackson.core:jackson-annotations</include>
-									<include>com.fasterxml.jackson.dataformat:jackson-dataformat-cbor</include>
 									<include>joda-time:joda-time</include>
 									<include>commons-codec:commons-codec</include>
 									<include>commons-io:commons-io</include>
@@ -95,10 +91,6 @@ under the License.
 								</filter>
 							</filters>
 							<relocations>
-								<relocation>
-									<pattern>com.fasterxml.jackson</pattern>
-									<shadedPattern>org.apache.flink.kinesis.shaded.com.fasterxml.jackson</shadedPattern>
-								</relocation>
 								<relocation>
 									<pattern>org.apache.commons</pattern>
 									<shadedPattern>org.apache.flink.kinesis.shaded.org.apache.commons</shadedPattern>

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,3 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - com.google.guava:guava:29.0-jre
 - com.google.guava:failureaccess:1.0.1
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2


### PR DESCRIPTION
## What is the purpose of the change

- Shade and relocate Jackson dependencies within `flink-kinesis-connector` to avoid conflicts with user code

## Brief change log

- Shade and relocate Jackson dependencies within `flink-kinesis-connector`
- Update NOTICE file in `flink-kinesis-connector` and `flink-sql-kinesis-connector`

## Verifying this change

This change is already covered by existing tests, such as unit tests, integration and end-to-end tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
