### PR TITLE
[FLINK-29501] Add option to override job vertex parallelisms during job submission

### DIFF
--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -81,6 +81,12 @@
             <td>A semicolon-separated list of the jars to package with the job jars to be sent to the cluster. These have to be valid paths.</td>
         </tr>
         <tr>
+            <td><h5>pipeline.jobvertex-parallelism-overrides</h5></td>
+            <td style="word-wrap: break-word;"></td>
+            <td>Map</td>
+            <td>A parallelism override map (jobVertexId -&gt; parallelism) which will be used to update the parallelism of the corresponding job vertices of submitted JobGraphs.</td>
+        </tr>
+        <tr>
             <td><h5>pipeline.max-parallelism</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -24,6 +24,7 @@ import org.apache.flink.configuration.description.Description;
 import org.apache.flink.configuration.description.TextElement;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -164,6 +165,14 @@ public class PipelineOptions {
                     .withDescription(
                             "Register a custom, serializable user configuration object. The configuration can be "
                                     + " accessed in operators");
+
+    public static final ConfigOption<Map<String, String>> PARALLELISM_OVERRIDES =
+            key("pipeline.jobvertex-parallelism-overrides")
+                    .mapType()
+                    .defaultValue(Collections.emptyMap())
+                    .withDescription(
+                            "A parallelism override map (jobVertexId -> parallelism) which will be used to update"
+                                    + " the parallelism of the corresponding job vertices of submitted JobGraphs.");
 
     public static final ConfigOption<Integer> MAX_PARALLELISM =
             key("pipeline.max-parallelism")


### PR DESCRIPTION
## What is the purpose of the change

This allows to change the job vertex parallelism of a JobGraph during job submission time without having to modify the JobGraph upfront.

The initial idea was to add a new field to the payload of the job submit Rest endpoint. However, it is probably more practical to handle the overrides in the same way as other PipelineOptions already do it, i.e. via the configuration.

The implementation is deliberately lenient with respect to the presence of job vertices. If vertices have been removed or new ones have been added, only the ones found will have their parallelism overrides. The verification should be performed by the caller, not by Flink. In particular, we want to support scenarios where users modify the deployment and we might not yet have overrides for all vertices.

Based on feedback in https://github.com/apache/flink/pull/20953.

## Brief change log

- Add option to override job vertex parallelisms during job submission

## Verifying this change

Tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
