### PR TITLE
[FLINK-29553][table]Support UNIX_TIMESTAMP built-in function in Table API

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -495,8 +495,10 @@ temporal:
     table: fromUnixtime(NUMERIC[, STRING])
     description: Returns a representation of the numeric argument as a value in string format (default is 'yyyy-MM-dd HH:mm:ss'). numeric is an internal timestamp value representing seconds since '1970-01-01 00:00:00' UTC, such as produced by the UNIX_TIMESTAMP() function. The return value is expressed in the session time zone (specified in TableConfig). E.g., FROM_UNIXTIME(44) returns '1970-01-01 00:00:44' if in UTC time zone, but returns '1970-01-01 09:00:44' if in 'Asia/Tokyo' time zone.
   - sql: UNIX_TIMESTAMP()
+    table: unixTimestamp()
     description: Gets current Unix timestamp in seconds. This function is not deterministic which means the value would be recalculated for each record.
   - sql: UNIX_TIMESTAMP(string1[, string2])
+    table: unixTimestamp(string1[, string2])
     description: 'Converts date time string string1 in format string2 (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.'
   - sql: TO_DATE(string1[, string2])
     table: toDate(STRING1[, STRING2])

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -623,8 +623,10 @@ temporal:
       （在 TableConfig 中指定）。例如，如果在 UTC 时区，FROM_UNIXTIME(44) 返回 '1970-01-01 00:00:44'，如果在
       'Asia/Tokyo' 时区，则返回 '1970-01-01 09:00:44'。
   - sql: UNIX_TIMESTAMP()
+    table: unixTimestamp()
     description: 以秒为单位获取当前的 Unix 时间戳。此函数不是确定性的，这意味着将为每个记录重新计算该值。
   - sql: UNIX_TIMESTAMP(string1[, string2])
+    table: unixTimestamp(string1[, string2])
     description: |
       使用表配置中指定的时区将格式为 string2 的日期时间字符串 string1（如果未指定默认情况下：yyyy-MM-dd HH:mm:ss）
       转换为 Unix 时间戳（以秒为单位）。

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -33,7 +33,7 @@ __all__ = ['if_then_else', 'lit', 'col', 'range_', 'and_', 'or_', 'not_', 'UNBOU
            'concat_ws', 'uuid', 'null_of', 'log', 'with_columns', 'without_columns', 'json_string',
            'json_object', 'json_object_agg', 'json_array', 'json_array_agg', 'call', 'call_sql',
            'source_watermark', 'to_timestamp_ltz', 'from_unixtime', 'to_date', 'to_timestamp',
-           'convert_tz']
+           'convert_tz', 'unix_timestamp']
 
 
 def _leaf_op(op_name: str) -> Expression:
@@ -412,6 +412,19 @@ def from_unixtime(unixtime, format=None) -> Expression:
     else:
         return _binary_op("fromUnixtime", unixtime, format)
 
