### PR TITLE
[FLINK-29664][runtime] Collect subpartition sizes of blocking result partitions

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/Execution.java
@@ -1548,7 +1548,17 @@ public class Execution
             }
         }
         if (metrics != null) {
-            this.ioMetrics = metrics;
+            // Drop IOMetrics#resultPartitionBytes because it will not be used anymore. It can
+            // result in very high memory usage when there are many executions and sub-partitions.
+            this.ioMetrics =
+                    new IOMetrics(
+                            metrics.getNumBytesIn(),
+                            metrics.getNumBytesOut(),
+                            metrics.getNumRecordsIn(),
+                            metrics.getNumRecordsOut(),
+                            metrics.getAccumulateIdleTime(),
+                            metrics.getAccumulateBusyTime(),
+                            metrics.getAccumulateBackPressuredTime());
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ResultPartitionBytes.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ResultPartitionBytes.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.executiongraph;
+
+import java.io.Serializable;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** This class represents a snapshot of the result partition bytes metrics. */
+public class ResultPartitionBytes implements Serializable {
+
+    private final long[] subpartitionBytes;
+
+    public ResultPartitionBytes(long[] subpartitionBytes) {
+        this.subpartitionBytes = checkNotNull(subpartitionBytes);
+    }
+
+    public long[] getSubpartitionBytes() {
+        return subpartitionBytes;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/ResultPartitionBytesCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/metrics/ResultPartitionBytesCounter.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.metrics;
+
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** This counter will count the data size of a partition. */
+public class ResultPartitionBytesCounter {
+
+    /** The data size of each subpartition. */
+    private final List<Counter> subpartitionBytes;
+
+    public ResultPartitionBytesCounter(int numSubpartitions) {
+        this.subpartitionBytes = new ArrayList<>();
+        for (int i = 0; i < numSubpartitions; ++i) {
+            subpartitionBytes.add(new SimpleCounter());
+        }
+    }
+
+    public void inc(int targetSubpartition, long bytes) {
+        subpartitionBytes.get(targetSubpartition).inc(bytes);
+    }
+
+    public void incAll(long bytes) {
+        subpartitionBytes.forEach(counter -> counter.inc(bytes));
+    }
+
+    public ResultPartitionBytes createSnapshot() {
+        return new ResultPartitionBytes(
+                subpartitionBytes.stream().mapToLong(Counter::getCount).toArray());
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/BufferWritingResultPartition.java
@@ -423,7 +423,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
         final BufferBuilder bufferBuilder = unicastBufferBuilders[targetSubpartition];
         if (bufferBuilder != null) {
             int bytes = bufferBuilder.finish();
-            numBytesProduced.inc(bytes);
+            resultPartitionBytes.inc(targetSubpartition, bytes);
             numBytesOut.inc(bytes);
             numBuffersOut.inc();
             unicastBufferBuilders[targetSubpartition] = null;
@@ -440,7 +440,7 @@ public abstract class BufferWritingResultPartition extends ResultPartition {
     private void finishBroadcastBufferBuilder() {
         if (broadcastBufferBuilder != null) {
             int bytes = broadcastBufferBuilder.finish();
-            numBytesProduced.inc(bytes);
+            resultPartitionBytes.incAll(bytes);
             numBytesOut.inc(bytes * numSubpartitions);
             numBuffersOut.inc(numSubpartitions);
             broadcastBufferBuilder.close();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -391,7 +391,7 @@ public class SortMergeResultPartition extends ResultPartition {
                 break;
             }
 
-            updateStatistics(bufferWithChannel.getBuffer(), isBroadcast);
+            updateStatistics(bufferWithChannel, isBroadcast);
             toWrite.add(compressBufferIfPossible(bufferWithChannel));
         } while (true);
 
@@ -424,10 +424,14 @@ public class SortMergeResultPartition extends ResultPartition {
         return new BufferWithChannel(buffer, bufferWithChannel.getChannelIndex());
     }
 
-    private void updateStatistics(Buffer buffer, boolean isBroadcast) {
+    private void updateStatistics(BufferWithChannel bufferWithChannel, boolean isBroadcast) {
         numBuffersOut.inc(isBroadcast ? numSubpartitions : 1);
-        long readableBytes = buffer.readableBytes();
-        numBytesProduced.inc(readableBytes);
+        long readableBytes = bufferWithChannel.getBuffer().readableBytes();
+        if (isBroadcast) {
+            resultPartitionBytes.incAll(readableBytes);
+        } else {
+            resultPartitionBytes.inc(bufferWithChannel.getChannelIndex(), readableBytes);
+        }
         numBytesOut.inc(isBroadcast ? readableBytes * numSubpartitions : readableBytes);
     }
 
@@ -456,7 +460,7 @@ public class SortMergeResultPartition extends ResultPartition {
 
             NetworkBuffer buffer = new NetworkBuffer(writeBuffer, (buf) -> {}, dataType, toCopy);
             BufferWithChannel bufferWithChannel = new BufferWithChannel(buffer, targetSubpartition);
-            updateStatistics(buffer, isBroadcast);
+            updateStatistics(bufferWithChannel, isBroadcast);
             toWrite.add(compressBufferIfPossible(bufferWithChannel));
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -152,7 +152,7 @@ public class HsResultPartition extends ResultPartition {
 
     @Override
     public void emitRecord(ByteBuffer record, int targetSubpartition) throws IOException {
-        numBytesProduced.inc(record.remaining());
+        resultPartitionBytes.inc(targetSubpartition, record.remaining());
         emit(record, targetSubpartition, Buffer.DataType.DATA_BUFFER);
     }
 
@@ -173,7 +173,7 @@ public class HsResultPartition extends ResultPartition {
     }
 
     private void broadcast(ByteBuffer record, Buffer.DataType dataType) throws IOException {
-        numBytesProduced.inc(record.remaining());
+        resultPartitionBytes.incAll(record.remaining());
         if (isBroadcastOnly) {
             emit(record, BROADCAST_CHANNEL, dataType);
         } else {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.Meter;
 import org.apache.flink.metrics.MeterView;
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.io.network.metrics.ResultPartitionBytesCounter;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.metrics.DescriptiveStatisticsHistogram;
 import org.apache.flink.runtime.metrics.MetricNames;
@@ -71,8 +72,8 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
 
     private long taskStartTime;
 
-    private final Map<IntermediateResultPartitionID, Counter> numBytesProducedOfPartitions =
-            new HashMap<>();
+    private final Map<IntermediateResultPartitionID, ResultPartitionBytesCounter>
+            resultPartitionBytes = new HashMap<>();
 
     public TaskIOMetricGroup(TaskMetricGroup parent) {
         super(parent);
@@ -135,10 +136,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
                 numRecordsOutRate,
                 numBytesInRate,
                 numBytesOutRate,
-                numBytesProducedOfPartitions,
                 accumulatedBackPressuredTime,
                 accumulatedIdleTime,
-                accumulatedBusyTime);
+                accumulatedBusyTime,
+                resultPartitionBytes);
     }
 
     // ============================================================================================
@@ -238,9 +239,10 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         this.numRecordsOut.addCounter(numRecordsOutCounter);
     }
 
-    public void registerNumBytesProducedCounterForPartition(
-            IntermediateResultPartitionID resultPartitionId, Counter numBytesProducedCounter) {
-        this.numBytesProducedOfPartitions.put(resultPartitionId, numBytesProducedCounter);
+    public void registerResultPartitionBytesCounter(
+            IntermediateResultPartitionID resultPartitionId,
+            ResultPartitionBytesCounter resultPartitionBytesCounter) {
+        this.resultPartitionBytes.put(resultPartitionId, resultPartitionBytesCounter);
     }
 
     public void registerMailboxSizeSupplier(SizeGauge.SizeSupplier<Integer> supplier) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ExecutionFailureHandler;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategy;
@@ -215,7 +216,7 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
     }
 
     @Override
-    protected void onTaskFinished(final Execution execution) {
+    protected void onTaskFinished(final Execution execution, final IOMetrics ioMetrics) {
         checkState(execution.getState() == ExecutionState.FINISHED);
 
         final ExecutionVertexID executionVertexId = execution.getVertex().getID();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.JobStatusProvider;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
@@ -733,7 +734,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         // can be refined in FLINK-14233 after the actions are factored out from ExecutionGraph.
         switch (taskExecutionState.getExecutionState()) {
             case FINISHED:
-                onTaskFinished(execution);
+                onTaskFinished(execution, taskExecutionState.getIOMetrics());
                 break;
             case FAILED:
                 onTaskFailed(execution);
@@ -741,7 +742,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
         }
     }
 
-    protected abstract void onTaskFinished(final Execution execution);
+    protected abstract void onTaskFinished(final Execution execution, final IOMetrics ioMetrics);
 
     protected abstract void onTaskFailed(final Execution execution);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AbstractBlockingResultInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AbstractBlockingResultInfo.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Base blocking result info. */
+abstract class AbstractBlockingResultInfo implements BlockingResultInfo {
+
+    private final IntermediateDataSetID resultId;
+
+    protected final int numOfPartitions;
+
+    protected final int numOfSubpartitions;
+
+    /**
+     * The subpartition bytes map. The key is the partition index, value is a subpartition bytes
+     * list.
+     */
+    protected final Map<Integer, long[]> subpartitionBytesByPartitionIndex;
+
+    AbstractBlockingResultInfo(
+            IntermediateDataSetID resultId, int numOfPartitions, int numOfSubpartitions) {
+        this.resultId = checkNotNull(resultId);
+        this.numOfPartitions = numOfPartitions;
+        this.numOfSubpartitions = numOfSubpartitions;
+        this.subpartitionBytesByPartitionIndex = new HashMap<>();
+    }
+
+    @Override
+    public IntermediateDataSetID getResultId() {
+        return resultId;
+    }
+
+    @Override
+    public void recordPartitionInfo(int partitionIndex, ResultPartitionBytes partitionBytes) {
+        checkState(partitionBytes.getSubpartitionBytes().length == numOfSubpartitions);
+        subpartitionBytesByPartitionIndex.put(
+                partitionIndex, partitionBytes.getSubpartitionBytes());
+    }
+
+    @Override
+    public void resetPartitionInfo(int partitionIndex) {
+        subpartitionBytesByPartitionIndex.remove(partitionIndex);
+    }
+
+    @VisibleForTesting
+    int getNumOfRecordedPartitions() {
+        return subpartitionBytesByPartitionIndex.size();
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AllToAllBlockingResultInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AllToAllBlockingResultInfo.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import javax.annotation.Nullable;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Information of All-To-All result. */
+public class AllToAllBlockingResultInfo extends AbstractBlockingResultInfo {
+
+    private final boolean isBroadcast;
+
+    /**
+     * Aggregated subpartition bytes, which aggregates the subpartition bytes with the same
+     * subpartition index in different partitions. Note that We can aggregate them because they will
+     * be consumed by the same downstream task.
+     */
+    @Nullable private List<Long> aggregatedSubpartitionBytes;
+
+    AllToAllBlockingResultInfo(
+            IntermediateDataSetID resultId,
+            int numOfPartitions,
+            int numOfSubpartitions,
+            boolean isBroadcast) {
+        super(resultId, numOfPartitions, numOfSubpartitions);
+        this.isBroadcast = isBroadcast;
+    }
+
+    @Override
+    public boolean isBroadcast() {
+        return isBroadcast;
+    }
+
+    @Override
+    public boolean isPointwise() {
+        return false;
+    }
+
+    @Override
+    public long getNumBytesProduced() {
+        checkState(aggregatedSubpartitionBytes != null, "Not all partition infos are ready");
+        if (isBroadcast) {
+            return aggregatedSubpartitionBytes.get(0);
+        } else {
+            return aggregatedSubpartitionBytes.stream().reduce(0L, Long::sum);
+        }
+    }
+
+    @Override
+    public void recordPartitionInfo(int partitionIndex, ResultPartitionBytes partitionBytes) {
+        // Once all partitions are finished, we can convert the subpartition bytes to aggregated
+        // value to reduce the space usage, because the distribution of source splits does not
+        // affect the distribution of data consumed by downstream tasks of ALL_TO_ALL edges(Hashing
+        // or Rebalancing, we do not consider rare cases such as custom partitions here).
+        if (aggregatedSubpartitionBytes == null) {
+            super.recordPartitionInfo(partitionIndex, partitionBytes);
+
+            if (subpartitionBytesByPartitionIndex.size() == numOfPartitions) {
+                long[] aggregatedBytes = new long[numOfSubpartitions];
+                subpartitionBytesByPartitionIndex
+                        .values()
+                        .forEach(
+                                subpartitionBytes -> {
+                                    checkState(subpartitionBytes.length == numOfSubpartitions);
+                                    for (int i = 0; i < subpartitionBytes.length; ++i) {
+                                        aggregatedBytes[i] += subpartitionBytes[i];
+                                    }
+                                });
+                this.aggregatedSubpartitionBytes =
+                        Arrays.stream(aggregatedBytes).boxed().collect(Collectors.toList());
+                this.subpartitionBytesByPartitionIndex.clear();
+            }
+        }
+    }
+
+    @Override
+    public void resetPartitionInfo(int partitionIndex) {
+        if (aggregatedSubpartitionBytes == null) {
+            super.resetPartitionInfo(partitionIndex);
+        }
+    }
+
+    public List<Long> getAggregatedSubpartitionBytes() {
+        checkState(aggregatedSubpartitionBytes != null, "Not all partition infos are ready");
+        return Collections.unmodifiableList(aggregatedSubpartitionBytes);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/BlockingResultInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/BlockingResultInfo.java
@@ -18,63 +18,60 @@
 
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
-import org.apache.flink.annotation.VisibleForTesting;
-import org.apache.flink.runtime.executiongraph.IOMetrics;
-import org.apache.flink.runtime.executiongraph.IntermediateResult;
-import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 
-import java.util.ArrayList;
-import java.util.List;
+/**
+ * The blocking result info, which will be used to calculate the vertex parallelism and input infos.
+ */
+public interface BlockingResultInfo {
 
-import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.apache.flink.util.Preconditions.checkState;
+    /**
+     * Get the intermediate result id.
+     *
+     * @return the intermediate result id
+     */
+    IntermediateDataSetID getResultId();
 
-/** The blocking result info, which will be used to calculate the vertex parallelism. */
-public class BlockingResultInfo {
+    /**
+     * Whether it is a broadcast result.
+     *
+     * @return whether it is a broadcast result
+     */
+    boolean isBroadcast();
 
-    private final List<Long> blockingPartitionSizes;
+    /**
+     * Whether it is a pointwise result.
+     *
+     * @return whether it is a pointwise result
+     */
+    boolean isPointwise();
 
-    private final boolean isBroadcast;
+    /**
+     * Return the num of bytes produced(numBytesProduced) by the producer.
+     *
+     * <p>The difference between numBytesProduced and numBytesOut : numBytesProduced represents the
+     * number of bytes actually produced, and numBytesOut represents the number of bytes sent to
+     * downstream tasks. In unicast scenarios, these two values should be equal. In broadcast
+     * scenarios, numBytesOut should be (N * numBytesProduced), where N refers to the number of
+     * subpartitions.
+     *
+     * @return the num of bytes produced by the producer
+     */
+    long getNumBytesProduced();
 
-    private BlockingResultInfo(List<Long> blockingPartitionSizes, boolean isBroadcast) {
-        this.blockingPartitionSizes = blockingPartitionSizes;
-        this.isBroadcast = isBroadcast;
-    }
+    /**
+     * Record the information of the result partition.
+     *
+     * @param partitionIndex the intermediate result partition index
+     * @param partitionBytes the {@link ResultPartitionBytes} of the partition
+     */
+    void recordPartitionInfo(int partitionIndex, ResultPartitionBytes partitionBytes);
 
-    public List<Long> getBlockingPartitionSizes() {
-        return blockingPartitionSizes;
-    }
-
-    public boolean isBroadcast() {
-        return isBroadcast;
-    }
-
-    @VisibleForTesting
-    static BlockingResultInfo createFromBroadcastResult(List<Long> blockingPartitionSizes) {
-        return new BlockingResultInfo(blockingPartitionSizes, true);
-    }
-
-    @VisibleForTesting
-    static BlockingResultInfo createFromNonBroadcastResult(List<Long> blockingPartitionSizes) {
-        return new BlockingResultInfo(blockingPartitionSizes, false);
-    }
-
-    public static BlockingResultInfo createFromIntermediateResult(
-            IntermediateResult intermediateResult) {
-        checkArgument(intermediateResult != null);
-
-        List<Long> blockingPartitionSizes = new ArrayList<>();
-        for (IntermediateResultPartition partition : intermediateResult.getPartitions()) {
-            checkState(partition.isConsumable());
-
-            IOMetrics ioMetrics = partition.getProducer().getPartitionProducer().getIOMetrics();
-            checkNotNull(ioMetrics, "IOMetrics should not be null.");
-
-            blockingPartitionSizes.add(
-                    ioMetrics.getNumBytesProducedOfPartitions().get(partition.getPartitionId()));
-        }
-
-        return new BlockingResultInfo(blockingPartitionSizes, intermediateResult.isBroadcast());
-    }
+    /**
+     * Reset the information of the result partition.
+     *
+     * @param partitionIndex the intermediate result partition index
+     */
+    void resetPartitionInfo(int partitionIndex);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDecider.java
@@ -92,19 +92,13 @@ public class DefaultVertexParallelismDecider implements VertexParallelismDecider
         long broadcastBytes =
                 consumedResults.stream()
                         .filter(BlockingResultInfo::isBroadcast)
-                        .mapToLong(
-                                consumedResult ->
-                                        consumedResult.getBlockingPartitionSizes().stream()
-                                                .reduce(0L, Long::sum))
+                        .mapToLong(BlockingResultInfo::getNumBytesProduced)
                         .sum();
 
         long nonBroadcastBytes =
                 consumedResults.stream()
                         .filter(consumedResult -> !consumedResult.isBroadcast())
-                        .mapToLong(
-                                consumedResult ->
-                                        consumedResult.getBlockingPartitionSizes().stream()
-                                                .reduce(0L, Long::sum))
+                        .mapToLong(BlockingResultInfo::getNumBytesProduced)
                         .sum();
 
         long expectedMaxBroadcastBytes =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/PointwiseBlockingResultInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/PointwiseBlockingResultInfo.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import java.util.Arrays;
+
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Information of Pointwise result. */
+public class PointwiseBlockingResultInfo extends AbstractBlockingResultInfo {
+    PointwiseBlockingResultInfo(
+            IntermediateDataSetID resultId, int numOfPartitions, int numOfSubpartitions) {
+        super(resultId, numOfPartitions, numOfSubpartitions);
+    }
+
+    @Override
+    public boolean isBroadcast() {
+        return false;
+    }
+
+    @Override
+    public boolean isPointwise() {
+        return true;
+    }
+
+    @Override
+    public long getNumBytesProduced() {
+        checkState(
+                subpartitionBytesByPartitionIndex.size() == numOfPartitions,
+                "Not all partition infos are ready");
+        return subpartitionBytesByPartitionIndex.values().stream()
+                .flatMapToLong(Arrays::stream)
+                .reduce(0L, Long::sum);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.SpeculativeExecutionVertex;
 import org.apache.flink.runtime.executiongraph.failover.flip1.FailoverStrategy;
@@ -194,7 +195,7 @@ public class SpeculativeScheduler extends AdaptiveBatchScheduler
     }
 
     @Override
-    protected void onTaskFinished(final Execution execution) {
+    protected void onTaskFinished(final Execution execution, final IOMetrics ioMetrics) {
         if (!isOriginalAttempt(execution)) {
             numEffectiveSpeculativeExecutionsCounter.inc();
         }
@@ -202,7 +203,7 @@ public class SpeculativeScheduler extends AdaptiveBatchScheduler
         // cancel all un-terminated executions because the execution vertex has finished
         FutureUtils.assertNoException(cancelPendingExecutions(execution.getVertex().getID()));
 
-        super.onTaskFinished(execution);
+        super.onTaskFinished(execution, ioMetrics);
     }
 
     private static boolean isOriginalAttempt(final Execution execution) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -336,7 +336,7 @@ class DefaultExecutionGraphDeploymentTest {
 
         scheduler.updateTaskExecutionState(state);
 
-        assertThat(execution1.getIOMetrics()).isEqualTo(ioMetrics);
+        assertIOMetricsEqual(execution1.getIOMetrics(), ioMetrics);
         assertThat(execution1.getUserAccumulators()).isNotNull();
         assertThat(execution1.getUserAccumulators().get("acc").getLocalValue()).isEqualTo(4);
 
@@ -359,7 +359,7 @@ class DefaultExecutionGraphDeploymentTest {
 
         scheduler.updateTaskExecutionState(state2);
 
-        assertThat(execution2.getIOMetrics()).isEqualTo(ioMetrics2);
+        assertIOMetricsEqual(execution2.getIOMetrics(), ioMetrics2);
         assertThat(execution2.getUserAccumulators()).isNotNull();
         assertThat(execution2.getUserAccumulators().get("acc").getLocalValue()).isEqualTo(8);
     }
@@ -388,13 +388,13 @@ class DefaultExecutionGraphDeploymentTest {
         execution1.cancel();
         execution1.completeCancelling(accumulators, ioMetrics, false);
 
-        assertThat(execution1.getIOMetrics()).isEqualTo(ioMetrics);
+        assertIOMetricsEqual(execution1.getIOMetrics(), ioMetrics);
         assertThat(execution1.getUserAccumulators()).isEqualTo(accumulators);
 
         Execution execution2 = executions.values().iterator().next();
         execution2.markFailed(new Throwable(), false, accumulators, ioMetrics, false, true);
 
-        assertThat(execution2.getIOMetrics()).isEqualTo(ioMetrics);
+        assertIOMetricsEqual(execution2.getIOMetrics(), ioMetrics);
         assertThat(execution2.getUserAccumulators()).isEqualTo(accumulators);
     }
 
@@ -667,7 +667,7 @@ class DefaultExecutionGraphDeploymentTest {
                 .build(EXECUTOR_EXTENSION.getExecutor());
     }
 
-    private boolean isDeployedInTopologicalOrder(
+    private static boolean isDeployedInTopologicalOrder(
             List<ExecutionAttemptID> submissionOrder,
             List<Collection<ExecutionAttemptID>> executionStages) {
         final Iterator<ExecutionAttemptID> submissionIterator = submissionOrder.iterator();
@@ -687,5 +687,17 @@ class DefaultExecutionGraphDeploymentTest {
         }
 
         return !submissionIterator.hasNext();
+    }
+
+    private void assertIOMetricsEqual(IOMetrics ioMetrics1, IOMetrics ioMetrics2) {
+        assertThat(ioMetrics1.numBytesIn).isEqualTo(ioMetrics2.numBytesIn);
+        assertThat(ioMetrics1.numBytesOut).isEqualTo(ioMetrics2.numBytesOut);
+        assertThat(ioMetrics1.numRecordsIn).isEqualTo(ioMetrics2.numRecordsIn);
+        assertThat(ioMetrics1.numRecordsOut).isEqualTo(ioMetrics2.numRecordsOut);
+        assertThat(ioMetrics1.accumulateIdleTime).isEqualTo(ioMetrics2.accumulateIdleTime);
+        assertThat(ioMetrics1.accumulateBusyTime).isEqualTo(ioMetrics2.accumulateBusyTime);
+        assertThat(ioMetrics1.accumulateBackPressuredTime)
+                .isEqualTo(ioMetrics2.accumulateBackPressuredTime);
+        assertThat(ioMetrics1.resultPartitionBytes).isEqualTo(ioMetrics2.resultPartitionBytes);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentTest.java
@@ -66,14 +66,11 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 import org.apache.flink.util.function.FunctionUtils;
 
-import org.hamcrest.Description;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -87,19 +84,14 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DefaultExecutionGraph} deployment. */
-public class DefaultExecutionGraphDeploymentTest extends TestLogger {
+class DefaultExecutionGraphDeploymentTest {
 
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+    @RegisterExtension
+    static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
+            TestingUtils.defaultExecutorExtension();
 
     /** BLOB server instance to use for the job graph. */
     protected BlobWriter blobWriter = VoidBlobWriter.getInstance();
@@ -117,7 +109,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
      * @param eg the execution graph that was created
      */
     protected void checkJobOffloaded(DefaultExecutionGraph eg) throws Exception {
-        assertTrue(eg.getJobInformationOrBlobKey().isLeft());
+        assertThat(eg.getJobInformationOrBlobKey().isLeft()).isTrue();
     }
 
     /**
@@ -128,11 +120,11 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
      * @param jobVertexId job vertex ID
      */
     protected void checkTaskOffloaded(ExecutionGraph eg, JobVertexID jobVertexId) throws Exception {
-        assertTrue(eg.getJobVertex(jobVertexId).getTaskInformationOrBlobKey().isLeft());
+        assertThat(eg.getJobVertex(jobVertexId).getTaskInformationOrBlobKey().isLeft()).isTrue();
     }
 
     @Test
-    public void testBuildDeploymentDescriptor() throws Exception {
+    void testBuildDeploymentDescriptor() throws Exception {
 
         final JobVertexID jid1 = new JobVertexID();
         final JobVertexID jid2 = new JobVertexID();
@@ -194,7 +186,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                         .setTaskManagerGateway(taskManagerGateway)
                         .createTestingLogicalSlot();
 
-        assertEquals(ExecutionState.CREATED, vertex.getExecutionState());
+        assertThat(vertex.getExecutionState()).isEqualTo(ExecutionState.CREATED);
         vertex.getCurrentExecutionAttempt().transitionState(ExecutionState.SCHEDULED);
 
         vertex.getCurrentExecutionAttempt()
@@ -202,128 +194,111 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                 .get();
         vertex.deployToSlot(slot);
 
-        assertEquals(ExecutionState.DEPLOYING, vertex.getExecutionState());
+        assertThat(vertex.getExecutionState()).isEqualTo(ExecutionState.DEPLOYING);
         checkTaskOffloaded(eg, vertex.getJobvertexId());
 
         TaskDeploymentDescriptor descr = tdd.get();
-        assertNotNull(descr);
+        assertThat(descr).isNotNull();
 
         JobInformation jobInformation =
                 descr.getSerializedJobInformation().deserializeValue(getClass().getClassLoader());
         TaskInformation taskInformation =
                 descr.getSerializedTaskInformation().deserializeValue(getClass().getClassLoader());
 
-        assertEquals(jobId, descr.getJobId());
-        assertEquals(jobId, jobInformation.getJobId());
-        assertEquals(jid2, taskInformation.getJobVertexId());
-        assertEquals(3, descr.getSubtaskIndex());
-        assertEquals(10, taskInformation.getNumberOfSubtasks());
-        assertEquals(BatchTask.class.getName(), taskInformation.getInvokableClassName());
-        assertEquals("v2", taskInformation.getTaskName());
+        assertThat(descr.getJobId()).isEqualTo(jobId);
+        assertThat(jobInformation.getJobId()).isEqualTo(jobId);
+        assertThat(taskInformation.getJobVertexId()).isEqualTo(jid2);
+        assertThat(descr.getSubtaskIndex()).isEqualTo(3);
+        assertThat(taskInformation.getNumberOfSubtasks()).isEqualTo(10);
+        assertThat(taskInformation.getInvokableClassName()).isEqualTo(BatchTask.class.getName());
+        assertThat(taskInformation.getTaskName()).isEqualTo("v2");
 
         Collection<ResultPartitionDeploymentDescriptor> producedPartitions =
                 descr.getProducedPartitions();
         Collection<InputGateDeploymentDescriptor> consumedPartitions = descr.getInputGates();
 
-        assertEquals(2, producedPartitions.size());
-        assertEquals(1, consumedPartitions.size());
+        assertThat(producedPartitions.size()).isEqualTo(2);
+        assertThat(consumedPartitions.size()).isEqualTo(1);
 
         Iterator<ResultPartitionDeploymentDescriptor> iteratorProducedPartitions =
                 producedPartitions.iterator();
         Iterator<InputGateDeploymentDescriptor> iteratorConsumedPartitions =
                 consumedPartitions.iterator();
 
-        assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
-        assertEquals(10, iteratorProducedPartitions.next().getNumberOfSubpartitions());
+        assertThat(iteratorProducedPartitions.next().getNumberOfSubpartitions()).isEqualTo(10);
+        assertThat(iteratorProducedPartitions.next().getNumberOfSubpartitions()).isEqualTo(10);
 
         ShuffleDescriptor[] shuffleDescriptors =
                 iteratorConsumedPartitions.next().getShuffleDescriptors();
-        assertEquals(10, shuffleDescriptors.length);
+        assertThat(shuffleDescriptors.length).isEqualTo(10);
 
         Iterator<ConsumedPartitionGroup> iteratorConsumedPartitionGroup =
                 vertex.getAllConsumedPartitionGroups().iterator();
         int idx = 0;
         for (IntermediateResultPartitionID partitionId : iteratorConsumedPartitionGroup.next()) {
-            assertEquals(
-                    partitionId, shuffleDescriptors[idx++].getResultPartitionID().getPartitionId());
+            assertThat(shuffleDescriptors[idx++].getResultPartitionID().getPartitionId())
+                    .isEqualTo(partitionId);
         }
     }
 
     @Test
-    public void testRegistrationOfExecutionsFinishing() {
-        try {
-            final JobVertexID jid1 = new JobVertexID();
-            final JobVertexID jid2 = new JobVertexID();
+    void testRegistrationOfExecutionsFinishing() throws Exception {
 
-            JobVertex v1 = new JobVertex("v1", jid1);
-            JobVertex v2 = new JobVertex("v2", jid2);
+        final JobVertexID jid1 = new JobVertexID();
+        final JobVertexID jid2 = new JobVertexID();
 
-            SchedulerBase scheduler = setupScheduler(v1, 7650, v2, 2350);
-            Collection<Execution> executions =
-                    new ArrayList<>(
-                            scheduler.getExecutionGraph().getRegisteredExecutions().values());
+        JobVertex v1 = new JobVertex("v1", jid1);
+        JobVertex v2 = new JobVertex("v2", jid2);
 
-            for (Execution e : executions) {
-                e.markFinished();
-            }
+        SchedulerBase scheduler = setupScheduler(v1, 7650, v2, 2350);
+        Collection<Execution> executions =
+                new ArrayList<>(scheduler.getExecutionGraph().getRegisteredExecutions().values());
 
-            assertEquals(0, scheduler.getExecutionGraph().getRegisteredExecutions().size());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        for (Execution e : executions) {
+            e.markFinished();
         }
+
+        assertThat(scheduler.getExecutionGraph().getRegisteredExecutions()).isEmpty();
     }
 
     @Test
-    public void testRegistrationOfExecutionsFailing() {
-        try {
+    void testRegistrationOfExecutionsFailing() throws Exception {
 
-            final JobVertexID jid1 = new JobVertexID();
-            final JobVertexID jid2 = new JobVertexID();
+        final JobVertexID jid1 = new JobVertexID();
+        final JobVertexID jid2 = new JobVertexID();
 
-            JobVertex v1 = new JobVertex("v1", jid1);
-            JobVertex v2 = new JobVertex("v2", jid2);
+        JobVertex v1 = new JobVertex("v1", jid1);
+        JobVertex v2 = new JobVertex("v2", jid2);
 
-            SchedulerBase scheduler = setupScheduler(v1, 7, v2, 6);
-            Collection<Execution> executions =
-                    new ArrayList<>(
-                            scheduler.getExecutionGraph().getRegisteredExecutions().values());
+        SchedulerBase scheduler = setupScheduler(v1, 7, v2, 6);
+        Collection<Execution> executions =
+                new ArrayList<>(scheduler.getExecutionGraph().getRegisteredExecutions().values());
 
-            for (Execution e : executions) {
-                e.markFailed(null);
-            }
-
-            assertEquals(0, scheduler.getExecutionGraph().getRegisteredExecutions().size());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        for (Execution e : executions) {
+            e.markFailed(null);
         }
+
+        assertThat(scheduler.getExecutionGraph().getRegisteredExecutions()).isEmpty();
     }
 
     @Test
-    public void testRegistrationOfExecutionsFailedExternally() {
-        try {
+    void testRegistrationOfExecutionsFailedExternally() throws Exception {
 
-            final JobVertexID jid1 = new JobVertexID();
-            final JobVertexID jid2 = new JobVertexID();
+        final JobVertexID jid1 = new JobVertexID();
+        final JobVertexID jid2 = new JobVertexID();
 
-            JobVertex v1 = new JobVertex("v1", jid1);
-            JobVertex v2 = new JobVertex("v2", jid2);
+        JobVertex v1 = new JobVertex("v1", jid1);
+        JobVertex v2 = new JobVertex("v2", jid2);
 
-            SchedulerBase scheduler = setupScheduler(v1, 7, v2, 6);
-            Collection<Execution> executions =
-                    new ArrayList<>(
-                            scheduler.getExecutionGraph().getRegisteredExecutions().values());
+        SchedulerBase scheduler = setupScheduler(v1, 7, v2, 6);
+        Collection<Execution> executions =
+                new ArrayList<>(scheduler.getExecutionGraph().getRegisteredExecutions().values());
 
-            for (Execution e : executions) {
-                e.fail(null);
-            }
-
-            assertEquals(0, scheduler.getExecutionGraph().getRegisteredExecutions().size());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        for (Execution e : executions) {
+            e.fail(null);
         }
+
+        assertThat(scheduler.getExecutionGraph().getRegisteredExecutions()).isEmpty();
     }
 
     /**
@@ -331,7 +306,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
      * accumulators and metrics for an execution that failed or was canceled.
      */
     @Test
-    public void testAccumulatorsAndMetricsForwarding() throws Exception {
+    void testAccumulatorsAndMetricsForwarding() throws Exception {
         final JobVertexID jid1 = new JobVertexID();
         final JobVertexID jid2 = new JobVertexID();
 
@@ -361,9 +336,9 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
 
         scheduler.updateTaskExecutionState(state);
 
-        assertEquals(ioMetrics, execution1.getIOMetrics());
-        assertNotNull(execution1.getUserAccumulators());
-        assertEquals(4, execution1.getUserAccumulators().get("acc").getLocalValue());
+        assertThat(execution1.getIOMetrics()).isEqualTo(ioMetrics);
+        assertThat(execution1.getUserAccumulators()).isNotNull();
+        assertThat(execution1.getUserAccumulators().get("acc").getLocalValue()).isEqualTo(4);
 
         // verify behavior for failed executions
         Execution execution2 = executions.values().iterator().next();
@@ -384,9 +359,9 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
 
         scheduler.updateTaskExecutionState(state2);
 
-        assertEquals(ioMetrics2, execution2.getIOMetrics());
-        assertNotNull(execution2.getUserAccumulators());
-        assertEquals(8, execution2.getUserAccumulators().get("acc").getLocalValue());
+        assertThat(execution2.getIOMetrics()).isEqualTo(ioMetrics2);
+        assertThat(execution2.getUserAccumulators()).isNotNull();
+        assertThat(execution2.getUserAccumulators().get("acc").getLocalValue()).isEqualTo(8);
     }
 
     /**
@@ -395,7 +370,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
      * accumulators and metrics correctly.
      */
     @Test
-    public void testAccumulatorsAndMetricsStorage() throws Exception {
+    void testAccumulatorsAndMetricsStorage() throws Exception {
         final JobVertexID jid1 = new JobVertexID();
         final JobVertexID jid2 = new JobVertexID();
 
@@ -413,41 +388,35 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
         execution1.cancel();
         execution1.completeCancelling(accumulators, ioMetrics, false);
 
-        assertEquals(ioMetrics, execution1.getIOMetrics());
-        assertEquals(accumulators, execution1.getUserAccumulators());
+        assertThat(execution1.getIOMetrics()).isEqualTo(ioMetrics);
+        assertThat(execution1.getUserAccumulators()).isEqualTo(accumulators);
 
         Execution execution2 = executions.values().iterator().next();
         execution2.markFailed(new Throwable(), false, accumulators, ioMetrics, false, true);
 
-        assertEquals(ioMetrics, execution2.getIOMetrics());
-        assertEquals(accumulators, execution2.getUserAccumulators());
+        assertThat(execution2.getIOMetrics()).isEqualTo(ioMetrics);
+        assertThat(execution2.getUserAccumulators()).isEqualTo(accumulators);
     }
 
     @Test
-    public void testRegistrationOfExecutionsCanceled() {
-        try {
+    void testRegistrationOfExecutionsCanceled() throws Exception {
 
-            final JobVertexID jid1 = new JobVertexID();
-            final JobVertexID jid2 = new JobVertexID();
+        final JobVertexID jid1 = new JobVertexID();
+        final JobVertexID jid2 = new JobVertexID();
 
-            JobVertex v1 = new JobVertex("v1", jid1);
-            JobVertex v2 = new JobVertex("v2", jid2);
+        JobVertex v1 = new JobVertex("v1", jid1);
+        JobVertex v2 = new JobVertex("v2", jid2);
 
-            SchedulerBase scheduler = setupScheduler(v1, 19, v2, 37);
-            Collection<Execution> executions =
-                    new ArrayList<>(
-                            scheduler.getExecutionGraph().getRegisteredExecutions().values());
+        SchedulerBase scheduler = setupScheduler(v1, 19, v2, 37);
+        Collection<Execution> executions =
+                new ArrayList<>(scheduler.getExecutionGraph().getRegisteredExecutions().values());
 
-            for (Execution e : executions) {
-                e.cancel();
-                e.completeCancelling();
-            }
-
-            assertEquals(0, scheduler.getExecutionGraph().getRegisteredExecutions().size());
-        } catch (Exception e) {
-            e.printStackTrace();
-            fail(e.getMessage());
+        for (Execution e : executions) {
+            e.cancel();
+            e.completeCancelling();
         }
+
+        assertThat(scheduler.getExecutionGraph().getRegisteredExecutions()).isEmpty();
     }
 
     /**
@@ -456,7 +425,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
      * swallow the fail exception when scheduling a consumer task.
      */
     @Test
-    public void testNoResourceAvailableFailure() throws Exception {
+    void testNoResourceAvailableFailure() throws Exception {
         JobVertex v1 = new JobVertex("source");
         JobVertex v2 = new JobVertex("sink");
 
@@ -481,7 +450,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                 new DefaultSchedulerBuilder(
                                 graph,
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                EXECUTOR_RESOURCE.getExecutor())
+                                EXECUTOR_EXTENSION.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         TestingPhysicalSlotProvider
@@ -507,7 +476,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
         scheduler.updateTaskExecutionState(
                 new TaskExecutionState(attemptID, ExecutionState.FINISHED, null));
 
-        assertEquals(JobStatus.FAILED, eg.getState());
+        assertThat(eg.getState()).isEqualTo(JobStatus.FAILED);
     }
 
     // ------------------------------------------------------------------------
@@ -515,16 +484,16 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
     // ------------------------------------------------------------------------
 
     @Test
-    public void testSettingDefaultMaxNumberOfCheckpointsToRetain() throws Exception {
+    void testSettingDefaultMaxNumberOfCheckpointsToRetain() throws Exception {
         final Configuration jobManagerConfig = new Configuration();
 
         final ExecutionGraph eg = createExecutionGraph(jobManagerConfig);
 
-        assertEquals(
-                CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue(),
-                eg.getCheckpointCoordinator()
-                        .getCheckpointStore()
-                        .getMaxNumberOfRetainedCheckpoints());
+        assertThat(
+                        eg.getCheckpointCoordinator()
+                                .getCheckpointStore()
+                                .getMaxNumberOfRetainedCheckpoints())
+                .isEqualTo(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue());
     }
 
     private SchedulerBase setupScheduler(JobVertex v1, int dop1, JobVertex v2, int dop2)
@@ -542,7 +511,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                 new DefaultSchedulerBuilder(
                                 JobGraphTestUtils.streamingJobGraph(v1, v2),
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                EXECUTOR_RESOURCE.getExecutor())
+                                EXECUTOR_EXTENSION.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory())
                         .setFutureExecutor(executorService)
@@ -556,13 +525,13 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
         scheduler.startScheduling();
 
         Map<ExecutionAttemptID, Execution> executions = eg.getRegisteredExecutions();
-        assertEquals(dop1 + dop2, executions.size());
+        assertThat(executions.size()).isEqualTo(dop1 + dop2);
 
         return scheduler;
     }
 
     @Test
-    public void testSettingIllegalMaxNumberOfCheckpointsToRetain() throws Exception {
+    void testSettingIllegalMaxNumberOfCheckpointsToRetain() throws Exception {
 
         final int negativeMaxNumberOfCheckpointsToRetain = -10;
 
@@ -573,22 +542,22 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
 
         final ExecutionGraph eg = createExecutionGraph(jobManagerConfig);
 
-        assertNotEquals(
-                negativeMaxNumberOfCheckpointsToRetain,
-                eg.getCheckpointCoordinator()
-                        .getCheckpointStore()
-                        .getMaxNumberOfRetainedCheckpoints());
+        assertThat(
+                        eg.getCheckpointCoordinator()
+                                .getCheckpointStore()
+                                .getMaxNumberOfRetainedCheckpoints())
+                .isNotEqualTo(negativeMaxNumberOfCheckpointsToRetain);
 
-        assertEquals(
-                CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue(),
-                eg.getCheckpointCoordinator()
-                        .getCheckpointStore()
-                        .getMaxNumberOfRetainedCheckpoints());
+        assertThat(
+                        eg.getCheckpointCoordinator()
+                                .getCheckpointStore()
+                                .getMaxNumberOfRetainedCheckpoints())
+                .isEqualTo(CheckpointingOptions.MAX_RETAINED_CHECKPOINTS.defaultValue().intValue());
     }
 
     /** Tests that the {@link ExecutionGraph} is deployed in topological order. */
     @Test
-    public void testExecutionGraphIsDeployedInTopologicalOrder() throws Exception {
+    void testExecutionGraphIsDeployedInTopologicalOrder() throws Exception {
         final int sourceParallelism = 2;
         final int sinkParallelism = 1;
 
@@ -628,7 +597,7 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                 new DefaultSchedulerBuilder(
                                 jobGraph,
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                EXECUTOR_RESOURCE.getExecutor())
+                                EXECUTOR_EXTENSION.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
                                         physicalSlotProvider))
@@ -670,7 +639,9 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
         }
 
         assertThat(
-                submittedTasks, new ExecutionStageMatcher(Arrays.asList(firstStage, secondStage)));
+                        isDeployedInTopologicalOrder(
+                                submittedTasks, Arrays.asList(firstStage, secondStage)))
+                .isTrue();
     }
 
     private ExecutionGraph createExecutionGraph(Configuration configuration) throws Exception {
@@ -693,41 +664,28 @@ public class DefaultExecutionGraphDeploymentTest extends TestLogger {
                 .setJobGraph(jobGraph)
                 .setJobMasterConfig(configuration)
                 .setBlobWriter(blobWriter)
-                .build(EXECUTOR_RESOURCE.getExecutor());
+                .build(EXECUTOR_EXTENSION.getExecutor());
     }
 
-    private static final class ExecutionStageMatcher
-            extends TypeSafeMatcher<List<ExecutionAttemptID>> {
-        private final List<Collection<ExecutionAttemptID>> executionStages;
+    private boolean isDeployedInTopologicalOrder(
+            List<ExecutionAttemptID> submissionOrder,
+            List<Collection<ExecutionAttemptID>> executionStages) {
+        final Iterator<ExecutionAttemptID> submissionIterator = submissionOrder.iterator();
 
-        private ExecutionStageMatcher(List<Collection<ExecutionAttemptID>> executionStages) {
-            this.executionStages = executionStages;
-        }
+        for (Collection<ExecutionAttemptID> stage : executionStages) {
+            final Collection<ExecutionAttemptID> currentStage = new ArrayList<>(stage);
 
-        @Override
-        protected boolean matchesSafely(List<ExecutionAttemptID> submissionOrder) {
-            final Iterator<ExecutionAttemptID> submissionIterator = submissionOrder.iterator();
-
-            for (Collection<ExecutionAttemptID> stage : executionStages) {
-                final Collection<ExecutionAttemptID> currentStage = new ArrayList<>(stage);
-
-                while (!currentStage.isEmpty() && submissionIterator.hasNext()) {
-                    if (!currentStage.remove(submissionIterator.next())) {
-                        return false;
-                    }
-                }
-
-                if (!currentStage.isEmpty()) {
+            while (!currentStage.isEmpty() && submissionIterator.hasNext()) {
+                if (!currentStage.remove(submissionIterator.next())) {
                     return false;
                 }
             }
 
-            return !submissionIterator.hasNext();
+            if (!currentStage.isEmpty()) {
+                return false;
+            }
         }
 
-        @Override
-        public void describeTo(Description description) {
-            description.appendValueList("<[", ", ", "]>", executionStages);
-        }
+        return !submissionIterator.hasNext();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobCacheTest.java
@@ -23,9 +23,10 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
 import org.apache.flink.runtime.blob.PermanentBlobCache;
 import org.apache.flink.runtime.blob.VoidBlobStore;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -34,26 +35,31 @@ import java.net.InetSocketAddress;
  * Tests {@link ExecutionGraph} deployment when offloading job and task information into the BLOB
  * server.
  */
-public class DefaultExecutionGraphDeploymentWithBlobCacheTest
+class DefaultExecutionGraphDeploymentWithBlobCacheTest
         extends DefaultExecutionGraphDeploymentWithBlobServerTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void setupBlobServer() throws IOException {
         Configuration config = new Configuration();
         // always offload the serialized job and task information
         config.setInteger(BlobServerOptions.OFFLOAD_MINSIZE, 0);
-        blobServer = new BlobServer(config, TEMPORARY_FOLDER.newFolder(), new VoidBlobStore());
+        blobServer =
+                new BlobServer(
+                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
         blobServer.start();
         blobWriter = blobServer;
 
         InetSocketAddress serverAddress = new InetSocketAddress("localhost", blobServer.getPort());
         blobCache =
                 new PermanentBlobCache(
-                        config, TEMPORARY_FOLDER.newFolder(), new VoidBlobStore(), serverAddress);
+                        config,
+                        TempDirUtils.newFolder(temporaryFolder),
+                        new VoidBlobStore(),
+                        serverAddress);
     }
 
-    @After
+    @AfterEach
     @Override
     public void shutdownBlobServer() throws IOException {
         if (blobServer != null) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobServerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithBlobServerTest.java
@@ -22,71 +22,57 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.BlobServerOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobServer;
+import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.blob.PermanentBlobKey;
 import org.apache.flink.runtime.blob.VoidBlobStore;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.types.Either;
 import org.apache.flink.util.SerializedValue;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.rules.TemporaryFolder;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests {@link ExecutionGraph} deployment when offloading job and task information into the BLOB
  * server.
  */
-public class DefaultExecutionGraphDeploymentWithBlobServerTest
+class DefaultExecutionGraphDeploymentWithBlobServerTest
         extends DefaultExecutionGraphDeploymentTest {
 
-    @ClassRule public static final TemporaryFolder TEMPORARY_FOLDER = new TemporaryFolder();
+    @TempDir Path temporaryFolder;
 
     private Set<byte[]> seenHashes =
             Collections.newSetFromMap(new ConcurrentHashMap<byte[], Boolean>());
 
     protected BlobServer blobServer = null;
 
-    @Before
+    @BeforeEach
     public void setupBlobServer() throws IOException {
         Configuration config = new Configuration();
         // always offload the serialized job and task information
         config.setInteger(BlobServerOptions.OFFLOAD_MINSIZE, 0);
         blobServer =
-                Mockito.spy(
-                        new BlobServer(config, TEMPORARY_FOLDER.newFolder(), new VoidBlobStore()));
+                new AssertBlobServer(
+                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
         blobWriter = blobServer;
         blobCache = blobServer;
 
         seenHashes.clear();
-
-        // verify that we do not upload the same content more than once
-        doAnswer(
-                        invocation -> {
-                            PermanentBlobKey key = (PermanentBlobKey) invocation.callRealMethod();
-
-                            assertTrue(seenHashes.add(key.getHash()));
-
-                            return key;
-                        })
-                .when(blobServer)
-                .putPermanent(any(JobID.class), Matchers.<byte[]>any());
-
         blobServer.start();
     }
 
-    @After
+    @AfterEach
     public void shutdownBlobServer() throws IOException {
         if (blobServer != null) {
             blobServer.close();
@@ -98,7 +84,7 @@ public class DefaultExecutionGraphDeploymentWithBlobServerTest
         Either<SerializedValue<JobInformation>, PermanentBlobKey> jobInformationOrBlobKey =
                 eg.getJobInformationOrBlobKey();
 
-        assertTrue(jobInformationOrBlobKey.isRight());
+        assertThat(jobInformationOrBlobKey.isRight()).isTrue();
 
         // must not throw:
         blobServer.getFile(eg.getJobID(), jobInformationOrBlobKey.right());
@@ -109,9 +95,24 @@ public class DefaultExecutionGraphDeploymentWithBlobServerTest
         Either<SerializedValue<TaskInformation>, PermanentBlobKey> taskInformationOrBlobKey =
                 eg.getJobVertex(jobVertexId).getTaskInformationOrBlobKey();
 
-        assertTrue(taskInformationOrBlobKey.isRight());
+        assertThat(taskInformationOrBlobKey.isRight()).isTrue();
 
         // must not throw:
         blobServer.getFile(eg.getJobID(), taskInformationOrBlobKey.right());
+    }
+
+    private class AssertBlobServer extends BlobServer {
+        public AssertBlobServer(Configuration config, File storageDir, BlobStore blobStore)
+                throws IOException {
+            super(config, storageDir, blobStore);
+        }
+
+        @Override
+        public PermanentBlobKey putPermanent(JobID jobId, byte[] value) throws IOException {
+            PermanentBlobKey key = super.putPermanent(jobId, value);
+            // verify that we do not upload the same content more than once
+            assertThat(seenHashes.add(key.getHash())).isTrue();
+            return key;
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest.java
@@ -43,10 +43,11 @@ import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.operators.BatchTask;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.testutils.DirectScheduledExecutorService;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 import org.apache.flink.util.function.FunctionUtils;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -55,8 +56,7 @@ import java.util.List;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests {@link ExecutionGraph} deployment when job and task information are offloaded into the BLOB
@@ -65,17 +65,19 @@ import static org.junit.Assert.assertNotNull;
  * even the size limit of {@link BlobCacheSizeTracker} in {@link PermanentBlobCache} is set to the
  * minimum value.
  */
-public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
+class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         extends DefaultExecutionGraphDeploymentWithBlobCacheTest {
 
-    @Before
+    @BeforeEach
     @Override
     public void setupBlobServer() throws IOException {
         Configuration config = new Configuration();
         // Always offload the serialized JobInformation, TaskInformation and cached
         // ShuffleDescriptors
         config.setInteger(BlobServerOptions.OFFLOAD_MINSIZE, 0);
-        blobServer = new BlobServer(config, TEMPORARY_FOLDER.newFolder(), new VoidBlobStore());
+        blobServer =
+                new BlobServer(
+                        config, TempDirUtils.newFolder(temporaryFolder), new VoidBlobStore());
         blobServer.start();
         blobWriter = blobServer;
 
@@ -85,7 +87,7 @@ public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         blobCache =
                 new PermanentBlobCache(
                         config,
-                        TEMPORARY_FOLDER.newFolder(),
+                        TempDirUtils.newFolder(temporaryFolder),
                         new VoidBlobStore(),
                         serverAddress,
                         blobCacheSizeTracker);
@@ -103,7 +105,7 @@ public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
      * larger than 1 and the deletion won't happen so frequently.
      */
     @Test
-    public void testDeployMultipleTasksWithSmallBlobCacheSizeLimit() throws Exception {
+    void testDeployMultipleTasksWithSmallBlobCacheSizeLimit() throws Exception {
 
         final int numberOfVertices = 4;
         final int parallelism = 10;
@@ -124,7 +126,7 @@ public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
         for (ExecutionJobVertex ejv : eg.getVerticesTopologically()) {
             for (ExecutionVertex ev : ejv.getTaskVertices()) {
 
-                assertEquals(ExecutionState.CREATED, ev.getExecutionState());
+                assertThat(ev.getExecutionState()).isEqualTo(ExecutionState.CREATED);
 
                 LogicalSlot slot =
                         new TestingLogicalSlotBuilder()
@@ -134,13 +136,13 @@ public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
                 execution.transitionState(ExecutionState.SCHEDULED);
                 execution.registerProducedPartitions(slot.getTaskManagerLocation()).get();
                 ev.deployToSlot(slot);
-                assertEquals(ExecutionState.DEPLOYING, ev.getExecutionState());
+                assertThat(ev.getExecutionState()).isEqualTo(ExecutionState.DEPLOYING);
 
                 TaskDeploymentDescriptor tdd = tdds.take();
-                assertNotNull(tdd);
+                assertThat(tdd).isNotNull();
 
                 List<InputGateDeploymentDescriptor> igdds = tdd.getInputGates();
-                assertEquals(ev.getAllConsumedPartitionGroups().size(), igdds.size());
+                assertThat(igdds).hasSize(ev.getAllConsumedPartitionGroups().size());
 
                 if (igdds.size() > 0) {
                     checkShuffleDescriptors(igdds.get(0), ev.getConsumedPartitionGroup(0));
@@ -188,9 +190,8 @@ public class DefaultExecutionGraphDeploymentWithSmallBlobCacheSizeLimitTest
             InputGateDeploymentDescriptor igdd, ConsumedPartitionGroup consumedPartitionGroup) {
         int idx = 0;
         for (IntermediateResultPartitionID consumedPartitionId : consumedPartitionGroup) {
-            assertEquals(
-                    consumedPartitionId,
-                    igdd.getShuffleDescriptors()[idx++].getResultPartitionID().getPartitionId());
+            assertThat(igdd.getShuffleDescriptors()[idx++].getResultPartitionID().getPartitionId())
+                    .isEqualTo(consumedPartitionId);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
@@ -30,40 +30,38 @@ import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.buffer.CompositeBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.testutils.junit.utils.TempDirUtils;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import static org.apache.flink.util.Preconditions.checkNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link SortMergeResultPartition}. */
-@RunWith(Parameterized.class)
-public class SortMergeResultPartitionTest extends TestLogger {
+@ExtendWith(ParameterizedTestExtension.class)
+public class SortMergeResultPartitionTest {
 
     private static final int bufferSize = 1024;
 
@@ -73,7 +71,7 @@ public class SortMergeResultPartitionTest extends TestLogger {
 
     private static final int numThreads = 4;
 
-    private final boolean useHashDataBuffer;
+    @Parameter public boolean useHashDataBuffer;
 
     private final TestBufferAvailabilityListener listener = new TestBufferAvailabilityListener();
 
@@ -85,38 +83,33 @@ public class SortMergeResultPartitionTest extends TestLogger {
 
     private ExecutorService readIOExecutor;
 
-    @Rule public final TemporaryFolder tmpFolder = new TemporaryFolder();
+    @TempDir private Path tmpFolder;
 
-    @Rule public Timeout timeout = new Timeout(60, TimeUnit.SECONDS);
-
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() throws IOException {
         fileChannelManager =
-                new FileChannelManagerImpl(new String[] {tmpFolder.getRoot().getPath()}, "testing");
+                new FileChannelManagerImpl(
+                        new String[] {TempDirUtils.newFolder(tmpFolder).toString()}, "testing");
         globalPool = new NetworkBufferPool(totalBuffers, bufferSize);
         readBufferPool = new BatchShuffleReadBufferPool(totalBytes, bufferSize);
         readIOExecutor = Executors.newFixedThreadPool(numThreads);
     }
 
-    @After
-    public void shutdown() throws Exception {
+    @AfterEach
+    void shutdown() throws Exception {
         fileChannelManager.close();
         globalPool.destroy();
         readBufferPool.destroy();
         readIOExecutor.shutdown();
     }
 
-    @Parameterized.Parameters(name = "UseHashDataBuffer = {0}")
-    public static Object[] parameters() {
-        return new Object[] {true, false};
+    @Parameters(name = "useHashDataBuffer={0}")
+    public static Collection<Boolean> parameters() {
+        return Arrays.asList(false, true);
     }
 
-    public SortMergeResultPartitionTest(boolean useHashDataBuffer) {
-        this.useHashDataBuffer = useHashDataBuffer;
-    }
-
-    @Test
-    public void testWriteAndRead() throws Exception {
+    @TestTemplate
+    void testWriteAndRead() throws Exception {
         int numBuffers = useHashDataBuffer ? 100 : 15;
         int numSubpartitions = 10;
         int numRecords = 1000;
@@ -232,8 +225,8 @@ public class SortMergeResultPartitionTest extends TestLogger {
 
                     if (!buffer.isBuffer()) {
                         ++numEndOfPartitionEvents;
-                        assertFalse(
-                                view.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable());
+                        assertThat(view.getAvailabilityAndBacklog(Integer.MAX_VALUE).isAvailable())
+                                .isFalse();
                         view.releaseAllResources();
                     }
                     bufferAndBacklog = view.getNextBuffer();
@@ -252,16 +245,16 @@ public class SortMergeResultPartitionTest extends TestLogger {
         return views;
     }
 
-    @Test
-    public void testWriteLargeRecord() throws Exception {
+    @TestTemplate
+    void testWriteLargeRecord() throws Exception {
         int numBuffers = useHashDataBuffer ? 100 : 15;
         BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
         SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
 
         ByteBuffer recordWritten = generateRandomData(bufferSize * numBuffers, new Random());
         partition.emitRecord(recordWritten, 0);
-        assertEquals(
-                useHashDataBuffer ? numBuffers : 0, bufferPool.bestEffortGetNumOfUsedBuffers());
+        assertThat(bufferPool.bestEffortGetNumOfUsedBuffers())
+                .isEqualTo(useHashDataBuffer ? numBuffers : 0);
 
         partition.finish();
         partition.close();
@@ -286,11 +279,11 @@ public class SortMergeResultPartitionTest extends TestLogger {
                 });
         recordWritten.rewind();
         recordRead.flip();
-        assertEquals(recordWritten, recordRead);
+        assertThat(recordRead).isEqualTo(recordWritten);
     }
 
-    @Test
-    public void testDataBroadcast() throws Exception {
+    @TestTemplate
+    void testDataBroadcast() throws Exception {
         int numSubpartitions = 10;
         int numBuffers = useHashDataBuffer ? 100 : 15;
         int numRecords = 10000;
@@ -308,11 +301,11 @@ public class SortMergeResultPartitionTest extends TestLogger {
 
         int eventSize = EventSerializer.toSerializedEvent(EndOfPartitionEvent.INSTANCE).remaining();
         long dataSize = numSubpartitions * numRecords * bufferSize + numSubpartitions * eventSize;
-        assertNotNull(partition.getResultFile());
-        assertEquals(2, checkNotNull(fileChannelManager.getPaths()[0].list()).length);
+        assertThat(partition.getResultFile()).isNotNull();
+        assertThat(checkNotNull(fileChannelManager.getPaths()[0].list()).length).isEqualTo(2);
         for (File file : checkNotNull(fileChannelManager.getPaths()[0].listFiles())) {
             if (file.getName().endsWith(PartitionedFile.DATA_FILE_SUFFIX)) {
-                assertTrue(file.length() < numSubpartitions * numRecords * bufferSize);
+                assertThat(file.length()).isLessThan(numSubpartitions * numRecords * bufferSize);
             }
         }
 
@@ -323,49 +316,47 @@ public class SortMergeResultPartitionTest extends TestLogger {
                         bufferWithChannel -> {
                             bufferWithChannel.getBuffer().recycleBuffer();
                         });
-        assertEquals(dataSize, dataRead);
+        assertThat(dataRead).isEqualTo(dataSize);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testReleaseWhileWriting() throws Exception {
+    @TestTemplate
+    void testReleaseWhileWriting() throws Exception {
         int numBuffers = useHashDataBuffer ? 100 : 15;
 
         BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
         SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
-        assertEquals(0, bufferPool.bestEffortGetNumOfUsedBuffers());
+        assertThat(bufferPool.bestEffortGetNumOfUsedBuffers()).isEqualTo(0);
 
         partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 0);
         partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 1);
 
         partition.emitRecord(ByteBuffer.allocate(bufferSize), 2);
-        assertNull(partition.getResultFile());
-        assertEquals(2, fileChannelManager.getPaths()[0].list().length);
+        assertThat(partition.getResultFile()).isNull();
+        assertThat(fileChannelManager.getPaths()[0].list().length).isEqualTo(2);
 
         partition.release();
-        try {
-            partition.emitRecord(ByteBuffer.allocate(bufferSize * numBuffers), 2);
-        } catch (IllegalStateException exception) {
-            assertEquals(0, fileChannelManager.getPaths()[0].list().length);
 
-            throw exception;
-        }
+        assertThatThrownBy(
+                        () -> partition.emitRecord(ByteBuffer.allocate(bufferSize * numBuffers), 2))
+                .isInstanceOf(IllegalStateException.class);
+        assertThat(fileChannelManager.getPaths()[0].list().length).isEqualTo(0);
     }
 
-    @Test
-    public void testRelease() throws Exception {
+    @TestTemplate
+    void testRelease() throws Exception {
         int numBuffers = useHashDataBuffer ? 100 : 15;
 
         BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
         SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
-        assertEquals(0, bufferPool.bestEffortGetNumOfUsedBuffers());
+        assertThat(bufferPool.bestEffortGetNumOfUsedBuffers()).isEqualTo(0);
 
         partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 0);
         partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 1);
         partition.finish();
         partition.close();
 
-        assertEquals(3, partition.getResultFile().getNumRegions());
-        assertEquals(2, checkNotNull(fileChannelManager.getPaths()[0].list()).length);
+        assertThat(partition.getResultFile().getNumRegions()).isEqualTo(3);
+        assertThat(checkNotNull(fileChannelManager.getPaths()[0].list()).length).isEqualTo(2);
 
         ResultSubpartitionView view = partition.createSubpartitionView(0, listener);
         partition.release();
@@ -381,57 +372,54 @@ public class SortMergeResultPartitionTest extends TestLogger {
         while (partition.getResultFile() != null) {
             Thread.sleep(100);
         }
-        assertEquals(0, checkNotNull(fileChannelManager.getPaths()[0].list()).length);
+        assertThat(checkNotNull(fileChannelManager.getPaths()[0].list()).length).isEqualTo(0);
     }
 
-    @Test
-    public void testCloseReleasesAllBuffers() throws Exception {
+    @TestTemplate
+    void testCloseReleasesAllBuffers() throws Exception {
         int numBuffers = useHashDataBuffer ? 100 : 15;
 
         BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
         SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
-        assertEquals(0, bufferPool.bestEffortGetNumOfUsedBuffers());
+        assertThat(bufferPool.bestEffortGetNumOfUsedBuffers()).isEqualTo(0);
 
         partition.emitRecord(ByteBuffer.allocate(bufferSize * (numBuffers - 1)), 5);
-        assertEquals(
-                useHashDataBuffer ? numBuffers : 0, bufferPool.bestEffortGetNumOfUsedBuffers());
+        assertThat(bufferPool.bestEffortGetNumOfUsedBuffers())
+                .isEqualTo(useHashDataBuffer ? numBuffers : 0);
 
         partition.close();
-        assertTrue(bufferPool.isDestroyed());
-        assertEquals(totalBuffers, globalPool.getNumberOfAvailableMemorySegments());
+        assertThat(bufferPool.isDestroyed()).isTrue();
+        assertThat(globalPool.getNumberOfAvailableMemorySegments()).isEqualTo(totalBuffers);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testReadUnfinishedPartition() throws Exception {
+    @TestTemplate
+    void testReadUnfinishedPartition() throws Exception {
         BufferPool bufferPool = globalPool.createBufferPool(10, 10);
-        try {
-            SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
-            partition.createSubpartitionView(0, listener);
-        } finally {
-            bufferPool.lazyDestroy();
-        }
+        SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+        assertThatThrownBy(() -> partition.createSubpartitionView(0, listener))
+                .isInstanceOf(IllegalStateException.class);
+        bufferPool.lazyDestroy();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testReadReleasedPartition() throws Exception {
+    @TestTemplate
+    void testReadReleasedPartition() throws Exception {
         BufferPool bufferPool = globalPool.createBufferPool(10, 10);
-        try {
-            SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
-            partition.finish();
-            partition.release();
-            partition.createSubpartitionView(0, listener);
-        } finally {
-            bufferPool.lazyDestroy();
-        }
+        SortMergeResultPartition partition = createSortMergedPartition(10, bufferPool);
+        partition.finish();
+        partition.release();
+
+        assertThatThrownBy(() -> partition.createSubpartitionView(0, listener))
+                .isInstanceOf(IllegalStateException.class);
+        bufferPool.lazyDestroy();
     }
 
-    @Test
-    public void testNumBytesProducedCounterForUnicast() throws IOException {
+    @TestTemplate
+    void testNumBytesProducedCounterForUnicast() throws IOException {
         testNumBytesProducedCounter(false);
     }
 
-    @Test
-    public void testNumBytesProducedCounterForBroadcast() throws IOException {
+    @TestTemplate
+    void testNumBytesProducedCounterForBroadcast() throws IOException {
         testNumBytesProducedCounter(true);
     }
 
@@ -447,14 +435,16 @@ public class SortMergeResultPartitionTest extends TestLogger {
             partition.broadcastRecord(ByteBuffer.allocate(bufferSize));
             partition.finish();
 
-            assertEquals(bufferSize + 4, partition.numBytesProduced.getCount());
-            assertEquals(numSubpartitions * (bufferSize + 4), partition.numBytesOut.getCount());
+            assertThat(partition.numBytesProduced.getCount()).isEqualTo(bufferSize + 4);
+            assertThat(partition.numBytesOut.getCount())
+                    .isEqualTo(numSubpartitions * (bufferSize + 4));
         } else {
             partition.emitRecord(ByteBuffer.allocate(bufferSize), 0);
             partition.finish();
 
-            assertEquals(bufferSize + 4, partition.numBytesProduced.getCount());
-            assertEquals(bufferSize + numSubpartitions * 4, partition.numBytesOut.getCount());
+            assertThat(partition.numBytesProduced.getCount()).isEqualTo(bufferSize + 4);
+            assertThat(partition.numBytesOut.getCount())
+                    .isEqualTo(bufferSize + numSubpartitions * 4);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.core.memory.MemorySegmentFactory;
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.runtime.event.AbstractEvent;
 import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
 import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.disk.FileChannelManagerImpl;
@@ -439,9 +440,11 @@ class HsResultPartitionTest {
             assertThat(taskIOMetricGroup.getNumBytesOutCounter().getCount())
                     .isEqualTo(3 * bufferSize);
             IOMetrics ioMetrics = taskIOMetricGroup.createSnapshot();
-            assertThat(ioMetrics.getNumBytesProducedOfPartitions())
-                    .hasSize(1)
-                    .containsValue((long) 2 * bufferSize);
+            assertThat(ioMetrics.getResultPartitionBytes()).hasSize(1);
+            ResultPartitionBytes partitionBytes =
+                    ioMetrics.getResultPartitionBytes().values().iterator().next();
+            assertThat(partitionBytes.getSubpartitionBytes())
+                    .containsExactly((long) 2 * bufferSize, (long) bufferSize);
         }
     }
 
@@ -498,9 +501,11 @@ class HsResultPartitionTest {
             assertThat(taskIOMetricGroup.getNumBuffersOutCounter().getCount()).isEqualTo(1);
             assertThat(taskIOMetricGroup.getNumBytesOutCounter().getCount()).isEqualTo(bufferSize);
             IOMetrics ioMetrics = taskIOMetricGroup.createSnapshot();
-            assertThat(ioMetrics.getNumBytesProducedOfPartitions())
-                    .hasSize(1)
-                    .containsValue((long) bufferSize);
+            assertThat(ioMetrics.getResultPartitionBytes()).hasSize(1);
+            ResultPartitionBytes partitionBytes =
+                    ioMetrics.getResultPartitionBytes().values().iterator().next();
+            assertThat(partitionBytes.getSubpartitionBytes())
+                    .containsExactly((long) bufferSize, (long) bufferSize);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerTest.java
@@ -136,6 +136,7 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.apache.flink.runtime.jobmaster.slotpool.DefaultDeclarativeSlotPoolTest.createSlotOffersForResourceRequirements;
 import static org.apache.flink.runtime.jobmaster.slotpool.SlotPoolTestUtils.offerSlots;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.acknowledgePendingCheckpoint;
+import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.createFailedTaskExecutionState;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.enableCheckpointing;
 import static org.apache.flink.runtime.scheduler.SchedulerTestingUtils.getCheckpointCoordinator;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
@@ -1780,12 +1781,6 @@ public class DefaultSchedulerTest extends TestLogger {
         checkpointServicesShutdownBlocked.countDown();
         cleanerClosed.await();
         schedulerClosed.get();
-    }
-
-    public static TaskExecutionState createFailedTaskExecutionState(
-            ExecutionAttemptID executionAttemptID) {
-        return new TaskExecutionState(
-                executionAttemptID, ExecutionState.FAILED, new Exception("Expected failure cause"));
     }
 
     private static long initiateFailure(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -35,11 +35,14 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.executiongraph.IOMetrics;
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
 import org.apache.flink.runtime.executiongraph.failover.flip1.TestRestartBackoffTimeStrategy;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -64,6 +67,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -433,5 +437,35 @@ public class SchedulerTestingUtils {
             vertex.tryAssignResource(slot);
             vertex.deploy();
         }
+    }
+
+    public static TaskExecutionState createFinishedTaskExecutionState(
+            ExecutionAttemptID attemptId,
+            Map<IntermediateResultPartitionID, ResultPartitionBytes> resultPartitionBytes) {
+        return new TaskExecutionState(
+                attemptId,
+                ExecutionState.FINISHED,
+                null,
+                null,
+                new IOMetrics(0, 0, 0, 0, 0, 0, 0, resultPartitionBytes));
+    }
+
+    public static TaskExecutionState createFinishedTaskExecutionState(
+            ExecutionAttemptID attemptId) {
+        return createFinishedTaskExecutionState(attemptId, Collections.emptyMap());
+    }
+
+    public static TaskExecutionState createFailedTaskExecutionState(
+            ExecutionAttemptID attemptId, Throwable failureCause) {
+        return new TaskExecutionState(attemptId, ExecutionState.FAILED, failureCause);
+    }
+
+    public static TaskExecutionState createFailedTaskExecutionState(ExecutionAttemptID attemptId) {
+        return createFailedTaskExecutionState(attemptId, new Exception("Expected failure cause"));
+    }
+
+    public static TaskExecutionState createCanceledTaskExecutionState(
+            ExecutionAttemptID attemptId) {
+        return new TaskExecutionState(attemptId, ExecutionState.CANCELED);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AllToAllBlockingResultInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AllToAllBlockingResultInfoTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link AllToAllBlockingResultInfo}. */
+class AllToAllBlockingResultInfoTest {
+
+    @Test
+    void testGetNumBytesProducedForNonBroadcast() {
+        testGetNumBytesProduced(false, 192L);
+    }
+
+    @Test
+    void testGetNumBytesProducedForBroadcast() {
+        testGetNumBytesProduced(true, 96L);
+    }
+
+    @Test
+    void testGetAggregatedSubpartitionBytes() {
+        AllToAllBlockingResultInfo resultInfo =
+                new AllToAllBlockingResultInfo(new IntermediateDataSetID(), 2, 2, false);
+        resultInfo.recordPartitionInfo(0, new ResultPartitionBytes(new long[] {32L, 64L}));
+        resultInfo.recordPartitionInfo(1, new ResultPartitionBytes(new long[] {128L, 256L}));
+
+        assertThat(resultInfo.getAggregatedSubpartitionBytes()).containsExactly(160L, 320L);
+    }
+
+    @Test
+    void testGetBytesWithPartialPartitionInfos() {
+        AllToAllBlockingResultInfo resultInfo =
+                new AllToAllBlockingResultInfo(new IntermediateDataSetID(), 2, 2, false);
+        resultInfo.recordPartitionInfo(0, new ResultPartitionBytes(new long[] {32L, 64L}));
+
+        assertThatThrownBy(resultInfo::getNumBytesProduced)
+                .isInstanceOf(IllegalStateException.class);
+        assertThatThrownBy(resultInfo::getAggregatedSubpartitionBytes)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testRecordPartitionInfoMultiTimes() {
+        AllToAllBlockingResultInfo resultInfo =
+                new AllToAllBlockingResultInfo(new IntermediateDataSetID(), 2, 2, false);
+
+        ResultPartitionBytes partitionBytes1 = new ResultPartitionBytes(new long[] {32L, 64L});
+        ResultPartitionBytes partitionBytes2 = new ResultPartitionBytes(new long[] {64L, 128L});
+        ResultPartitionBytes partitionBytes3 = new ResultPartitionBytes(new long[] {128L, 256L});
+        ResultPartitionBytes partitionBytes4 = new ResultPartitionBytes(new long[] {256L, 512L});
+
+        // record partitionBytes1 for subtask 0 and then reset it
+        resultInfo.recordPartitionInfo(0, partitionBytes1);
+        assertThat(resultInfo.getNumOfRecordedPartitions()).isEqualTo(1);
+        resultInfo.resetPartitionInfo(0);
+        assertThat(resultInfo.getNumOfRecordedPartitions()).isEqualTo(0);
+
+        // record partitionBytes2 for subtask 0 and record partitionBytes3 for subtask 1
+        resultInfo.recordPartitionInfo(0, partitionBytes2);
+        resultInfo.recordPartitionInfo(1, partitionBytes3);
+
+        // The result info should be (partitionBytes2 + partitionBytes3)
+        assertThat(resultInfo.getNumBytesProduced()).isEqualTo(576L);
+        assertThat(resultInfo.getAggregatedSubpartitionBytes()).containsExactly(192L, 384L);
+        // The raw info should be clear
+        assertThat(resultInfo.getNumOfRecordedPartitions()).isEqualTo(0);
+
+        // reset subtask 0 and then record partitionBytes4 for subtask 0
+        resultInfo.resetPartitionInfo(0);
+        resultInfo.recordPartitionInfo(0, partitionBytes4);
+
+        // The result info should still be (partitionBytes2 + partitionBytes3)
+        assertThat(resultInfo.getNumBytesProduced()).isEqualTo(576L);
+        assertThat(resultInfo.getAggregatedSubpartitionBytes()).containsExactly(192L, 384L);
+        assertThat(resultInfo.getNumOfRecordedPartitions()).isEqualTo(0);
+    }
+
+    private void testGetNumBytesProduced(boolean isBroadcast, long expectedBytes) {
+        AllToAllBlockingResultInfo resultInfo =
+                new AllToAllBlockingResultInfo(new IntermediateDataSetID(), 2, 2, isBroadcast);
+        resultInfo.recordPartitionInfo(0, new ResultPartitionBytes(new long[] {32L, 32L}));
+        resultInfo.recordPartitionInfo(1, new ResultPartitionBytes(new long[] {64L, 64L}));
+
+        assertThat(resultInfo.getNumBytesProduced()).isEqualTo(expectedBytes);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismDeciderTest.java
@@ -22,17 +22,16 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.MemorySize;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link DefaultVertexParallelismDecider}. */
-public class DefaultVertexParallelismDeciderTest {
+class DefaultVertexParallelismDeciderTest {
 
     private static final long BYTE_256_MB = 256 * 1024 * 1024L;
     private static final long BYTE_512_MB = 512 * 1024 * 1024L;
@@ -47,8 +46,8 @@ public class DefaultVertexParallelismDeciderTest {
 
     private DefaultVertexParallelismDecider decider;
 
-    @Before
-    public void before() throws Exception {
+    @BeforeEach
+    void before() throws Exception {
         Configuration configuration = new Configuration();
 
         configuration.setInteger(
@@ -66,19 +65,19 @@ public class DefaultVertexParallelismDeciderTest {
     }
 
     @Test
-    public void testNormalizedMaxAndMinParallelism() {
-        assertThat(decider.getMaxParallelism(), is(64));
-        assertThat(decider.getMinParallelism(), is(4));
+    void testNormalizedMaxAndMinParallelism() {
+        assertThat(decider.getMaxParallelism()).isEqualTo(64);
+        assertThat(decider.getMinParallelism()).isEqualTo(4);
     }
 
     @Test
-    public void testSourceJobVertex() {
+    void testSourceJobVertex() {
         int parallelism = decider.decideParallelismForVertex(Collections.emptyList());
-        assertThat(parallelism, is(DEFAULT_SOURCE_PARALLELISM));
+        assertThat(parallelism).isEqualTo(DEFAULT_SOURCE_PARALLELISM);
     }
 
     @Test
-    public void testNormalizeParallelismDownToPowerOf2() {
+    void testNormalizeParallelismDownToPowerOf2() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
         BlockingResultInfo resultInfo2 =
@@ -88,11 +87,11 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(8));
+        assertThat(parallelism).isEqualTo(8);
     }
 
     @Test
-    public void testNormalizeParallelismUpToPowerOf2() {
+    void testNormalizeParallelismUpToPowerOf2() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
         BlockingResultInfo resultInfo2 =
@@ -102,11 +101,11 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(16));
+        assertThat(parallelism).isEqualTo(16);
     }
 
     @Test
-    public void testInitiallyNormalizedParallelismIsLargerThanMaxParallelism() {
+    void testInitiallyNormalizedParallelismIsLargerThanMaxParallelism() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
         BlockingResultInfo resultInfo2 =
@@ -116,11 +115,11 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(64));
+        assertThat(parallelism).isEqualTo(64);
     }
 
     @Test
-    public void testInitiallyNormalizedParallelismIsSmallerThanMinParallelism() {
+    void testInitiallyNormalizedParallelismIsSmallerThanMinParallelism() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_256_MB));
         BlockingResultInfo resultInfo2 =
@@ -129,11 +128,11 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(4));
+        assertThat(parallelism).isEqualTo(4);
     }
 
     @Test
-    public void testBroadcastRatioExceedsCapRatio() {
+    void testBroadcastRatioExceedsCapRatio() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_1_GB));
         BlockingResultInfo resultInfo2 =
@@ -142,11 +141,11 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(16));
+        assertThat(parallelism).isEqualTo(16);
     }
 
     @Test
-    public void testNonBroadcastBytesCanNotDividedEvenly() {
+    void testNonBroadcastBytesCanNotDividedEvenly() {
         BlockingResultInfo resultInfo1 =
                 BlockingResultInfo.createFromBroadcastResult(Arrays.asList(BYTE_512_MB));
         BlockingResultInfo resultInfo2 =
@@ -156,6 +155,6 @@ public class DefaultVertexParallelismDeciderTest {
         int parallelism =
                 decider.decideParallelismForVertex(Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism, is(16));
+        assertThat(parallelism).isEqualTo(16);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/PointwiseBlockingResultInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/PointwiseBlockingResultInfoTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptivebatch;
+
+import org.apache.flink.runtime.executiongraph.ResultPartitionBytes;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link PointwiseBlockingResultInfo}. */
+class PointwiseBlockingResultInfoTest {
+
+    @Test
+    void testGetNumBytesProduced() {
+        PointwiseBlockingResultInfo resultInfo =
+                new PointwiseBlockingResultInfo(new IntermediateDataSetID(), 2, 2);
+        resultInfo.recordPartitionInfo(0, new ResultPartitionBytes(new long[] {32L, 32L}));
+        resultInfo.recordPartitionInfo(1, new ResultPartitionBytes(new long[] {64L, 64L}));
+
+        assertThat(resultInfo.getNumBytesProduced()).isEqualTo(192L);
+    }
+
+    @Test
+    void testGetBytesWithPartialPartitionInfos() {
+        PointwiseBlockingResultInfo resultInfo =
+                new PointwiseBlockingResultInfo(new IntermediateDataSetID(), 2, 2);
+        resultInfo.recordPartitionInfo(0, new ResultPartitionBytes(new long[] {32L, 64L}));
+        assertThatThrownBy(resultInfo::getNumBytesProduced)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testPartitionFinishedMultiTimes() {
+        PointwiseBlockingResultInfo resultInfo =
+                new PointwiseBlockingResultInfo(new IntermediateDataSetID(), 2, 2);
+
+        resultInfo.recordPartitionInfo(0, new ResultPartitionBytes(new long[] {32L, 64L}));
+        resultInfo.recordPartitionInfo(1, new ResultPartitionBytes(new long[] {64L, 128L}));
+        assertThat(resultInfo.getNumOfRecordedPartitions()).isEqualTo(2);
+        assertThat(resultInfo.getNumBytesProduced()).isEqualTo(288L);
+
+        // reset partition info
+        resultInfo.resetPartitionInfo(0);
+        assertThat(resultInfo.getNumOfRecordedPartitions()).isEqualTo(1);
+
+        // record partition info again
+        resultInfo.recordPartitionInfo(0, new ResultPartitionBytes(new long[] {64L, 128L}));
+        assertThat(resultInfo.getNumBytesProduced()).isEqualTo(384L);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Collect subpartition sizes of blocking result partitions

## Verifying this change
Some unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
