### PR TITLE
[FLINK-29623][Metrics][Prometheus] Update Prometheus Java Client to 0.16.0

### DIFF
--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<name>Flink : Metrics : Prometheus</name>
 
 	<properties>
-		<prometheus.version>0.8.1</prometheus.version>
+		<prometheus.version>0.16.0</prometheus.version>
 	</properties>
 
 	<dependencies>

--- a/flink-metrics/flink-metrics-prometheus/src/main/resources/META-INF/NOTICE
+++ b/flink-metrics/flink-metrics-prometheus/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- io.prometheus:simpleclient:0.8.1
-- io.prometheus:simpleclient_common:0.8.1
-- io.prometheus:simpleclient_httpserver:0.8.1
-- io.prometheus:simpleclient_pushgateway:0.8.1
+- io.prometheus:simpleclient:0.16.0
+- io.prometheus:simpleclient_common:0.16.0
+- io.prometheus:simpleclient_httpserver:0.16.0
+- io.prometheus:simpleclient_pushgateway:0.16.0
+- io.prometheus:simpleclient_tracer_common:0.16.0
+- io.prometheus:simpleclient_tracer_otel:0.16.0
+- io.prometheus:simpleclient_tracer_otel_agent:0.16.0


### PR DESCRIPTION
## What is the purpose of the change

* Flink uses an old and no longer supported version of io.prometheus:simpleclient. We should upgrade to the latest version

## Brief change log

* Updated POM and NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
