### PR TITLE
[BP-1.16][FLINK-29567][connector/common] Change numRecordsSend / numBytesSend / numRecordsSendError back to numRecordsOut / numBytesOut / numRecordsOutError in sink

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkWriter.java
@@ -96,11 +96,7 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                     RESOURCE_NOT_FOUND_EXCEPTION_CLASSIFIER,
                     getSdkClientMisconfiguredExceptionClassifier());
 
-    // deprecated, use numRecordsSendErrorsCounter instead.
-    @Deprecated private final Counter numRecordsOutErrorsCounter;
-
-    /* A counter for the total number of records that have encountered an error during put */
-    private final Counter numRecordsSendErrorsCounter;
+    private final Counter numRecordsOutErrorsCounter;
 
     /* Name of the delivery stream in Kinesis Data Firehose */
     private final String deliveryStreamName;
@@ -173,7 +169,6 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
         this.deliveryStreamName = deliveryStreamName;
         this.metrics = context.metricGroup();
         this.numRecordsOutErrorsCounter = metrics.getNumRecordsOutErrorsCounter();
-        this.numRecordsSendErrorsCounter = metrics.getNumRecordsSendErrorsCounter();
         this.httpClient = createHttpClient(firehoseClientProperties);
         this.firehoseClient = createFirehoseClient(firehoseClientProperties, httpClient);
     }
@@ -221,7 +216,6 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                 requestEntries.get(0).toString(),
                 err);
         numRecordsOutErrorsCounter.inc(requestEntries.size());
-        numRecordsSendErrorsCounter.inc(requestEntries.size());
 
         if (isRetryable(err)) {
             requestResult.accept(requestEntries);
@@ -237,7 +231,6 @@ class KinesisFirehoseSinkWriter<InputT> extends AsyncSinkWriter<InputT, Record> 
                 requestEntries.size(),
                 requestEntries.get(0).toString());
         numRecordsOutErrorsCounter.inc(response.failedPutCount());
-        numRecordsSendErrorsCounter.inc(response.failedPutCount());
 
         if (failOnError) {
             getFatalExceptionCons()

--- a/flink-connectors/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkWriter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/src/main/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkWriter.java
@@ -77,11 +77,7 @@ class KinesisStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRecord
                     RESOURCE_NOT_FOUND_EXCEPTION_CLASSIFIER,
                     getSdkClientMisconfiguredExceptionClassifier());
 
-    // deprecated, use numRecordsSendErrorsCounter instead.
-    @Deprecated private final Counter numRecordsOutErrorsCounter;
-
-    /* A counter for the total number of records that have encountered an error during put */
-    private final Counter numRecordsSendErrorsCounter;
+    private final Counter numRecordsOutErrorsCounter;
 
     /* Name of the stream in Kinesis Data Streams */
     private final String streamName;
@@ -154,7 +150,6 @@ class KinesisStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRecord
         this.streamName = streamName;
         this.metrics = context.metricGroup();
         this.numRecordsOutErrorsCounter = metrics.getNumRecordsOutErrorsCounter();
-        this.numRecordsSendErrorsCounter = metrics.getNumRecordsSendErrorsCounter();
         this.httpClient = AWSGeneralUtil.createAsyncHttpClient(kinesisClientProperties);
         this.kinesisClient = buildClient(kinesisClientProperties, this.httpClient);
     }
@@ -207,7 +202,6 @@ class KinesisStreamsSinkWriter<InputT> extends AsyncSinkWriter<InputT, PutRecord
                 requestEntries.size(),
                 err);
         numRecordsOutErrorsCounter.inc(requestEntries.size());
-        numRecordsSendErrorsCounter.inc(requestEntries.size());
 
         if (isRetryable(err)) {
             requestResult.accept(requestEntries);

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
@@ -71,10 +71,10 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
     private final SinkWriterMetricGroup metrics;
 
     /* Counter for number of bytes this sink has attempted to send to the destination. */
-    private final Counter numBytesSendCounter;
+    private final Counter numBytesOutCounter;
 
     /* Counter for number of records this sink has attempted to send to the destination. */
-    private final Counter numRecordsSendCounter;
+    private final Counter numRecordsOutCounter;
 
     private final RateLimitingStrategy rateLimitingStrategy;
 
@@ -292,8 +292,8 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
 
         this.metrics = context.metricGroup();
         this.metrics.setCurrentSendTimeGauge(() -> this.ackTime - this.lastSendTimestamp);
-        this.numBytesSendCounter = this.metrics.getNumBytesSendCounter();
-        this.numRecordsSendCounter = this.metrics.getNumRecordsSendCounter();
+        this.numBytesOutCounter = this.metrics.getIOMetricGroup().getNumBytesOutCounter();
+        this.numRecordsOutCounter = this.metrics.getIOMetricGroup().getNumRecordsOutCounter();
 
         this.fatalExceptionCons =
                 exception ->
@@ -410,8 +410,8 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
             batchSizeBytes += requestEntrySize;
         }
 
