### PR TITLE
[FLINK-29502][Filesystem][S3] Update the Hadoop implementation for filesystems to 3.3.4

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -68,6 +68,14 @@ under the License.
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-common</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -10,15 +10,15 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop:hadoop-azure:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
-- org.codehaus.jackson:jackson-mapper-asl:1.9.13
 - org.codehaus.jackson:jackson-core-asl:1.9.13
-- org.eclipse.jetty:jetty-util:9.3.24.v20180605
+- org.codehaus.jackson:jackson-mapper-asl:1.9.13
 - org.eclipse.jetty:jetty-util-ajax:9.3.24.v20180605
+- org.eclipse.jetty:jetty-util:9.3.24.v20180605
 - org.wildfly.openssl:wildfly-openssl:1.0.7.Final
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 
 This project bundles the following dependencies under the MIT (https://opensource.org/licenses/MIT)
 

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
-- org.apache.hadoop:hadoop-azure:3.3.2
+- org.apache.hadoop:hadoop-azure:3.3.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jackson:jackson-core-asl:1.9.13

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -169,6 +169,14 @@ under the License.
 					<groupId>net.minidev</groupId>
 					<artifactId>json-smart</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 	</dependencies>

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -24,9 +24,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop:hadoop-annotations:3.3.2
-- org.apache.hadoop:hadoop-auth:3.3.2
-- org.apache.hadoop:hadoop-common:3.3.2
+- org.apache.hadoop:hadoop-annotations:3.3.4
+- org.apache.hadoop:hadoop-auth:3.3.4
+- org.apache.hadoop:hadoop-common:3.3.4
 - org.apache.kerby:kerb-core:1.0.1
 - org.apache.kerby:kerby-asn1:1.0.1
 - org.apache.kerby:kerby-pkix:1.0.1
@@ -65,7 +65,7 @@ the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.google.protobuf:protobuf-java:3.7.1
 
-This project bundles org.apache.hadoop:*:3.3.2 from which it inherits the following notices:
+This project bundles org.apache.hadoop:*:3.3.4 from which it inherits the following notices:
 
 The Apache Hadoop project contains subcomponents with separate copyright
 notices and license terms. Your use of the source code for the these

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -6,30 +6,30 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.hadoop:hadoop-annotations:3.3.2
-- org.apache.hadoop:hadoop-auth:3.3.2
-- org.apache.hadoop:hadoop-common:3.3.2
-- org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.3.2
-- org.apache.commons:commons-text:1.4
-- org.apache.commons:commons-compress:1.21
-- commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
-- commons-logging:commons-logging:1.1.3
-- commons-beanutils:commons-beanutils:1.9.4
-- com.google.guava:failureaccess:1.0
-- com.google.guava:guava:27.0-jre
-- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
-- com.google.j2objc:j2objc-annotations:1.1
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.fasterxml.jackson.core:jackson-databind:2.13.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
+- com.google.guava:failureaccess:1.0
+- com.google.guava:guava:27.0-jre
+- com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+- com.google.j2objc:j2objc-annotations:1.1
+- commons-beanutils:commons-beanutils:1.9.4
+- commons-collections:commons-collections:3.2.2
+- commons-io:commons-io:2.11.0
+- commons-logging:commons-logging:1.1.3
+- org.apache.commons:commons-compress:1.21
+- org.apache.commons:commons-configuration2:2.1.1
+- org.apache.commons:commons-lang3:3.3.2
+- org.apache.commons:commons-text:1.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
+- org.apache.hadoop:hadoop-annotations:3.3.2
+- org.apache.hadoop:hadoop-auth:3.3.2
+- org.apache.hadoop:hadoop-common:3.3.2
 - org.apache.kerby:kerb-core:1.0.1
-- org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
 - org.xerial.snappy:snappy-java:1.1.8.3
 

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -143,6 +143,16 @@ under the License.
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-common</artifactId>
 				<version>${fs.hadoopshaded.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-reload4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<!-- Force grpc dependencies to the same version -->

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -66,6 +66,14 @@ under the License.
 					<groupId>org.apache.hadoop</groupId>
 					<artifactId>hadoop-common</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.opentracing:opentracing-api:0.33.0
 - io.opentracing:opentracing-noop:0.33.0
 - io.opentracing:opentracing-util:0.33.0
-- org.apache.hadoop:hadoop-aliyun:3.3.2
+- org.apache.hadoop:hadoop-aliyun:3.3.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jettison:jettison:1.1

--- a/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-oss-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -8,20 +8,20 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.aliyun.oss:aliyun-sdk-oss:3.13.2
 - com.aliyun:aliyun-java-sdk-core:4.5.10
-- com.aliyun:aliyun-java-sdk-ram:3.1.0
 - com.aliyun:aliyun-java-sdk-kms:2.11.0
+- com.aliyun:aliyun-java-sdk-ram:3.1.0
+- com.google.code.gson:gson:2.8.6
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
+- io.opentracing:opentracing-api:0.33.0
+- io.opentracing:opentracing-noop:0.33.0
+- io.opentracing:opentracing-util:0.33.0
 - org.apache.hadoop:hadoop-aliyun:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.codehaus.jettison:jettison:1.1
-- stax:stax-api:1.0.1
-- com.google.code.gson:gson:2.8.6
 - org.ini4j:ini4j:0.5.4
-- io.opentracing:opentracing-api:0.33.0
-- io.opentracing:opentracing-util:0.33.0
-- io.opentracing:opentracing-noop:0.33.0
+- stax:stax-api:1.0.1
 
 The binary distribution of this product bundles these dependencies under the Eclipse Public License - v 2.0 (https://www.eclipse.org/org/documents/epl-2.0/EPL-2.0.txt)
 - org.jacoco:org.jacoco.agent:runtime:0.8.5

--- a/flink-filesystems/flink-s3-fs-base/pom.xml
+++ b/flink-filesystems/flink-s3-fs-base/pom.xml
@@ -50,7 +50,6 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
 			<version>${fs.hadoopshaded.version}</version>
-
 			<exclusions>
 				<exclusion>
 					<groupId>jdk.tools</groupId>
@@ -168,6 +167,14 @@ under the License.
 					<groupId>net.minidev</groupId>
 					<artifactId>json-smart</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 
@@ -214,6 +221,14 @@ under the License.
 				<exclusion>
 					<groupId>com.amazonaws</groupId>
 					<artifactId>aws-java-sdk-bundle</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>ch.qos.reload4j</groupId>
+					<artifactId>reload4j</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-reload4j</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -39,6 +39,16 @@ under the License.
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-common</artifactId>
 				<version>${fs.hadoopshaded.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-reload4j</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 
 			<dependency>

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -30,10 +30,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop:hadoop-annotations:3.3.2
-- org.apache.hadoop:hadoop-auth:3.3.2
-- org.apache.hadoop:hadoop-aws:3.3.2
-- org.apache.hadoop:hadoop-common:3.3.2
+- org.apache.hadoop:hadoop-annotations:3.3.4
+- org.apache.hadoop:hadoop-auth:3.3.4
+- org.apache.hadoop:hadoop-aws:3.3.4
+- org.apache.hadoop:hadoop-common:3.3.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.kerby:kerb-core:1.0.1

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -24,25 +24,25 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-io:commons-io:2.11.0
 - commons-logging:commons-logging:1.1.3
 - joda-time:joda-time:2.5
+- org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-text:1.4
-- org.apache.commons:commons-compress:1.21
-- org.apache.hadoop:hadoop-auth:3.3.2
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.2
+- org.apache.hadoop:hadoop-auth:3.3.2
 - org.apache.hadoop:hadoop-aws:3.3.2
 - org.apache.hadoop:hadoop-common:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
-- software.amazon.ion:ion-java:1.0.2
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.kerby:kerb-core:1.0.1
-- org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
-- org.xerial.snappy:snappy-java:1.1.8.3
 - org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+- org.xerial.snappy:snappy-java:1.1.8.3
+- software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -365,6 +365,14 @@ under the License.
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
 					</exclusion>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-reload4j</artifactId>
+					</exclusion>
 				</exclusions>
 			</dependency>
 			<dependency>
@@ -383,6 +391,14 @@ under the License.
 					<exclusion>
 						<groupId>org.slf4j</groupId>
 						<artifactId>slf4j-log4j12</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>ch.qos.reload4j</groupId>
+						<artifactId>reload4j</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.slf4j</groupId>
+						<artifactId>slf4j-reload4j</artifactId>
 					</exclusion>
 				</exclusions>
 			</dependency>

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -42,10 +42,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-text:1.4
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop:hadoop-annotations:3.3.2
-- org.apache.hadoop:hadoop-auth:3.3.2
-- org.apache.hadoop:hadoop-aws:3.3.2
-- org.apache.hadoop:hadoop-common:3.3.2
+- org.apache.hadoop:hadoop-annotations:3.3.4
+- org.apache.hadoop:hadoop-auth:3.3.4
+- org.apache.hadoop:hadoop-aws:3.3.4
+- org.apache.hadoop:hadoop-common:3.3.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.hudi:hudi-presto-bundle:0.10.1

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -6,22 +6,20 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- commons-beanutils:commons-beanutils:1.9.4
-- commons-codec:commons-codec:1.15
-- commons-collections:commons-collections:3.2.2
-- commons-io:commons-io:2.11.0
-- commons-logging:commons-logging:1.1.3
 - com.amazonaws:aws-java-sdk-core:1.11.951
 - com.amazonaws:aws-java-sdk-dynamodb:1.11.951
 - com.amazonaws:aws-java-sdk-kms:1.11.951
 - com.amazonaws:aws-java-sdk-s3:1.11.951
 - com.amazonaws:aws-java-sdk-sts:1.11.951
 - com.amazonaws:jmespath-java:1.11.951
+- com.facebook.airlift:configuration:0.201
+- com.facebook.airlift:log:0.201
+- com.facebook.airlift:stats:0.201
+- com.facebook.presto.hadoop:hadoop-apache2:2.7.4-9
 - com.facebook.presto:presto-common:0.272
-- com.facebook.presto:presto-hive:0.272
 - com.facebook.presto:presto-hive-common:0.272
 - com.facebook.presto:presto-hive-metastore:0.272
-- com.facebook.presto.hadoop:hadoop-apache2:2.7.4-9
+- com.facebook.presto:presto-hive:0.272
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.fasterxml.jackson.core:jackson-databind:2.13.4
@@ -29,34 +27,36 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2
-- com.facebook.airlift:configuration:0.201
-- com.facebook.airlift:log:0.201
-- com.facebook.airlift:stats:0.201
-- io.airlift:units:1.3
+- commons-beanutils:commons-beanutils:1.9.4
+- commons-codec:commons-codec:1.15
+- commons-collections:commons-collections:3.2.2
+- commons-io:commons-io:2.11.0
+- commons-logging:commons-logging:1.1.3
 - io.airlift:slice:0.38
+- io.airlift:units:1.3
 - joda-time:joda-time:2.5
 - org.alluxio:alluxio-shaded-client:2.7.3
+- org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
 - org.apache.commons:commons-lang3:3.3.2
 - org.apache.commons:commons-text:1.4
-- org.apache.commons:commons-compress:1.21
+- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
+- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.2
-- org.apache.hadoop:hadoop-aws:3.3.2
 - org.apache.hadoop:hadoop-auth:3.3.2
+- org.apache.hadoop:hadoop-aws:3.3.2
 - org.apache.hadoop:hadoop-common:3.3.2
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - org.apache.hudi:hudi-presto-bundle:0.10.1
-- org.weakref:jmxutils:1.19
-- software.amazon.ion:ion-java:1.0.2
-- org.xerial.snappy:snappy-java:1.1.8.3
-- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
-- org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.kerby:kerb-core:1.0.1
-- org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-asn1:1.0.1
+- org.apache.kerby:kerby-pkix:1.0.1
 - org.apache.kerby:kerby-util:1.0.1
+- org.weakref:jmxutils:1.19
 - org.wildfly.openssl:wildfly-openssl:1.0.7.Final
+- org.xerial.snappy:snappy-java:1.1.8.3
+- software.amazon.ion:ion-java:1.0.2
 
 This project bundles the following dependencies under BSD-2 License (https://opensource.org/licenses/BSD-2-Clause).
 See bundled license files for details.

--- a/flink-filesystems/pom.xml
+++ b/flink-filesystems/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<packaging>pom</packaging>
 
 	<properties>
-		<fs.hadoopshaded.version>3.3.2</fs.hadoopshaded.version>
+		<fs.hadoopshaded.version>3.3.4</fs.hadoopshaded.version>
 	</properties>
 
 	<modules>


### PR DESCRIPTION
## What is the purpose of the change

* Bump Hadoop dependencies for filesystems implementations

## Brief change log

* Updated POM
* Updated NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
