### PR TITLE
[FLINK-29498] Add Scala Async Retry Strategies and ResultPredicates Helper Classes

### DIFF
--- a/docs/content.zh/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content.zh/docs/dev/datastream/operators/asyncio.md
@@ -125,8 +125,8 @@ DataStream<Tuple2<String, String>> resultStream =
 // 通过工具类创建一个异步重试策略, 或用户实现自定义的策略
 AsyncRetryStrategy asyncRetryStrategy =
 	new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(3, 100L) // maxAttempts=3, fixedDelay=100ms
-		.retryIfResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
-		.retryIfException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+		.ifResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
+		.ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
 		.build();
 
 // 应用异步 I/O 转换操作并启用重试
@@ -170,7 +170,11 @@ val resultStream: DataStream[(String, String)] =
 
 // 或 应用异步 I/O 转换操作并启用重试
 // 创建一个异步重试策略
-val asyncRetryStrategy: AsyncRetryStrategy[OUT] = ...
+val asyncRetryStrategy: AsyncRetryStrategy[String] =
+  new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(3, 100L) // maxAttempts=3, fixedDelay=100ms
+    .ifResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
+    .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+    .build();
 
 // 应用异步 I/O 转换操作并启用重试
 val resultStream: DataStream[(String, String)] =

--- a/docs/content/docs/dev/datastream/operators/asyncio.md
+++ b/docs/content/docs/dev/datastream/operators/asyncio.md
@@ -140,8 +140,8 @@ DataStream<Tuple2<String, String>> resultStream =
 // create an async retry strategy via utility class or a user defined strategy
 AsyncRetryStrategy asyncRetryStrategy =
 	new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(3, 100L) // maxAttempts=3, fixedDelay=100ms
-		.retryIfResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
-		.retryIfException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+		.ifResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
+		.ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
 		.build();
 
 // apply the async I/O transformation with retry
@@ -185,7 +185,11 @@ val resultStream: DataStream[(String, String)] =
 
 // apply the async I/O transformation with retry
 // create an AsyncRetryStrategy
-val asyncRetryStrategy: AsyncRetryStrategy[OUT] = ...
+val asyncRetryStrategy: AsyncRetryStrategy[String] =
+  new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(3, 100L) // maxAttempts=3, fixedDelay=100ms
+    .ifResult(RetryPredicates.EMPTY_RESULT_PREDICATE)
+    .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+    .build();
 
 // apply the async I/O transformation with retry
 val resultStream: DataStream[(String, String)] =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -430,7 +430,7 @@ public class AsyncWaitOperator<IN, OUT>
         /**
          * A guard similar to ResultHandler#complete to prevent repeated complete calls from
          * ill-written AsyncFunction. This flag indicates a retry is in-flight, new retry will be
-         * rejected if it is ture, and it will be reset to false after the retry fired.
+         * rejected if it is true, and it will be reset to false after the retry fired.
          */
         private final AtomicBoolean retryAwaiting = new AtomicBoolean(false);
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
@@ -66,6 +66,10 @@ object AsyncRetryStrategies {
     }
   }
 
