### PR TITLE
[FLINK-28049][connectors] Introduce FLIP-208 functionality to stop So…

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEmitter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEmitter.java
@@ -47,5 +47,6 @@ public interface RecordEmitter<E, T, SplitStateT> {
      * @param output The output to which the final records are emit to.
      * @param splitState The state of the split.
      */
-    void emitRecord(E element, SourceOutput<T> output, SplitStateT splitState) throws Exception;
+    void emitRecord(E element, SourceOutputWrapper<T> output, SplitStateT splitState)
+            throws Exception;
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEvaluator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEvaluator.java
@@ -16,18 +16,25 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.base.source.reader.mocks;
+package org.apache.flink.connector.base.source.reader;
 
-import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.connector.base.source.reader.SourceOutputWrapper;
+import org.apache.flink.annotation.PublicEvolving;
 
-/** A record emitter that pipes records directly into the source output. */
-public final class PassThroughRecordEmitter<E, SplitStateT>
-        implements RecordEmitter<E, E, SplitStateT> {
+import java.io.Serializable;
 
-    @Override
-    public void emitRecord(E element, SourceOutputWrapper<E> output, SplitStateT splitState)
-            throws Exception {
-        output.collect(element);
-    }
+/**
+ * An interface that evaluates whether a de-serialized record should trigger certain control-flow
+ * operations (e.g. end of stream).
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface RecordEvaluator<T> extends Serializable {
+    /**
+     * Determines whether a record should trigger the end of stream for its split. The given record
+     * wouldn't be emitted from the source if the returned result is true.
+     *
+     * @param record a de-serialized record from the split.
+     * @return a boolean indicating whether the split has reached end of stream.
+     */
+    boolean isEndOfStream(T record);
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -27,6 +27,8 @@ import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcher
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
+import javax.annotation.Nullable;
+
 import java.util.function.Supplier;
 
 /**
@@ -100,6 +102,22 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
                 context);
     }
 
+    public SingleThreadMultiplexSourceReaderBase(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+            Supplier<SplitReader<E, SplitT>> splitReaderSupplier,
+            RecordEmitter<E, T, SplitStateT> recordEmitter,
+            @Nullable RecordEvaluator<T> eofRecordEvaluator,
+            Configuration config,
+            SourceReaderContext context) {
+        super(
+                elementsQueue,
+                new SingleThreadFetcherManager<>(elementsQueue, splitReaderSupplier, config),
+                recordEmitter,
+                eofRecordEvaluator,
+                config,
+                context);
+    }
+
     /**
      * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
      * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
@@ -109,8 +127,15 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
             RecordEmitter<E, T, SplitStateT> recordEmitter,
+            @Nullable RecordEvaluator<T> eofRecordEvaluator,
             Configuration config,
             SourceReaderContext context) {
-        super(elementsQueue, splitFetcherManager, recordEmitter, config, context);
+        super(
+                elementsQueue,
+                splitFetcherManager,
+                recordEmitter,
+                eofRecordEvaluator,
+                config,
+                context);
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceOutputWrapper.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceOutputWrapper.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expre
+ * ss or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.reader;
+
+import org.apache.flink.api.common.eventtime.TimestampAssigner;
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.util.Collector;
+
+/** Wrapper over {@link SourceOutput} to check if {@link RecordEvaluator} condition is met. */
+public class SourceOutputWrapper<T> implements Collector<T> {
+
+    private SourceOutput<T> sourceOutput;
+    private long timestamp = TimestampAssigner.NO_TIMESTAMP;
+    private RecordEvaluator<T> recordEvaluator;
+    private boolean endOfStreamReached = false;
+
+    @Override
+    public void collect(T record) {
+        collect(record, timestamp);
+    }
+
+    public void collect(T record, Long timestamp) {
+        sourceOutput.collect(record, timestamp);
+        if (recordEvaluator != null && recordEvaluator.isEndOfStream(record)) {
+            endOfStreamReached = true;
+        }
+    }
+
+    @Override
+    public void close() {}
+
+    public void setSourceOutput(SourceOutput<T> sourceOutput) {
+        this.sourceOutput = sourceOutput;
+    }
+
+    public void setTimestamp(long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public void setRecordEvaluator(RecordEvaluator<T> recordEvaluator) {
+        this.recordEvaluator = recordEvaluator;
+    }
+
+    public boolean isEndOfStreamReached() {
+        return endOfStreamReached;
+    }
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -99,6 +99,11 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
     @Nullable private SplitContext<T, SplitStateT> currentSplitContext;
     @Nullable private SourceOutput<T> currentSplitOutput;
 
+    private SourceOutputWrapper<T> currentSplitOutputWrapper;
+
+    /** The record evaluator to handle end of input event. */
+    @Nullable protected RecordEvaluator<T> recordEvaluator;
+
     /** Indicating whether the SourceReader will be assigned more splits or not. */
     private boolean noMoreSplitsAssignment;
 
@@ -118,6 +123,17 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
         this.noMoreSplitsAssignment = false;
 
         numRecordsInCounter = context.metricGroup().getIOMetricGroup().getNumRecordsInCounter();
+    }
+
+    public SourceReaderBase(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+            SplitFetcherManager<E, SplitT> splitFetcherManager,
+            RecordEmitter<E, T, SplitStateT> recordEmitter,
+            @Nullable RecordEvaluator<T> eofRecordEvaluator,
+            Configuration config,
+            SourceReaderContext context) {
+        this(elementsQueue, splitFetcherManager, recordEmitter, config, context);
+        this.recordEvaluator = eofRecordEvaluator;
     }
 
     @Override
@@ -141,8 +157,15 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
             if (record != null) {
                 // emit the record.
                 numRecordsInCounter.inc(1);
-                recordEmitter.emitRecord(record, currentSplitOutput, currentSplitContext.state);
+                currentSplitOutputWrapper = new SourceOutputWrapper<>();
+                currentSplitOutputWrapper.setSourceOutput(currentSplitOutput);
+                currentSplitOutputWrapper.setRecordEvaluator(recordEvaluator);
+                recordEmitter.emitRecord(
+                        record, currentSplitOutputWrapper, currentSplitContext.state);
                 LOG.trace("Emitted record: {}", record);
+                if (currentSplitOutputWrapper.isEndOfStreamReached()) {
+                    return trace(InputStatus.END_OF_INPUT);
+                }
 
                 // We always emit MORE_AVAILABLE here, even though we do not strictly know whether
                 // more is available. If nothing more is available, the next invocation will find

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockRecordEmitter.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockRecordEmitter.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.connector.base.source.reader.mocks;
 
-import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.SourceOutputWrapper;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 
 import java.util.Collections;
@@ -47,7 +47,8 @@ public class MockRecordEmitter implements RecordEmitter<int[], Integer, MockSpli
     }
 
     @Override
-    public void emitRecord(int[] record, SourceOutput<Integer> output, MockSplitState splitState) {
+    public void emitRecord(
+            int[] record, SourceOutputWrapper<Integer> output, MockSplitState splitState) {
         knownSplits.add(splitState);
         if (record[0] % 2 == 0) {
             this.metricGroup.getNumRecordsInErrorsCounter().inc();

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockRecordEvaluator.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockRecordEvaluator.java
@@ -18,16 +18,19 @@
 
 package org.apache.flink.connector.base.source.reader.mocks;
 
-import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.connector.base.source.reader.SourceOutputWrapper;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 
-/** A record emitter that pipes records directly into the source output. */
-public final class PassThroughRecordEmitter<E, SplitStateT>
-        implements RecordEmitter<E, E, SplitStateT> {
+/** A mock {@link RecordEvaluator} that stops input on stopValue. */
+public class MockRecordEvaluator<T> implements RecordEvaluator<T> {
+
+    private final Integer stopValue;
+
+    public MockRecordEvaluator(int stopValue) {
+        this.stopValue = stopValue;
+    }
 
     @Override
-    public void emitRecord(E element, SourceOutputWrapper<E> output, SplitStateT splitState)
-            throws Exception {
-        output.collect(element);
+    public boolean isEndOfStream(T record) {
+        return record == stopValue;
     }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.base.source.reader.mocks;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
@@ -44,6 +45,7 @@ public class MockSourceReader
                 elementsQueue,
                 splitFetcherSupplier,
                 new MockRecordEmitter(context.metricGroup()),
+                null,
                 config,
                 context);
     }
@@ -57,6 +59,22 @@ public class MockSourceReader
                 elementsQueue,
                 splitSplitFetcherManager,
                 new MockRecordEmitter(context.metricGroup()),
+                null,
+                config,
+                context);
+    }
+
+    public MockSourceReader(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
+            Supplier<SplitReader<int[], MockSourceSplit>> splitFetcherSupplier,
+            RecordEvaluator recordEvaluator,
+            Configuration config,
+            SourceReaderContext context) {
+        super(
+                elementsQueue,
+                splitFetcherSupplier,
+                new MockRecordEmitter(context.metricGroup()),
+                recordEvaluator,
                 config,
                 context);
     }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceRecordEmitter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceRecordEmitter.java
@@ -19,8 +19,8 @@ limitations under the License.
 package org.apache.flink.connector.file.src.impl;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.SourceOutputWrapper;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.FileSourceSplitState;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
@@ -39,7 +39,7 @@ final class FileSourceRecordEmitter<T, SplitT extends FileSourceSplit>
     @Override
     public void emitRecord(
             final RecordAndPosition<T> element,
-            final SourceOutput<T> output,
+            final SourceOutputWrapper<T> output,
             final FileSourceSplitState<SplitT> splitState) {
 
         output.collect(element.getRecord());

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.kafka.source;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStoppingOffsetsInitializer;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializerValidator;
@@ -100,6 +101,7 @@ public class KafkaSourceBuilder<OUT> {
     private KafkaRecordDeserializationSchema<OUT> deserializationSchema;
     // The configurations.
     protected Properties props;
+    private RecordEvaluator<OUT> eofRecordEvaluator;
 
     KafkaSourceBuilder() {
         this.subscriber = null;
@@ -108,6 +110,7 @@ public class KafkaSourceBuilder<OUT> {
         this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
         this.deserializationSchema = null;
         this.props = new Properties();
+        this.eofRecordEvaluator = null;
     }
 
     /**
@@ -355,6 +358,11 @@ public class KafkaSourceBuilder<OUT> {
         return setProperty(KafkaSourceOptions.CLIENT_ID_PREFIX.key(), prefix);
     }
 
+    public KafkaSourceBuilder<OUT> setEofRecordEvaluator(RecordEvaluator<OUT> eofRecordEvaluator) {
+        this.eofRecordEvaluator = eofRecordEvaluator;
+        return this;
+    }
+
     /**
      * Set an arbitrary property for the KafkaSource and KafkaConsumer. The valid keys can be found
      * in {@link ConsumerConfig} and {@link KafkaSourceOptions}.
@@ -420,6 +428,7 @@ public class KafkaSourceBuilder<OUT> {
                 subscriber,
                 startingOffsetsInitializer,
                 stoppingOffsetsInitializer,
+                eofRecordEvaluator,
                 boundedness,
                 deserializationSchema,
                 props);

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
@@ -67,10 +68,17 @@ public class KafkaSourceReader<T>
             KafkaSourceFetcherManager kafkaSourceFetcherManager,
             RecordEmitter<ConsumerRecord<byte[], byte[]>, T, KafkaPartitionSplitState>
                     recordEmitter,
+            RecordEvaluator<T> recordEvaluator,
             Configuration config,
             SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
-        super(elementsQueue, kafkaSourceFetcherManager, recordEmitter, config, context);
+        super(
+                elementsQueue,
+                kafkaSourceFetcherManager,
+                recordEmitter,
+                recordEvaluator,
+                config,
+                context);
         this.offsetsToCommit = Collections.synchronizedSortedMap(new TreeMap<>());
         this.offsetsOfFinishedSplits = new ConcurrentHashMap<>();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilderTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsIni
 import org.apache.flink.connector.kafka.source.enumerator.subscriber.KafkaSubscriber;
 import org.apache.flink.connector.kafka.source.reader.deserializer.KafkaRecordDeserializationSchema;
 import org.apache.flink.connector.kafka.source.split.KafkaPartitionSplit;
+import org.apache.flink.connector.kafka.testutils.KafkaSourceTestRecordEvaluator;
 import org.apache.flink.util.TestLoggerExtension;
 
 import org.apache.kafka.clients.admin.AdminClient;
@@ -117,6 +118,11 @@ public class KafkaSourceBuilderTest {
                 .setProperty(KafkaSourceOptions.COMMIT_OFFSETS_ON_CHECKPOINT.key(), "false")
                 .build();
         getBasicBuilder().setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false").build();
+    }
+
+    @Test
+    public void testSetRecordEvaluator() {
+        getBasicBuilder().setEofRecordEvaluator(new KafkaSourceTestRecordEvaluator<>(1)).build();
     }
 
     @Test

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceTestRecordEvaluator.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceTestRecordEvaluator.java
@@ -11,23 +11,29 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expre
+ * ss or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
-package org.apache.flink.connector.base.source.reader.mocks;
+package org.apache.flink.connector.kafka.testutils;
 
-import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.connector.base.source.reader.SourceOutputWrapper;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 
-/** A record emitter that pipes records directly into the source output. */
-public final class PassThroughRecordEmitter<E, SplitStateT>
-        implements RecordEmitter<E, E, SplitStateT> {
+/** {@link RecordEvaluator} for kafka tests. Stops input when maxRecords is reached. */
+public class KafkaSourceTestRecordEvaluator<T> implements RecordEvaluator<T> {
+
+    private final int maxRecords;
+    private int count = 0;
+
+    public KafkaSourceTestRecordEvaluator(int maxRecords) {
+        this.maxRecords = maxRecords;
+    }
 
     @Override
-    public void emitRecord(E element, SourceOutputWrapper<E> output, SplitStateT splitState)
-            throws Exception {
-        output.collect(element);
+    public boolean isEndOfStream(T record) {
+        count++;
+        return count == maxRecords;
     }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumState;
 import org.apache.flink.connector.pulsar.source.enumerator.PulsarSourceEnumStateSerializer;
@@ -89,6 +90,8 @@ public final class PulsarSource<OUT>
     /** The pulsar deserialization schema used for deserializing message. */
     private final PulsarDeserializationSchema<OUT> deserializationSchema;
 
+    private final RecordEvaluator recordEvaluator;
+
     /**
      * The constructor for PulsarSource, it's package protected for forcing using {@link
      * PulsarSourceBuilder}.
@@ -99,6 +102,7 @@ public final class PulsarSource<OUT>
             RangeGenerator rangeGenerator,
             StartCursor startCursor,
             StopCursor stopCursor,
+            RecordEvaluator recordEvaluator,
             Boundedness boundedness,
             PulsarDeserializationSchema<OUT> deserializationSchema) {
         this.sourceConfiguration = sourceConfiguration;
@@ -106,6 +110,7 @@ public final class PulsarSource<OUT>
         this.rangeGenerator = rangeGenerator;
         this.startCursor = startCursor;
         this.stopCursor = stopCursor;
+        this.recordEvaluator = recordEvaluator;
         this.boundedness = boundedness;
         this.deserializationSchema = deserializationSchema;
     }
@@ -134,7 +139,7 @@ public final class PulsarSource<OUT>
         deserializationSchema.open(initializationContext, sourceConfiguration);
 
         return PulsarSourceReaderFactory.create(
-                readerContext, deserializationSchema, sourceConfiguration);
+                readerContext, deserializationSchema, sourceConfiguration, recordEvaluator);
     }
 
     @Internal

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderFactory.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.pulsar.source.reader;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
@@ -63,7 +64,8 @@ public final class PulsarSourceReaderFactory {
     public static <OUT> SourceReader<OUT, PulsarPartitionSplit> create(
             SourceReaderContext readerContext,
             PulsarDeserializationSchema<OUT> deserializationSchema,
-            SourceConfiguration sourceConfiguration) {
+            SourceConfiguration sourceConfiguration,
+            RecordEvaluator<OUT> recordEvaluator) {
 
         PulsarClient pulsarClient = createClient(sourceConfiguration);
         PulsarAdmin pulsarAdmin = createAdmin(sourceConfiguration);
@@ -91,6 +93,7 @@ public final class PulsarSourceReaderFactory {
                     splitReaderSupplier,
                     readerContext,
                     sourceConfiguration,
+                    recordEvaluator,
                     pulsarClient,
                     pulsarAdmin);
         } else if (subscriptionType == SubscriptionType.Shared
@@ -116,6 +119,7 @@ public final class PulsarSourceReaderFactory {
                     splitReaderSupplier,
                     readerContext,
                     sourceConfiguration,
+                    recordEvaluator,
                     pulsarClient,
                     pulsarAdmin,
                     coordinatorClient);

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/emitter/PulsarRecordEmitter.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/emitter/PulsarRecordEmitter.java
@@ -18,8 +18,8 @@
 
 package org.apache.flink.connector.pulsar.source.reader.emitter;
 
-import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.base.source.reader.SourceOutputWrapper;
 import org.apache.flink.connector.pulsar.source.reader.message.PulsarMessage;
 import org.apache.flink.connector.pulsar.source.reader.source.PulsarOrderedSourceReader;
 import org.apache.flink.connector.pulsar.source.reader.source.PulsarUnorderedSourceReader;
@@ -35,7 +35,9 @@ public class PulsarRecordEmitter<T>
 
     @Override
     public void emitRecord(
-            PulsarMessage<T> element, SourceOutput<T> output, PulsarPartitionSplitState splitState)
+            PulsarMessage<T> element,
+            SourceOutputWrapper<T> output,
+            PulsarPartitionSplitState splitState)
             throws Exception {
         // Sink the record to source output.
         output.collect(element.getValue(), element.getEventTime());

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarOrderedSourceReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarOrderedSourceReader.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
@@ -71,6 +72,7 @@ public class PulsarOrderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT> 
             Supplier<PulsarOrderedPartitionSplitReader<OUT>> splitReaderSupplier,
             SourceReaderContext context,
             SourceConfiguration sourceConfiguration,
+            RecordEvaluator<OUT> recordEvaluator,
             PulsarClient pulsarClient,
             PulsarAdmin pulsarAdmin) {
         super(
@@ -79,6 +81,7 @@ public class PulsarOrderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT> 
                         elementsQueue, splitReaderSupplier::get, context.getConfiguration()),
                 context,
                 sourceConfiguration,
+                recordEvaluator,
                 pulsarClient,
                 pulsarAdmin);
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.pulsar.source.reader.source;
 
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderBase;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
@@ -52,12 +53,14 @@ abstract class PulsarSourceReaderBase<OUT>
             PulsarFetcherManagerBase<OUT> splitFetcherManager,
             SourceReaderContext context,
             SourceConfiguration sourceConfiguration,
+            RecordEvaluator<OUT> recordEvaluator,
             PulsarClient pulsarClient,
             PulsarAdmin pulsarAdmin) {
         super(
                 elementsQueue,
                 splitFetcherManager,
                 new PulsarRecordEmitter<>(),
+                recordEvaluator,
                 sourceConfiguration,
                 context);
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarUnorderedSourceReader.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.pulsar.source.reader.source;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.pulsar.source.config.SourceConfiguration;
@@ -67,6 +68,7 @@ public class PulsarUnorderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT
             Supplier<PulsarUnorderedPartitionSplitReader<OUT>> splitReaderSupplier,
             SourceReaderContext context,
             SourceConfiguration sourceConfiguration,
+            RecordEvaluator<OUT> recordEvaluator,
             PulsarClient pulsarClient,
             PulsarAdmin pulsarAdmin,
             @Nullable TransactionCoordinatorClient coordinatorClient) {
@@ -76,6 +78,7 @@ public class PulsarUnorderedSourceReader<OUT> extends PulsarSourceReaderBase<OUT
                         elementsQueue, splitReaderSupplier::get, context.getConfiguration()),
                 context,
                 sourceConfiguration,
+                recordEvaluator,
                 pulsarClient,
                 pulsarAdmin);
 

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceRecordEvaluatorITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceRecordEvaluatorITCase.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expre
+ * ss or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.source;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.connector.pulsar.testutils.PulsarSourceTestRecordEvaluator;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
+import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntime;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.util.CloseableIterator;
+
+import org.apache.pulsar.client.api.Schema;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.connector.pulsar.source.enumerator.topic.TopicNameUtils.topicNameWithPartition;
+import static org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema.pulsarSchema;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test class for {@link PulsarSource} with {@link
+ * org.apache.flink.connector.base.source.reader.RecordEvaluator}.
+ */
+public class PulsarSourceRecordEvaluatorITCase {
+
+    @Test
+    void testRecordEvaluator() throws Exception {
+        String topicName = "recordEvaluatorTopic";
+        int maxRecords = 10;
+        PulsarTestEnvironment pulsar = new PulsarTestEnvironment(PulsarRuntime.mock());
+        pulsar.startUp();
+        pulsar.operator().createTopic(topicName, 1);
+        PulsarSourceBuilder<Integer> builder =
+                new PulsarSourceBuilder<Integer>()
+                        .setTopics(topicName)
+                        .setAdminUrl(pulsar.operator().adminUrl())
+                        .setServiceUrl(pulsar.operator().serviceUrl())
+                        .setSubscriptionName("subscription-name")
+                        .setDeserializationSchema(pulsarSchema(Schema.INT32))
+                        .setEofRecordEvaluator(new PulsarSourceTestRecordEvaluator<>(maxRecords));
+        PulsarSource<Integer> source = builder.build();
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        CloseableIterator<Integer> result =
+                env.fromSource(
+                                source,
+                                WatermarkStrategy.noWatermarks(),
+                                "testRecordEvaluatorSource")
+                        .executeAndCollect();
+
+        int sumToCheck = 0;
+        for (int i = 0; i < maxRecords * 2; i++) {
+            pulsar.operator()
+                    .sendMessage(topicNameWithPartition(topicName, 0), Schema.INT32, i * 10);
+            if (i < maxRecords) {
+                sumToCheck += i * 10;
+            }
+        }
+        AtomicInteger actualCount = new AtomicInteger();
+        AtomicInteger actualSum = new AtomicInteger();
+        result.forEachRemaining(
+                value -> {
+                    actualCount.getAndIncrement();
+                    actualSum.addAndGet(value);
+                });
+
+        assertThat(actualCount.get()).isEqualTo(maxRecords);
+        assertThat(actualSum.get()).isEqualTo(sumToCheck);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderTestBase.java
@@ -150,7 +150,7 @@ abstract class PulsarSourceReaderTestBase extends PulsarTestSuiteBase {
         SourceConfiguration sourceConfiguration = new SourceConfiguration(configuration);
         return (PulsarSourceReaderBase<Integer>)
                 PulsarSourceReaderFactory.create(
-                        context, deserializationSchema, sourceConfiguration);
+                        context, deserializationSchema, sourceConfiguration, null);
     }
 
     public class PulsarSourceReaderInvocationContextProvider

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarSourceTestRecordEvaluator.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarSourceTestRecordEvaluator.java
@@ -11,23 +11,29 @@
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expre
+ * ss or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
 
-package org.apache.flink.connector.base.source.reader.mocks;
+package org.apache.flink.connector.pulsar.testutils;
 
-import org.apache.flink.connector.base.source.reader.RecordEmitter;
-import org.apache.flink.connector.base.source.reader.SourceOutputWrapper;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 
-/** A record emitter that pipes records directly into the source output. */
-public final class PassThroughRecordEmitter<E, SplitStateT>
-        implements RecordEmitter<E, E, SplitStateT> {
+/** {@link RecordEvaluator} for pulsar tests. Stops input when maxRecords is reached. */
+public class PulsarSourceTestRecordEvaluator<T> implements RecordEvaluator<T> {
+
+    private final int maxRecords;
+    private int count = 0;
+
+    public PulsarSourceTestRecordEvaluator(int maxRecords) {
+        this.maxRecords = maxRecords;
+    }
 
     @Override
-    public void emitRecord(E element, SourceOutputWrapper<E> output, SplitStateT splitState)
-            throws Exception {
-        output.collect(element);
+    public boolean isEndOfStream(T record) {
+        count++;
+        return count == maxRecords;
     }
 }


### PR DESCRIPTION
…urce based on consumed records. Add interfaces for Kafka and Pulsar sources.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request provides interface for creating RecordEvalutor classes to stop source based on consumed records. Added functionality works for Kafka and Pulsar sources.


## Brief change log

  - Added RecordEvalutor interface
  - Added SourceOutPutWrapper to 
  - Modified SourceReaderBase and SingleThreadMultiplexSourceReaderBase to work with evaluator
  - Added setEofRecordEvaluator methods for Kafka and Pulsar connectors


## Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - Added tests to validate stopping of the job when number element is reached
  - 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (don't know)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
