### PR TITLE
[FLINK-29378][coordination] Improve logging of failed execution state transitions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1226,8 +1226,8 @@ public class Execution
             } else {
                 String message =
                         String.format(
-                                "Concurrent unexpected state transition of task %s to %s while deployment was in progress.",
-                                getVertexWithAttempt(), currentState);
+                                "Concurrent unexpected state transition of task %s from %s (expected %s) to %s while deployment was in progress.",
+                                getAttemptId(), currentState, from, to);
 
                 LOG.debug(message);
 


### PR DESCRIPTION
Before:
`Concurrent unexpected state transition of task HelloWorld_1 to DEPLOYING while deployment was in progress.`
After:
`Concurrent unexpected state transition of task abc_def_1 from DEPLOYING (expected INITIALIZING) to RUNNING while deployment was in progress.`