### PR TITLE
[FLINK-29389][docs] Update documentation of JDBC and HBase lookup table for new caching options

### DIFF
--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -172,7 +172,7 @@ ON myTopic.key = hTable.rowkey;
       <td>可选</td>
       <td style="word-wrap: break-word;">NONE</td>
       <td><p>枚举类型</p>可选值: NONE, PARTIAL</td>
-      <td>维表的缓存策略。 目前支持 NONE（不缓存）和 PARTIAL（伴随在外部数据库中查找数据的过程缓存）。</td>
+      <td>维表的缓存策略。 目前支持 NONE（不缓存）和 PARTIAL（只在外部数据库中查找数据时缓存）。</td>
     </tr>
     <tr>
       <td><h5>lookup.partial-cache.max-rows</h5></td>
@@ -245,7 +245,7 @@ ON myTopic.key = hTable.rowkey;
           <td>yes</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>Integer</td>
-          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.max-rows" 作为替代</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.max-rows" 代替</td>
         </tr>
         <tr>
           <td><h5>lookup.cache.ttl</h5></td>
@@ -253,7 +253,7 @@ ON myTopic.key = hTable.rowkey;
           <td>yes</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>Duration</td>
-          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.expire-after-write" 作为替代</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.expire-after-write" 代替</td>
         </tr>
     </tbody>
 <table>

--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -168,18 +168,42 @@ ON myTopic.key = hTable.rowkey;
       <td>是否启用异步查找。如果为真，查找将是异步的。注意：异步方式只支持 hbase-2.2 连接器</td>
     </tr>
     <tr>
-      <td><h5>lookup.cache.max-rows</h5></td>
+      <td><h5>lookup.cache</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">-1</td>
-      <td>Long</td>
-      <td>查找缓存的最大行数，超过这个值，最旧的行将过期。注意："lookup.cache.max-rows" 和 "lookup.cache.ttl" 必须同时被设置。默认情况下，查找缓存是禁用的。 </td>
+      <td style="word-wrap: break-word;">NONE</td>
+      <td><p>枚举类型</p>可选值: NONE, PARTIAL</td>
+      <td>维表的缓存策略。 目前支持 NONE（不缓存）和 PARTIAL（伴随在外部数据库中查找数据的过程缓存）。</td>
     </tr>
     <tr>
-      <td><h5>lookup.cache.ttl</h5></td>
+      <td><h5>lookup.partial-cache.max-rows</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">0 s</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Long</td>
+      <td>查找缓存的最大行数，超过这个值，最旧的行将过期。使用该配置时 "lookup.cache" 必须设置为 "PARTIAL”。</td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.expire-after-write</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">(none)</td>
       <td>Duration</td>
-      <td>查找缓存中每一行的最大生存时间，在这段时间内，最老的行将过期。注意："lookup.cache.max-rows" 和 "lookup.cache.ttl" 必须同时被设置。默认情况下，查找缓存是禁用的。</td>
+      <td>在记录写入缓存后该记录的最大保留时间。
+      使用该配置时 "lookup.cache" 必须设置为 "PARTIAL”。</td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.expire-after-access</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Duration</td>
+      <td>在缓存中的记录被访问后该记录的最大保留时间。
+      使用该配置时 "lookup.cache" 必须设置为 "PARTIAL”。</td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.caching-missing-key</h5></td>
+      <td>可选</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>是否缓存维表中不存在的键，默认为true。
+        使用该配置时 "lookup.cache" 必须设置为 "PARTIAL”。</td>
     </tr>
     <tr>
       <td><h5>lookup.max-retries</h5></td>

--- a/docs/content.zh/docs/connectors/table/hbase.md
+++ b/docs/content.zh/docs/connectors/table/hbase.md
@@ -225,6 +225,39 @@ ON myTopic.key = hTable.rowkey;
     </tbody>
 </table>
 
+### 已弃用的配置
+这些弃用配置已经被上述的新配置代替，而且最终会被弃用。请优先考虑使用新配置。
+<table>
+    <thead>
+      <tr>
+        <th class="text-left" style="width: 25%">Option</th>
+        <th class="text-left" style="width: 8%">Required</th>
+        <th class="text-left" style="width: 8%">Forwarded</th>
+        <th class="text-left" style="width: 7%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 42%">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td><h5>lookup.cache.max-rows</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Integer</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.max-rows" 作为替代</td>
+        </tr>
+        <tr>
+          <td><h5>lookup.cache.ttl</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Duration</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.expire-after-write" 作为替代</td>
+        </tr>
+    </tbody>
+<table>
+
 
 
 数据类型映射表

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -279,6 +279,47 @@ ON myTopic.key = MyUserTable.id;
     </tbody>
 </table>
 
