### PR TITLE
[FLINK-29582][state-processor] Relax 1+ operator requirement 

### DIFF
--- a/docs/content.zh/docs/libs/state_processor_api.md
+++ b/docs/content.zh/docs/libs/state_processor_api.md
@@ -343,7 +343,7 @@ a savepoint for the Scala DataStream API please manually pass in all type inform
 int maxParallelism = 128;
 
 SavepointWriter
-    .newSavepoint(new HashMapStateBackend(), maxParallelism)
+    .newSavepoint(env, new HashMapStateBackend(), maxParallelism)
     .withOperator(OperatorIdentifier.forUid("uid1"), transformation1)
     .withOperator(OperatorIdentifier.forUid("uid2"), transformation2)
     .write(savepointPath);
@@ -489,7 +489,7 @@ Besides creating a savepoint from scratch, you can base one off an existing save
 
 ```java
 SavepointWriter
-    .fromExistingSavepoint(oldPath, new HashMapStateBackend())
+    .fromExistingSavepoint(env, oldPath, new HashMapStateBackend())
     .withOperator(OperatorIdentifier.forUid("uid"), transformation)
     .write(newPath);
 ```

--- a/docs/content/docs/libs/state_processor_api.md
+++ b/docs/content/docs/libs/state_processor_api.md
@@ -342,7 +342,7 @@ a savepoint for the Scala DataStream API please manually pass in all type inform
 int maxParallelism = 128;
 
 SavepointWriter
-    .newSavepoint(new HashMapStateBackend(), maxParallelism)
+    .newSavepoint(env, new HashMapStateBackend(), maxParallelism)
     .withOperator(OperatorIdentifier.forUid("uid1"), transformation1)
     .withOperator(OperatorIdentifier.forUid("uid2"), transformation2)
     .write(savepointPath);
