### PR TITLE
[FLINK-26759][connector] Legacy source support waiting for recordWriter to be available

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/AbstractFetcher.java
@@ -356,6 +356,8 @@ public abstract class AbstractFetcher<T, KPH> {
             KafkaTopicPartitionState<T, KPH> partitionState,
             long offset,
             long kafkaEventTimestamp) {
+        sourceContext.ensureRecordWriterIsAvailable();
+
         // emit the records, using the checkpoint lock to guarantee
         // atomicity of record emission and offset state update
         synchronized (checkpointLock) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -213,6 +213,8 @@ public interface SourceFunction<T> extends Function, Serializable {
          */
         Object getCheckpointLock();
 
+        default void ensureRecordWriterIsAvailable() {}
+
         /** This method is called by the system to shut down the context. */
         void close();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGeneratorSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/DataGeneratorSource.java
@@ -112,6 +112,7 @@ public class DataGeneratorSource<T> extends RichParallelSourceFunction<T>
                 if (isRunning
                         && generator.hasNext()
                         && (numberOfRows == null || outputSoFar < toOutput)) {
+                    ctx.ensureRecordWriterIsAvailable();
                     synchronized (ctx.getCheckpointLock()) {
                         outputSoFar++;
                         ctx.collect(this.generator.next());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/SourceStreamTask.java
@@ -330,7 +330,11 @@ public class SourceStreamTask<
                     LOG.debug(
                             "Legacy source {} skip execution since the task is finished on restore",
                             getTaskNameWithSubtaskAndId());
-                    mainOperator.run(lock, operatorChain);
+                    mainOperator.run(
+                            lock,
+                            operatorChain,
+                            configuration.isUnalignedCheckpointsEnabled(),
+                            recordWriter);
                 }
                 completeProcessing();
                 completionFuture.complete(null);


### PR DESCRIPTION
## What is the purpose of the change

Legacy source support waiting for recordWriter to be available.

## Brief change log

Check whether the recordWriter is available before collect data.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): a little
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  JavaDocs / not documented
