### PR TITLE
[FLINK-29547][table] Fix the bug of Select a[1] which is  array type for parquet complex type throw ClassCastException

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/ArrayObjectArrayConverter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/conversion/ArrayObjectArrayConverter.java
@@ -100,7 +100,6 @@ public class ArrayObjectArrayConverter<E> implements DataStructureConverter<Arra
             if (genericArray.isPrimitiveArray()) {
                 return genericToJavaArrayConverter.convert((GenericArrayData) internal);
             }
-            return (E[]) genericArray.toObjectArray();
         }
         return toJavaArray(internal);
     }


### PR DESCRIPTION
## What is the purpose of the change
Fix the bug of Select a[1] which is  array type for parquet complex type throw ClassCastException


## Brief change log

  - *Fix the bug of Select a[1] which is  array type for parquet complex type throw ClassCastException*


## Verifying this change

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for in HiveTableSourceITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