-        numRecordsSendCounter.inc(batch.size());
-        numBytesSendCounter.inc(batchSizeBytes);
+        numRecordsOutCounter.inc(batch.size());
+        numBytesOutCounter.inc(batchSizeBytes);
 
         return batch;
     }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestSinkInitContext.java
@@ -146,10 +146,10 @@ public class TestSinkInitContext implements Sink.InitContext {
     }
 
     public Counter getNumRecordsOutCounter() {
-        return metricGroup.getNumRecordsSendCounter();
+        return metricGroup.getIOMetricGroup().getNumRecordsOutCounter();
     }
 
     public Counter getNumBytesOutCounter() {
-        return metricGroup.getNumBytesSendCounter();
+        return metricGroup.getIOMetricGroup().getNumBytesOutCounter();
     }
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/sink/writer/FileWriter.java
@@ -92,7 +92,7 @@ public class FileWriter<IN>
 
     private final OutputFileConfig outputFileConfig;
 
-    private final Counter numRecordsSendCounter;
+    private final Counter numRecordsOutCounter;
 
     private boolean endOfInput;
 
@@ -128,7 +128,8 @@ public class FileWriter<IN>
         this.activeBuckets = new HashMap<>();
         this.bucketerContext = new BucketerContext();
 
-        this.numRecordsSendCounter = checkNotNull(metricGroup).getNumRecordsSendCounter();
+        this.numRecordsOutCounter =
+                checkNotNull(metricGroup).getIOMetricGroup().getNumRecordsOutCounter();
         this.processingTimeService = checkNotNull(processingTimeService);
         checkArgument(
                 bucketCheckInterval > 0,
@@ -195,7 +196,7 @@ public class FileWriter<IN>
         final String bucketId = bucketAssigner.getBucketId(element, bucketerContext);
         final FileWriterBucket<IN> bucket = getOrCreateBucketForBucketId(bucketId);
         bucket.write(element, processingTimeService.getCurrentProcessingTime());
-        numRecordsSendCounter.inc();
+        numRecordsOutCounter.inc();
     }
 
     @Override

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/sink/writer/FileWriterTest.java
@@ -295,7 +295,7 @@ class FileWriterTest {
                 InternalSinkWriterMetricGroup.mock(
                         metricListener.getMetricGroup(), operatorIOMetricGroup);
 
-        Counter recordsCounter = sinkWriterMetricGroup.getNumRecordsSendCounter();
+        Counter recordsCounter = sinkWriterMetricGroup.getIOMetricGroup().getNumRecordsOutCounter();
         SinkWriter.Context context = new ContextImpl();
         FileWriter<String> fileWriter =
                 createWriter(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -139,21 +139,21 @@ public class KafkaWriterITCase {
         try (final KafkaWriter<Integer> writer =
                 createWriterWithConfiguration(
                         getKafkaClientConfiguration(), DeliveryGuarantee.NONE, metricGroup)) {
-            final Counter numBytesSend = metricGroup.getNumBytesSendCounter();
-            final Counter numRecordsSend = metricGroup.getNumRecordsSendCounter();
-            final Counter numRecordsWrittenErrors = metricGroup.getNumRecordsOutErrorsCounter();
+            final Counter numBytesOut = metricGroup.getIOMetricGroup().getNumBytesOutCounter();
+            final Counter numRecordsOut = metricGroup.getIOMetricGroup().getNumRecordsOutCounter();
+            final Counter numRecordsOutErrors = metricGroup.getNumRecordsOutErrorsCounter();
             final Counter numRecordsSendErrors = metricGroup.getNumRecordsSendErrorsCounter();
-            assertThat(numBytesSend.getCount()).isEqualTo(0L);
-            assertThat(numRecordsSend.getCount()).isEqualTo(0);
-            assertThat(numRecordsWrittenErrors.getCount()).isEqualTo(0);
+            assertThat(numBytesOut.getCount()).isEqualTo(0L);
+            assertThat(numRecordsOut.getCount()).isEqualTo(0);
+            assertThat(numRecordsOutErrors.getCount()).isEqualTo(0);
             assertThat(numRecordsSendErrors.getCount()).isEqualTo(0);
 
             writer.write(1, SINK_WRITER_CONTEXT);
             timeService.trigger();
-            assertThat(numRecordsSend.getCount()).isEqualTo(1);
-            assertThat(numRecordsWrittenErrors.getCount()).isEqualTo(0);
+            assertThat(numRecordsOut.getCount()).isEqualTo(1);
+            assertThat(numRecordsOutErrors.getCount()).isEqualTo(0);
             assertThat(numRecordsSendErrors.getCount()).isEqualTo(0);
-            assertThat(numBytesSend.getCount()).isGreaterThan(0L);
+            assertThat(numBytesOut.getCount()).isGreaterThan(0L);
         }
     }
 
@@ -197,13 +197,10 @@ public class KafkaWriterITCase {
                 createWriterWithConfiguration(
                         properties, DeliveryGuarantee.EXACTLY_ONCE, metricGroup)) {
             final Counter numRecordsOutErrors = metricGroup.getNumRecordsOutErrorsCounter();
-            final Counter numRecordsSendErrors = metricGroup.getNumRecordsSendErrorsCounter();
             assertThat(numRecordsOutErrors.getCount()).isEqualTo(0L);
-            assertThat(numRecordsSendErrors.getCount()).isEqualTo(0L);
 
             writer.write(1, SINK_WRITER_CONTEXT);
             assertThat(numRecordsOutErrors.getCount()).isEqualTo(0L);
-            assertThat(numRecordsSendErrors.getCount()).isEqualTo(0L);
 
             final String transactionalId = writer.getCurrentProducer().getTransactionalId();
 
@@ -220,7 +217,6 @@ public class KafkaWriterITCase {
             writer.flush(false);
             writer.prepareCommit();
             assertThat(numRecordsOutErrors.getCount()).isEqualTo(1L);
-            assertThat(numRecordsSendErrors.getCount()).isEqualTo(1L);
         }
     }
 

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SinkWriterMetricGroup.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/groups/SinkWriterMetricGroup.java
@@ -29,11 +29,14 @@ import org.apache.flink.metrics.Gauge;
 @PublicEvolving
 public interface SinkWriterMetricGroup extends OperatorMetricGroup {
 
-    /** @deprecated use {@link #getNumRecordsSendErrorsCounter()} instead. */
-    @Deprecated
+    /** The total number of records failed to send. */
     Counter getNumRecordsOutErrorsCounter();
 
-    /** The total number of records failed to send. */
+    /**
+     * The total number of records failed to send.
+     *
+     * <p>This metric has the same value as {@code numRecordsOutError}.
+     */
     Counter getNumRecordsSendErrorsCounter();
 
     /**
@@ -44,10 +47,16 @@ public interface SinkWriterMetricGroup extends OperatorMetricGroup {
      * may have issue to perform the persistence action within its scope. Therefore, this count may
      * include the number of records that are failed to write by the downstream system, which should
      * be counted by {@link #getNumRecordsSendErrorsCounter()}.
+     *
+     * <p>This metric has the same value as {@code numRecordsOut} of the operator.
      */
     Counter getNumRecordsSendCounter();
 
-    /** The total number of output send bytes since the task started. */
+    /**
+     * The total number of output send bytes since the task started.
+     *
+     * <p>This metric has the same value as {@code numBytesOut} of the operator
+     */
     Counter getNumBytesSendCounter();
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -87,8 +87,7 @@ public class MetricNames {
     public static final String DEBLOATED_BUFFER_SIZE = "debloatedBufferSize";
 
     // FLIP-33 sink
-    // deprecated use NUM_RECORDS_SEND_ERRORS instead.
-    @Deprecated public static final String NUM_RECORDS_OUT_ERRORS = "numRecordsOutErrors";
+    public static final String NUM_RECORDS_OUT_ERRORS = "numRecordsOutErrors";
     public static final String NUM_RECORDS_SEND_ERRORS = "numRecordsSendErrors";
     public static final String CURRENT_SEND_TIME = "currentSendTime";
     public static final String NUM_RECORDS_SEND = "numRecordsSend";

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorIOMetricGroup.java
@@ -52,8 +52,10 @@ public class InternalOperatorIOMetricGroup extends ProxyMetricGroup<InternalOper
         numRecordsOutRate =
                 parentMetricGroup.meter(
                         MetricNames.IO_NUM_RECORDS_OUT_RATE, new MeterView(numRecordsOut));
-        numBytesIn = parentMetricGroup.getTaskIOMetricGroup().getNumBytesInCounter();
-        numBytesOut = parentMetricGroup.getTaskIOMetricGroup().getNumBytesOutCounter();
+        numBytesIn = parentMetricGroup.counter(MetricNames.IO_NUM_BYTES_IN);
+        numBytesOut = parentMetricGroup.counter(MetricNames.IO_NUM_BYTES_OUT);
+        parentMetricGroup.meter(MetricNames.IO_NUM_BYTES_IN_RATE, new MeterView(numBytesIn));
+        parentMetricGroup.meter(MetricNames.IO_NUM_BYTES_OUT_RATE, new MeterView(numBytesOut));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSinkWriterMetricGroup.java
@@ -34,8 +34,7 @@ import org.apache.flink.runtime.metrics.MetricNames;
 public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
         implements SinkWriterMetricGroup {
 
-    // deprecated, use numRecordsSendErrors instead.
-    @Deprecated private final Counter numRecordsOutErrors;
+    private final Counter numRecordsOutErrors;
     private final Counter numRecordsSendErrors;
     private final Counter numRecordsWritten;
     private final Counter numBytesWritten;
@@ -45,9 +44,15 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
             MetricGroup parentMetricGroup, OperatorIOMetricGroup operatorIOMetricGroup) {
         super(parentMetricGroup);
         numRecordsOutErrors = parentMetricGroup.counter(MetricNames.NUM_RECORDS_OUT_ERRORS);
-        numRecordsSendErrors = parentMetricGroup.counter(MetricNames.NUM_RECORDS_SEND_ERRORS);
-        numRecordsWritten = parentMetricGroup.counter(MetricNames.NUM_RECORDS_SEND);
-        numBytesWritten = parentMetricGroup.counter(MetricNames.NUM_BYTES_SEND);
+        numRecordsSendErrors =
+                parentMetricGroup.counter(MetricNames.NUM_RECORDS_SEND_ERRORS, numRecordsOutErrors);
+        numRecordsWritten =
+                parentMetricGroup.counter(
+                        MetricNames.NUM_RECORDS_SEND,
+                        operatorIOMetricGroup.getNumRecordsOutCounter());
+        numBytesWritten =
+                parentMetricGroup.counter(
+                        MetricNames.NUM_BYTES_SEND, operatorIOMetricGroup.getNumBytesOutCounter());
         this.operatorIOMetricGroup = operatorIOMetricGroup;
     }
 
@@ -73,7 +78,6 @@ public class InternalSinkWriterMetricGroup extends ProxyMetricGroup<MetricGroup>
         return operatorIOMetricGroup;
     }
 
-    @Deprecated
     @Override
     public Counter getNumRecordsOutErrorsCounter() {
         return numRecordsOutErrors;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractStreamOperator.java
@@ -164,10 +164,7 @@ public abstract class AbstractStreamOperator<OUT>
                     environment
                             .getMetricGroup()
                             .getOrAddOperator(config.getOperatorID(), config.getOperatorName());
-            this.output =
-                    new CountingOutput<>(
-                            output,
-                            operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
+            this.output = registerCounterOnOutput(output, operatorMetricGroup);
             if (config.isChainEnd()) {
                 operatorMetricGroup.getIOMetricGroup().reuseOutputMetricsForTask();
             }
@@ -648,5 +645,11 @@ public abstract class AbstractStreamOperator<OUT>
 
     protected Optional<InternalTimeServiceManager<?>> getTimeServiceManager() {
         return Optional.ofNullable(timeServiceManager);
+    }
+
+    protected Output<StreamRecord<OUT>> registerCounterOnOutput(
+            Output<StreamRecord<OUT>> output, OperatorMetricGroup operatorMetricGroup) {
+        return new CountingOutput<>(
+                output, operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter());
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
@@ -30,6 +30,7 @@ import org.apache.flink.api.connector.sink2.StatefulSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -41,6 +42,7 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -214,6 +216,22 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
     @Override
     public void close() throws Exception {
         closeAll(sinkWriter, super::close);
+    }
+
+    /**
+     * Skip registering numRecordsOut counter on output.
+     *
+     * <p>Metric "numRecordsOut" is defined as the total number of records written to the external
+     * system in FLIP-33, but this metric is occupied in AbstractStreamOperator as the number of
+     * records sent to downstream operators, which is number of Committable batches sent to
+     * SinkCommitter. So we skip registering this metric on output and leave this metric to sink
+     * writer implementations to report.
+     */
+    @Override
+    protected Output<StreamRecord<CommittableMessage<CommT>>> registerCounterOnOutput(
+            Output<StreamRecord<CommittableMessage<CommT>>> output,
+            OperatorMetricGroup operatorMetricGroup) {
+        return output;
     }
 
     private void emit(

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/SinkMetricsITCase.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.sink.Sink;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.execution.JobClient;
-import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
@@ -133,22 +132,28 @@ public class SinkMetricsITCase extends TestLogger {
         for (OperatorMetricGroup group : groups) {
             Map<String, Metric> metrics = reporter.getMetricsByGroup(group);
             // There are only 2 splits assigned; so two groups will not update metrics.
-            // There is no other way to access the counter via OperatorMetricGroup, we have to use
-            // metrics from the reporter.
-            if (((Counter) metrics.get(MetricNames.NUM_RECORDS_SEND)).getCount() == 0) {
+            if (group.getIOMetricGroup().getNumRecordsOutCounter().getCount() == 0) {
                 continue;
             }
             subtaskWithMetrics++;
+
             // SinkWriterMetricGroup metrics
-            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_SEND))
+            assertThatCounter(metrics.get(MetricNames.IO_NUM_RECORDS_OUT))
                     .isEqualTo(processedRecordsPerSubtask);
-            assertThatCounter(metrics.get(MetricNames.NUM_BYTES_SEND))
+            assertThatCounter(metrics.get(MetricNames.IO_NUM_BYTES_OUT))
                     .isEqualTo(processedRecordsPerSubtask * MetricWriter.RECORD_SIZE_IN_BYTES);
             // MetricWriter is just incrementing errors every even record
             assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_OUT_ERRORS))
                     .isEqualTo((processedRecordsPerSubtask + 1) / 2);
+
+            // Test "send" metric series has the same value as "out" metric series.
+            assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_SEND))
+                    .isEqualTo(processedRecordsPerSubtask);
+            assertThatCounter(metrics.get(MetricNames.NUM_BYTES_SEND))
+                    .isEqualTo(processedRecordsPerSubtask * MetricWriter.RECORD_SIZE_IN_BYTES);
             assertThatCounter(metrics.get(MetricNames.NUM_RECORDS_SEND_ERRORS))
                     .isEqualTo((processedRecordsPerSubtask + 1) / 2);
+
             // check if the latest send time is fetched
             assertThatGauge(metrics.get(MetricNames.CURRENT_SEND_TIME))
                     .isEqualTo((processedRecordsPerSubtask - 1) * MetricWriter.BASE_SEND_TIME);
@@ -172,12 +177,11 @@ public class SinkMetricsITCase extends TestLogger {
         public void write(Long element, Context context) {
             super.write(element, context);
             sendTime = element * BASE_SEND_TIME;
-            metricGroup.getNumRecordsSendCounter().inc();
+            metricGroup.getIOMetricGroup().getNumRecordsOutCounter().inc();
             if (element % 2 == 0) {
                 metricGroup.getNumRecordsOutErrorsCounter().inc();
-                metricGroup.getNumRecordsSendErrorsCounter().inc();
             }
-            metricGroup.getNumBytesSendCounter().inc(RECORD_SIZE_IN_BYTES);
+            metricGroup.getIOMetricGroup().getNumBytesOutCounter().inc(RECORD_SIZE_IN_BYTES);
         }
     }
 }


### PR DESCRIPTION
Unchanged backport of #21065 on release-1.16