### PR TITLE
[FLINK-29479][python] Supports whether uses system env for python.

### DIFF
--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -110,5 +110,11 @@
             <td>Integer</td>
             <td>The maximum number of states cached in a Python UDF worker. Note that this is an experimental flag and might not be available in future releases.</td>
         </tr>
+        <tr>
+            <td><h5>python.systemenv.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Specify whether to load System Environment when starting Python worker.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -83,6 +83,14 @@ public class PythonOptions {
                                     + "The interval between each profiling is determined by the config options "
                                     + "python.fn-execution.bundle.size and python.fn-execution.bundle.time.");
 
+    /** The configuration to enable or disable system env for Python execution. */
+    public static final ConfigOption<Boolean> PYTHON_SYSTEMENV_ENABLED =
+            ConfigOptions.key("python.systemenv.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Specify whether to load System Environment when starting Python worker.");
+
     /** The configuration to enable or disable python operator chaining. */
     public static final ConfigOption<Boolean> PYTHON_OPERATOR_CHAINING_ENABLED =
             ConfigOptions.key("python.operator-chaining.enabled")

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/AbstractPythonFunctionOperator.java
@@ -40,6 +40,7 @@ import java.util.concurrent.ScheduledFuture;
 import static org.apache.flink.python.PythonOptions.MAX_BUNDLE_SIZE;
 import static org.apache.flink.python.PythonOptions.MAX_BUNDLE_TIME_MILLS;
 import static org.apache.flink.python.PythonOptions.PYTHON_METRIC_ENABLED;
+import static org.apache.flink.python.PythonOptions.PYTHON_SYSTEMENV_ENABLED;
 import static org.apache.flink.streaming.api.utils.ClassLeakCleaner.cleanUpLeakingClasses;
 import static org.apache.flink.streaming.api.utils.PythonOperatorUtils.inBatchExecutionMode;
 
@@ -50,6 +51,8 @@ public abstract class AbstractPythonFunctionOperator<OUT> extends AbstractStream
     private static final long serialVersionUID = 1L;
 
     protected final Configuration config;
+
+    protected transient boolean systemEnvEnabled;
 
     /** Max number of elements to include in a bundle. */
     protected transient int maxBundleSize;
@@ -77,6 +80,7 @@ public abstract class AbstractPythonFunctionOperator<OUT> extends AbstractStream
     @Override
     public void open() throws Exception {
         try {
+            this.systemEnvEnabled = config.get(PYTHON_SYSTEMENV_ENABLED);
             this.maxBundleSize = config.get(MAX_BUNDLE_SIZE);
             if (this.maxBundleSize <= 0) {
                 this.maxBundleSize = MAX_BUNDLE_SIZE.defaultValue();

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractEmbeddedPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/AbstractEmbeddedPythonFunctionOperator.java
@@ -141,7 +141,7 @@ public abstract class AbstractEmbeddedPythonFunctionOperator<OUT>
         return new EmbeddedPythonEnvironmentManager(
                 dependencyInfo,
                 getContainingTask().getEnvironment().getTaskManagerInfo().getTmpDirectories(),
-                new HashMap<>(System.getenv()),
+                systemEnvEnabled ? new HashMap<>(System.getenv()) : new HashMap<>(),
                 getRuntimeContext().getJobId());
     }
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/process/AbstractExternalPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/process/AbstractExternalPythonFunctionOperator.java
@@ -127,7 +127,7 @@ public abstract class AbstractExternalPythonFunctionOperator<OUT>
             return new ProcessPythonEnvironmentManager(
                     dependencyInfo,
                     getContainingTask().getEnvironment().getTaskManagerInfo().getTmpDirectories(),
-                    new HashMap<>(System.getenv()),
+                    systemEnvEnabled ? new HashMap<>(System.getenv()) : new HashMap<>(),
                     getRuntimeContext().getJobId());
         } else {
             throw new UnsupportedOperationException(

--- a/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
+++ b/flink-python/src/test/java/org/apache/flink/python/PythonOptionsTest.java
@@ -172,4 +172,20 @@ class PythonOptionsTest {
                 configuration.get(PythonOptions.PYTHON_CLIENT_EXECUTABLE);
         assertThat(actualPythonClientExecutable).isEqualTo(expectedPythonClientExecutable);
     }
+
+    @Test
+    void testPythonSystemEnvEnabled() {
+        final Configuration configuration = new Configuration();
+        final boolean isSystemEnvEnabled =
+                configuration.getBoolean(PythonOptions.PYTHON_SYSTEMENV_ENABLED);
+        assertThat(isSystemEnvEnabled)
+                .isEqualTo(PythonOptions.PYTHON_SYSTEMENV_ENABLED.defaultValue());
+
+        final boolean expectedIsSystemEnvEnabled = false;
+        configuration.setBoolean(PythonOptions.PYTHON_SYSTEMENV_ENABLED, false);
+
+        final boolean actualIsSystemEnvEnabled =
+                configuration.getBoolean(PythonOptions.PYTHON_SYSTEMENV_ENABLED);
+        assertThat(actualIsSystemEnvEnabled).isEqualTo(expectedIsSystemEnvEnabled);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

*Supports whether uses system env for python.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
