### PR TITLE
[FLINK-13703][flink-formats/flink-avro] AvroTypeInfo requires objects to be strict POJOs (mutable, with setters)

### DIFF
--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeExtractionTest.java
@@ -44,6 +44,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Pojo Type tests.
@@ -185,6 +186,34 @@ public class PojoTypeExtractionTest {
         public void setUsers(Collection<String> users) {
             this.users = users;
         }
+    }
+
+    public static class PojoWithOptionalGetters {
+        public String field1;
+        public Integer field2;
+
+        public PojoWithOptionalGetters() {}
+
+        public PojoWithOptionalGetters(String f1, Integer f2) {
+            this.field1 = f1;
+            this.field2 = f2;
+        }
+
+        public Optional<String> getMyField1() {
+            return Optional.ofNullable(field1);
+        }
+
+        public Optional<Integer> getMyField2() {
+            return Optional.ofNullable(field2);
+        }
+    }
+
+    @Test
+    public void testPojoWithOptionalGetters() {
+        TypeInformation<?> typeForClass =
+                TypeExtractor.createTypeInfo(PojoWithOptionalGetters.class);
+
+        Assert.assertTrue(typeForClass instanceof PojoTypeInfo<?>);
     }
 
     @Test

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/PojoTypeInfoTest.java
@@ -20,6 +20,8 @@ package org.apache.flink.api.java.typeutils;
 
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 
+import java.util.Optional;
+
 /** Test for {@link PojoTypeInfo}. */
 class PojoTypeInfoTest extends TypeInformationTestBase<PojoTypeInfo<?>> {
 
@@ -29,7 +31,8 @@ class PojoTypeInfoTest extends TypeInformationTestBase<PojoTypeInfo<?>> {
             (PojoTypeInfo<?>) TypeExtractor.getForClass(TestPojo.class),
             (PojoTypeInfo<?>) TypeExtractor.getForClass(AlternatePojo.class),
             (PojoTypeInfo<?>) TypeExtractor.getForClass(PrimitivePojo.class),
-            (PojoTypeInfo<?>) TypeExtractor.getForClass(UnderscorePojo.class)
+            (PojoTypeInfo<?>) TypeExtractor.getForClass(UnderscorePojo.class),
+            (PojoTypeInfo<?>) TypeExtractor.getForClass(PojoWithOptionalGetters.class)
         };
     }
 
@@ -90,6 +93,27 @@ class PojoTypeInfoTest extends TypeInformationTestBase<PojoTypeInfo<?>> {
 
         public Integer getSomeInt() {
             return this.some_int;
+        }
+    }
+
+    public static final class PojoWithOptionalGetters {
+        private String someString;
+        private Integer someInt;
+
+        public void setSomeString(String str) {
+            this.someString = str;
+        }
+
+        public void setSomeInt(Integer i) {
+            this.someInt = i;
+        }
+
+        public Optional<String> getSomeString() {
+            return Optional.ofNullable(someString);
+        }
+
+        public Optional<Integer> getSomeInt() {
+            return Optional.ofNullable(someInt);
         }
     }
 }

--- a/flink-formats/flink-avro/pom.xml
+++ b/flink-formats/flink-avro/pom.xml
@@ -244,15 +244,30 @@ under the License.
 				<groupId>org.apache.avro</groupId>
 				<artifactId>avro-maven-plugin</artifactId>
 				<version>${avro.version}</version>
+				<configuration>
+					<testOutputDirectory>${project.basedir}/target/generated-test-sources/</testOutputDirectory>
+				</configuration>
 				<executions>
 					<execution>
+						<id>1</id>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>schema</goal>
+						</goals>
+						<configuration>
+							<testSourceDirectory>${project.basedir}/src/test/resources/avro/optional</testSourceDirectory>
+							<gettersReturnOptional>true</gettersReturnOptional>
+							<optionalGettersForNullableFieldsOnly>true</optionalGettersForNullableFieldsOnly>
+						</configuration>
+					</execution>
+					<execution>
+						<id>2</id>
 						<phase>generate-sources</phase>
 						<goals>
 							<goal>schema</goal>
 						</goals>
 						<configuration>
 							<testSourceDirectory>${project.basedir}/src/test/resources/avro</testSourceDirectory>
