### PR TITLE
[FLINK-29551][table] Improving adaptive hash join by using sort merge join strategy per partition instead of all partitions

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/BinaryHashPartition.java
@@ -172,7 +172,7 @@ public class BinaryHashPartition extends AbstractPagedInputView implements Seeka
      *
      * @return This partition's number.
      */
-    int getPartitionNumber() {
+    public int getPartitionNumber() {
         return this.partitionNumber;
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/hashtable/LongHashPartition.java
@@ -415,7 +415,7 @@ public class LongHashPartition extends AbstractPagedInputView implements Seekabl
         return this.buildSideChannel;
     }
 
-    int getPartitionNumber() {
+    public int getPartitionNumber() {
         return this.partitionNum;
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/join/SortMergeJoinFunction.java
@@ -200,14 +200,16 @@ public class SortMergeJoinFunction implements Serializable {
         this.rightNullRow = new GenericRowData(serializer2.getArity());
         this.joinedRow = new JoinedRowData();
 
-        condFuncCode = null;
-        computer1 = null;
-        comparator1 = null;
-        computer2 = null;
-        comparator2 = null;
-        projectionCode1 = null;
-        projectionCode2 = null;
-        genKeyComparator = null;
+        if (!adaptiveHashJoin) {
+            condFuncCode = null;
+            computer1 = null;
+            comparator1 = null;
+            computer2 = null;
+            comparator2 = null;
+            projectionCode1 = null;
+            projectionCode2 = null;
+            genKeyComparator = null;
+        }
 
         operatorMetricGroup.gauge(
                 "memoryUsedSizeInBytes",


### PR DESCRIPTION

## What is the purpose of the change

Improving adaptive hash join by using sort-merge join strategy per partition instead of all partitions

## Brief change log

  - *Improving adaptive hash join by using sort merge join strategy per partition instead of all partitions*


## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not documented)
