### PR TITLE
[FLINK-28960][Connector/Pulsar] Add jaxb-api back to pulsar-client-all dependencies.

### DIFF
--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -174,10 +174,6 @@ under the License.
 					<artifactId>validation-api</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>javax.xml.bind</groupId>
-					<artifactId>jaxb-api</artifactId>
-				</exclusion>
-				<exclusion>
 					<groupId>net.jcip</groupId>
 					<artifactId>jcip-annotations</artifactId>
 				</exclusion>


### PR DESCRIPTION
## What is the purpose of the change

`pulsar-client-all` requires `jaxb-api` to serialize some Admin API. We shouldn't exclude it in current dependency list. So we just add it back to `flink-connector-pulsar`.

## Brief change log

Same above.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
