### PR TITLE
[BP-1.16][FLINK-29638][connectors][filesystems][formats] Update Jackson-BOM to 2.13.4.2 because of CVE-2022-42003

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -17,6 +17,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-cloudwatch:1.12.276
 - com.amazonaws:dynamodb-streams-kinesis-adapter:1.5.3
 - com.amazonaws:jmespath-java:1.12.276
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14
 - software.amazon.ion:ion-java:1.0.2

--- a/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -19,7 +19,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:jmespath-java:1.12.276
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - org.apache.httpcomponents:httpclient:4.5.13
 - org.apache.httpcomponents:httpcore:4.4.14

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.4

--- a/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch6/src/main/resources/META-INF/NOTICE
@@ -6,12 +6,12 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3
 - org.apache.httpcomponents:httpasyncclient:4.1.2

--- a/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-elasticsearch7/src/main/resources/META-INF/NOTICE
@@ -7,10 +7,10 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - com.carrotsearch:hppc:0.8.1
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
 - com.github.spullara.mustache.java:compiler:0.9.6
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -14,7 +14,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - org.apache.commons:commons-lang3:3.3.2
 - com.google.guava:guava:29.0-jre
 - com.google.guava:failureaccess:1.0.1
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4

--- a/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-kinesis/src/main/resources/META-INF/NOTICE
@@ -15,6 +15,6 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:29.0-jre
 - com.google.guava:failureaccess:1.0.1
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4

--- a/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-aws-kinesis-firehose/pom.xml
@@ -83,19 +83,16 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.13.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.13.2</version>
 		</dependency>
 
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.13.2.2</version>
 		</dependency>
 
 		<dependency>

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.google.guava:guava:20.0
 - commons-codec:commons-codec:1.15
 - commons-logging:commons-logging:1.1.3

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -21,9 +21,9 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.guava:guava:27.0-jre
 - com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
 - com.google.j2objc:j2objc-annotations:1.1
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1

--- a/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-fs-hadoop-shaded/src/main/resources/META-INF/NOTICE
@@ -23,7 +23,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.google.j2objc:j2objc-annotations:1.1
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:1.1.1
 - org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.1.1

--- a/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-gs-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -6,7 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-core:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
 - com.google.android:annotations:4.1.1.4
 - com.google.api-client:google-api-client-jackson2:1.32.2
 - com.google.api-client:google-api-client:1.33.0

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -9,10 +9,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:aws-java-sdk-s3:1.11.951
 - com.amazonaws:aws-java-sdk-sts:1.11.951
 - com.amazonaws:jmespath-java:1.11.951
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0
 - com.google.guava:guava:27.0-jre

--- a/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-hadoop/src/main/resources/META-INF/NOTICE
@@ -11,7 +11,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.amazonaws:jmespath-java:1.11.951
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:failureaccess:1.0

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -24,7 +24,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.4-9
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:26.0-jre

--- a/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
+++ b/flink-filesystems/flink-s3-fs-presto/src/main/resources/META-INF/NOTICE
@@ -22,10 +22,10 @@ This project bundles the following dependencies under the Apache Software Licens
 - com.facebook.presto:presto-hive-common:0.272
 - com.facebook.presto:presto-hive-metastore:0.272
 - com.facebook.presto.hadoop:hadoop-apache2:2.7.4-9
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.2
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.13.4
 - com.fasterxml.woodstox:woodstox-core:5.3.0
 - com.google.guava:guava:26.0-jre
 - com.google.inject:guice:4.2.2

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -7,9 +7,9 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.11.1
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - org.apache.commons:commons-compress:1.21
 - io.confluent:kafka-schema-registry-client:6.2.2
 - org.apache.kafka:kafka-clients:6.2.2-ccs

--- a/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro-confluent-registry/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - org.apache.avro:avro:1.11.1
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - org.apache.commons:commons-compress:1.21
 - io.confluent:kafka-schema-registry-client:6.2.2

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -7,7 +7,7 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
 - org.apache.avro:avro:1.11.1
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - org.apache.commons:commons-compress:1.21

--- a/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
+++ b/flink-formats/flink-sql-avro/src/main/resources/META-INF/NOTICE
@@ -8,6 +8,6 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - org.apache.avro:avro:1.11.1
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - org.apache.commons:commons-compress:1.21

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -6,11 +6,11 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
-- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2
-- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
+- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4
 - com.squareup.okhttp3:logging-interceptor:3.14.9
 - com.squareup.okhttp3:okhttp:3.14.9
 - com.squareup.okio:okio:1.17.2

--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.4
 - com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.4
 - com.squareup.okhttp3:logging-interceptor:3.14.9

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -6,9 +6,9 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- com.fasterxml.jackson.core:jackson-annotations:2.13.2
-- com.fasterxml.jackson.core:jackson-core:2.13.2
-- com.fasterxml.jackson.core:jackson-databind:2.13.2.2
+- com.fasterxml.jackson.core:jackson-annotations:2.13.4
+- com.fasterxml.jackson.core:jackson-core:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4
 - com.google.flatbuffers:flatbuffers-java:1.12.0
 - io.netty:netty-buffer:4.1.70.Final
 - io.netty:netty-common:4.1.70.Final

--- a/flink-python/src/main/resources/META-INF/NOTICE
+++ b/flink-python/src/main/resources/META-INF/NOTICE
@@ -8,7 +8,7 @@ This project bundles the following dependencies under the Apache Software Licens
 
 - com.fasterxml.jackson.core:jackson-annotations:2.13.4
 - com.fasterxml.jackson.core:jackson-core:2.13.4
-- com.fasterxml.jackson.core:jackson-databind:2.13.4
+- com.fasterxml.jackson.core:jackson-databind:2.13.4.2
 - com.google.flatbuffers:flatbuffers-java:1.12.0
 - io.netty:netty-buffer:4.1.70.Final
 - io.netty:netty-common:4.1.70.Final

--- a/pom.xml
+++ b/pom.xml
@@ -591,7 +591,7 @@ under the License.
 				<artifactId>jackson-bom</artifactId>
 				<type>pom</type>
 				<scope>import</scope>
-				<version>2.13.2.20220328</version>
+				<version>2.13.4</version>
 			</dependency>
 
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@ under the License.
 		<curator.version>5.2.0</curator.version>
 		<avro.version>1.11.1</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
-		<jackson-bom.version>2.13.4</jackson-bom.version>
+		<jackson-bom.version>2.13.4.20221013</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,8 @@ under the License.
 		<zookeeper.version>3.5.9</zookeeper.version>
 		<curator.version>5.2.0</curator.version>
 		<avro.version>1.11.1</avro.version>
+		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->
+		<jackson-bom.version>2.13.4</jackson-bom.version>
 		<javax.activation.api.version>1.2.0</javax.activation.api.version>
 		<jaxb.api.version>2.3.1</jaxb.api.version>
 		<junit4.version>4.13.2</junit4.version>
@@ -591,7 +593,7 @@ under the License.
 				<artifactId>jackson-bom</artifactId>
 				<type>pom</type>
 				<scope>import</scope>
-				<version>2.13.4</version>
+				<version>${jackson-bom.version}</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
This PR is a backport of PR #21064 including also the changes related to FLINK-29468 to make backporting of jackson version bumps easier.