### PR TITLE
[FLINK-29626][Runtime] Update Akka to 2.6.20

### DIFF
--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -201,6 +201,17 @@ under the License.
 										<exclude>META-INF/NOTICE.txt</exclude>
 									</excludes>
 								</filter>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<!-- Only some of these licenses actually apply to the JAR and have been manually
+											 placed in this module's resources directory. -->
+										<exclude>LICENSE</exclude>
+										<!-- Only parts of NOTICE file actually apply to the netty JAR and have been manually
+											 copied into this modules's NOTICE file. -->
+										<exclude>NOTICE</exclude>
+									</excludes>
+								</filter>
 							</filters>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -145,11 +145,6 @@ under the License.
 				<artifactId>scala-reflect</artifactId>
 				<version>${scala.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>org.scala-lang.modules</groupId>
-				<artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
-				<version>1.1.2</version>
-			</dependency>
 			<!-- For dependency convergence in Akka 2.6.20 -->
 			<dependency>
 				<groupId>com.typesafe</groupId>
@@ -202,13 +197,10 @@ under the License.
 									</excludes>
 								</filter>
 								<filter>
-									<artifact>*:*</artifact>
+									<artifact>org.scala-lang:*</artifact>
 									<excludes>
-										<!-- Only some of these licenses actually apply to the JAR and have been manually
-											 placed in this module's resources directory. -->
+										<!-- For deduplication purposes. -->
 										<exclude>LICENSE</exclude>
-										<!-- Only parts of NOTICE file actually apply to the netty JAR and have been manually
-											 copied into this modules's NOTICE file. -->
 										<exclude>NOTICE</exclude>
 									</excludes>
 								</filter>

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<akka.version>2.6.15</akka.version>
+		<akka.version>2.6.20</akka.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<scala.version>2.12.7</scala.version>
 	</properties>

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -150,6 +150,12 @@ under the License.
 				<artifactId>scala-parser-combinators_${scala.binary.version}</artifactId>
 				<version>1.1.2</version>
 			</dependency>
+			<!-- For dependency convergence in Akka 2.6.20 -->
+			<dependency>
+				<groupId>com.typesafe</groupId>
+				<artifactId>config</artifactId>
+				<version>1.4.2</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<properties>
 		<akka.version>2.6.20</akka.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<scala.version>2.12.7</scala.version>
+		<scala.version>2.12.16</scala.version>
 	</properties>
 
 	<dependencies>

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -9,12 +9,12 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.hierynomus:asn-one:0.5.0
 - com.typesafe:config:1.4.0
 - com.typesafe:ssl-config-core_2.12:0.4.2
-- com.typesafe.akka:akka-actor_2.12:2.6.15
-- com.typesafe.akka:akka-remote_2.12:2.6.15
-- com.typesafe.akka:akka-pki_2.12:2.6.15
-- com.typesafe.akka:akka-protobuf-v3_2.12:2.6.15
-- com.typesafe.akka:akka-slf4j_2.12:2.6.15
-- com.typesafe.akka:akka-stream_2.12:2.6.15
+- com.typesafe.akka:akka-actor_2.12:2.6.20
+- com.typesafe.akka:akka-remote_2.12:2.6.20
+- com.typesafe.akka:akka-pki_2.12:2.6.20
+- com.typesafe.akka:akka-protobuf-v3_2.12:2.6.20
+- com.typesafe.akka:akka-slf4j_2.12:2.6.20
+- com.typesafe.akka:akka-stream_2.12:2.6.20
 - io.netty:netty:3.10.6.Final
 - org.agrona:agrona:1.9.0
 

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.hierynomus:asn-one:0.5.0
 - com.typesafe:config:1.4.2
-- com.typesafe:ssl-config-core_2.12:0.4.2
+- com.typesafe:ssl-config-core_2.12:0.4.3
 - com.typesafe.akka:akka-actor_2.12:2.6.20
 - com.typesafe.akka:akka-remote_2.12:2.6.20
 - com.typesafe.akka:akka-pki_2.12:2.6.20

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.hierynomus:asn-one:0.5.0
-- com.typesafe:config:1.4.0
+- com.typesafe:config:1.4.2
 - com.typesafe:ssl-config-core_2.12:0.4.2
 - com.typesafe.akka:akka-actor_2.12:2.6.20
 - com.typesafe.akka:akka-remote_2.12:2.6.20

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -17,14 +17,14 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.typesafe.akka:akka-stream_2.12:2.6.20
 - io.netty:netty:3.10.6.Final
 - org.agrona:agrona:1.15.1
-
-The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
-
 - org.scala-lang:scala-compiler:2.12.16
 - org.scala-lang:scala-library:2.12.16
 - org.scala-lang:scala-reflect:2.12.16
-- org.scala-lang.modules:scala-java8-compat_2.12:0.8.0
 - org.scala-lang.modules:scala-parser-combinators_2.12:1.1.2
+
+The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
+
+- org.scala-lang.modules:scala-java8-compat_2.12:0.8.0
 - org.scala-lang.modules:scala-xml_2.12:1.0.6
 
 This project bundles the following dependencies under the Creative Commons CC0 "No Rights Reserved".
@@ -65,3 +65,20 @@ WebSocket and HTTP server:
     * licenses/LICENSE.webbit (BSD License)
   * HOMEPAGE:
     * https://github.com/joewalnes/webbit
+
+Scala
+Copyright (c) 2002-2022 EPFL
+Copyright (c) 2011-2022 Lightbend, Inc.
+
+Scala includes software developed at
+LAMP/EPFL (https://lamp.epfl.ch/) and
+Lightbend, Inc. (https://www.lightbend.com/).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This software includes projects with other licenses -- see `doc/LICENSE.md`.

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -16,7 +16,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.typesafe.akka:akka-slf4j_2.12:2.6.20
 - com.typesafe.akka:akka-stream_2.12:2.6.20
 - io.netty:netty:3.10.6.Final
-- org.agrona:agrona:1.9.0
+- org.agrona:agrona:1.15.1
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 

--- a/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
+++ b/flink-rpc/flink-rpc-akka/src/main/resources/META-INF/NOTICE
@@ -20,9 +20,9 @@ This project bundles the following dependencies under the Apache Software Licens
 
 The following dependencies all share the same BSD license which you find under licenses/LICENSE.scala.
 
-- org.scala-lang:scala-compiler:2.12.7
-- org.scala-lang:scala-library:2.12.7
-- org.scala-lang:scala-reflect:2.12.7
+- org.scala-lang:scala-compiler:2.12.16
+- org.scala-lang:scala-library:2.12.16
+- org.scala-lang:scala-reflect:2.12.16
 - org.scala-lang.modules:scala-java8-compat_2.12:0.8.0
 - org.scala-lang.modules:scala-parser-combinators_2.12:1.1.2
 - org.scala-lang.modules:scala-xml_2.12:1.0.6


### PR DESCRIPTION
## What is the purpose of the change

* Update Akka to the latest 2.6 patch version, which is still under Apache license

## Brief change log

* Updated POM and NOTICE files

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
 
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
