### PR TITLE
[FLINK-29340][coordination][tests] Avoid selfGateway implementation d…

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/ResourceManagerTest.java
@@ -363,11 +363,11 @@ class ResourceManagerTest {
                         () -> {
                             assertThat(processRequirementsFuture.isDone()).isFalse();
                             readyToServeFuture.complete(null);
-                            assertThat(processRequirementsFuture.isDone()).isTrue();
                             return null;
                         },
                         TIMEOUT)
                 .get(TIMEOUT.toMilliseconds(), TimeUnit.MILLISECONDS);
+        processRequirementsFuture.get();
     }
 
     @Test


### PR DESCRIPTION
The test incorrectly assumes that the `declareRequiredResources` has already been run when calling `runInMainThread`, while the RPC could (theoretically) still be in flight.
Currently this won't happen due to how the akka self gateways work, but I'd prefer tests to not rely on that to allow other implementations.

This could result in the test failing because within `runInMainThread` the test assumes that completing the `readyToServeFuture` will immediately result in the processing of resources, due to this workflow having been set up within `delcareRequiredResources`. If that didn't happen (yet) the test will just fail because the completion of the future has in practice no effect.