### PR TITLE
[FLINK-29477][python] Fix ClassCastException when collecting primitive array

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -1470,9 +1470,16 @@ class CommonDataStreamTests(PyFlinkTestCase):
                       decimal.Decimal('2000000000000000000.061111111111111'
                                       '11111111111111'))]
         expected = test_data
-        ds = self.env.from_collection(test_data).map(lambda a: a)
+        ds = self.env.from_collection(test_data)
         with ds.execute_and_collect() as results:
             actual = [result for result in results]
+            self.assert_equals_sorted(expected, actual)
+
+        test_data = [[1, 2, 3], [4, 5]]
+        expected = test_data
+        ds = self.env.from_collection(test_data, type_info=Types.PRIMITIVE_ARRAY(Types.INT()))
+        with ds.execute_and_collect() as results:
+            actual = [r for r in results]
             self.assert_equals_sorted(expected, actual)
 
     def test_function_with_error(self):


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes a bug that throwing ClassCastException when `execute_and_collect` Java primitive array back to Python.


## Verifying this change

This change added tests and can be verified as follows:
+ modified test `test_execute_and_collect`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
