### PR TITLE
[FLINK-29497] Add option to allow deploy of flink-dist jar

### DIFF
--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -35,6 +35,7 @@ under the License.
 	<properties>
 		<zookeeper.optional.version>3.6.3</zookeeper.optional.version>
 		<japicmp.skip>true</japicmp.skip>
+		<flink-dist.deploy.skip>true</flink-dist.deploy.skip>
 	</properties>
 
 	<dependencies>
@@ -823,7 +824,7 @@ under the License.
 				<artifactId>maven-deploy-plugin</artifactId>
 				<version>2.4</version><!--$NO-MVN-MAN-VER$-->
 				<configuration>
-					<skip>true</skip>
+					<skip>${flink-dist.deploy.skip}</skip>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
## What is the purpose of the change

Adds a maven property to control publishing of the flink-dist jar. By default the jar file isn't published, retaining the existing behavior. Publishing can be enabled via `-Dflink-dist.deploy.skip=false`


## Verifying this change

`mvn deploy -Dflink-dist.deploy.skip=false`
