### PR TITLE
[FLINK-29622][runtime][security] Start kerberos delegation token provider only if the user provided valid credentials

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerFactory.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
 /** A factory for {@link KerberosDelegationTokenManager}. */
@@ -40,12 +41,21 @@ public class KerberosDelegationTokenManagerFactory {
             ClassLoader classLoader,
             Configuration configuration,
             @Nullable ScheduledExecutor scheduledExecutor,
-            @Nullable ExecutorService ioExecutor) {
+            @Nullable ExecutorService ioExecutor)
+            throws IOException {
 
         if (configuration.getBoolean(SecurityOptions.KERBEROS_FETCH_DELEGATION_TOKEN)) {
             if (HadoopDependency.isHadoopCommonOnClasspath(classLoader)) {
-                return new KerberosDelegationTokenManager(
-                        configuration, scheduledExecutor, ioExecutor);
+                KerberosLoginProvider kerberosLoginProvider =
+                        new KerberosLoginProvider(configuration);
+                if (kerberosLoginProvider.isLoginPossible()) {
+                    return new KerberosDelegationTokenManager(
+                            configuration, scheduledExecutor, ioExecutor);
+                } else {
+                    LOG.info(
+                            "Cannot use kerberos delegation token manager no valid kerberos credentials provided.");
+                    return new NoOpDelegationTokenManager();
+                }
             } else {
                 LOG.info(
                         "Cannot use kerberos delegation token manager because Hadoop cannot be found in the Classpath.");


### PR DESCRIPTION
## What is the purpose of the change

Kerberos delegation token manager starts even if the user not provided valid credentials. This is simply wrong behavior.

## Brief change log

Load kerberos delegation token manager only if the user provided valid credentials.

## Verifying this change

* Executed `EventTimeWindowCheckpointingITCase` and double checked that exception is not thrown

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