+### 已弃用的配置
+这些弃用配置已经被上述的新配置代替，而且最终会被弃用。请优先考虑使用新配置。
+<table>
+    <thead>
+      <tr>
+        <th class="text-left" style="width: 25%">Option</th>
+        <th class="text-left" style="width: 8%">Required</th>
+        <th class="text-left" style="width: 8%">Forwarded</th>
+        <th class="text-left" style="width: 7%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 42%">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td><h5>lookup.cache.max-rows</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Integer</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.max-rows" 作为替代</td>
+        </tr>
+        <tr>
+          <td><h5>lookup.cache.ttl</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Duration</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.expire-after-write" 作为替代</td>
+        </tr>
+        <tr>
+          <td><h5>lookup.cache.caching-missing-key</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">true</td>
+          <td>Boolean</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.caching-missing-key" 作为替代</td>
+        </tr>
+    </tbody>
+<table>
+
 <a name="features"></a>
 
 特性

--- a/docs/content.zh/docs/connectors/table/jdbc.md
+++ b/docs/content.zh/docs/connectors/table/jdbc.md
@@ -207,7 +207,7 @@ ON myTopic.key = MyUserTable.id;
       <td>可选</td>
       <td style="word-wrap: break-word;">NONE</td>
       <td><p>枚举类型</p>可选值: NONE, PARTIAL</td>
-      <td>维表的缓存策略。 目前支持 NONE（不缓存）和 PARTIAL（伴随在外部数据库中查找数据的过程缓存）。</td>
+      <td>维表的缓存策略。 目前支持 NONE（不缓存）和 PARTIAL（只在外部数据库中查找数据时缓存）。</td>
     </tr>
     <tr>
       <td><h5>lookup.cache.max-rows</h5></td>
@@ -299,7 +299,7 @@ ON myTopic.key = MyUserTable.id;
           <td>yes</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>Integer</td>
-          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.max-rows" 作为替代</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.max-rows" 代替</td>
         </tr>
         <tr>
           <td><h5>lookup.cache.ttl</h5></td>
@@ -307,7 +307,7 @@ ON myTopic.key = MyUserTable.id;
           <td>yes</td>
           <td style="word-wrap: break-word;">(none)</td>
           <td>Duration</td>
-          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.expire-after-write" 作为替代</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.expire-after-write" 代替</td>
         </tr>
         <tr>
           <td><h5>lookup.cache.caching-missing-key</h5></td>
@@ -315,7 +315,7 @@ ON myTopic.key = MyUserTable.id;
           <td>yes</td>
           <td style="word-wrap: break-word;">true</td>
           <td>Boolean</td>
-          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.caching-missing-key" 作为替代</td>
+          <td>请配置 "lookup.cache" = "PARTIAL" 并使用 "lookup.partial-cache.caching-missing-key" 代替</td>
         </tr>
     </tbody>
 <table>

--- a/docs/content/docs/connectors/table/hbase.md
+++ b/docs/content/docs/connectors/table/hbase.md
@@ -252,6 +252,39 @@ Connector Options
     </tbody>
 </table>
 
+### Deprecated Options
+These deprecated options has been replaced by new options listed above and will be removed eventually. Please consider using new options first.
+<table>
+    <thead>
+      <tr>
+        <th class="text-left" style="width: 25%">Option</th>
+        <th class="text-left" style="width: 8%">Required</th>
+        <th class="text-left" style="width: 8%">Forwarded</th>
+        <th class="text-left" style="width: 7%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 42%">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td><h5>lookup.cache.max-rows</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Integer</td>
+          <td>Please set "lookup.cache" = "PARTIAL" and use "lookup.partial-cache.max-rows" instead.</td>
+        </tr>
+        <tr>
+          <td><h5>lookup.cache.ttl</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Duration</td>
+          <td>Please set "lookup.cache" = "PARTIAL" and use "lookup.partial-cache.expire-after-write" instead.</td>
+        </tr>
+    </tbody>
+<table>
+
 
 
 Data Type Mapping

--- a/docs/content/docs/connectors/table/hbase.md
+++ b/docs/content/docs/connectors/table/hbase.md
@@ -188,20 +188,48 @@ Connector Options
       <td>Whether async lookup are enabled. If true, the lookup will be async. Note, async only supports hbase-2.2 connector.</td>
     </tr>
     <tr>
