### PR TITLE
[FLINK-29406][table] Expose finish method for TableFunction

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
@@ -207,4 +207,18 @@ public abstract class TableFunction<T> extends UserDefinedFunction {
     public TypeInference getTypeInference(DataTypeFactory typeFactory) {
         return TypeInferenceExtractor.forTableFunction(typeFactory, (Class) getClass());
     }
+
+    /**
+     * This method is called at the end of data processing. After this method is called, no more
+     * records can be produced for the downstream operators.
+     *
+     * <p><b>NOTE:</b>This method does not need to close any resources. You should release external
+     * resources in the {@link #close()} method. More details can see {@link StreamOperator#finish}.
+     *
+     * <p><b>NOTE:</b>Emit record in the {@link #close()} method is impossible since flink-1.14, *
+     * if you need to emit records at the end of processing, do so in the {@link #finish()} method.
+     */
+    public void finish() throws Exception {
+        // do nothing
+    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/TableFunction.java
@@ -213,10 +213,12 @@ public abstract class TableFunction<T> extends UserDefinedFunction {
      * records can be produced for the downstream operators.
      *
      * <p><b>NOTE:</b>This method does not need to close any resources. You should release external
-     * resources in the {@link #close()} method. More details can see {@link StreamOperator#finish}.
+     * resources in the {@link #close()} method. More details can see {@link
+     * StreamOperator#finish()}.
      *
-     * <p><b>NOTE:</b>Emit record in the {@link #close()} method is impossible since flink-1.14, *
-     * if you need to emit records at the end of processing, do so in the {@link #finish()} method.
+     * <p><b>Important:</b>Emit record in the {@link #close()} method is impossible since
+     * flink-1.14, if you need to emit records at the end of data processing, do so in the {@link
+     * #finish()} method.
      */
     public void finish() throws Exception {
         // do nothing

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGeneratorContext.scala
@@ -786,17 +786,11 @@ class CodeGeneratorContext(val tableConfig: ReadableConfig, val classLoader: Cla
     reusableOpenStatements.add(openFunction)
 
     if (function.isInstanceOf[TableFunction[_]]) {
-      val finishFunction =
-        s"""
-           |$fieldTerm.finish();
-       """.stripMargin
+      val finishFunction = s"$fieldTerm.finish();"
       reusableFinishStatements.add(finishFunction)
     }
 
-    val closeFunction =
-      s"""
-         |$fieldTerm.close();
-       """.stripMargin
+    val closeFunction = s"$fieldTerm.close();"
     reusableCloseStatements.add(closeFunction)
 
     fieldTerm

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/OperatorCodeGenerator.scala
@@ -110,9 +110,15 @@ object OperatorCodeGenerator extends Logging {
         $endInput
 
         @Override
+        public void finish() throws Exception {
+            ${ctx.reuseFinishCode()}
+            super.finish();
+        }
+
+        @Override
         public void close() throws Exception {
            super.close();
-          ${ctx.reuseCloseCode()}
+           ${ctx.reuseCloseCode()}
         }
 
         ${ctx.reuseInnerClassDefinitionCode()}
@@ -239,6 +245,13 @@ object OperatorCodeGenerator extends Logging {
         $nextSel
 
         $endInput
+
+        @Override
+        public void finish() throws Exception {
+          super.finish();
+          ${ctx.reuseFinishCode()}
+        }
+
 
         @Override
         public void close() throws Exception {

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TemporalTableFunctionJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/table/TemporalTableFunctionJoinTest.xml
@@ -25,7 +25,7 @@ LogicalJoin(condition=[=($3, $1)], joinType=[inner])
 :     +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
 :        :- LogicalProject(o_rowtime=[AS($0, _UTF-16LE'o_rowtime')], o_comment=[AS($1, _UTF-16LE'o_comment')], o_amount=[AS($2, _UTF-16LE'o_amount')], o_currency=[AS($3, _UTF-16LE'o_currency')], o_secondary_key=[AS($4, _UTF-16LE'o_secondary_key')])
 :        :  +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-:        +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$bbf912e58a3fb2d083552961c0f87dbe*($0)], rowType=[RecordType(TIMESTAMP(3) *ROWTIME* rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)])
+:        +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$ffedaa7cf97f1aa4cbee41a2ca3818aa*($0)], rowType=[RecordType(TIMESTAMP(3) *ROWTIME* rowtime, VARCHAR(2147483647) comment, VARCHAR(2147483647) currency, INTEGER rate, INTEGER secondary_key)])
 +- LogicalTableScan(table=[[default_catalog, default_database, ThirdTable]])
 ]]>
     </Resource>
@@ -53,7 +53,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$225833b9896cb7740aed9150b8cc7fd9*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$879a015df4f2347140c72805efc864d7*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -95,7 +95,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, ProctimeOrders]])
-      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$170cc46c47df69784f267e43f61e8e9d*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP_LTZ(3) *PROCTIME* proctime)])
+      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$8bddfd63aa10cca9377dd286e2721dee*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP_LTZ(3) *PROCTIME* proctime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
@@ -117,7 +117,7 @@ LogicalProject(rate=[AS(*($0, $4), _UTF-16LE'rate')])
 +- LogicalFilter(condition=[=($3, $1)])
    +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{}])
       :- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
