### PR TITLE
[FLINK-26822] Add Source for Cassandra connector

### DIFF
--- a/flink-connectors/flink-connector-cassandra/pom.xml
+++ b/flink-connectors/flink-connector-cassandra/pom.xml
@@ -95,6 +95,12 @@ under the License.
 			<version>${project.version}</version>
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 
 		<!--Using datastax provided shaded driver which includes relocated netty-->
 		<!--https://docs.datastax.com/en/developer/java-driver/3.1/manual/shaded_jar/-->
@@ -191,6 +197,12 @@ under the License.
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils</artifactId>
 			<version>${project.version}</version>
 			<scope>test</scope>
@@ -214,5 +226,5 @@ under the License.
 			<artifactId>flink-architecture-tests-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-	</dependencies>
+  </dependencies>
 </project>

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/CassandraSource.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/CassandraSource.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.java.ClosureCleaner;
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+import org.apache.flink.connector.cassandra.source.enumerator.CassandraEnumeratorState;
+import org.apache.flink.connector.cassandra.source.enumerator.CassandraEnumeratorStateSerializer;
+import org.apache.flink.connector.cassandra.source.enumerator.CassandraSplitEnumerator;
+import org.apache.flink.connector.cassandra.source.reader.CassandraSourceReader;
+import org.apache.flink.connector.cassandra.source.reader.CassandraSplitReader;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplit;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplitSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.streaming.connectors.cassandra.MapperOptions;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * A bounded source to read from Cassandra and return a collection of entities as {@code
+ * DataStream<Entity>}. An entity is built by Cassandra mapper ({@code
+ * com.datastax.driver.mapping.EntityMapper}) based on a POJO containing annotations (as described
+ * in <a
+ * href="https://docs.datastax.com/en/developer/java-driver/3.11/manual/object_mapper/creating/">
+ * Cassandra object mapper</a>).
+ *
+ * <p>To use it, do the following:
+ *
+ * <pre>{@code
+ * ClusterBuilder clusterBuilder = new ClusterBuilder() {
+ *   @Override
+ *   protected Cluster buildCluster(Cluster.Builder builder) {
+ *     return builder.addContactPointsWithPorts(new InetSocketAddress(HOST,PORT))
+ *                   .withQueryOptions(new QueryOptions().setConsistencyLevel(CL))
+ *                   .withSocketOptions(new SocketOptions()
+ *                   .setConnectTimeoutMillis(CONNECT_TIMEOUT)
+ *                   .setReadTimeoutMillis(READ_TIMEOUT))
+ *                   .build();
+ *   }
+ * };
+ * Source cassandraSource = new CassandraSource(clusterBuilder,
+ *                                              Pojo.class,
+ *                                              "select ... from KEYSPACE.TABLE ...;",
+ *                                              () -> new Mapper.Option[] {Mapper.Option.saveNullFields(true)});
+ *
+ * DataStream<Pojo> stream = env.fromSource(cassandraSource, WatermarkStrategy.noWatermarks(),
+ * "CassandraSource");
+ * }</pre>
+ */
+@PublicEvolving
+public class CassandraSource<OUT>
+        implements Source<OUT, CassandraSplit, CassandraEnumeratorState>, ResultTypeQueryable<OUT> {
+
+    public static final String CQL_PROHIBITTED_CLAUSES_REGEXP =
+            "(?i).*(AVG|COUNT|MIN|MAX|SUM|ORDER|GROUP BY).*";
+    private static final long serialVersionUID = 7773196541275567433L;
+
+    private final ClusterBuilder clusterBuilder;
+    private final Class<OUT> pojoClass;
+    private final String query;
+    private final MapperOptions mapperOptions;
+
+    public CassandraSource(
+            ClusterBuilder clusterBuilder,
+            Class<OUT> pojoClass,
+            String query,
+            MapperOptions mapperOptions) {
+        checkNotNull(clusterBuilder, "ClusterBuilder required but not provided");
+        checkNotNull(pojoClass, "POJO class required but not provided");
+        checkQueryValidity(query);
+        this.clusterBuilder = clusterBuilder;
+        ClosureCleaner.clean(clusterBuilder, ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+        this.pojoClass = pojoClass;
+        this.query = query;
+        this.mapperOptions = mapperOptions;
+    }
+
+    @Override
+    public Boundedness getBoundedness() {
+        return Boundedness.BOUNDED;
+    }
+
+    @Override
+    public SourceReader<OUT, CassandraSplit> createReader(SourceReaderContext readerContext) {
+        return new CassandraSourceReader<>(
+                readerContext, clusterBuilder, pojoClass, query, mapperOptions);
+    }
+
+    @Override
+    public SplitEnumerator<CassandraSplit, CassandraEnumeratorState> createEnumerator(
+            SplitEnumeratorContext<CassandraSplit> enumContext) {
+        return new CassandraSplitEnumerator(enumContext, null, clusterBuilder);
+    }
+
+    @Override
+    public SplitEnumerator<CassandraSplit, CassandraEnumeratorState> restoreEnumerator(
+            SplitEnumeratorContext<CassandraSplit> enumContext,
+            CassandraEnumeratorState enumCheckpoint) {
+        return new CassandraSplitEnumerator(enumContext, enumCheckpoint, clusterBuilder);
+    }
+
+    @Override
+    public SimpleVersionedSerializer<CassandraSplit> getSplitSerializer() {
+        return CassandraSplitSerializer.INSTANCE;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<CassandraEnumeratorState> getEnumeratorCheckpointSerializer() {
+        return CassandraEnumeratorStateSerializer.INSTANCE;
+    }
+
+    @Override
+    public TypeInformation<OUT> getProducedType() {
+        return TypeInformation.of(pojoClass);
+    }
+
+    @VisibleForTesting
+    public static void checkQueryValidity(String query) {
+        checkNotNull(query, "query required but not provided");
+        checkState(
+                query.matches(CassandraSplitReader.SELECT_REGEXP),
+                "query must be of the form select ... from keyspace.table ...;");
+        checkState(
+                !query.matches(CQL_PROHIBITTED_CLAUSES_REGEXP),
+                "query must not contain aggregate or order clauses because they will be done per split. "
+                        + "So they will be incorrect after merging the splits");
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/CassandraSource.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/CassandraSource.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.cassandra.source;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.ExecutionConfig;
@@ -108,18 +109,21 @@ public class CassandraSource<OUT>
         return Boundedness.BOUNDED;
     }
 
+    @Internal
     @Override
     public SourceReader<OUT, CassandraSplit> createReader(SourceReaderContext readerContext) {
         return new CassandraSourceReader<>(
                 readerContext, clusterBuilder, pojoClass, query, mapperOptions);
     }
 
+    @Internal
     @Override
     public SplitEnumerator<CassandraSplit, CassandraEnumeratorState> createEnumerator(
             SplitEnumeratorContext<CassandraSplit> enumContext) {
         return new CassandraSplitEnumerator(enumContext, null, clusterBuilder);
     }
 
+    @Internal
     @Override
     public SplitEnumerator<CassandraSplit, CassandraEnumeratorState> restoreEnumerator(
             SplitEnumeratorContext<CassandraSplit> enumContext,
@@ -127,11 +131,13 @@ public class CassandraSource<OUT>
         return new CassandraSplitEnumerator(enumContext, enumCheckpoint, clusterBuilder);
     }
 
+    @Internal
     @Override
     public SimpleVersionedSerializer<CassandraSplit> getSplitSerializer() {
         return CassandraSplitSerializer.INSTANCE;
     }
 
+    @Internal
     @Override
     public SimpleVersionedSerializer<CassandraEnumeratorState> getEnumeratorCheckpointSerializer() {
         return CassandraEnumeratorStateSerializer.INSTANCE;

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraEnumeratorState.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraEnumeratorState.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.enumerator;
+
+import org.apache.flink.connector.cassandra.source.split.CassandraSplit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/** Sate for {@link CassandraSplitEnumerator} to track the splits yet to assign. */
+public class CassandraEnumeratorState implements Serializable {
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraEnumeratorState.class);
+
+    // map readerId to splits
+    private final Map<Integer, Set<CassandraSplit>> unassignedSplits = new HashMap<>();
+
+    public void addNewSplits(Collection<CassandraSplit> newSplits, int numReaders) {
+        for (CassandraSplit split : newSplits) {
+            int ownerReader = getOwnerReader(numReaders, split);
+            unassignedSplits.computeIfAbsent(ownerReader, r -> new HashSet<>()).add(split);
+        }
+    }
+
+    private int getOwnerReader(int numReaders, CassandraSplit split) {
+        // readerId == subTaksId == 0 or 1 if numReaders == 2 so  modulo is fine for ownerReader
+        final int rawOwnerId = split.splitId().hashCode() % numReaders;
+        // split.splitId().hashCode() can be negative
+        return Math.abs(rawOwnerId);
+    }
+
+    public Set<CassandraSplit> getSplitsForReader(int readerId) {
+        return unassignedSplits.remove(readerId);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CassandraEnumeratorState that = (CassandraEnumeratorState) o;
+        return this.unassignedSplits.equals(that.unassignedSplits);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(unassignedSplits);
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraEnumeratorStateSerializer.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraEnumeratorStateSerializer.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.enumerator;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/** Serializer for {@link CassandraEnumeratorState}. */
+public class CassandraEnumeratorStateSerializer
+        implements SimpleVersionedSerializer<CassandraEnumeratorState> {
+
+    public static final CassandraEnumeratorStateSerializer INSTANCE =
+            new CassandraEnumeratorStateSerializer();
+    public static final int CURRENT_VERSION = 0;
+
+    private CassandraEnumeratorStateSerializer() { // singleton
+    }
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(CassandraEnumeratorState cassandraEnumeratorState) throws IOException {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                ObjectOutputStream objectOutputStream =
+                        new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(cassandraEnumeratorState);
+            objectOutputStream.flush();
+            return byteArrayOutputStream.toByteArray();
+        }
+    }
+
+    @Override
+    public CassandraEnumeratorState deserialize(int version, byte[] serialized) throws IOException {
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serialized);
+                ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
+            return (CassandraEnumeratorState) objectInputStream.readObject();
+        } catch (ClassNotFoundException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraSplitEnumerator.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraSplitEnumerator.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.enumerator;
+
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplit;
+import org.apache.flink.connector.cassandra.source.split.SplitsGenerator;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Metadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/** {@link SplitEnumerator} that splits Cassandra cluster into {@link CassandraSplit}s. */
+public final class CassandraSplitEnumerator
+        implements SplitEnumerator<CassandraSplit, CassandraEnumeratorState> {
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraSplitEnumerator.class);
+    private static final String MURMUR3PARTITIONER = "org.apache.cassandra.dht.Murmur3Partitioner";
+
+    private final SplitEnumeratorContext<CassandraSplit> enumeratorContext;
+    private final CassandraEnumeratorState state;
+    private final Cluster cluster;
+
+    public CassandraSplitEnumerator(
+            SplitEnumeratorContext<CassandraSplit> enumeratorContext,
+            CassandraEnumeratorState state,
+            ClusterBuilder clusterBuilder) {
+        this.enumeratorContext = enumeratorContext;
+        this.state = state == null ? new CassandraEnumeratorState() : state /* snapshot restore*/;
+        this.cluster = clusterBuilder.getCluster();
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String requesterHostname) {
+        assignUnprocessedSplitsToReader(subtaskId);
+    }
+
+    @Override
+    public void start() {
+        // discover the splits and update unprocessed splits and then assign them.
+        // There is only an initial splits discovery, no periodic discovery.
+        enumeratorContext.callAsync(
+                this::discoverSplits,
+                (splits, throwable) -> {
+                    LOG.info("Add {} splits to CassandraSplitEnumerator.", splits.size());
+                    state.addNewSplits(splits, enumeratorContext.currentParallelism());
+                });
+    }
+
+    private List<CassandraSplit> discoverSplits() {
+        final int numberOfSplits = enumeratorContext.currentParallelism();
+        final Metadata clusterMetadata = cluster.getMetadata();
+        final String partitioner = clusterMetadata.getPartitioner();
+        final SplitsGenerator splitsGenerator = new SplitsGenerator(partitioner);
+        if (MURMUR3PARTITIONER.equals(partitioner)) {
+            LOG.info("Murmur3Partitioner detected, splitting");
+            List<BigInteger> tokens =
+                    clusterMetadata.getTokenRanges().stream()
+                            .map(
+                                    tokenRange ->
+                                            new BigInteger(
+                                                    tokenRange.getEnd().getValue().toString()))
+                            .collect(Collectors.toList());
+            return splitsGenerator.generateSplits(numberOfSplits, tokens);
+        } else {
+            // Murmur3Partitioner is the default and recommended partitioner for Cassandra 1.2+
+            // see
+            // https://docs.datastax.com/en/cassandra-oss/3.x/cassandra/architecture/archPartitionerAbout.html
+            LOG.warn(
+                    "The current Cassandra partitioner is {}, only Murmur3Partitioner is supported "
+                            + "for splitting, using an single split",
+                    partitioner);
+            return splitsGenerator.generateSplits(1, Collections.emptyList());
+        }
+    }
+
+    @Override
+    public void addSplitsBack(List<CassandraSplit> splits, int subtaskId) {
+        LOG.info("Add {} splits back to CassandraSplitEnumerator.", splits.size());
+        state.addNewSplits(splits, enumeratorContext.currentParallelism());
+        assignUnprocessedSplitsToReader(subtaskId);
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        LOG.info("Adding reader {} to CassandraSplitEnumerator.", subtaskId);
+        assignUnprocessedSplitsToReader(subtaskId);
+    }
+
+    private void assignUnprocessedSplitsToReader(int readerId) {
+        checkReaderRegistered(readerId);
+
+        final Set<CassandraSplit> splitsForReader = state.getSplitsForReader(readerId);
+        if (splitsForReader != null && !splitsForReader.isEmpty()) {
+            Map<Integer, List<CassandraSplit>> assignment = new HashMap<>();
+            assignment.put(readerId, Lists.newArrayList(splitsForReader));
+            LOG.info("Assigning splits to reader {}", assignment);
+            enumeratorContext.assignSplits(new SplitsAssignment<>(assignment));
+        }
+
+        // periodically partition discovery is disabled, signal NoMoreSplitsEvent to the reader
+        LOG.debug(
+                "No more CassandraSplits to assign. Sending NoMoreSplitsEvent to reader {}.",
+                readerId);
+        enumeratorContext.signalNoMoreSplits(readerId);
+    }
+
+    private void checkReaderRegistered(int readerId) {
+        if (!enumeratorContext.registeredReaders().containsKey(readerId)) {
+            throw new IllegalStateException(
+                    String.format("Reader %d is not registered to source coordinator", readerId));
+        }
+    }
+
+    @Override
+    public CassandraEnumeratorState snapshotState(long checkpointId) throws Exception {
+        return state;
+    }
+
+    @Override
+    public void close() throws IOException {
+        cluster.close();
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraRecordEmitter.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraRecordEmitter.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.reader;
+
+import org.apache.flink.api.connector.source.SourceOutput;
+import org.apache.flink.connector.base.source.reader.RecordEmitter;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplitState;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.streaming.connectors.cassandra.MapperOptions;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.Mapper;
+import com.datastax.driver.mapping.MappingManager;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * {@link RecordEmitter} that converts the {@link CassandraRow} read by the {@link
+ * CassandraSplitReader} to specified POJO and output it while updating splits state. This class
+ * uses the Cassandra driver mapper to map the row to the POJO.
+ *
+ * @param <OUT> type of POJO record to output
+ */
+public class CassandraRecordEmitter<OUT>
+        implements RecordEmitter<CassandraRow, OUT, CassandraSplitState> {
+
+    private final Mapper<OUT> mapper;
+
+    public CassandraRecordEmitter(
+            Class<OUT> pojoClass, ClusterBuilder clusterBuilder, MapperOptions mapperOptions) {
+        // session and cluster are managed at the SplitReader level. So we need to create one
+        // locally here just to me able to create the mapper.
+        final Cluster cluster = clusterBuilder.getCluster();
+        final Session session = cluster.connect();
+        mapper = new MappingManager(session).mapper(pojoClass);
+        if (mapperOptions != null) {
+            Mapper.Option[] optionsArray = mapperOptions.getMapperOptions();
+            if (optionsArray != null) {
+                mapper.setDefaultGetOptions(optionsArray);
+            }
+        }
+        // close the temporary cluster and session
+        session.close();
+        cluster.close();
+    }
+
+    @Override
+    public void emitRecord(
+            CassandraRow cassandraRow,
+            SourceOutput<OUT> output,
+            CassandraSplitState cassandraSplitState) {
+        final Row row = cassandraRow.getRow();
+        // Mapping from a row to a Class<OUT> is a complex operation involving reflection API.
+        // It is better to use Cassandra mapper for it.
+        // but the mapper takes only a resultSet as input hence forging one containing the row
+        ResultSet resultSet =
+                new ResultSet() {
+                    @Override
+                    public Row one() {
+                        return row;
+                    }
+
+                    @Override
+                    public ColumnDefinitions getColumnDefinitions() {
+                        return row.getColumnDefinitions();
+                    }
+
+                    @Override
+                    public boolean wasApplied() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isExhausted() {
+                        return true;
+                    }
+
+                    @Override
+                    public boolean isFullyFetched() {
+                        return true;
+                    }
+
+                    @Override
+                    public int getAvailableWithoutFetching() {
+                        return 1;
+                    }
+
+                    @Override
+                    public ListenableFuture<ResultSet> fetchMoreResults() {
+                        return Futures.immediateFuture(null);
+                    }
+
+                    @Override
+                    public List<Row> all() {
+                        return Collections.singletonList(row);
+                    }
+
+                    @Override
+                    public Iterator<Row> iterator() {
+                        return new Iterator<Row>() {
+
+                            @Override
+                            public boolean hasNext() {
+                                return true;
+                            }
+
+                            @Override
+                            public Row next() {
+                                return row;
+                            }
+                        };
+                    }
+
+                    @Override
+                    public ExecutionInfo getExecutionInfo() {
+                        return cassandraRow.getExecutionInfo();
+                    }
+
+                    @Override
+                    public List<ExecutionInfo> getAllExecutionInfo() {
+                        return Collections.singletonList(cassandraRow.getExecutionInfo());
+                    }
+                };
+        // output the pojo based on the cassandraRow
+        output.collect(mapper.map(resultSet).one());
+        // update cassandraSplitState to reflect the emitted records
+        cassandraSplitState.markRingRangeAsFinished(cassandraRow.getAssociatedRingRange());
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraRow.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraRow.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.reader;
+
+import org.apache.flink.connector.cassandra.source.split.RingRange;
+
+import com.datastax.driver.core.ExecutionInfo;
+import com.datastax.driver.core.Row;
+
+/**
+ * Wrapper for Cassandra {@link Row} that stores associated {@link RingRange} to be able to update
+ * split states. It also stores {@link ExecutionInfo} Cassandra statistics about the query execution
+ * that produced this row.
+ */
+public class CassandraRow {
+
+    private final Row row;
+    private final RingRange associatedRingRange;
+    private final ExecutionInfo executionInfo;
+
+    public CassandraRow(Row row, RingRange associatedRingRange, ExecutionInfo executionInfo) {
+        this.row = row;
+        this.associatedRingRange = associatedRingRange;
+        this.executionInfo = executionInfo;
+    }
+
+    public Row getRow() {
+        return row;
+    }
+
+    public RingRange getAssociatedRingRange() {
+        return associatedRingRange;
+    }
+
+    public ExecutionInfo getExecutionInfo() {
+        return executionInfo;
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraSourceReader.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraSourceReader.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.reader;
+
+import org.apache.flink.api.connector.source.SourceReader;
+import org.apache.flink.api.connector.source.SourceReaderContext;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplit;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplitState;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.streaming.connectors.cassandra.MapperOptions;
+
+import java.util.Map;
+
+/**
+ * Cassandra {@link SourceReader} that reads one {@link CassandraSplit} using a single thread.
+ * Indeed, this is for reducing the load on Cassandra cluster (see {@link CassandraSplit}).
+ *
+ * @param <OUT> the type of elements produced by the source
+ */
+public class CassandraSourceReader<OUT>
+        extends SingleThreadMultiplexSourceReaderBase<
+                CassandraRow, OUT, CassandraSplit, CassandraSplitState> {
+
+    public CassandraSourceReader(
+            SourceReaderContext context,
+            ClusterBuilder clusterBuilder,
+            Class<OUT> pojoClass,
+            String query,
+            MapperOptions mapperOptions) {
+        super(
+                () -> new CassandraSplitReader(clusterBuilder, query),
+                new CassandraRecordEmitter<>(pojoClass, clusterBuilder, mapperOptions),
+                new Configuration(),
+                context);
+    }
+
+    @Override
+    protected void onSplitFinished(Map<String, CassandraSplitState> finishedSplitIds) {
+        finishedSplitIds.forEach((key, splitState) -> splitState.markAllRingRangesAsFinished());
+    }
+
+    @Override
+    protected CassandraSplitState initializedState(CassandraSplit cassandraSplit) {
+        // no need to deep copy the ringRanges as this method is called only by SourceReaderBase,
+        // there will be no serialization involved
+        return new CassandraSplitState(cassandraSplit.getRingRanges(), cassandraSplit.splitId());
+    }
+
+    @Override
+    protected CassandraSplit toSplitType(String splitId, CassandraSplitState splitState) {
+        // no need to deep copy the ringRanges as this method is called only by SourceReaderBase,
+        // there will be no serialization involved
+        return new CassandraSplit(splitState.getUnprocessedRingRanges());
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraSplitReader.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/reader/CassandraSplitReader.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.reader;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.connector.base.source.reader.RecordsBySplits;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplit;
+import org.apache.flink.connector.cassandra.source.split.CassandraSplitState;
+import org.apache.flink.connector.cassandra.source.split.RingRange;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ResultSet;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Token;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * {@link SplitReader} for Cassandra source. This class is responsible for fetching the records as
+ * {@link CassandraRow}. For that, it executes a range query (query that outputs records belonging
+ * to a {@link RingRange}) based on the user specified query. This class manages the Cassandra
+ * cluster and session.
+ */
+public class CassandraSplitReader implements SplitReader<CassandraRow, CassandraSplit> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraSplitReader.class);
+    public static final String SELECT_REGEXP = "(?i)select .+ from (\\w+)\\.(\\w+).*;$";
+
+    private final Cluster cluster;
+    private final Session session;
+    private final Set<CassandraSplitState> unprocessedSplits;
+    private final AtomicBoolean wakeup = new AtomicBoolean(false);
+    private final String query;
+
+    public CassandraSplitReader(ClusterBuilder clusterBuilder, String query) {
+        // need a thread safe set
+        this.unprocessedSplits = ConcurrentHashMap.newKeySet();
+        this.query = query;
+        cluster = clusterBuilder.getCluster();
+        session = cluster.connect();
+    }
+
+    @Override
+    public RecordsWithSplitIds<CassandraRow> fetch() {
+        Map<String, Collection<CassandraRow>> recordsBySplit = new HashMap<>();
+        Set<String> finishedSplits = new HashSet<>();
+        Metadata clusterMetadata = cluster.getMetadata();
+
+        String partitionKey = getPartitionKey(clusterMetadata);
+        String finalQuery = generateRangeQuery(query, partitionKey);
+        PreparedStatement preparedStatement = session.prepare(finalQuery);
+        // Set wakeup to false to start consuming.
+        wakeup.compareAndSet(true, false);
+        for (CassandraSplitState cassandraSplitState : unprocessedSplits) {
+            // allow to interrupt the reading of splits as requested in the API
+            if (wakeup.get()) {
+                break;
+            }
+            if (!cassandraSplitState.isEmpty()) {
+                try {
+                    final Set<RingRange> ringRanges =
+                            cassandraSplitState.getUnprocessedRingRanges();
+                    final String cassandraSplitId = cassandraSplitState.getSplitId();
+
+                    for (RingRange ringRange : ringRanges) {
+                        Token startToken =
+                                clusterMetadata.newToken(ringRange.getStart().toString());
+                        Token endToken = clusterMetadata.newToken(ringRange.getEnd().toString());
+                        if (ringRange.isWrapping()) {
+                            // A wrapping range is one that overlaps from the end of the partitioner
+                            // range and its
+                            // start (ie : when the start token of the split is greater than the end
+                            // token)
+                            // We need to generate two queries here : one that goes from the start
+                            // token to the end
+                            // of
+                            // the partitioner range, and the other from the start of the
+                            // partitioner range to the
+                            // end token of the split.
+
+                            addRecordsToOutput(
+                                    session.execute(
+                                            getLowestSplitQuery(
+                                                    query, partitionKey, ringRange.getEnd())),
+                                    recordsBySplit,
+                                    cassandraSplitId,
+                                    ringRange);
+                            addRecordsToOutput(
+                                    session.execute(
+                                            getHighestSplitQuery(
+                                                    query, partitionKey, ringRange.getStart())),
+                                    recordsBySplit,
+                                    cassandraSplitId,
+                                    ringRange);
+                        } else {
+                            addRecordsToOutput(
+                                    session.execute(
+                                            preparedStatement
+                                                    .bind()
+                                                    .setToken(0, startToken)
+                                                    .setToken(1, endToken)),
+                                    recordsBySplit,
+                                    cassandraSplitId,
+                                    ringRange);
+                        }
+                        cassandraSplitState.markRingRangeAsFinished(ringRange);
+                    }
+                    // put the already read split to finished splits
+                    finishedSplits.add(cassandraSplitState.getSplitId());
+                    // for reentrant calls: if fetch is woken up,
+                    // do not reprocess the already processed splits
+                    unprocessedSplits.remove(cassandraSplitState);
+                } catch (Exception ex) {
+                    LOG.error("Error while reading split ", ex);
+                }
+            } else {
+                finishedSplits.add(cassandraSplitState.getSplitId());
+            }
+        }
+        return new RecordsBySplits<>(recordsBySplit, finishedSplits);
+    }
+
+    private String getPartitionKey(Metadata clusterMetadata) {
+        Matcher queryMatcher = Pattern.compile(SELECT_REGEXP).matcher(query);
+        if (!queryMatcher.matches()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Failed to extract keyspace and table out of the provided query: %s",
+                            query));
+        }
+        String keyspace = queryMatcher.group(1);
+        String table = queryMatcher.group(2);
+        return clusterMetadata.getKeyspace(keyspace).getTable(table).getPartitionKey().stream()
+                .map(ColumnMetadata::getName)
+                .collect(Collectors.joining(","));
+    }
+
+    @Override
+    public void wakeUp() {
+        wakeup.compareAndSet(false, true);
+    }
+
+    @Override
+    public void handleSplitsChanges(SplitsChange<CassandraSplit> splitsChanges) {
+        for (CassandraSplit cassandraSplit : splitsChanges.splits()) {
+            unprocessedSplits.add(
+                    new CassandraSplitState(
+                            cassandraSplit.getRingRanges(), cassandraSplit.splitId()));
+        }
+    }
+
+    @VisibleForTesting
+    static String getHighestSplitQuery(String query, String partitionKey, BigInteger highest) {
+        return generateQuery(
+                query, partitionKey, highest, " (token(%s) >= %d) AND", " WHERE (token(%s) >= %d)");
+    }
+
+    @VisibleForTesting
+    static String getLowestSplitQuery(String query, String partitionKey, BigInteger lowest) {
+        return generateQuery(
+                query, partitionKey, lowest, " (token(%s) < %d) AND", " WHERE (token(%s) < %d)");
+    }
+
+    @VisibleForTesting
+    static String generateRangeQuery(String query, String partitionKey) {
+        return generateQuery(
+                query,
+                partitionKey,
+                null,
+                " (token(%s) >= ?) AND (token(%s) < ?) AND",
+                " WHERE (token(%s) >= ?) AND (token(%s) < ?)");
+    }
+
+    private static String generateQuery(
+            String query,
+            String partitionKey,
+            @Nullable BigInteger token,
+            String whereFilter,
+            String noWhereFilter) {
+        Matcher queryMatcher = Pattern.compile(SELECT_REGEXP).matcher(query);
+        if (!queryMatcher.matches()) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Failed to extract keyspace and table out of the provided query: %s",
+                            query));
+        }
+        final int whereIndex = query.toLowerCase().indexOf("where");
+        int insertionPoint;
+        String filter;
+        if (whereIndex != -1) {
+            insertionPoint = whereIndex + "where".length();
+            filter =
+                    (token == null)
+                            ? String.format(whereFilter, partitionKey, partitionKey)
+                            : String.format(whereFilter, partitionKey, token);
+        } else {
+            // end of keyspace.table
+            insertionPoint = queryMatcher.end(2);
+            filter =
+                    (token == null)
+                            ? String.format(noWhereFilter, partitionKey, partitionKey)
+                            : String.format(noWhereFilter, partitionKey, token);
+        }
+        return String.format(
+                "%s%s%s",
+                query.substring(0, insertionPoint), filter, query.substring(insertionPoint));
+    }
+
+    /**
+     * This method populates the {@code Map<String, Collection<CassandraRow>> recordsBySplit} map
+     * that is used to create the {@link RecordsBySplits} that are output by the fetch method. It
+     * modifies its {@code output} parameter.
+     */
+    private void addRecordsToOutput(
+            ResultSet resultSet,
+            Map<String, Collection<CassandraRow>> output,
+            String cassandraSplitId,
+            RingRange ringRange) {
+        resultSet.forEach(
+                row ->
+                        output.computeIfAbsent(cassandraSplitId, id -> new ArrayList<>())
+                                .add(
+                                        new CassandraRow(
+                                                row, ringRange, resultSet.getExecutionInfo())));
+    }
+
+    @Override
+    public void close() throws Exception {
+        try {
+            if (session != null) {
+                session.close();
+            }
+        } catch (Exception e) {
+            LOG.error("Error while closing session.", e);
+        }
+        try {
+            if (cluster != null) {
+                cluster.close();
+            }
+        } catch (Exception e) {
+            LOG.error("Error while closing cluster.", e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/CassandraSplit.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/CassandraSplit.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.split;
+
+import org.apache.flink.api.connector.source.SourceSplit;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * {@link SourceSplit} for Cassandra source. A Cassandra split is just a set of {@link RingRange}s
+ * (a range between 2 tokens). Tokens are spread across the Cassandra cluster with each node
+ * managing a share of the token ring. Each split can contain several token ranges in order to
+ * reduce the overhead on Cassandra vnodes.
+ */
+public class CassandraSplit implements SourceSplit, Serializable {
+
+    private final Set<RingRange> ringRanges;
+
+    public CassandraSplit(Set<RingRange> ringRanges) {
+        this.ringRanges = ringRanges;
+    }
+
+    public Set<RingRange> getRingRanges() {
+        return ringRanges;
+    }
+
+    @Override
+    public String splitId() {
+        return ringRanges.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        CassandraSplit that = (CassandraSplit) o;
+        return ringRanges.equals(that.ringRanges);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ringRanges);
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/CassandraSplitSerializer.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/CassandraSplitSerializer.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.split;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+/** Serializer for {@link CassandraSplit}. */
+public class CassandraSplitSerializer implements SimpleVersionedSerializer<CassandraSplit> {
+
+    public static final CassandraSplitSerializer INSTANCE = new CassandraSplitSerializer();
+
+    public static final int CURRENT_VERSION = 0;
+
+    private CassandraSplitSerializer() {}
+
+    @Override
+    public int getVersion() {
+        return CURRENT_VERSION;
+    }
+
+    @Override
+    public byte[] serialize(CassandraSplit cassandraSplit) throws IOException {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+                ObjectOutputStream objectOutputStream =
+                        new ObjectOutputStream(byteArrayOutputStream)) {
+            objectOutputStream.writeObject(cassandraSplit);
+            objectOutputStream.flush();
+            return byteArrayOutputStream.toByteArray();
+        }
+    }
+
+    @Override
+    public CassandraSplit deserialize(int version, byte[] serialized) throws IOException {
+        try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(serialized);
+                ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
+            return (CassandraSplit) objectInputStream.readObject();
+        } catch (ClassNotFoundException e) {
+            throw new IOException(e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/CassandraSplitState.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/CassandraSplitState.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.split;
+
+import java.util.Set;
+
+/** Mutable {@link CassandraSplit} for state management. */
+public class CassandraSplitState {
+    private final Set<RingRange> unprocessedRingRanges;
+    private final String splitId;
+
+    public CassandraSplitState(Set<RingRange> unprocessedRingRanges, String splitId) {
+        this.unprocessedRingRanges = unprocessedRingRanges;
+        this.splitId = splitId;
+    }
+
+    public Set<RingRange> getUnprocessedRingRanges() {
+        return unprocessedRingRanges;
+    }
+
+    public void markRingRangeAsFinished(RingRange ringRange) {
+        unprocessedRingRanges.remove(ringRange);
+    }
+
+    public void markAllRingRangesAsFinished() {
+        unprocessedRingRanges.clear();
+    }
+
+    public boolean isEmpty() {
+        return unprocessedRingRanges.isEmpty();
+    }
+
+    public String getSplitId() {
+        return splitId;
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/RingRange.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/RingRange.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.split;
+
+import javax.annotation.Nullable;
+
+import java.io.Serializable;
+import java.math.BigInteger;
+
+/**
+ * Represents a portion of Cassandra token ring. It is a range between a start token and an end
+ * token.
+ */
+public final class RingRange implements Serializable {
+
+    private final BigInteger start;
+    private final BigInteger end;
+
+    private RingRange(BigInteger start, BigInteger end) {
+        this.start = start;
+        this.end = end;
+    }
+
+    public static RingRange of(BigInteger start, BigInteger end) {
+        return new RingRange(start, end);
+    }
+
+    public BigInteger getStart() {
+        return start;
+    }
+
+    public BigInteger getEnd() {
+        return end;
+    }
+
+    /**
+     * Returns the size of this range.
+     *
+     * @return size of the range, max - range, in case of wrap
+     */
+    BigInteger span(BigInteger ringSize) {
+        return (start.compareTo(end) >= 0)
+                ? end.subtract(start).add(ringSize)
+                : end.subtract(start);
+    }
+
+    /** @return true if the ringRange overlaps. Note that if start == end, then wrapping is true */
+    public boolean isWrapping() {
+        return start.compareTo(end) >= 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("(%s,%s]", start.toString(), end.toString());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RingRange ringRange = (RingRange) o;
+
+        if (getStart() != null
+                ? !getStart().equals(ringRange.getStart())
+                : ringRange.getStart() != null) {
+            return false;
+        }
+        return getEnd() != null ? getEnd().equals(ringRange.getEnd()) : ringRange.getEnd() == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = getStart() != null ? getStart().hashCode() : 0;
+        result = 31 * result + (getEnd() != null ? getEnd().hashCode() : 0);
+        return result;
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/SplitsGenerator.java
+++ b/flink-connectors/flink-connector-cassandra/src/main/java/org/apache/flink/connector/cassandra/source/split/SplitsGenerator.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.split;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Sets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * This class generates {@link CassandraSplit}s by generating {@link RingRange}s based on Cassandra
+ * cluster partitioner and Flink source parallelism.
+ */
+public final class SplitsGenerator {
+    private static final Logger LOG = LoggerFactory.getLogger(SplitsGenerator.class);
+
+    private final String partitioner;
+    private final BigInteger rangeMin;
+    private final BigInteger rangeMax;
+    private final BigInteger rangeSize;
+
+    public SplitsGenerator(String partitioner) {
+        this.partitioner = partitioner;
+        rangeMin = getRangeMin();
+        rangeMax = getRangeMax();
+        rangeSize = getRangeSize();
+    }
+
+    private BigInteger getRangeMin() {
+        if (partitioner.endsWith("RandomPartitioner")) {
+            return BigInteger.ZERO;
+        } else if (partitioner.endsWith("Murmur3Partitioner")) {
+            return BigInteger.valueOf(2).pow(63).negate();
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported partitioner. " + "Only Random and Murmur3 are supported");
+        }
+    }
+
+    private BigInteger getRangeMax() {
+        if (partitioner.endsWith("RandomPartitioner")) {
+            return BigInteger.valueOf(2).pow(127).subtract(BigInteger.ONE);
+        } else if (partitioner.endsWith("Murmur3Partitioner")) {
+            return BigInteger.valueOf(2).pow(63).subtract(BigInteger.ONE);
+        } else {
+            throw new UnsupportedOperationException(
+                    "Unsupported partitioner. " + "Only Random and Murmur3 are supported");
+        }
+    }
+
+    private BigInteger getRangeSize() {
+        return rangeMax.subtract(rangeMin).add(BigInteger.ONE);
+    }
+
+    /**
+     * Given properly ordered list of Cassandra tokens, compute at least {@code totalSplitCount}
+     * splits. Each split can contain several token ranges in order to reduce the overhead of
+     * Cassandra vnodes. Currently, token range grouping is not smart and doesn't check if they
+     * share the same replicas.
+     *
+     * @param totalSplitCount requested total amount of splits. This function may generate more
+     *     splits.
+     * @param ringTokens list of all start tokens in Cassandra cluster. They have to be in ring
+     *     order.
+     * @return list containing at least {@code totalSplitCount} CassandraSplits.
+     */
+    public List<CassandraSplit> generateSplits(long totalSplitCount, List<BigInteger> ringTokens) {
+        if (totalSplitCount == 1) {
+            RingRange totalRingRange = RingRange.of(rangeMin, rangeMax);
+            // needs to be mutable
+            return Collections.singletonList(new CassandraSplit(Sets.newHashSet(totalRingRange)));
+        }
+        int tokenRangeCount = ringTokens.size();
+
+        List<RingRange> ringRanges = new ArrayList<>();
+        for (int i = 0; i < tokenRangeCount; i++) {
+            BigInteger start = ringTokens.get(i);
+            BigInteger stop = ringTokens.get((i + 1) % tokenRangeCount);
+
+            if (isNotInRange(start) || isNotInRange(stop)) {
+                throw new RuntimeException(
+                        String.format(
+                                "Tokens (%s,%s) not in range of %s", start, stop, partitioner));
+            }
+            if (start.equals(stop) && tokenRangeCount != 1) {
+                throw new RuntimeException(
+                        String.format(
+                                "Tokens (%s,%s): two nodes have the same token", start, stop));
+            }
+
+            BigInteger rangeSize = stop.subtract(start);
+            if (rangeSize.compareTo(BigInteger.ZERO) <= 0) {
+                // wrap around case
+                rangeSize = rangeSize.add(this.rangeSize);
+            }
+
+            // the below, in essence, does this:
+            // splitCount = Maths.ceil((rangeSize / cluster range size) * totalSplitCount)
+            BigInteger[] splitCountAndRemainder =
+                    rangeSize
+                            .multiply(BigInteger.valueOf(totalSplitCount))
+                            .divideAndRemainder(this.rangeSize);
+
+            int splitCount =
+                    splitCountAndRemainder[0].intValue()
+                            + (splitCountAndRemainder[1].equals(BigInteger.ZERO) ? 0 : 1);
+
+            LOG.debug("Dividing token range [{},{}) into {} splits", start, stop, splitCount);
+
+            // Make BigInteger list of all the endpoints for the splits, including both start and
+            // stop
+            List<BigInteger> endpointTokens = new ArrayList<>();
+            for (int j = 0; j <= splitCount; j++) {
+                BigInteger offset =
+                        rangeSize
+                                .multiply(BigInteger.valueOf(j))
+                                .divide(BigInteger.valueOf(splitCount));
+                BigInteger token = start.add(offset);
+                if (token.compareTo(rangeMax) > 0) {
+                    token = token.subtract(this.rangeSize);
+                }
+                // Long.MIN_VALUE is not a valid token and has to be silently incremented.
+                // See https://issues.apache.org/jira/browse/CASSANDRA-14684
+                endpointTokens.add(
+                        token.equals(BigInteger.valueOf(Long.MIN_VALUE))
+                                ? token.add(BigInteger.ONE)
+                                : token);
+            }
+
+            // Append the ringRanges between the endpoints
+            for (int j = 0; j < splitCount; j++) {
+                ringRanges.add(RingRange.of(endpointTokens.get(j), endpointTokens.get(j + 1)));
+                LOG.debug(
+                        "Split #{}: [{},{})",
+                        j + 1,
+                        endpointTokens.get(j),
+                        endpointTokens.get(j + 1));
+            }
+        }
+
+        BigInteger total = BigInteger.ZERO;
+        for (RingRange split : ringRanges) {
+            BigInteger size = split.span(rangeSize);
+            total = total.add(size);
+        }
+        if (!total.equals(rangeSize)) {
+            throw new RuntimeException(
+                    "Some tokens are missing from the splits. This should not happen.");
+        }
+        return coalesceRingRanges(getTargetSplitSize(totalSplitCount), ringRanges);
+    }
+
+    private boolean isNotInRange(BigInteger token) {
+        return token.compareTo(rangeMin) < 0 || token.compareTo(rangeMax) > 0;
+    }
+
+    private List<CassandraSplit> coalesceRingRanges(
+            BigInteger targetSplitSize, List<RingRange> ringRanges) {
+        List<CassandraSplit> coalescedSplits = new ArrayList<>();
+        List<RingRange> tokenRangesForCurrentSplit = new ArrayList<>();
+        BigInteger tokenCount = BigInteger.ZERO;
+
+        for (RingRange tokenRange : ringRanges) {
+            if (tokenRange.span(rangeSize).add(tokenCount).compareTo(targetSplitSize) > 0
+                    && !tokenRangesForCurrentSplit.isEmpty()) {
+                // enough tokens in that segment
+                LOG.debug(
+                        "Got enough tokens for one split ({}) : {}",
+                        tokenCount,
+                        tokenRangesForCurrentSplit);
+                coalescedSplits.add(new CassandraSplit(new HashSet<>(tokenRangesForCurrentSplit)));
+                tokenRangesForCurrentSplit = new ArrayList<>();
+                tokenCount = BigInteger.ZERO;
+            }
+
+            tokenCount = tokenCount.add(tokenRange.span(rangeSize));
+            tokenRangesForCurrentSplit.add(tokenRange);
+        }
+
+        if (!tokenRangesForCurrentSplit.isEmpty()) {
+            coalescedSplits.add(new CassandraSplit(new HashSet<>(tokenRangesForCurrentSplit)));
+        }
+        return coalescedSplits;
+    }
+
+    private BigInteger getTargetSplitSize(long splitCount) {
+        return rangeMax.subtract(rangeMin).divide(BigInteger.valueOf(splitCount));
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/example/BatchPojoExample.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/batch/connectors/cassandra/example/BatchPojoExample.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.batch.connectors.cassandra.CassandraPojoInputFormat;
 import org.apache.flink.batch.connectors.cassandra.CassandraPojoOutputFormat;
+import org.apache.flink.connectors.cassandra.utils.Pojo;
 import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
 
 import com.datastax.driver.core.Cluster;

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraSourceITCase.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraSourceITCase.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source;
+
+import org.apache.flink.connector.testframe.environment.ClusterControllable;
+import org.apache.flink.connector.testframe.environment.MiniClusterTestEnvironment;
+import org.apache.flink.connector.testframe.environment.TestEnvironment;
+import org.apache.flink.connector.testframe.external.source.DataStreamSourceExternalContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
+import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem;
+import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
+import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
+import org.apache.flink.connector.testframe.utils.CollectIteratorAssertions;
+import org.apache.flink.connectors.cassandra.utils.Pojo;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.util.CloseableIterator;
+
+import org.junit.jupiter.api.Disabled;
+
+import java.util.List;
+
+import static java.util.concurrent.CompletableFuture.runAsync;
+import static org.apache.flink.connector.cassandra.source.CassandraTestContext.CassandraTestContextFactory;
+import static org.apache.flink.connector.testframe.utils.ConnectorTestConstants.DEFAULT_COLLECT_DATA_TIMEOUT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/** Test for the Cassandra source. */
+public class CassandraSourceITCase extends SourceTestSuiteBase<Pojo> {
+    @TestEnv MiniClusterTestEnvironment flinkTestEnvironment = new MiniClusterTestEnvironment();
+
+    @TestExternalSystem
+    CassandraTestEnvironment cassandraTestEnvironment = new CassandraTestEnvironment();
+
+    @TestSemantics
+    CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
+
+    @TestContext
+    CassandraTestContextFactory contextFactory =
+            new CassandraTestContextFactory(cassandraTestEnvironment);
+
+    // overridden to use unordered checks
+    @Override
+    protected void checkResultWithSemantic(
+            CloseableIterator<Pojo> resultIterator,
+            List<List<Pojo>> testData,
+            CheckpointingMode semantic,
+            Integer limit) {
+        if (limit != null) {
+            Runnable runnable =
+                    () ->
+                            CollectIteratorAssertions.assertUnordered(resultIterator)
+                                    .withNumRecordsLimit(limit)
+                                    .matchesRecordsFromSource(testData, semantic);
+
+            assertThat(runAsync(runnable)).succeedsWithin(DEFAULT_COLLECT_DATA_TIMEOUT);
+        } else {
+            CollectIteratorAssertions.assertUnordered(resultIterator)
+                    .matchesRecordsFromSource(testData, semantic);
+        }
+    }
+
+    @Disabled("Not a unbounded source")
+    @Override
+    public void testSavepoint(
+            TestEnvironment testEnv,
+            DataStreamSourceExternalContext<Pojo> externalContext,
+            CheckpointingMode semantic)
+            throws Exception {}
+
+    @Disabled("Not a unbounded source")
+    @Override
+    public void testScaleUp(
+            TestEnvironment testEnv,
+            DataStreamSourceExternalContext<Pojo> externalContext,
+            CheckpointingMode semantic)
+            throws Exception {}
+
+    @Disabled("Not a unbounded source")
+    @Override
+    public void testScaleDown(
+            TestEnvironment testEnv,
+            DataStreamSourceExternalContext<Pojo> externalContext,
+            CheckpointingMode semantic)
+            throws Exception {}
+
+    @Disabled("Not a unbounded source")
+    @Override
+    public void testTaskManagerFailure(
+            TestEnvironment testEnv,
+            DataStreamSourceExternalContext<Pojo> externalContext,
+            ClusterControllable controller,
+            CheckpointingMode semantic)
+            throws Exception {}
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraTestContext.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraTestContext.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.connector.testframe.external.ExternalContextFactory;
+import org.apache.flink.connector.testframe.external.ExternalSystemSplitDataWriter;
+import org.apache.flink.connector.testframe.external.source.DataStreamSourceExternalContext;
+import org.apache.flink.connector.testframe.external.source.TestingSourceSettings;
+import org.apache.flink.connectors.cassandra.utils.Pojo;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.streaming.connectors.cassandra.MapperOptions;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.mapping.Mapper;
+import com.datastax.driver.mapping.MappingManager;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Junit context {@link DataStreamSourceExternalContext} that contains everything related to
+ * Cassandra source test cases especially test table management.
+ */
+public class CassandraTestContext implements DataStreamSourceExternalContext<Pojo> {
+
+    static final String TABLE_NAME = "batches";
+
+    private static final String CREATE_TABLE_QUERY =
+            "CREATE TABLE "
+                    + CassandraTestEnvironment.KEYSPACE
+                    + "."
+                    + TABLE_NAME
+                    + " (id text PRIMARY KEY, counter int, batch_id int)"
+                    + ";";
+
+    private static final String DROP_TABLE_QUERY =
+            "DROP TABLE " + CassandraTestEnvironment.KEYSPACE + "." + TABLE_NAME + ";";
+
+    private static final int RECORDS_PER_SPLIT = 20;
+
+    private final Mapper<Pojo> mapper;
+    private final MapperOptions mapperOptions;
+    private final ClusterBuilder clusterBuilder;
+    private final Session session;
+    private ExternalSystemSplitDataWriter<Pojo> splitDataWriter;
+
+    public CassandraTestContext(CassandraTestEnvironment cassandraTestEnvironment) {
+        clusterBuilder = cassandraTestEnvironment.getClusterBuilder();
+        session = cassandraTestEnvironment.getSession();
+        createTable();
+        mapper = new MappingManager(cassandraTestEnvironment.getSession()).mapper(Pojo.class);
+        mapperOptions = () -> new Mapper.Option[] {Mapper.Option.saveNullFields(true)};
+    }
+
+    @Override
+    public TypeInformation<Pojo> getProducedType() {
+        return TypeInformation.of(Pojo.class);
+    }
+
+    @Override
+    public List<URL> getConnectorJarPaths() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Source<Pojo, ?, ?> createSource(TestingSourceSettings sourceSettings)
+            throws UnsupportedOperationException {
+
+        return new CassandraSource<>(
+                clusterBuilder,
+                Pojo.class,
+                String.format(
+                        "SELECT * FROM %s.%s;", CassandraTestEnvironment.KEYSPACE, TABLE_NAME),
+                mapperOptions);
+    }
+
+    @Override
+    public ExternalSystemSplitDataWriter<Pojo> createSourceSplitDataWriter(
+            TestingSourceSettings sourceSettings) {
+        splitDataWriter =
+                new ExternalSystemSplitDataWriter<Pojo>() {
+
+                    @Override
+                    public void writeRecords(List<Pojo> records) {
+                        for (Pojo pojo : records) {
+                            mapper.save(pojo, mapperOptions.getMapperOptions());
+                        }
+                    }
+
+                    @Override
+                    public void close() throws Exception {
+                        // nothing to do, cluster/session is shared at the CassandraTestEnvironment
+                        // level
+                    }
+                };
+        return splitDataWriter;
+    }
+
+    @Override
+    public List<Pojo> generateTestData(
+            TestingSourceSettings sourceSettings, int splitIndex, long seed) {
+        List<Pojo> testData = new ArrayList<>(RECORDS_PER_SPLIT);
+        // generate RECORDS_PER_SPLIT pojos per split and use splitId as pojo batchIndex so that
+        // pojos are
+        // considered equal when they belong to the same split as requested in implementation
+        // notes.
+        for (int i = 0; i < RECORDS_PER_SPLIT; i++) {
+            Pojo pojo = new Pojo(String.valueOf(seed + i), i, splitIndex);
+            testData.add(pojo);
+        }
+        return testData;
+    }
+
+    @Override
+    public void close() throws Exception {
+        splitDataWriter.close();
+        dropTable();
+        // NB: cluster/session is shared at the CassandraTestEnvironment level
+    }
+
+    private void createTable() {
+        session.execute(CassandraTestEnvironment.requestWithTimeout(CREATE_TABLE_QUERY));
+    }
+
+    private void dropTable() {
+        session.execute(CassandraTestEnvironment.requestWithTimeout(DROP_TABLE_QUERY));
+    }
+
+    static class CassandraTestContextFactory
+            implements ExternalContextFactory<CassandraTestContext> {
+
+        private final CassandraTestEnvironment cassandraTestEnvironment;
+
+        public CassandraTestContextFactory(CassandraTestEnvironment cassandraTestEnvironment) {
+            this.cassandraTestEnvironment = cassandraTestEnvironment;
+        }
+
+        @Override
+        public CassandraTestContext createExternalContext(String testName) {
+            return new CassandraTestContext(cassandraTestEnvironment);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraTestEnvironment.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/CassandraTestEnvironment.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source;
+
+import org.apache.flink.connector.testframe.TestResource;
+import org.apache.flink.streaming.connectors.cassandra.ClusterBuilder;
+import org.apache.flink.util.DockerImageVersions;
+
+import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.QueryOptions;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.SimpleStatement;
+import com.datastax.driver.core.SocketOptions;
+import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.exceptions.NoHostAvailableException;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+/**
+ * Junit test environment that contains everything needed at the test suite level: testContainer
+ * setup, keyspace setup, Cassandra cluster/session management ClusterBuilder setup).
+ */
+@Testcontainers
+public class CassandraTestEnvironment implements TestResource {
+    private static final int PORT = 9042;
+
+    private static final int MAX_CONNECTION_RETRY = 3;
+    private static final long CONNECTION_RETRY_DELAY = 500L;
+
+    static final String KEYSPACE = "flink";
+
+    private static final String CREATE_KEYSPACE_QUERY =
+            "CREATE KEYSPACE "
+                    + KEYSPACE
+                    + " WITH replication= {'class':'SimpleStrategy', 'replication_factor':1};";
+
+    @Container
+    private static final CassandraContainer CASSANDRA_CONTAINER = createCassandraContainer();
+
+    @TempDir private File tempDir;
+
+    private static Cluster cluster;
+    private static Session session;
+    private ClusterBuilder clusterBuilder;
+
+    private static final Logger LOG = LoggerFactory.getLogger(CassandraTestEnvironment.class);
+
+    private static final int READ_TIMEOUT_MILLIS = 36000;
+
+    @Override
+    public void startUp() throws Exception {
+        startEnv();
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        stopEnv();
+    }
+
+    private void startEnv() {
+        // need to start the container to be able to patch the configuration file inside the
+        // container
+        // CASSANDRA_CONTAINER#start() already contains retrials
+        CASSANDRA_CONTAINER.start();
+        CASSANDRA_CONTAINER.followOutput(
+                new Slf4jLogConsumer(LOG),
+                OutputFrame.OutputType.END,
+                OutputFrame.OutputType.STDERR,
+                OutputFrame.OutputType.STDOUT);
+        raiseCassandraRequestsTimeouts();
+        // restart the container so that the new timeouts are taken into account
+        CASSANDRA_CONTAINER.stop();
+        CASSANDRA_CONTAINER.start();
+        cluster = CASSANDRA_CONTAINER.getCluster();
+        clusterBuilder = createBuilderWithConsistencyLevel(ConsistencyLevel.ONE);
+
+        int retried = 0;
+        while (retried < MAX_CONNECTION_RETRY) {
+            try {
+                session = cluster.connect();
+                break;
+            } catch (NoHostAvailableException e) {
+                retried++;
+                LOG.debug(
+                        "Connection failed with NoHostAvailableException : retry number {}, will retry to connect within {} ms",
+                        retried,
+                        CONNECTION_RETRY_DELAY);
+                if (retried == MAX_CONNECTION_RETRY) {
+                    throw new RuntimeException(
+                            String.format(
+                                    "Failed to connect to Cassandra cluster after %d retries every %d ms",
+                                    retried, CONNECTION_RETRY_DELAY),
+                            e);
+                }
+                try {
+                    Thread.sleep(CONNECTION_RETRY_DELAY);
+                } catch (InterruptedException ignored) {
+                }
+            }
+        }
+        session.execute(requestWithTimeout(CREATE_KEYSPACE_QUERY));
+    }
+
+    private void stopEnv() {
+        if (session != null) {
+            session.close();
+        }
+        if (cluster != null) {
+            cluster.close();
+        }
+        CASSANDRA_CONTAINER.stop();
+    }
+
+    private ClusterBuilder createBuilderWithConsistencyLevel(ConsistencyLevel consistencyLevel) {
+        return new ClusterBuilder() {
+            @Override
+            protected Cluster buildCluster(Cluster.Builder builder) {
+                return builder.addContactPointsWithPorts(
+                                new InetSocketAddress(
+                                        CASSANDRA_CONTAINER.getHost(),
+                                        CASSANDRA_CONTAINER.getMappedPort(PORT)))
+                        .withQueryOptions(
+                                new QueryOptions()
+                                        .setConsistencyLevel(consistencyLevel)
+                                        .setSerialConsistencyLevel(ConsistencyLevel.LOCAL_SERIAL))
+                        .withSocketOptions(
+                                new SocketOptions()
+                                        // default timeout x 3
+                                        .setConnectTimeoutMillis(15000)
+                                        // default timeout x3 and higher than
+                                        // request_timeout_in_ms at the cluster level
+                                        .setReadTimeoutMillis(READ_TIMEOUT_MILLIS))
+                        .withoutJMXReporting()
+                        .withoutMetrics()
+                        .build();
+            }
+        };
+    }
+
+    public static CassandraContainer createCassandraContainer() {
+        CassandraContainer cassandra = new CassandraContainer(DockerImageVersions.CASSANDRA_4_0);
+        cassandra.withJmxReporting(false);
+        return cassandra;
+    }
+
+    private void raiseCassandraRequestsTimeouts() {
+        final File tempConfiguration = new File(tempDir, "configuration");
+        try {
+            CASSANDRA_CONTAINER.copyFileFromContainer(
+                    "/etc/cassandra/cassandra.yaml", tempConfiguration.getAbsolutePath());
+            String configuration =
+                    new String(
+                            Files.readAllBytes(tempConfiguration.toPath()), StandardCharsets.UTF_8);
+            String patchedConfiguration =
+                    configuration
+                            .replaceAll(
+                                    "request_timeout_in_ms: [0-9]+",
+                                    "request_timeout_in_ms: 30000") // x3 default timeout
+                            .replaceAll(
+                                    "read_request_timeout_in_ms: [0-9]+",
+                                    "read_request_timeout_in_ms: 15000") // x3 default timeout
+                            .replaceAll(
+                                    "write_request_timeout_in_ms: [0-9]+",
+                                    "write_request_timeout_in_ms: 6000"); // x3 default timeout
+            CASSANDRA_CONTAINER.copyFileToContainer(
+                    Transferable.of(patchedConfiguration.getBytes(StandardCharsets.UTF_8)),
+                    "/etc/cassandra/cassandra.yaml");
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to open Cassandra configuration file ", e);
+        } finally {
+            tempConfiguration.delete();
+        }
+    }
+
+    static Statement requestWithTimeout(String query) {
+        return new SimpleStatement(query).setReadTimeoutMillis(READ_TIMEOUT_MILLIS);
+    }
+
+    public ClusterBuilder getClusterBuilder() {
+        return clusterBuilder;
+    }
+
+    public Session getSession() {
+        return session;
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraEnumeratorStateSerializerTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/enumerator/CassandraEnumeratorStateSerializerTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.enumerator;
+
+import org.apache.flink.connector.cassandra.source.split.CassandraSplit;
+import org.apache.flink.connector.cassandra.source.split.RingRange;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableList;
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CassandraEnumeratorStateSerializer}. */
+public class CassandraEnumeratorStateSerializerTest {
+
+    @Test
+    public void testSerdeRoundtrip() throws Exception {
+        final CassandraEnumeratorState cassandraEnumeratorState = new CassandraEnumeratorState();
+        final List<CassandraSplit> testData =
+                ImmutableList.of(
+                        new CassandraSplit(
+                                ImmutableSet.of(
+                                        RingRange.of(BigInteger.ONE, BigInteger.TEN),
+                                        RingRange.of(BigInteger.ZERO, BigInteger.TEN))),
+                        new CassandraSplit(
+                                ImmutableSet.of(
+                                        RingRange.of(BigInteger.ZERO, BigInteger.ONE),
+                                        RingRange.of(BigInteger.ONE, BigInteger.TEN))));
+
+        cassandraEnumeratorState.addNewSplits(testData, 1);
+        final byte[] serialized =
+                CassandraEnumeratorStateSerializer.INSTANCE.serialize(cassandraEnumeratorState);
+        final CassandraEnumeratorState deserialized =
+                CassandraEnumeratorStateSerializer.INSTANCE.deserialize(
+                        CassandraEnumeratorStateSerializer.CURRENT_VERSION, serialized);
+        assertThat(deserialized)
+                .isEqualTo(cassandraEnumeratorState)
+                .withFailMessage(
+                        "CassandraEnumeratorState is not the same as input object after serde roundtrip");
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/reader/CassandraQueryTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/reader/CassandraQueryTest.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.reader;
+
+import org.apache.flink.connector.cassandra.source.CassandraSource;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** tests for query generation and query sanity checks. */
+class CassandraQueryTest {
+
+    @Test
+    public void testKeySpaceTableExtractionRegexp() {
+        final Pattern pattern = Pattern.compile(CassandraSplitReader.SELECT_REGEXP);
+        Matcher matcher;
+        matcher = pattern.matcher("SELECT field FROM keyspace.table where field = value;");
+        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("keyspace");
+        assertThat(matcher.group(2)).isEqualTo("table");
+
+        matcher = pattern.matcher("SELECT * FROM keyspace.table;");
+        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("keyspace");
+        assertThat(matcher.group(2)).isEqualTo("table");
+
+        matcher = pattern.matcher("select field1, field2 from keyspace.table;");
+        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("keyspace");
+        assertThat(matcher.group(2)).isEqualTo("table");
+
+        matcher = pattern.matcher("select field1, field2 from keyspace.table LIMIT(1000);");
+        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("keyspace");
+        assertThat(matcher.group(2)).isEqualTo("table");
+
+        matcher = pattern.matcher("select field1 from keyspace.table ;");
+        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("keyspace");
+        assertThat(matcher.group(2)).isEqualTo("table");
+
+        matcher = pattern.matcher("select field1 from keyspace.table where field1=1;");
+        assertThat(matcher.matches()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("keyspace");
+        assertThat(matcher.group(2)).isEqualTo("table");
+
+        matcher = pattern.matcher("select field1 from table;"); // missing keyspace
+        assertThat(matcher.matches()).isFalse();
+
+        matcher = pattern.matcher("select field1 from keyspace.table"); // missing ";"
+        assertThat(matcher.matches()).isFalse();
+    }
+
+    @Test
+    public void testProhibitedClauses() {
+        assertThatThrownBy(
+                        () ->
+                                CassandraSource.checkQueryValidity(
+                                        "SELECT COUNT(*) from flink.table;"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("query must not contain aggregate or order clauses ");
+        assertThatThrownBy(
+                        () -> CassandraSource.checkQueryValidity("SELECT AVG(*) from flink.table;"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("query must not contain aggregate or order clauses ");
+
+        assertThatThrownBy(
+                        () -> CassandraSource.checkQueryValidity("SELECT MIN(*) from flink.table;"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("query must not contain aggregate or order clauses ");
+        assertThatThrownBy(
+                        () -> CassandraSource.checkQueryValidity("SELECT MAX(*) from flink.table;"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("query must not contain aggregate or order clauses ");
+        assertThatThrownBy(
+                        () -> CassandraSource.checkQueryValidity("SELECT SUM(*) from flink.table;"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("query must not contain aggregate or order clauses ");
+        assertThatThrownBy(
+                        () ->
+                                CassandraSource.checkQueryValidity(
+                                        "SELECT field1, field2 from flink.table ORDER BY field1;"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("query must not contain aggregate or order clauses ");
+        assertThatThrownBy(
+                        () ->
+                                CassandraSource.checkQueryValidity(
+                                        "SELECT field1, field2 from flink.table GROUP BY field1;"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("query must not contain aggregate or order clauses ");
+    }
+
+    @Test
+    public void testGenerateRangeQuery() {
+        String query;
+        String outputQuery;
+
+        // query with where clause
+        query = "SELECT field FROM keyspace.table WHERE field = value;";
+        outputQuery = CassandraSplitReader.generateRangeQuery(query, "field");
+        assertThat(outputQuery)
+                .isEqualTo(
+                        "SELECT field FROM keyspace.table WHERE (token(field) >= ?) AND (token(field) < ?) AND field = value;");
+
+        // query without where clause
+        query = "SELECT * FROM keyspace.table;";
+        outputQuery = CassandraSplitReader.generateRangeQuery(query, "field");
+        assertThat(outputQuery)
+                .isEqualTo(
+                        "SELECT * FROM keyspace.table WHERE (token(field) >= ?) AND (token(field) < ?);");
+
+        // query without where clause but with another trailing clause
+        query = "SELECT field FROM keyspace.table LIMIT(1000);";
+        outputQuery = CassandraSplitReader.generateRangeQuery(query, "field");
+        assertThat(outputQuery)
+                .isEqualTo(
+                        "SELECT field FROM keyspace.table WHERE (token(field) >= ?) AND (token(field) < ?) LIMIT(1000);");
+    }
+
+    @Test
+    public void testGetHighestSplitQuery() {
+        String query;
+        String outputQuery;
+
+        // query with where clause
+        query = "SELECT field FROM keyspace.table WHERE field = value;";
+        outputQuery = CassandraSplitReader.getHighestSplitQuery(query, "field", BigInteger.ZERO);
+        assertThat(outputQuery)
+                .isEqualTo(
+                        "SELECT field FROM keyspace.table WHERE (token(field) >= 0) AND field = value;");
+
+        // query without where clause
+        query = "SELECT * FROM keyspace.table;";
+        outputQuery = CassandraSplitReader.getHighestSplitQuery(query, "field", BigInteger.ZERO);
+        assertThat(outputQuery)
+                .isEqualTo("SELECT * FROM keyspace.table WHERE (token(field) >= 0);");
+
+        // query without where clause but with another trailing clause
+        query = "SELECT field FROM keyspace.table LIMIT(1000);";
+        outputQuery = CassandraSplitReader.getHighestSplitQuery(query, "field", BigInteger.ZERO);
+        assertThat(outputQuery)
+                .isEqualTo(
+                        "SELECT field FROM keyspace.table WHERE (token(field) >= 0) LIMIT(1000);");
+    }
+
+    @Test
+    public void testGetLowestSplitQuery() {
+        String query;
+        String outputQuery;
+
+        // query with where clause
+        query = "SELECT field FROM keyspace.table WHERE field = value;";
+        outputQuery = CassandraSplitReader.getLowestSplitQuery(query, "field", BigInteger.ZERO);
+        assertThat(outputQuery)
+                .isEqualTo(
+                        "SELECT field FROM keyspace.table WHERE (token(field) < 0) AND field = value;");
+
+        // query without where clause
+        query = "SELECT * FROM keyspace.table;";
+        outputQuery = CassandraSplitReader.getLowestSplitQuery(query, "field", BigInteger.ZERO);
+        assertThat(outputQuery).isEqualTo("SELECT * FROM keyspace.table WHERE (token(field) < 0);");
+
+        // query without where clause but with another trailing clause
+        query = "SELECT field FROM keyspace.table LIMIT(1000);";
+        outputQuery = CassandraSplitReader.getLowestSplitQuery(query, "field", BigInteger.ZERO);
+        assertThat(outputQuery)
+                .isEqualTo(
+                        "SELECT field FROM keyspace.table WHERE (token(field) < 0) LIMIT(1000);");
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/split/CassandraSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/split/CassandraSplitSerializerTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.split;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link CassandraSplitSerializer}. */
+public class CassandraSplitSerializerTest {
+
+    @Test
+    public void testSerdeRoundtrip() throws IOException {
+        final CassandraSplit testData =
+                new CassandraSplit(
+                        ImmutableSet.of(
+                                RingRange.of(BigInteger.ONE, BigInteger.TEN),
+                                RingRange.of(BigInteger.ZERO, BigInteger.TEN)));
+        final byte[] serialized = CassandraSplitSerializer.INSTANCE.serialize(testData);
+        final CassandraSplit deserialized =
+                CassandraSplitSerializer.INSTANCE.deserialize(
+                        CassandraSplitSerializer.CURRENT_VERSION, serialized);
+        assertThat(deserialized)
+                .isEqualTo(testData)
+                .withFailMessage(
+                        "CassandraSplit is not the same as input object after serde roundtrip");
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/split/SplitsGeneratorTest.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connector/cassandra/source/split/SplitsGeneratorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.cassandra.source.split;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link SplitsGenerator}. */
+public final class SplitsGeneratorTest {
+
+    @Test
+    public void testGenerateSegments() {
+        List<BigInteger> tokens =
+                Stream.of(
+                                "0",
+                                "1",
+                                "56713727820156410577229101238628035242",
+                                "56713727820156410577229101238628035243",
+                                "113427455640312821154458202477256070484",
+                                "113427455640312821154458202477256070485")
+                        .map(BigInteger::new)
+                        .collect(Collectors.toList());
+
+        SplitsGenerator generator = new SplitsGenerator("foo.bar.RandomPartitioner");
+        List<CassandraSplit> segments = generator.generateSplits(10, tokens);
+
+        assertThat(segments.size()).isEqualTo(12);
+        assertThat(segments.get(0).getRingRanges().toString())
+                .isEqualTo("[(0,1], (1,14178431955039102644307275309657008811]]");
+        assertThat(segments.get(1).getRingRanges().toString())
+                .isEqualTo(
+                        "[(14178431955039102644307275309657008811,28356863910078205288614550619314017621]]");
+        assertThat(segments.get(5).getRingRanges().toString())
+                .isEqualTo(
+                        "[(70892159775195513221536376548285044053,85070591730234615865843651857942052863]]");
+
+        tokens =
+                Stream.of(
+                                "5",
+                                "6",
+                                "56713727820156410577229101238628035242",
+                                "56713727820156410577229101238628035243",
+                                "113427455640312821154458202477256070484",
+                                "113427455640312821154458202477256070485")
+                        .map(BigInteger::new)
+                        .collect(Collectors.toList());
+
+        segments = generator.generateSplits(10, tokens);
+
+        assertThat(segments.size()).isEqualTo(12);
+        assertThat(segments.get(0).getRingRanges().toString())
+                .isEqualTo("[(5,6], (6,14178431955039102644307275309657008815]]");
+        assertThat(segments.get(5).getRingRanges().toString())
+                .isEqualTo(
+                        "[(70892159775195513221536376548285044053,85070591730234615865843651857942052863]]");
+        assertThat(segments.get(10).getRingRanges().toString())
+                .isEqualTo(
+                        "[(141784319550391026443072753096570088109,155962751505430129087380028406227096921]]");
+    }
+
+    @Test
+    public void testZeroSizeRange() {
+        List<String> tokenStrings =
+                Arrays.asList(
+                        "0",
+                        "1",
+                        "56713727820156410577229101238628035242",
+                        "56713727820156410577229101238628035242",
+                        "113427455640312821154458202477256070484",
+                        "113427455640312821154458202477256070485");
+
+        List<BigInteger> tokens =
+                tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
+
+        SplitsGenerator generator = new SplitsGenerator("foo.bar.RandomPartitioner");
+        assertThatThrownBy(() -> generator.generateSplits(10, tokens))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    public void testRotatedRing() {
+        List<String> tokenStrings =
+                Arrays.asList(
+                        "56713727820156410577229101238628035243",
+                        "113427455640312821154458202477256070484",
+                        "113427455640312821154458202477256070485",
+                        "5",
+                        "6",
+                        "56713727820156410577229101238628035242");
+
+        List<BigInteger> tokens =
+                tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
+
+        SplitsGenerator generator = new SplitsGenerator("foo.bar.RandomPartitioner");
+        List<CassandraSplit> splits = generator.generateSplits(5, tokens);
+        assertThat(splits.size()).isEqualTo(6);
+        assertThat(splits.get(1).getRingRanges())
+                .containsExactlyInAnyOrder(
+                        RingRange.of(
+                                new BigInteger("85070591730234615865843651857942052863"),
+                                new BigInteger("113427455640312821154458202477256070484")),
+                        RingRange.of(
+                                new BigInteger("113427455640312821154458202477256070484"),
+                                new BigInteger("113427455640312821154458202477256070485")));
+
+        assertThat(splits.get(2).getRingRanges())
+                .containsExactlyInAnyOrder(
+                        RingRange.of(
+                                new BigInteger("113427455640312821154458202477256070485"),
+                                new BigInteger("141784319550391026443072753096570088109")));
+
+        assertThat(splits.get(3).getRingRanges())
+                .containsExactlyInAnyOrder(
+                        RingRange.of(
+                                new BigInteger("141784319550391026443072753096570088109"),
+                                new BigInteger("5")),
+                        RingRange.of(new BigInteger("5"), new BigInteger("6")));
+    }
+
+    @Test
+    public void testDisorderedRing() {
+        List<String> tokenStrings =
+                Arrays.asList(
+                        "0",
+                        "113427455640312821154458202477256070485",
+                        "1",
+                        "56713727820156410577229101238628035242",
+                        "56713727820156410577229101238628035243",
+                        "113427455640312821154458202477256070484");
+
+        List<BigInteger> tokens =
+                tokenStrings.stream().map(BigInteger::new).collect(Collectors.toList());
+
+        SplitsGenerator generator = new SplitsGenerator("foo.bar.RandomPartitioner");
+        // Will throw an exception when concluding that the repair segments don't add up.
+        // This is because the tokens were supplied out of order.
+        assertThatThrownBy(() -> generator.generateSplits(10, tokens))
+                .isInstanceOf(RuntimeException.class);
+    }
+}

--- a/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connectors/cassandra/utils/Pojo.java
+++ b/flink-connectors/flink-connector-cassandra/src/test/java/org/apache/flink/connectors/cassandra/utils/Pojo.java
@@ -1,12 +1,13 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,12 +16,13 @@
  * limitations under the License.
  */
 
-package org.apache.flink.batch.connectors.cassandra.example;
+package org.apache.flink.connectors.cassandra.utils;
 
 import com.datastax.driver.mapping.annotations.Column;
 import com.datastax.driver.mapping.annotations.Table;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /** Test Pojo with DataStax annotations used. */
 @Table(keyspace = "flink", name = "batches")
@@ -68,5 +70,28 @@ public class Pojo implements Serializable {
 
     public void setBatchID(int batchId) {
         this.batchID = batchId;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+                "{\"id\":\"%s\", \"counter\":%d, \"batchID\":%d}", id, counter, batchID);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Pojo pojo = (Pojo) o;
+        return counter == pojo.counter && batchID == pojo.batchID && id.equals(pojo.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, counter, batchID);
     }
 }

--- a/flink-connectors/flink-connector-cassandra/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-cassandra/src/test/resources/log4j2-test.properties
@@ -18,7 +18,7 @@
 
 # Set root logger level to OFF to not flood build logs
 # set manually to INFO for debugging purposes
-rootLogger.level = OFF
+rootLogger.level = INFO
 rootLogger.appenderRef.test.ref = TestLogger
 
 appender.testlogger.name = TestLogger

--- a/tools/maven/suppressions.xml
+++ b/tools/maven/suppressions.xml
@@ -53,7 +53,7 @@ under the License.
 			checks="IllegalImport"/>
 		<!-- Cassandra connectors have to use guava directly -->
 		<suppress
-			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormatBase.java|OutputFormatBase.java|OutputFormatBaseTest.java|CassandraColumnarOutputFormatBase.java|CassandraSinkBase.java|CassandraSinkBaseTest.java|CassandraPojoSink.java|CassandraRowSink.java|CassandraTupleWriteAheadSink.java|CassandraRowWriteAheadSink.java|CassandraPojoOutputFormat.java"
+			files="AbstractCassandraTupleSink.java|CassandraInputFormat.java|CassandraOutputFormatBase.java|OutputFormatBase.java|OutputFormatBaseTest.java|CassandraColumnarOutputFormatBase.java|CassandraSinkBase.java|CassandraSinkBaseTest.java|CassandraPojoSink.java|CassandraRowSink.java|CassandraTupleWriteAheadSink.java|CassandraRowWriteAheadSink.java|CassandraPojoOutputFormat.java|CassandraRecordEmitter"
 			checks="IllegalImport"/>
 		<!-- Kinesis producer has to use guava directly -->
 		<suppress


### PR DESCRIPTION
## What is the purpose of the change

Add a flink source for Cassandra database compliant with [FLIP-27](https://cwiki.apache.org/confluence/display/FLINK/FLIP-27%3A+Refactor+Source+Interface)

## Brief change log

Implement everything needed for the source: enumerator, cassandra splits, source reader, split reader etc... + the related unit tests and integration tests.

Moved the annotated Pojo class used in Cassandra batch example to a common place (tests / casssandra utils) to be able to use it with both example and source tests


## Verifying this change

This change added tests and can be verified as follows:
- CassandraSourceITCase: integration test using the new source test framework and a Cassandra test container
- CassandraEnumeratorStateSerializerTest and CassandraSplitSerializerTest:  for serialization tests
- CassandraQueryTest: tests for query generation and query sanity checks
- SplitsGeneratorTest: test for ring ranges creation (use for splits)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): add connector base and connector test utils
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: adds a new `@Public(Evolving)` API
  - The serializers: add some new ones
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? javadoc

R: @zentol 
CC: @MartijnVisser 