### PR TITLE
[FLINK-29425] Hybrid full spilling strategy triggering spilling frequently

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategy.Decision;
+import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.SupplierWithException;
 
@@ -40,6 +41,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -71,6 +75,17 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
     private final Map<Integer, HsSubpartitionViewInternalOperations> subpartitionViewOperationsMap =
             new ConcurrentHashMap<>();
 
+    /**
+     * Currently, it is only used to regularly check the actual size of local buffer pool (the size
+     * will change dynamically due to the redistribution of network buffers). When the size of the
+     * buffer pool changes, it attempts to trigger the spilling strategy.
+     */
+    private final ScheduledExecutorService poolSizeChecker =
+            Executors.newSingleThreadScheduledExecutor(
+                    new ExecutorThreadFactory("hybrid-shuffle-pool-size-checker-executor"));
+
+    private int previousPoolSize;
+
     public HsMemoryDataManager(
             int numSubpartitions,
             int bufferSize,
@@ -78,7 +93,8 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
             HsSpillingStrategy spillStrategy,
             HsFileDataIndex fileDataIndex,
             Path dataFilePath,
-            BufferCompressor bufferCompressor)
+            BufferCompressor bufferCompressor,
+            long poolSizeCheckInterval)
             throws IOException {
         this.numSubpartitions = numSubpartitions;
         this.bufferPool = bufferPool;
@@ -98,6 +114,20 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
                             readWriteLock.readLock(),
                             bufferCompressor,
                             this);
+        }
+        this.previousPoolSize = getPoolSize();
+        if (poolSizeCheckInterval > 0) {
+            poolSizeChecker.scheduleAtFixedRate(
+                    () -> {
+                        int currentPoolSize = getPoolSize();
+                        if (previousPoolSize > currentPoolSize) {
+                            callWithLock(() -> spillStrategy.decideActionWithGlobalInfo(this));
+                        }
+                        previousPoolSize = currentPoolSize;
+                    },
+                    poolSizeCheckInterval,
+                    poolSizeCheckInterval,
+                    TimeUnit.MILLISECONDS);
         }
     }
 
@@ -144,6 +174,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
         Decision decision = callWithLock(() -> spillStrategy.onResultPartitionClosed(this));
         handleDecision(Optional.of(decision));
         spiller.close();
+        poolSizeChecker.shutdown();
     }
 
     /**
@@ -240,7 +271,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
     @Override
     public void onBufferFinished() {
         Optional<Decision> decision =
-                spillStrategy.onBufferFinished(numUnSpillBuffers.incrementAndGet());
+                spillStrategy.onBufferFinished(numUnSpillBuffers.incrementAndGet(), getPoolSize());
         handleDecision(decision);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -127,7 +127,8 @@ public class HsResultPartition extends ResultPartition {
                         getSpillingStrategy(hybridShuffleConfiguration),
                         dataIndex,
                         dataFilePath,
-                        bufferCompressor);
+                        bufferCompressor,
+                        hybridShuffleConfiguration.getBufferPoolSizeCheckIntervalMs());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
@@ -45,7 +45,7 @@ public class HsSelectiveSpillingStrategy implements HsSpillingStrategy {
     // For the case of buffer finished, there is no need to take action for
     // HsSelectiveSpillingStrategy.
     @Override
-    public Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers) {
+    public Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers, int currentPoolSize) {
         return Optional.of(Decision.NO_ACTION);
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingStrategy.java
@@ -51,7 +51,7 @@ public interface HsSpillingStrategy {
      * @return A {@link Decision} based on the provided information, or {@link Optional#empty()} if
      *     the decision cannot be made, which indicates global information is needed.
      */
