### PR TITLE
[Flink 29627][streaming][test] Adding new test to SinkITCase.java that will test SinkV1 architecture with Cluster recovery scenario.

### DIFF
--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/CheckpointCountingSource.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/streaming/util/CheckpointCountingSource.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.util;
+
+import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.function.Function;
+
+/**
+ * Each of the source operators outputs records in given number of checkpoints. Number of records
+ * per checkpoint is constant between checkpoints, and defined by user. When all records are
+ * emitted, the source waits for two more checkpoints until it finishes.
+ *
+ * <p>Main credits for this implementation should go to <b>Grzegorz
+ * Kolakowski/https://github.com/grzegorz8</b> who implemented the original version of this class
+ * for Delta-Flink connector.
+ */
+public class CheckpointCountingSource<OUT> extends RichParallelSourceFunction<OUT>
+        implements CheckpointListener, CheckpointedFunction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CheckpointCountingSource.class);
+
+    private final int numberOfCheckpoints;
+    private final int recordsPerCheckpoint;
+    private final Function<Integer, OUT> elementProducer;
+
+    private ListState<Integer> nextValueState;
+    private int nextValue;
+    private volatile boolean isCanceled;
+    private volatile boolean waitingForCheckpoint;
+
+    public CheckpointCountingSource(
+            int recordsPerCheckpoint,
+            int numberOfCheckpoints,
+            Function<Integer, OUT> elementProducer) {
+        this.numberOfCheckpoints = numberOfCheckpoints;
+        this.recordsPerCheckpoint = recordsPerCheckpoint;
+        this.elementProducer = elementProducer;
+    }
+
+    @Override
+    public void initializeState(FunctionInitializationContext context) throws Exception {
+        nextValueState =
+                context.getOperatorStateStore()
+                        .getListState(new ListStateDescriptor<>("nextValue", Integer.class));
+
+        if (nextValueState.get() != null && nextValueState.get().iterator().hasNext()) {
+            nextValue = nextValueState.get().iterator().next();
+        }
+        waitingForCheckpoint = false;
+    }
+
+    @Override
+    public void run(SourceContext<OUT> ctx) throws Exception {
+        LOGGER.info(
+                "Run subtask={}; attempt={}.",
+                getRuntimeContext().getIndexOfThisSubtask(),
+                getRuntimeContext().getAttemptNumber());
+
+        sendRecordsUntil(numberOfCheckpoints, ctx);
+        idleUntilNextCheckpoint(ctx);
+        LOGGER.info("Source task done; subtask={}.", getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    private void sendRecordsUntil(int targetCheckpoints, SourceContext<OUT> ctx)
+            throws InterruptedException {
+        while (!isCanceled && nextValue < targetCheckpoints * recordsPerCheckpoint) {
+            synchronized (ctx.getCheckpointLock()) {
+                emitRecordsBatch(recordsPerCheckpoint, ctx);
+                waitingForCheckpoint = true;
+            }
+            LOGGER.info(
+                    "Waiting for checkpoint to complete; subtask={}.",
+                    getRuntimeContext().getIndexOfThisSubtask());
+            while (waitingForCheckpoint) {
+                Thread.sleep(100);
+            }
+        }
+    }
+
+    private void emitRecordsBatch(int batchSize, SourceContext<OUT> ctx) {
+        for (int i = 0; i < batchSize; ++i) {
+            OUT row = elementProducer.apply(nextValue++);
+            ctx.collect(row);
+        }
+
+        LOGGER.info(
+                "Emitted {} records (total {}); subtask={}.",
+                batchSize,
+                nextValue,
+                getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    private void idleUntilNextCheckpoint(SourceContext<OUT> ctx) throws InterruptedException {
+        // Idle until the next checkpoint completes to avoid any premature job termination and
+        // race conditions.
+        LOGGER.info(
+                "Waiting for an additional checkpoint to complete; subtask={}.",
+                getRuntimeContext().getIndexOfThisSubtask());
+        synchronized (ctx.getCheckpointLock()) {
+            waitingForCheckpoint = true;
+        }
+        while (waitingForCheckpoint) {
+            Thread.sleep(100);
+        }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        nextValueState.update(Collections.singletonList(nextValue));
+        LOGGER.info(
+                "state snapshot done; checkpointId={}; subtask={}.",
+                context.getCheckpointId(),
+                getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) {
+        waitingForCheckpoint = false;
+        LOGGER.info(
+                "Checkpoint {} complete; subtask={}.",
+                checkpointId,
+                getRuntimeContext().getIndexOfThisSubtask());
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) throws Exception {
+        LOGGER.info(
+                "Checkpoint {} aborted; subtask={}.",
+                checkpointId,
+                getRuntimeContext().getIndexOfThisSubtask());
+        CheckpointListener.super.notifyCheckpointAborted(checkpointId);
+    }
+
+    @Override
+    public void cancel() {
+        isCanceled = true;
+    }
+}

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkITCase.java
@@ -22,6 +22,9 @@ import org.apache.flink.api.common.typeinfo.IntegerTypeInfo;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.runtime.operators.sink.TestSink;
+import org.apache.flink.streaming.runtime.operators.sink.TestSink.FailOnCommitGlobalCommitter;
+import org.apache.flink.streaming.runtime.operators.sink.TestSink.StringCommittableSerializer;
+import org.apache.flink.streaming.util.CheckpointCountingSource;
 import org.apache.flink.streaming.util.FiniteTestSource;
 import org.apache.flink.test.util.AbstractTestBase;
 
@@ -31,10 +34,13 @@ import org.junit.Test;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.BooleanSupplier;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -42,6 +48,8 @@ import static java.util.stream.Collectors.joining;
 import static org.apache.flink.streaming.runtime.operators.sink.TestSink.END_OF_INPUT_STR;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 /**
  * Integration test for {@link org.apache.flink.api.connector.sink.Sink} run time implementation.
@@ -111,6 +119,68 @@ public class SinkITCase extends AbstractTestBase {
     public void init() {
         COMMIT_QUEUE.clear();
         GLOBAL_COMMIT_QUEUE.clear();
+    }
+
+    /**
+     * This test executes Sink operator with committer and global committer. The global committer
+     * throws exception on 3rd checkpoint (commitNumberToFailOn == 2). The local mini cluster is
+     * executing the recovery, we should expect no data loss. In this particular setup unique number
+     * of rows persisted by committer should be same as unique number of rows persisted by
+     * GlobalCommitter.
+     */
+    @Test
+    public void testGlobalCommitterNotMissingRecordsDuringRecovery() throws Exception {
+
+        final StreamExecutionEnvironment env = buildStreamEnv();
+        env.enableCheckpointing(5000L);
+        env.setParallelism(1);
+
+        final int commitNumberToFailOn = 2;
+        final int recordsPerCheckpoint = 20;
+        final int numberOfCheckpoints = 5;
+        final int expectedNumberOfRecords = recordsPerCheckpoint * numberOfCheckpoints;
+
+        CheckpointCountingSource<Integer> source =
+                new CheckpointCountingSource<>(
+                        recordsPerCheckpoint,
+                        numberOfCheckpoints,
+                        (Function<Integer, Integer> & Serializable) i -> i);
+
+        env.addSource(source, IntegerTypeInfo.INT_TYPE_INFO)
+                .setParallelism(1)
+                .sinkTo(
+                        TestSink.newBuilder()
+                                .setDefaultCommitter(
+                                        (Supplier<Queue<String>> & Serializable) () -> COMMIT_QUEUE)
+                                .setGlobalCommitter(
+                                        new FailOnCommitGlobalCommitter(
+                                                commitNumberToFailOn,
+                                                (Supplier<Queue<String>> & Serializable)
+                                                        () -> GLOBAL_COMMIT_QUEUE))
+                                .setGlobalCommittableSerializer(
+                                        StringCommittableSerializer.INSTANCE)
+                                .build())
+                .setParallelism(2);
+
+        env.execute();
+
+        GLOBAL_COMMIT_QUEUE.remove(END_OF_INPUT_STR);
+
+        // Convert to Set to get only unique values, discard duplicates after source recovery.
+        Set<String> committerData = new HashSet<>(COMMIT_QUEUE);
+        Set<String> globalCommittedData = new HashSet<>(getSplittedGlobalCommittedData());
+
+        assertAll(
+                () -> {
+                    assertThat(
+                            "Committer lost data.",
+                            committerData.size(),
+                            equalTo(expectedNumberOfRecords));
+                    assertThat(
+                            "GlobalCommitter lost data.",
+                            globalCommittedData.size(),
+                            equalTo(expectedNumberOfRecords));
+                });
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

This PR is based on [PR-21101](https://github.com/apache/flink/pull/21101) and will have to be rebased. 

Add integration test for SinkV1 archtecture to verify end to end tickets [FLINK-29627](https://issues.apache.org/jira/browse/FLINK-29627). 

Test verifies cluster recovery scenario after Exception throw from GlobalCommitter before committing data. Test expects certain number of records processed by Commiters and GlobalCommitter.

Additionally add a new test V1 Source CheckpointCountingSource used in new SinkITCase::testGlobalCommitterNotMissingRecordsDuringRecovery test.

## Brief change log
- Add new integration test `SinkITCase::testGlobalCommitterNotMissingRecordsDuringRecovery` to check Sink V1 recovery. Test expects certain number of records processed by Commiters and GlobalCommitter. 
- Add new test V1 Source `CheckpointCountingSource` used in new `SinkITCase::testGlobalCommitterNotMissingRecordsDuringRecovery` test.

## Verifying this change
PR adds new tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
