### PR TITLE
[FLINK-28890][table] Fix semantic of latestLoadTime in caching lookup function

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/CachingLookupFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/CachingLookupFunction.java
@@ -159,9 +159,10 @@ public class CachingLookupFunction extends LookupFunction {
             Preconditions.checkState(
                     delegate != null,
                     "User's lookup function can't be null, if there are possible cache misses.");
+            long loadStart = System.currentTimeMillis();
             Collection<RowData> lookupValues = delegate.lookup(keyRow);
+            updateLatestLoadTime(System.currentTimeMillis() - loadStart);
             loadCounter.inc();
-            updateLatestLoadTime();
             return lookupValues;
         } catch (Exception e) {
             // TODO: Should implement retry on failure logic as proposed in FLIP-234
@@ -170,7 +171,7 @@ public class CachingLookupFunction extends LookupFunction {
         }
     }
 
-    private void updateLatestLoadTime() {
+    private void updateLatestLoadTime(long loadTime) {
         checkNotNull(
                 cacheMetricGroup,
                 "Could not register metric '%s' as cache metric group is not initialized",
@@ -179,6 +180,6 @@ public class CachingLookupFunction extends LookupFunction {
         if (latestLoadTime == UNINITIALIZED) {
             cacheMetricGroup.latestLoadTimeGauge(() -> latestLoadTime);
         }
-        latestLoadTime = System.currentTimeMillis();
+        latestLoadTime = loadTime;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the semantic of latestLoadTime in caching lookup function

## Brief change log

- Fix semantic of latestLoadTime in caching lookup function


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
