### PR TITLE
[FLINK-29624][Common][Connector][Filesystem] Upgrade commons-lang3 to 3.12.0

### DIFF
--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -40,7 +40,6 @@ under the License.
 		<!-- Test Libraries -->
 		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 		<os-maven-plugin.version>1.7.0</os-maven-plugin.version>
-		<pulsar-commons-lang3.version>3.11</pulsar-commons-lang3.version>
 		<pulsar-netty.version>4.1.77.Final</pulsar-netty.version>
 		<pulsar-grpc.version>1.45.1</pulsar-grpc.version>
 	</properties>
@@ -133,15 +132,6 @@ under the License.
 			<groupId>org.apache.pulsar</groupId>
 			<artifactId>pulsar-broker</artifactId>
 			<version>${pulsar.version}</version>
-			<scope>test</scope>
-		</dependency>
-
-		<!-- Pulsar use a newer commons-lang3 in broker. -->
-		<!-- Bump the version only for testing. -->
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>${pulsar-commons-lang3.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/src/main/resources/META-INF/NOTICE
@@ -10,7 +10,7 @@ This project bundles the following dependencies under the Apache Software Licens
  - io.netty:netty-all:4.1.70.Final
  - io.dropwizard.metrics:metrics-core:3.2.6
  - org.apache.commons:commons-crypto:1.0.0
- - org.apache.commons:commons-lang3:3.3.2
+ - org.apache.commons:commons-lang3:3.12.0
  - org.apache.hbase:hbase-client:2.2.3
  - org.apache.hbase:hbase-common:2.2.3
  - org.apache.hbase:hbase-protocol:2.2.3

--- a/flink-connectors/flink-sql-connector-hive-3.1.3/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-hive-3.1.3/src/main/resources/META-INF/NOTICE
@@ -6,8 +6,8 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.avro:avro:1.8.2
 - org.apache.avro:avro-mapred:hadoop2:1.8.2
+- org.apache.avro:avro:1.8.2
 - org.apache.hive:hive-exec:3.1.3
 
 This project bundles the following dependencies under the BSD license.
@@ -26,18 +26,18 @@ the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 - javax.jdo:jdo-api:3.0.1
 - joda-time:joda-time:2.9.9
 - net.sf.opencsv:opencsv:2.3
-- org.apache.commons:commons-lang3:3.9
+- org.apache.commons:commons-lang3:3.12.0
+- org.apache.hive.shims:hive-shims-0.23:3.1.3
+- org.apache.hive.shims:hive-shims-common:3.1.3
 - org.apache.hive:hive-common:3.1.3
 - org.apache.hive:hive-llap-client:3.1.3
 - org.apache.hive:hive-llap-common:3.1.3
 - org.apache.hive:hive-metastore:3.1.3
 - org.apache.hive:hive-serde:3.1.3
 - org.apache.hive:hive-service-rpc:3.1.3
+- org.apache.hive:hive-spark-client:3.1.3
 - org.apache.hive:hive-standalone-metastore:3.1.3
 - org.apache.hive:hive-storage-api:2.7.0
-- org.apache.hive:hive-spark-client:3.1.3
-- org.apache.hive.shims:hive-shims-0.23:3.1.3
-- org.apache.hive.shims:hive-shims-common:3.1.3
 - org.apache.orc:orc-core:1.5.8
 - org.apache.orc:orc-shims:1.5.8
 - org.apache.orc:orc-tools:1.5.8

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -11,6 +11,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-lang:commons-lang:2.6
 - commons-logging:commons-logging:1.1.3
 - commons-codec:commons-codec:1.15
-- org.apache.commons:commons-lang3:3.3.2
+- org.apache.commons:commons-lang3:3.12.0
 - com.google.guava:guava:29.0-jre
 - com.google.guava:failureaccess:1.0.1

--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -63,6 +63,13 @@ under the License.
 			<!-- managed version -->
 		</dependency>
 
+		<!-- standard utilities -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+			<!-- managed version -->
+		</dependency>
+
 		<!-- for the fallback generic serializer -->
 		<dependency>
 			<groupId>com.esotericsoftware.kryo</groupId>

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.ververica:frocksdbjni:6.20.3-ververica-1.0
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
+- com.ververica:frocksdbjni:6.20.3-ververica-1.0
 - commons-cli:commons-cli:1.5.0
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.11.0

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -13,8 +13,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-collections:commons-collections:3.2.2
 - commons-io:commons-io:2.11.0
 - org.apache.commons:commons-compress:1.21
-- org.apache.commons:commons-lang3:3.3.2
+- org.apache.commons:commons-lang3:3.12.0
 - org.apache.commons:commons-math3:3.6.1
+- org.apache.commons:commons-text:1.10.0
 - org.javassist:javassist:3.24.0-GA
 - org.lz4:lz4-java:1.8.0
 - org.objenesis:objenesis:2.1

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -20,8 +20,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - commons-logging:commons-logging:1.1.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.3.2
-- org.apache.commons:commons-text:1.4
+- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.4

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -26,8 +26,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - joda-time:joda-time:2.5
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.3.2
-- org.apache.commons:commons-text:1.4
+- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.4

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -38,8 +38,8 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.alluxio:alluxio-shaded-client:2.7.3
 - org.apache.commons:commons-compress:1.21
 - org.apache.commons:commons-configuration2:2.1.1
-- org.apache.commons:commons-lang3:3.3.2
-- org.apache.commons:commons-text:1.4
+- org.apache.commons:commons-lang3:3.12.0
+- org.apache.commons:commons-text:1.10.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop:hadoop-annotations:3.3.4

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvCommons.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvCommons.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.ValidationException;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.HashSet;
 import java.util.Set;

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFileFormatFactory.java
@@ -53,7 +53,7 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.node.Obje
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.dataformat.csv.CsvSchema;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Collections;
 import java.util.List;

--- a/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatFactory.java
+++ b/flink-formats/flink-csv/src/main/java/org/apache/flink/formats/csv/CsvFormatFactory.java
@@ -39,7 +39,7 @@ import org.apache.flink.table.factories.SerializationFormatFactory;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.Collections;
 import java.util.Set;

--- a/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/PlanJSONDumpGenerator.java
+++ b/flink-optimizer/src/main/java/org/apache/flink/optimizer/plandump/PlanJSONDumpGenerator.java
@@ -41,7 +41,7 @@ import org.apache.flink.runtime.operators.DriverStrategy;
 import org.apache.flink.runtime.operators.shipping.ShipStrategyType;
 import org.apache.flink.util.StringUtils;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -143,6 +143,11 @@ under the License.
 		</dependency>
 
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-text</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 		</dependency>

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonPlanGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/jsonplan/JsonPlanGenerator.java
@@ -30,7 +30,7 @@ import org.apache.flink.runtime.scheduler.adaptive.allocator.VertexParallelism;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonFactory;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.io.StringWriter;
 import java.util.Collections;

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
@@ -40,7 +40,7 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.util.SqlShuttle;
 import org.apache.calcite.util.NlsString;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointITCase.java
@@ -247,8 +247,8 @@ public class UnalignedCheckpointITCase extends UnalignedCheckpointTestBase {
                 .map(
                         params ->
                                 new Object[][] {
-                                    ArrayUtils.add(params, 0),
-                                    ArrayUtils.add(params, BUFFER_PER_CHANNEL)
+                                    ArrayUtils.insert(params.length, params, 0),
+                                    ArrayUtils.insert(params.length, params, BUFFER_PER_CHANNEL)
                                 })
                 .flatMap(Arrays::stream)
                 .toArray(Object[][]::new);

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/UnalignedCheckpointRescaleITCase.java
@@ -504,8 +504,8 @@ public class UnalignedCheckpointRescaleITCase extends UnalignedCheckpointTestBas
                 .map(
                         params ->
                                 new Object[][] {
-                                    ArrayUtils.add(params, 0),
-                                    ArrayUtils.add(params, BUFFER_PER_CHANNEL)
+                                    ArrayUtils.insert(params.length, params, 0),
+                                    ArrayUtils.insert(params.length, params, BUFFER_PER_CHANNEL)
                                 })
                 .flatMap(Arrays::stream)
                 .toArray(Object[][]::new);

--- a/pom.xml
+++ b/pom.xml
@@ -532,7 +532,13 @@ under the License.
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.3.2</version>
+				<version>3.12.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>1.10.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
## What is the purpose of the change

* Upgrade org.apache.commons:commons-lang3 from 3.3.2 to 3.12.0 to avoid being falsely flagged for CVEs CVE-2021-29425 and CVE-2020-15250

## Brief change log

* Update POM file and NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
