### PR TITLE
[FLINK-29574] Upgrade software.amazon.glue:schema-registry-common and…

### DIFF
--- a/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<properties>
 		<aws.sdk.version>1.12.276</aws.sdk.version>
 		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
-		<kotlin.version>1.3.50</kotlin.version>
+		<kotlin.version>1.7.10</kotlin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -83,6 +83,11 @@ under the License.
 			<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-scripting-compiler-embeddable</artifactId>
 				<version>${kotlin.version}</version>
 			</dependency>
 			<dependency>

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
@@ -34,7 +34,7 @@ under the License.
 	<properties>
 		<aws.sdk.version>1.12.276</aws.sdk.version>
 		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
-		<kotlin.version>1.3.50</kotlin.version>
+		<kotlin.version>1.7.10</kotlin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -83,6 +83,11 @@ under the License.
 			<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-scripting-compiler-embeddable</artifactId>
 				<version>${kotlin.version}</version>
 			</dependency>
 			<dependency>

--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -33,9 +33,9 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<glue.schema.registry.version>1.1.8</glue.schema.registry.version>
+		<glue.schema.registry.version>1.1.14</glue.schema.registry.version>
 		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
-		<kotlin.version>1.3.50</kotlin.version>
+		<kotlin.version>1.7.10</kotlin.version>
 	</properties>
 
 	<dependencyManagement>
@@ -77,6 +77,11 @@ under the License.
 			<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-scripting-compiler-embeddable</artifactId>
 				<version>${kotlin.version}</version>
 			</dependency>
 			<dependency>

--- a/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSchemaCoderTest.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/test/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryAvroSchemaCoderTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.formats.avro.glue.schema.registry;
 
 import com.amazonaws.services.schemaregistry.common.AWSSchemaRegistryClient;
+import com.amazonaws.services.schemaregistry.common.SchemaByDefinitionFetcher;
 import com.amazonaws.services.schemaregistry.common.configs.GlueSchemaRegistryConfiguration;
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
@@ -64,7 +65,6 @@ class GlueSchemaRegistryAvroSchemaCoderTest {
             DefaultCredentialsProvider.builder().build();
     private static Schema userSchema;
     private static User userDefinedPojo;
-    private static AWSSchemaRegistryClient mockClient;
     private static GlueSchemaRegistryInputStreamDeserializer mockInputStreamDeserializer;
     private static GlueSchemaRegistryOutputStreamSerializer mockOutputStreamSerializer;
 
@@ -125,11 +125,14 @@ class GlueSchemaRegistryAvroSchemaCoderTest {
     @Test
     void testWriteSchema_withoutAutoRegistration_throwsException() {
         configs.put(AWSSchemaRegistryConstants.SCHEMA_AUTO_REGISTRATION_SETTING, false);
-        mockClient = new MockAWSSchemaRegistryClient();
+        SchemaByDefinitionFetcher fetcher =
+                new SchemaByDefinitionFetcher(
+                        new MockAWSSchemaRegistryClient(),
+                        new GlueSchemaRegistryConfiguration(configs));
 
         GlueSchemaRegistrySerializationFacade glueSchemaRegistrySerializationFacade =
                 GlueSchemaRegistrySerializationFacade.builder()
-                        .schemaRegistryClient(mockClient)
+                        .schemaByDefinitionFetcher(fetcher)
                         .credentialProvider(credentialsProvider)
                         .glueSchemaRegistryConfiguration(
                                 new GlueSchemaRegistryConfiguration(configs))

--- a/flink-formats/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-json-glue-schema-registry/pom.xml
@@ -32,10 +32,10 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<glue.schema.registry.version>1.1.8</glue.schema.registry.version>
+		<glue.schema.registry.version>1.1.14</glue.schema.registry.version>
 		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
 		<netty.version>4.1.68.Final</netty.version>
-		<kotlin.version>1.3.50</kotlin.version>
+		<kotlin.version>1.7.10</kotlin.version>
 		<classgraph.version>4.8.120</classgraph.version>
 	</properties>
 
@@ -78,6 +78,11 @@ under the License.
 			<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
 				<artifactId>kotlin-stdlib-jdk8</artifactId>
+				<version>${kotlin.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jetbrains.kotlin</groupId>
+				<artifactId>kotlin-scripting-compiler-embeddable</artifactId>
 				<version>${kotlin.version}</version>
 			</dependency>
 			<dependency>
@@ -137,12 +142,6 @@ under the License.
 			<groupId>com.kjetland</groupId>
 			<artifactId>mbknor-jackson-jsonschema_${scala.binary.version}</artifactId>
 			<version>1.0.39</version>
-		</dependency>
-
-		<dependency>
-			<groupId>com.github.erosb</groupId>
-			<artifactId>everit-json-schema</artifactId>
-			<version>1.12.2</version>
 		</dependency>
 
 		<!-- ArchUit test dependencies -->


### PR DESCRIPTION
… software.amazon.glue:schema-registry-serde dependency from 1.1.8 to 1.1.14

## What is the purpose of the change

- Update Glue schema registry dependencies

## Brief change log

 - Updated POM file
 - Fixed unit test to account for signature change

## Verifying this change
- Unit tests/e2e tests
- Manual regression 
  - `flink-glue-schema-registry-avro-test` :: `mvn clean test -Prun-end-to-end-tests` (providing GSR keys)
  - `flink-glue-schema-registry-json-test` :: `mvn clean test -Prun-end-to-end-tests` (providing GSR keys)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
