### PR TITLE
[FLINK-29363][runtime-web] allow fully redirection in web dashboard

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
+++ b/flink-runtime-web/web-dashboard/src/app/app.interceptor.ts
@@ -16,7 +16,14 @@
  * limitations under the License.
  */
 
-import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import {
+  HttpEvent,
+  HttpHandler,
+  HttpInterceptor,
+  HttpRequest,
+  HttpResponseBase,
+  HttpStatusCode
+} from '@angular/common/http';
 import { Injectable, Injector } from '@angular/core';
 import { Observable, throwError } from 'rxjs';
 import { catchError } from 'rxjs/operators';
@@ -39,6 +46,16 @@ export class AppInterceptor implements HttpInterceptor {
 
     return next.handle(req.clone({ withCredentials: true })).pipe(
       catchError(res => {
+        if (
+          res instanceof HttpResponseBase &&
+          (res.status == HttpStatusCode.MovedPermanently ||
+            res.status == HttpStatusCode.TemporaryRedirect ||
+            res.status == HttpStatusCode.SeeOther) &&
+          res.headers.has('Location')
+        ) {
+          window.location.href = String(res.headers.get('Location'));
+        }
+
         const errorMessage = res && res.error && res.error.errors && res.error.errors[0];
         if (
           errorMessage &&


### PR DESCRIPTION
## What is the purpose of the change
Remove operator related configs from flink runtime config, so that users will not see any operator related config in web ui.

## Brief change log
  - remove operator configs before deployments in Flink services.

## Verifying this change

This change is a trivial rework / code cleanup with unit test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (no)
  - Core observer or reconciler logic that is regularly executed: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
