### PR TITLE
[FLINK-29571] Support Map<String, T> ConfigOptions

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -64,13 +64,20 @@ public class ConfigOption<T> {
      *
      * <ul>
      *   <li>typeClass == atomic class (e.g. {@code Integer.class}) -> {@code ConfigOption<Integer>}
-     *   <li>typeClass == {@code Map.class} -> {@code ConfigOption<Map<String, String>>}
-     *   <li>typeClass == atomic class and isList == true for {@code ConfigOption<List<Integer>>}
+     *   <li>typeClass == atomic class and type == LIST for {@code ConfigOption<List<Integer>>}
+     *   <li>typeClass == atomic class and type == MAP for {@code ConfigOption<Map<String,
+     *       Integer>>}
      * </ul>
      */
     private final Class<?> clazz;
 
-    private final boolean isList;
+    enum Type {
+        VALUE,
+        LIST,
+        MAP
+    }
+
+    private final Type valueType;
 
     // ------------------------------------------------------------------------
 
@@ -78,8 +85,16 @@ public class ConfigOption<T> {
         return clazz;
     }
 
+    public Type getType() {
+        return valueType;
+    }
+
     boolean isList() {
-        return isList;
+        return valueType == Type.LIST;
+    }
+
+    boolean isMap() {
+        return valueType == Type.MAP;
     }
 
     /**
@@ -89,8 +104,8 @@ public class ConfigOption<T> {
      * @param clazz describes type of the ConfigOption, see description of the clazz field
      * @param description Description for that option
      * @param defaultValue The default value for this option
-     * @param isList tells if the ConfigOption describes a list option, see description of the clazz
-     *     field
+     * @param valueType tells if the ConfigOption describes a list option, see description of the
+     *     clazz field
      * @param fallbackKeys The list of fallback keys, in the order to be checked
      */
     ConfigOption(
@@ -98,14 +113,14 @@ public class ConfigOption<T> {
             Class<?> clazz,
             Description description,
             T defaultValue,
-            boolean isList,
+            Type valueType,
             FallbackKey... fallbackKeys) {
         this.key = checkNotNull(key);
         this.description = description;
         this.defaultValue = defaultValue;
         this.fallbackKeys = fallbackKeys == null || fallbackKeys.length == 0 ? EMPTY : fallbackKeys;
         this.clazz = checkNotNull(clazz);
-        this.isList = isList;
+        this.valueType = valueType;
     }
 
     // ------------------------------------------------------------------------
@@ -131,7 +146,7 @@ public class ConfigOption<T> {
         final FallbackKey[] mergedAlternativeKeys =
                 Stream.concat(newFallbackKeys, currentAlternativeKeys).toArray(FallbackKey[]::new);
         return new ConfigOption<>(
-                key, clazz, description, defaultValue, isList, mergedAlternativeKeys);
+                key, clazz, description, defaultValue, valueType, mergedAlternativeKeys);
     }
 
     /**
@@ -156,7 +171,7 @@ public class ConfigOption<T> {
                 Stream.concat(currentAlternativeKeys, newDeprecatedKeys)
                         .toArray(FallbackKey[]::new);
         return new ConfigOption<>(
-                key, clazz, description, defaultValue, isList, mergedAlternativeKeys);
+                key, clazz, description, defaultValue, valueType, mergedAlternativeKeys);
     }
 
     /**
@@ -178,7 +193,7 @@ public class ConfigOption<T> {
      * @return A new config option, with given description.
      */
     public ConfigOption<T> withDescription(final Description description) {
-        return new ConfigOption<>(key, clazz, description, defaultValue, isList, fallbackKeys);
+        return new ConfigOption<>(key, clazz, description, defaultValue, valueType, fallbackKeys);
     }
 
     // ------------------------------------------------------------------------

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOption.java
@@ -85,7 +85,7 @@ public class ConfigOption<T> {
         return clazz;
     }
 
-    public Type getType() {
+    Type getType() {
         return valueType;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
@@ -23,7 +23,6 @@ import org.apache.flink.configuration.description.Description;
 
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -308,8 +307,7 @@ public class ConfigOptions {
         }
 
         public ConfigOption<Map<String, V>> noDefaultValue() {
-            return new ConfigOption<>(
-                    key, clazz, ConfigOption.EMPTY_DESCRIPTION, null, MAP);
+            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, null, MAP);
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
@@ -309,7 +309,7 @@ public class ConfigOptions {
 
         public ConfigOption<Map<String, V>> noDefaultValue() {
             return new ConfigOption<>(
-                    key, clazz, ConfigOption.EMPTY_DESCRIPTION, Collections.emptyMap(), MAP);
+                    key, clazz, ConfigOption.EMPTY_DESCRIPTION, null, MAP);
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ConfigOptions.java
@@ -23,9 +23,13 @@ import org.apache.flink.configuration.description.Description;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.flink.configuration.ConfigOption.Type.LIST;
+import static org.apache.flink.configuration.ConfigOption.Type.MAP;
+import static org.apache.flink.configuration.ConfigOption.Type.VALUE;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -87,13 +91,6 @@ public class ConfigOptions {
      * ConfigOptions#key(String)}.
      */
     public static final class OptionBuilder {
-        /**
-         * Workaround to reuse the {@link TypedConfigOptionBuilder} for a {@link Map Map&lt;String,
-         * String&gt;}.
-         */
-        @SuppressWarnings("unchecked")
-        private static final Class<Map<String, String>> PROPERTIES_MAP_CLASS =
-                (Class<Map<String, String>>) (Class<?>) Map.class;
 
         /** The key for the config option. */
         private final String key;
@@ -160,8 +157,16 @@ public class ConfigOptions {
          * Defines that the value of the option should be a set of properties, which can be
          * represented as {@code Map<String, String>}.
          */
-        public TypedConfigOptionBuilder<Map<String, String>> mapType() {
-            return new TypedConfigOptionBuilder<>(key, PROPERTIES_MAP_CLASS);
+        public MapConfigOptionBuilder<String> mapType() {
+            return mapType(String.class);
+        }
+
+        /**
+         * Defines that the value of the option should be a set of properties, which can be
+         * represented as {@code Map<String, T>}.
+         */
+        public <T> MapConfigOptionBuilder<T> mapType(Class<T> valueClazz) {
+            return new MapConfigOptionBuilder<>(key, valueClazz);
         }
 
         /**
@@ -180,7 +185,7 @@ public class ConfigOptions {
         public <T> ConfigOption<T> defaultValue(T value) {
             checkNotNull(value);
             return new ConfigOption<>(
-                    key, value.getClass(), ConfigOption.EMPTY_DESCRIPTION, value, false);
+                    key, value.getClass(), ConfigOption.EMPTY_DESCRIPTION, value, VALUE);
         }
 
         /**
@@ -194,7 +199,7 @@ public class ConfigOptions {
         @Deprecated
         public ConfigOption<String> noDefaultValue() {
             return new ConfigOption<>(
-                    key, String.class, ConfigOption.EMPTY_DESCRIPTION, null, false);
+                    key, String.class, ConfigOption.EMPTY_DESCRIPTION, null, VALUE);
         }
     }
 
@@ -218,13 +223,21 @@ public class ConfigOptions {
         }
 
         /**
+         * Defines that the option's type should be a map with values of the previously defined
+         * atomic type.
+         */
+        public MapConfigOptionBuilder<T> asMap() {
+            return new MapConfigOptionBuilder<>(key, clazz);
+        }
+
+        /**
          * Creates a ConfigOption with the given default value.
          *
          * @param value The default value for the config option
          * @return The config option with the default value.
          */
         public ConfigOption<T> defaultValue(T value) {
-            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, value, false);
+            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, value, VALUE);
         }
 
         /**
@@ -234,7 +247,7 @@ public class ConfigOptions {
          */
         public ConfigOption<T> noDefaultValue() {
             return new ConfigOption<>(
-                    key, clazz, Description.builder().text("").build(), null, false);
+                    key, clazz, Description.builder().text("").build(), null, VALUE);
         }
     }
 
@@ -261,7 +274,7 @@ public class ConfigOptions {
         @SafeVarargs
         public final ConfigOption<List<E>> defaultValues(E... values) {
             return new ConfigOption<>(
-                    key, clazz, ConfigOption.EMPTY_DESCRIPTION, Arrays.asList(values), true);
+                    key, clazz, ConfigOption.EMPTY_DESCRIPTION, Arrays.asList(values), LIST);
         }
 
         /**
@@ -270,7 +283,33 @@ public class ConfigOptions {
          * @return The config option without a default value.
          */
         public ConfigOption<List<E>> noDefaultValue() {
-            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, null, true);
+            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, null, LIST);
+        }
+    }
+
+    /** Builder for map type {@link ConfigOption} with a value type V. */
+    public static class MapConfigOptionBuilder<V> {
+        private final String key;
+        private final Class<V> clazz;
+
+        MapConfigOptionBuilder(String key, Class<V> clazz) {
+            this.key = key;
+            this.clazz = clazz;
+        }
+
+        /** Defines that the option's type should be a list of previously defined atomic type. */
+        @SuppressWarnings("rawtypes")
+        public ListConfigOptionBuilder<Map<String, V>> asList() {
+            return (ListConfigOptionBuilder) new ListConfigOptionBuilder<>(key, Map.class);
+        }
+
+        public final ConfigOption<Map<String, V>> defaultValue(Map<String, V> defaultMap) {
+            return new ConfigOption<>(key, clazz, ConfigOption.EMPTY_DESCRIPTION, defaultMap, MAP);
+        }
+
+        public ConfigOption<Map<String, V>> noDefaultValue() {
+            return new ConfigOption<>(
+                    key, clazz, ConfigOption.EMPTY_DESCRIPTION, Collections.emptyMap(), MAP);
         }
     }
 

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -712,6 +712,8 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         try {
             if (option.isList()) {
                 return rawValue.map(v -> ConfigurationUtils.convertToList(v, clazz));
+            } else if (option.isMap()) {
+                return rawValue.map(v -> ConfigurationUtils.convertToMap(v, clazz));
             } else {
                 return rawValue.map(v -> ConfigurationUtils.convertValue(v, clazz));
             }

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -402,7 +402,7 @@ public final class DelegatingConfiguration extends Configuration {
                 option.getClazz(),
                 option.description(),
                 option.defaultValue(),
-                option.isList(),
+                option.getType(),
                 deprecated);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -54,14 +54,24 @@ public class ConfigurationTest extends TestLogger {
     private static final ConfigOption<Map<String, String>> MAP_OPTION =
             ConfigOptions.key("test-map-key").mapType().noDefaultValue();
 
+    private static final ConfigOption<Map<String, Integer>> MAP_OPTION_INTEGER_TYPE =
+            ConfigOptions.key("test-map-key").mapType(Integer.class).noDefaultValue();
+
+    private static final ConfigOption<List<Map<String, String>>> MAP_OPTION_LIST =
+            ConfigOptions.key("test-map-list-key").mapType().asList().noDefaultValue();
+
     private static final ConfigOption<Duration> DURATION_OPTION =
             ConfigOptions.key("test-duration-key").durationType().noDefaultValue();
 
     private static final Map<String, String> PROPERTIES_MAP = new HashMap<>();
 
+    private static final Map<String, Integer> PROPERTIES_MAP2 = new HashMap<>();
+
     static {
         PROPERTIES_MAP.put("prop1", "value1");
         PROPERTIES_MAP.put("prop2", "12");
+        PROPERTIES_MAP2.put("prop1", 1);
+        PROPERTIES_MAP2.put("prop2", 2);
     }
 
     private static final String MAP_PROPERTY_1 = MAP_OPTION.key() + ".prop1";
@@ -433,6 +443,48 @@ public class ConfigurationTest extends TestLogger {
         assertFalse(cfg.contains(MAP_OPTION));
         assertFalse(cfg.containsKey(MAP_PROPERTY_1));
         assertFalse(cfg.containsKey(MAP_PROPERTY_2));
+    }
+
+    @Test
+    public void testMapWithIntegerType() {
+        final Configuration cfg = new Configuration();
+        Map<String, Integer> map = Map.of("one", 1, "two", 2);
+        cfg.set(MAP_OPTION_INTEGER_TYPE, map);
+
+        assertEquals(map, cfg.get(MAP_OPTION_INTEGER_TYPE));
+    }
+
+    @Test
+    public void testMapWithIntegerTypeParsing() {
+        final Configuration cfg = new Configuration();
+        cfg.setString(MAP_OPTION_INTEGER_TYPE.key() + ".prop1", "1");
+        cfg.setString(MAP_OPTION_INTEGER_TYPE.key() + ".prop2", "2");
+
+        Map<String, Integer> stringIntegerMap = cfg.get(MAP_OPTION_INTEGER_TYPE);
+        assertEquals((Integer) 1, stringIntegerMap.get("prop1"));
+    }
+
+    @Test
+    public void testMapList() {
+        final Configuration cfg = new Configuration();
+        Map<String, String> first = Map.of("test1", "first");
+        Map<String, String> second = Map.of("test2", "second");
+        cfg.set(MAP_OPTION_LIST, List.of(first, second));
+
+        List<Map<String, String>> stringIntegerMap = cfg.get(MAP_OPTION_LIST);
+        assertEquals(first, stringIntegerMap.get(0));
+        assertEquals(second, stringIntegerMap.get(1));
+    }
+
+    @Test
+    public void testMapListParsing() {
+        final Configuration cfg = new Configuration();
+        Map<String, String> first = Map.of("test1", "one");
+        Map<String, String> second = Map.of("test2", "two", "test3", "three");
+        cfg.setString(MAP_OPTION_LIST.key(), "test1:one;" + "test2:two,test3:three");
+
+        List<Map<String, String>> listMap = cfg.get(MAP_OPTION_LIST);
+        assertEquals(List.of(first, second), listMap);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -21,6 +21,8 @@ package org.apache.flink.configuration;
 import org.apache.flink.util.InstantiationUtil;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableMap;
+
 import org.junit.Test;
 
 import java.time.Duration;
@@ -448,7 +450,7 @@ public class ConfigurationTest extends TestLogger {
     @Test
     public void testMapWithIntegerType() {
         final Configuration cfg = new Configuration();
-        Map<String, Integer> map = Map.of("one", 1, "two", 2);
+        Map<String, Integer> map = ImmutableMap.of("one", 1, "two", 2);
         cfg.set(MAP_OPTION_INTEGER_TYPE, map);
 
         assertEquals(map, cfg.get(MAP_OPTION_INTEGER_TYPE));
@@ -467,8 +469,8 @@ public class ConfigurationTest extends TestLogger {
     @Test
     public void testMapList() {
         final Configuration cfg = new Configuration();
-        Map<String, String> first = Map.of("test1", "first");
-        Map<String, String> second = Map.of("test2", "second");
+        Map<String, String> first = ImmutableMap.of("test1", "first");
+        Map<String, String> second = ImmutableMap.of("test2", "second");
         cfg.set(MAP_OPTION_LIST, List.of(first, second));
 
         List<Map<String, String>> stringIntegerMap = cfg.get(MAP_OPTION_LIST);
@@ -479,8 +481,8 @@ public class ConfigurationTest extends TestLogger {
     @Test
     public void testMapListParsing() {
         final Configuration cfg = new Configuration();
-        Map<String, String> first = Map.of("test1", "one");
-        Map<String, String> second = Map.of("test2", "two", "test3", "three");
+        Map<String, String> first = ImmutableMap.of("test1", "one");
+        Map<String, String> second = ImmutableMap.of("test2", "two", "test3", "three");
         cfg.setString(MAP_OPTION_LIST.key(), "test1:one;" + "test2:two,test3:three");
 
         List<Map<String, String>> listMap = cfg.get(MAP_OPTION_LIST);

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -471,7 +471,7 @@ public class ConfigurationTest extends TestLogger {
         final Configuration cfg = new Configuration();
         Map<String, String> first = ImmutableMap.of("test1", "first");
         Map<String, String> second = ImmutableMap.of("test2", "second");
-        cfg.set(MAP_OPTION_LIST, List.of(first, second));
+        cfg.set(MAP_OPTION_LIST, Arrays.asList(first, second));
 
         List<Map<String, String>> stringIntegerMap = cfg.get(MAP_OPTION_LIST);
         assertEquals(first, stringIntegerMap.get(0));
@@ -486,7 +486,7 @@ public class ConfigurationTest extends TestLogger {
         cfg.setString(MAP_OPTION_LIST.key(), "test1:one;" + "test2:two,test3:three");
 
         List<Map<String, String>> listMap = cfg.get(MAP_OPTION_LIST);
-        assertEquals(List.of(first, second), listMap);
+        assertEquals(Arrays.asList(first, second), listMap);
     }
 
     // --------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

Allow Map<String, T> ConfigOptions

## Brief change log

- Allow Map<String, T> ConfigOptions

## Verifying this change

Tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (no)
