### PR TITLE
[FLINK-29375][rpc] Move getSelfGateway() into RpcService

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -197,6 +197,20 @@ public class AkkaRpcService implements RpcService {
         return port;
     }
 
+    public <C extends RpcGateway> C getSelfGateway(Class<C> selfGatewayType, RpcServer rpcServer) {
+        if (selfGatewayType.isInstance(rpcServer)) {
+            @SuppressWarnings("unchecked")
+            C selfGateway = ((C) rpcServer);
+
+            return selfGateway;
+        } else {
+            throw new RuntimeException(
+                    "RpcEndpoint does not implement the RpcGateway interface of type "
+                            + selfGatewayType
+                            + '.');
+        }
+    }
+
     // this method does not mutate state and is thus thread-safe
     @Override
     public <C extends RpcGateway> CompletableFuture<C> connect(

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaRpcService.java
@@ -204,7 +204,7 @@ public class AkkaRpcService implements RpcService {
 
             return selfGateway;
         } else {
-            throw new RuntimeException(
+            throw new ClassCastException(
                     "RpcEndpoint does not implement the RpcGateway interface of type "
                             + selfGatewayType
                             + '.');

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcEndpoint.java
@@ -308,17 +308,7 @@ public abstract class RpcEndpoint implements RpcGateway, AutoCloseableAsync {
      * @return Self gateway of the specified type which can be used to issue asynchronous rpcs
      */
     public <C extends RpcGateway> C getSelfGateway(Class<C> selfGatewayType) {
-        if (selfGatewayType.isInstance(rpcServer)) {
-            @SuppressWarnings("unchecked")
-            C selfGateway = ((C) rpcServer);
-
-            return selfGateway;
-        } else {
-            throw new RuntimeException(
-                    "RpcEndpoint does not implement the RpcGateway interface of type "
-                            + selfGatewayType
-                            + '.');
-        }
+        return rpcService.getSelfGateway(selfGatewayType, rpcServer);
     }
 
     /**

--- a/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
+++ b/flink-rpc/flink-rpc-core/src/main/java/org/apache/flink/runtime/rpc/RpcService.java
@@ -48,6 +48,19 @@ public interface RpcService {
     int getPort();
 
     /**
+     * Returns a self gateway of the specified type which can be used to issue asynchronous calls
+     * against the RpcEndpoint.
+     *
+     * <p>IMPORTANT: The self gateway type must be implemented by the RpcEndpoint. Otherwise the
+     * method will fail.
+     *
+     * @param <C> type of the self gateway to create
+     * @param selfGatewayType class of the self gateway type
+     * @return Self gateway of the specified type which can be used to issue asynchronous rpcs
+     */
+    <C extends RpcGateway> C getSelfGateway(Class<C> selfGatewayType, RpcServer rpcServer);
+
+    /**
      * Connect to a remote rpc server under the provided address. Returns a rpc gateway which can be
      * used to communicate with the rpc server. If the connection failed, then the returned future
      * is failed with a {@link RpcConnectionException}.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rpc/TestingRpcService.java
@@ -190,6 +190,11 @@ public class TestingRpcService implements RpcService {
     }
 
     @Override
+    public <C extends RpcGateway> C getSelfGateway(Class<C> selfGatewayType, RpcServer rpcServer) {
+        return backingRpcService.getSelfGateway(selfGatewayType, rpcServer);
+    }
+
+    @Override
     public <C extends RpcEndpoint & RpcGateway> RpcServer startServer(C rpcEndpoint) {
         return backingRpcService.startServer(rpcEndpoint);
     }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorEventSendingCheckpointITCase.java
@@ -478,6 +478,12 @@ public class OperatorEventSendingCheckpointITCase extends TestLogger {
         }
 
         @Override
+        public <C extends RpcGateway> C getSelfGateway(
+                Class<C> selfGatewayType, RpcServer rpcServer) {
+            return rpcService.getSelfGateway(selfGatewayType, rpcServer);
+        }
+
+        @Override
         public <C extends RpcGateway> CompletableFuture<C> connect(String address, Class<C> clazz) {
             final CompletableFuture<C> future = rpcService.connect(address, clazz);
             return clazz == TaskExecutorGateway.class ? decorateTmGateway(future) : future;


### PR DESCRIPTION
Give RpcServices control over how self gateways are implemented.
(Note that we don't really have a definition of what a self-gateway even _is_. Right now it's a sort of local gateway that skips serialization; but generally speaking that isn't required and more-or-less a performance optimization).

This is particularly interesting because how we implement it for Akka is rather strange, with the AkkaInvocationHandler impklementing both the `RpcGateway` _and_ `RpcServer` interface, despite never actually acting as an rpc server, making it difficult to wrap your head around what this handler actually does.
I don't think we should replicate that for other rpc implementations.