### PR TITLE
[FLINK-29509] Set proper subtaskId and numberOfSubtasks on CheckpointCommittableManagerImpl during recovery/deserialization.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
@@ -45,18 +45,17 @@ class CheckpointCommittableManagerImpl<CommT> implements CheckpointCommittableMa
 
     CheckpointCommittableManagerImpl(
             int subtaskId, int numberOfSubtasks, @Nullable Long checkpointId) {
-        this.subtaskId = subtaskId;
-        this.numberOfSubtasks = numberOfSubtasks;
-        this.checkpointId = checkpointId;
-        this.subtasksCommittableManagers = new HashMap<>();
+        this(new HashMap<>(), subtaskId, numberOfSubtasks, checkpointId);
     }
 
     CheckpointCommittableManagerImpl(
             Map<Integer, SubtaskCommittableManager<CommT>> subtasksCommittableManagers,
+            int subtaskId,
+            int numberOfSubtasks,
             @Nullable Long checkpointId) {
         this.subtasksCommittableManagers = checkNotNull(subtasksCommittableManagers);
-        this.subtaskId = 0;
-        this.numberOfSubtasks = 1;
+        this.subtaskId = subtaskId;
+        this.numberOfSubtasks = numberOfSubtasks;
         this.checkpointId = checkpointId;
     }
 
@@ -158,6 +157,8 @@ class CheckpointCommittableManagerImpl<CommT> implements CheckpointCommittableMa
         return new CheckpointCommittableManagerImpl<>(
                 subtasksCommittableManagers.entrySet().stream()
                         .collect(Collectors.toMap(Map.Entry::getKey, (e) -> e.getValue().copy())),
+                subtaskId,
+                numberOfSubtasks,
                 checkpointId);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorSerializer.java
@@ -152,6 +152,8 @@ public final class CommittableCollectorSerializer<CommT>
                             .collect(
                                     Collectors.toMap(
                                             SubtaskCommittableManager::getSubtaskId, e -> e)),
+                    subtaskId,
+                    numberOfSubtasks,
                     checkpointId);
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/sink2/CommittableSummaryAssert.java
@@ -36,11 +36,24 @@ public class CommittableSummaryAssert
         isNotNull();
         assertThat(actual.getSubtaskId()).isEqualTo(summary.getSubtaskId());
         assertThat(actual.getCheckpointId()).isEqualTo(summary.getCheckpointId());
+        assertThat(actual.getNumberOfSubtasks()).isEqualTo(summary.getNumberOfSubtasks());
         assertThat(actual.getNumberOfCommittables()).isEqualTo(summary.getNumberOfCommittables());
         assertThat(actual.getNumberOfPendingCommittables())
                 .isEqualTo(summary.getNumberOfPendingCommittables());
         assertThat(actual.getNumberOfFailedCommittables())
                 .isEqualTo(summary.getNumberOfFailedCommittables());
+        return this;
+    }
+
+    public CommittableSummaryAssert hasSubtaskId(int subtaskId) {
+        isNotNull();
+        assertThat(actual.getSubtaskId()).isEqualTo(subtaskId);
+        return this;
+    }
+
+    public CommittableSummaryAssert hasNumberOfSubtasks(int numberOfSubtasks) {
+        isNotNull();
+        assertThat(actual.getNumberOfSubtasks()).isEqualTo(numberOfSubtasks);
         return this;
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Fixing FLINK-29509 by setting the correct `subtaskId` and `numberOfSubtasks`  for `CheckpointCommittableManagerImpl` during recovery of committables for Sink V2 architecture.

## Brief change log
 - Remove constructor from `CheckpointCommittableManagerImpl` that was previously used only during deserialization and replace it with a new one that accepts `Map<Integer, SubtaskCommittableManager<CommT>> subtasksCommittableManagers` along with `subtaskId` and  `numberOfSubtasks`.
  - Use new `CheckpointCommittableManagerImpl` constructor in `CommittableCollectorSerializer` deserialize method for  `CheckpointCommittableManagerImpl` passing `subtaskId` and `numberOfSubtasks` from serializer instance.


## Verifying this change

This changed enhanced existing `CommittableCollectorSerializerTest::testCommittableCollectorV2SerDe()` test by verifying `sybtaskId` and `numberOfSubtasks` on `deserialized CheckpointCommittableManagerImpl` instance.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**yes**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