+  /**
+   * FixedDelayRetryStrategyBuilder for building an {@link AsyncRetryStrategy} with fixed delay
+   * retrying behaviours.
+   */
   @PublicEvolving
   @SerialVersionUID(1L)
   class FixedDelayRetryStrategyBuilder[OUT](
@@ -90,6 +94,10 @@ object AsyncRetryStrategies {
     def build(): AsyncRetryStrategy[OUT] = new JavaToScalaRetryStrategy[OUT](builder.build())
   }
 
+  /**
+   * ExponentialBackoffDelayRetryStrategyBuilder for building an {@link AsyncRetryStrategy} with
+   * exponential delay retrying behaviours.
+   */
   @PublicEvolving
   @SerialVersionUID(1L)
   class ExponentialBackoffDelayRetryStrategyBuilder[OUT](

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.scala.async
+
+import org.apache.flink.streaming.api.functions.async
+import org.apache.flink.streaming.api.functions.async.{AsyncRetryStrategy => JAsyncRetryStrategy}
+import org.apache.flink.streaming.util.retryable.{AsyncRetryStrategies => JAsyncRetryStrategies}
+
+import java.{util => ju}
+import java.util.function.Predicate
+
+object AsyncRetryStrategies {
+
+  final private class JavaToScalaRetryStrategy[T] {
+    def convert(retryStrategy: JAsyncRetryStrategy[T]): AsyncRetryStrategy[T] = {
+      new AsyncRetryStrategy[T] {
+        override def canRetry(currentAttempts: Int): Boolean =
+          retryStrategy.canRetry(currentAttempts)
+
+        override def getBackoffTimeMillis(currentAttempts: Int): Long =
+          retryStrategy.getBackoffTimeMillis(currentAttempts)
+
+        override def getRetryPredicate(): AsyncRetryPredicate[T] = new AsyncRetryPredicate[T] {
+          val retryPredicates: async.AsyncRetryPredicate[T] = retryStrategy.getRetryPredicate
+
+          override def resultPredicate: Option[Predicate[ju.Collection[T]]] = {
+            if (retryPredicates.resultPredicate.isPresent)
+              Option(retryPredicates.resultPredicate.get)
+            else Option.empty
+          }
+
+          override def exceptionPredicate: Option[Predicate[Throwable]] = {
+            if (retryPredicates.exceptionPredicate.isPresent)
+              Option(retryPredicates.exceptionPredicate.get)
+            else Option.empty
+          }
+        }
+      }
+    }
+  }
+
+  @SerialVersionUID(1L)
+  class FixedDelayRetryStrategyBuilder[OUT](
+      private val maxAttempts: Int,
+      private val backoffTimeMillis: Long
+  ) {
+    private val converter = new JavaToScalaRetryStrategy[OUT]
+    private var builder =
+      new JAsyncRetryStrategies.FixedDelayRetryStrategyBuilder[OUT](maxAttempts, backoffTimeMillis)
+
+    def ifResult(resultRetryPredicate: Predicate[ju.Collection[OUT]])
+        : FixedDelayRetryStrategyBuilder[OUT] = {
+      this.builder = this.builder.ifResult(resultRetryPredicate)
+      this
+    }
+
+    def ifException(
+        exceptionRetryPredicate: Predicate[Throwable]): FixedDelayRetryStrategyBuilder[OUT] = {
+      this.builder = this.builder.ifException(exceptionRetryPredicate)
+      this
+    }
+
+    def build(): AsyncRetryStrategy[OUT] = {
+      converter.convert(builder.build())
+    }
+  }
+
+  @SerialVersionUID(1L)
+  class ExponentialBackoffDelayRetryStrategyBuilder[OUT](
+      private val maxAttempts: Int,
+      private val initialDelay: Long,
+      private val maxRetryDelay: Long,
+      private val multiplier: Double
+  ) {
+    private val converter = new JavaToScalaRetryStrategy[OUT]
+    private var builder =
+      new JAsyncRetryStrategies.ExponentialBackoffDelayRetryStrategyBuilder[OUT](
+        maxAttempts,
+        initialDelay,
+        maxRetryDelay,
+        multiplier)
+
+    def ifResult(resultRetryPredicate: Predicate[ju.Collection[OUT]])
+        : ExponentialBackoffDelayRetryStrategyBuilder[OUT] = {
+      this.builder = this.builder.ifResult(resultRetryPredicate)
+      this
+    }
+
+    def ifException(exceptionRetryPredicate: Predicate[Throwable])
+        : ExponentialBackoffDelayRetryStrategyBuilder[OUT] = {
+      this.builder = this.builder.ifException(exceptionRetryPredicate)
+      this
+    }
+
+    def build(): AsyncRetryStrategy[OUT] = {
+      converter.convert(builder.build())
+    }
+  }
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
@@ -25,10 +25,11 @@ import org.apache.flink.streaming.util.retryable.{AsyncRetryStrategies => JAsync
 import java.{util => ju}
 import java.util.function.Predicate
 
+/** Utility class to create concrete {@link AsyncRetryStrategy}. */
 object AsyncRetryStrategies {
 
   final private class JavaToScalaRetryStrategy[T] {
-    def convert(retryStrategy: JAsyncRetryStrategy[T]): AsyncRetryStrategy[T] = {
+    def convert(retryStrategy: JAsyncRetryStrategy[T]): AsyncRetryStrategy[T] =
       new AsyncRetryStrategy[T] {
         override def canRetry(currentAttempts: Int): Boolean =
           retryStrategy.canRetry(currentAttempts)
@@ -46,7 +47,6 @@ object AsyncRetryStrategies {
             retryPredicates.exceptionPredicate.orElse(null))
         }
       }
-    }
   }
 
   @PublicEvolving
@@ -71,9 +71,7 @@ object AsyncRetryStrategies {
       this
     }
 
-    def build(): AsyncRetryStrategy[OUT] = {
-      converter.convert(builder.build())
-    }
+    def build(): AsyncRetryStrategy[OUT] = converter.convert(builder.build())
   }
 
   @PublicEvolving
@@ -104,8 +102,6 @@ object AsyncRetryStrategies {
       this
     }
 
-    def build(): AsyncRetryStrategy[OUT] = {
-      converter.convert(builder.build())
-    }
+    def build(): AsyncRetryStrategy[OUT] = converter.convert(builder.build())
   }
 }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
@@ -17,6 +17,7 @@
  */
 package org.apache.flink.streaming.api.scala.async
 
+import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.streaming.api.functions.async
 import org.apache.flink.streaming.api.functions.async.{AsyncRetryStrategy => JAsyncRetryStrategy}
 import org.apache.flink.streaming.util.retryable.{AsyncRetryStrategies => JAsyncRetryStrategies}
@@ -48,6 +49,7 @@ object AsyncRetryStrategies {
     }
   }
 