+def unix_timestamp(unixtime = None, format = None) -> Expression:
+    """
+    if no args
+        gets current Unix timestamp in seconds.
+    else
+        convert date time string the given format. The default format is "yyyy-MM-dd HH:mm:ss".
+    """
+    if unixtime is None:
+        return _leaf_op("unixTimestamp")
+    elif format is None:
+        return _unary_op("unixTimestamp", unixtime)
+    else:
+        return _binary_op("unixTimestamp", unixtime, format)
 
 def array(head, *tail) -> Expression:
     """

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -27,7 +27,7 @@ from pyflink.table.expressions import (col, lit, range_, and_, or_, current_date
                                        rand, rand_integer, atan2, negative, concat, concat_ws, uuid,
                                        null_of, log, if_then_else, with_columns, call,
                                        to_timestamp_ltz, from_unixtime, to_date, to_timestamp,
-                                       convert_tz)
+                                       convert_tz, unix_timestamp)
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 
@@ -285,6 +285,8 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual("fromUnixtime(1)", str(from_unixtime(1)))
         self.assertEqual("fromUnixtime(1, 'yy-MM-dd HH-mm-ss')",
                          str(from_unixtime(1, 'yy-MM-dd HH-mm-ss')))
+        self.assertEqual("unixTimestamp('2015-07-24 10:00:00')", str(unix_timestamp("2015-07-24 10:00:00")))
+        self.assertEqual("unixTimestamp('2015/07/24 10:00:00.5', 'yyyy/MM/dd HH:mm:ss.S')", str(unix_timestamp("2015/07/24 10:00:00.5", "yyyy/MM/dd HH:mm:ss.S")))
         self.assertEqual('array(1, 2, 3)', str(array(1, 2, 3)))
         self.assertEqual("row('key1', 1)", str(row("key1", 1)))
         self.assertEqual("map('key1', 1, 'key2', 2, 'key3', 3)",

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -472,6 +472,37 @@ public final class Expressions {
         return apiCall(BuiltInFunctionDefinitions.FROM_UNIXTIME, unixtime, format);
     }
 
+    /**
+     * Gets current Unix timestamp in seconds.
+     * This function is not deterministic.
+     *
+     * @return The current Unix timestamp in seconds.
+     */
+    public static ApiExpression unixTimestamp() {
+        return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP);
+    }
+
+    /**
+     * Converts date time string in format (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     *
+     * @param unixtime The data time with string type.
+     * @return The current Unix timestamp in seconds.
+     */
+    public static ApiExpression unixTimestamp(Object unixtime) {
+        return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP, unixtime);
+    }
+
+    /**
+     * Converts date time string in format (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     *
+     * @param unixtime The data time with string type.
+     * @param format The format of the string.
+     * @return The current Unix timestamp in seconds.
+     */
+    public static ApiExpression unixTimestamp(Object unixtime, Object format) {
+        return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP, unixtime, format);
+    }
+
     /** Creates an array of literals. */
     public static ApiExpression array(Object head, Object... tail) {
         return apiCallAtLeastOneArgument(BuiltInFunctionDefinitions.ARRAY, head, tail);

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -477,7 +477,7 @@ public final class Expressions {
      *
      * @return The current Unix timestamp in seconds.
      */
-    public static ApiExpression unixTimestamp() {
+      public static ApiExpression unixTimestamp() {
         return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -477,7 +477,7 @@ public final class Expressions {
      *
      * @return The current Unix timestamp in seconds.
      */
-      public static ApiExpression unixTimestamp() {
+    public static ApiExpression unixTimestamp() {
         return apiCall(BuiltInFunctionDefinitions.UNIX_TIMESTAMP);
     }
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -473,8 +473,7 @@ public final class Expressions {
     }
 
     /**
-     * Gets current Unix timestamp in seconds.
-     * This function is not deterministic.
+     * Gets current Unix timestamp in seconds. This function is not deterministic.
      *
      * @return The current Unix timestamp in seconds.
      */
@@ -483,7 +482,8 @@ public final class Expressions {
     }
 
     /**
-     * Converts date time string in format (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     * Converts date time string in format (by default: yyyy-MM-dd HH:mm:ss if not specified) to
+     * Unix timestamp (in seconds), using the specified timezone in table config.
      *
      * @param unixtime The data time with string type.
      * @return The current Unix timestamp in seconds.
@@ -493,7 +493,8 @@ public final class Expressions {
     }
 
     /**
-     * Converts date time string in format (by default: yyyy-MM-dd HH:mm:ss if not specified) to Unix timestamp (in seconds), using the specified timezone in table config.
+     * Converts date time string in format (by default: yyyy-MM-dd HH:mm:ss if not specified) to
+     * Unix timestamp (in seconds), using the specified timezone in table config.
      *
      * @param unixtime The data time with string type.
      * @param format The format of the string.

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -496,16 +496,16 @@ trait ImplicitExpressionConversions {
   }
 
   /**
-   * Converts the date time string with format 'yyyy-MM-dd HH:mm:ss' under the 'UTC+0' time zone
-   * to a timestamp value of [[DataTypes.TIMESTAMP]].
+   * Converts the date time string with format 'yyyy-MM-dd HH:mm:ss' under the 'UTC+0' time zone to
+   * a timestamp value of [[DataTypes.TIMESTAMP]].
    */
   def toTimestamp(timestampStr: Expression): Expression = {
     Expressions.toTimestamp(timestampStr)
   }
 
   /**
-   * Converts the date time string with the specified format under the 'UTC+0' time zone
-   * to a timestamp value of [[DataTypes.TIMESTAMP]].
+   * Converts the date time string with the specified format under the 'UTC+0' time zone to a
+   * timestamp value of [[DataTypes.TIMESTAMP]].
    */
   def toTimestamp(timestampStr: Expression, format: Expression): Expression = {
     Expressions.toTimestamp(timestampStr, format)
@@ -580,10 +580,9 @@ trait ImplicitExpressionConversions {
 
   /**
    * Converts a datetime dateStr (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time
-   * zone tzFrom to time zone tzTo. The format of time zone should be either an abbreviation
-   * such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00".
-   * E.g., convertTz('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31
-   * 16:00:00'.
+   * zone tzFrom to time zone tzTo. The format of time zone should be either an abbreviation such as
+   * "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00". E.g.,
+   * convertTz('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31 16:00:00'.
    *
    * @param dateStr
    *   dateStr the date time string
@@ -611,25 +610,23 @@ trait ImplicitExpressionConversions {
   def fromUnixtime(unixtime: Expression, format: Expression): Expression =
     Expressions.fromUnixtime(unixtime, format)
 
-  /**
-    * Gets current Unix timestamp in seconds value of [[DataTypes.BIGINT]].
-    */
+  /** Gets current Unix timestamp in seconds value of [[DataTypes.BIGINT]]. */
   def unixTimestamp(): Expression = {
     Expressions.unixTimestamp()
   }
 
   /**
-    * Converts the date time string with the default format(yyyy-MM-dd HH:mm:ss) under the specified timezone in table config
-    * to a Unix timestamp (in seconds) value of [[DataTypes.BIGINT]].
-    */
+   * Converts the date time string with the default format(yyyy-MM-dd HH:mm:ss) under the specified
+   * timezone in table config to a Unix timestamp (in seconds) value of [[DataTypes.BIGINT]].
+   */
   def unixTimestamp(timestampStr: Expression): Expression = {
     Expressions.unixTimestamp(timestampStr)
   }
 
   /**
-    * Converts the date time string with the specified format under the specified timezone in table config
-    * to a Unix timestamp (in seconds) value of [[DataTypes.BIGINT()]].
-    */
+   * Converts the date time string with the specified format under the specified timezone in table
+   * config to a Unix timestamp (in seconds) value of [[DataTypes.BIGINT()]].
+   */
   def unixTimestamp(timestampStr: Expression, format: Expression): Expression = {
     Expressions.unixTimestamp(timestampStr, format)
   }

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -496,16 +496,16 @@ trait ImplicitExpressionConversions {
   }
 
   /**
-   * Converts the date time string with format 'yyyy-MM-dd HH:mm:ss' under the 'UTC+0' time zone to
-   * a timestamp value of [[DataTypes.TIMESTAMP]].
+   * Converts the date time string with format 'yyyy-MM-dd HH:mm:ss' under the 'UTC+0' time zone
+   * to a timestamp value of [[DataTypes.TIMESTAMP]].
    */
   def toTimestamp(timestampStr: Expression): Expression = {
     Expressions.toTimestamp(timestampStr)
   }
 
   /**
-   * Converts the date time string with the specified format under the 'UTC+0' time zone to a
-   * timestamp value of [[DataTypes.TIMESTAMP]].
+   * Converts the date time string with the specified format under the 'UTC+0' time zone
+   * to a timestamp value of [[DataTypes.TIMESTAMP]].
    */
   def toTimestamp(timestampStr: Expression, format: Expression): Expression = {
     Expressions.toTimestamp(timestampStr, format)
@@ -580,9 +580,10 @@ trait ImplicitExpressionConversions {
 
   /**
    * Converts a datetime dateStr (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time
-   * zone tzFrom to time zone tzTo. The format of time zone should be either an abbreviation such as
-   * "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00". E.g.,
-   * convertTz('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31 16:00:00'.
+   * zone tzFrom to time zone tzTo. The format of time zone should be either an abbreviation
+   * such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00".
+   * E.g., convertTz('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31
+   * 16:00:00'.
    *
    * @param dateStr
    *   dateStr the date time string

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -611,9 +611,9 @@ trait ImplicitExpressionConversions {
     Expressions.fromUnixtime(unixtime, format)
 
   /** Gets current Unix timestamp in seconds value of [[DataTypes.BIGINT]]. */
-  def unixTimestamp(): Expression = {
+   def unixTimestamp(): Expression = {
     Expressions.unixTimestamp()
-  }
+   }
 
   /**
    * Converts the date time string with the default format(yyyy-MM-dd HH:mm:ss) under the specified

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -611,9 +611,9 @@ trait ImplicitExpressionConversions {
     Expressions.fromUnixtime(unixtime, format)
 
   /** Gets current Unix timestamp in seconds value of [[DataTypes.BIGINT]]. */
-   def unixTimestamp(): Expression = {
+  def unixTimestamp(): Expression = {
     Expressions.unixTimestamp()
-   }
+  }
 
   /**
    * Converts the date time string with the default format(yyyy-MM-dd HH:mm:ss) under the specified

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -496,16 +496,16 @@ trait ImplicitExpressionConversions {
   }
 
   /**
-   * Converts the date time string with format 'yyyy-MM-dd HH:mm:ss' under the 'UTC+0' time zone
-   * to a timestamp value of [[DataTypes.TIMESTAMP]].
+   * Converts the date time string with format 'yyyy-MM-dd HH:mm:ss' under the 'UTC+0' time zone to
+   * a timestamp value of [[DataTypes.TIMESTAMP]].
    */
   def toTimestamp(timestampStr: Expression): Expression = {
     Expressions.toTimestamp(timestampStr)
   }
 
   /**
-   * Converts the date time string with the specified format under the 'UTC+0' time zone
-   * to a timestamp value of [[DataTypes.TIMESTAMP]].
+   * Converts the date time string with the specified format under the 'UTC+0' time zone to a
+   * timestamp value of [[DataTypes.TIMESTAMP]].
    */
   def toTimestamp(timestampStr: Expression, format: Expression): Expression = {
     Expressions.toTimestamp(timestampStr, format)
@@ -580,10 +580,9 @@ trait ImplicitExpressionConversions {
 
   /**
    * Converts a datetime dateStr (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time
-   * zone tzFrom to time zone tzTo. The format of time zone should be either an abbreviation
-   * such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00".
-   * E.g., convertTz('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31
-   * 16:00:00'.
+   * zone tzFrom to time zone tzTo. The format of time zone should be either an abbreviation such as
+   * "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00". E.g.,
+   * convertTz('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31 16:00:00'.
    *
    * @param dateStr
    *   dateStr the date time string

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -611,6 +611,29 @@ trait ImplicitExpressionConversions {
   def fromUnixtime(unixtime: Expression, format: Expression): Expression =
     Expressions.fromUnixtime(unixtime, format)
 
+  /**
+    * Gets current Unix timestamp in seconds value of [[DataTypes.BIGINT]].
+    */
+  def unixTimestamp(): Expression = {
+    Expressions.unixTimestamp()
+  }
+
+  /**
+    * Converts the date time string with the default format(yyyy-MM-dd HH:mm:ss) under the specified timezone in table config
+    * to a Unix timestamp (in seconds) value of [[DataTypes.BIGINT]].
+    */
+  def unixTimestamp(timestampStr: Expression): Expression = {
+    Expressions.unixTimestamp(timestampStr)
+  }
+
+  /**
+    * Converts the date time string with the specified format under the specified timezone in table config
+    * to a Unix timestamp (in seconds) value of [[DataTypes.BIGINT()]].
+    */
+  def unixTimestamp(timestampStr: Expression, format: Expression): Expression = {
+    Expressions.unixTimestamp(timestampStr, format)
+  }
+
   /** Creates an array of literals. */
   def array(head: Expression, tail: Expression*): Expression = {
     Expressions.array(head, tail: _*)

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1560,6 +1560,20 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition UNIX_TIMESTAMP =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("unixTimestamp")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            or(
+                                    NO_ARGS,
+                                    sequence(logical(LogicalTypeFamily.CHARACTER_STRING)),
+                                    sequence(
+                                            logical(LogicalTypeFamily.CHARACTER_STRING),
+                                            logical(LogicalTypeFamily.CHARACTER_STRING))))
+                    .outputTypeStrategy(nullableIfArgs(explicit(BIGINT())))
+                    .build();
+
     public static final BuiltInFunctionDefinition TO_DATE =
             BuiltInFunctionDefinition.newBuilder()
                     .name("toDate")

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1564,6 +1564,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("unixTimestamp")
                     .kind(SCALAR)
+                    .notDeterministic()
                     .inputTypeStrategy(
                             or(
                                     NO_ARGS,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -210,6 +210,8 @@ public class DirectConvertRule implements CallExpressionConvertRule {
         DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.FROM_UNIXTIME, FlinkSqlOperatorTable.FROM_UNIXTIME);
         DEFINITION_OPERATOR_MAP.put(
+                BuiltInFunctionDefinitions.UNIX_TIMESTAMP, FlinkSqlOperatorTable.UNIX_TIMESTAMP);
+        DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.TO_DATE, FlinkSqlOperatorTable.TO_DATE);
         DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.TO_TIMESTAMP_LTZ,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -951,11 +951,18 @@ class TemporalTypesTest extends ExpressionTestBase {
     testSqlApi(s"UNIX_TIMESTAMP('$ss2')", (ts2.getTime / 1000L).toString)
     testSqlApi(s"UNIX_TIMESTAMP('$s1', '$fmt')", (ts1.getTime / 1000L).toString)
     testSqlApi(s"UNIX_TIMESTAMP('$s2', '$fmt')", (ts2.getTime / 1000L).toString)
+
+    testAllApis(unixTimestamp(ss1), s"UNIX_TIMESTAMP('$ss1')", (ts1.getTime / 1000L).toString)
+    testAllApis(unixTimestamp(ss2), s"UNIX_TIMESTAMP('$ss2')", (ts2.getTime / 1000L).toString)
+    testAllApis(unixTimestamp(s1, fmt), s"UNIX_TIMESTAMP('$s1', '$fmt')", (ts1.getTime / 1000L).toString)
+    testAllApis(unixTimestamp(s2, fmt), s"UNIX_TIMESTAMP('$s2', '$fmt')", (ts2.getTime / 1000L).toString)
   }
 
   @Test
   def testUnixTimestampInTokyo(): Unit = {
     tableConfig.setLocalTimeZone(ZoneId.of("Asia/Tokyo"))
+    testAllApis(unixTimestamp("2015-07-24 10:00:00"), "UNIX_TIMESTAMP('2015-07-24 10:00:00')", "1437699600")
+    testAllApis(unixTimestamp("2015/07/24 10:00:00.5", "yyyy/MM/dd HH:mm:ss.S"), "UNIX_TIMESTAMP('2015/07/24 10:00:00.5', 'yyyy/MM/dd HH:mm:ss.S')", "1437699600")
     testSqlApi("UNIX_TIMESTAMP('2015-07-24 10:00:00')", "1437699600")
     testSqlApi("UNIX_TIMESTAMP('2015/07/24 10:00:00.5', 'yyyy/MM/dd HH:mm:ss.S')", "1437699600")
   }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -954,15 +954,27 @@ class TemporalTypesTest extends ExpressionTestBase {
 
     testAllApis(unixTimestamp(ss1), s"UNIX_TIMESTAMP('$ss1')", (ts1.getTime / 1000L).toString)
     testAllApis(unixTimestamp(ss2), s"UNIX_TIMESTAMP('$ss2')", (ts2.getTime / 1000L).toString)
-    testAllApis(unixTimestamp(s1, fmt), s"UNIX_TIMESTAMP('$s1', '$fmt')", (ts1.getTime / 1000L).toString)
-    testAllApis(unixTimestamp(s2, fmt), s"UNIX_TIMESTAMP('$s2', '$fmt')", (ts2.getTime / 1000L).toString)
+    testAllApis(
+      unixTimestamp(s1, fmt),
+      s"UNIX_TIMESTAMP('$s1', '$fmt')",
+      (ts1.getTime / 1000L).toString)
+    testAllApis(
+      unixTimestamp(s2, fmt),
+      s"UNIX_TIMESTAMP('$s2', '$fmt')",
+      (ts2.getTime / 1000L).toString)
   }
 
   @Test
   def testUnixTimestampInTokyo(): Unit = {
     tableConfig.setLocalTimeZone(ZoneId.of("Asia/Tokyo"))
-    testAllApis(unixTimestamp("2015-07-24 10:00:00"), "UNIX_TIMESTAMP('2015-07-24 10:00:00')", "1437699600")
-    testAllApis(unixTimestamp("2015/07/24 10:00:00.5", "yyyy/MM/dd HH:mm:ss.S"), "UNIX_TIMESTAMP('2015/07/24 10:00:00.5', 'yyyy/MM/dd HH:mm:ss.S')", "1437699600")
+    testAllApis(
+      unixTimestamp("2015-07-24 10:00:00"),
+      "UNIX_TIMESTAMP('2015-07-24 10:00:00')",
+      "1437699600")
+    testAllApis(
+      unixTimestamp("2015/07/24 10:00:00.5", "yyyy/MM/dd HH:mm:ss.S"),
+      "UNIX_TIMESTAMP('2015/07/24 10:00:00.5', 'yyyy/MM/dd HH:mm:ss.S')",
+      "1437699600")
     testSqlApi("UNIX_TIMESTAMP('2015-07-24 10:00:00')", "1437699600")
     testSqlApi("UNIX_TIMESTAMP('2015/07/24 10:00:00.5', 'yyyy/MM/dd HH:mm:ss.S')", "1437699600")
   }


### PR DESCRIPTION
## What is the purpose of the change
Support unix_timestamp  built-in function in Table API.

##  Brief change log
Support unix_timestamp built-in functions in Table API.
Support unix_timestamp  built-in functions in Python Table API.

##  Verifying this change
This change added tests and can be verified as follows:

Added test that validates that unix_timestamp in Table API work
Added test that validates that unix_timestamp in Python Table API work


## Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (yes)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
The S3 file system connector: (no)

##  Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (docs)