### PR TITLE
[FLINK-29613][Connector/Pulsar] Fix wrong batch size assertion.

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/start/MessageIdStartCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/start/MessageIdStartCursor.java
@@ -23,7 +23,6 @@ import org.apache.flink.connector.pulsar.source.enumerator.cursor.StartCursor;
 
 import org.apache.pulsar.client.api.ConsumerBuilder;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 
 import static org.apache.flink.connector.pulsar.source.enumerator.cursor.MessageIdUtils.nextMessageId;
 import static org.apache.flink.connector.pulsar.source.enumerator.cursor.MessageIdUtils.unwrapMessageId;
@@ -49,11 +48,12 @@ public class MessageIdStartCursor implements StartCursor {
      *     MessageId#latest}.
      */
     public MessageIdStartCursor(MessageId messageId, boolean inclusive) {
-        MessageIdImpl idImpl = unwrapMessageId(messageId);
-        if (MessageId.earliest.equals(idImpl) || MessageId.latest.equals(idImpl) || inclusive) {
-            this.messageId = idImpl;
+        if (MessageId.earliest.equals(messageId)
+                || MessageId.latest.equals(messageId)
+                || inclusive) {
+            this.messageId = unwrapMessageId(messageId);
         } else {
-            this.messageId = nextMessageId(idImpl);
+            this.messageId = nextMessageId(messageId);
         }
     }
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/MessageIdStopCursor.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/stop/MessageIdStopCursor.java
@@ -22,7 +22,6 @@ import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
-import org.apache.pulsar.client.impl.MessageIdImpl;
 
 import static org.apache.flink.connector.pulsar.source.enumerator.cursor.MessageIdUtils.unwrapMessageId;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -41,13 +40,10 @@ public class MessageIdStopCursor implements StopCursor {
     private final boolean inclusive;
 
     public MessageIdStopCursor(MessageId messageId, boolean inclusive) {
-        MessageIdImpl idImpl = unwrapMessageId(messageId);
-        checkArgument(!earliest.equals(idImpl), "MessageId.earliest is not supported.");
-        checkArgument(
-                !latest.equals(idImpl),
-                "MessageId.latest is not supported, use LatestMessageStopCursor instead.");
+        checkArgument(!earliest.equals(messageId), "MessageId.earliest is not supported.");
+        checkArgument(!latest.equals(messageId), "Use LatestMessageStopCursor instead.");
 
-        this.messageId = idImpl;
+        this.messageId = unwrapMessageId(messageId);
         this.inclusive = inclusive;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

Pulsar did a wrong batch message size assertion in code. We require every batch message should have size 1. But sometimes the message size could be 0 due to the serialization and deserialization. So we should change the assertion logic.

## Brief change log

Change the implementation in `MessageIdUtils.unwrapMessageId(MessageId)`.

## Verifying this change

This change is a trivial fix without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
