### PR TITLE
[FLINK-29353]Support UNIX_TIMESTAMP built-in function in Table API

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -491,10 +491,10 @@ temporal:
     table: fromUnixtime(NUMERIC[, STRING])
     description: Returns a representation of the numeric argument as a value in string format (default is 'yyyy-MM-dd HH:mm:ss'). numeric is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC, such as produced by the UNIX_TIMESTAMP() function. The return value is expressed in the session time zone (specified in TableConfig). E.g., FROM_UNIXTIME(44) returns '1970-01-01 00:00:44' if in UTC time zone, but returns '1970-01-01 09:00:44' if in 'Asia/Tokyo' time zone.
   - sql: UNIX_TIMESTAMP()
-    table: unixtimestamp()
+    table: unixTimestamp()
     description: Gets current Unix timestamp in seconds. This function is not deterministic which means the value would be recalculated for each record.
   - sql: UNIX_TIMESTAMP(string1[, string2])
-    table: unixtimestamp(string1[, string2])
+    table: unixTimestamp(string1[, string2])
     description: 'Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.'
   - sql: TO_DATE(string1[, string2])
     description: Converts a date string string1 with format string2 (by default 'yyyy-MM-dd') to a date.

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -494,7 +494,7 @@ temporal:
     table: unixTimestamp()
     description: Gets current Unix timestamp in seconds. This function is not deterministic which means the value would be recalculated for each record.
   - sql: UNIX_TIMESTAMP(string1[, string2])
-    table: unixTimestamp(string1[, string2])
+    table: unixTimestamp(STRING1[, STRING2])
     description: 'Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.'
   - sql: TO_DATE(string1[, string2])
     description: Converts a date string string1 with format string2 (by default 'yyyy-MM-dd') to a date.

--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -491,8 +491,10 @@ temporal:
     table: fromUnixtime(NUMERIC[, STRING])
     description: Returns a representation of the numeric argument as a value in string format (default is 'yyyy-MM-dd HH:mm:ss'). numeric is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC, such as produced by the UNIX_TIMESTAMP() function. The return value is expressed in the session time zone (specified in TableConfig). E.g., FROM_UNIXTIME(44) returns '1970-01-01 00:00:44' if in UTC time zone, but returns '1970-01-01 09:00:44' if in 'Asia/Tokyo' time zone.
   - sql: UNIX_TIMESTAMP()
+    table: unixtimestamp()
     description: Gets current Unix timestamp in seconds. This function is not deterministic which means the value would be recalculated for each record.
   - sql: UNIX_TIMESTAMP(string1[, string2])
+    table: unixtimestamp(string1[, string2])
     description: 'Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.'
   - sql: TO_DATE(string1[, string2])
     description: Converts a date string string1 with format string2 (by default 'yyyy-MM-dd') to a date.

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -617,8 +617,10 @@ temporal:
       （在 TableConfig 中指定）。例如，如果在 UTC 时区，FROM_UNIXTIME(44) 返回 '1970-01-01 00:00:44'，如果在
       'Asia/Tokyo' 时区，则返回 '1970-01-01 09:00:44'。
   - sql: UNIX_TIMESTAMP()
+    table: unixtimestamp()
     description: 以秒为单位获取当前的 Unix 时间戳。此函数不是确定性的，这意味着将为每个记录重新计算该值。
   - sql: UNIX_TIMESTAMP(string1[, string2])
+    table: unixtimestamp(string1[, string2])
     description: |
       使用表配置中指定的时区将格式为 string2 的日期时间字符串 string1（如果未指定默认情况下：yyyy-MM-dd HH:mm:ss）
       转换为 Unix 时间戳（以秒为单位）。

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -620,7 +620,7 @@ temporal:
     table: unixTimestamp()
     description: 以秒为单位获取当前的 Unix 时间戳。此函数不是确定性的，这意味着将为每个记录重新计算该值。
   - sql: UNIX_TIMESTAMP(string1[, string2])
