### PR TITLE
[FLINK-29485] Introduces FlinkVersionBasedTestDataGenerationUtils to handle test data generation

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaConsumerBaseMigrationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
@@ -38,7 +39,6 @@ import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 import org.apache.flink.util.SerializedValue;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.assumeFlinkVersionWithDescriptiveTextMessageJUnit4;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -63,19 +64,11 @@ import static org.powermock.api.mockito.PowerMockito.when;
  * Tests for checking whether {@link FlinkKafkaConsumerBase} can restore from snapshots that were
  * done using previous Flink versions' {@link FlinkKafkaConsumerBase}.
  *
- * <p>For regenerating the binary snapshot files run {@link #writeSnapshot()} on the corresponding
- * Flink release-* branch.
+ * <p>See {@link FlinkVersionBasedTestDataGenerationUtils} for details on how to generate new test
+ * data.
  */
 @RunWith(Parameterized.class)
 public class FlinkKafkaConsumerBaseMigrationTest {
-
-    /**
-     * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
-     * methods to generate savepoints TODO Note: You should generate the savepoint based on the
-     * release branch instead of the master.
-     */
-    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
     private static final HashMap<KafkaTopicPartition, Long> PARTITION_STATE = new HashMap<>();
 
@@ -92,7 +85,7 @@ public class FlinkKafkaConsumerBaseMigrationTest {
 
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
-        return FlinkVersion.rangeOf(FlinkVersion.v1_4, FlinkVersion.v1_15);
+        return FlinkVersionBasedTestDataGenerationUtils.rangeFrom(FlinkVersion.v1_4);
     }
 
     public FlinkKafkaConsumerBaseMigrationTest(FlinkVersion testMigrateVersion) {
@@ -100,19 +93,19 @@ public class FlinkKafkaConsumerBaseMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
         writeSnapshot(
                 "src/test/resources/kafka-consumer-migration-test-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot",
                 PARTITION_STATE);
 
         final HashMap<KafkaTopicPartition, Long> emptyState = new HashMap<>();
         writeSnapshot(
                 "src/test/resources/kafka-consumer-migration-test-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-empty-state-snapshot",
                 emptyState);
     }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaProducerMigrationTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.streaming.connectors.kafka;
 
 import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.streaming.api.operators.StreamSink;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -35,14 +36,14 @@ import java.util.Properties;
  * Tests for checking whether {@link FlinkKafkaProducer} can restore from snapshots that were done
  * using previous Flink versions' {@link FlinkKafkaProducer}.
  *
- * <p>For regenerating the binary snapshot files run {@link #writeSnapshot()} on the corresponding
- * Flink release-* branch.
+ * <p>See {@link FlinkVersionBasedTestDataGenerationUtils} for details on how to generate new test
+ * data.
  */
 @RunWith(Parameterized.class)
 public class FlinkKafkaProducerMigrationTest extends KafkaMigrationTestBase {
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
-        return FlinkVersion.rangeOf(FlinkVersion.v1_8, FlinkVersion.v1_15);
+        return FlinkVersionBasedTestDataGenerationUtils.rangeFrom(FlinkVersion.v1_8);
     }
 
     public FlinkKafkaProducerMigrationTest(FlinkVersion testMigrateVersion) {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaMigrationTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaMigrationTestBase.java
@@ -21,6 +21,7 @@ import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.serialization.TypeInformationSerializationSchema;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.connectors.kafka.internals.KeyedSerializationSchemaWrapper;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
@@ -29,17 +30,14 @@ import org.apache.flink.streaming.util.serialization.KeyedSerializationSchema;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
-import java.util.Optional;
 import java.util.Properties;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
 
 /** The base class with migration tests for the Kafka Exactly-Once Producer. */
 @SuppressWarnings("serial")
@@ -54,14 +52,6 @@ public abstract class KafkaMigrationTestBase extends KafkaTestBase {
                     BasicTypeInfo.INT_TYPE_INFO, new ExecutionConfig());
     protected final KeyedSerializationSchema<Integer> integerKeyedSerializationSchema =
             new KeyedSerializationSchemaWrapper<>(integerSerializationSchema);
-
-    /**
-     * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
-     * methods to generate savepoints TODO Note: You should generate the savepoint based on the
-     * release branch instead of the master.
-     */
-    protected final Optional<FlinkVersion> flinkGenerateSavepointVersion = Optional.empty();
 
     public KafkaMigrationTestBase(FlinkVersion testMigrateVersion) {
         this.testMigrateVersion = checkNotNull(testMigrateVersion);
@@ -89,17 +79,16 @@ public abstract class KafkaMigrationTestBase extends KafkaTestBase {
     @AfterClass
     public static void shutDownServices() throws Exception {}
 
-    /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeSnapshot() throws Exception {
+        FlinkVersionBasedTestDataGenerationUtils.assumeFlinkVersionWithDescriptiveMessage(
+                testMigrateVersion);
         try {
-            checkState(flinkGenerateSavepointVersion.isPresent());
             startClusters();
 
             OperatorSubtaskState snapshot = initializeTestState();
             OperatorSnapshotUtil.writeStateHandle(
-                    snapshot, getOperatorSnapshotPath(flinkGenerateSavepointVersion.get()));
+                    snapshot, getOperatorSnapshotPath(testMigrateVersion));
         } finally {
             shutdownClusters();
         }

--- a/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
+++ b/flink-fs-tests/src/test/java/org/apache/flink/hdfstests/ContinuousFileProcessingMigrationTest.java
@@ -59,8 +59,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.mostRecentlyPublishedBaseMinorVersion;
 import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
 /** Tests that verify the migration from previous Flink version snapshots. */
 @RunWith(Parameterized.class)
@@ -72,20 +75,28 @@ public class ContinuousFileProcessingMigrationTest {
 
     @Parameterized.Parameters(name = "Migration Savepoint / Mod Time: {0}")
     public static Collection<Tuple2<FlinkVersion, Long>> parameters() {
-        return Arrays.asList(
-                Tuple2.of(FlinkVersion.v1_3, 1496532000000L),
-                Tuple2.of(FlinkVersion.v1_4, 1516897628000L),
-                Tuple2.of(FlinkVersion.v1_5, 1533639934000L),
-                Tuple2.of(FlinkVersion.v1_6, 1534696817000L),
-                Tuple2.of(FlinkVersion.v1_7, 1544024599000L),
-                Tuple2.of(FlinkVersion.v1_8, 1555215710000L),
-                Tuple2.of(FlinkVersion.v1_9, 1567499868000L),
-                Tuple2.of(FlinkVersion.v1_10, 1594559333000L),
-                Tuple2.of(FlinkVersion.v1_11, 1594561663000L),
-                Tuple2.of(FlinkVersion.v1_12, 1613720148000L),
-                Tuple2.of(FlinkVersion.v1_13, 1627550216000L),
-                Tuple2.of(FlinkVersion.v1_14, 1633938795000L),
-                Tuple2.of(FlinkVersion.v1_15, 1651918450000L));
+        final List<Tuple2<FlinkVersion, Long>> testData =
+                Arrays.asList(
+                        Tuple2.of(FlinkVersion.v1_3, 1496532000000L),
+                        Tuple2.of(FlinkVersion.v1_4, 1516897628000L),
+                        Tuple2.of(FlinkVersion.v1_5, 1533639934000L),
+                        Tuple2.of(FlinkVersion.v1_6, 1534696817000L),
+                        Tuple2.of(FlinkVersion.v1_7, 1544024599000L),
+                        Tuple2.of(FlinkVersion.v1_8, 1555215710000L),
+                        Tuple2.of(FlinkVersion.v1_9, 1567499868000L),
+                        Tuple2.of(FlinkVersion.v1_10, 1594559333000L),
+                        Tuple2.of(FlinkVersion.v1_11, 1594561663000L),
+                        Tuple2.of(FlinkVersion.v1_12, 1613720148000L),
+                        Tuple2.of(FlinkVersion.v1_13, 1627550216000L),
+                        Tuple2.of(FlinkVersion.v1_14, 1633938795000L),
+                        Tuple2.of(FlinkVersion.v1_15, 1651918450000L));
+        checkState(
+                testData.size()
+                        == FlinkVersion.rangeOf(
+                                        FlinkVersion.v1_3, mostRecentlyPublishedBaseMinorVersion())
+                                .size(),
+                "The test data should match the range from Flink 1.3 up to the most recently published Minor version.");
+        return testData;
     }
 
     /**

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/operator/CEPMigrationTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.cep.nfa.compiler.NFACompiler;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.cep.utils.CepOperatorTestUtilities;
+import org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
@@ -36,7 +37,6 @@ import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.assumeFlinkVersionWithDescriptiveTextMessageJUnit4;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -53,35 +54,26 @@ import static org.junit.Assert.assertTrue;
  * Tests for checking whether CEP operator can restore from snapshots that were done using previous
  * Flink versions.
  *
- * <p>For regenerating the binary snapshot file of previous versions you have to run the {@code
- * write*()} method on the corresponding Flink release-* branch.
+ * <p>See {@link FlinkVersionBasedTestDataGenerationUtils} for details on how to generate new test
+ * data.
  */
 @RunWith(Parameterized.class)
 public class CEPMigrationTest {
-
-    /**
-     * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
-     * methods to generate savepoints TODO Note: You should generate the savepoint based on the
-     * release branch instead of the master.
-     */
-    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
     private final FlinkVersion migrateVersion;
 
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
-        return FlinkVersion.rangeOf(FlinkVersion.v1_6, FlinkVersion.v1_15);
+        return FlinkVersionBasedTestDataGenerationUtils.rangeFrom(FlinkVersion.v1_6);
     }
 
     public CEPMigrationTest(FlinkVersion migrateVersion) {
         this.migrateVersion = migrateVersion;
     }
 
-    /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeAfterBranchingPatternSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(migrateVersion);
 
         KeySelector<Event, Integer> keySelector =
                 new KeySelector<Event, Integer>() {
@@ -121,7 +113,7 @@ public class CEPMigrationTest {
             OperatorSnapshotUtil.writeStateHandle(
                     snapshot,
                     "src/test/resources/cep-migration-after-branching-flink"
-                            + flinkGenerateSavepointVersion
+                            + migrateVersion
                             + "-snapshot");
         } finally {
             harness.close();
@@ -247,9 +239,9 @@ public class CEPMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeStartingNewPatternAfterMigrationSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(migrateVersion);
 
         KeySelector<Event, Integer> keySelector =
                 new KeySelector<Event, Integer>() {
@@ -285,7 +277,7 @@ public class CEPMigrationTest {
             OperatorSnapshotUtil.writeStateHandle(
                     snapshot,
                     "src/test/resources/cep-migration-starting-new-pattern-flink"
-                            + flinkGenerateSavepointVersion
+                            + migrateVersion
                             + "-snapshot");
         } finally {
             harness.close();
@@ -428,9 +420,9 @@ public class CEPMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeSinglePatternAfterMigrationSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(migrateVersion);
 
         KeySelector<Event, Integer> keySelector =
                 new KeySelector<Event, Integer>() {
@@ -461,7 +453,7 @@ public class CEPMigrationTest {
             OperatorSnapshotUtil.writeStateHandle(
                     snapshot,
                     "src/test/resources/cep-migration-single-pattern-afterwards-flink"
-                            + flinkGenerateSavepointVersion
+                            + migrateVersion
                             + "-snapshot");
         } finally {
             harness.close();
@@ -526,9 +518,9 @@ public class CEPMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeAndOrSubtypConditionsPatternAfterMigrationSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(migrateVersion);
 
         KeySelector<Event, Integer> keySelector =
                 new KeySelector<Event, Integer>() {
@@ -560,7 +552,7 @@ public class CEPMigrationTest {
             OperatorSnapshotUtil.writeStateHandle(
                     snapshot,
                     "src/test/resources/cep-migration-conditions-flink"
-                            + flinkGenerateSavepointVersion
+                            + migrateVersion
                             + "-snapshot");
         } finally {
             harness.close();

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/operators/windowing/WindowOperatorMigrationTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.runtime.kryo.KryoSerializer;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils;
 import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.streaming.api.functions.windowing.PassThroughWindowFunction;
 import org.apache.flink.streaming.api.functions.windowing.RichWindowFunction;
@@ -56,7 +57,6 @@ import org.apache.flink.streaming.util.OperatorSnapshotUtil;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.Collector;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -66,6 +66,7 @@ import java.util.Comparator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.assumeFlinkVersionWithDescriptiveTextMessageJUnit4;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -76,27 +77,19 @@ import static org.junit.Assert.fail;
  * <p>This also checks whether {@link WindowOperator} can restore from a checkpoint of the aligned
  * processing-time windows operator of previous Flink versions.
  *
- * <p>For regenerating the binary snapshot file you have to run the {@code write*()} method on the
- * corresponding Flink release-* branch.
+ * <p>See {@link FlinkVersionBasedTestDataGenerationUtils} for details on how to generate new test
+ * data.
  */
 @RunWith(Parameterized.class)
 public class WindowOperatorMigrationTest {
 
     @Parameterized.Parameters(name = "Migration Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
-        return FlinkVersion.rangeOf(FlinkVersion.v1_3, FlinkVersion.v1_15);
+        return FlinkVersionBasedTestDataGenerationUtils.rangeFrom(FlinkVersion.v1_3);
     }
 
     private static final TypeInformation<Tuple2<String, Integer>> STRING_INT_TUPLE =
             TypeInformation.of(new TypeHint<Tuple2<String, Integer>>() {});
-
-    /**
-     * TODO change this to the corresponding savepoint version to be written (e.g. {@link
-     * FlinkVersion#v1_3} for 1.3) TODO and remove all @Ignore annotations on write*Snapshot()
-     * methods to generate savepoints TODO Note: You should generate the savepoint based on the
-     * release branch instead of the master.
-     */
-    private final FlinkVersion flinkGenerateSavepointVersion = null;
 
     private final FlinkVersion testMigrateVersion;
 
@@ -105,9 +98,10 @@ public class WindowOperatorMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeSessionWindowsWithCountTriggerSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
+
         final int sessionSize = 3;
 
         ListStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -157,7 +151,7 @@ public class WindowOperatorMigrationTest {
         OperatorSnapshotUtil.writeStateHandle(
                 snapshot,
                 "src/test/resources/win-op-migration-test-session-with-stateful-trigger-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot");
 
         testHarness.close();
@@ -237,9 +231,9 @@ public class WindowOperatorMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeSessionWindowsWithCountTriggerInMintConditionSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
 
         final int sessionSize = 3;
 
@@ -280,7 +274,7 @@ public class WindowOperatorMigrationTest {
         OperatorSnapshotUtil.writeStateHandle(
                 snapshot,
                 "src/test/resources/win-op-migration-test-session-with-stateful-trigger-mint-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot");
 
         testHarness.close();
@@ -375,9 +369,10 @@ public class WindowOperatorMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeReducingEventTimeWindowsSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
+
         final int windowSize = 3;
 
         ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -450,7 +445,7 @@ public class WindowOperatorMigrationTest {
         OperatorSnapshotUtil.writeStateHandle(
                 snapshot,
                 "src/test/resources/win-op-migration-test-reduce-event-time-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot");
 
         testHarness.close();
@@ -528,9 +523,10 @@ public class WindowOperatorMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeApplyEventTimeWindowsSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
+
         final int windowSize = 3;
 
         ListStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -601,7 +597,7 @@ public class WindowOperatorMigrationTest {
         OperatorSnapshotUtil.writeStateHandle(
                 snapshot,
                 "src/test/resources/win-op-migration-test-apply-event-time-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot");
 
         testHarness.close();
@@ -677,9 +673,10 @@ public class WindowOperatorMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeReducingProcessingTimeWindowsSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
+
         final int windowSize = 3;
 
         ReducingStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -742,7 +739,7 @@ public class WindowOperatorMigrationTest {
         OperatorSnapshotUtil.writeStateHandle(
                 snapshot,
                 "src/test/resources/win-op-migration-test-reduce-processing-time-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot");
 
         testHarness.close();
@@ -816,9 +813,10 @@ public class WindowOperatorMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeApplyProcessingTimeWindowsSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
+
         final int windowSize = 3;
 
         ListStateDescriptor<Tuple2<String, Integer>> stateDesc =
@@ -879,7 +877,7 @@ public class WindowOperatorMigrationTest {
         OperatorSnapshotUtil.writeStateHandle(
                 snapshot,
                 "src/test/resources/win-op-migration-test-apply-processing-time-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot");
 
         testHarness.close();
@@ -951,9 +949,10 @@ public class WindowOperatorMigrationTest {
     }
 
     /** Manually run this to write binary snapshot data. */
-    @Ignore
     @Test
     public void writeWindowsWithKryoSerializedKeysSnapshot() throws Exception {
+        assumeFlinkVersionWithDescriptiveTextMessageJUnit4(testMigrateVersion);
+
         final int windowSize = 3;
 
         TypeInformation<Tuple2<NonPojoType, Integer>> inputType =
@@ -1041,7 +1040,7 @@ public class WindowOperatorMigrationTest {
         OperatorSnapshotUtil.writeStateHandle(
                 snapshot,
                 "src/test/resources/win-op-migration-test-kryo-serialized-key-flink"
-                        + flinkGenerateSavepointVersion
+                        + testMigrateVersion
                         + "-snapshot");
 
         testHarness.close();

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializerUpgradeTest.java
@@ -33,6 +33,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.mostRecentlyPublishedBaseMinorVersion;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link LinkedListSerializer}. */
@@ -41,7 +42,8 @@ public class LinkedListSerializerUpgradeTest
         extends TypeSerializerUpgradeTestBase<LinkedList<Long>, LinkedList<Long>> {
 
     public Collection<TestSpecification<?, ?>> createTestSpecifications() {
-        return FlinkVersion.rangeOf(FlinkVersion.v1_13, CURRENT_VERSION).stream()
+        return FlinkVersion.rangeOf(FlinkVersion.v1_13, mostRecentlyPublishedBaseMinorVersion())
+                .stream()
                 .map(
                         version -> {
                             try {

--- a/flink-test-utils-parent/flink-test-utils-junit/pom.xml
+++ b/flink-test-utils-parent/flink-test-utils-junit/pom.xml
@@ -35,6 +35,13 @@ under the License.
 
 	<dependencies>
 		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-annotations</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
 			<scope>compile</scope>

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkVersionBasedTestDataGenerationUtils.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/core/testutils/FlinkVersionBasedTestDataGenerationUtils.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.core.testutils;
+
+import org.apache.flink.FlinkVersion;
+
+import org.junit.Assume;
+
+import java.util.Collection;
+import java.util.Set;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+/**
+ * {@code FlinkVerionBasedTestDataGenerationUtils} collects functionality around generating test
+ * data for migration tests.
+ */
+public class FlinkVersionBasedTestDataGenerationUtils {
+
+    /**
+     * Run the test suite on the corresponding release branch and enable the test data generation by
+     * setting {@code GENERATE_MIGRATION_TEST_DATA_PROPERTY} as a system property.
+     *
+     * <p>{@link #mostRecentlyPublishedBaseMinorVersion()} needs to match the version specified in
+     * the system property.
+     */
+    public static final String GENERATE_MIGRATION_TEST_DATA_PROPERTY =
+            "generate-migration-test-data";
+
+    /**
+     * Some migration tests rely on snapshots being generated after the initial version of a new
+     * major/minor version (i.e. x.y.0) was released. These tests will rely on this method to return
+     * upper threshold of the relevant version range.
+     *
+     * <p>Usually, related tests will fail due to the missing snapshot data. Upgrading this method's
+     * return value would require generating the snapshot data for the corresponding tests. See
+     * {@code FlinkVersionBasedTestDataGenerationUtils} in the {@code flink-test-utils} module for
+     * further details on how to generate the test data.
+     */
+    public static FlinkVersion mostRecentlyPublishedBaseMinorVersion() {
+        return FlinkVersion.v1_15;
+    }
+
+    /**
+     * Creates an {@code Iterable} of {@link FlinkVersion} instances starting from {@code
+     * minInclVersion} up to {@link #mostRecentlyPublishedBaseMinorVersion()}.
+     *
+     * @param minInclVersion The smallest minor version that should be part of the range.
+     * @return A {@code Collection} (instead of {@code Iterable}) to support JUnit4
+     *     {@code @Parameterized.Parameters}.
+     */
+    public static Collection<FlinkVersion> rangeFrom(FlinkVersion minInclVersion) {
+        return FlinkVersion.rangeOf(minInclVersion, mostRecentlyPublishedBaseMinorVersion());
+    }
+
+    /**
+     * Creates an {@code Iterable} of {@link FlinkVersion} instances starting from {@code
+     * minInclVersion} up to {@link #mostRecentlyPublishedBaseMinorVersion()} without the {@code
+     * FlinkVersions} that are meant to be excluded from this range.
+     *
+     * @param minInclVersion The smallest minor version that should be part of the range.
+     * @param excludedVersions {@code FlinkVersion} instances that would fall into the range but
+     *     should be excluded.
+     * @return A {@code Collection} (instead of {@code Iterable}) to support JUnit4
+     *     {@code @Parameterized.Parameters}.
+     */
+    public static Collection<FlinkVersion> rangeFromVersionExcludingIntermediates(
+            FlinkVersion minInclVersion, FlinkVersion... excludedVersions) {
+        final Set<FlinkVersion> versions =
+                FlinkVersion.rangeOf(minInclVersion, mostRecentlyPublishedBaseMinorVersion());
+        for (FlinkVersion excludedVersion : excludedVersions) {
+            versions.remove(excludedVersion);
+        }
+
+        return versions;
+    }
+
+    public static void assumeFlinkVersionWithDescriptiveTextMessageJUnit4(
+            FlinkVersion flinkVersionOfRun) {
+        Assume.assumeTrue(
+                getAssumptionMessageForDisabledTestDataGeneration(),
+                testDataGenerationEnabledFor(flinkVersionOfRun));
+    }
+
+    public static void assumeFlinkVersionBasedTestDataGenerationDisabledJUnit4() {
+        Assume.assumeTrue(
+                getAssumptionMessageForEnabledTestDataGeneration(), testDataGenerationDisabled());
+    }
+
+    public static void assumeFlinkVersionWithDescriptiveMessage(FlinkVersion flinkVersionOfRun) {
+        assumeThat(testDataGenerationEnabledFor(flinkVersionOfRun))
+                .as(getAssumptionMessageForDisabledTestDataGeneration());
+    }
+
+    public static void assumeFlinkVersionBasedTestDataGenerationDisabled() {
+        assumeThat(testDataGenerationDisabled())
+                .as(getAssumptionMessageForDisabledTestDataGeneration());
+    }
+
+    private static boolean testDataGenerationDisabled() {
+        return System.getProperty(GENERATE_MIGRATION_TEST_DATA_PROPERTY) == null;
+    }
+
+    public static boolean testDataGenerationEnabledFor(FlinkVersion flinkVersion) {
+        return FlinkVersion.byCode(System.getProperty(GENERATE_MIGRATION_TEST_DATA_PROPERTY))
+                .filter(v -> v == flinkVersion)
+                .isPresent();
+    }
+
+    public static String getAssumptionMessageForDisabledTestDataGeneration() {
+        return "Generating test data is disabled due to "
+                + GENERATE_MIGRATION_TEST_DATA_PROPERTY
+                + " not being set as a system property.";
+    }
+
+    private static String getAssumptionMessageForEnabledTestDataGeneration() {
+        return "Generating test data is enabled (due to "
+                + GENERATE_MIGRATION_TEST_DATA_PROPERTY
+                + " being set as a system property) which makes this test being skipped.";
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/migration/TypeSerializerSnapshotMigrationITCase.java
@@ -49,6 +49,8 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.mostRecentlyPublishedBaseMinorVersion;
+
 /**
  * Migration IT cases for upgrading a legacy {@link TypeSerializerConfigSnapshot} that is written in
  * checkpoints to {@link TypeSerializerSnapshot} interface.
@@ -62,8 +64,7 @@ public class TypeSerializerSnapshotMigrationITCase extends SnapshotMigrationTest
 
     private static final int NUM_SOURCE_ELEMENTS = 4;
 
-    // TODO increase this to newer version to create and test snapshot migration for newer versions
-    private static final FlinkVersion currentVersion = FlinkVersion.v1_15;
+    private static final FlinkVersion currentVersion = mostRecentlyPublishedBaseMinorVersion();
 
     // TODO change this to CREATE_SNAPSHOT to (re)create binary snapshots
     // TODO Note: You should generate the snapshot based on the release branch instead of the

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/AbstractKeyedOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/keyed/AbstractKeyedOperatorRestoreTestBase.java
@@ -30,6 +30,8 @@ import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.mostRecentlyPublishedBaseMinorVersion;
+
 /** Base class for all keyed operator restore tests. */
 @RunWith(Parameterized.class)
 public abstract class AbstractKeyedOperatorRestoreTestBase extends AbstractOperatorRestoreTestBase {
@@ -38,7 +40,7 @@ public abstract class AbstractKeyedOperatorRestoreTestBase extends AbstractOpera
 
     @Parameterized.Parameters(name = "Migrate Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
-        return FlinkVersion.rangeOf(FlinkVersion.v1_3, FlinkVersion.v1_15);
+        return FlinkVersion.rangeOf(FlinkVersion.v1_3, mostRecentlyPublishedBaseMinorVersion());
     }
 
     public AbstractKeyedOperatorRestoreTestBase(FlinkVersion flinkVersion) {

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/AbstractNonKeyedOperatorRestoreTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/unkeyed/AbstractNonKeyedOperatorRestoreTestBase.java
@@ -30,6 +30,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Collection;
 
+import static org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.mostRecentlyPublishedBaseMinorVersion;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createFirstStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSecondStatefulMap;
 import static org.apache.flink.test.state.operator.restore.unkeyed.NonKeyedJob.createSource;
@@ -45,7 +46,7 @@ public abstract class AbstractNonKeyedOperatorRestoreTestBase
 
     @Parameterized.Parameters(name = "Migrate Savepoint: {0}")
     public static Collection<FlinkVersion> parameters() {
-        return FlinkVersion.rangeOf(FlinkVersion.v1_3, FlinkVersion.v1_15);
+        return FlinkVersion.rangeOf(FlinkVersion.v1_3, mostRecentlyPublishedBaseMinorVersion());
     }
 
     protected AbstractNonKeyedOperatorRestoreTestBase(FlinkVersion flinkVersion) {

--- a/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
+++ b/flink-tests/src/test/scala/org/apache/flink/api/scala/migration/StatefulJobSavepointMigrationITCase.scala
@@ -27,6 +27,7 @@ import org.apache.flink.api.scala._
 import org.apache.flink.api.scala.migration.CustomEnum.CustomEnum
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.contrib.streaming.state.EmbeddedRocksDBStateBackend
+import org.apache.flink.core.testutils.FlinkVersionBasedTestDataGenerationUtils.mostRecentlyPublishedBaseMinorVersion
 import org.apache.flink.runtime.state.{FunctionInitializationContext, FunctionSnapshotContext, StateBackendLoader}
 import org.apache.flink.runtime.state.hashmap.HashMapStateBackend
 import org.apache.flink.runtime.state.memory.MemoryStateBackend
@@ -52,7 +53,7 @@ import scala.util.{Failure, Try}
 object StatefulJobSavepointMigrationITCase {
 
   // TODO increase this to newer version to create and test snapshot migration for newer versions
-  val currentVersion = FlinkVersion.v1_15
+  val currentVersion = mostRecentlyPublishedBaseMinorVersion();
 
   // TODO change this to CREATE_SNAPSHOT to (re)create binary snapshots
   // TODO Note: You should generate the snapshot based on the release branch instead of the


### PR DESCRIPTION
## What is the purpose of the change

The test data generation is kind of a manual work. This PR introduces the ability to enable test data generation based on a system property (i.e. `-Dgenerate-migration-test-data`). Currently, it's documented in the [Creating a Flink Release documentation](https://cwiki.apache.org/confluence/display/FLINK/Creating+a+Flink+Release#CreatingaFlinkRelease-Checklisttodeclaretheprocesscompleted) in item 15 under subsection `Checklist to declare the process completed` that individual tests need to be touched to generate the test data:
> (major/minor only) Update migration tests in master to cover migration from new version: (search for usages of FlinkVersion)
> AbstractOperatorRestoreTestBase
> CEPMigrationTest
> BucketingSinkMigrationTest
> FlinkKafkaConsumerBaseMigrationTest
> ContinuousFileProcessingMigrationTest
> WindowOperatorMigrationTest
> StatefulJobSavepointMigrationITCase
>StatefulJobWBroadcastStateMigrationITCase

This PR's change only requires a single code location (i.e. [FlinkVersionBasedTestDataGenerationUtils:57](https://github.com/apache/flink/pull/20954/files#diff-c284104d133a0335d10289911d253b61fad2525e86b752864207ac36931bae7bR57)) and a test run with the aforementioned system property being enabled.

## Brief change log

* Introduction of `FlinkVersionBasedTestDataGenerationUtils`
* Integrating `FlinkVersionBasedTestDataGenerationUtils` into any test that generates test data based on `FlinkVersion` right now

## Verifying this change

* TODO: Final test run verifying that the right data was generated

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs & Confluence