-							<testOutputDirectory>${project.basedir}/target/generated-test-sources/</testOutputDirectory>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfoTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeInfoTest.java
@@ -22,9 +22,12 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.formats.avro.generated.Address;
+import org.apache.flink.formats.avro.generated.OptionalUser;
 import org.apache.flink.formats.avro.generated.User;
 
-import org.junit.jupiter.api.Test;
+import org.apache.avro.specific.SpecificRecordBase;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,14 +37,17 @@ class AvroTypeInfoTest extends TypeInformationTestBase<AvroTypeInfo<?>> {
     @Override
     protected AvroTypeInfo<?>[] getTestData() {
         return new AvroTypeInfo<?>[] {
-            new AvroTypeInfo<>(Address.class), new AvroTypeInfo<>(User.class),
+            new AvroTypeInfo<>(Address.class),
+            new AvroTypeInfo<>(User.class),
+            new AvroTypeInfo<>(OptionalUser.class)
         };
     }
 
-    @Test
-    void testAvroByDefault() {
-        final TypeSerializer<User> serializer =
-                new AvroTypeInfo<>(User.class).createSerializer(new ExecutionConfig());
+    @ParameterizedTest
+    @ValueSource(classes = {User.class, Address.class, OptionalUser.class})
+    <T extends SpecificRecordBase> void testAvroByDefault(Class<T> clazz) {
+        final TypeSerializer<T> serializer =
+                new AvroTypeInfo<>(clazz).createSerializer(new ExecutionConfig());
         assertThat(serializer).isInstanceOf(AvroSerializer.class);
     }
 }

--- a/flink-formats/flink-avro/src/test/resources/avro/optional/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/optional/user.avsc
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 [
   {"namespace": "org.apache.flink.formats.avro.generated",
     "type": "record",

--- a/flink-formats/flink-avro/src/test/resources/avro/optional/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/optional/user.avsc
@@ -1,0 +1,106 @@
+[
+  {"namespace": "org.apache.flink.formats.avro.generated",
+    "type": "record",
+    "name": "OptionalUnionLogicalType",
+    "fields": [
+      {"name": "nullableTimestamp", "type": [ "null", {"type": "long", "logicalType": "timestamp-millis"}]}
+    ]
+  },
+  {"namespace": "org.apache.flink.formats.avro.generated",
+    "type": "record",
+    "name": "Address",
+    "fields": [
+      {"name": "num", "type": "int"},
+      {"name": "street", "type": "string"},
+      {"name": "city", "type": "string"},
+      {"name": "state", "type": "string"},
+      {"name": "zip", "type": "string"}
+    ]
+  },
+  {"namespace": "org.apache.flink.formats.avro.generated",
+    "type": "record",
+    "name": "OptionalUser",
+    "fields": [
+      {"name": "name", "type": "string"},
+      {"name": "favorite_number",  "type": ["int", "null"]},
+      {"name": "favorite_color", "type": ["string", "null"]},
+      {"name": "type_long_test", "type": ["long", "null"]},
+      {"name": "type_double_test", "type": "double"},
+      {"name": "type_null_test", "type": ["null"]},
+      {"name": "type_bool_test", "type": ["boolean"]},
+      {"name": "type_array_string", "type" : {"type" : "array", "items" : "string"}},
+      {"name": "type_array_boolean", "type" : {"type" : "array", "items" : "boolean"}},
+      {"name": "type_nullable_array", "type": ["null", {"type":"array", "items":"string"}], "default":null},
+      {"name": "type_enum", "type": {"type": "enum", "name": "Colors", "symbols" : ["RED", "GREEN", "BLUE"]}},
+      {"name": "type_map", "type": {"type": "map", "values": "long"}},
+      {"name": "type_fixed",
+        "size": 16,
+        "type": ["null", {"name": "Fixed16", "size": 16, "type": "fixed"}]},
+      {"name": "type_union", "type": ["null", "boolean", "long", "double"]},
+      {"name": "type_nested", "type": ["null", "Address"]},
+      {"name": "type_bytes", "type": "bytes"},
+      {"name": "type_date", "type": {"type": "int", "logicalType": "date"}},
+      {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}},
+      {"name": "type_time_micros", "type": {"type": "long", "logicalType": "time-micros"}},
+      {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+      {"name": "type_timestamp_micros", "type": {"type": "long", "logicalType": "timestamp-micros"}},
+      {"name": "type_decimal_bytes", "type": {"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2}},
+      {"name": "type_decimal_fixed", "type": {"name": "Fixed2", "size": 2, "type": "fixed", "logicalType": "decimal", "precision": 4, "scale": 2}}
+    ]
+  },
+  {"namespace": "org.apache.flink.formats.avro.generated",
+    "type": "record",
+    "name": "OptionalSimpleRecord",
+    "fields": [
+      {"name": "name", "type": "string"},
+      {"name": "optionalField",  "type": ["null", "int"], "default": null}
+    ]
+  },
+  /**
+   * The BackwardsCompatibleAvroSerializer does not support custom Kryo
+   * registrations (which logical types require for Avro 1.8 because Kryo does not support Joda-Time).
+   * We introduce a simpler user record for pre-Avro 1.8 test cases. This record can be dropped when
+   * we drop support for 1.3 savepoints.
+   */
+  {"namespace": "org.apache.flink.formats.avro.generated",
+    "type": "record",
+    "name": "OptionalSimpleUser",
+    "fields": [
+      {"name": "name", "type": "string"},
+      {"name": "favorite_number",  "type": ["int", "null"]},
+      {"name": "favorite_color", "type": ["string", "null"]},
+      {"name": "type_long_test", "type": ["long", "null"]},
+      {"name": "type_double_test", "type": "double"},
+      {"name": "type_null_test", "type": ["null"]},
+      {"name": "type_bool_test", "type": ["boolean"]},
+      {"name": "type_array_string", "type" : {"type" : "array", "items" : "string"}},
+      {"name": "type_array_boolean", "type" : {"type" : "array", "items" : "boolean"}},
+      {"name": "type_nullable_array", "type": ["null", {"type":"array", "items":"string"}], "default":null},
+      {"name": "type_enum", "type": "Colors"},
+      {"name": "type_map", "type": {"type": "map", "values": "long"}},
+      {"name": "type_fixed", "type": ["null", "Fixed16"]},
+      {"name": "type_union", "type": ["null", "boolean", "long", "double"]},
+      {"name": "type_nested", "type": ["null", "Address"]},
+      {"name": "type_bytes", "type": "bytes"}
+    ]
+  },
+  {"namespace": "org.apache.flink.formats.avro.generated",
+    "type": "record",
+    "name": "OptionalSchemaRecord",
+    "fields": [
+      {"name": "field1", "type": ["null", "long"], "default": null},
+      {"name": "field2", "type": ["null", "string"], "default": null},
+      {"name": "time1", "type": "long"},
+      {"name": "time2", "type": "long"},
+      {"name": "field3", "type": ["null", "double"], "default": null}
+    ]
+  },
+  {"namespace": "org.apache.flink.formats.avro.generated",
+    "type": "record",
+    "name": "LogicalTimeRecord",
+    "fields": [
+      {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
+      {"name": "type_date", "type": {"type": "int", "logicalType": "date"}},
+      {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}}
+    ]
+  }]


### PR DESCRIPTION
## What is the purpose of the change

This change will allow Flink to handle avro-compiled classes with following settings:
- `gettersReturnOptional = true`
- `optionalGettersForNullableFieldsOnly = true`

more info here: [FLINK-13703](https://issues.apache.org/jira/browse/FLINK-13703)


## Change log
  - *Modified isValidPojoField logic to handle Optional getters*
  - *Added flink-core tests*
  - *Added flink-avro tests*


## Verifying this change

  - **flink-core tests**:
    - added:
      - `PojoTypeExtractionTest#testPojoWithOptionalGetters`
      - `TypeExtractorTest#testPojoWithOptionalGetters`
    - extended:
      - `PojoTypeInfoTest`
 - **flink-avro tests**:
   - added:
     - `AvroStreamingFileSinkITCase#testWriteAvroSpecificWithOptionalGetters`
     - `RegistryAvroDeserializationSchemaTest#testSpecificRecordReadMoreFieldsThanWereWrittenOptionalEmpty`
     - `AvroTypeExtractionTest#testSerializeWithAvroOptionalGetters`
     - `AvroTypeExtractionTest#testKeySelectionOptional`
     - `AvroTypeExtractionTest#testWithAvroGenericSerOptional`
     - `AvroTypeExtractionTest#testWithKryoGenericSerOptional`
   - extended:
     - `AvroOutputFormatTest#testSerialization`
     - `AvroTypeExtractionTest#testSimpleAvroRead`
     - `AvroTypeInfoTest#AvroTypeInfoTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature: **no**