-    table: unixTimestamp(string1[, string2])
+    table: unixTimestamp(STRING1[, STRING2])
     description: |
       使用表配置中指定的时区将格式为 string2 的日期时间字符串 string1（如果未指定默认情况下：yyyy-MM-dd HH:mm:ss）
       转换为 Unix 时间戳（以秒为单位）。

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -617,10 +617,10 @@ temporal:
       （在 TableConfig 中指定）。例如，如果在 UTC 时区，FROM_UNIXTIME(44) 返回 '1970-01-01 00:00:44'，如果在
       'Asia/Tokyo' 时区，则返回 '1970-01-01 09:00:44'。
   - sql: UNIX_TIMESTAMP()
-    table: unixtimestamp()
+    table: unixTimestamp()
     description: 以秒为单位获取当前的 Unix 时间戳。此函数不是确定性的，这意味着将为每个记录重新计算该值。
   - sql: UNIX_TIMESTAMP(string1[, string2])
-    table: unixtimestamp(string1[, string2])
+    table: unixTimestamp(string1[, string2])
     description: |
       使用表配置中指定的时区将格式为 string2 的日期时间字符串 string1（如果未指定默认情况下：yyyy-MM-dd HH:mm:ss）
       转换为 Unix 时间戳（以秒为单位）。

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -361,15 +361,15 @@ def from_unixtime(unixtime, format=None) -> Expression:
 def unix_timestamp(date_str: str = None, format: str = None) -> Expression:
     if date_str is None:
         """
-        Gets current Unix timestamp in seconds. This function is not deterministic which means the 
-        value would be recalculated for each record.
+        Gets current Unix timestamp in seconds. This function is not deterministic which means
+        the value would be recalculated for each record.
         """
         return _leaf_op("unixTimestamp")
     elif format is None:
         """
-        Convert the date time string `date_str` to the default format (the default is yyyy-MM-dd 
-        HH:mm:ss) to the Unix timestamp (in seconds), using the time zone specified in the table 
-        config.
+        Convert the date time string `date_str` to the default format (the default is
+        yyyy-MM-dd HH:mm:ss) to the Unix timestamp (in seconds), using the time zone
+        specified in the table config.
         """
         return _unary_op("unixTimestamp", date_str)
     else:

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -32,7 +32,7 @@ __all__ = ['if_then_else', 'lit', 'col', 'range_', 'and_', 'or_', 'not_', 'UNBOU
            'row_interval', 'pi', 'e', 'rand', 'rand_integer', 'atan2', 'negative', 'concat',
            'concat_ws', 'uuid', 'null_of', 'log', 'with_columns', 'without_columns', 'json_string',
            'json_object', 'json_object_agg', 'json_array', 'json_array_agg', 'call', 'call_sql',
-           'source_watermark']
+           'source_watermark', 'unix_timestamp']
 
 
 def _leaf_op(op_name: str) -> Expression:

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -358,6 +358,19 @@ def from_unixtime(unixtime, format=None) -> Expression:
         return _binary_op("fromUnixtime", unixtime, format)
 
 
