### PR TITLE
[FLINK-29545][runtime] add netty idle state handler

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -427,6 +427,15 @@ public class NettyShuffleEnvironmentOptions {
                                     + " based on the platform. Note that the \"epoll\" mode can get better performance, less GC and have more advanced features which are"
                                     + " only available on modern Linux.");
 
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Long> NETWORK_IDLE_TIMEOUT_MILLISECONDS =
+            key("taskmanager.network.netty.idle-timeout-millisecond")
+                    .longType()
+                    .defaultValue(-1L)
+                    .withDescription(
+                            "The timeout millisecond for idle state handler to trigger warning for"
+                                    + "tcp connection heartbeat timeout.");
+
     // ------------------------------------------------------------------------
     //  Partition Request Options
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/PartitionRequestClient.java
@@ -65,6 +65,13 @@ public interface PartitionRequestClient {
     void resumeConsumption(RemoteInputChannel inputChannel);
 
     /**
+     * Heartbeats to signal the netty client is still alive.
+     *
+     * @param inputChannel The remote input channel who is supposed to receive the heartbeat.
+     */
+    void HearbeatForConnection(RemoteInputChannel inputChannel);
+
+    /**
      * Acknowledges all user records are processed for this channel.
      *
      * @param inputChannel The input channel to resume data consumption.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyConfig.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.net.InetAddress;
+import java.time.Duration;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -129,6 +130,10 @@ public class NettyConfig {
         return config.getInteger(NettyShuffleEnvironmentOptions.SEND_RECEIVE_BUFFER_SIZE);
     }
 
+    public long getHealthCheckTimeOutMilliSecond() {
+        return config.getLong(NettyShuffleEnvironmentOptions.NETWORK_IDLE_TIMEOUT_MILLISECONDS);
+    }
+
     public TransportType getTransportType() {
         String transport = config.getString(NettyShuffleEnvironmentOptions.TRANSPORT_TYPE);
 
@@ -174,7 +179,8 @@ public class NettyConfig {
                         + "number of client threads: %d (%s), "
                         + "server connect backlog: %d (%s), "
                         + "client connect timeout (sec): %d, "
-                        + "send/receive buffer size (bytes): %d (%s)]";
+                        + "send/receive buffer size (bytes): %d (%s), "
+                        + "tcp idle timeout millisecond: %d]";
 
         String def = "use Netty's default";
         String man = "manual";
@@ -194,6 +200,7 @@ public class NettyConfig {
                 getServerConnectBacklog() == 0 ? def : man,
                 getClientConnectTimeoutSeconds(),
                 getSendAndReceiveBufferSize(),
-                getSendAndReceiveBufferSize() == 0 ? def : man);
+                getSendAndReceiveBufferSize() == 0 ? def : man,
+                getHealthCheckTimeOutMilliSecond());
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -229,6 +229,12 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
     }
 
     @Override
+    public void HearbeatForConnection(RemoteInputChannel inputChannel) {
+        sendToChannel(new HeartBeatMessage(inputChannel));
+    }
+
+
+    @Override
     public void acknowledgeAllRecordsProcessed(RemoteInputChannel inputChannel) {
         sendToChannel(new AcknowledgeAllRecordsProcessedMessage(inputChannel));
     }
@@ -329,6 +335,17 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
         @Override
         Object buildMessage() {
             return new NettyMessage.AckAllUserRecordsProcessed(inputChannel.getInputChannelId());
+        }
+    }
+
+    private static class HeartBeatMessage extends ClientOutboundMessage {
+        HeartBeatMessage(RemoteInputChannel inputChannel) {
+            super(checkNotNull(inputChannel));
+        }
+
+        @Override
+        public Object buildMessage() {
+            return new NettyMessage.HeartBeat(inputChannel.getInputChannelId());
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyServer.java
@@ -69,7 +69,7 @@ class NettyServer {
     int init(final NettyProtocol protocol, NettyBufferPool nettyBufferPool) throws IOException {
         return init(
                 nettyBufferPool,
-                sslHandlerFactory -> new ServerChannelInitializer(protocol, sslHandlerFactory));
+                sslHandlerFactory -> new ServerChannelInitializer(protocol, sslHandlerFactory, config.getHealthCheckTimeOutMilliSecond()));
     }
 
     int init(
@@ -211,11 +211,13 @@ class NettyServer {
     static class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
         private final NettyProtocol protocol;
         private final SSLHandlerFactory sslHandlerFactory;
+        private final Long nettyIdleTimeout;
 
         public ServerChannelInitializer(
-                NettyProtocol protocol, SSLHandlerFactory sslHandlerFactory) {
+                NettyProtocol protocol, SSLHandlerFactory sslHandlerFactory, Long nettyIdleTimeout) {
             this.protocol = protocol;
             this.sslHandlerFactory = sslHandlerFactory;
+            this.nettyIdleTimeout = nettyIdleTimeout;
         }
 
         @Override
@@ -225,7 +227,7 @@ class NettyServer {
                         .addLast("ssl", sslHandlerFactory.createNettySSLHandler(channel.alloc()));
             }
 
-            channel.pipeline().addLast(protocol.getServerChannelHandlers());
+            channel.pipeline().addLast(protocol.getServerChannelHandlers(this.nettyIdleTimeout));
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestServerHandler.java
@@ -49,6 +49,8 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
 
     private final PartitionRequestQueue outboundQueue;
 
+    private boolean firstHeartbeat = true;
+
     PartitionRequestServerHandler(
             ResultPartitionProvider partitionProvider,
             TaskEventPublisher taskEventPublisher,
@@ -132,6 +134,14 @@ class PartitionRequestServerHandler extends SimpleChannelInboundHandler<NettyMes
                 NewBufferSize request = (NewBufferSize) msg;
 
                 outboundQueue.notifyNewBufferSize(request.receiverId, request.bufferSize);
+            } else if (msgClazz == NettyMessage.HeartBeat.class) {
+                if (firstHeartbeat) {
+                    LOG.debug("Received heartbeat request: {} from {}",
+                            msg,
+                            ctx.channel().remoteAddress()
+                    );
+                    firstHeartbeat = false;
+                }
             } else {
                 LOG.warn("Received unexpected client request: {}", msg);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/idlehandle/ServerIdleCheckHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/idlehandle/ServerIdleCheckHandler.java
@@ -1,0 +1,33 @@
+package org.apache.flink.runtime.io.network.netty.idlehandle;
+
+
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.handler.timeout.IdleStateEvent;
+import org.apache.flink.shaded.netty4.io.netty.handler.timeout.IdleStateHandler;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+
+public class ServerIdleCheckHandler extends IdleStateHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(ServerIdleCheckHandler.class);
+
+    public ServerIdleCheckHandler(Long readerIdleTime) {
+        super(readerIdleTime, 0, 0, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected void channelIdle(ChannelHandlerContext ctx, IdleStateEvent evt) throws Exception {
+        if (evt == IdleStateEvent.READER_IDLE_STATE_EVENT) {
+            LOG.warn(
+                    "server idle check happen, timeout {} millisecond",
+                    super.getReaderIdleTimeInMillis()
+            );
+            return;
+        }
+
+        super.channelIdle(ctx, evt);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannel.java
@@ -375,4 +375,6 @@ public abstract class InputChannel {
     }
 
     void setup() throws IOException {}
+
+    void HearbeatForConnection() {}
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/RemoteInputChannel.java
@@ -165,6 +165,11 @@ public class RemoteInputChannel extends InputChannel {
         bufferManager.requestExclusiveBuffers(initialCredit);
     }
 
+    @Override
+    void HearbeatForConnection() {
+        partitionRequestClient.HearbeatForConnection(this);
+    }
+
     // ------------------------------------------------------------------------
     // Consume
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGate.java
@@ -275,6 +275,20 @@ public class SingleInputGate extends IndexedInputGate {
         setBufferPool(bufferPool);
 
         setupChannels();
+
+
+        new Thread(() -> {
+            while(true) {
+                try {
+                    Thread.sleep(10 * 1000);
+                    for (InputChannel inputChannel: inputChannels.values()) {
+                        inputChannel.HearbeatForConnection();
+                    }
+                } catch (InterruptedException e) {
+                    // continue
+                }
+            }
+        }).start();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -81,7 +81,7 @@ public class ClientTransportErrorHandlingTest {
                         mock(ResultPartitionProvider.class), mock(TaskEventDispatcher.class)) {
 
                     @Override
-                    public ChannelHandler[] getServerChannelHandlers() {
+                    public ChannelHandler[] getServerChannelHandlers(Long idleTimeout) {
                         return new ChannelHandler[0];
                     }
                 };
@@ -230,7 +230,7 @@ public class ClientTransportErrorHandlingTest {
                         mock(ResultPartitionProvider.class), mock(TaskEventDispatcher.class)) {
 
                     @Override
-                    public ChannelHandler[] getServerChannelHandlers() {
+                    public ChannelHandler[] getServerChannelHandlers(Long idleTimeout) {
                         return new ChannelHandler[] {
                             // Close on read
                             new ChannelInboundHandlerAdapter() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyClientServerSslTest.java
@@ -333,7 +333,7 @@ public class NettyClientServerSslTest extends TestLogger {
         }
 
         @Override
-        public ChannelHandler[] getServerChannelHandlers() {
+        public ChannelHandler[] getServerChannelHandlers(Long idleTimeout) {
             return new ChannelHandler[0];
         }
 
@@ -357,7 +357,7 @@ public class NettyClientServerSslTest extends TestLogger {
                 SSLHandlerFactory sslHandlerFactory,
                 OneShotLatch latch,
                 SslHandler[] serverHandler) {
-            super(protocol, sslHandlerFactory);
+            super(protocol, sslHandlerFactory, -1L);
             this.latch = latch;
             this.serverHandler = serverHandler;
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -262,7 +262,7 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
                 new NettyProtocol(null, null) {
 
                     @Override
-                    public ChannelHandler[] getServerChannelHandlers() {
+                    public ChannelHandler[] getServerChannelHandlers(Long idleTimeout) {
                         return new ChannelHandler[10];
                     }
 


### PR DESCRIPTION


## What is the purpose of the change

detect network connection problem


## Brief change log

add an idle state handler for netty protocol


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing



This change is a trivial rework / code cleanup without any test coverage.



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
