### PR TITLE
[FLINK-29460] fix the unstable test HsResultPartitionTest.testRelease

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -124,7 +124,8 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
                         int newSize = this.bufferPool.getNumBuffers();
                         int oldSize = poolSize.getAndSet(newSize);
                         if (oldSize > newSize) {
-                            callWithLock(() -> spillStrategy.decideActionWithGlobalInfo(this));
+                            // pass Optional.empty to trigger global decision.
+                            handleDecision(Optional.empty());
                         }
                     },
                     poolSizeCheckInterval,


### PR DESCRIPTION
## What is the purpose of the change

*HsResultPartitionTest.testRelease failed with AssertionFailedError. This is caused by FLINK-29425, it changes the conditions for spilling, which may cause some buffers to be released during the test.*


## Brief change log

  - *Set FullStrategyNumBuffersTriggerSpillingRatio and FullStrategyReleaseBufferRatio manually.*


## Verifying this change

This change fixes unstable test `HsResultPartitionTest.testRelease`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