-      <td><h5>lookup.cache.max-rows</h5></td>
+      <td><h5>lookup.cache</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">-1</td>
-      <td>Long</td>
-      <td>The max number of rows of lookup cache, over this value, the oldest rows will be expired. Note, "lookup.cache.max-rows" and "lookup.cache.ttl" options must all be specified if any of them is specified. Lookup cache is disabled by default.</td>
+      <td style="word-wrap: break-word;">NONE</td>
+      <td><p>Enum</p>Possible values: NONE, PARTIAL</td>
+      <td>The cache strategy for the lookup table. Currently supports NONE (no caching) and PARTIAL (caching entries on lookup operation in external database).</td>
     </tr>
     <tr>
-      <td><h5>lookup.cache.ttl</h5></td>
+      <td><h5>lookup.partial-cache.max-rows</h5></td>
       <td>optional</td>
       <td>yes</td>
-      <td style="word-wrap: break-word;">0 s</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Long</td>
+      <td>The max number of rows of lookup cache, over this value, the oldest rows will be expired. 
+        "lookup.cache" must be set to "PARTIAL" to use this option.</td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.expire-after-write</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">(none)</td>
       <td>Duration</td>
-      <td>The max time to live for each rows in lookup cache, over this time, the oldest rows will be expired. Note, "cache.max-rows" and "cache.ttl" options must all be specified if any of them is specified.Lookup cache is disabled by default.</td>
+      <td>The max time to live for each rows in lookup cache after writing into the cache
+        "lookup.cache" must be set to "PARTIAL" to use this option. </td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.expire-after-access</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Duration</td>
+      <td>The max time to live for each rows in lookup cache after accessing the entry in the cache.
+      "lookup.cache" must be set to "PARTIAL" to use this option. </td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.caching-missing-key</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">true</td>
+      <td>Boolean</td>
+      <td>Whether to store an empty value into the cache if the lookup key doesn't match any rows in the table. 
+        "lookup.cache" must be set to "PARTIAL" to use this option.</td>
     </tr>
     <tr>
       <td><h5>lookup.max-retries</h5></td>

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -297,6 +297,47 @@ Connector Options
     </tbody>
 </table>
 
+### Deprecated Options
+These deprecated options has been replaced by new options listed above and will be removed eventually. Please consider using new options first.
+<table>
+    <thead>
+      <tr>
+        <th class="text-left" style="width: 25%">Option</th>
+        <th class="text-left" style="width: 8%">Required</th>
+        <th class="text-left" style="width: 8%">Forwarded</th>
+        <th class="text-left" style="width: 7%">Default</th>
+        <th class="text-left" style="width: 10%">Type</th>
+        <th class="text-left" style="width: 42%">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+        <tr>
+          <td><h5>lookup.cache.max-rows</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Integer</td>
+          <td>Please set "lookup.cache" = "PARTIAL" and use "lookup.partial-cache.max-rows" instead.</td>
+        </tr>
+        <tr>
+          <td><h5>lookup.cache.ttl</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">(none)</td>
+          <td>Duration</td>
+          <td>Please set "lookup.cache" = "PARTIAL" and use "lookup.partial-cache.expire-after-write" instead.</td>
+        </tr>
+        <tr>
+          <td><h5>lookup.cache.caching-missing-key</h5></td>
+          <td>optional</td>
+          <td>yes</td>
+          <td style="word-wrap: break-word;">true</td>
+          <td>Boolean</td>
+          <td>Please set "lookup.cache" = "PARTIAL" and use "lookup.partial-cache.caching-missing-key" instead.</td>
+        </tr>
+    </tbody>
+<table>
+
 Features
 --------
 

--- a/docs/content/docs/connectors/table/jdbc.md
+++ b/docs/content/docs/connectors/table/jdbc.md
@@ -211,30 +211,48 @@ Connector Options
       <a href="https://jdbc.postgresql.org/documentation/head/query.html#query-with-cursor">Postgres</a>, may require this to be set to false in order to stream results.</td>
     </tr>
     <tr>
-      <td><h5>lookup.cache.max-rows</h5></td>
+      <td><h5>lookup.cache</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">NONE</td>
+      <td><p>Enum</p>Possible values: NONE, PARTIAL</td>
+      <td>The cache strategy for the lookup table. Currently supports NONE (no caching) and PARTIAL (caching entries on lookup operation in external database).</td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.max-rows</h5></td>
       <td>optional</td>
       <td>yes</td>
       <td style="word-wrap: break-word;">(none)</td>
