### PR TITLE
[FLINK-29531][Formats][Protobuf] Bump protoc and protobuf-java dependencies to 3.21.7

### DIFF
--- a/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
@@ -58,7 +58,7 @@ under the License.
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>3.19.4</version>
+				<version>3.21.7</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
@@ -58,7 +58,7 @@ under the License.
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>3.19.4</version>
+				<version>3.21.7</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -52,7 +52,7 @@ under the License.
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>3.19.4</version>
+				<version>3.21.7</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/flink-formats/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-json-glue-schema-registry/pom.xml
@@ -53,7 +53,7 @@ under the License.
 			<dependency>
 				<groupId>com.google.protobuf</groupId>
 				<artifactId>protobuf-java</artifactId>
-				<version>3.19.4</version>
+				<version>3.21.7</version>
 			</dependency>
 			<dependency>
 				<groupId>com.google.guava</groupId>

--- a/flink-formats/flink-sql-protobuf/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-protobuf/src/main/resources/META-INF/NOTICE
@@ -7,4 +7,4 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under BSD-3 License (https://opensource.org/licenses/BSD-3-Clause).
 See bundled license files for details.
 
-- com.google.protobuf:protobuf-java:3.21.2
+- com.google.protobuf:protobuf-java:3.21.7

--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -33,4 +33,4 @@ grpcio>=1.29.0,<=1.46.3
 grpcio-tools>=1.29.0,<=1.46.3
 pemja==0.2.4; python_version >= '3.7' and platform_system != 'Windows'
 httplib2>=0.19.0,<=0.20.4
-protobuf<3.18
+protobuf<=3.21

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -34,7 +34,7 @@ This project bundles the following dependencies under the BSD license.
 See bundled license files for details
 
 - net.sf.py4j:py4j:0.10.9.3
-- com.google.protobuf:protobuf-java:3.21.2
+- com.google.protobuf:protobuf-java:3.21.7
 
 This project bundles the following dependencies under the MIT license. (https://opensource.org/licenses/MIT)
 See bundled license files for details.

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@ under the License.
 		<assertj.version>3.23.1</assertj.version>
 		<py4j.version>0.10.9.3</py4j.version>
 		<beam.version>2.38.0</beam.version>
-		<protoc.version>3.21.2</protoc.version>
+		<protoc.version>3.21.7</protoc.version>
 		<okhttp.version>3.14.9</okhttp.version>
 		<testcontainers.version>1.17.2</testcontainers.version>
 		<lz4.version>1.8.0</lz4.version>


### PR DESCRIPTION
## What is the purpose of the change

* Bump protoc and protobuf-java dependencies to at least 3.21.7 to avoid false positive scans on Protobuf vulnerabilities

## Brief change log

* Updated version on POM/requirements 
* Updated NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
