### PR TITLE
[FLINK-29457][state-processor] Add UID (hash) remapping fuction

### DIFF
--- a/docs/content.zh/docs/libs/state_processor_api.md
+++ b/docs/content.zh/docs/libs/state_processor_api.md
@@ -493,3 +493,25 @@ SavepointWriter
     .withOperator(OperatorIdentifier.forUid("uid"), transformation)
     .write(newPath);
 ```
+
+### Changing UID (hashes)
+
+`SavepointWriter#changeOperatorIdenfifier` can be used to modify the [UIDs]({{< ref "docs/concepts/glossary" >}}#uid) or [UID hash]({{< ref "docs/concepts/glossary" >}}#uid-hash) of an operator.
+
+If a `UID` was not explicitly set (and was thus auto-generated and is effectively unknown), you can assign a `UID` provided that you know the `UID hash` (e.g., by parsing the logs):
+```java
+savepointWriter
+    .changeOperatorIdentifier(
+        OperatorIdentifier.forUidHash("2feb7f8bcc404c3ac8a981959780bd78"),
+        OperatorIdentifier.forUid("new-uid"))
+    ...
+```
+
+You can also replace one `UID` with another:
+```java
+savepointWriter
+    .changeOperatorIdentifier(
+        OperatorIdentifier.forUid("old-uid"),
+        OperatorIdentifier.forUid("new-uid"))
+    ...
+```

--- a/docs/content/docs/libs/state_processor_api.md
+++ b/docs/content/docs/libs/state_processor_api.md
@@ -492,3 +492,25 @@ SavepointWriter
     .withOperator(OperatorIdentifier.forUid("uid"), transformation)
     .write(newPath);
 ```
+
+### Changing UID (hashes)
+
+`SavepointWriter#changeOperatorIdenfifier` can be used to modify the [UIDs]({{< ref "docs/concepts/glossary" >}}#uid) or [UID hash]({{< ref "docs/concepts/glossary" >}}#uid-hash) of an operator.
+
+If a `UID` was not explicitly set (and was thus auto-generated and is effectively unknown), you can assign a `UID` provided that you know the `UID hash` (e.g., by parsing the logs):
+```java
+savepointWriter
+    .changeOperatorIdentifier(
+        OperatorIdentifier.forUidHash("2feb7f8bcc404c3ac8a981959780bd78"),
+        OperatorIdentifier.forUid("new-uid"))
+    ...
+```
+
+You can also replace one `UID` with another:
+```java
+savepointWriter
+    .changeOperatorIdentifier(
+        OperatorIdentifier.forUid("old-uid"),
+        OperatorIdentifier.forUid("new-uid"))
+    ...
+```

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorIdentifier.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/OperatorIdentifier.java
@@ -80,4 +80,9 @@ public final class OperatorIdentifier implements Serializable {
     public int hashCode() {
         return Objects.hash(operatorId);
     }
+
+    @Override
+    public String toString() {
+        return uid != null ? uid + "(" + operatorId.toHexString() + ")" : operatorId.toHexString();
+    }
 }

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointWriter.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/SavepointWriter.java
@@ -19,6 +19,7 @@
 package org.apache.flink.state.api;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
@@ -36,6 +37,7 @@ import org.apache.flink.state.api.runtime.StateBootstrapTransformationWithID;
 import org.apache.flink.state.api.runtime.metadata.SavepointMetadataV2;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction;
+import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
@@ -43,7 +45,10 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.UPPER_BOUND_MAX_PARALLELISM;
 
