### PR TITLE
[FLINK-29532][BP 1.16][Connector/Pulsar] Update Pulsar dependency to 2.10.1. 

### DIFF
--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -35,14 +35,14 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<pulsar.version>2.10.0</pulsar.version>
+		<pulsar.version>2.10.1</pulsar.version>
 
 		<!-- Test Libraries -->
 		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 		<os-maven-plugin.version>1.7.0</os-maven-plugin.version>
 		<pulsar-commons-lang3.version>3.11</pulsar-commons-lang3.version>
-		<pulsar-netty.version>4.1.74.Final</pulsar-netty.version>
-		<pulsar-grpc.version>1.42.1</pulsar-grpc.version>
+		<pulsar-netty.version>4.1.77.Final</pulsar-netty.version>
+		<pulsar-grpc.version>1.45.1</pulsar-grpc.version>
 	</properties>
 
 	<dependencies>

--- a/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.pulsar:bouncy-castle-bc:pkg:2.10.0
-- org.apache.pulsar:pulsar-client-admin-api:2.10.0
-- org.apache.pulsar:pulsar-client-all:2.10.0
-- org.apache.pulsar:pulsar-client-api:2.10.0
+- org.apache.pulsar:bouncy-castle-bc:pkg:2.10.1
+- org.apache.pulsar:pulsar-client-admin-api:2.10.1
+- org.apache.pulsar:pulsar-client-all:2.10.1
+- org.apache.pulsar:pulsar-client-api:2.10.1
 - org.slf4j:jul-to-slf4j:1.7.32
 
 This project bundles the following dependencies under the Bouncy Castle license.

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	<name>Flink : E2E Tests : Pulsar</name>
 
 	<properties>
-		<pulsar.version>2.10.0</pulsar.version>
+		<pulsar.version>2.10.1</pulsar.version>
 		<bouncycastle.version>1.69</bouncycastle.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 	</properties>

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -42,7 +42,7 @@ public class DockerImageVersions {
 
     public static final String LOCALSTACK = "localstack/localstack:0.13.3";
 
-    public static final String PULSAR = "apachepulsar/pulsar:2.10.0";
+    public static final String PULSAR = "apachepulsar/pulsar:2.10.1";
 
     public static final String CASSANDRA_4_0 = "cassandra:4.0.3";
 


### PR DESCRIPTION
Unchanged backport of https://github.com/apache/flink/pull/20980