+def unix_timestamp(date_str: str = None, format: str = None) -> Expression:
+    """
+    Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
+    specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+    """
+    if date_str is None:
+        return _leaf_op("unixTimestamp")
+    elif format is None:
+        return _unary_op("unixTimestamp", date_str)
+    else:
+        return _binary_op("unixTimestamp", date_str, format)
+
+
 def array(head, *tail) -> Expression:
     """
     Creates an array of literals.

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -359,15 +359,24 @@ def from_unixtime(unixtime, format=None) -> Expression:
 
 
 def unix_timestamp(date_str: str = None, format: str = None) -> Expression:
-    """
-    Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
-    specified) to Unix timestamp (in seconds), using the specified timezone in table config.
-    """
     if date_str is None:
+        """
+        Gets current Unix timestamp in seconds. This function is not deterministic which means the 
+        value would be recalculated for each record.
+        """
         return _leaf_op("unixTimestamp")
     elif format is None:
+        """
+        Convert the date time string `date_str` to the default format (the default is yyyy-MM-dd 
+        HH:mm:ss) to the Unix timestamp (in seconds), using the time zone specified in the table 
+        config.
+        """
         return _unary_op("unixTimestamp", date_str)
     else:
+        """
+        Converts date time string `date_str` in format `format` (by default: yyyy-MM-dd HH:mm:ss if
+        not specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+        """
         return _binary_op("unixTimestamp", date_str, format)
 
 

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -275,6 +275,7 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("fromUnixtime(1)", str(from_unixtime(1)))
         self.assertEqual("fromUnixtime(1, 'yy-MM-dd HH-mm-ss')",
                          str(from_unixtime(1, 'yy-MM-dd HH-mm-ss')))
+        self.assertEqual("unixTimestamp()", str(unix_timestamp()))
         self.assertEqual("unixTimestamp('2015-07-24 10:00:00')",
                          str(unix_timestamp('2015-07-24 10:00:00')))
         self.assertEqual("unixTimestamp('2015-07-24 10:00:00', 'yy-MM-dd HH-mm-ss')",

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -26,7 +26,7 @@ from pyflink.table.expressions import (col, lit, range_, and_, or_, current_date
                                        timestamp_diff, array, row, map_, row_interval, pi, e,
                                        rand, rand_integer, atan2, negative, concat, concat_ws, uuid,
                                        null_of, log, if_then_else, with_columns, call,
-                                       to_timestamp_ltz, from_unixtime)
+                                       to_timestamp_ltz, from_unixtime, unix_timestamp)
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 
@@ -275,6 +275,10 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("fromUnixtime(1)", str(from_unixtime(1)))
         self.assertEqual("fromUnixtime(1, 'yy-MM-dd HH-mm-ss')",
                          str(from_unixtime(1, 'yy-MM-dd HH-mm-ss')))
+        self.assertEqual("unixTimestamp('2015-07-24 10:00:00')",
+                         str(unix_timestamp('2015-07-24 10:00:00')))
+        self.assertEqual("unixTimestamp('2015-07-24 10:00:00', 'yy-MM-dd HH-mm-ss')",
+                         str(unix_timestamp('2015-07-24 10:00:00', 'yy-MM-dd HH-mm-ss')))
         self.assertEqual('array(1, 2, 3)', str(array(1, 2, 3)))
         self.assertEqual("row('key1', 1)", str(row("key1", 1)))
         self.assertEqual("map('key1', 1, 'key2', 2, 'key3', 3)",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -423,8 +423,9 @@ public final class Expressions {
     }
 
     /**
-     * Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
-     * specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     * Convert the date time string `dateStr` to the default format (the default is yyyy-MM-dd
+     * HH:mm:ss) to the Unix timestamp (in seconds), using the time zone specified in the table
+     * config.
      *
      * @param dateStr dateStr the date time string.
      * @return The formatted timestamp as string.
@@ -434,8 +435,8 @@ public final class Expressions {
     }
 
     /**
-     * Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
-     * specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     * Converts date time string `dateStr` in format `format` (by default: yyyy-MM-dd HH:mm:ss if
+     * not specified) to Unix timestamp (in seconds), using the specified timezone in table config.
      *
      * @param dateStr The unix timestamp with numeric type.
      * @param format The format of the string.

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -412,6 +412,39 @@ public final class Expressions {
         return apiCall(BuiltInFunctionDefinitions.FROM_UNIXTIME, unixtime, format);
     }
 
+    /**
+     * Gets current Unix timestamp in seconds. This function is not deterministic which means the
+     * value would be recalculated for each record.
+     *
+     * @return The formatted timestamp as string.
+     */
+    public static ApiExpression unixTimestamp() {
+        return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP);
+    }
+
+    /**
+     * Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
+     * specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     *
+     * @param dateStr dateStr the date time string.
+     * @return The formatted timestamp as string.
+     */
+    public static ApiExpression unixTimestamp(Object dateStr) {
+        return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP, dateStr);
+    }
+
+    /**
+     * Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
+     * specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     *
+     * @param dateStr The unix timestamp with numeric type.
+     * @param format The format of the string.
+     * @return The formatted timestamp as string.
+     */
+    public static ApiExpression unixTimestamp(Object dateStr, Object format) {
+        return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP, dateStr, format);
+    }
+
     /** Creates an array of literals. */
     public static ApiExpression array(Object head, Object... tail) {
         return apiCallAtLeastOneArgument(BuiltInFunctionDefinitions.ARRAY, head, tail);

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -561,6 +561,28 @@ trait ImplicitExpressionConversions {
   def fromUnixtime(unixtime: Expression, format: Expression): Expression =
     Expressions.fromUnixtime(unixtime, format)
 
+  /**
+   * Gets current Unix timestamp in seconds. This function is not deterministic which means the
+   * value would be recalculated for each record.
+   */
+  def unixTimestamp(): Expression = Expressions.unixTimestamp()
+
+  /**
+   * Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
+   * specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+   */
+  def unixTimestamp(dateStr: Expression): Expression = {
+    Expressions.unixTimestamp(dateStr)
+  }
+
+  /**
+   * Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not
+   * specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+   */
+  def unixTimestamp(dateStr: Expression, format: Expression): Expression = {
+    Expressions.unixTimestamp(dateStr, format)
+  }
+
   /** Creates an array of literals. */
   def array(head: Expression, tail: Expression*): Expression = {
     Expressions.array(head, tail: _*)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1548,6 +1548,20 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition UNIX_TIMESTAMP =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("unixTimestamp")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    NO_ARGS,
+                                    sequence(logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                    sequence(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(BIGINT())))
+                    .build();
+
     public static final BuiltInFunctionDefinition TO_TIMESTAMP_LTZ =
             BuiltInFunctionDefinition.newBuilder()
                     .name("toTimestampLtz")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1559,7 +1559,7 @@ public final class BuiltInFunctionDefinitions {
                                     sequence(
                                             logical(LogicalTypeFamily.CHARACTER_STRING),
                                             logical(LogicalTypeFamily.CHARACTER_STRING))))
-                    .outputTypeStrategy(nullableIfArgs(explicit(BIGINT())))
+                    .outputTypeStrategy(explicit(BIGINT().nullable()))
                     .build();
 
     public static final BuiltInFunctionDefinition TO_TIMESTAMP_LTZ =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -208,6 +208,8 @@ public class DirectConvertRule implements CallExpressionConvertRule {
         DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.FROM_UNIXTIME, FlinkSqlOperatorTable.FROM_UNIXTIME);
         DEFINITION_OPERATOR_MAP.put(
+                BuiltInFunctionDefinitions.UNIX_TIMESTAMP, FlinkSqlOperatorTable.UNIX_TIMESTAMP);
+        DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.TO_TIMESTAMP_LTZ,
                 FlinkSqlOperatorTable.TO_TIMESTAMP_LTZ);
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -943,9 +943,7 @@ class TemporalTypesTest extends ExpressionTestBase {
       (ts2.getTime / 1000L).toString)
 
     testSqlApi(s"UNIX_TIMESTAMP('$ss1')", (ts1.getTime / 1000L).toString)
-    testSqlApi(s"UNIX_TIMESTAMP('$ss2')", (ts2.getTime / 1000L).toString)
     testSqlApi(s"UNIX_TIMESTAMP('$s1', '$fmt')", (ts1.getTime / 1000L).toString)
-    testSqlApi(s"UNIX_TIMESTAMP('$s2', '$fmt')", (ts2.getTime / 1000L).toString)
   }
 
   @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -931,6 +931,17 @@ class TemporalTypesTest extends ExpressionTestBase {
     val ss2 = "2015-07-25 02:02:02"
     val fmt = "yyyy/MM/dd HH:mm:ss.S"
 
+    testAllApis(unixTimestamp(ss1), s"UNIX_TIMESTAMP('$ss1')", (ts1.getTime / 1000L).toString)
+    testAllApis(unixTimestamp(ss2), s"UNIX_TIMESTAMP('$ss2')", (ts2.getTime / 1000L).toString)
+    testAllApis(
+      unixTimestamp(s1, fmt),
+      s"UNIX_TIMESTAMP('$s1', '$fmt')",
+      (ts1.getTime / 1000L).toString)
+    testAllApis(
+      unixTimestamp(s2, fmt),
+      s"UNIX_TIMESTAMP('$s2', '$fmt')",
+      (ts2.getTime / 1000L).toString)
+
     testSqlApi(s"UNIX_TIMESTAMP('$ss1')", (ts1.getTime / 1000L).toString)
     testSqlApi(s"UNIX_TIMESTAMP('$ss2')", (ts2.getTime / 1000L).toString)
     testSqlApi(s"UNIX_TIMESTAMP('$s1', '$fmt')", (ts1.getTime / 1000L).toString)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