-    Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers);
+    Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers, int currentPoolSize);
 
     /**
      * Make a decision when a buffer is consumed.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerTest.java
@@ -65,7 +65,7 @@ class HsMemoryDataManagerTest {
         HsSpillingStrategy spillingStrategy =
                 TestingSpillingStrategy.builder()
                         .setOnBufferFinishedFunction(
-                                (numTotalUnSpillBuffers) -> {
+                                (numTotalUnSpillBuffers, currentPoolSize) -> {
                                     finishedBuffers.incrementAndGet();
                                     return Optional.of(Decision.NO_ACTION);
                                 })
@@ -120,7 +120,7 @@ class HsMemoryDataManagerTest {
         HsSpillingStrategy spillingStrategy =
                 TestingSpillingStrategy.builder()
                         .setOnBufferFinishedFunction(
-                                (numFinishedBuffers) -> {
+                                (numFinishedBuffers, poolSize) -> {
                                     if (numFinishedBuffers < numFinishedBufferToTriggerDecision) {
                                         return Optional.of(Decision.NO_ACTION);
                                     }
@@ -160,7 +160,7 @@ class HsMemoryDataManagerTest {
         HsSpillingStrategy spillingStrategy =
                 TestingSpillingStrategy.builder()
                         .setOnBufferFinishedFunction(
-                                (finishedBuffer) -> {
+                                (finishedBuffer, poolSize) -> {
                                     // return empty optional to trigger global decision.
                                     return Optional.empty();
                                 })
@@ -192,6 +192,34 @@ class HsMemoryDataManagerTest {
         assertThat(resultPartitionReleaseFuture).isCompleted();
     }
 
+    @Test
+    void testPoolSizeCheck() throws Exception {
+        final int requiredBuffers = 10;
+        final int maxBuffers = 100;
+        CompletableFuture<Void> triggerGlobalDecision = new CompletableFuture<>();
+
+        NetworkBufferPool networkBufferPool = new NetworkBufferPool(maxBuffers, bufferSize);
+        BufferPool bufferPool = networkBufferPool.createBufferPool(requiredBuffers, maxBuffers);
+        assertThat(bufferPool.getNumBuffers()).isEqualTo(maxBuffers);
+
+        HsSpillingStrategy spillingStrategy =
+                TestingSpillingStrategy.builder()
+                        .setDecideActionWithGlobalInfoFunction(
+                                (spillingInfoProvider) -> {
+                                    assertThat(spillingInfoProvider.getPoolSize())
+                                            .isEqualTo(requiredBuffers);
+                                    triggerGlobalDecision.complete(null);
+                                    return Decision.NO_ACTION;
+                                })
+                        .build();
+
+        createMemoryDataManager(spillingStrategy, bufferPool);
+        networkBufferPool.createBufferPool(maxBuffers - requiredBuffers, maxBuffers);
+        assertThat(bufferPool.getNumBuffers()).isEqualTo(requiredBuffers);
+
+        assertThat(triggerGlobalDecision).succeedsWithin(10, TimeUnit.SECONDS);
+    }
+
     private HsMemoryDataManager createMemoryDataManager(HsSpillingStrategy spillStrategy)
             throws Exception {
         return createMemoryDataManager(spillStrategy, new HsFileDataIndexImpl(NUM_SUBPARTITIONS));
@@ -201,6 +229,18 @@ class HsMemoryDataManagerTest {
             HsSpillingStrategy spillStrategy, HsFileDataIndex fileDataIndex) throws Exception {
         NetworkBufferPool networkBufferPool = new NetworkBufferPool(NUM_BUFFERS, bufferSize);
         BufferPool bufferPool = networkBufferPool.createBufferPool(poolSize, poolSize);
+        return createMemoryDataManager(bufferPool, spillStrategy, fileDataIndex);
+    }
+
+    private HsMemoryDataManager createMemoryDataManager(
+            HsSpillingStrategy spillingStrategy, BufferPool bufferPool) throws Exception {
+        return createMemoryDataManager(
+                bufferPool, spillingStrategy, new HsFileDataIndexImpl(NUM_SUBPARTITIONS));
+    }
+
+    private HsMemoryDataManager createMemoryDataManager(
+            BufferPool bufferPool, HsSpillingStrategy spillStrategy, HsFileDataIndex fileDataIndex)
+            throws Exception {
         HsMemoryDataManager memoryDataManager =
                 new HsMemoryDataManager(
                         NUM_SUBPARTITIONS,
@@ -209,7 +249,8 @@ class HsMemoryDataManagerTest {
                         spillStrategy,
                         fileDataIndex,
                         dataFilePath,
-                        null);
+                        null,
+                        1000);
         memoryDataManager.setOutputMetrics(createTestingOutputMetrics());
         return memoryDataManager;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
@@ -41,7 +41,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionManager;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartitionView;
-import org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleConfiguration.SpillingStrategyType;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.util.IOUtils;
@@ -378,33 +377,6 @@ class HsResultPartitionTest {
         byte[] dataWritten = new byte[dataSize];
         random.nextBytes(dataWritten);
         return ByteBuffer.wrap(dataWritten);
-    }
-
-    private HsResultPartition createHsResultPartition(
-            int numSubpartitions, BufferPool bufferPool, int numBuffersTriggerSpilling)
-            throws IOException {
-        HsResultPartition hsResultPartition =
-                new HsResultPartition(
-                        "HsResultPartitionTest",
-                        0,
-                        new ResultPartitionID(),
-                        ResultPartitionType.HYBRID_FULL,
-                        numSubpartitions,
-                        numSubpartitions,
-                        readBufferPool,
-                        readIOExecutor,
-                        new ResultPartitionManager(),
-                        fileChannelManager.createChannel().getPath(),
-                        bufferSize,
-                        HybridShuffleConfiguration.builder(
-                                        numSubpartitions, readBufferPool.getNumBuffersPerRequest())
-                                .setSpillingStrategyType(SpillingStrategyType.FULL)
-                                .setFullStrategyNumBuffersTriggerSpilling(numBuffersTriggerSpilling)
-                                .build(),
-                        null,
-                        () -> bufferPool);
-        hsResultPartition.setup();
-        return hsResultPartition;
     }
 
     private HsResultPartition createHsResultPartition(int numSubpartitions, BufferPool bufferPool)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategyTest.java
@@ -49,7 +49,7 @@ class HsSelectiveSpillingStrategyTest {
 
     @Test
     void testOnBufferFinished() {
-        Optional<Decision> finishedDecision = spillStrategy.onBufferFinished(5);
+        Optional<Decision> finishedDecision = spillStrategy.onBufferFinished(5, 10);
         assertThat(finishedDecision).hasValue(Decision.NO_ACTION);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
@@ -114,7 +114,8 @@ class HsSubpartitionViewTest {
                         spillingStrategy,
                         new HsFileDataIndexImpl(1),
                         dataFilePath.resolve(".data"),
-                        null);
+                        null,
+                        0);
         memoryDataManager.setOutputMetrics(createTestingOutputMetrics());
         HsDataView hsDataView = memoryDataManager.registerSubpartitionView(0, subpartitionView);
         subpartitionView.setMemoryDataView(hsDataView);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingStrategy.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingStrategy.java
@@ -26,7 +26,7 @@ import java.util.function.Function;
 public class TestingSpillingStrategy implements HsSpillingStrategy {
     private final BiFunction<Integer, Integer, Optional<Decision>> onMemoryUsageChangedFunction;
 
-    private final Function<Integer, Optional<Decision>> onBufferFinishedFunction;
+    private final BiFunction<Integer, Integer, Optional<Decision>> onBufferFinishedFunction;
 
     private final Function<BufferIndexAndChannel, Optional<Decision>> onBufferConsumedFunction;
 
@@ -36,7 +36,7 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
 
     private TestingSpillingStrategy(
             BiFunction<Integer, Integer, Optional<Decision>> onMemoryUsageChangedFunction,
-            Function<Integer, Optional<Decision>> onBufferFinishedFunction,
+            BiFunction<Integer, Integer, Optional<Decision>> onBufferFinishedFunction,
             Function<BufferIndexAndChannel, Optional<Decision>> onBufferConsumedFunction,
             Function<HsSpillingInfoProvider, Decision> decideActionWithGlobalInfoFunction,
             Function<HsSpillingInfoProvider, Decision> onResultPartitionClosedFunction) {
@@ -54,8 +54,8 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
     }
 
     @Override
-    public Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers) {
-        return onBufferFinishedFunction.apply(numTotalUnSpillBuffers);
+    public Optional<Decision> onBufferFinished(int numTotalUnSpillBuffers, int currentPoolSize) {
+        return onBufferFinishedFunction.apply(numTotalUnSpillBuffers, currentPoolSize);
     }
 
     @Override
@@ -82,8 +82,8 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
         private BiFunction<Integer, Integer, Optional<Decision>> onMemoryUsageChangedFunction =
                 (ignore1, ignore2) -> Optional.of(Decision.NO_ACTION);
 
-        private Function<Integer, Optional<Decision>> onBufferFinishedFunction =
-                (ignore) -> Optional.of(Decision.NO_ACTION);
+        private BiFunction<Integer, Integer, Optional<Decision>> onBufferFinishedFunction =
+                (ignore1, ignore2) -> Optional.of(Decision.NO_ACTION);
 
         private Function<BufferIndexAndChannel, Optional<Decision>> onBufferConsumedFunction =
                 (ignore) -> Optional.of(Decision.NO_ACTION);
@@ -103,7 +103,7 @@ public class TestingSpillingStrategy implements HsSpillingStrategy {
         }
 
         public Builder setOnBufferFinishedFunction(
-                Function<Integer, Optional<Decision>> onBufferFinishedFunction) {
+                BiFunction<Integer, Integer, Optional<Decision>> onBufferFinishedFunction) {
             this.onBufferFinishedFunction = onBufferFinishedFunction;
             return this;
         }


### PR DESCRIPTION
## What is the purpose of the change

*Fix the problem that hybrid full spilling strategy triggering spilling frequently.*


## Brief change log

  - *Adopt an adaptive strategy to determine the spilling frequency.*
  - *Add a pool size checker to avoid deadlock caused by buffer pool redistribution.*


## Verifying this change

This change added a unit test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
