### PR TITLE
[FLINK-29562][rest][docs] Distinct titles for JM/SQL gateway specs

### DIFF
--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/OpenApiSpecGenerator.java
@@ -108,7 +108,10 @@ public class OpenApiSpecGenerator {
 
     @VisibleForTesting
     static void createDocumentationFile(
-            DocumentingRestEndpoint restEndpoint, RestAPIVersion apiVersion, Path outputFile)
+            String title,
+            DocumentingRestEndpoint restEndpoint,
+            RestAPIVersion apiVersion,
+            Path outputFile)
             throws IOException {
         final OpenAPI openApi = new OpenAPI();
 
@@ -116,7 +119,7 @@ public class OpenApiSpecGenerator {
         openApi.setPaths(new io.swagger.v3.oas.models.Paths());
         openApi.setComponents(new Components());
 
-        setInfo(openApi, apiVersion);
+        setInfo(openApi, title, apiVersion);
 
         List<MessageHeaders> specs =
                 restEndpoint.getSpecs().stream()
@@ -173,10 +176,11 @@ public class OpenApiSpecGenerator {
         return spec.getClass().getAnnotation(Documentation.ExcludeFromDocumentation.class) == null;
     }
 
-    private static void setInfo(final OpenAPI openApi, final RestAPIVersion apiVersion) {
+    private static void setInfo(
+            final OpenAPI openApi, String title, final RestAPIVersion apiVersion) {
         openApi.info(
                 new Info()
-                        .title("Flink JobManager REST API")
+                        .title(title)
                         .version(
                                 String.format(
                                         "%s/%s",

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/RuntimeOpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/RuntimeOpenApiSpecGenerator.java
@@ -51,6 +51,7 @@ public class RuntimeOpenApiSpecGenerator {
                 continue;
             }
             createDocumentationFile(
+                    "Flink JobManager REST API",
                     new DocumentingDispatcherRestEndpoint(),
                     apiVersion,
                     Paths.get(

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/SqlGatewayOpenApiSpecGenerator.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/SqlGatewayOpenApiSpecGenerator.java
@@ -51,6 +51,7 @@ public class SqlGatewayOpenApiSpecGenerator {
                 continue;
             }
             createDocumentationFile(
+                    "Flink SQL Gateway REST API",
                     new DocumentingSqlGatewayRestEndpoint(),
                     apiVersion,
                     Paths.get(

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/OpenApiSpecGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/OpenApiSpecGeneratorTest.java
@@ -42,10 +42,28 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 class OpenApiSpecGeneratorTest {
 
     @Test
+    void testTitle() throws Exception {
+        final String title = "Funky title";
+
+        File file = File.createTempFile("rest_v0_", ".html");
+        OpenApiSpecGenerator.createDocumentationFile(
+                title,
+                new TestExcludeDocumentingRestEndpoint(),
+                RuntimeRestAPIVersion.V0,
+                file.toPath());
+        String actual = FileUtils.readFile(file, "UTF-8");
+
+        assertThat(actual).contains("title: " + title);
+    }
+
+    @Test
     void testExcludeFromDocumentation() throws Exception {
         File file = File.createTempFile("rest_v0_", ".html");
         OpenApiSpecGenerator.createDocumentationFile(
-                new TestExcludeDocumentingRestEndpoint(), RuntimeRestAPIVersion.V0, file.toPath());
+                "title",
+                new TestExcludeDocumentingRestEndpoint(),
+                RuntimeRestAPIVersion.V0,
+                file.toPath());
         String actual = FileUtils.readFile(file, "UTF-8");
 
         assertThat(actual).contains("/test/empty1");
@@ -94,6 +112,7 @@ class OpenApiSpecGeneratorTest {
         assertThatThrownBy(
                         () ->
                                 OpenApiSpecGenerator.createDocumentationFile(
+                                        "title",
                                         new TestDuplicateOperationIdDocumentingRestEndpoint(),
                                         RuntimeRestAPIVersion.V0,
                                         file.toPath()))


### PR DESCRIPTION
Separate titles so the title+version tuple is actually distinct between the 2 APIs.

Current specs aren't updated in this PR because I already applied the changes in a hotfix a while back (don't ask what made me think that wouldn't be overridden the next time they are generated...).