@@ -53,6 +58,9 @@ import static org.apache.flink.runtime.state.KeyGroupRangeAssignment.UPPER_BOUND
  */
 @PublicEvolving
 public class SavepointWriter {
+
+    private final Map<OperatorIdentifier, OperatorIdentifier> uidTransformationMap =
+            new HashMap<>();
 
     /**
      * Loads an existing savepoint. Useful if you want to modify or extend the state of an existing
@@ -224,6 +232,51 @@ public class SavepointWriter {
     }
 
     /**
+     * Changes the identifier of an operator.
+     *
+     * <p>This method is comparatively cheap since it only modifies savepoint metadata without
+     * reading the entire savepoint data.
+     *
+     * <p>Use-cases include, but are not limited to:
+     *
+     * <ul>
+     *   <li>assigning a UID to an operator that did not have a UID assigned before
+     *   <li>changing the UID of an operator
+     *   <li>swapping the states of 2 operators
+     * </ul>
+     *
+     * <p>Identifier changes are applied after all other operations; in the following example the
+     * savepoint will only contain UID_2.
+     *
+     * <pre>
+     *     SavepointWriter savepoint = ...
+     *     savepoint.withOperator(UID_1, ...)
+     *     savepoint.changeOperatorIdentifier(UID_1, UID_2)
+     *     savepoint.write(...)
+     * </pre>
+     *
+     * <p>You cannot define a chain of changes; in the following example the savepoint will only
+     * contain UID_2.
+     *
+     * <pre>
+     *     SavepointWriter savepoint = ...
+     *     savepoint.withOperator(UID_1, ...)
+     *     savepoint.changeOperatorIdentifier(UID_1, UID_2)
+     *     savepoint.changeOperatorIdentifier(UID_2, UID_3)
+     *     savepoint.write(...)
+     * </pre>
+     *
+     * @param from operator whose identifier should be changed
+     * @param to desired identifier
+     * @return The modified savepoint.
+     */
+    public SavepointWriter changeOperatorIdentifier(
+            OperatorIdentifier from, OperatorIdentifier to) {
+        this.uidTransformationMap.put(from, to);
+        return this;
+    }
+
+    /**
      * Write out a new or updated savepoint.
      *
      * @param path The path to where the savepoint should be written.
@@ -262,6 +315,8 @@ public class SavepointWriter {
                         new GroupReduceOperator<>(
                                 new MergeOperatorStates(metadata.getMasterStates())))
                 .forceNonParallel()
+                .map(new CheckpointMetadataCheckpointMetadataMapFunction(this.uidTransformationMap))
+                .setParallelism(1)
                 .addSink(new OutputFormatSinkFunction<>(new SavepointOutputFormat(savepointPath)))
                 .setParallelism(1)
                 .name(path);
@@ -287,5 +342,52 @@ public class SavepointWriter {
                         () ->
                                 new IllegalStateException(
                                         "Savepoint must contain at least one operator"));
+    }
+
+    private static class CheckpointMetadataCheckpointMetadataMapFunction
+            extends RichMapFunction<CheckpointMetadata, CheckpointMetadata> {
+        private static final long serialVersionUID = 1L;
+
+        private final Map<OperatorIdentifier, OperatorIdentifier> uidTransformationMap;
+
+        public CheckpointMetadataCheckpointMetadataMapFunction(
+                Map<OperatorIdentifier, OperatorIdentifier> uidTransformationMap) {
+            this.uidTransformationMap = new HashMap<>(uidTransformationMap);
+        }
+
+        @Override
+        public CheckpointMetadata map(CheckpointMetadata value) throws Exception {
+            final List<OperatorState> mapped =
+                    value.getOperatorStates().stream()
+                            .map(
+                                    operatorState -> {
+                                        OperatorIdentifier operatorIdentifier =
+                                                OperatorIdentifier.forUidHash(
+                                                        operatorState
+                                                                .getOperatorID()
+                                                                .toHexString());
+
+                                        final OperatorIdentifier transformedIdentifier =
+                                                uidTransformationMap.remove(operatorIdentifier);
+                                        if (transformedIdentifier != null) {
+                                            return operatorState.copyWithNewOperatorID(
+                                                    transformedIdentifier.getOperatorId());
+                                        }
+                                        return operatorState;
+                                    })
+                            .collect(Collectors.toList());
+            return new CheckpointMetadata(value.getCheckpointId(), mapped, value.getMasterStates());
+        }
+
+        @Override
+        public void close() throws Exception {
+            if (!uidTransformationMap.isEmpty()) {
+                throw new FlinkRuntimeException(
+                        "Some identifier changes were never applied!"
+                                + uidTransformationMap.entrySet().stream()
+                                        .map(Map.Entry::toString)
+                                        .collect(Collectors.joining("\n\t", "\n\t", "")));
+            }
+        }
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterUidModificationITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterUidModificationITCase.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.state.api;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction;
+import org.apache.flink.state.api.functions.StateBootstrapFunction;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.graph.StreamGraph;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.util.AbstractID;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT test for modifying UIDs in savepoints. */
+public class SavepointWriterUidModificationITCase {
+
+    @RegisterExtension
+    static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(4)
+                            .build());
+
+    private static final Collection<Integer> STATE_1 = Arrays.asList(1, 2, 3);
+    private static final Collection<Integer> STATE_2 = Arrays.asList(4, 5, 6);
+
+    private static final ValueStateDescriptor<Integer> STATE_DESCRIPTOR =
+            new ValueStateDescriptor<>("number", Types.INT);
+
+    @Test
+    public void testAddUid(@TempDir Path tmp) throws Exception {
+        final String uidHash = new AbstractID().toHexString();
+        final String uid = "uid";
+        final String originalSavepoint =
+                bootstrapState(
+                        tmp,
+                        (env, writer) ->
+                                writer.withOperator(
+                                        OperatorIdentifier.forUidHash(uidHash),
+                                        bootstrap(env, STATE_1)));
+        final String newSavepoint =
+                modifySavepoint(
+                        tmp,
+                        originalSavepoint,
+                        writer ->
+                                writer.changeOperatorIdentifier(
+                                        OperatorIdentifier.forUidHash(uidHash),
+                                        OperatorIdentifier.forUid(uid)));
+
+        runAndValidate(newSavepoint, Tuple2.of(STATE_1, uid));
+    }
+
+    @Test
+    public void testChangeUid(@TempDir Path tmp) throws Exception {
+        final String uid = "uid";
+        final String newUid = "fabulous";
+        final String originalSavepoint =
+                bootstrapState(
+                        tmp,
+                        (env, writer) ->
+                                writer.withOperator(
+                                        OperatorIdentifier.forUid(uid), bootstrap(env, STATE_1)));
+        final String newSavepoint =
+                modifySavepoint(
+                        tmp,
+                        originalSavepoint,
+                        writer ->
+                                writer.changeOperatorIdentifier(
+                                        OperatorIdentifier.forUid(uid),
+                                        OperatorIdentifier.forUid(newUid)));
+
+        runAndValidate(newSavepoint, Tuple2.of(STATE_1, newUid));
+    }
+
+    @Test
+    public void testSwapUid(@TempDir Path tmp) throws Exception {
+        final String uid1 = "uid1";
+        final String uid2 = "uid2";
+        final String originalSavepoint =
+                bootstrapState(
+                        tmp,
+                        (env, writer) ->
+                                writer.withOperator(
+                                                OperatorIdentifier.forUid(uid1),
+                                                bootstrap(env, STATE_1))
+                                        .withOperator(
+                                                OperatorIdentifier.forUid(uid2),
+                                                bootstrap(env, STATE_2)));
+        final String newSavepoint =
+                modifySavepoint(
+                        tmp,
+                        originalSavepoint,
+                        writer ->
+                                writer.changeOperatorIdentifier(
+                                                OperatorIdentifier.forUid(uid1),
+                                                OperatorIdentifier.forUid(uid2))
+                                        .changeOperatorIdentifier(
+                                                OperatorIdentifier.forUid(uid2),
+                                                OperatorIdentifier.forUid(uid1)));
+
+        runAndValidate(newSavepoint, Tuple2.of(STATE_1, uid2), Tuple2.of(STATE_2, uid1));
+    }
+
+    private static String bootstrapState(
+            Path tmp, BiConsumer<StreamExecutionEnvironment, SavepointWriter> mutator)
+            throws Exception {
+        final String savepointPath =
+                tmp.resolve(new AbstractID().toHexString()).toAbsolutePath().toString();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.AUTOMATIC);
+
+        final SavepointWriter writer = SavepointWriter.newSavepoint(128);
+
+        mutator.accept(env, writer);
+
+        writer.write(savepointPath);
+
+        env.execute("Bootstrap");
+
+        return savepointPath;
+    }
+
+    private static StateBootstrapTransformation<Integer> bootstrap(
+            StreamExecutionEnvironment env, Collection<Integer> data) {
+        return OperatorTransformation.bootstrapWith(env.fromCollection(data))
+                .keyBy(v -> v)
+                .transform(new StateBootstrapper());
+    }
+
+    private static String modifySavepoint(
+            Path tmp, String savepointPath, Consumer<SavepointWriter> mutator) throws Exception {
+        final String newSavepointPath =
+                tmp.resolve(new AbstractID().toHexString()).toAbsolutePath().toString();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setRuntimeMode(RuntimeExecutionMode.AUTOMATIC);
+
+        SavepointWriter writer = SavepointWriter.fromExistingSavepoint(savepointPath);
+
+        // SavepointWriter enforces at least one operation; add a dummy that doesn't write anything
+        writer.withOperator(
+                OperatorIdentifier.forUid("dummy"),
+                OperatorTransformation.bootstrapWith(env.fromElements(1))
+                        .transform(new DummyBootstrapper()));
+
+        mutator.accept(writer);
+        writer.write(newSavepointPath);
+
+        env.execute("Modifying");
+
+        return newSavepointPath;
+    }
+
+    @SafeVarargs
+    private static void runAndValidate(
+            String savepointPath, Tuple2<Collection<Integer>, String>... assertions)
+            throws Exception {
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        // prepare collection of state
+        final List<CloseableIterator<Integer>> iterators = new ArrayList<>();
+        for (Tuple2<Collection<Integer>, String> assertion : assertions) {
+            iterators.add(
+                    env.fromCollection(assertion.f0)
+                            .keyBy(v -> v)
+                            .map(new StateReader())
+                            .uid(assertion.f1)
+                            .collectAsync());
+        }
+
+        // run job
+        StreamGraph streamGraph = env.getStreamGraph();
+        streamGraph.setSavepointRestoreSettings(
+                SavepointRestoreSettings.forPath(savepointPath, false));
+        env.executeAsync(streamGraph);
+
+        // validate state
+        for (int i = 0; i < assertions.length; i++) {
+            assertThat(iterators.get(i))
+                    .toIterable()
+                    .containsExactlyInAnyOrderElementsOf(assertions[i].f0);
+        }
+
+        for (CloseableIterator<Integer> iterator : iterators) {
+            iterator.close();
+        }
+    }
+
+    /** A savepoint writer function. */
+    public static class StateBootstrapper extends KeyedStateBootstrapFunction<Integer, Integer> {
+        private transient ValueState<Integer> state;
+
+        @Override
+        public void open(Configuration parameters) {
+            state = getRuntimeContext().getState(STATE_DESCRIPTOR);
+        }
+
+        @Override
+        public void processElement(Integer value, Context ctx) throws Exception {
+            state.update(value);
+        }
+    }
+
+    /** A savepoint reader function. */
+    public static class StateReader extends RichMapFunction<Integer, Integer> {
+        private transient ValueState<Integer> state;
+
+        @Override
+        public void open(Configuration parameters) {
+            state = getRuntimeContext().getState(STATE_DESCRIPTOR);
+        }
+
+        @Override
+        public Integer map(Integer value) throws Exception {
+            return state.value();
+        }
+    }
+
+    /**
+     * A dummy bootstreap function to satisfy the SavepointWriter requirement of having at least 1
+     * operator.
+     */
+    public static class DummyBootstrapper extends StateBootstrapFunction<Integer> {
+
+        @Override
+        public void processElement(Integer value, Context ctx) throws Exception {}
+
+        @Override
+        public void snapshotState(FunctionSnapshotContext context) throws Exception {}
+
+        @Override
+        public void initializeState(FunctionInitializationContext context) throws Exception {}
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/OperatorState.java
@@ -141,6 +141,12 @@ public class OperatorState implements CompositeStateHandle {
         return maxParallelism;
     }
 
+    public OperatorState copyWithNewOperatorID(OperatorID newOperatorId) {
+        OperatorState newState = new OperatorState(newOperatorId, parallelism, maxParallelism);
+        operatorSubtaskStates.forEach(newState::putState);
+        return newState;
+    }
+
     public OperatorState copyAndDiscardInFlightData() {
         OperatorState newState = new OperatorState(operatorID, parallelism, maxParallelism);
 


### PR DESCRIPTION
Adds the final piece for supporting UID hashes: a cheap way to map a uid hash to a UID.
This was implemented as a generic UID(hash) -> UID(hash) replacement, so you can also just replace a hash with another hash, or just change UID from one to another.

All without having to read the actual savepoint data.