### PR TITLE
[FLINK-29504][rest] Add schema to jar upload content 

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -97,7 +97,10 @@ paths:
       operationId: uploadJar
       requestBody:
         content:
-          application/x-java-archive: {}
+          application/x-java-archive:
+            schema:
+              type: string
+              format: binary
         required: true
       responses:
         "200":

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -398,7 +398,11 @@ public class OpenApiSpecGenerator {
                                     new Content()
                                             .addMediaType(
                                                     "application/x-java-archive",
-                                                    new MediaType())));
+                                                    new MediaType()
+                                                            .schema(
+                                                                    new Schema<>()
+                                                                            .type("string")
+                                                                            .format("binary")))));
         }
 
         // TODO: unhack


### PR DESCRIPTION
Fixes an issue where no schema was defined for the jar upload content.