### PR TITLE
[FLINK-29516]Support TIMESTAMPADD built-in function in Table API

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -485,6 +485,8 @@ temporal:
     table: dateFormat(TIMESTAMP, STRING)
     description: Converts timestamp to a value of string in the format specified by the date format string. The format string is compatible with Java's SimpleDateFormat.
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
+    table: timestampAdd(TIMEINTERVALUNIT, INTERVAL, TIMEPOINT)
+    description: "Returns the time after adding the specified time interval to the timepoint. For example `TIMESTAMPADD(HOUR, +8, TIMESTAMP '2017-11-29 10:58:58.998')` returns `2017-11-29 18:58:58.998`'. If interval is negative, returns the time after the timepoint is reduced by the specified time interval.."
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)
     description: 'Returns the (signed) number of timepointunit between timepoint1 and timepoint2. The unit for the interval is given by the first argument, which should be one of the following values: SECOND, MINUTE, HOUR, DAY, MONTH, or YEAR.'

--- a/docs/data/sql_functions_zh.yml
+++ b/docs/data/sql_functions_zh.yml
@@ -604,6 +604,11 @@ temporal:
     description: |
       将时间戳 timestamp 转换为日期格式字符串 string 指定格式的字符串值。格式字符串与 Java 的 SimpleDateFormat 兼容。
   - sql: TIMESTAMPADD(timeintervalunit, interval, timepoint)
+    table: timestampAdd(TIMEINTERVALUNIT, INTERVAL, TIMEPOINT)
+    description: |
+      返回将时间点timepoint 增加指定的时间间隔INTERVAL后的时间。
+      例如`TIMESTAMPADD(HOUR, +8, TIMESTAMP '2017-11-29 10:58:58.998')` 返回 `2017-11-29 18:58:58.998`'。
+      若interval 为负数，则返回时间点timepoint 减少指定的时间间隔INTERVAL后的时间。
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)
     description: |

--- a/flink-python/pyflink/table/expressions.py
+++ b/flink-python/pyflink/table/expressions.py
@@ -19,7 +19,8 @@ from typing import Union
 
 from pyflink import add_version_doc
 from pyflink.java_gateway import get_gateway
-from pyflink.table.expression import Expression, _get_java_expression, TimePointUnit, JsonOnNull
+from pyflink.table.expression import Expression, _get_java_expression, TimePointUnit, JsonOnNull, \
+    TimeIntervalUnit
 from pyflink.table.types import _to_java_data_type, DataType
 from pyflink.table.udf import UserDefinedFunctionWrapper
 from pyflink.util.java_utils import to_jarray, load_java_class
