### PR TITLE
[FLINK-28229][streaming-java] Introduce Source API alternatives for StreamExecutionEnvironment#fromCollection() methods

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/CollectionSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/CollectionSource.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.connector.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceEnumerator;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceReader;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
+import org.apache.flink.streaming.util.serialization.CollectionSerializer;
+import org.apache.flink.streaming.util.serialization.SimpleObjectSerializer;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+/**
+ * A {@link Source} implementation that reads data from a collection.
+ *
+ * <p>This source serializes the elements using Flink's type information. That way, any object
+ * transport using Java serialization will not be affected by the serializability of the elements.
+ *
+ * <p>Note: Parallelism of this source must be 1.
+ */
+@Internal
+public class CollectionSource<E>
+        implements Source<E, SerializedElementsSplit<E>, Collection<SerializedElementsSplit<E>>>,
+                OutputTypeConfigurable<E> {
+    private final transient Iterable<E> elements;
+    private final int elementsCount;
+
+    private byte[] serializedElements;
+    private TypeSerializer<E> serializer;
+
+    public CollectionSource(Iterable<E> elements, TypeSerializer<E> serializer) {
+        this.elements = Preconditions.checkNotNull(elements);
+        this.serializer = Preconditions.checkNotNull(serializer);
+        this.elementsCount = Iterables.size(elements);
+        checkIterable(elements, Object.class);
+        serializeElements();
+    }
+
+    public CollectionSource(Iterable<E> elements) {
+        this.elements = Preconditions.checkNotNull(elements);
+        this.elementsCount = Iterables.size(elements);
+        checkIterable(elements, Object.class);
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.BOUNDED;
+    }
+
+    @Override
+    public SourceReader<E, SerializedElementsSplit<E>> createReader(
+            SourceReaderContext readerContext) throws Exception {
+        return new IteratorSourceReader<>(readerContext);
+    }
+
+    @Override
+    public SplitEnumerator<SerializedElementsSplit<E>, Collection<SerializedElementsSplit<E>>>
+            createEnumerator(SplitEnumeratorContext<SerializedElementsSplit<E>> enumContext)
+                    throws Exception {
+        SerializedElementsSplit<E> split =
+                new SerializedElementsSplit<>(serializedElements, elementsCount, serializer);
+        return new IteratorSourceEnumerator<>(enumContext, Collections.singletonList(split));
+    }
+
+    @Override
+    public SplitEnumerator<SerializedElementsSplit<E>, Collection<SerializedElementsSplit<E>>>
+            restoreEnumerator(
+                    SplitEnumeratorContext<SerializedElementsSplit<E>> enumContext,
+                    Collection<SerializedElementsSplit<E>> restoredSplits)
+                    throws Exception {
+        Preconditions.checkArgument(
+                restoredSplits.size() <= 1, "Parallelism of CollectionSource should be 1");
+        return new IteratorSourceEnumerator<>(enumContext, restoredSplits);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<SerializedElementsSplit<E>> getSplitSerializer() {
+        return new ElementsSplitSerializer();
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Collection<SerializedElementsSplit<E>>>
+            getEnumeratorCheckpointSerializer() {
+        return new CollectionSerializer<>(new ElementsSplitSerializer());
+    }
+
+    private void serializeElements() {
+        Preconditions.checkState(serializer != null, "serializer not set");
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                DataOutputViewStreamWrapper wrapper = new DataOutputViewStreamWrapper(baos)) {
+            for (E element : elements) {
+                serializer.serialize(element, wrapper);
+            }
+            this.serializedElements = baos.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Serializing the source elements failed: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void setOutputType(TypeInformation<E> outTypeInfo, ExecutionConfig executionConfig) {
+        Preconditions.checkState(
+                outTypeInfo != null,
+                "The output type should've been specified before shipping the graph to the cluster");
+        checkIterable(elements, outTypeInfo.getTypeClass());
+        TypeSerializer<E> newSerializer = outTypeInfo.createSerializer(executionConfig);
+        if (Objects.equals(serializer, newSerializer)) {
+            return;
+        }
+        serializer = newSerializer;
+        serializeElements();
+    }
+
+    @VisibleForTesting
+    byte[] getSerializedElements() {
+        return serializedElements;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    public TypeSerializer<E> getSerializer() {
+        return serializer;
+    }
+
+    /** {@link SerializedElementsSplit} serializer. */
+    @Internal
+    public class ElementsSplitSerializer
+            extends SimpleObjectSerializer<SerializedElementsSplit<E>> {
+        static final int VERSION = 1;
+
+        @Override
+        public int getVersion() {
+            return VERSION;
+        }
+
+        @Override
+        public void serialize(SerializedElementsSplit<E> obj, ObjectOutputStream outputStream)
+                throws IOException {
+            byte[] serializedData = obj.getSerializedData();
+            outputStream.writeInt(serializedData.length);
+            outputStream.write(serializedData);
+            outputStream.writeInt(obj.getElementsCount());
+            outputStream.writeInt(obj.getCurrentOffset());
+        }
+
+        @Override
+        public SerializedElementsSplit<E> deserialize(ObjectInputStream inputStream)
+                throws IOException, ClassNotFoundException {
+            int buffSize = inputStream.readInt();
+            byte[] serializedData = new byte[buffSize];
+            inputStream.readFully(serializedData);
+            int elementsCount = inputStream.readInt();
+            int currentOffset = inputStream.readInt();
+            return new SerializedElementsSplit<>(
+                    serializedData, elementsCount, serializer, currentOffset);
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  Utilities
+    // ------------------------------------------------------------------------
+
+    /**
+     * Verifies that all elements in the collection are non-null, and are of the given class, or a
+     * subclass thereof.
+     *
+     * @param elements The collection to check.
+     * @param viewedAs The class to which the elements must be assignable to.
+     * @param <OUT> The generic type of the collection to be checked.
+     */
+    public static <OUT> void checkIterable(Iterable<OUT> elements, Class<?> viewedAs) {
+        for (OUT elem : elements) {
+            if (elem == null) {
+                throw new IllegalArgumentException("The collection contains a null element");
+            }
+
+            if (!viewedAs.isAssignableFrom(elem.getClass())) {
+                throw new IllegalArgumentException(
+                        "The elements in the collection are not all subclasses of "
+                                + viewedAs.getCanonicalName());
+            }
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/IteratorSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/IteratorSource.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.connector.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceEnumerator;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceReader;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.util.serialization.CollectionSerializer;
+import org.apache.flink.streaming.util.serialization.SimpleObjectSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+/**
+ * A Source that reads elements from an {@link Iterator} and emits them.
+ *
+ * <p>Note: Parallelism of this source must be 1.
+ */
+@Internal
+public class IteratorSource<E>
+        implements Source<E, IteratorSplit<E>, Collection<IteratorSplit<E>>> {
+    private final Iterator<E> iterator;
+
+    /** Creates bounded {@link IteratorSource} from specified iterator. */
+    public IteratorSource(Iterator<E> iterator) {
+        this.iterator = iterator;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.BOUNDED;
+    }
+
+    @Override
+    public SourceReader<E, IteratorSplit<E>> createReader(SourceReaderContext readerContext)
+            throws Exception {
+        return new IteratorSourceReader<>(readerContext);
+    }
+
+    @Override
+    public SplitEnumerator<IteratorSplit<E>, Collection<IteratorSplit<E>>> createEnumerator(
+            SplitEnumeratorContext<IteratorSplit<E>> enumContext) throws Exception {
+        IteratorSplit<E> split = new IteratorSplit<>(iterator);
+        return new IteratorSourceEnumerator<>(enumContext, Collections.singletonList(split));
+    }
+
+    @Override
+    public SplitEnumerator<IteratorSplit<E>, Collection<IteratorSplit<E>>> restoreEnumerator(
+            SplitEnumeratorContext<IteratorSplit<E>> enumContext,
+            Collection<IteratorSplit<E>> restoredSplits)
+            throws Exception {
+        Preconditions.checkArgument(
+                restoredSplits.size() <= 1, "Parallelism of IteratorSource should be 1");
+        return new IteratorSourceEnumerator<>(enumContext, restoredSplits);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<IteratorSplit<E>> getSplitSerializer() {
+        return new IteratorSplitSerializer<>();
+    }
+
+    @Override
+    public SimpleVersionedSerializer<Collection<IteratorSplit<E>>>
+            getEnumeratorCheckpointSerializer() {
+        return new CollectionSerializer<>(new IteratorSplitSerializer<>());
+    }
+
+    /** {@link IteratorSplit} serializer. */
+    @Internal
+    public static class IteratorSplitSerializer<E>
+            extends SimpleObjectSerializer<IteratorSplit<E>> {
+
+        private static final int VERSION = 1;
+
+        @Override
+        public int getVersion() {
+            return VERSION;
+        }
+
+        @Override
+        public void serialize(IteratorSplit<E> obj, ObjectOutputStream outputStream)
+                throws IOException {
+            outputStream.writeObject(obj.getIterator());
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public IteratorSplit<E> deserialize(ObjectInputStream inputStream)
+                throws IOException, ClassNotFoundException {
+            Iterator<E> iterator = (Iterator<E>) inputStream.readObject();
+            return new IteratorSplit<>(iterator);
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/IteratorSplit.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/IteratorSplit.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.connector.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
+
+import java.util.Iterator;
+
+/** A split of the {@link IteratorSource}, backed by serializable iterator. */
+@Internal
+public class IteratorSplit<E> implements IteratorSourceSplit<E, Iterator<E>> {
+    private static final String SPLIT_ID = "0";
+
+    private final Iterator<E> iterator;
+
+    public IteratorSplit(Iterator<E> iterator) {
+        this.iterator = iterator;
+    }
+
+    @Override
+    public String splitId() {
+        return SPLIT_ID;
+    }
+
+    @Override
+    public Iterator<E> getIterator() {
+        return iterator;
+    }
+
+    @Override
+    public IteratorSourceSplit<E, Iterator<E>> getUpdatedSplitForIterator(Iterator<E> iterator) {
+        return new IteratorSplit<>(iterator);
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/SerializedElementsSplit.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/connector/source/SerializedElementsSplit.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.connector.source;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.connector.source.lib.util.IteratorSourceSplit;
+import org.apache.flink.core.memory.DataInputViewStreamWrapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/** A split of the {@link CollectionSource}, contains serialized part of collection. */
+@Internal
+public class SerializedElementsSplit<E>
+        implements IteratorSourceSplit<E, Iterator<E>>, Serializable {
+    private static final String SPLIT_ID = "0";
+
+    private final byte[] serializedData;
+    private final TypeSerializer<E> serializer;
+    private final int elementsCount;
+
+    private int currentOffset;
+
+    public SerializedElementsSplit(
+            byte[] serializedData, int elementsCount, TypeSerializer<E> serializer) {
+        this(serializedData, elementsCount, serializer, 0);
+    }
+
+    public SerializedElementsSplit(
+            byte[] serializedData,
+            int elementsCount,
+            TypeSerializer<E> serializer,
+            int currentOffset) {
+        this.serializer = serializer;
+        this.elementsCount = elementsCount;
+        this.serializedData = serializedData;
+        this.currentOffset = currentOffset;
+    }
+
+    @Override
+    public String splitId() {
+        return SPLIT_ID;
+    }
+
+    @Override
+    public Iterator<E> getIterator() {
+        return new ElementsSplitIterator(currentOffset);
+    }
+
+    @Override
+    public IteratorSourceSplit<E, Iterator<E>> getUpdatedSplitForIterator(Iterator<E> iterator) {
+        return new SerializedElementsSplit<>(
+                serializedData, elementsCount, serializer, currentOffset);
+    }
+
+    public int getCurrentOffset() {
+        return currentOffset;
+    }
+
+    public byte[] getSerializedData() {
+        return serializedData;
+    }
+
+    public TypeSerializer<E> getSerializer() {
+        return serializer;
+    }
+
+    public int getElementsCount() {
+        return elementsCount;
+    }
+
+    /** Iterates through serializedElements, lazily deserializing them. */
+    @Internal
+    public class ElementsSplitIterator implements Iterator<E> {
+        private final DataInputViewStreamWrapper serializedElementsStream;
+
+        public ElementsSplitIterator(int currentOffset) {
+            this.serializedElementsStream =
+                    new DataInputViewStreamWrapper(new ByteArrayInputStream(serializedData));
+            skipElements(currentOffset);
+        }
+
+        @Override
+        public boolean hasNext() {
+            return currentOffset < elementsCount;
+        }
+
+        @Override
+        public E next() {
+            if (!hasNext()) {
+                throw new NoSuchElementException();
+            }
+
+            try {
+                E record = serializer.deserialize(serializedElementsStream);
+                ++currentOffset;
+                return record;
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to deserialize an element from the source.", e);
+            }
+        }
+
+        private void skipElements(int elementsToSkip) {
+            int toSkip = elementsToSkip;
+            try {
+                serializedElementsStream.reset();
+                while (toSkip > 0) {
+                    serializer.deserialize(serializedElementsStream);
+                    toSkip--;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to deserialize an element from the source.", e);
+            }
+        }
+
+        public int getCurrentOffset() {
+            return currentOffset;
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -37,7 +37,7 @@ import org.apache.flink.streaming.api.transformations.SourceTransformation;
 @Public
 public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
 
-    private final boolean isParallel;
+    private boolean isParallel;
 
     public DataStreamSource(
             StreamExecutionEnvironment environment,
@@ -113,6 +113,13 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
     public DataStreamSource<T> setParallelism(int parallelism) {
         OperatorValidationUtils.validateParallelism(parallelism, isParallel);
         super.setParallelism(parallelism);
+        return this;
+    }
+
+    @Override
+    public DataStreamSource<T> forceNonParallel() {
+        super.forceNonParallel();
+        this.isParallel = false;
         return this;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromElementsFunction.java
@@ -31,6 +31,7 @@ import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.connector.source.CollectionSource;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
 import org.apache.flink.util.IterableUtils;
 import org.apache.flink.util.Preconditions;
@@ -57,8 +58,10 @@ import java.util.Objects;
  * <p><b>NOTE:</b> This source has a parallelism of 1.
  *
  * @param <T> The type of elements returned by this function.
+ * @deprecated Use {@link CollectionSource} instead.
  */
 @PublicEvolving
+@Deprecated
 public class FromElementsFunction<T>
         implements SourceFunction<T>, CheckpointedFunction, OutputTypeConfigurable<T> {
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/FromIteratorFunction.java
@@ -18,11 +18,17 @@
 package org.apache.flink.streaming.api.functions.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.streaming.api.connector.source.IteratorSource;
 
 import java.util.Iterator;
 
-/** A {@link SourceFunction} that reads elements from an {@link Iterator} and emits them. */
+/**
+ * A {@link SourceFunction} that reads elements from an {@link Iterator} and emits them.
+ *
+ * @deprecated Use {@link IteratorSource} instead.
+ */
 @PublicEvolving
+@Deprecated
 public class FromIteratorFunction<T> implements SourceFunction<T> {
 
     private static final long serialVersionUID = 1L;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
@@ -18,7 +18,9 @@ limitations under the License.
 
 package org.apache.flink.streaming.api.operators;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.SourceReader;
@@ -149,6 +151,20 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
     @Override
     public boolean isStreamSource() {
         return true;
+    }
+
+    @Override
+    public boolean isOutputTypeConfigurable() {
+        return source instanceof OutputTypeConfigurable<?>;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public void setOutputType(TypeInformation<OUT> type, ExecutionConfig executionConfig) {
+        if (!isOutputTypeConfigurable()) {
+            return;
+        }
+        ((OutputTypeConfigurable<OUT>) source).setOutputType(type, executionConfig);
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/CollectionSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/CollectionSerializer.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.serialization;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/** A simple serializer for versioned serialization of collections. */
+@PublicEvolving
+public class CollectionSerializer<E> implements SimpleVersionedSerializer<Collection<E>> {
+    static final int VERSION = 1;
+
+    private final SimpleObjectSerializer<E> delegate;
+
+    public CollectionSerializer(SimpleObjectSerializer<E> delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public byte[] serialize(Collection<E> elements) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            outputStream.writeInt(elements.size());
+            for (E element : elements) {
+                delegate.serialize(element, outputStream);
+            }
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    @Override
+    public Collection<E> deserialize(int version, byte[] serialized) throws IOException {
+        Preconditions.checkArgument(version == VERSION);
+        try (ObjectInputStream inputStream =
+                new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            int size = inputStream.readInt();
+            List<E> splits = new ArrayList<>();
+
+            while (--size > 0) {
+                splits.add(delegate.deserialize(inputStream));
+            }
+            return splits;
+        } catch (ClassNotFoundException exc) {
+            throw new IOException("Failed to deserialize FromElementsSplit", exc);
+        }
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/SimpleObjectSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/util/serialization/SimpleObjectSerializer.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util.serialization;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.util.Preconditions;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/** A simple serializer for versioned serialization via Object(Output/Input)Stream. */
+@PublicEvolving
+public abstract class SimpleObjectSerializer<E> implements SimpleVersionedSerializer<E> {
+
+    @Override
+    public byte[] serialize(E obj) throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            serialize(obj, outputStream);
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    @Override
+    public E deserialize(int version, byte[] serialized) throws IOException {
+        Preconditions.checkArgument(version == getVersion());
+        try (ObjectInputStream inputStream =
+                new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+            return deserialize(inputStream);
+        } catch (ClassNotFoundException exc) {
+            throw new IOException("Failed to deserialize FromElementsSplit", exc);
+        }
+    }
+
+    /** Serializes the given object to the outputStream. */
+    protected abstract void serialize(E obj, ObjectOutputStream outputStream) throws IOException;
+
+    /** Deserializes the given object from the inputStream. */
+    protected abstract E deserialize(ObjectInputStream inputStream)
+            throws IOException, ClassNotFoundException;
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/source/CollectionSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/source/CollectionSourceTest.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.connector.source;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.streaming.util.SourceTestHarnessUtils;
+
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** {@link CollectionSource} test. */
+public class CollectionSourceTest {
+
+    @Test
+    public void testCreateSourceWithNullElement() {
+        List<String> collectionWithNull = Lists.newArrayList("1", null, "2");
+
+        CommonTestUtils.assertThrows(
+                "The collection contains a null element",
+                RuntimeException.class,
+                () -> {
+                    new CollectionSource<>(collectionWithNull, StringSerializer.INSTANCE);
+                    return null;
+                });
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public void testSetOutputTypeWithIncompatibleType() {
+        List<String> elements = Lists.newArrayList("1", "2");
+        CollectionSource<String> source = new CollectionSource<>(elements);
+
+        CommonTestUtils.assertThrows(
+                "The elements in the collection are not all subclasses of",
+                RuntimeException.class,
+                () -> {
+                    source.setOutputType((TypeInformation) Types.LONG, new ExecutionConfig());
+                    return null;
+                });
+    }
+
+    @Test
+    public void testReadNonSerializableElements() throws Exception {
+        List<NonSerializablePojo> elements =
+                Lists.newArrayList(
+                        new NonSerializablePojo(1, 2),
+                        new NonSerializablePojo(3, 4),
+                        new NonSerializablePojo(5, 6),
+                        new NonSerializablePojo(7, 8));
+        TypeSerializer<NonSerializablePojo> serializer =
+                TypeExtractor.getForClass(NonSerializablePojo.class)
+                        .createSerializer(new ExecutionConfig());
+
+        CollectionSource<NonSerializablePojo> source = new CollectionSource<>(elements, serializer);
+        List<NonSerializablePojo> result =
+                SourceTestHarnessUtils.testBoundedSourceWithHarness(
+                        source,
+                        elements.size(),
+                        Collections.singletonList(
+                                new SerializedElementsSplit<>(
+                                        source.getSerializedElements(),
+                                        elements.size(),
+                                        serializer)));
+        assertEquals(elements, result);
+    }
+
+    @Test
+    public void testReadSerializableElements() throws Exception {
+        List<Integer> elements = IntStream.range(0, 10000).boxed().collect(Collectors.toList());
+        CollectionSource<Integer> source = new CollectionSource<>(elements, IntSerializer.INSTANCE);
+
+        List<Integer> result =
+                SourceTestHarnessUtils.testBoundedSourceWithHarness(
+                        source,
+                        elements.size(),
+                        Collections.singletonList(
+                                new SerializedElementsSplit<>(
+                                        source.getSerializedElements(),
+                                        elements.size(),
+                                        IntSerializer.INSTANCE)));
+        assertEquals(elements, result);
+    }
+
+    private static class NonSerializablePojo {
+        public long val1;
+        public int val2;
+
+        public NonSerializablePojo() {}
+
+        public NonSerializablePojo(long val1, int val2) {
+            this.val1 = val1;
+            this.val2 = val2;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            NonSerializablePojo that = (NonSerializablePojo) o;
+            return val1 == that.val1 && val2 == that.val2;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(val1, val2);
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/source/IteratorSourceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/connector/source/IteratorSourceTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.connector.source;
+
+import org.apache.flink.streaming.util.SourceTestHarnessUtils;
+import org.apache.flink.util.IterableUtils;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** {@link IteratorSource} test. */
+public class IteratorSourceTest {
+    private static final int TEST_ELEMENTS_COUNT = 10000;
+
+    @Test
+    public void testReadNonSerializableElements() throws Exception {
+        CountIterator iterator = new CountIterator(TEST_ELEMENTS_COUNT);
+        IteratorSource<Integer> source = new IteratorSource<>(iterator);
+        List<Integer> result =
+                SourceTestHarnessUtils.testBoundedSourceWithHarness(
+                        source,
+                        TEST_ELEMENTS_COUNT,
+                        Collections.singletonList(new IteratorSplit<>(iterator)));
+
+        List<Integer> expected =
+                IterableUtils.toStream(() -> new CountIterator(TEST_ELEMENTS_COUNT))
+                        .collect(Collectors.toList());
+        assertEquals(expected, result);
+    }
+
+    /** Simple serializable iterator, returns numbers in order up to the transmitted limit. */
+    public static class CountIterator implements Iterator<Integer>, Serializable {
+
+        private final int limit;
+
+        private int offset = 0;
+
+        public CountIterator(int limit) {
+            this.limit = limit;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return offset < limit;
+        }
+
+        @Override
+        public Integer next() {
+            return offset++;
+        }
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamGraphGeneratorTest.java
@@ -52,10 +52,10 @@ import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.OutputTypeConfigurable;
+import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
-import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
 import org.apache.flink.streaming.api.transformations.CacheTransformation;
 import org.apache.flink.streaming.api.transformations.MultipleInputTransformation;
@@ -158,7 +158,8 @@ public class StreamGraphGeneratorTest extends TestLogger {
                     Assertions.assertThat(node.getBufferTimeout()).isEqualTo(77L);
                     break;
                 default:
-                    Assertions.assertThat(node.getOperator()).isInstanceOf(StreamSource.class);
+                    Assertions.assertThat(node.getOperatorFactory())
+                            .isInstanceOf(SourceOperatorFactory.class);
             }
         }
     }
@@ -566,15 +567,15 @@ public class StreamGraphGeneratorTest extends TestLogger {
         int maxParallelism = 42;
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        DataStream<Integer> input1 = env.fromElements(1, 2, 3, 4).setMaxParallelism(128);
-        DataStream<Integer> input2 = env.fromElements(1, 2, 3, 4).setMaxParallelism(129);
+        DataStream<Long> input1 = env.fromSequence(1, 4).setMaxParallelism(128);
+        DataStream<Long> input2 = env.fromSequence(1, 4).setMaxParallelism(129);
 
         env.getConfig().setMaxParallelism(maxParallelism);
 
-        DataStream<Integer> keyedResult =
+        DataStream<Long> keyedResult =
                 input1.connect(input2)
                         .keyBy(value -> value, value -> value)
-                        .map(new NoOpIntCoMap());
+                        .map(new NoOpLongCoMap());
 
         keyedResult.addSink(new DiscardingSink<>());
 
@@ -1151,14 +1152,14 @@ public class StreamGraphGeneratorTest extends TestLogger {
         }
     }
 
-    static class NoOpIntCoMap implements CoMapFunction<Integer, Integer, Integer> {
+    static class NoOpLongCoMap implements CoMapFunction<Long, Long, Long> {
         private static final long serialVersionUID = 1886595528149124270L;
 
-        public Integer map1(Integer value) throws Exception {
+        public Long map1(Long value) throws Exception {
             return value;
         }
 
-        public Integer map2(Integer value) throws Exception {
+        public Long map2(Long value) throws Exception {
             return value;
         }
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -73,6 +73,7 @@ import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
+import org.apache.flink.streaming.api.functions.source.FromElementsFunction;
 import org.apache.flink.streaming.api.functions.source.InputFormatSourceFunction;
 import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
@@ -956,7 +957,8 @@ class StreamingJobGraphGeneratorTest {
     void testYieldingOperatorNotChainableToTaskChainedToLegacySource() {
         StreamExecutionEnvironment chainEnv = StreamExecutionEnvironment.createLocalEnvironment(1);
 
-        chainEnv.fromElements(1)
+        chainEnv.addSource(new FromElementsFunction<>(1))
+                .returns(Integer.class)
                 .map((x) -> x)
                 // not chainable because of YieldingOperatorFactory and legacy source
                 .transform(
@@ -1003,8 +1005,8 @@ class StreamingJobGraphGeneratorTest {
     @Test
     void testYieldingOperatorProperlyChainedOnLegacySources() {
         StreamExecutionEnvironment chainEnv = StreamExecutionEnvironment.createLocalEnvironment(1);
-
-        chainEnv.fromElements(1)
+        chainEnv.addSource(new FromElementsFunction<>(1))
+                .returns(Integer.class)
                 .map((x) -> x)
                 // should automatically break chain here
                 .transform("test", BasicTypeInfo.INT_TYPE_INFO, new YieldingTestOperatorFactory<>())

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceTestHarnessUtils.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/SourceTestHarnessUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.runtime.operators.testutils.MockEnvironmentBuilder;
+import org.apache.flink.streaming.api.operators.SourceOperator;
+import org.apache.flink.streaming.api.operators.SourceOperatorFactory;
+import org.apache.flink.streaming.runtime.io.PushingAsyncDataInput;
+import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Util class for performing tests with SourceOperator {@link AbstractStreamOperatorTestHarness}.
+ */
+public class SourceTestHarnessUtils {
+    /**
+     * Runs the specified bounded source, previously transferring the initial splits to it. After
+     * emitting half of the values, the checkpoint behavior and operator recovery are simulated.
+     *
+     * @return record values emitted by source
+     */
+    public static <V, SplitT extends SourceSplit> List<V> testBoundedSourceWithHarness(
+            Source<V, SplitT, ?> source, int elementsSize, List<SplitT> initialSplits)
+            throws Exception {
+        try (AbstractStreamOperatorTestHarness<V> testHarness = buildSourceHarness(source)) {
+            testHarness.open();
+            testHarness.setup();
+            SourceOperator<V, SplitT> sourceOperator =
+                    (SourceOperator<V, SplitT>) testHarness.getOperator();
+            sourceOperator.getSourceReader().addSplits(initialSplits);
+
+            RecordValueCollectingDataOutput<V> dataOutput = new RecordValueCollectingDataOutput<>();
+
+            int elementsPerCycle = elementsSize / 2;
+            for (int i = 0; i <= elementsPerCycle; ++i) {
+                sourceOperator.emitNext(dataOutput);
+            }
+            OperatorSubtaskState state = testHarness.snapshot(1L, 1L);
+            testHarness.close();
+
+            AbstractStreamOperatorTestHarness<V> restoredHarness = buildSourceHarness(source);
+            restoredHarness.initializeState(state);
+            restoredHarness.open();
+            restoredHarness.setup();
+            sourceOperator = (SourceOperator<V, SplitT>) restoredHarness.getOperator();
+
+            for (int i = elementsPerCycle; i <= elementsSize; ++i) {
+                sourceOperator.emitNext(dataOutput);
+            }
+            return dataOutput.getRecordValues();
+        }
+    }
+
+    private static <V, SplitT extends SourceSplit>
+            AbstractStreamOperatorTestHarness<V> buildSourceHarness(Source<V, SplitT, ?> source)
+                    throws Exception {
+        return new AbstractStreamOperatorTestHarness<>(
+                new SourceOperatorFactory<>(source, WatermarkStrategy.noWatermarks()),
+                new MockEnvironmentBuilder().build());
+    }
+
+    /** DataOutput which saves all incoming record values in buffer. */
+    public static final class RecordValueCollectingDataOutput<E>
+            implements PushingAsyncDataInput.DataOutput<E> {
+
+        final List<E> recordValues = new ArrayList<>();
+
+        @Override
+        public void emitWatermark(org.apache.flink.streaming.api.watermark.Watermark watermark)
+                throws Exception {}
+
+        @Override
+        public void emitWatermarkStatus(WatermarkStatus watermarkStatus) throws Exception {}
+
+        @Override
+        public void emitRecord(StreamRecord<E> streamRecord) throws Exception {
+            recordValues.add(streamRecord.getValue());
+        }
+
+        @Override
+        public void emitLatencyMarker(LatencyMarker latencyMarker) throws Exception {}
+
+        public List<E> getRecordValues() {
+            return recordValues;
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
+import org.apache.flink.streaming.api.functions.source.StatefulSequenceSource;
 import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
@@ -133,7 +134,8 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
     }
 
     private void createNonChainableStream(TableTestUtil util) {
-        DataStreamSource<Integer> dataStream = util.getStreamEnv().fromElements(1, 2, 3);
+        DataStreamSource<Long> dataStream =
+                util.getStreamEnv().addSource(new StatefulSequenceSource(1, 2));
         TableTestUtil.createTemporaryView(
                 util.tableEnv(),
                 "nonChainableStream",

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/MultipleInputCreationTest.xml
@@ -229,7 +229,7 @@ Calc(select=[a])
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM
-  (SELECT a FROM (SELECT a FROM x) UNION ALL (SELECT a FROM t)) T1
+  (SELECT a FROM (SELECT a FROM x) UNION ALL (SELECT a FROM nonchainable)) T1
   LEFT JOIN y ON T1.a = y.d
 ]]>
     </Resource>
@@ -241,7 +241,7 @@ LogicalProject(a=[$0], d=[$1], e=[$2], f=[$3], ny=[$4])
    :  :- LogicalProject(a=[$0])
    :  :  +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
    :  +- LogicalProject(a=[$0])
-   :     +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, nonchainable]])
    +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
 ]]>
     </Resource>
@@ -252,7 +252,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[(a = d)], select=[a, d, e, f, ny
 :  :- Calc(select=[a])
 :  :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
 :  +- Calc(select=[a])
-:     +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:     +- BoundedStreamScan(table=[[default_catalog, default_database, nonchainable]], fields=[a, b, c])
 +- Exchange(distribution=[broadcast])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
 ]]>
@@ -262,7 +262,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[(a = d)], select=[a, d, e, f, ny
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM
-  (SELECT a FROM (SELECT a FROM x) UNION ALL (SELECT a FROM t)) T1
+  (SELECT a FROM (SELECT a FROM x) UNION ALL (SELECT a FROM nonchainable)) T1
   LEFT JOIN y ON T1.a = y.d
 ]]>
     </Resource>
@@ -274,7 +274,7 @@ LogicalProject(a=[$0], d=[$1], e=[$2], f=[$3], ny=[$4])
    :  :- LogicalProject(a=[$0])
    :  :  +- LogicalTableScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]])
    :  +- LogicalProject(a=[$0])
-   :     +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, nonchainable]])
    +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
 ]]>
     </Resource>
@@ -285,7 +285,7 @@ NestedLoopJoin(joinType=[LeftOuterJoin], where=[(a = d)], select=[a, d, e, f, ny
 :  :- Calc(select=[a])
 :  :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, x, source: [TestTableSource(a, b, c, nx)]]], fields=[a, b, c, nx])
 :  +- Calc(select=[a])
-:     +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+:     +- BoundedStreamScan(table=[[default_catalog, default_database, nonchainable]], fields=[a, b, c])
 +- Exchange(distribution=[broadcast])
    +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
 ]]>
@@ -588,7 +588,7 @@ MultipleInput(readOrder=[0,0,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJo
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM
-  (SELECT a FROM (SELECT a FROM chainable) UNION ALL (SELECT a FROM t)) T1
+  (SELECT a FROM (SELECT a FROM chainable) UNION ALL (SELECT a FROM nonchainable)) T1
   LEFT JOIN y ON T1.a = y.d
 ]]>
     </Resource>
@@ -600,7 +600,7 @@ LogicalProject(a=[$0], d=[$1], e=[$2], f=[$3], ny=[$4])
    :  :- LogicalProject(a=[$0])
    :  :  +- LogicalTableScan(table=[[default_catalog, default_database, chainable]])
    :  +- LogicalProject(a=[$0])
-   :     +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, nonchainable]])
    +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
 ]]>
     </Resource>
@@ -611,7 +611,7 @@ MultipleInput(readOrder=[0,1,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJo
 :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
 :- BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])
 +- Calc(select=[a])
-   +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+   +- BoundedStreamScan(table=[[default_catalog, default_database, nonchainable]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>
@@ -619,7 +619,7 @@ MultipleInput(readOrder=[0,1,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJo
     <Resource name="sql">
       <![CDATA[
 SELECT * FROM
-  (SELECT a FROM (SELECT a FROM chainable) UNION ALL (SELECT a FROM t)) T1
+  (SELECT a FROM (SELECT a FROM chainable) UNION ALL (SELECT a FROM nonchainable)) T1
   LEFT JOIN y ON T1.a = y.d
 ]]>
     </Resource>
@@ -631,7 +631,7 @@ LogicalProject(a=[$0], d=[$1], e=[$2], f=[$3], ny=[$4])
    :  :- LogicalProject(a=[$0])
    :  :  +- LogicalTableScan(table=[[default_catalog, default_database, chainable]])
    :  +- LogicalProject(a=[$0])
-   :     +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+   :     +- LogicalTableScan(table=[[default_catalog, default_database, nonchainable]])
    +- LogicalTableScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]])
 ]]>
     </Resource>
@@ -642,7 +642,7 @@ MultipleInput(readOrder=[0,1,1], members=[\nNestedLoopJoin(joinType=[LeftOuterJo
 :  +- LegacyTableSourceScan(table=[[default_catalog, default_database, y, source: [TestTableSource(d, e, f, ny)]]], fields=[d, e, f, ny])
 :- BoundedStreamScan(table=[[default_catalog, default_database, chainable]], fields=[a])
 +- Calc(select=[a])
-   +- BoundedStreamScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+   +- BoundedStreamScan(table=[[default_catalog, default_database, nonchainable]], fields=[a, b, c])
 ]]>
     </Resource>
   </TestCase>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request adds FLIP-27 Source API alternatives for `FromElementsFunction` and `FromIteratorFunction`.

## Brief change log

  - Added CollectionSource
  - Added IteratorSource

## Verifying this change

This change added tests and can be verified as follows:

  - Added tests for both sources, validating elements emission, snapshot and recovery from snapshot logic.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)