### PR TITLE
[FLINK-29399][tests] Wait until job was cancelled

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableITCase.scala
@@ -119,16 +119,15 @@ class TableITCase(tableEnvName: String, isStreaming: Boolean) extends AbstractTe
     assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult.getResultKind)
     val it = tableResult.collect()
     it.close()
-    val jobStatus =
+    var jobStatus = JobStatus.RUNNING
+    while (jobStatus == JobStatus.RUNNING) {
       try {
-        Some(tableResult.getJobClient.get().getJobStatus.get())
+        jobStatus = tableResult.getJobClient.get().getJobStatus.get()
       } catch {
         // ignore the exception,
         // because the MiniCluster maybe already been shut down when getting job status
         case _: Throwable => None
       }
-    if (jobStatus.isDefined) {
-      assertNotEquals(JobStatus.RUNNING, jobStatus.get)
     }
   }
 


### PR DESCRIPTION
Fixes an issue where the TableITCase could fail because the cancellation hasn't gone through yet.