### PR TITLE
[FLINK-29437] Align the partition of data before and after the Kafka Shuffle

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionAssigner.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/internals/KafkaTopicPartitionAssigner.java
@@ -47,12 +47,15 @@ public class KafkaTopicPartitionAssigner {
      * @return index of the target subtask that the Kafka partition should be assigned to.
      */
     public static int assign(KafkaTopicPartition partition, int numParallelSubtasks) {
-        int startIndex =
-                ((partition.getTopic().hashCode() * 31) & 0x7FFFFFFF) % numParallelSubtasks;
+        return assign(partition.getTopic(), partition.getPartition(), numParallelSubtasks);
+    }
+
+    public static int assign(String topic, int partition, int numParallelSubtasks) {
+        int startIndex = ((topic.hashCode() * 31) & 0x7FFFFFFF) % numParallelSubtasks;
 
         // here, the assumption is that the id of Kafka partitions are always ascending
         // starting from 0, and therefore can be used directly as the offset clockwise from the
         // start index
-        return (startIndex + partition.getPartition()) % numParallelSubtasks;
+        return (startIndex + partition) % numParallelSubtasks;
     }
 }

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/shuffle/FlinkKafkaShuffle.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/shuffle/FlinkKafkaShuffle.java
@@ -342,6 +342,8 @@ public class FlinkKafkaShuffle {
                 "Missing partition number for Kafka Shuffle");
         int numberOfPartitions =
                 PropertiesUtil.getInt(kafkaProperties, PARTITION_NUMBER, Integer.MIN_VALUE);
+        // Set the parallelism / max parallelism of the keyed stream in consumer side as the number
+        // of kafka partitions
         DataStream<T> outputDataStream =
                 env.addSource(kafkaConsumer)
                         .setParallelism(numberOfPartitions)

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/shuffle/FlinkKafkaShuffle.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/shuffle/FlinkKafkaShuffle.java
@@ -343,7 +343,9 @@ public class FlinkKafkaShuffle {
         int numberOfPartitions =
                 PropertiesUtil.getInt(kafkaProperties, PARTITION_NUMBER, Integer.MIN_VALUE);
         DataStream<T> outputDataStream =
-                env.addSource(kafkaConsumer).setParallelism(numberOfPartitions);
+                env.addSource(kafkaConsumer)
+                        .setParallelism(numberOfPartitions)
+                        .setMaxParallelism(numberOfPartitions);
 
         return DataStreamUtils.reinterpretAsKeyedStream(outputDataStream, keySelector);
     }


### PR DESCRIPTION
## What is the purpose of the change
Currently, the key group range in consumer side of Kafka Shuffle is not aligned with the producer side, there are two problems:

- The data partitioning of the sink(producer) is exactly the same way as a keyed stream that as the same maximum parallelism as the number of kafka partitions does, but in consumer side the number of partitions and key groups are not the same.
- There is a distribution of assigning kafka partitions to consumer subtasks (See KafkaTopicPartitionAssigner#assign), but the producer of Kafka Shuffle simply assume the partition index equals the subtask index.

For more details, please check [FLINK-29437](https://issues.apache.org/jira/browse/FLINK-29437).

## Brief change log

- Set the max parallelism of the key stream in consumer side as the number of kafka partitions. 
- Use the same method when assigning kafka partitions to consumer subtasks to maintain a map from subtasks to kafka partitions, which is used by the producer to insert into the right partition for data for a subtask.


## Verifying this change

This change is already covered by existing tests, such as [KafkaShuffleTestBase.java](https://github.com/apache/flink/compare/master...Zakelly:flink:f29437#diff-7bf23cc4a08595fe6ee179b109255e1ac6d36284a43bb184437268ae331c5c90).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
