### PR TITLE
FLINK-29244 Add metric lastMaterializationDuration to ChangelogMaterializationMetricGroup

### DIFF
--- a/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
+++ b/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
@@ -39,9 +39,15 @@ public class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<Metric
     @VisibleForTesting
     public static final String FAILED_MATERIALIZATION = PREFIX + ".failedMaterialization";
 
+    @VisibleForTesting
+    public static final String LAST_MATERIALIZATION_DURATION =
+            PREFIX + ".lastMaterializationDuration";
+
     private final Counter startedMaterializationCounter;
     private final Counter completedMaterializationCounter;
     private final Counter failedMaterializationCounter;
+
+    private volatile long lastDuration = -1;
 
     public ChangelogMaterializationMetricGroup(MetricGroup parentMetricGroup) {
         super(parentMetricGroup);
@@ -51,6 +57,8 @@ public class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<Metric
                 counter(COMPLETED_MATERIALIZATION, new ThreadSafeSimpleCounter());
         this.failedMaterializationCounter =
                 counter(FAILED_MATERIALIZATION, new ThreadSafeSimpleCounter());
+
+        gauge(LAST_MATERIALIZATION_DURATION, () -> lastDuration);
     }
 
     void reportStartedMaterialization() {
@@ -63,5 +71,9 @@ public class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<Metric
 
     void reportFailedMaterialization() {
         failedMaterializationCounter.inc();
+    }
+
+    void reportMaterializationDuration(long duration) {
+        lastDuration = duration;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add metric ChangelogMaterialization.lastMaterializationDuration, described in [FLINK-29244](https://issues.apache.org/jira/browse/FLINK-29244).


## Brief change log

Add metric ChangelogMaterialization.lastMaterializationDuration.


## Verifying this change

This change is already covered by existing tests, such as ChangelogMetricGroupTest.testCompletedMaterialization(), ChangelogMetricGroupTest.testFailedMaterialization().


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