+  @PublicEvolving
   @SerialVersionUID(1L)
   class FixedDelayRetryStrategyBuilder[OUT](
       private val maxAttempts: Int,
@@ -74,6 +76,7 @@ object AsyncRetryStrategies {
     }
   }
 
+  @PublicEvolving
   @SerialVersionUID(1L)
   class ExponentialBackoffDelayRetryStrategyBuilder[OUT](
       private val maxAttempts: Int,

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/AsyncRetryStrategies.scala
@@ -38,17 +38,11 @@ object AsyncRetryStrategies {
         override def getRetryPredicate(): AsyncRetryPredicate[T] = new AsyncRetryPredicate[T] {
           val retryPredicates: async.AsyncRetryPredicate[T] = retryStrategy.getRetryPredicate
 
-          override def resultPredicate: Option[Predicate[ju.Collection[T]]] = {
-            if (retryPredicates.resultPredicate.isPresent)
-              Option(retryPredicates.resultPredicate.get)
-            else Option.empty
-          }
+          override def resultPredicate: Option[Predicate[ju.Collection[T]]] = Option(
+            retryPredicates.resultPredicate.orElse(null))
 
-          override def exceptionPredicate: Option[Predicate[Throwable]] = {
-            if (retryPredicates.exceptionPredicate.isPresent)
-              Option(retryPredicates.exceptionPredicate.get)
-            else Option.empty
-          }
+          override def exceptionPredicate: Option[Predicate[Throwable]] = Option(
+            retryPredicates.exceptionPredicate.orElse(null))
         }
       }
     }

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.scala.async
+
+import org.apache.flink.streaming.util.retryable.{RetryPredicates => JRetryPredicates}
+
+import java.util
+import java.util.function.Predicate
+
+object RetryPredicates {
+
+  def EMPTY_RESULT_PREDICATE[T]: Predicate[util.Collection[T]] =
+    JRetryPredicates.EMPTY_RESULT_PREDICATE.asInstanceOf[Predicate[util.Collection[T]]]
+
+  def HAS_EXCEPTION_PREDICATE: Predicate[Throwable] =
+    JRetryPredicates.HAS_EXCEPTION_PREDICATE.asInstanceOf[Predicate[Throwable]]
+
+}

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
@@ -23,12 +23,15 @@ import org.apache.flink.streaming.util.retryable.{RetryPredicates => JRetryPredi
 import java.util
 import java.util.function.Predicate
 
+/** Utility class to create concrete retry predicates. */
 @PublicEvolving
 object RetryPredicates {
 
+  /** A predicate matches empty result which means an empty {@link Collection}. */
   def EMPTY_RESULT_PREDICATE[T]: Predicate[util.Collection[T]] =
     JRetryPredicates.EMPTY_RESULT_PREDICATE.asInstanceOf[Predicate[util.Collection[T]]]
 
+  /** A predicate matches any exception which means a non-null{@link Throwable}. */
   def HAS_EXCEPTION_PREDICATE: Predicate[Throwable] =
     JRetryPredicates.HAS_EXCEPTION_PREDICATE.asInstanceOf[Predicate[Throwable]]
 

--- a/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
+++ b/flink-streaming-scala/src/main/scala/org/apache/flink/streaming/api/scala/async/RetryPredicates.scala
@@ -17,11 +17,13 @@
  */
 package org.apache.flink.streaming.api.scala.async
 
+import org.apache.flink.annotation.PublicEvolving
 import org.apache.flink.streaming.util.retryable.{RetryPredicates => JRetryPredicates}
 
 import java.util
 import java.util.function.Predicate
 
+@PublicEvolving
 object RetryPredicates {
 
   def EMPTY_RESULT_PREDICATE[T]: Predicate[util.Collection[T]] =


### PR DESCRIPTION
## What is the purpose of the change
Fixes [FLIP-29498](https://issues.apache.org/jira/browse/FLINK-29498)

## Brief change log
* Adds the utility builder classes for creating a `FixedDelayRetryStrategy` and `ExponentialBackoffDelayRetryStrategy` retry strategy in the Scala API.
* Adds the utility RetryPredicates to the Scala API.
* Replaces code in test that builds a retry strategy to use the builder classes.
* Edit docs to use correct builder functions.

## Verifying this change
`AsyncDataStreamITCase`

## Documentation
* Does this pull request introduce a new feature? (yes)
* If yes, how is the feature documented?