### PR TITLE
[FLINK-22243] Reactive Mode parallelism changes are not shown in the job graph visualization in the UI

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonPlanGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonPlanGenerator.java
@@ -18,9 +18,14 @@
 
 package org.apache.flink.runtime.jobgraph.jsonplan;
 
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.JobEdge;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
@@ -28,14 +33,43 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.io.StringWriter;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
+@Internal
 public class JsonPlanGenerator {
 
     private static final String NOT_SET = "";
     private static final String EMPTY = "{}";
+    private static final VertexParallelism EMPTY_VERTEX_PARALLELISM =
+            new VertexParallelism() {
+                @Override
+                public Map<JobVertexID, Integer> getMaxParallelismForVertices() {
+                    return Collections.emptyMap();
+                }
+
+                @Override
+                public int getParallelism(JobVertexID jobVertexId) {
+                    return -1;
+                }
+            };
 
     public static String generatePlan(JobGraph jg) {
+        return generatePlan(
+                jg.getJobID(),
+                jg.getName(),
+                jg.getJobType(),
+                jg.getVertices(),
+                EMPTY_VERTEX_PARALLELISM);
+    }
+
+    public static String generatePlan(
+            JobID jobID,
+            String jobName,
+            JobType jobType,
+            Iterable<JobVertex> vertices,
+            VertexParallelism vertexParallelism) {
         try {
             final StringWriter writer = new StringWriter(1024);
 
@@ -44,13 +78,13 @@ public class JsonPlanGenerator {
 
             // start of everything
             gen.writeStartObject();
-            gen.writeStringField("jid", jg.getJobID().toString());
-            gen.writeStringField("name", jg.getName());
-            gen.writeStringField("type", jg.getJobType().name());
+            gen.writeStringField("jid", jobID.toString());
+            gen.writeStringField("name", jobName);
+            gen.writeStringField("type", jobType.name());
             gen.writeArrayFieldStart("nodes");
 
             // info per vertex
-            for (JobVertex vertex : jg.getVertices()) {
+            for (JobVertex vertex : vertices) {
 
                 String operator =
                         vertex.getOperatorName() != null ? vertex.getOperatorName() : NOT_SET;
@@ -81,8 +115,12 @@ public class JsonPlanGenerator {
                 gen.writeStartObject();
 
                 // write the core properties
-                gen.writeStringField("id", vertex.getID().toString());
-                gen.writeNumberField("parallelism", vertex.getParallelism());
+                JobVertexID vertexID = vertex.getID();
+                int storeParallelism = vertexParallelism.getParallelism(vertexID);
+                gen.writeStringField("id", vertexID.toString());
+                gen.writeNumberField(
+                        "parallelism",
+                        storeParallelism != -1 ? storeParallelism : vertex.getParallelism());
                 gen.writeStringField("operator", operator);
                 gen.writeStringField("operator_strategy", operatorDescr);
                 gen.writeStringField("description", description);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -173,6 +173,9 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     }
 
     @Override
+    public void setJsonPlan(String jsonPlan) {}
+
+    @Override
     public JobID getJobID() {
         return jobId;
     }
@@ -282,11 +285,6 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
 
     @Override
     public KvStateLocationRegistry getKvStateLocationRegistry() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void setJsonPlan(String jsonPlan) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/ReactiveModeITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.SchedulerExecutionMode;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.rest.messages.job.JobDetailsInfo;
 import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
@@ -35,6 +36,9 @@ import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunctio
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.jackson.JacksonMapperFactory;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,12 +46,16 @@ import org.junit.rules.TemporaryFolder;
 
 import java.util.concurrent.ExecutionException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Tests for Reactive Mode (FLIP-159). */
 public class ReactiveModeITCase extends TestLogger {
     private static final int NUMBER_SLOTS_PER_TASK_MANAGER = 2;
     private static final int INITIAL_NUMBER_TASK_MANAGERS = 1;
 
     private static final Configuration configuration = getReactiveModeConfiguration();
+
+    private static final ObjectMapper OBJECT_MAPPER = JacksonMapperFactory.createObjectMapper();
 
     @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -108,6 +116,55 @@ public class ReactiveModeITCase extends TestLogger {
                 miniClusterResource.getRestClusterClient(),
                 jobClient.getJobID(),
                 NUMBER_SLOTS_PER_TASK_MANAGER * (INITIAL_NUMBER_TASK_MANAGERS + 1));
+    }
+
+    @Test
+    public void testJsonPlanParallelismAfterRescale() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        final DataStream<String> input = env.addSource(new DummySource());
+        input.addSink(new DiscardingSink<>());
+
+        final JobClient jobClient = env.executeAsync();
+
+        int initialParallelism = NUMBER_SLOTS_PER_TASK_MANAGER * INITIAL_NUMBER_TASK_MANAGERS;
+        waitUntilParallelismForVertexReached(
+                miniClusterResource.getRestClusterClient(),
+                jobClient.getJobID(),
+                initialParallelism);
+
+        ArchivedExecutionGraph archivedExecutionGraph =
+                miniClusterResource
+                        .getMiniCluster()
+                        .getArchivedExecutionGraph(jobClient.getJobID())
+                        .get();
+
+        assertThat(
+                        OBJECT_MAPPER
+                                .readTree(archivedExecutionGraph.getJsonPlan())
+                                .findValues("parallelism"))
+                .allMatch(n -> n.asInt() == initialParallelism);
+
+        // scale up to 2 TaskManagers:
+        miniClusterResource.getMiniCluster().startTaskManager();
+
+        int rescaledParallelism =
+                NUMBER_SLOTS_PER_TASK_MANAGER * (INITIAL_NUMBER_TASK_MANAGERS + 1);
+        waitUntilParallelismForVertexReached(
+                miniClusterResource.getRestClusterClient(),
+                jobClient.getJobID(),
+                rescaledParallelism);
+
+        archivedExecutionGraph =
+                miniClusterResource
+                        .getMiniCluster()
+                        .getArchivedExecutionGraph(jobClient.getJobID())
+                        .get();
+
+        assertThat(
+                        OBJECT_MAPPER
+                                .readTree(archivedExecutionGraph.getJsonPlan())
+                                .findValues("parallelism"))
+                .allMatch(n -> n.asInt() == rescaledParallelism);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Update the JsonPlan of ExecutionGraph with the correct parallelism instead of using the original one from the JobGraph.

## Verifying this change
Added a test in `ReactiveModeITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