@@ -488,7 +488,7 @@ Besides creating a savepoint from scratch, you can base one off an existing save
 
 ```java
 SavepointWriter
-    .fromExistingSavepoint(oldPath, new HashMapStateBackend())
+    .fromExistingSavepoint(env, oldPath, new HashMapStateBackend())
     .withOperator(OperatorIdentifier.forUid("uid"), transformation)
     .write(newPath);
 ```

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointDeepCopyTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointDeepCopyTest.java
@@ -146,7 +146,7 @@ public class SavepointDeepCopyTest extends AbstractTestBase {
         File savepointUrl1 = createAndRegisterTempFile(new AbstractID().toHexString());
         String savepointPath1 = savepointUrl1.getPath();
 
-        SavepointWriter.newSavepoint(backend, 128)
+        SavepointWriter.newSavepoint(env, backend, 128)
                 .withConfiguration(FS_SMALL_FILE_THRESHOLD, FILE_STATE_SIZE_THRESHOLD)
                 .withOperator(OperatorIdentifier.forUid("Operator1"), transformation)
                 .write(savepointPath1);
@@ -164,7 +164,7 @@ public class SavepointDeepCopyTest extends AbstractTestBase {
         String savepointPath2 = savepointUrl2.getPath();
 
         SavepointWriter savepoint2 =
-                SavepointWriter.fromExistingSavepoint(savepointPath1, backend)
+                SavepointWriter.fromExistingSavepoint(env, savepointPath1, backend)
                         .withConfiguration(FS_SMALL_FILE_THRESHOLD, FILE_STATE_SIZE_THRESHOLD);
 
         savepoint2

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterITCase.java
@@ -123,8 +123,8 @@ public class SavepointWriterITCase extends AbstractTestBase {
 
         SavepointWriter writer =
                 backend == null
-                        ? SavepointWriter.newSavepoint(128)
-                        : SavepointWriter.newSavepoint(backend, 128);
+                        ? SavepointWriter.newSavepoint(env, 128)
+                        : SavepointWriter.newSavepoint(env, backend, 128);
 
         writer.withOperator(OperatorIdentifier.forUid(ACCOUNT_UID), transformation)
                 .withOperator(getUidHashFromUid(CURRENCY_UID), broadcastTransformation)
@@ -175,8 +175,8 @@ public class SavepointWriterITCase extends AbstractTestBase {
 
         SavepointWriter writer =
                 backend == null
-                        ? SavepointWriter.fromExistingSavepoint(savepointPath)
-                        : SavepointWriter.fromExistingSavepoint(savepointPath, backend);
+                        ? SavepointWriter.fromExistingSavepoint(env, savepointPath)
+                        : SavepointWriter.fromExistingSavepoint(env, savepointPath, backend);
 
         writer.removeOperator(OperatorIdentifier.forUid(CURRENCY_UID))
                 .withOperator(getUidHashFromUid(MODIFY_UID), transformation)

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterTest.java
@@ -43,4 +43,21 @@ class SavepointWriterTest {
         assertThatThrownBy(() -> env.configure(configuration))
                 .isInstanceOf(CustomStateBackendFactory.ExpectedException.class);
     }
+
+    @Test
+    void testCantCreateSavepointFromNothing() {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+
+        assertThatThrownBy(() -> SavepointWriter.newSavepoint(env, 128).write("file:///tmp/path"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("at least one operator to be created");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void testMustContainOneOperatorWithoutEnvironment() {
+        assertThatThrownBy(() -> SavepointWriter.newSavepoint(128).write("file:///tmp/path"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("if no execution environment was provided");
+    }
 }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterTest.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterTest.java
@@ -22,43 +22,25 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.StateBackendOptions;
-import org.apache.flink.state.api.functions.KeyedStateBootstrapFunction;
 import org.apache.flink.state.api.utils.CustomStateBackendFactory;
-import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for the savepoint writer. */
-public class SavepointWriterTest {
+class SavepointWriterTest {
 
-    @Test(expected = CustomStateBackendFactory.ExpectedException.class)
-    public void testCustomStateBackend() throws Exception {
+    @Test
+    void testCustomStateBackend() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Configuration configuration = new Configuration();
         configuration.set(
                 StateBackendOptions.STATE_BACKEND,
                 CustomStateBackendFactory.class.getCanonicalName());
         configuration.set(ExecutionOptions.RUNTIME_MODE, RuntimeExecutionMode.BATCH);
-        env.configure(configuration);
-
-        DataStream<String> input = env.fromElements("");
-
-        StateBootstrapTransformation<String> transformation =
-                OperatorTransformation.bootstrapWith(input)
-                        .keyBy(element -> element)
-                        .transform(new Bootstrapper());
-
-        SavepointWriter.newSavepoint(128)
-                .withOperator(OperatorIdentifier.forUid("uid"), transformation)
-                .write("file:///tmp/path");
-
-        env.execute();
-    }
-
-    private static class Bootstrapper extends KeyedStateBootstrapFunction<String, String> {
-
-        @Override
-        public void processElement(String value, Context ctx) throws Exception {}
+        assertThatThrownBy(() -> env.configure(configuration))
+                .isInstanceOf(CustomStateBackendFactory.ExpectedException.class);
     }
 }

--- a/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
+++ b/flink-libraries/flink-state-processing-api/src/test/java/org/apache/flink/state/api/SavepointWriterWindowITCase.java
@@ -158,7 +158,7 @@ public class SavepointWriterWindowITCase extends AbstractTestBase {
                         .keyBy(tuple -> tuple.f0, Types.STRING)
                         .window(TumblingEventTimeWindows.of(Time.milliseconds(5)));
 
-        SavepointWriter.newSavepoint(stateBackend, 128)
+        SavepointWriter.newSavepoint(env, stateBackend, 128)
                 .withOperator(
                         OperatorIdentifier.forUid(UID), windowBootstrap.bootstrap(transformation))
                 .write(savepointPath);
@@ -203,7 +203,7 @@ public class SavepointWriterWindowITCase extends AbstractTestBase {
                         .window(TumblingEventTimeWindows.of(Time.milliseconds(5)))
                         .evictor(CountEvictor.of(1));
 
-        SavepointWriter.newSavepoint(stateBackend, 128)
+        SavepointWriter.newSavepoint(env, stateBackend, 128)
                 .withOperator(
                         OperatorIdentifier.forUid(UID), windowBootstrap.bootstrap(transformation))
                 .write(savepointPath);
@@ -249,7 +249,7 @@ public class SavepointWriterWindowITCase extends AbstractTestBase {
                                 SlidingEventTimeWindows.of(
                                         Time.milliseconds(5), Time.milliseconds(1)));
 
-        SavepointWriter.newSavepoint(stateBackend, 128)
+        SavepointWriter.newSavepoint(env, stateBackend, 128)
                 .withOperator(
                         OperatorIdentifier.forUid(UID), windowBootstrap.bootstrap(transformation))
                 .write(savepointPath);
@@ -298,7 +298,7 @@ public class SavepointWriterWindowITCase extends AbstractTestBase {
                                         Time.milliseconds(5), Time.milliseconds(1)))
                         .evictor(CountEvictor.of(1));
 
-        SavepointWriter.newSavepoint(stateBackend, 128)
+        SavepointWriter.newSavepoint(env, stateBackend, 128)
                 .withOperator(
                         OperatorIdentifier.forUid(UID), windowBootstrap.bootstrap(transformation))
                 .write(savepointPath);


### PR DESCRIPTION
Based on #21085.

The SavepointWriter previously had to enforce that the user provides at least 1 operator because we used them to get access to the execution environment. No operator -> no environment -> can't setup remaining operations.

This PR adds new factory methods that have the user explicitly pass the environment. With that we can define any operation we like internally without requiring another operator.
The existing factory methods were deprecated. They will continue to work, but it they are used the program is still subject to the old requirement of having at least 1 operator.