### PR TITLE
[FLINK-29395][Connector/Kinesis] Handle empty deaggregated records…

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisher.java
@@ -44,9 +44,11 @@ import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
 
+import static com.amazonaws.services.kinesis.model.ShardIteratorType.AT_TIMESTAMP;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.CANCELLED;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 import static software.amazon.awssdk.services.kinesis.model.StartingPosition.builder;
 
 /**
@@ -116,8 +118,7 @@ public class FanOutRecordPublisher implements RecordPublisher {
                                     subscribedShard,
                                     event.millisBehindLatest());
                     SequenceNumber sequenceNumber = recordConsumer.accept(recordBatch);
-                    nextStartingPosition =
-                            StartingPosition.continueFromSequenceNumber(sequenceNumber);
+                    nextStartingPosition = getNextStartingPosition(sequenceNumber);
                 };
 
         RecordPublisherRunResult result = runWithBackoff(eventConsumer);
@@ -129,6 +130,20 @@ public class FanOutRecordPublisher implements RecordPublisher {
                 result);
 
         return result;
+    }
+
+    private StartingPosition getNextStartingPosition(final SequenceNumber latestSequenceNumber) {
+        // When consuming from a timestamp sentinel/AT_TIMESTAMP ShardIteratorType.
+        // If the first RecordBatch has no deaggregated records, then the latestSequenceNumber would
+        // be the timestamp sentinel.
+        // This is because we have not yet received any real sequence numbers on this shard.
+        // In this condition we should retry from the previous starting position (AT_TIMESTAMP).
+        if (SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().equals(latestSequenceNumber)) {
+            Preconditions.checkState(nextStartingPosition.getShardIteratorType() == AT_TIMESTAMP);
+            return nextStartingPosition;
+        } else {
+            return StartingPosition.continueFromSequenceNumber(latestSequenceNumber);
+        }
     }
 
     /**

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherTest.java
@@ -25,12 +25,15 @@ import org.apache.flink.streaming.connectors.kinesis.model.StartingPosition;
 import org.apache.flink.streaming.connectors.kinesis.proxy.FullJitterBackoff;
 import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyV2Interface;
 import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory;
+import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.AbstractSingleShardFanOutKinesisV2;
 import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.SingleShardFanOutKinesisV2;
 import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.SubscriptionErrorKinesisV2;
 import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils.TestConsumer;
 
 import com.amazonaws.http.timers.client.SdkInterruptedException;
+import com.amazonaws.kinesis.agg.RecordAggregator;
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord;
+import com.amazonaws.services.kinesis.model.HashKeyRange;
 import io.netty.handler.timeout.ReadTimeoutException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -42,12 +45,16 @@ import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.kinesis.model.SubscribeToShardEvent;
 
 import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.emptyList;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.EFO_CONSUMER_NAME;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RECORD_PUBLISHER_TYPE;
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.RecordPublisherType.EFO;
@@ -58,9 +65,11 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.CANCELLED;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.COMPLETE;
 import static org.apache.flink.streaming.connectors.kinesis.internals.publisher.RecordPublisher.RecordPublisherRunResult.INCOMPLETE;
+import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_EARLIEST_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.model.SentinelSequenceNumber.SENTINEL_LATEST_SEQUENCE_NUM;
 import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.emptyShard;
+import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.singleShardWithEvents;
 import static org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisFanOutBehavioursFactory.singletonShard;
 import static org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils.createDummyStreamShardHandle;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,6 +174,56 @@ public class FanOutRecordPublisherTest {
         assertThat(kinesis.getStartingPositionForSubscription(0).timestamp())
                 .isEqualTo(now.toInstant());
         assertThat(kinesis.getStartingPositionForSubscription(0).type()).isEqualTo(AT_TIMESTAMP);
+    }
+
+    @Test
+    public void testToSdkV2StartingPositionAtTimestampWithDroppedAggregatedRecord()
+            throws Exception {
+        // Create Aggregate Record with explicit hash keys 0 and 1
+        RecordAggregator recordAggregator = new RecordAggregator();
+        recordAggregator.addUserRecord("pk", "0", randomAlphabetic(32).getBytes(UTF_8));
+        recordAggregator.addUserRecord("pk", "1", randomAlphabetic(32).getBytes(UTF_8));
+        Record record =
+                Record.builder()
+                        .approximateArrivalTimestamp(Instant.now())
+                        .data(
+                                SdkBytes.fromByteArray(
+                                        recordAggregator.clearAndGet().toRecordBytes()))
+                        .sequenceNumber("1")
+                        .partitionKey("pk")
+                        .build();
+
+        // Create 2 Subscription events for asserting that requested sequence number stays the same
+        List<SubscribeToShardEvent> events = new ArrayList<>();
+        events.add(createSubscribeToShardEvent(record));
+        events.add(createSubscribeToShardEvent(record));
+
+        AbstractSingleShardFanOutKinesisV2 kinesis = singleShardWithEvents(events);
+        Date now = new Date();
+
+        // Create ShardHandle with HashKeyRange excluding single UserRecord with hash key 0
+        HashKeyRange hashKeyRange =
+                new HashKeyRange().withStartingHashKey("1").withEndingHashKey("100");
+
+        RecordPublisher publisher =
+                new FanOutRecordPublisher(
+                        StartingPosition.fromTimestamp(now),
+                        "arn",
+                        createDummyStreamShardHandle("stream-name", "shardId-00000", hashKeyRange),
+                        kinesis,
+                        createConfiguration(),
+                        new FullJitterBackoff());
+        publisher.run(
+                new TestConsumer(SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().getSequenceNumber()));
+
+        // Run a second time to ensure the StartingPosition is still respected, indicating we are
+        // still using the original AT_TIMESTAMP behaviour
+        publisher.run(
+                new TestConsumer(SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().getSequenceNumber()));
+
+        assertThat(kinesis.getStartingPositionForSubscription(1).timestamp())
+                .isEqualTo(now.toInstant());
+        assertThat(kinesis.getStartingPositionForSubscription(1).type()).isEqualTo(AT_TIMESTAMP);
     }
 
     @Test

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisFanOutBehavioursFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisFanOutBehavioursFactory.java
@@ -84,6 +84,11 @@ public class FakeKinesisFanOutBehavioursFactory {
         return new SingletonEventFanOutKinesisV2(event);
     }
 
+    public static AbstractSingleShardFanOutKinesisV2 singleShardWithEvents(
+            final List<SubscribeToShardEvent> events) {
+        return new EventFanOutKinesisV2(events);
+    }
+
     public static SingleShardFanOutKinesisV2 emptyShard() {
         return new SingleShardFanOutKinesisV2.Builder().withBatchCount(0).build();
     }
@@ -259,6 +264,21 @@ public class FakeKinesisFanOutBehavioursFactory {
         @Override
         List<SubscribeToShardEvent> getEventsToSend() {
             return Collections.singletonList(event);
+        }
+    }
+
+    private static class EventFanOutKinesisV2 extends AbstractSingleShardFanOutKinesisV2 {
+
+        private final List<SubscribeToShardEvent> events;
+
+        private EventFanOutKinesisV2(List<SubscribeToShardEvent> events) {
+            super(1);
+            this.events = events;
+        }
+
+        @Override
+        List<SubscribeToShardEvent> getEventsToSend() {
+            return events;
         }
     }
 

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/TestUtils.java
@@ -118,18 +118,24 @@ public class TestUtils {
 
     public static StreamShardHandle createDummyStreamShardHandle(
             final String streamName, final String shardId) {
+        return createDummyStreamShardHandle(
+                streamName,
+                shardId,
+                new HashKeyRange()
+                        .withStartingHashKey("0")
+                        .withEndingHashKey(
+                                new BigInteger(StringUtils.repeat("FF", 16), 16).toString()));
+    }
+
+    public static StreamShardHandle createDummyStreamShardHandle(
+            final String streamName, final String shardId, final HashKeyRange hashKeyRange) {
         final Shard shard =
                 new Shard()
                         .withSequenceNumberRange(
                                 new SequenceNumberRange()
                                         .withStartingSequenceNumber("0")
                                         .withEndingSequenceNumber("9999999999999"))
-                        .withHashKeyRange(
-                                new HashKeyRange()
-                                        .withStartingHashKey("0")
-                                        .withEndingHashKey(
-                                                new BigInteger(StringUtils.repeat("FF", 16), 16)
-                                                        .toString()))
+                        .withHashKeyRange(hashKeyRange)
                         .withShardId(shardId);
 
         return new StreamShardHandle(streamName, shard);
@@ -173,6 +179,14 @@ public class TestUtils {
     public static class TestConsumer implements RecordPublisher.RecordBatchConsumer {
         private final List<RecordBatch> recordBatches = new ArrayList<>();
         private String latestSequenceNumber;
+
+        public TestConsumer() {
+            this(null);
+        }
+
+        public TestConsumer(String latestSequenceNumber) {
+            this.latestSequenceNumber = latestSequenceNumber;
+        }
 
         @Override
         public SequenceNumber accept(final RecordBatch batch) {


### PR DESCRIPTION
…in FanOutRecordPublisher

## What is the purpose of the change

The consumer fails when three conditions are met:
1. Kinesis EFO record publisher uses an AT_TIMESTAMP starting position.
2. The first record batch is not empty.
3. The deaggregated record batch is empty.

This can happen when the user writes aggregated records into their Kinesis stream whilst specifying the explicitHashKey for every single user record. When resharding occurs, there is a possibility that records within the same aggregated batch fall into two different shards, since they have different explicit hash keys. When this happens, the deaggregated records are dropped. (We need to do this in Kinesis Consumer so we do not process duplicate records. See https://github.com/awslabs/kinesis-aggregation/issues/11)

If all deaggregated records are dropped, the consumer receives an empty deaggregated record batch even though the record batch is not empty.

## Brief change log

This is fixed by returning the AT_TIMESTAMP starting position when receiving an AT_TIMESTAMP sentinel sequence number.

## Verifying this change
- Unit tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
