### PR TITLE
[FLINK-18436][table] Let FileSystemTableSource implements LookupTableSource

### DIFF
--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -63,6 +63,12 @@ under the License.
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemBulkFormatPartitionReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemBulkFormatPartitionReader.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.enumerate.NonSplittingRecursiveEnumerator;
+import org.apache.flink.connector.file.src.reader.BulkFormat;
+import org.apache.flink.connector.file.src.util.RecordAndPosition;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.table.data.RowData;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+public class FileSystemBulkFormatPartitionReader implements PartitionReader<Path, RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final BulkFormat<RowData, FileSourceSplit> bulkFormat;
+    private final Configuration configuration;
+
+    private transient ArrayList<FileSourceSplit> fileSourceSplits;
+    private transient BulkFormat.Reader<RowData> reader;
+    private transient BulkFormat.RecordIterator<RowData> recordIterator;
+    private transient int readingSplitId;
+
+    public FileSystemBulkFormatPartitionReader(
+            BulkFormat<RowData, FileSourceSplit> bulkFormat, ReadableConfig configuration) {
+        this.bulkFormat = bulkFormat;
+        checkArgument(configuration instanceof Configuration);
+        this.configuration = (Configuration) configuration;
+    }
+
+    @Override
+    public void open(List<Path> partitions) throws IOException {
+        NonSplittingRecursiveEnumerator enumerator = new NonSplittingRecursiveEnumerator();
+        fileSourceSplits = new ArrayList<>();
+        fileSourceSplits.addAll(enumerator.enumerateSplits(partitions.toArray(new Path[0]), 1));
+        readingSplitId = 0;
+        if (fileSourceSplits.size() > 0) {
+            reader = bulkFormat.createReader(configuration, fileSourceSplits.get(readingSplitId));
+            recordIterator = reader.readBatch();
+        }
+    }
+
+    @Nullable
+    @Override
+    public RowData read(RowData reuse) throws IOException {
+        while (readingSplitId < fileSourceSplits.size()) {
+            while (recordIterator != null) {
+                RecordAndPosition<RowData> recordAndPosition = recordIterator.next();
+                if (recordAndPosition != null) {
+                    return recordAndPosition.getRecord();
+                }
+                recordIterator.releaseBatch();
+                recordIterator = reader.readBatch();
+            }
+            readingSplitId++;
+            if (readingSplitId < fileSourceSplits.size()) {
+                reader =
+                        bulkFormat.createReader(
+                                configuration, fileSourceSplits.get(readingSplitId));
+                recordIterator = reader.readBatch();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reader != null) {
+            reader.close();
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemRowDataLookupFunction.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemRowDataLookupFunction.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.functions.FunctionContext;
+import org.apache.flink.table.functions.LookupFunction;
+import org.apache.flink.table.runtime.typeutils.InternalSerializers;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.FlinkRuntimeException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class FileSystemRowDataLookupFunction<P> extends LookupFunction {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(FileSystemRowDataLookupFunction.class);
+
+    // interval between retries
+    private static final Duration RETRY_INTERVAL = Duration.ofSeconds(10);
+
+    private final PartitionFetcher<P> partitionFetcher;
+    private final PartitionFetcher.Context<P> fetcherContext;
+    private final PartitionReader<P, RowData> partitionReader;
+    private final RowData.FieldGetter[] lookupFieldGetters;
+    private final int lookupMaxRetryTimes;
+    private final TypeSerializer<RowData> serializer;
+    private final RowType rowType;
+    private final Duration periodicReloadInterval;
+
+    // cache for lookup data
+    private transient Map<RowData, List<RowData>> cache;
+    // timestamp when cache expires
+    private transient long nextLoadTime;
+
+    public FileSystemRowDataLookupFunction(
+            PartitionFetcher<P> partitionFetcher,
+            PartitionFetcher.Context<P> fetcherContext,
+            PartitionReader<P, RowData> partitionReader,
+            RowType rowType,
+            int[] lookupKeys,
+            int lookupMaxRetryTimes,
+            Duration periodicReloadInterval) {
+        this.fetcherContext = fetcherContext;
+        this.partitionFetcher = partitionFetcher;
+        this.partitionReader = partitionReader;
+        this.rowType = rowType;
+        this.lookupFieldGetters = new RowData.FieldGetter[lookupKeys.length];
+        for (int i = 0; i < lookupKeys.length; i++) {
+            lookupFieldGetters[i] =
+                    RowData.createFieldGetter(rowType.getTypeAt(lookupKeys[i]), lookupKeys[i]);
+        }
+        this.lookupMaxRetryTimes = lookupMaxRetryTimes;
+        this.serializer = InternalSerializers.create(rowType);
+        this.periodicReloadInterval = periodicReloadInterval;
+    }
+
+    @Override
+    public void open(FunctionContext context) throws Exception {
+        super.open(context);
+        fetcherContext.open();
+        cache = new HashMap<>();
+        nextLoadTime = -1L;
+    }
+
+    /**
+     * This is a lookup method which is called by Flink framework in runtime.
+     *
+     * @param keyRow lookup keys
+     */
+    @Override
+    public Collection<RowData> lookup(RowData keyRow) throws IOException {
+        checkCacheReload();
+        List<RowData> matchedRows = cache.get(keyRow);
+        return matchedRows;
+    }
+
+    private void checkCacheReload() {
+        if (nextLoadTime > System.currentTimeMillis()) {
+            return;
+        }
+        if (nextLoadTime > 0) {
+            LOG.info(
+                    "Lookup join cache has expired after {} minute(s), reloading",
+                    periodicReloadInterval.toMinutes());
+        } else {
+            LOG.info("Populating lookup join cache");
+        }
+        int numRetry = 0;
+        while (true) {
+            cache.clear();
+            try {
+                long count = 0;
+                GenericRowData reuse = new GenericRowData(rowType.getFieldCount());
+                partitionReader.open(partitionFetcher.fetch(fetcherContext));
+                RowData row;
+                while ((row = partitionReader.read(reuse)) != null) {
+                    count++;
+                    RowData rowData = serializer.copy(row);
+                    RowData key = extractLookupKey(rowData);
+                    List<RowData> rows = cache.computeIfAbsent(key, k -> new ArrayList<>());
+                    rows.add(rowData);
+                }
+                partitionReader.close();
+                nextLoadTime = System.currentTimeMillis() + periodicReloadInterval.toMillis();
+                LOG.info("Loaded {} row(s) into lookup join cache", count);
+                return;
+            } catch (Exception e) {
+                if (numRetry >= lookupMaxRetryTimes) {
+                    throw new FlinkRuntimeException(
+                            String.format(
+                                    "Failed to load table into cache after %d retries", numRetry),
+                            e);
+                }
+                numRetry++;
+                long toSleep = numRetry * RETRY_INTERVAL.toMillis();
+                LOG.warn(
+                        String.format(
+                                "Failed to load table into cache, will retry in %d seconds",
+                                toSleep / 1000),
+                        e);
+                try {
+                    Thread.sleep(toSleep);
+                } catch (InterruptedException ex) {
+                    LOG.warn("Interrupted while waiting to retry failed cache load, aborting");
+                    throw new FlinkRuntimeException(ex);
+                }
+            }
+        }
+    }
+
+    private RowData extractLookupKey(RowData row) {
+        GenericRowData key = new GenericRowData(lookupFieldGetters.length);
+        for (int i = 0; i < lookupFieldGetters.length; i++) {
+            key.setField(i, lookupFieldGetters[i].getFieldOrNull(row));
+        }
+        return key;
+    }
+
+    @Override
+    public void close() throws Exception {
+        this.fetcherContext.close();
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableFactory.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.connector.format.DecodingFormat;
 import org.apache.flink.table.connector.format.EncodingFormat;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.lookup.LookupOptions;
 import org.apache.flink.table.factories.DecodingFormatFactory;
 import org.apache.flink.table.factories.DeserializationFormatFactory;
 import org.apache.flink.table.factories.DynamicTableSinkFactory;
@@ -75,7 +76,8 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
                 context.getCatalogTable().getPartitionKeys(),
                 helper.getOptions(),
                 discoverDecodingFormat(context, BulkReaderFormatFactory.class),
-                discoverDecodingFormat(context, DeserializationFormatFactory.class));
+                discoverDecodingFormat(context, DeserializationFormatFactory.class),
+                helper.getOptions().get(LookupOptions.MAX_RETRIES));
     }
 
     @Override
@@ -125,6 +127,8 @@ public class FileSystemTableFactory implements DynamicTableSourceFactory, Dynami
         options.add(FileSystemConnectorOptions.AUTO_COMPACTION);
         options.add(FileSystemConnectorOptions.COMPACTION_FILE_SIZE);
         options.add(FileSystemConnectorOptions.SINK_PARALLELISM);
+        options.add(LookupOptions.MAX_RETRIES);
+        options.add(LookupOptions.FULL_CACHE_PERIODIC_RELOAD_INTERVAL);
         return options;
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemLookupJoinITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/file/table/FileSystemLookupJoinITCase.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableImpl;
+import org.apache.flink.table.catalog.CatalogPartitionImpl;
+import org.apache.flink.table.catalog.CatalogPartitionSpec;
+import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.planner.factories.utils.TestCollectionTableFactory;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test lookup join of file system. */
+public class FileSystemLookupJoinITCase {
+    private static TableEnvironment tEnv;
+    @TempDir private static File file;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        // create probe table
+        TestCollectionTableFactory.initData(
+                Arrays.asList(
+                        Row.of(1, "a"),
+                        Row.of(1, "c"),
+                        Row.of(2, "b"),
+                        Row.of(2, "c"),
+                        Row.of(3, "c"),
+                        Row.of(4, "d")));
+        tEnv.executeSql(
+                "create table probe (x int,y string, p as proctime()) "
+                        + "with ('connector'='COLLECTION','is-bounded' = 'false')");
+
+        String filePath1 =
+                createFileAndWriteData(
+                        file, "00-00.tmp", Arrays.asList("1,a,10", "2,a,21", "2,b,22", "3,c,33"));
+        String ddl1 =
+                String.format(
+                        "CREATE TABLE bounded_table (\n"
+                                + "  x int,\n"
+                                + "  y string,\n"
+                                + "  z int\n"
+                                + ") with (\n"
+                                + " 'connector' = 'filesystem',"
+                                + " 'format' = 'testcsv',"
+                                + " 'lookup.full-cache.periodic-reload.interval' = '10s',"
+                                + " 'path' = '%s')",
+                        filePath1);
+        tEnv.executeSql(ddl1);
+
+        File partitionDataPath = new File(file, "partitionData");
+        partitionDataPath.mkdirs();
+        writeData(new File(partitionDataPath, "z=10"), Arrays.asList("1,a,10", "2,b,10"));
+        writeData(new File(partitionDataPath, "z=21"), Collections.singletonList("2,a,21"));
+        writeData(new File(partitionDataPath, "z=22"), Arrays.asList("2,b,22", "3,c,22"));
+        String ddl2 =
+                String.format(
+                        "CREATE TABLE bounded_partition_table (\n"
+                                + "  x int,\n"
+                                + "  y string,\n"
+                                + "  z int \n"
+                                + ") partitioned by(z) with (\n"
+                                + " 'connector' = 'filesystem',"
+                                + " 'format' = 'testcsv',"
+                                + " 'lookup.full-cache.periodic-reload.interval' = '10s',"
+                                + " 'path' = '%s')",
+                        partitionDataPath.toURI());
+        tEnv.executeSql(ddl2);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .createPartition(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "bounded_partition_table"),
+                        new CatalogPartitionSpec(Collections.singletonMap("z", "10")),
+                        new CatalogPartitionImpl(new HashMap<>(), ""),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .createPartition(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "bounded_partition_table"),
+                        new CatalogPartitionSpec(Collections.singletonMap("z", "21")),
+                        new CatalogPartitionImpl(new HashMap<>(), ""),
+                        false);
+        tEnv.getCatalog(tEnv.getCurrentCatalog())
+                .orElseThrow(Exception::new)
+                .createPartition(
+                        new ObjectPath(tEnv.getCurrentDatabase(), "bounded_partition_table"),
+                        new CatalogPartitionSpec(Collections.singletonMap("z", "22")),
+                        new CatalogPartitionImpl(new HashMap<>(), ""),
+                        false);
+    }
+
+    @Test
+    public void testLookupJoinBoundedTable() {
+        TableImpl flinkTable =
+                (TableImpl)
+                        tEnv.sqlQuery(
+                                "select p.x, p.y, b.z from "
+                                        + " probe as p "
+                                        + " join bounded_table for system_time as of p.p as b on p.x=b.x");
+        List<Row> rows = CollectionUtil.iteratorToList(flinkTable.execute().collect());
+        assertThat(rows.toString())
+                .isEqualTo(
+                        "[+I[1, a, 10], +I[1, c, 10], +I[2, b, 21], +I[2, b, 22], +I[2, c, 21], +I[2, c, 22], +I[3, c, 33]]");
+    }
+
+    @Test
+    public void testLookupJoinBoundedPartitionedTable() {
+        TableImpl flinkTable =
+                (TableImpl)
+                        tEnv.sqlQuery(
+                                "select p.x, p.y, b.z from "
+                                        + " probe as p"
+                                        + " join bounded_partition_table for system_time as of p.p as b on p.x=b.x where p.y = 'a'");
+        List<Row> results = CollectionUtil.iteratorToList(flinkTable.execute().collect());
+        assertThat(results.toString()).isEqualTo("[+I[1, a, 10]]");
+    }
+
+    private void writeData(File file, List<String> data) throws IOException {
+        Files.write(file.toPath(), String.join("\n", data).getBytes());
+    }
+
+    private String createFileAndWriteData(File path, String fileName, List<String> data)
+            throws IOException {
+        String file = path.getAbsolutePath() + "/" + fileName;
+        Files.write(new File(file).toPath(), String.join("\n", data).getBytes());
+        return file;
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pr is aims to let FileSystemTableSource implements LookupTableSource。This pr designs FileSystemRowDataLookupFunction which extends the new LookupFunction announced in [FLIP-221](https://cwiki.apache.org/confluence/display/FLINK/FLIP-221%3A+Abstraction+for+lookup+source+cache+and+metric)。we will read all the data into the cache each time, and set the reload interval.
Later, partition push down for FileSystemLookupTableSource will be realized in this pr.

## Brief change log

- Add a new FileSystemBulkFormatPartitionReader to reader data according to partition path.
- Add a new FileSystemRowDataLookupFunction to realize lookup read data from file system source.
- Add ITCase in FileSystemLookupJoinITCase to test Lookup Join.


## Verifying this change

- Add ITCase in FileSystemLookupJoinITCase to test Lookup Join.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? no document now
