### PR TITLE
[FLINK-29244][state/changelog] Add metric lastMaterializationDuration…

### DIFF
--- a/docs/content.zh/docs/ops/metrics.md
+++ b/docs/content.zh/docs/ops/metrics.md
@@ -1571,7 +1571,7 @@ Note that the metrics are only available via reporters.
       <td>Gauge</td>
     </tr>
     <tr>
-      <th rowspan="7"><strong>Task/Operator</strong></th>
+      <th rowspan="8"><strong>Task/Operator</strong></th>
       <td>startedMaterialization</td>
       <td>The number of started materializations.</td>
       <td>Counter</td>
@@ -1585,6 +1585,11 @@ Note that the metrics are only available via reporters.
       <td>failedMaterialization</td>
       <td>The number of failed materializations.</td>
       <td>Counter</td>
+    </tr>
+    <tr>
+      <td>lastDurationOfMaterialization</td>
+      <td>The duration of the last materialization (in milliseconds).</td>
+      <td>Gauge</td>
     </tr>
     <tr>
       <td>lastFullSizeOfMaterialization</td>

--- a/docs/content/docs/ops/metrics.md
+++ b/docs/content/docs/ops/metrics.md
@@ -1556,7 +1556,7 @@ Note that the metrics are only available via reporters.
       <td>Gauge</td>
     </tr>
     <tr>
-      <th rowspan="7"><strong>Task/Operator</strong></th>
+      <th rowspan="8"><strong>Task/Operator</strong></th>
       <td>startedMaterialization</td>
       <td>The number of started materializations.</td>
       <td>Counter</td>
@@ -1570,6 +1570,11 @@ Note that the metrics are only available via reporters.
       <td>failedMaterialization</td>
       <td>The number of failed materializations.</td>
       <td>Counter</td>
+    </tr>
+    <tr>
+      <td>lastDurationOfMaterialization</td>
+      <td>The duration of the last materialization (in milliseconds).</td>
+      <td>Gauge</td>
     </tr>
     <tr>
       <td>lastFullSizeOfMaterialization</td>

--- a/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
+++ b/flink-state-backends/flink-statebackend-common/src/main/java/org/apache/flink/state/common/ChangelogMaterializationMetricGroup.java
@@ -39,9 +39,15 @@ public class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<Metric
     @VisibleForTesting
     public static final String FAILED_MATERIALIZATION = PREFIX + ".failedMaterialization";
 
+    @VisibleForTesting
+    public static final String LAST_DURATION_OF_MATERIALIZATION =
+            PREFIX + ".lastDurationOfMaterialization";
+
     private final Counter startedMaterializationCounter;
     private final Counter completedMaterializationCounter;
     private final Counter failedMaterializationCounter;
+
+    private volatile long lastDuration = -1;
 
     public ChangelogMaterializationMetricGroup(MetricGroup parentMetricGroup) {
         super(parentMetricGroup);
@@ -51,14 +57,17 @@ public class ChangelogMaterializationMetricGroup extends ProxyMetricGroup<Metric
                 counter(COMPLETED_MATERIALIZATION, new ThreadSafeSimpleCounter());
         this.failedMaterializationCounter =
                 counter(FAILED_MATERIALIZATION, new ThreadSafeSimpleCounter());
+
+        gauge(LAST_DURATION_OF_MATERIALIZATION, () -> lastDuration);
     }
 
     void reportStartedMaterialization() {
         startedMaterializationCounter.inc();
     }
 
-    void reportCompletedMaterialization() {
+    void reportCompletedMaterialization(long duration) {
         completedMaterializationCounter.inc();
+        lastDuration = duration;
     }
 
     void reportFailedMaterialization() {


### PR DESCRIPTION
… to ChangelogMaterializationMetricGroup


## What is the purpose of the change

Add metric lastMaterializationDuration to ChangelogMaterializationMetricGroup, described in [FLINK-29244](https://issues.apache.org/jira/browse/FLINK-29244).

## Brief change log
Add metric lastMaterializationDuration to ChangelogMaterializationMetricGroup.


## Verifying this change

This change is already covered by existing tests, such as ChangelogMetricGroupTest.testCompletedMaterialization().


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
