### PR TITLE
[FLINK-29645] BatchExecutionKeyedStateBackend is using incorrect ExecutionConfig when creating serializer

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/benchmark/StateBackendBenchmarkUtils.java
@@ -36,6 +36,7 @@ import org.apache.flink.contrib.streaming.state.RocksDBResourceContainer;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.state.AbstractStateBackend;
 import org.apache.flink.runtime.state.CheckpointableKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;
@@ -89,7 +90,7 @@ public class StateBackendBenchmarkUtils {
     private static CheckpointableKeyedStateBackend<Long> createBatchExecutionStateBackend() {
         return new BatchExecutionStateBackend()
                 .createKeyedStateBackend(
-                        null,
+                        MockEnvironment.builder().build(),
                         new JobID(),
                         "Test",
                         new LongSerializer(),

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionKeyedStateBackend.java
@@ -93,10 +93,15 @@ public class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedSt
     private final Map<String, KeyGroupedInternalPriorityQueue<?>> priorityQueues = new HashMap<>();
     private final KeyGroupRange keyGroupRange;
 
+    private final ExecutionConfig executionConfig;
+
     public BatchExecutionKeyedStateBackend(
-            TypeSerializer<K> keySerializer, KeyGroupRange keyGroupRange) {
+            TypeSerializer<K> keySerializer,
+            KeyGroupRange keyGroupRange,
+            ExecutionConfig executionConfig) {
         this.keySerializer = keySerializer;
         this.keyGroupRange = keyGroupRange;
+        this.executionConfig = executionConfig;
     }
 
     @Override
@@ -167,7 +172,7 @@ public class BatchExecutionKeyedStateBackend<K> implements CheckpointableKeyedSt
                         + "This operation cannot use partitioned state.");
 
         if (!stateDescriptor.isSerializerInitialized()) {
-            stateDescriptor.initializeSerializerUnlessSet(new ExecutionConfig());
+            stateDescriptor.initializeSerializerUnlessSet(executionConfig);
         }
 
         State state = states.get(stateDescriptor.getName());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackend.java
@@ -53,7 +53,8 @@ public class BatchExecutionStateBackend implements StateBackend {
             MetricGroup metricGroup,
             @Nonnull Collection<KeyedStateHandle> stateHandles,
             CloseableRegistry cancelStreamRegistry) {
-        return new BatchExecutionKeyedStateBackend<>(keySerializer, keyGroupRange);
+        return new BatchExecutionKeyedStateBackend<>(
+                keySerializer, keyGroupRange, env.getExecutionConfig());
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.sorted.state;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.core.fs.CloseableRegistry;
@@ -125,7 +126,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
     @Test
     public void testFiringEventTimeTimers() throws Exception {
         BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend =
-                new BatchExecutionKeyedStateBackend<>(KEY_SERIALIZER, new KeyGroupRange(0, 1));
+                new BatchExecutionKeyedStateBackend<>(
+                        KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
                         keyedStatedBackend,
@@ -159,7 +161,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
     @Test
     public void testSettingSameKeyDoesNotFireTimers() {
         BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend =
-                new BatchExecutionKeyedStateBackend<>(KEY_SERIALIZER, new KeyGroupRange(0, 1));
+                new BatchExecutionKeyedStateBackend<>(
+                        KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
                         keyedStatedBackend,
@@ -186,7 +189,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
     @Test
     public void testCurrentWatermark() throws Exception {
         BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend =
-                new BatchExecutionKeyedStateBackend<>(KEY_SERIALIZER, new KeyGroupRange(0, 1));
+                new BatchExecutionKeyedStateBackend<>(
+                        KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
                         keyedStatedBackend,
@@ -230,7 +234,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
     @Test
     public void testProcessingTimeTimers() {
         BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend =
-                new BatchExecutionKeyedStateBackend<>(KEY_SERIALIZER, new KeyGroupRange(0, 1));
+                new BatchExecutionKeyedStateBackend<>(
+                        KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
@@ -263,7 +268,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
     @Test
     public void testIgnoringEventTimeTimersFromWithinCallback() {
         BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend =
-                new BatchExecutionKeyedStateBackend<>(KEY_SERIALIZER, new KeyGroupRange(0, 1));
+                new BatchExecutionKeyedStateBackend<>(
+                        KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(
@@ -301,7 +307,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
     @Test
     public void testIgnoringProcessingTimeTimersFromWithinCallback() {
         BatchExecutionKeyedStateBackend<Integer> keyedStatedBackend =
-                new BatchExecutionKeyedStateBackend<>(KEY_SERIALIZER, new KeyGroupRange(0, 1));
+                new BatchExecutionKeyedStateBackend<>(
+                        KEY_SERIALIZER, new KeyGroupRange(0, 1), new ExecutionConfig());
         TestProcessingTimeService processingTimeService = new TestProcessingTimeService();
         InternalTimeServiceManager<Integer> timeServiceManager =
                 BatchExecutionInternalTimeServiceManager.create(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.sorted.state;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.api.common.functions.ReduceFunction;
 import org.apache.flink.api.common.state.AggregatingState;
@@ -80,7 +81,8 @@ public class BatchExecutionStateBackendTest extends TestLogger {
 
     private <K> CheckpointableKeyedStateBackend<K> createKeyedBackend(
             TypeSerializer<K> keySerializer) {
-        return new BatchExecutionKeyedStateBackend<>(keySerializer, new KeyGroupRange(0, 9));
+        return new BatchExecutionKeyedStateBackend<>(
+                keySerializer, new KeyGroupRange(0, 9), new ExecutionConfig());
     }
 
     /**

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionStateBackendVerificationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.sorted.state;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeutils.base.LongSerializer;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -45,7 +46,8 @@ public class BatchExecutionStateBackendVerificationTest extends TestLogger {
         expectedException.expectMessage("Snapshotting is not supported in BATCH runtime mode.");
 
         BatchExecutionKeyedStateBackend<Long> stateBackend =
-                new BatchExecutionKeyedStateBackend<>(LONG_SERIALIZER, new KeyGroupRange(0, 9));
+                new BatchExecutionKeyedStateBackend<>(
+                        LONG_SERIALIZER, new KeyGroupRange(0, 9), new ExecutionConfig());
 
         long checkpointId = 0L;
         CheckpointStreamFactory streamFactory = new MemCheckpointStreamFactory(10);


### PR DESCRIPTION
## What is the purpose of the change

Use correct `ExecutionConfig` in `BatchExecutionKeyedStateBackend`


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
