### PR TITLE
[FLINK-29501] Add option to override job vertex parallelisms during job submission

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -64,13 +64,20 @@ public class ConfigOption<T> {
      *
      * <ul>
      *   <li>typeClass == atomic class (e.g. {@code Integer.class}) -> {@code ConfigOption<Integer>}
-     *   <li>typeClass == {@code Map.class} -> {@code ConfigOption<Map<String, String>>}
-     *   <li>typeClass == atomic class and isList == true for {@code ConfigOption<List<Integer>>}
+     *   <li>typeClass == atomic class and type == LIST for {@code ConfigOption<List<Integer>>}
+     *   <li>typeClass == atomic class and type == MAP for {@code ConfigOption<Map<String,
+     *       Integer>>}
      * </ul>
      */
     private final Class<?> clazz;
 
-    private final boolean isList;
+    enum Type {
+        VALUE,
+        LIST,
+        MAP
+    }
+
+    private final Type valueType;
 
     // ------------------------------------------------------------------------
 
@@ -78,8 +85,16 @@ public class ConfigOption<T> {
         return clazz;
     }
 
+    public Type getType() {
+        return valueType;
+    }
+
     boolean isList() {
-        return isList;
+        return valueType == Type.LIST;
+    }
+
+    boolean isMap() {
+        return valueType == Type.MAP;
     }
 
     /**
@@ -89,8 +104,8 @@ public class ConfigOption<T> {
      * @param clazz describes type of the ConfigOption, see description of the clazz field
      * @param description Description for that option
      * @param defaultValue The default value for this option
-     * @param isList tells if the ConfigOption describes a list option, see description of the clazz
-     *     field
+     * @param valueType tells if the ConfigOption describes a list option, see description of the
+     *     clazz field
      * @param fallbackKeys The list of fallback keys, in the order to be checked
      */
     ConfigOption(
@@ -98,14 +113,14 @@ public class ConfigOption<T> {
             Class<?> clazz,
             Description description,
             T defaultValue,
-            boolean isList,
+            Type valueType,
             FallbackKey... fallbackKeys) {
         this.key = checkNotNull(key);
         this.description = description;
         this.defaultValue = defaultValue;
         this.fallbackKeys = fallbackKeys == null || fallbackKeys.length == 0 ? EMPTY : fallbackKeys;
         this.clazz = checkNotNull(clazz);
-        this.isList = isList;
+        this.valueType = valueType;
     }
 
     // ------------------------------------------------------------------------
@@ -131,7 +146,7 @@ public class ConfigOption<T> {
         final FallbackKey[] mergedAlternativeKeys =
                 Stream.concat(newFallbackKeys, currentAlternativeKeys).toArray(FallbackKey[]::new);
         return new ConfigOption<>(
-                key, clazz, description, defaultValue, isList, mergedAlternativeKeys);
+                key, clazz, description, defaultValue, valueType, mergedAlternativeKeys);
     }
 
     /**
@@ -156,7 +171,7 @@ public class ConfigOption<T> {
                 Stream.concat(currentAlternativeKeys, newDeprecatedKeys)
                         .toArray(FallbackKey[]::new);
         return new ConfigOption<>(
-                key, clazz, description, defaultValue, isList, mergedAlternativeKeys);
+                key, clazz, description, defaultValue, valueType, mergedAlternativeKeys);
     }
 
     /**
@@ -178,7 +193,7 @@ public class ConfigOption<T> {
      * @return A new config option, with given description.
      */
     public ConfigOption<T> withDescription(final Description description) {
-        return new ConfigOption<>(key, clazz, description, defaultValue, isList, fallbackKeys);
+        return new ConfigOption<>(key, clazz, description, defaultValue, valueType, fallbackKeys);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
@@ -298,8 +298,9 @@ public class ConfigOptions {
         }
 
         /** Defines that the option's type should be a list of previously defined atomic type. */
-        public ListConfigOptionBuilder<Map> asList() {
-            return new ListConfigOptionBuilder<>(key, Map.class);
+        @SuppressWarnings("rawtypes")
+        public ListConfigOptionBuilder<Map<String, V>> asList() {
+            return (ListConfigOptionBuilder) new ListConfigOptionBuilder<>(key, Map.class);
         }
 
         public final ConfigOption<Map<String, V>> defaultValue(Map<String, V> defaultMap) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -712,6 +712,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         try {
             if (option.isList()) {
                 return rawValue.map(v -> ConfigurationUtils.convertToList(v, clazz));
+            } else if (option.isMap()) {
+                return rawValue.map(v -> ConfigurationUtils.convertToMap(v, clazz));
             } else {
                 return rawValue.map(v -> ConfigurationUtils.convertValue(v, clazz));
             }

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -402,7 +402,7 @@ public final class DelegatingConfiguration extends Configuration {
                 option.getClazz(),
                 option.description(),
                 option.defaultValue(),
-                option.isList(),
+                option.getType(),
                 deprecated);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -164,6 +165,14 @@ public class PipelineOptions {
                     .withDescription(
                             "Register a custom, serializable user configuration object. The configuration can be "
                                     + " accessed in operators");
+
+    public static final ConfigOption<Map<String, Integer>> PARALLELISM_OVERRIDES =
+            key("pipeline.jobvertex-parallelism-overrides")
+                    .mapType(Integer.class)
+                    .defaultValue(Collections.emptyMap())
+                    .withDescription(
+                            "A parallelism override map (jobVertexId -> parallelism) which will be used to update"
+                                    + " the parallelism of the corresponding job vertices of submitted JobGraphs.");
 
     public static final ConfigOption<Integer> MAX_PARALLELISM =
             key("pipeline.max-parallelism")

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -54,19 +54,30 @@ public class ConfigurationTest extends TestLogger {
     private static final ConfigOption<Map<String, String>> MAP_OPTION =
             ConfigOptions.key("test-map-key").mapType().noDefaultValue();
 
+    private static final ConfigOption<Map<String, Integer>> MAP_OPTION_INTEGER_TYPE =
+            ConfigOptions.key("test-map-key").mapType(Integer.class).noDefaultValue();
+
     private static final ConfigOption<Duration> DURATION_OPTION =
             ConfigOptions.key("test-duration-key").durationType().noDefaultValue();
 
     private static final Map<String, String> PROPERTIES_MAP = new HashMap<>();
 
+    private static final Map<String, Integer> PROPERTIES_MAP2 = new HashMap<>();
+
     static {
         PROPERTIES_MAP.put("prop1", "value1");
         PROPERTIES_MAP.put("prop2", "12");
+        PROPERTIES_MAP2.put("prop1", 1);
+        PROPERTIES_MAP2.put("prop2", 2);
     }
 
     private static final String MAP_PROPERTY_1 = MAP_OPTION.key() + ".prop1";
 
     private static final String MAP_PROPERTY_2 = MAP_OPTION.key() + ".prop2";
+
+    private static final String MAP2_PROPERTY_1 = MAP_OPTION_INTEGER_TYPE.key() + ".prop1";
+
+    private static final String MAP2_PROPERTY_2 = MAP_OPTION_INTEGER_TYPE.key() + ".prop2";
 
     /** This test checks the serialization/deserialization of configuration objects. */
     @Test
@@ -433,6 +444,16 @@ public class ConfigurationTest extends TestLogger {
         assertFalse(cfg.contains(MAP_OPTION));
         assertFalse(cfg.containsKey(MAP_PROPERTY_1));
         assertFalse(cfg.containsKey(MAP_PROPERTY_2));
+    }
+
+    @Test
+    public void testMapWorksWithNonStringValue() {
+        final Configuration cfg = new Configuration();
+        cfg.setString(MAP2_PROPERTY_1, "1");
+        cfg.setString(MAP2_PROPERTY_2, "2");
+
+        Map<String, Integer> stringIntegerMap = cfg.get(MAP_OPTION_INTEGER_TYPE);
+        assertEquals(1L, (long) stringIntegerMap.get("prop1"));
     }
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

This allows to change the job vertex parallelism of a JobGraph during job submission time without having to modify the JobGraph upfront.

The initial idea was to add a new field to the payload of the job submit Rest endpoint. However, it is probably more practical to handle the overrides in the same way as other PipelineOptions already do it, i.e. via the configuration.

The implementation is deliberately lenient with respect to the presence of job vertices. If vertices have been removed or new ones have been added, only the ones found will have their parallelism overrides. The verification should be performed by the caller, not by Flink. In particular, we want to support scenarios where users modify the deployment and we might not yet have overrides for all vertices.

## Brief change log

- Add option to override job vertex parallelisms during job submission
- Allow Map<String, T> ConfigOptions

## Verifying this change

Tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
