### PR TITLE
[FLINK-29576][runtime] Adds concurrency support to JobVertex#addOperatorCoordinator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -78,10 +78,10 @@ public class JobVertex implements java.io.Serializable {
     private final Map<IntermediateDataSetID, IntermediateDataSet> results = new LinkedHashMap<>();
 
     /** List of edges with incoming data. One per Reader. */
-    private final ArrayList<JobEdge> inputs = new ArrayList<>();
+    private final List<JobEdge> inputs = new ArrayList<>();
 
     /** The list of factories for operator coordinators. */
-    private final ArrayList<SerializedValue<OperatorCoordinator.Provider>> operatorCoordinators =
+    private final List<SerializedValue<OperatorCoordinator.Provider>> operatorCoordinators =
             new ArrayList<>();
 
     /** Number of subtasks to split this task into at runtime. */


### PR DESCRIPTION
## What is the purpose of the change

Concurrent serialization for `OperatorCoordinators` was added in FLINK-26675. These are added concurrently to `JobVertex` which uses `ArrayList` internally to collect them. `ArrayList` isn't thread-safe and, therefore, might cause issues where `OperatorCoordinator.Provider` instances are actually dropped during runtime.

## Brief change log

* Replaces `ArrayList` type by `List`
* ~Synchronizes adding the `OperatorCoordinator.Provider` instances~ Collect all serialized OperatorCoordinator instances before adding them in a single for loop sequentially to `JobVertex`

## Verifying this change

Repeating run of `SourceNAryInputChainingITCase#testDirectSourcesOnlyExecution` with and without the change:
* 5000 test runs including the PR's fix without any error
* repeated test runs without fix: 9 failures out of 5000

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
