### PR TITLE
[hotfix] Remove unused private method LocalExecutorITCase#executeAndVerifySinkResult

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -690,11 +690,6 @@ public class CliClient implements AutoCloseable {
         terminal.flush();
     }
 
-    private void printWarning(String message) {
-        terminal.writer().println(CliStrings.messageWarning(message).toAnsi());
-        terminal.flush();
-    }
-
     // --------------------------------------------------------------------------------------------
 
     private void closeTerminal() {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -82,7 +82,6 @@ import static org.apache.flink.table.client.config.SqlClientOptions.EXECUTION_MA
 import static org.apache.flink.table.client.config.SqlClientOptions.EXECUTION_RESULT_MODE;
 import static org.apache.flink.table.utils.UserDefinedFunctions.GENERATED_LOWER_UDF_CLASS;
 import static org.apache.flink.table.utils.UserDefinedFunctions.GENERATED_LOWER_UDF_CODE;
-import static org.apache.flink.util.Preconditions.checkState;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Contains basic tests for the {@link LocalExecutor}. */

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -62,7 +62,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
-import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -475,11 +474,6 @@ public class LocalExecutorITCase extends TestLogger {
     // Helper method
     // --------------------------------------------------------------------------------------------
 
-    private TableResult executeSql(Executor executor, String sessionId, String sql) {
-        Operation operation = executor.parseStatement(sessionId, sql);
-        return executor.executeOperation(sessionId, operation);
-    }
-
     private ResultDescriptor executeQuery(Executor executor, String sessionId, String query) {
         Operation operation = executor.parseStatement(sessionId, query);
         return executor.executeQuery(sessionId, (QueryOperation) operation);
@@ -592,20 +586,6 @@ public class LocalExecutorITCase extends TestLogger {
             }
         }
         return actualResults;
-    }
-
-    private void verifySinkResult(String path) throws IOException {
-        final List<String> actualResults = new ArrayList<>();
-        TestBaseUtils.readAllResultLines(actualResults, path);
-        final List<String> expectedResults = new ArrayList<>();
-        expectedResults.add("TRUE,\"hello world\",\"2020-01-01 00:00:01\"");
-        expectedResults.add("FALSE,\"hello world\",\"2020-01-01 00:00:02\"");
-        expectedResults.add("FALSE,\"hello world\",\"2020-01-01 00:00:03\"");
-        expectedResults.add("FALSE,\"hello world\",\"2020-01-01 00:00:04\"");
-        expectedResults.add("TRUE,\"hello world\",\"2020-01-01 00:00:05\"");
-        expectedResults.add("FALSE,\"hello world!!!!\",\"2020-01-01 00:00:06\"");
-        TestBaseUtils.compareResultCollections(
-                expectedResults, actualResults, Comparator.naturalOrder());
     }
 
     private Map<String, String> getDefaultSessionConfigMap() {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -609,17 +609,6 @@ public class LocalExecutorITCase extends TestLogger {
                 expectedResults, actualResults, Comparator.naturalOrder());
     }
 
-    private void executeAndVerifySinkResult(
-            Executor executor, String sessionId, String statement, String resultPath)
-            throws Exception {
-        final TableResult tableResult = executeSql(executor, sessionId, statement);
-        checkState(tableResult.getJobClient().isPresent());
-        // wait for job completion
-        tableResult.await();
-        // verify result
-        verifySinkResult(resultPath);
-    }
-
     private Map<String, String> getDefaultSessionConfigMap() {
         HashMap<String, String> configMap = new HashMap<>();
         configMap.put(RUNTIME_MODE.key(), RuntimeExecutionMode.STREAMING.name());


### PR DESCRIPTION
## What is the purpose of the change

There are unused methods 
`LocalExecutorITCase#executeAndVerifySinkResult`, 
`LocalExecutorITCase#verifySinkResult`
`LocalExecutorITCase#executeSql`
`CliClient#printWarning`
 and the PR removes it

## Brief change log

_flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java_
_flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java_

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