-      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$225833b9896cb7740aed9150b8cc7fd9*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
+      +- LogicalTableFunctionScan(invocation=[*org.apache.flink.table.functions.TemporalTableFunctionImpl$879a015df4f2347140c72805efc864d7*($2)], rowType=[RecordType(VARCHAR(2147483647) currency, INTEGER rate, TIMESTAMP(3) *ROWTIME* rowtime)])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CorrelateITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/CorrelateITCase.scala
@@ -31,7 +31,7 @@ import org.apache.flink.table.planner.runtime.utils.BatchTestBase.row
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedTableFunctions.JavaTableFunc0
 import org.apache.flink.table.planner.runtime.utils.TestData._
 import org.apache.flink.table.planner.runtime.utils.UserDefinedFunctionTestUtils.{MyPojo, MyPojoFunc}
-import org.apache.flink.table.planner.utils.{HierarchyTableFunction, PojoTableFunc, RichTableFunc1, TableFunc0, TableFunc1, TableFunc2, TableFunc3, VarArgsFunc0}
+import org.apache.flink.table.planner.utils.{HierarchyTableFunction, PojoTableFunc, RichTableFunc1, RichTableFuncWithFinish, TableFunc0, TableFunc1, TableFunc2, TableFunc3, VarArgsFunc0}
 import org.apache.flink.table.planner.utils.DateTimeTestUtil._
 import org.apache.flink.table.runtime.typeutils.StringDataTypeInfo
 import org.apache.flink.types.Row
@@ -39,7 +39,6 @@ import org.apache.flink.types.Row
 import org.junit.{Before, Test}
 
 import scala.collection.JavaConversions._
-import scala.collection.Seq
 
 class CorrelateITCase extends BatchTestBase {
 
@@ -247,6 +246,15 @@ class CorrelateITCase extends BatchTestBase {
     checkResult(
       "select b from MyTable, LATERAL TABLE(toPojoTFunc(pojoFunc(a))) as T(b, c)",
       Seq(row(105), row(11), row(12)))
+  }
+
+  @Test
+  def testTableFunctionWithFinishMethod(): Unit = {
+    registerTemporarySystemFunction("udtfWithFinish", classOf[RichTableFuncWithFinish])
+    checkResult(
+      "select s from inputT, LATERAL TABLE(udtfWithFinish(c)) as T(s)",
+      Seq(row("Jack#22"), row("John#19"), row("Anna#44"), row("nosharp"))
+    )
   }
 
 // TODO support dynamic type

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/UserDefinedTableFunctions.scala
@@ -25,9 +25,12 @@ import org.apache.flink.table.annotation.DataTypeHint
 import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.functions.{FunctionContext, ScalarFunction, TableFunction}
 import org.apache.flink.table.functions.python.{PythonEnv, PythonFunction}
+import org.apache.flink.table.planner.JList
 import org.apache.flink.types.Row
 
 import org.junit.Assert
+
+import java.util
 
 import scala.annotation.varargs
 
@@ -509,5 +512,26 @@ class RichTableFunc1 extends TableFunction[String] {
 
   override def close(): Unit = {
     separator = None
+  }
+}
+
+@SerialVersionUID(1L)
+class RichTableFuncWithFinish extends TableFunction[String] {
+  var buffer: JList[String] = _
+
+  override def open(context: FunctionContext): Unit = {
+    buffer = new util.ArrayList[String]()
+  }
+
+  def eval(str: String): Unit = {
+    buffer.add(str)
+  }
+
+  override def finish(): Unit = {
+    buffer.forEach(collect(_))
+  }
+
+  override def close(): Unit = {
+    buffer = null
   }
 }


### PR DESCRIPTION
## What is the purpose of the change
The task lifecycle was changed in FLINK-22972: a new finish() phase was introduced (extracted the ‘finish’ part out of the ‘close’) and the behavior  changed in `close` method. This was some kind of 'break change' for TableFunction users who did some flush work in previous `close` method(< 1.14). This pr aims to provide a possible migration path to support it again. If necessary, we can also consider backporting it to the corresponding older versions, including 1.14~1.16.
However, as a method that is not recommended for most users, I tend not to add it to the user documentation (just as  we didn't actively prompt users to do flush data in the close method before), so it is only been described in the method comments of the TableFunction, users who used this 'advanced' usage in previous versions 'should' be also able to get the usage of the new method.

## Brief change log
- new finish() method in TableFunction
- add finish() method invocation in related code generated operator

## Verifying this change
CorrelateITCase#testTableFunctionWithFinishMethod

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)