-      <td>Integer</td>
+      <td>Long</td>
       <td>The max number of rows of lookup cache, over this value, the oldest rows will be expired.
-      Lookup cache is disabled by default. See the following <a href="#lookup-cache">Lookup Cache</a> section for more details.</td>
+      "lookup.cache" must be set to "PARTIAL" to use this option. See the following <a href="#lookup-cache">Lookup Cache</a> section for more details.</td>
     </tr>
     <tr>
-      <td><h5>lookup.cache.ttl</h5></td>
+      <td><h5>lookup.partial-cache.expire-after-write</h5></td>
       <td>optional</td>
       <td>yes</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>Duration</td>
-      <td>The max time to live for each rows in lookup cache, over this time, the oldest rows will be expired.
-      Lookup cache is disabled by default. See the following <a href="#lookup-cache">Lookup Cache</a> section for more details. </td>
+      <td>The max time to live for each rows in lookup cache after writing into the cache. 
+      "lookup.cache" must be set to "PARTIAL" to use this option. See the following <a href="#lookup-cache">Lookup Cache</a> section for more details. </td>
     </tr>
     <tr>
-      <td><h5>lookup.cache.caching-missing-key</h5></td>
+      <td><h5>lookup.partial-cache.expire-after-access</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">(none)</td>
+      <td>Duration</td>
+      <td>The max time to live for each rows in lookup cache after accessing the entry in the cache.
+      "lookup.cache" must be set to "PARTIAL" to use this option. See the following <a href="#lookup-cache">Lookup Cache</a> section for more details. </td>
+    </tr>
+    <tr>
+      <td><h5>lookup.partial-cache.caching-missing-key</h5></td>
       <td>optional</td>
       <td>yes</td>
       <td style="word-wrap: break-word;">true</td>
       <td>Boolean</td>
-      <td>Flag to cache missing key, true by default</td>
+      <td>Whether to store an empty value into the cache if the lookup key doesn't match any rows in the table. 
+        "lookup.cache" must be set to "PARTIAL" to use this option.</td>
     </tr>
     <tr>
       <td><h5>lookup.max-retries</h5></td>
@@ -306,14 +324,14 @@ The `scan.partition.column` must be a numeric, date, or timestamp column from th
 
 JDBC connector can be used in temporal join as a lookup source (aka. dimension table). Currently, only sync lookup mode is supported.
 
-By default, lookup cache is not enabled. You can enable it by setting both `lookup.cache.max-rows` and `lookup.cache.ttl`.
+By default, lookup cache is not enabled. You can enable it by setting `lookup.cache` to `PARTIAL`.
 
 The lookup cache is used to improve performance of temporal join the JDBC connector. By default, lookup cache is not enabled, so all the requests are sent to external database.
 When lookup cache is enabled, each process (i.e. TaskManager) will hold a cache. Flink will lookup the cache first, and only send requests to external database when cache missing, and update cache with the rows returned.
-The oldest rows in cache will be expired when the cache hit to the max cached rows `lookup.cache.max-rows` or when the row exceeds the max time to live `lookup.cache.ttl`.
-The cached rows might not be the latest, users can tune `lookup.cache.ttl` to a smaller value to have a better fresh data, but this may increase the number of requests send to database. So this is a balance between throughput and correctness.
+The oldest rows in cache will be expired when the cache hit to the max cached rows `lookup.partial-cache.max-rows` or when the row exceeds the max time to live specified by `lookup.partial-cache.expire-after-write` or `lookup.partial-cache.expire-after-access`.
+The cached rows might not be the latest, users can tune expiration options to a smaller value to have a better fresh data, but this may increase the number of requests send to database. So this is a balance between throughput and correctness.
 
-By default, flink will cache the empty query result for a Primary key, you can toggle the behaviour by setting `lookup.cache.caching-missing-key` to false. 
+By default, flink will cache the empty query result for a Primary key, you can toggle the behaviour by setting `lookup.partial-cache.caching-missing-key` to false.
 
 ### Idempotent Writes
 


### PR DESCRIPTION
## What is the purpose of the change

This pull request updates documentation of JDBC and HBase lookup table for new caching options.


## Brief change log

- Update documentation of JDBC and HBase lookup table for new caching options

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
