### PR TITLE
[hotfix] Use getParameterCount rather than getParameterTypes().length

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisConsumerTest.java
@@ -819,13 +819,9 @@ public class FlinkKinesisConsumerTest extends TestLogger {
         java.lang.reflect.Constructor<KinesisDataFetcher> ctor =
                 (java.lang.reflect.Constructor<KinesisDataFetcher>)
                         KinesisDataFetcher.class.getConstructors()[0];
-        Class<?>[] otherParamTypes = new Class<?>[ctor.getParameterTypes().length - 1];
+        Class<?>[] otherParamTypes = new Class<?>[ctor.getParameterCount() - 1];
         System.arraycopy(
-                ctor.getParameterTypes(),
-                1,
-                otherParamTypes,
-                0,
-                ctor.getParameterTypes().length - 1);
+                ctor.getParameterTypes(), 1, otherParamTypes, 0, ctor.getParameterCount() - 1);
 
         Supplier<Object[]> argumentSupplier =
                 () -> {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/TypeExtractor.java
@@ -552,7 +552,7 @@ public class TypeExtractor {
 
                 // number of parameters the SAM of implemented interface has; the parameter indexing
                 // applies to this range
-                final int baseParametersLen = sam.getParameterTypes().length;
+                final int baseParametersLen = sam.getParameterCount();
 
                 final Type output;
                 if (lambdaOutputTypeArgumentIndices.length > 0) {
@@ -687,7 +687,7 @@ public class TypeExtractor {
             if (exec != null) {
 
                 final Method sam = TypeExtractionUtils.getSingleAbstractMethod(baseClass);
-                final int baseParametersLen = sam.getParameterTypes().length;
+                final int baseParametersLen = sam.getParameterCount();
 
                 // parameters must be accessed from behind, since JVM can add additional parameters
                 // e.g. when using local variables inside lambda function
@@ -2004,7 +2004,7 @@ public class TypeExtractor {
                                 || methodNameLow.equals(fieldNameLow))
                         &&
                         // no arguments for the getter
-                        m.getParameterTypes().length == 0
+                        m.getParameterCount() == 0
                         &&
                         // return type is same as field type (or the generic variant of it)
                         (m.getGenericReturnType().equals(fieldType)
@@ -2015,7 +2015,7 @@ public class TypeExtractor {
                 // check for setters (<FieldName>_$eq for scala)
                 if ((methodNameLow.equals("set" + fieldNameLow)
                                 || methodNameLow.equals(fieldNameLow + "_$eq"))
-                        && m.getParameterTypes().length == 1
+                        && m.getParameterCount() == 1
                         && // one parameter of the field's type
                         (m.getGenericParameterTypes()[0].equals(fieldType)
                                 || (m.getParameterTypes()[0].equals(fieldTypeWrapper))

--- a/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
+++ b/flink-core/src/main/java/org/apache/flink/util/InstantiationUtil.java
@@ -456,7 +456,7 @@ public final class InstantiationUtil {
     public static boolean hasPublicNullaryConstructor(Class<?> clazz) {
         Constructor<?>[] constructors = clazz.getConstructors();
         for (Constructor<?> constructor : constructors) {
-            if (constructor.getParameterTypes().length == 0
+            if (constructor.getParameterCount() == 0
                     && Modifier.isPublic(constructor.getModifiers())) {
                 return true;
             }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/extraction/ExtractionUtils.java
@@ -633,7 +633,7 @@ public final class ExtractionUtils {
         for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
             final boolean qualifyingConstructor =
                     Modifier.isPublic(constructor.getModifiers())
-                            && constructor.getParameterTypes().length == fields.size();
+                            && constructor.getParameterCount() == fields.size();
             if (!qualifyingConstructor) {
                 continue;
             }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/TreeNode.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/expressions/TreeNode.scala
@@ -81,7 +81,7 @@ abstract class TreeNode[A <: TreeNode[A]] extends Product { self: A =>
    * children change.
    */
   private[flink] def makeCopy(newArgs: Array[AnyRef]): A = {
-    val ctors = getClass.getConstructors.filter(_.getParameterTypes.length > 0)
+    val ctors = getClass.getConstructors.filter(_.getParameterCount > 0)
     if (ctors.isEmpty) {
       throw new RuntimeException(s"No valid constructor for ${getClass.getSimpleName}")
     }
@@ -89,7 +89,7 @@ abstract class TreeNode[A <: TreeNode[A]] extends Product { self: A =>
     val defaultCtor = ctors
       .find {
         ctor =>
-          if (ctor.getParameterTypes.length != newArgs.length) {
+          if (ctor.getParameterCount != newArgs.length) {
             false
           } else if (newArgs.contains(null)) {
             false
@@ -98,7 +98,7 @@ abstract class TreeNode[A <: TreeNode[A]] extends Product { self: A =>
             TypeInfoCheckUtils.isAssignable(argsClasses, ctor.getParameterTypes)
           }
       }
-      .getOrElse(ctors.maxBy(_.getParameterTypes.length))
+      .getOrElse(ctors.maxBy(_.getParameterCount))
 
     try {
       defaultCtor.newInstance(newArgs: _*).asInstanceOf[A]

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/functions/utils/ScalarSqlFunction.scala
@@ -151,7 +151,7 @@ object ScalarSqlFunction {
         var isVarargs = false
         methods.foreach(
           m => {
-            var len = m.getParameterTypes.length
+            var len = m.getParameterCount
             if (len > 0 && m.isVarArgs && m.getParameterTypes()(len - 1).isArray) {
               isVarargs = true
               len = len - 1

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/functions/utils/TableSqlFunction.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/functions/utils/TableSqlFunction.scala
@@ -192,7 +192,7 @@ class OperandMetadata(name: String, udtf: TableFunction[_], methods: Array[Metho
     var isVarargs = false
     methods.foreach(
       m => {
-        var len = m.getParameterTypes.length
+        var len = m.getParameterCount
         if (len > 0 && m.isVarArgs && m.getParameterTypes()(len - 1).isArray) {
           isVarargs = true
           len = len - 1


### PR DESCRIPTION
## What is the purpose of the change

Since jdk1.8+ there is `Method#getParameterCount` which allows to get number of parameters. 
In several places `Method#getParametersTypes` is used for that like `getParameterTypes().length`
The issue with `Method#getParametersTypes` is that during each invocation it creates a new array by cloning an existing one.
The PR is replacing  `getParameterTypes().length` with  `Method#getParameterCount` 

## Brief change log

Replacement of  `getParameterTypes().length` with  `Method#getParameterCount` 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes )
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
