### PR TITLE
Flink 29590 hive3

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionLoader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionLoader.java
@@ -136,11 +136,12 @@ public class PartitionLoader implements Closeable {
     private void overwrite(Path destDir) throws Exception {
         if (overwrite) {
             // delete existing files for overwrite
-            FileStatus[] existingFiles = listStatusWithoutHidden(destDir.getFileSystem(), destDir);
+            FileSystem destFS = destDir.getFileSystem();
+            FileStatus[] existingFiles = listStatusWithoutHidden(destFS, destDir);
             if (existingFiles != null) {
                 for (FileStatus existingFile : existingFiles) {
                     // TODO: We need move to trash when auto-purge is false.
-                    fs.delete(existingFile.getPath(), true);
+                    destFS.delete(existingFile.getPath(), true);
                 }
             }
         }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserTypeCheckProcFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserTypeCheckProcFactory.java
@@ -76,6 +76,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBaseCompare;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInternalInterval;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFNvl;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPDivide;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNegative;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNot;
@@ -88,6 +89,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.HiveDecimalUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.ListTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.MapTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
@@ -1234,6 +1236,46 @@ public class HiveParserTypeCheckProcFactory {
                     desc =
                             ExprNodeGenericFuncDesc.newInstance(
                                     new HiveGenericUDFInternalInterval(), funcText, children);
+                } else if (genericUDF instanceof GenericUDFOPDivide && children.size() == 2) {
+                    // special case for GenericUDFOPDivide
+                    // if the divisor or dividend is decimal type and the other one
+                    // parameter is int/long literal, the TypeInfo of the ExprNodeGenericFuncDesc
+                    // may be different with inferred result type, which will cause "Mismatch of
+                    // expected output data type 'DECIMAL(..)' and function's output type
+                    // 'DECIMAL(..)'" in BridgingFunctionGenUtil#verifyOutputType
+
+                    // the reason is: in here we got expected result type, which will consider
+                    // int/long literal parameter as actual precision,
+                    // but in the phase to infer result type phase, the
+                    // int/long literal parameter will always be considered as max precision. 10 for
+                    // int, and 19 for long.
+                    // To fix it, in here, we also should consider the int/long literal parameter as
+                    // max precision.
+                    ExprNodeDesc exprNodeDesc1 = children.get(0);
+                    ExprNodeDesc exprNodeDesc2 = children.get(1);
+                    // if one parameter is decimal type, and the other is int or long
+                    if ((isDecimalTypeInfo(exprNodeDesc1)
+                                    && isIntOrLongTypeInfo(exprNodeDesc2)
+                                    && exprNodeDesc2 instanceof ExprNodeConstantDesc)
+                            || isDecimalTypeInfo(exprNodeDesc2)
+                                    && isIntOrLongTypeInfo(exprNodeDesc1)
+                                    && exprNodeDesc1 instanceof ExprNodeConstantDesc) {
+                        // find which parameter we should change
+                        int childToChange = isIntOrLongTypeInfo(exprNodeDesc1) ? 0 : 1;
+                        // change the int/long literal parameter to decimal type with the max
+                        // precision of int/long literal which is consistent to infer logic.
+                        children.set(
+                                childToChange,
+                                new ExprNodeConstantDesc(
+                                        HiveDecimalUtils.getDecimalTypeForPrimitiveCategory(
+                                                (PrimitiveTypeInfo)
+                                                        children.get(childToChange).getTypeInfo()),
+                                        HiveDecimal.create(
+                                                ((ExprNodeConstantDesc) children.get(childToChange))
+                                                        .getValue()
+                                                        .toString())));
+                    }
+                    desc = ExprNodeGenericFuncDesc.newInstance(genericUDF, funcText, children);
                 } else {
                     desc = ExprNodeGenericFuncDesc.newInstance(genericUDF, funcText, children);
                 }
@@ -1246,7 +1288,13 @@ public class HiveParserTypeCheckProcFactory {
                         && HiveParserExprNodeDescUtils.isAllConstants(children)) {
                     ExprNodeDesc constantExpr =
                             ConstantPropagateProcFactory.foldExpr((ExprNodeGenericFuncDesc) desc);
-                    if (constantExpr != null) {
+                    if (constantExpr != null
+                            // if constantExpr is instanceof ExprNodeConstantDesc, we should check
+                            // whether it can be folded to constant safely for some folded constant
+                            // can't be converted to calcite literal currently.
+                            && (!(constantExpr instanceof ExprNodeConstantDesc)
+                                    || canSafeFoldToConstant(
+                                            (ExprNodeConstantDesc) constantExpr))) {
                         desc = constantExpr;
                     }
                 }
@@ -1353,6 +1401,46 @@ public class HiveParserTypeCheckProcFactory {
                 }
             }
             return false;
+        }
+
+        private boolean isDecimalTypeInfo(ExprNodeDesc exprNodeDesc) {
+            TypeInfo typeInfo = exprNodeDesc.getTypeInfo();
+            return typeInfo instanceof PrimitiveTypeInfo
+                    && ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory()
+                            == PrimitiveObjectInspector.PrimitiveCategory.DECIMAL;
+        }
+
+        private boolean isIntOrLongTypeInfo(ExprNodeDesc exprNodeDesc) {
+            TypeInfo typeInfo = exprNodeDesc.getTypeInfo();
+            if (!(typeInfo instanceof PrimitiveTypeInfo)) {
+                return false;
+            }
+            return ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory()
+                            == PrimitiveObjectInspector.PrimitiveCategory.INT
+                    || ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory()
+                            == PrimitiveObjectInspector.PrimitiveCategory.LONG;
+        }
+
+        private boolean canSafeFoldToConstant(ExprNodeConstantDesc constantExpr) {
+            // if it's not primitive type, can't be folded to constant safely
+            boolean isPrimitiveTyp = constantExpr.getTypeInfo() instanceof PrimitiveTypeInfo;
+            if (!isPrimitiveTyp) {
+                return false;
+            }
+            // if it's binary type, can't be folded to constant safely
+            boolean isBinaryConstant =
+                    constantExpr.getTypeInfo() instanceof PrimitiveTypeInfo
+                            && (((PrimitiveTypeInfo) constantExpr.getTypeInfo())
+                                            .getPrimitiveCategory()
+                                    == PrimitiveObjectInspector.PrimitiveCategory.BINARY);
+            if (isBinaryConstant) {
+                return false;
+            }
+            // if it's Double.NAN, can't be folded to constant safely
+            boolean isNAN =
+                    constantExpr.getValue() instanceof Double
+                            && Double.isNaN((Double) constantExpr.getValue());
+            return !isNAN;
         }
 
         protected ExprNodeDesc processQualifiedColRef(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserTypeCheckProcFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserTypeCheckProcFactory.java
@@ -1255,11 +1255,11 @@ public class HiveParserTypeCheckProcFactory {
                     ExprNodeDesc exprNodeDesc2 = children.get(1);
                     // if one parameter is decimal type, and the other is int or long
                     if ((isDecimalTypeInfo(exprNodeDesc1)
-                                    && isIntOrLongTypeInfo(exprNodeDesc2)
-                                    && exprNodeDesc2 instanceof ExprNodeConstantDesc)
-                            || isDecimalTypeInfo(exprNodeDesc2)
-                                    && isIntOrLongTypeInfo(exprNodeDesc1)
-                                    && exprNodeDesc1 instanceof ExprNodeConstantDesc) {
+                                    && exprNodeDesc2 instanceof ExprNodeConstantDesc
+                                    && isIntOrLongTypeInfo(exprNodeDesc2))
+                            || (isDecimalTypeInfo(exprNodeDesc2)
+                                    && exprNodeDesc1 instanceof ExprNodeConstantDesc
+                                    && isIntOrLongTypeInfo(exprNodeDesc1))) {
                         // find which parameter we should change
                         int childToChange = isIntOrLongTypeInfo(exprNodeDesc1) ? 0 : 1;
                         // change the int/long literal parameter to decimal type with the max
@@ -1436,10 +1436,12 @@ public class HiveParserTypeCheckProcFactory {
             if (isBinaryConstant) {
                 return false;
             }
-            // if it's Double.NAN, can't be folded to constant safely
+            // if it's NAN, can't be folded to constant safely
             boolean isNAN =
-                    constantExpr.getValue() instanceof Double
-                            && Double.isNaN((Double) constantExpr.getValue());
+                    ((constantExpr.getValue() instanceof Double
+                                    && Double.isNaN((Double) constantExpr.getValue()))
+                            || (constantExpr.getValue() instanceof Float
+                                    && Float.isNaN((Float) constantExpr.getValue())));
             return !isNAN;
         }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -39,6 +39,8 @@ import org.apache.flink.table.delegation.ExtendedOperationExecutor;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.functions.hive.HiveGenericUDTFTest;
 import org.apache.flink.table.functions.hive.util.TestSplitUDTFInitializeWithStructObjectInspector;
+import org.apache.flink.table.module.CoreModule;
+import org.apache.flink.table.module.hive.HiveModule;
 import org.apache.flink.table.operations.DescribeTableOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.command.AddJarOperation;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectITCase.java
@@ -39,8 +39,6 @@ import org.apache.flink.table.delegation.ExtendedOperationExecutor;
 import org.apache.flink.table.delegation.Parser;
 import org.apache.flink.table.functions.hive.HiveGenericUDTFTest;
 import org.apache.flink.table.functions.hive.util.TestSplitUDTFInitializeWithStructObjectInspector;
-import org.apache.flink.table.module.CoreModule;
-import org.apache.flink.table.module.hive.HiveModule;
 import org.apache.flink.table.operations.DescribeTableOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.operations.command.AddJarOperation;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -853,6 +853,29 @@ public class HiveDialectQueryITCase {
     }
 
     @Test
+    public void testLiteral() throws Exception {
+        List<Row> result =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("SELECT asin(2), binary('1'), struct(2, 9, 7)")
+                                .collect());
+        assertThat(result.toString()).isEqualTo("[+I[NaN, [49], +I[2, 9, 7]]]");
+        tableEnv.executeSql("create table test_decimal_literal(d decimal(10, 2))");
+        try {
+            tableEnv.executeSql("insert into test_decimal_literal values (1.2)").await();
+            result =
+                    CollectionUtil.iteratorToList(
+                            tableEnv.executeSql(
+                                            "select d / 3, d / 3L, 6 / d, 6L / d from test_decimal_literal")
+                                    .collect());
+            assertThat(result.toString())
+                    .isEqualTo("[+I[0.400000, 0.400000, 5.00000000000, 5.00000000000]]");
+
+        } finally {
+            tableEnv.executeSql("drop table test_decimal_literal");
+        }
+    }
+
+    @Test
     public void testCrossCatalogQueryNoHiveTable() throws Exception {
         // register a new in-memory catalog
         Catalog inMemoryCatalog = new GenericInMemoryCatalog("m_catalog", "db");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -858,7 +858,11 @@ public class HiveDialectQueryITCase {
                 CollectionUtil.iteratorToList(
                         tableEnv.executeSql("SELECT asin(2), binary('1'), struct(2, 9, 7)")
                                 .collect());
-        assertThat(result.toString()).isEqualTo("[+I[NaN, [49], +I[2, 9, 7]]]");
+        if (HiveVersionTestUtil.HIVE_310_OR_LATER) {
+            assertThat(result.toString()).isEqualTo("[+I[null, [49], +I[2, 9, 7]]]");
+        } else {
+            assertThat(result.toString()).isEqualTo("[+I[NaN, [49], +I[2, 9, 7]]]");
+        }
         tableEnv.executeSql("create table test_decimal_literal(d decimal(10, 2))");
         try {
             tableEnv.executeSql("insert into test_decimal_literal values (1.2)").await();

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -70,7 +70,7 @@ stages:
             name: Default
           e2e_pool_definition:
             vmImage: 'ubuntu-20.04'
-          environment: PROFILE="-Dflink.hadoop.version=2.8.5 -Dinclude_hadoop_aws -Dscala-2.12"
+          environment: PROFILE="-Dflink.hadoop.version=3.1.3 -Dinclude_hadoop_aws -Dscala-2.12 -Phadoop3-tests,hive3"
           run_end_to_end: false
           container: flink-build-container
           jdk: 8


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
