### PR TITLE
[FLINK-29648][python] Fix "LocalDateTime not supported" error

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pxd
@@ -194,16 +194,10 @@ cdef class AvroCoderImpl(FieldCoderImpl):
     cdef object _writer
 
 cdef class LocalDateCoderImpl(FieldCoderImpl):
-    @staticmethod
-    cdef _encode_to_stream(value, OutputStream out_stream)
-    @staticmethod
-    cdef _decode_from_stream(InputStream in_stream)
+    pass
 
 cdef class LocalTimeCoderImpl(FieldCoderImpl):
-    @staticmethod
-    cdef _encode_to_stream(value, OutputStream out_stream)
-    @staticmethod
-    cdef _decode_from_stream(InputStream in_stream)
+    pass
 
 cdef class LocalDateTimeCoderImpl(FieldCoderImpl):
     pass

--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -967,7 +967,7 @@ cdef class AvroCoderImpl(FieldCoderImpl):
 cdef class LocalDateCoderImpl(FieldCoderImpl):
 
     @staticmethod
-    cdef _encode_to_stream(value, OutputStream out_stream):
+    def _encode_to_stream(value, OutputStream out_stream):
         if value is None:
             out_stream.write_int32(0xFFFFFFFF)
             out_stream.write_int16(0xFFFF)
@@ -977,7 +977,7 @@ cdef class LocalDateCoderImpl(FieldCoderImpl):
             out_stream.write_int8(value.day)
 
     @staticmethod
-    cdef _decode_from_stream(InputStream in_stream):
+    def _decode_from_stream(InputStream in_stream):
         year = in_stream.read_int32()
         if year == 0xFFFFFFFF:
             in_stream.read(2)
@@ -987,15 +987,15 @@ cdef class LocalDateCoderImpl(FieldCoderImpl):
         return datetime.date(year, month, day)
 
     cpdef encode_to_stream(self, value, OutputStream out_stream):
-        return LocalDateCoderImpl._encode_to_stream(value, out_stream)
+        return self._encode_to_stream(value, out_stream)
 
     cpdef decode_from_stream(self, InputStream in_stream, size_t length):
-        return LocalDateCoderImpl._decode_from_stream(in_stream)
+        return self._decode_from_stream(in_stream)
 
 cdef class LocalTimeCoderImpl(FieldCoderImpl):
 
     @staticmethod
-    cdef _encode_to_stream(value, OutputStream out_stream):
+    def _encode_to_stream(value, OutputStream out_stream):
         if value is None:
             out_stream.write_int8(0xFF)
             out_stream.write_int16(0xFFFF)
@@ -1007,7 +1007,7 @@ cdef class LocalTimeCoderImpl(FieldCoderImpl):
             out_stream.write_int32(value.microsecond * 1000)
 
     @staticmethod
-    cdef _decode_from_stream(InputStream in_stream):
+    def _decode_from_stream(InputStream in_stream):
         hour = in_stream.read_int8()
         if hour == 0xFF:
             in_stream.read(6)
@@ -1018,10 +1018,10 @@ cdef class LocalTimeCoderImpl(FieldCoderImpl):
         return datetime.time(hour, minute, second, nano // 1000)
 
     cpdef encode_to_stream(self, value, OutputStream out_stream):
-        return LocalTimeCoderImpl._encode_to_stream(value, out_stream)
+        return self._encode_to_stream(value, out_stream)
 
     cpdef decode_from_stream(self, InputStream in_stream, size_t length):
-        return LocalTimeCoderImpl._decode_from_stream(in_stream)
+        return self._decode_from_stream(in_stream)
 
 cdef class LocalDateTimeCoderImpl(FieldCoderImpl):
 


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes "LocalTimeTypeInfo not supported" error when retrieving TypeInformation from PyFlink, e.g. calling `key_by` after `to_data_stream`.

## Verifying this change

This change added tests and can be verified as follows:
`test_to_data_stream_local_time` in test_table_environment_api.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