@@ -359,6 +360,23 @@ def date_format(timestamp, format) -> Expression:
     :return: The formatted timestamp as string.
     """
     return _binary_op("dateFormat", timestamp, format)
+
+
+def timestamp_add(time_interval_unit: TimeIntervalUnit, interval, timePoint) -> Expression:
+    """
+    Returns the time after adding the specified time interval to the `timepoint`.
+
+    For example,
+    `For example, timestampAdd(TimeIntervalUnit.HOUR, +8, lit("2017-11-29 10:58:58.998").toDate())`
+    returns `2017-11-29 18:58:58.998`'.
+
+    :param time_interval_unit: The unit of time interval.
+    :param interval: The time interval.
+    :param timePoint: The point of time.
+    :return: The time after adding the specified time interval to the `timePoint`.
+    """
+    return _ternary_op("timestampAdd", time_interval_unit._to_j_time_interval_unit(),
+                       interval, timePoint)
 
 
 def timestamp_diff(time_point_unit: TimePointUnit, time_point1, time_point2) -> Expression:

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -27,7 +27,7 @@ from pyflink.table.expressions import (col, lit, range_, and_, or_, current_date
                                        rand, rand_integer, atan2, negative, concat, concat_ws, uuid,
                                        null_of, log, if_then_else, with_columns, call,
                                        to_timestamp_ltz, from_unixtime, to_date, to_timestamp,
-                                       convert_tz, unix_timestamp)
+                                       convert_tz, unix_timestamp, timestamp_add)
 from pyflink.testing.test_case_utils import PyFlinkTestCase
 
 
@@ -275,6 +275,11 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
                              lit(2).hours)))
         self.assertEqual("dateFormat(time, '%Y, %d %M')",
                          str(date_format(col("time"), "%Y, %d %M")))
+        self.assertEqual("timestampAdd(MONTH, 8, TIMESTAMP '2020-03-01 00:00:00')",
+                         str(timestamp_add(
+                             TimeIntervalUnit.MONTH,
+                             8,
+                             lit("2020-03-01 00:00:00").to_timestamp)))
         self.assertEqual("timestampDiff(DAY, cast('2016-06-15', DATE), cast('2016-06-18', DATE))",
                          str(timestamp_diff(
                              TimePointUnit.DAY,

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/Expressions.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.SqlCallExpression;
+import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.expressions.TimePointUnit;
 import org.apache.flink.table.functions.BuiltInFunctionDefinition;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
@@ -411,6 +412,26 @@ public final class Expressions {
      */
     public static ApiExpression dateFormat(Object timestamp, Object format) {
         return apiCall(BuiltInFunctionDefinitions.DATE_FORMAT, timestamp, format);
+    }
+
+    /**
+     * Returns the time after adding the specified time interval to the `timepoint`.
+     *
+     * <p>For example, {@code timestampAdd(TimeIntervalUnit.HOUR, +8, lit("2017-11-29
+     * 10:58:58.998").toDate())} returns `2017-11-29 18:58:58.998`'.
+     *
+     * @param timeIntervalUnit The unit of time interval.
+     * @param interval The time interval.
+     * @param timePoint The point of time.
+     * @return The time after adding the specified time interval to the `timepoint`.
+     */
+    public static ApiExpression timestampAdd(
+            TimeIntervalUnit timeIntervalUnit, Object interval, Object timePoint) {
+        return apiCall(
+                BuiltInFunctionDefinitions.TIMESTAMP_ADD,
+                valueLiteral(timeIntervalUnit),
+                interval,
+                timePoint);
     }
 
     /**

--- a/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
+++ b/flink-table/flink-table-api-scala/src/main/scala/org/apache/flink/table/api/ImplicitExpressionConversions.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.api
 import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.table.connector.source.abilities.SupportsSourceWatermark
-import org.apache.flink.table.expressions.{ApiExpressionUtils, Expression, TableSymbol, TimePointUnit}
+import org.apache.flink.table.expressions.{ApiExpressionUtils, Expression, TableSymbol, TimeIntervalUnit, TimePointUnit}
 import org.apache.flink.table.expressions.ApiExpressionUtils.{unresolvedCall, unresolvedRef, valueLiteral}
 import org.apache.flink.table.functions.{ImperativeAggregateFunction, ScalarFunction, TableFunction, UserDefinedFunctionHelper, _}
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions.{DISTINCT, RANGE_TO}
@@ -554,6 +554,28 @@ trait ImplicitExpressionConversions {
    */
   def dateFormat(timestamp: Expression, format: Expression): Expression = {
     Expressions.dateFormat(timestamp, format)
+  }
+
+  /**
+   * Returns the time after adding the specified time interval to the `timepoint`.
+   *
+   * For example, timestampAdd(TimeIntervalUnit.HOUR, +8, lit("2017-11-29 10:58:58.998").toDate())
+   * returns `2017-11-29 18:58:58.998`'.
+   *
+   * @param timeIntervalUnit
+   *   The unit of time interval.
+   * @param interval
+   *   The time interval.
+   * @param timePoint
+   *   The point of time.
+   * @return
+   *   The time after adding the specified time interval to the `timepoint`.
+   */
+  def timestampAdd(
+      timeIntervalUnit: TimeIntervalUnit,
+      interval: Expression,
+      timePoint: Expression): Expression = {
+    Expressions.timestampAdd(timeIntervalUnit, interval, timePoint)
   }
 
   /**

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.api.JsonQueryWrapper;
 import org.apache.flink.table.api.JsonType;
 import org.apache.flink.table.api.JsonValueOnEmptyOrError;
 import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.TimeIntervalUnit;
 import org.apache.flink.table.expressions.TimePointUnit;
 import org.apache.flink.table.types.inference.ArgumentTypeStrategy;
 import org.apache.flink.table.types.inference.ConstantArgumentCount;
@@ -1513,6 +1514,26 @@ public final class BuiltInFunctionDefinitions {
                                             logical(LogicalTypeFamily.CHARACTER_STRING),
                                             logical(LogicalTypeFamily.CHARACTER_STRING))))
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
+                    .build();
+
+    public static final BuiltInFunctionDefinition TIMESTAMP_ADD =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("timestampAdd")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    symbol(
+                                            TimeIntervalUnit.YEAR,
+                                            TimeIntervalUnit.QUARTER,
+                                            TimeIntervalUnit.MONTH,
+                                            TimeIntervalUnit.WEEK,
+                                            TimeIntervalUnit.DAY,
+                                            TimeIntervalUnit.HOUR,
+                                            TimeIntervalUnit.MINUTE,
+                                            TimeIntervalUnit.SECOND),
+                                    logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                    logical(LogicalTypeFamily.DATETIME)))
+                    .outputTypeStrategy(nullableIfArgs(explicit(TIME())))
                     .build();
 
     public static final BuiltInFunctionDefinition TIMESTAMP_DIFF =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -206,6 +206,8 @@ public class DirectConvertRule implements CallExpressionConvertRule {
         DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.DATE_FORMAT, FlinkSqlOperatorTable.DATE_FORMAT);
         DEFINITION_OPERATOR_MAP.put(
+                BuiltInFunctionDefinitions.TIMESTAMP_ADD, FlinkSqlOperatorTable.TIMESTAMP_ADD);
+        DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.CONVERT_TZ, FlinkSqlOperatorTable.CONVERT_TZ);
         DEFINITION_OPERATOR_MAP.put(
                 BuiltInFunctionDefinitions.FROM_UNIXTIME, FlinkSqlOperatorTable.FROM_UNIXTIME);

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/TemporalTypesTest.scala
@@ -1346,6 +1346,17 @@ class TemporalTypesTest extends ExpressionTestBase {
   }
 
   @Test
+  def testTimestampAdd(): Unit = {
+    testSqlApi("TIMESTAMPADD(MONTH, 8, TIMESTAMP '2020-03-01 00:00:00')", "2020-11-01 00:00:00")
+
+    testAllApis(
+      timestampAdd(TimeIntervalUnit.MONTH, 8, "2020-03-01 00:00:00".toTimestamp),
+      "TIMESTAMPADD(MONTH, 8, TIMESTAMP '2020-03-01 00:00:00')",
+      "2020-11-01 00:00:00"
+    )
+  }
+
+  @Test
   def testTimestampLtzArithmetic(): Unit = {
     // TIMESTAMP_LTZ +/- INTERVAL should support nanosecond
     testSqlApi(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
