### PR TITLE
[FLINK-29961][doc] Make referencing custom image clearer for Docker

### DIFF
--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -432,7 +432,7 @@ services:
   You can then start creating tables and queries those.
 
 * Note that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
-  For example, if you would like to use the Kafka Connector, you can build a custom image.
+  For example, if you would like to add and use the SQL Kafka Connector, you need to build a custom image.
   1. Create a Dockerfile named `Kafka.Dockerfile` as follows:
 
   ```Dockerfile

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -433,7 +433,7 @@ services:
 
 * Note that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
   For example, if you would like to use the Kafka Connector, you can build a custom image.
-  1. Create a Dockerfile named `Dockerfile.kafka` as follows:
+  1. Create a Dockerfile named `Kafka.Dockerfile` as follows:
 
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -432,9 +432,8 @@ services:
   You can then start creating tables and queries those.
 
 * Note, that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
-  For example, if you would like to use the Kafka Connector, you can build a custom image.
-  Create a Dockerfile as follows:
-
+  For example, if you would like to use the Kafka Connector, you need to build a custom image.
+  Create a Dockerfile containing:
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
   RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/{{< version >}}/flink-sql-connector-kafka_scala{{< scala_version >}}-{{< version >}}.jar

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -445,7 +445,7 @@ services:
   ```yaml
   jobmanager:
     build:
-      dockerfile: ./Dockerfile.kafka
+      dockerfile: ./Kafka.Dockerfile
     ...
   ```
 

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -432,15 +432,15 @@ services:
   You can then start creating tables and queries those.
 
 * Note, that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
-  For example, if you would like to use the Kafka Connector create a custom image with the following Dockerfile
+  For example, if you would like to use the Kafka Connector, you can build a custom image.
+  Create a Dockerfile as follows:
 
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
   RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/{{< version >}}/flink-sql-connector-kafka_scala{{< scala_version >}}-{{< version >}}.jar
   ```
 
-  and reference it (e.g via the `build`) command in the Dockerfile.
-  and reference it (e.g via the `build`) command in the Dockerfile.
+  and reference this Dockerfile with the `build` command in the `docker-compose.yml` file.
   SQL Commands like `ADD JAR` will not work for JARs located on the host machine as they only work with the local filesystem, which in this case is Docker's overlay filesystem.
 
 ## Using Flink Python on Docker

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -433,19 +433,20 @@ services:
 
 * Note that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
   For example, if you would like to add and use the SQL Kafka Connector, you need to build a custom image.
-  1. Create a Dockerfile named `Kafka.Dockerfile` as follows:
+  1. Create a Dockerfile named `kafka.Dockerfile` as follows:
 
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
-  RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/{{< version >}}/flink-sql-connector-kafka_scala{{< scala_version >}}-{{< version >}}.jar
+  ARG kafka_connector_verion=3.0.0-1.17
+  RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$kafka_connector_verion/flink-sql-connector-kafka-$kafka_connector_verion.jar
   ```
 
   2. Replace the `image` config with the `build` command that references the Dockerfile for jobmanager, taskmanager and sql-client services.
-  For example, the jobmanager service will start with the following setting:
+  For example, the jobmanager service in the `docker-compose.yml` file will start with the following setting:
   ```yaml
   jobmanager:
     build:
-      dockerfile: ./Kafka.Dockerfile
+      dockerfile: ./kafka.Dockerfile
     ...
   ```
 

--- a/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content.zh/docs/deployment/resource-providers/standalone/docker.md
@@ -431,15 +431,24 @@ services:
   ```
   You can then start creating tables and queries those.
 
-* Note, that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
-  For example, if you would like to use the Kafka Connector, you need to build a custom image.
-  Create a Dockerfile containing:
+* Note that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
+  For example, if you would like to use the Kafka Connector, you can build a custom image.
+  1. Create a Dockerfile named `Dockerfile.kafka` as follows:
+
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
   RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/{{< version >}}/flink-sql-connector-kafka_scala{{< scala_version >}}-{{< version >}}.jar
   ```
 
-  and reference this Dockerfile with the `build` command in the `docker-compose.yml` file.
+  2. Replace the `image` config with the `build` command that references the Dockerfile for jobmanager, taskmanager and sql-client services.
+  For example, the jobmanager service will start with the following setting:
+  ```yaml
+  jobmanager:
+    build:
+      dockerfile: ./Dockerfile.kafka
+    ...
+  ```
+
   SQL Commands like `ADD JAR` will not work for JARs located on the host machine as they only work with the local filesystem, which in this case is Docker's overlay filesystem.
 
 ## Using Flink Python on Docker

--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -432,8 +432,8 @@ services:
   You can then start creating tables and queries those.
 
 * Note that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
-  For example, if you would like to use the Kafka Connector, you can build a custom image.
-  1. Create a Dockerfile named `Dockerfile.kafka` as follows:
+  For example, if you would like to add and use the SQL Kafka Connector, you need to build a custom image.
+  1. Create a Dockerfile named `Kafka.Dockerfile` as follows:
 
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
@@ -445,7 +445,7 @@ services:
   ```yaml
   jobmanager:
     build:
-      dockerfile: ./Dockerfile.kafka
+      dockerfile: ./Kafka.Dockerfile
     ...
   ```
 

--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -431,16 +431,25 @@ services:
   ```
   You can then start creating tables and queries those.
 
-* Note, that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
+* Note that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
   For example, if you would like to use the Kafka Connector, you can build a custom image.
-  Create a Dockerfile as follows:
+  1. Create a Dockerfile named `Dockerfile.kafka` as follows:
 
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
   RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/{{< version >}}/flink-sql-connector-kafka_scala{{< scala_version >}}-{{< version >}}.jar
   ```
   
-  and reference it (e.g via the `build`) command in the Dockerfile.
+  2. Replace the `image` config with the `build` command that references the Dockerfile for jobmanager, taskmanager and sql-client services.
+  For example, the jobmanager service will start with the following setting:
+  ```yaml
+  jobmanager:
+    build:
+      dockerfile: ./Dockerfile.kafka
+    ...
+  ```
+
+>>>>>>> 8ed09d4eb3e (Add example of using build command in docker-compose.yml)
   SQL Commands like `ADD JAR` will not work for JARs located on the host machine as they only work with the local filesystem, which in this case is Docker's overlay filesystem. 
 
 ## Using Flink Python on Docker

--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -432,8 +432,9 @@ services:
   You can then start creating tables and queries those.
 
 * Note, that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
-  For example, if you would like to use the Kafka Connector create a custom image with the following Dockerfile
-  
+  For example, if you would like to use the Kafka Connector, you can build a custom image.
+  Create a Dockerfile as follows:
+
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
   RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/{{< version >}}/flink-sql-connector-kafka_scala{{< scala_version >}}-{{< version >}}.jar

--- a/docs/content/docs/deployment/resource-providers/standalone/docker.md
+++ b/docs/content/docs/deployment/resource-providers/standalone/docker.md
@@ -433,11 +433,12 @@ services:
 
 * Note that all required dependencies (e.g. for connectors) need to be available in the cluster as well as the client.
   For example, if you would like to add and use the SQL Kafka Connector, you need to build a custom image.
-  1. Create a Dockerfile named `Kafka.Dockerfile` as follows:
+  1. Create a Dockerfile named `kafka.Dockerfile` as follows:
 
   ```Dockerfile
   FROM flink:{{< stable >}}{{< version >}}-scala{{< scala_version >}}{{< /stable >}}{{< unstable >}}latest{{< /unstable >}}
-  RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/{{< version >}}/flink-sql-connector-kafka_scala{{< scala_version >}}-{{< version >}}.jar
+  ARG kafka_connector_verion=3.0.0-1.17
+  RUN wget -P /opt/flink/lib https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka/$kafka_connector_verion/flink-sql-connector-kafka-$kafka_connector_verion.jar
   ```
   
   2. Replace the `image` config with the `build` command that references the Dockerfile for jobmanager, taskmanager and sql-client services.
@@ -445,11 +446,10 @@ services:
   ```yaml
   jobmanager:
     build:
-      dockerfile: ./Kafka.Dockerfile
+      dockerfile: ./kafka.Dockerfile
     ...
   ```
 
->>>>>>> 8ed09d4eb3e (Add example of using build command in docker-compose.yml)
   SQL Commands like `ADD JAR` will not work for JARs located on the host machine as they only work with the local filesystem, which in this case is Docker's overlay filesystem. 
 
 ## Using Flink Python on Docker


### PR DESCRIPTION
## What is the purpose of the change

Make referencing custom image clearer for Docker

## Brief change log

Rephrase the words how to reference custom image when building with Docker standalone mode.
Also add example code.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
