### PR TITLE
[FLINK-28889] Hybrid shuffle supports multiple consumer and broadcast optimization

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptor.java
@@ -63,6 +63,11 @@ public class ResultPartitionDeploymentDescriptor implements Serializable {
         return partitionDescriptor.getPartitionId();
     }
 
+    /** Whether the resultPartition is a broadcast edge. */
+    public boolean isBroadcast() {
+        return partitionDescriptor.isBroadcast();
+    }
+
     public ResultPartitionType getPartitionType() {
         return partitionDescriptor.getPartitionType();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -218,9 +218,13 @@ public class ResultPartitionFactory {
             }
         } else if (type == ResultPartitionType.HYBRID_FULL
                 || type == ResultPartitionType.HYBRID_SELECTIVE) {
-            if (isBroadcast) {
+            if (type == ResultPartitionType.HYBRID_SELECTIVE && isBroadcast) {
                 // for broadcast result partition, it can be optimized to always use full spilling
                 // strategy to significantly reduce shuffle data writing cost.
+                LOG.info(
+                        "{} result partition has been replaced by {} result partition to reduce shuffle data writing cost.",
+                        type,
+                        ResultPartitionType.HYBRID_FULL);
                 type = ResultPartitionType.HYBRID_FULL;
             }
             partition =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerId.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/** This class represents the identifier of hybrid shuffle's consumer. */
+public class HsConsumerId {
+    /**
+     * This consumer id is used in the scenarios that information related to specific consumer needs
+     * to be ignored.
+     */
+    public static final HsConsumerId ANY = new HsConsumerId(-1);
+
+    /**
+     * This consumer id is used in the scenarios that only one consumer is allowed for a single
+     * subpartition.
+     */
+    public static final HsConsumerId DEFAULT = new HsConsumerId(0);
+
+    /** This is a unique field for each consumer of a single subpartition. */
+    private final int id;
+
+    private HsConsumerId(int id) {
+        this.id = id;
+    }
+
+    public static HsConsumerId newId(@Nullable HsConsumerId lastId) {
+        return lastId == null ? DEFAULT : new HsConsumerId(lastId.id + 1);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HsConsumerId that = (HsConsumerId) o;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerId.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerId.java
@@ -30,10 +30,7 @@ public class HsConsumerId {
      */
     public static final HsConsumerId ANY = new HsConsumerId(-1);
 
-    /**
-     * This consumer id is used in the scenarios that only one consumer is allowed for a single
-     * subpartition.
-     */
+    /** This consumer id is used for the first consumer of a single subpartition. */
     public static final HsConsumerId DEFAULT = new HsConsumerId(0);
 
     /** This is a unique field for each consumer of a single subpartition. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsDataView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsDataView.java
@@ -24,8 +24,8 @@ import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAn
 import java.util.Optional;
 
 /**
- * A view for {@link HsSubpartitionView} to find out what data exists in memory or disk and polling
- * the data.
+ * A view for {@link HsSubpartitionConsumer} to find out what data exists in memory or disk and
+ * polling the data.
  */
 public interface HsDataView {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
@@ -153,7 +153,8 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
 
     /** This method only called by result partition to create subpartitionFileReader. */
     public HsDataView registerNewSubpartition(
-            int subpartitionId, HsSubpartitionViewInternalOperations operation) throws IOException {
+            int subpartitionId, HsSubpartitionConsumerInternalOperations operation)
+            throws IOException {
         synchronized (lock) {
             checkState(!isReleased, "HsFileDataManager is already released.");
             lazyInitialize();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
@@ -152,8 +152,10 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
     }
 
     /** This method only called by result partition to create subpartitionFileReader. */
-    public HsDataView registerNewSubpartition(
-            int subpartitionId, HsSubpartitionConsumerInternalOperations operation)
+    public HsDataView registerNewConsumer(
+            int subpartitionId,
+            HsConsumerId consumerId,
+            HsSubpartitionConsumerInternalOperations operation)
             throws IOException {
         synchronized (lock) {
             checkState(!isReleased, "HsFileDataManager is already released.");
@@ -162,6 +164,7 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
             HsSubpartitionFileReader subpartitionReader =
                     fileReaderFactory.createFileReader(
                             subpartitionId,
+                            consumerId,
                             dataFileChannel,
                             operation,
                             dataIndex,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategy.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid;
 
-import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatus;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatusWithId;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.SpillStatus;
 
 import java.util.ArrayDeque;
@@ -88,12 +88,14 @@ public class HsFullSpillingStrategy implements HsSpillingStrategy {
                             subpartitionId,
                             // get all not start spilling buffers.
                             spillingInfoProvider.getBuffersInOrder(
-                                    subpartitionId, SpillStatus.NOT_SPILL, ConsumeStatus.ALL))
+                                    subpartitionId,
+                                    SpillStatus.NOT_SPILL,
+                                    ConsumeStatusWithId.ALL_ANY))
                     .addBufferToRelease(
                             subpartitionId,
                             // get all not released buffers.
                             spillingInfoProvider.getBuffersInOrder(
-                                    subpartitionId, SpillStatus.ALL, ConsumeStatus.ALL));
+                                    subpartitionId, SpillStatus.ALL, ConsumeStatusWithId.ALL_ANY));
         }
         return builder.build();
     }
@@ -110,7 +112,7 @@ public class HsFullSpillingStrategy implements HsSpillingStrategy {
             builder.addBufferToSpill(
                     i,
                     spillingInfoProvider.getBuffersInOrder(
-                            i, SpillStatus.NOT_SPILL, ConsumeStatus.ALL));
+                            i, SpillStatus.NOT_SPILL, ConsumeStatusWithId.ALL_ANY));
         }
     }
 
@@ -135,7 +137,7 @@ public class HsFullSpillingStrategy implements HsSpillingStrategy {
         for (int subpartitionId = 0; subpartitionId < numSubpartitions; subpartitionId++) {
             Deque<BufferIndexAndChannel> buffersInOrder =
                     spillingInfoProvider.getBuffersInOrder(
-                            subpartitionId, SpillStatus.SPILL, ConsumeStatus.ALL);
+                            subpartitionId, SpillStatus.SPILL, ConsumeStatusWithId.ALL_ANY);
             // if the number of subpartition buffers less than survived buffers, reserved all of
             // them.
             int releaseNum = Math.max(0, buffersInOrder.size() - subpartitionSurvivedNum);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -223,10 +223,11 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
     // Write lock should be acquired before invoke this method.
     @Override
     public Deque<BufferIndexAndChannel> getBuffersInOrder(
-            int subpartitionId, SpillStatus spillStatus, ConsumeStatus consumeStatus) {
+            int subpartitionId, SpillStatus spillStatus, ConsumeStatusWithId consumeStatusWithId) {
         HsSubpartitionMemoryDataManager targetSubpartitionDataManager =
                 getSubpartitionMemoryDataManager(subpartitionId);
-        return targetSubpartitionDataManager.getBuffersSatisfyStatus(spillStatus, consumeStatus);
+        return targetSubpartitionDataManager.getBuffersSatisfyStatus(
+                spillStatus, consumeStatusWithId);
     }
 
     // Write lock should be acquired before invoke this method.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManager.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferPool;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingStrategy.Decision;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 import org.apache.flink.util.concurrent.FutureUtils;
 import org.apache.flink.util.function.SupplierWithException;
@@ -35,6 +36,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
@@ -72,8 +74,12 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
 
     private final AtomicInteger numUnSpillBuffers = new AtomicInteger(0);
 
-    private final Map<Integer, HsSubpartitionViewInternalOperations> subpartitionViewOperationsMap =
-            new ConcurrentHashMap<>();
+    /**
+     * Each element of the list is all views of the subpartition corresponding to its index, which
+     * are stored in the form of a map that maps consumer id to its subpartition view.
+     */
+    private final List<Map<HsConsumerId, HsSubpartitionConsumerInternalOperations>>
+            subpartitionViewOperationsMap;
 
     /**
      * Currently, it is only used to regularly check the actual size of local buffer pool (the size
@@ -106,6 +112,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
         ReadWriteLock readWriteLock = new ReentrantReadWriteLock(true);
         this.lock = readWriteLock.writeLock();
 
+        this.subpartitionViewOperationsMap = new ArrayList<>(numSubpartitions);
         for (int subpartitionId = 0; subpartitionId < numSubpartitions; ++subpartitionId) {
             subpartitionMemoryDataManagers[subpartitionId] =
                     new HsSubpartitionMemoryDataManager(
@@ -114,6 +121,7 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
                             readWriteLock.readLock(),
                             bufferCompressor,
                             this);
+            subpartitionViewOperationsMap.add(new ConcurrentHashMap<>());
         }
 
         poolSize = new AtomicInteger(this.bufferPool.getNumBuffers());
@@ -156,20 +164,19 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
     }
 
     /**
-     * Register {@link HsSubpartitionViewInternalOperations} to {@link
+     * Register {@link HsSubpartitionConsumerInternalOperations} to {@link
      * #subpartitionViewOperationsMap}. It is used to obtain the consumption progress of the
      * subpartition.
      */
-    public HsDataView registerSubpartitionView(
-            int subpartitionId, HsSubpartitionViewInternalOperations viewOperations) {
-        HsSubpartitionViewInternalOperations oldView =
-                subpartitionViewOperationsMap.put(subpartitionId, viewOperations);
-        if (oldView != null) {
-            LOG.debug(
-                    "subpartition : {} register subpartition view will replace old view. ",
-                    subpartitionId);
-        }
-        return getSubpartitionMemoryDataManager(subpartitionId);
+    public HsDataView registerNewConsumer(
+            int subpartitionId,
+            HsConsumerId consumerId,
+            HsSubpartitionConsumerInternalOperations viewOperations) {
+        HsSubpartitionConsumerInternalOperations oldView =
+                subpartitionViewOperationsMap.get(subpartitionId).put(consumerId, viewOperations);
+        Preconditions.checkState(
+                oldView == null, "Each subpartition view should have unique consumerId.");
+        return getSubpartitionMemoryDataManager(subpartitionId).registerNewConsumer(consumerId);
     }
 
     /** Close this {@link HsMemoryDataManager}, it means no data can append to memory. */
@@ -232,11 +239,11 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
 
     // Write lock should be acquired before invoke this method.
     @Override
-    public List<Integer> getNextBufferIndexToConsume() {
+    public List<Integer> getNextBufferIndexToConsume(HsConsumerId consumerId) {
         ArrayList<Integer> consumeIndexes = new ArrayList<>(numSubpartitions);
         for (int channel = 0; channel < numSubpartitions; channel++) {
-            HsSubpartitionViewInternalOperations viewOperation =
-                    subpartitionViewOperationsMap.get(channel);
+            HsSubpartitionConsumerInternalOperations viewOperation =
+                    subpartitionViewOperationsMap.get(channel).get(consumerId);
             // Access consuming offset without lock to prevent deadlock.
             // A consuming thread may being blocked on the memory data manager lock, while holding
             // the viewOperation lock.
@@ -280,12 +287,23 @@ public class HsMemoryDataManager implements HsSpillingInfoProvider, HsMemoryData
     }
 
     @Override
-    public void onDataAvailable(int subpartitionId) {
-        HsSubpartitionViewInternalOperations subpartitionViewInternalOperations =
+    public void onDataAvailable(int subpartitionId, Collection<HsConsumerId> consumerIds) {
+        Map<HsConsumerId, HsSubpartitionConsumerInternalOperations> consumerViewMap =
                 subpartitionViewOperationsMap.get(subpartitionId);
-        if (subpartitionViewInternalOperations != null) {
-            subpartitionViewInternalOperations.notifyDataAvailable();
-        }
+        consumerIds.forEach(
+                consumerId -> {
+                    HsSubpartitionConsumerInternalOperations consumerView =
+                            consumerViewMap.get(consumerId);
+                    if (consumerView != null) {
+                        consumerView.notifyDataAvailable();
+                    }
+                });
+    }
+
+    @Override
+    public void onConsumerReleased(int subpartitionId, HsConsumerId consumerId) {
+        subpartitionViewOperationsMap.get(subpartitionId).remove(consumerId);
+        getSubpartitionMemoryDataManager(subpartitionId).releaseConsumer(consumerId);
     }
 
     // ------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerOperation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerOperation.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.io.network.partition.hybrid;
 
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 
+import java.util.Collection;
+
 /**
  * This interface is used by {@link HsSubpartitionMemoryDataManager} to operate {@link
  * HsMemoryDataManager}. Spilling decision may be made and handled inside these operations.
@@ -53,7 +55,16 @@ public interface HsMemoryDataManagerOperation {
     /**
      * This method is called when subpartition data become available.
      *
-     * @param subpartitionId the subpartition need notify data available.
+     * @param subpartitionId the subpartition's identifier that this consumer belongs to.
+     * @param consumerIds the consumer's identifier which need notify data available.
      */
-    void onDataAvailable(int subpartitionId);
+    void onDataAvailable(int subpartitionId, Collection<HsConsumerId> consumerIds);
+
+    /**
+     * This method is called when consumer is decided to released.
+     *
+     * @param subpartitionId the subpartition's identifier that this consumer belongs to.
+     * @param consumerId the consumer's identifier which decided to be released.
+     */
+    void onConsumerReleased(int subpartitionId, HsConsumerId consumerId);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -188,7 +188,9 @@ public class HsResultPartition extends ResultPartition {
 
         HsSubpartitionConsumer subpartitionView = new HsSubpartitionConsumer(availabilityListener);
         HsDataView diskDataView =
-                fileDataManager.registerNewSubpartition(subpartitionId, subpartitionView);
+                // TODO pass real consumerId in the next commit.
+                fileDataManager.registerNewConsumer(
+                        subpartitionId, HsConsumerId.DEFAULT, subpartitionView);
 
         HsDataView memoryDataView =
                 checkNotNull(memoryDataManager)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -207,11 +207,12 @@ public class HsResultPartition extends ResultPartition {
 
         HsSubpartitionConsumer subpartitionConsumer =
                 new HsSubpartitionConsumer(availabilityListener);
+        HsConsumerId lastConsumerId = lastConsumerIds[subpartitionId];
+        checkMultipleConsumerIsAllowed(lastConsumerId, hybridShuffleConfiguration);
         // assign a unique id for each consumer, now it is guaranteed by the value that is one
         // higher than the last consumerId's id field.
-        HsConsumerId consumerId = HsConsumerId.newId(lastConsumerIds[subpartitionId]);
+        HsConsumerId consumerId = HsConsumerId.newId(lastConsumerId);
         lastConsumerIds[subpartitionId] = consumerId;
-        checkMultipleConsumerIsAllowed(consumerId, hybridShuffleConfiguration);
         HsDataView diskDataView =
                 fileDataManager.registerNewConsumer(
                         subpartitionId, consumerId, subpartitionConsumer);
@@ -313,11 +314,11 @@ public class HsResultPartition extends ResultPartition {
     }
 
     private void checkMultipleConsumerIsAllowed(
-            HsConsumerId newConsumerId, HybridShuffleConfiguration hybridShuffleConfiguration) {
+            HsConsumerId lastConsumerId, HybridShuffleConfiguration hybridShuffleConfiguration) {
         if (hybridShuffleConfiguration.getSpillingStrategyType()
                 == SpillingStrategyType.SELECTIVE) {
             checkState(
-                    newConsumerId == HsConsumerId.DEFAULT,
+                    lastConsumerId == null,
                     "Multiple consumer is not allowed for %s spilling strategy mode",
                     hybridShuffleConfiguration.getSpillingStrategyType());
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -186,13 +186,15 @@ public class HsResultPartition extends ResultPartition {
             throw new PartitionNotFoundException(getPartitionId());
         }
 
-        HsSubpartitionView subpartitionView = new HsSubpartitionView(availabilityListener);
+        HsSubpartitionConsumer subpartitionView = new HsSubpartitionConsumer(availabilityListener);
         HsDataView diskDataView =
                 fileDataManager.registerNewSubpartition(subpartitionId, subpartitionView);
 
         HsDataView memoryDataView =
                 checkNotNull(memoryDataManager)
-                        .registerSubpartitionView(subpartitionId, subpartitionView);
+                        // TODO pass real consumerId in the next commit.
+                        .registerNewConsumer(
+                                subpartitionId, HsConsumerId.DEFAULT, subpartitionView);
 
         subpartitionView.setDiskDataView(diskDataView);
         subpartitionView.setMemoryDataView(memoryDataView);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.hybrid;
 
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatus;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatusWithId;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.SpillStatus;
 
 import java.util.Deque;
@@ -85,7 +86,11 @@ public class HsSelectiveSpillingStrategy implements HsSpillingStrategy {
             subpartitionToBuffers.put(
                     channel,
                     spillingInfoProvider.getBuffersInOrder(
-                            channel, SpillStatus.NOT_SPILL, ConsumeStatus.NOT_CONSUMED));
+                            channel,
+                            SpillStatus.NOT_SPILL,
+                            // selective spilling strategy does not support multiple consumer.
+                            ConsumeStatusWithId.fromStatusAndConsumerId(
+                                    ConsumeStatus.NOT_CONSUMED, HsConsumerId.DEFAULT)));
         }
 
         TreeMap<Integer, List<BufferIndexAndChannel>> subpartitionToHighPriorityBuffers =
@@ -113,12 +118,14 @@ public class HsSelectiveSpillingStrategy implements HsSpillingStrategy {
                             subpartitionId,
                             // get all not start spilling buffers.
                             spillingInfoProvider.getBuffersInOrder(
-                                    subpartitionId, SpillStatus.NOT_SPILL, ConsumeStatus.ALL))
+                                    subpartitionId,
+                                    SpillStatus.NOT_SPILL,
+                                    ConsumeStatusWithId.ALL_ANY))
                     .addBufferToRelease(
                             subpartitionId,
                             // get all not released buffers.
                             spillingInfoProvider.getBuffersInOrder(
-                                    subpartitionId, SpillStatus.ALL, ConsumeStatus.ALL));
+                                    subpartitionId, SpillStatus.ALL, ConsumeStatusWithId.ALL_ANY));
         }
         return builder.build();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSelectiveSpillingStrategy.java
@@ -95,7 +95,8 @@ public class HsSelectiveSpillingStrategy implements HsSpillingStrategy {
 
         TreeMap<Integer, List<BufferIndexAndChannel>> subpartitionToHighPriorityBuffers =
                 getBuffersByConsumptionPriorityInOrder(
-                        spillingInfoProvider.getNextBufferIndexToConsume(),
+                        // selective spilling strategy does not support multiple consumer.
+                        spillingInfoProvider.getNextBufferIndexToConsume(HsConsumerId.DEFAULT),
                         subpartitionToBuffers,
                         spillNum);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingInfoProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingInfoProvider.java
@@ -43,13 +43,13 @@ public interface HsSpillingInfoProvider {
      *
      * @param subpartitionId target buffers belong to.
      * @param spillStatus expected buffer spill status.
-     * @param consumeStatus expected buffer consume status.
+     * @param consumeStatusWithId expected buffer consume status and consumer id.
      * @return all buffers satisfy specific status of this subpartition, This queue must be sorted
      *     according to bufferIndex from small to large, in other words, head is the buffer with the
      *     minimum bufferIndex in the current subpartition.
      */
     Deque<BufferIndexAndChannel> getBuffersInOrder(
-            int subpartitionId, SpillStatus spillStatus, ConsumeStatus consumeStatus);
+            int subpartitionId, SpillStatus spillStatus, ConsumeStatusWithId consumeStatusWithId);
 
     /** Get total number of not decided to spill buffers. */
     int getNumTotalUnSpillBuffers();
@@ -78,5 +78,25 @@ public interface HsSpillingInfoProvider {
         NOT_CONSUMED,
         /** The buffer is either consumed or not consumed. */
         ALL
+    }
+
+    /** This class represents a pair of {@link ConsumeStatus} and consumer id. */
+    class ConsumeStatusWithId {
+        public static final ConsumeStatusWithId ALL_ANY =
+                new ConsumeStatusWithId(ConsumeStatus.ALL, HsConsumerId.ANY);
+
+        ConsumeStatus status;
+
+        HsConsumerId consumerId;
+
+        private ConsumeStatusWithId(ConsumeStatus status, HsConsumerId consumerId) {
+            this.status = status;
+            this.consumerId = consumerId;
+        }
+
+        public static ConsumeStatusWithId fromStatusAndConsumerId(
+                ConsumeStatus consumeStatus, HsConsumerId consumerId) {
+            return new ConsumeStatusWithId(consumeStatus, consumerId);
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingInfoProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSpillingInfoProvider.java
@@ -31,12 +31,14 @@ public interface HsSpillingInfoProvider {
     int getNumSubpartitions();
 
     /**
-     * Get all downstream next buffer index to consume.
+     * Get all subpartition's next buffer index to consume of specific consumer.
      *
-     * @return A list containing all downstream next buffer index to consume, if the downstream
-     *     subpartition view has not been registered, the corresponding return value is -1.
+     * @param consumerId of the target downstream consumer.
+     * @return A list containing all subpartition's next buffer index to consume of specific
+     *     consumer, if the downstream subpartition view has not been registered, the corresponding
+     *     return value is -1.
      */
-    List<Integer> getNextBufferIndexToConsume();
+    List<Integer> getNextBufferIndexToConsume(HsConsumerId consumerId);
 
     /**
      * Get all buffers with the expected status from the subpartition.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerInternalOperations.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerInternalOperations.java
@@ -18,29 +18,22 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid;
 
-/** Mock {@link HsSubpartitionViewInternalOperations} for test. */
-public class TestingSubpartitionViewInternalOperation
-        implements HsSubpartitionViewInternalOperations {
-    // -1 indicates downstream just start consuming offset.
-    private int consumingOffset = -1;
+/**
+ * Operations provided by {@link HsSubpartitionConsumer} that are used by other internal components
+ * of hybrid result partition.
+ */
+public interface HsSubpartitionConsumerInternalOperations {
 
-    private Runnable notifyDataAvailableRunnable = () -> {};
+    /** Callback for new data become available. */
+    void notifyDataAvailable();
 
-    @Override
-    public void notifyDataAvailable() {
-        notifyDataAvailableRunnable.run();
-    }
-
-    @Override
-    public int getConsumingOffset(boolean withLock) {
-        return consumingOffset;
-    }
-
-    public void advanceConsumptionProgress() {
-        consumingOffset++;
-    }
-
-    public void setNotifyDataAvailableRunnable(Runnable notifyDataAvailableRunnable) {
-        this.notifyDataAvailableRunnable = notifyDataAvailableRunnable;
-    }
+    /**
+     * Get the latest consuming offset of the subpartition.
+     *
+     * @param withLock If true, read the consuming offset outside the guarding of lock. This is
+     *     sometimes desired to avoid lock contention, if the caller does not depend on any other
+     *     states to change atomically with the consuming offset.
+     * @return latest consuming offset.
+     */
+    int getConsumingOffset(boolean withLock);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManager.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+import org.apache.flink.util.function.SupplierWithException;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.Optional;
+import java.util.concurrent.locks.Lock;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * This class is responsible for managing the data of a single consumer. {@link
+ * HsSubpartitionMemoryDataManager} will create a new {@link
+ * HsSubpartitionConsumerMemoryDataManager} when a consumer is registered.
+ */
+public class HsSubpartitionConsumerMemoryDataManager implements HsDataView {
+
+    @GuardedBy("consumerLock")
+    private final Deque<HsBufferContext> unConsumedBuffers = new LinkedList<>();
+
+    private final Lock consumerLock;
+
+    private final Lock resultPartitionLock;
+
+    private final HsConsumerId consumerId;
+
+    private final int subpartitionId;
+
+    private final HsMemoryDataManagerOperation memoryDataManagerOperation;
+
+    public HsSubpartitionConsumerMemoryDataManager(
+            Lock resultPartitionLock,
+            Lock consumerLock,
+            int subpartitionId,
+            HsConsumerId consumerId,
+            HsMemoryDataManagerOperation memoryDataManagerOperation) {
+        this.resultPartitionLock = resultPartitionLock;
+        this.consumerLock = consumerLock;
+        this.subpartitionId = subpartitionId;
+        this.consumerId = consumerId;
+        this.memoryDataManagerOperation = memoryDataManagerOperation;
+    }
+
+    @GuardedBy("consumerLock")
+    // this method only called from subpartitionMemoryDataManager with write lock.
+    public void addInitialBuffers(Deque<HsBufferContext> buffers) {
+        unConsumedBuffers.addAll(buffers);
+    }
+
+    @GuardedBy("consumerLock")
+    // this method only called from subpartitionMemoryDataManager with write lock.
+    public boolean addBuffer(HsBufferContext bufferContext) {
+        unConsumedBuffers.add(bufferContext);
+        trimHeadingReleasedBuffers();
+        return unConsumedBuffers.size() <= 1;
+    }
+
+    /**
+     * Check whether the head of {@link #unConsumedBuffers} is the buffer to be consumed. If so,
+     * return the buffer and backlog.
+     *
+     * @param toConsumeIndex index of buffer to be consumed.
+     * @return If the head of {@link #unConsumedBuffers} is target, return optional of the buffer
+     *     and backlog. Otherwise, return {@link Optional#empty()}.
+     */
+    @SuppressWarnings("FieldAccessNotGuarded")
+    // Note that: callWithLock ensure that code block guarded by resultPartitionReadLock and
+    // subpartitionLock.
+    @Override
+    public Optional<ResultSubpartition.BufferAndBacklog> consumeBuffer(int toConsumeIndex) {
+        Optional<Tuple2<HsBufferContext, Buffer.DataType>> bufferAndNextDataType =
+                callWithLock(
+                        () -> {
+                            if (!checkFirstUnConsumedBufferIndex(toConsumeIndex)) {
+                                return Optional.empty();
+                            }
+
+                            HsBufferContext bufferContext =
+                                    checkNotNull(unConsumedBuffers.pollFirst());
+                            bufferContext.consumed(consumerId);
+                            Buffer.DataType nextDataType =
+                                    peekNextToConsumeDataTypeInternal(toConsumeIndex + 1);
+                            return Optional.of(Tuple2.of(bufferContext, nextDataType));
+                        });
+
+        bufferAndNextDataType.ifPresent(
+                tuple ->
+                        memoryDataManagerOperation.onBufferConsumed(
+                                tuple.f0.getBufferIndexAndChannel()));
+        return bufferAndNextDataType.map(
+                tuple ->
+                        new ResultSubpartition.BufferAndBacklog(
+                                tuple.f0.getBuffer().readOnlySlice(),
+                                getBacklog(),
+                                tuple.f1,
+                                toConsumeIndex));
+    }
+
+    /**
+     * Check whether the head of {@link #unConsumedBuffers} is the buffer to be consumed next time.
+     * If so, return the next buffer's data type.
+     *
+     * @param nextToConsumeIndex index of the buffer to be consumed next time.
+     * @return If the head of {@link #unConsumedBuffers} is target, return the buffer's data type.
+     *     Otherwise, return {@link Buffer.DataType#NONE}.
+     */
+    @SuppressWarnings("FieldAccessNotGuarded")
+    // Note that: callWithLock ensure that code block guarded by resultPartitionReadLock and
+    // consumerLock.
+    @Override
+    public Buffer.DataType peekNextToConsumeDataType(int nextToConsumeIndex) {
+        return callWithLock(() -> peekNextToConsumeDataTypeInternal(nextToConsumeIndex));
+    }
+
+    @GuardedBy("consumerLock")
+    private Buffer.DataType peekNextToConsumeDataTypeInternal(int nextToConsumeIndex) {
+        return checkFirstUnConsumedBufferIndex(nextToConsumeIndex)
+                ? checkNotNull(unConsumedBuffers.peekFirst()).getBuffer().getDataType()
+                : Buffer.DataType.NONE;
+    }
+
+    @GuardedBy("consumerLock")
+    private boolean checkFirstUnConsumedBufferIndex(int expectedBufferIndex) {
+        trimHeadingReleasedBuffers();
+        return !unConsumedBuffers.isEmpty()
+                && unConsumedBuffers.peekFirst().getBufferIndexAndChannel().getBufferIndex()
+                        == expectedBufferIndex;
+    }
+
+    @SuppressWarnings("FieldAccessNotGuarded")
+    // Un-synchronized get unConsumedBuffers size to provide memory data backlog,this will make the
+    // result greater than or equal to the actual backlog, but obtaining an accurate backlog will
+    // bring too much extra overhead.
+    @Override
+    public int getBacklog() {
+        return unConsumedBuffers.size();
+    }
+
+    @Override
+    public void releaseDataView() {
+        memoryDataManagerOperation.onConsumerReleased(subpartitionId, consumerId);
+    }
+
+    @GuardedBy("consumerLock")
+    private void trimHeadingReleasedBuffers() {
+        while (!unConsumedBuffers.isEmpty() && unConsumedBuffers.peekFirst().isReleased()) {
+            unConsumedBuffers.removeFirst();
+        }
+    }
+
+    private <R, E extends Exception> R callWithLock(SupplierWithException<R, E> callable) throws E {
+        try {
+            resultPartitionLock.lock();
+            consumerLock.lock();
+            return callable.get();
+        } finally {
+            consumerLock.unlock();
+            resultPartitionLock.unlock();
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
@@ -57,6 +57,7 @@ public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileR
     interface Factory {
         HsSubpartitionFileReader createFileReader(
                 int subpartitionId,
+                HsConsumerId consumerId,
                 FileChannel dataFileChannel,
                 HsSubpartitionConsumerInternalOperations operation,
                 HsFileDataIndex dataIndex,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReader.java
@@ -58,7 +58,7 @@ public interface HsSubpartitionFileReader extends Comparable<HsSubpartitionFileR
         HsSubpartitionFileReader createFileReader(
                 int subpartitionId,
                 FileChannel dataFileChannel,
-                HsSubpartitionViewInternalOperations operation,
+                HsSubpartitionConsumerInternalOperations operation,
                 HsFileDataIndex dataIndex,
                 int maxBuffersReadAhead,
                 Consumer<HsSubpartitionFileReader> fileReaderReleaser,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -55,6 +55,8 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
     private final int subpartitionId;
 
+    private final HsConsumerId consumerId;
+
     private final FileChannel dataFileChannel;
 
     private final HsSubpartitionConsumerInternalOperations operations;
@@ -71,6 +73,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
     public HsSubpartitionFileReaderImpl(
             int subpartitionId,
+            HsConsumerId consumerId,
             FileChannel dataFileChannel,
             HsSubpartitionConsumerInternalOperations operations,
             HsFileDataIndex dataIndex,
@@ -78,6 +81,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
             Consumer<HsSubpartitionFileReader> fileReaderReleaser,
             ByteBuffer headerBuf) {
         this.subpartitionId = subpartitionId;
+        this.consumerId = consumerId;
         this.dataFileChannel = dataFileChannel;
         this.operations = operations;
         this.headerBuf = headerBuf;
@@ -95,12 +99,12 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
             return false;
         }
         HsSubpartitionFileReaderImpl that = (HsSubpartitionFileReaderImpl) o;
-        return subpartitionId == that.subpartitionId;
+        return subpartitionId == that.subpartitionId && Objects.equals(consumerId, that.consumerId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(subpartitionId);
+        return Objects.hash(subpartitionId, consumerId);
     }
 
     /**
@@ -486,6 +490,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         @Override
         public HsSubpartitionFileReader createFileReader(
                 int subpartitionId,
+                HsConsumerId consumerId,
                 FileChannel dataFileChannel,
                 HsSubpartitionConsumerInternalOperations operation,
                 HsFileDataIndex dataIndex,
@@ -494,6 +499,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
                 ByteBuffer headerBuffer) {
             return new HsSubpartitionFileReaderImpl(
                     subpartitionId,
+                    consumerId,
                     dataFileChannel,
                     operation,
                     dataIndex,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -57,7 +57,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
     private final FileChannel dataFileChannel;
 
-    private final HsSubpartitionViewInternalOperations operations;
+    private final HsSubpartitionConsumerInternalOperations operations;
 
     private final CachedRegionManager cachedRegionManager;
 
@@ -72,7 +72,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
     public HsSubpartitionFileReaderImpl(
             int subpartitionId,
             FileChannel dataFileChannel,
-            HsSubpartitionViewInternalOperations operations,
+            HsSubpartitionConsumerInternalOperations operations,
             HsFileDataIndex dataIndex,
             int maxBufferReadAhead,
             Consumer<HsSubpartitionFileReader> fileReaderReleaser,
@@ -487,7 +487,7 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
         public HsSubpartitionFileReader createFileReader(
                 int subpartitionId,
                 FileChannel dataFileChannel,
-                HsSubpartitionViewInternalOperations operation,
+                HsSubpartitionConsumerInternalOperations operation,
                 HsFileDataIndex dataIndex,
                 int maxBuffersReadAhead,
                 Consumer<HsSubpartitionFileReader> fileReaderReleaser,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -47,6 +47,8 @@ public class ResultPartitionBuilder {
 
     private int numTargetKeyGroups = 1;
 
+    private boolean isBroadcast = false;
+
     private ResultPartitionManager partitionManager = new ResultPartitionManager();
 
     private FileChannelManager channelManager = NoOpFileChannelManager.INSTANCE;
@@ -211,6 +213,11 @@ public class ResultPartitionBuilder {
         return this;
     }
 
+    public ResultPartitionBuilder setBroadcast(boolean broadcast) {
+        isBroadcast = broadcast;
+        return this;
+    }
+
     public ResultPartition build() {
         ResultPartitionFactory resultPartitionFactory =
                 new ResultPartitionFactory(
@@ -244,6 +251,7 @@ public class ResultPartitionBuilder {
                 partitionType,
                 numberOfSubpartitions,
                 numTargetKeyGroups,
+                isBroadcast,
                 factory);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -63,10 +63,7 @@ class ResultPartitionFactoryTest {
                 (BoundedBlockingResultPartition)
                         createResultPartition(ResultPartitionType.BLOCKING);
         assertThat(resultPartition.subpartitions)
-                .allSatisfy(
-                        (sp) -> {
-                            assertThat(sp).isInstanceOf(BoundedBlockingSubpartition.class);
-                        });
+                .allSatisfy((sp) -> assertThat(sp).isInstanceOf(BoundedBlockingSubpartition.class));
     }
 
     @Test
@@ -74,10 +71,7 @@ class ResultPartitionFactoryTest {
         final PipelinedResultPartition resultPartition =
                 (PipelinedResultPartition) createResultPartition(ResultPartitionType.PIPELINED);
         assertThat(resultPartition.subpartitions)
-                .allSatisfy(
-                        (sp) -> {
-                            assertThat(sp).isInstanceOf(PipelinedResultPartition.class);
-                        });
+                .allSatisfy((sp) -> assertThat(sp).isInstanceOf(PipelinedSubpartition.class));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -138,12 +138,29 @@ class ResultPartitionFactoryTest {
         assertThat(resultPartition.isReleased()).isFalse();
     }
 
+    @Test
+    public void testHybridBroadcastEdgeAlwaysUseFullResultPartition() {
+        ResultPartition resultPartition =
+                createResultPartition(
+                        ResultPartitionType.HYBRID_SELECTIVE, Integer.MAX_VALUE, true);
+        assertThat(resultPartition.partitionType).isEqualTo(ResultPartitionType.HYBRID_FULL);
+
+        resultPartition =
+                createResultPartition(ResultPartitionType.HYBRID_FULL, Integer.MAX_VALUE, true);
+        assertThat(resultPartition.partitionType).isEqualTo(ResultPartitionType.HYBRID_FULL);
+    }
+
     private static ResultPartition createResultPartition(ResultPartitionType partitionType) {
         return createResultPartition(partitionType, Integer.MAX_VALUE);
     }
 
     private static ResultPartition createResultPartition(
             ResultPartitionType partitionType, int sortShuffleMinParallelism) {
+        return createResultPartition(partitionType, sortShuffleMinParallelism, false);
+    }
+
+    private static ResultPartition createResultPartition(
+            ResultPartitionType partitionType, int sortShuffleMinParallelism, boolean isBroadcast) {
         final ResultPartitionManager manager = new ResultPartitionManager();
 
         final ResultPartitionFactory factory =
@@ -169,6 +186,7 @@ class ResultPartitionFactoryTest {
                 new ResultPartitionDeploymentDescriptor(
                         PartitionDescriptorBuilder.newBuilder()
                                 .setPartitionType(partitionType)
+                                .setIsBroadcast(isBroadcast)
                                 .build(),
                         NettyShuffleDescriptorBuilder.newBuilder().buildLocal(),
                         1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -26,113 +26,116 @@ import org.apache.flink.runtime.io.network.partition.hybrid.HsResultPartition;
 import org.apache.flink.runtime.shuffle.PartitionDescriptorBuilder;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.Arrays;
 import java.util.concurrent.Executors;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link ResultPartitionFactory}. */
 @SuppressWarnings("StaticVariableUsedBeforeInitialization")
-public class ResultPartitionFactoryTest extends TestLogger {
+@ExtendWith(TestLoggerExtension.class)
+class ResultPartitionFactoryTest {
 
     private static final String tempDir = EnvironmentInformation.getTemporaryFileDirectory();
     private static final int SEGMENT_SIZE = 64;
 
     private static FileChannelManager fileChannelManager;
 
-    @BeforeClass
-    public static void setUp() {
+    @BeforeAll
+    static void setUp() {
         fileChannelManager = new FileChannelManagerImpl(new String[] {tempDir}, "testing");
     }
 
-    @AfterClass
-    public static void shutdown() throws Exception {
+    @AfterAll
+    static void shutdown() throws Exception {
         fileChannelManager.close();
     }
 
     @Test
-    public void testBoundedBlockingSubpartitionsCreated() {
+    void testBoundedBlockingSubpartitionsCreated() {
         final BoundedBlockingResultPartition resultPartition =
                 (BoundedBlockingResultPartition)
                         createResultPartition(ResultPartitionType.BLOCKING);
-        Arrays.stream(resultPartition.subpartitions)
-                .forEach(sp -> assertThat(sp, instanceOf(BoundedBlockingSubpartition.class)));
+        assertThat(resultPartition.subpartitions)
+                .allSatisfy(
+                        (sp) -> {
+                            assertThat(sp).isInstanceOf(BoundedBlockingSubpartition.class);
+                        });
     }
 
     @Test
-    public void testPipelinedSubpartitionsCreated() {
+    void testPipelinedSubpartitionsCreated() {
         final PipelinedResultPartition resultPartition =
                 (PipelinedResultPartition) createResultPartition(ResultPartitionType.PIPELINED);
-        Arrays.stream(resultPartition.subpartitions)
-                .forEach(sp -> assertThat(sp, instanceOf(PipelinedSubpartition.class)));
+        assertThat(resultPartition.subpartitions)
+                .allSatisfy(
+                        (sp) -> {
+                            assertThat(sp).isInstanceOf(PipelinedResultPartition.class);
+                        });
     }
 
     @Test
-    public void testSortMergePartitionCreated() {
+    void testSortMergePartitionCreated() {
         ResultPartition resultPartition = createResultPartition(ResultPartitionType.BLOCKING, 1);
-        assertTrue(resultPartition instanceof SortMergeResultPartition);
+        assertThat(resultPartition).isInstanceOf(SortMergeResultPartition.class);
     }
 
     @Test
-    public void testHybridFullResultPartitionCreated() {
+    void testHybridFullResultPartitionCreated() {
         ResultPartition resultPartition = createResultPartition(ResultPartitionType.HYBRID_FULL);
-        assertTrue(resultPartition instanceof HsResultPartition);
+        assertThat(resultPartition).isInstanceOf(HsResultPartition.class);
     }
 
     @Test
-    public void testHybridSelectiveResultPartitionCreated() {
+    void testHybridSelectiveResultPartitionCreated() {
         ResultPartition resultPartition =
                 createResultPartition(ResultPartitionType.HYBRID_SELECTIVE);
-        assertTrue(resultPartition instanceof HsResultPartition);
+        assertThat(resultPartition).isInstanceOf(HsResultPartition.class);
     }
 
     @Test
-    public void testNoReleaseOnConsumptionForBoundedBlockingPartition() {
+    void testNoReleaseOnConsumptionForBoundedBlockingPartition() {
         final ResultPartition resultPartition = createResultPartition(ResultPartitionType.BLOCKING);
 
         resultPartition.onConsumedSubpartition(0);
 
-        assertFalse(resultPartition.isReleased());
+        assertThat(resultPartition.isReleased()).isFalse();
     }
 
     @Test
-    public void testNoReleaseOnConsumptionForSortMergePartition() {
+    void testNoReleaseOnConsumptionForSortMergePartition() {
         final ResultPartition resultPartition =
                 createResultPartition(ResultPartitionType.BLOCKING, 1);
 
         resultPartition.onConsumedSubpartition(0);
 
-        assertFalse(resultPartition.isReleased());
+        assertThat(resultPartition.isReleased()).isFalse();
     }
 
     @Test
-    public void testNoReleaseOnConsumptionForHybridFullPartition() {
+    void testNoReleaseOnConsumptionForHybridFullPartition() {
         final ResultPartition resultPartition =
                 createResultPartition(ResultPartitionType.HYBRID_FULL);
 
         resultPartition.onConsumedSubpartition(0);
 
-        assertFalse(resultPartition.isReleased());
+        assertThat(resultPartition.isReleased()).isFalse();
     }
 
     @Test
-    public void testNoReleaseOnConsumptionForHybridSelectivePartition() {
+    void testNoReleaseOnConsumptionForHybridSelectivePartition() {
         final ResultPartition resultPartition =
                 createResultPartition(ResultPartitionType.HYBRID_SELECTIVE);
 
         resultPartition.onConsumedSubpartition(0);
 
-        assertFalse(resultPartition.isReleased());
+        assertThat(resultPartition.isReleased()).isFalse();
     }
 
     private static ResultPartition createResultPartition(ResultPartitionType partitionType) {
@@ -171,7 +174,7 @@ public class ResultPartitionFactoryTest extends TestLogger {
                         1);
 
         // guard our test assumptions
-        assertEquals(1, descriptor.getNumberOfSubpartitions());
+        assertThat(descriptor.getNumberOfSubpartitions()).isEqualTo(1);
 
         final ResultPartition partition = factory.create("test", 0, descriptor);
         manager.registerResultPartition(partition);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerIdTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerIdTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsConsumerId} */
+class HsConsumerIdTest {
+    @Test
+    void testNewIdFromNull() {
+        HsConsumerId consumerId = HsConsumerId.newId(null);
+        assertThat(consumerId).isNotNull().isEqualTo(HsConsumerId.DEFAULT);
+    }
+
+    @Test
+    void testConsumerIdEquals(){
+        HsConsumerId consumerId = HsConsumerId.newId(null);
+        HsConsumerId consumerId1 = HsConsumerId.newId(consumerId);
+        HsConsumerId consumerId2 = HsConsumerId.newId(consumerId);
+        assertThat(consumerId1.hashCode()).isEqualTo(consumerId2.hashCode());
+        assertThat(consumerId1).isEqualTo(consumerId2);
+
+        assertThat(HsConsumerId.newId(consumerId2)).isNotEqualTo(consumerId2);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerIdTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsConsumerIdTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Tests for {@link HsConsumerId} */
+/** Tests for {@link HsConsumerId}. */
 class HsConsumerIdTest {
     @Test
     void testNewIdFromNull() {
@@ -31,7 +31,7 @@ class HsConsumerIdTest {
     }
 
     @Test
-    void testConsumerIdEquals(){
+    void testConsumerIdEquals() {
         HsConsumerId consumerId = HsConsumerId.newId(null);
         HsConsumerId consumerId1 = HsConsumerId.newId(consumerId);
         HsConsumerId consumerId2 = HsConsumerId.newId(consumerId);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
@@ -52,6 +52,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsConsumerId.DEFAULT;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,7 +124,7 @@ class HsFileDataManagerTest {
 
         assertThat(reader.readBuffers).isEmpty();
 
-        fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionViewOperation);
 
         ioExecutor.trigger();
 
@@ -142,7 +143,7 @@ class HsFileDataManagerTest {
 
         factory.allReaders.add(reader);
 
-        fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionViewOperation);
 
         ioExecutor.trigger();
 
@@ -174,7 +175,7 @@ class HsFileDataManagerTest {
                 });
         factory.allReaders.add(reader);
 
-        fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionViewOperation);
 
         ioExecutor.trigger();
 
@@ -207,8 +208,8 @@ class HsFileDataManagerTest {
         factory.allReaders.add(reader1);
         factory.allReaders.add(reader2);
 
-        fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
-        fileDataManager.registerNewSubpartition(1, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(1, DEFAULT, subpartitionViewOperation);
 
         // trigger run.
         ioExecutor.trigger();
@@ -243,7 +244,7 @@ class HsFileDataManagerTest {
         reader.setFailConsumer((cause::complete));
         factory.allReaders.add(reader);
 
-        fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionViewOperation);
 
         ioExecutor.trigger();
 
@@ -269,7 +270,7 @@ class HsFileDataManagerTest {
                 });
         factory.allReaders.add(reader);
 
-        fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionViewOperation);
 
         ioExecutor.trigger();
 
@@ -314,7 +315,7 @@ class HsFileDataManagerTest {
                 };
         releaseThread.start();
 
-        fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
+        fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionViewOperation);
 
         ioExecutor.trigger();
 
@@ -335,7 +336,8 @@ class HsFileDataManagerTest {
         fileDataManager.release();
         assertThatThrownBy(
                         () -> {
-                            fileDataManager.registerNewSubpartition(0, subpartitionViewOperation);
+                            fileDataManager.registerNewConsumer(
+                                    0, DEFAULT, subpartitionViewOperation);
                             ioExecutor.trigger();
                         })
                 .isInstanceOf(IllegalStateException.class)
@@ -358,6 +360,7 @@ class HsFileDataManagerTest {
         HsSubpartitionFileReaderImpl subpartitionFileReader =
                 new HsSubpartitionFileReaderImpl(
                         0,
+                        DEFAULT,
                         dataFileChannel,
                         subpartitionView,
                         new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
@@ -376,7 +379,7 @@ class HsFileDataManagerTest {
                     }
                 };
         factory.allReaders.add(subpartitionFileReader);
-        HsDataView diskDataView = fileDataManager.registerNewSubpartition(0, subpartitionView);
+        HsDataView diskDataView = fileDataManager.registerNewConsumer(0, DEFAULT, subpartitionView);
         subpartitionView.setDiskDataView(diskDataView);
         TestingHsDataView memoryDataView =
                 TestingHsDataView.builder()
@@ -496,6 +499,7 @@ class HsFileDataManagerTest {
             @Override
             public HsSubpartitionFileReader createFileReader(
                     int subpartitionId,
+                    HsConsumerId consumerId,
                     FileChannel dataFileChannel,
                     HsSubpartitionConsumerInternalOperations operation,
                     HsFileDataIndex dataIndex,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
@@ -78,7 +78,7 @@ class HsFileDataManagerTest {
 
     private HsFileDataManager fileDataManager;
 
-    private TestingSubpartitionViewInternalOperation subpartitionViewOperation;
+    private TestingSubpartitionConsumerInternalOperation subpartitionViewOperation;
 
     private TestingHsSubpartitionFileReader.Factory factory;
 
@@ -101,7 +101,7 @@ class HsFileDataManagerTest {
                         HybridShuffleConfiguration.builder(
                                         NUM_SUBPARTITIONS, bufferPool.getNumBuffersPerRequest())
                                 .build());
-        subpartitionViewOperation = new TestingSubpartitionViewInternalOperation();
+        subpartitionViewOperation = new TestingSubpartitionConsumerInternalOperation();
     }
 
     @AfterEach
@@ -352,8 +352,8 @@ class HsFileDataManagerTest {
     void testConsumeWhileReleaseNoDeadlock() throws Exception {
         CompletableFuture<Void> consumerStart = new CompletableFuture<>();
         CompletableFuture<Void> readerFail = new CompletableFuture<>();
-        HsSubpartitionView subpartitionView =
-                new HsSubpartitionView(new NoOpBufferAvailablityListener());
+        HsSubpartitionConsumer subpartitionView =
+                new HsSubpartitionConsumer(new NoOpBufferAvailablityListener());
 
         HsSubpartitionFileReaderImpl subpartitionFileReader =
                 new HsSubpartitionFileReaderImpl(
@@ -497,7 +497,7 @@ class HsFileDataManagerTest {
             public HsSubpartitionFileReader createFileReader(
                     int subpartitionId,
                     FileChannel dataFileChannel,
-                    HsSubpartitionViewInternalOperations operation,
+                    HsSubpartitionConsumerInternalOperations operation,
                     HsFileDataIndex dataIndex,
                     int maxBuffersReadAhead,
                     Consumer<HsSubpartitionFileReader> fileReaderReleaser,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFullSpillingStrategyTest.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createBufferIndexAndChannelsList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.entry;
 
 /** Tests for {@link HsFullSpillingStrategy}. */
 class HsFullSpillingStrategyTest {
@@ -129,9 +128,7 @@ class HsFullSpillingStrategyTest {
                         .addSubpartitionBuffers(subpartition1, subpartitionBuffers1)
                         .addSubpartitionBuffers(subpartition2, subpartitionBuffers2)
                         .addSpillBuffers(subpartition1, Arrays.asList(0, 1, 2, 3))
-                        .addConsumedBuffers(subpartition1, Arrays.asList(0, 1))
                         .addSpillBuffers(subpartition2, Arrays.asList(1, 2, 3))
-                        .addConsumedBuffers(subpartition2, Arrays.asList(0, 1))
                         .setGetNumTotalUnSpillBuffersSupplier(
                                 () -> (int) (10 * NUM_BUFFERS_TRIGGER_SPILLING_RATIO))
                         .setGetNumTotalRequestedBuffersSupplier(() -> 10)
@@ -151,45 +148,11 @@ class HsFullSpillingStrategyTest {
         assertThat(decision.getBufferToSpill()).isEqualTo(expectedSpillBuffers);
 
         Map<Integer, List<BufferIndexAndChannel>> expectedReleaseBuffers = new HashMap<>();
-        // all consumed spill buffers should release.
         expectedReleaseBuffers.put(
                 subpartition1, new ArrayList<>(subpartitionBuffers1.subList(0, 2)));
-        // priority higher buffers should release.
-        expectedReleaseBuffers.get(subpartition1).addAll(subpartitionBuffers1.subList(3, 4));
-        // all consumed spill buffers should release.
         expectedReleaseBuffers.put(
-                subpartition2, new ArrayList<>(subpartitionBuffers2.subList(1, 2)));
-        // priority higher buffers should release.
-        expectedReleaseBuffers.get(subpartition2).addAll(subpartitionBuffers2.subList(2, 4));
+                subpartition2, new ArrayList<>(subpartitionBuffers2.subList(1, 3)));
         assertThat(decision.getBufferToRelease()).isEqualTo(expectedReleaseBuffers);
-    }
-
-    /** All consumed buffers that already spill should release regardless of the release ratio. */
-    @Test
-    void testDecideActionWithGlobalInfoAllConsumedSpillBufferShouldRelease() {
-        final int subpartitionId = 0;
-        List<BufferIndexAndChannel> subpartitionBuffers =
-                createBufferIndexAndChannelsList(subpartitionId, 0, 1, 2, 3, 4);
-
-        final int poolSize = 5;
-        TestingSpillingInfoProvider spillInfoProvider =
-                TestingSpillingInfoProvider.builder()
-                        .setGetNumSubpartitionsSupplier(() -> 1)
-                        .addSubpartitionBuffers(subpartitionId, subpartitionBuffers)
-                        .addSpillBuffers(subpartitionId, Arrays.asList(0, 1, 2, 3, 4))
-                        .addConsumedBuffers(subpartitionId, Arrays.asList(0, 1, 2, 3))
-                        .setGetNumTotalUnSpillBuffersSupplier(() -> 0)
-                        .setGetNumTotalRequestedBuffersSupplier(() -> poolSize)
-                        .setGetPoolSizeSupplier(() -> poolSize)
-                        .build();
-
-        int numReleaseBuffer = (int) (poolSize * FULL_SPILL_RELEASE_RATIO);
-        Decision decision = spillStrategy.decideActionWithGlobalInfo(spillInfoProvider);
-        assertThat(decision.getBufferToSpill()).isEmpty();
-        assertThat(decision.getBufferToRelease())
-                .containsOnly(entry(subpartitionId, subpartitionBuffers.subList(0, 4)))
-                .extractingByKey(subpartitionId)
-                .satisfies((buffers) -> assertThat(buffers).hasSizeGreaterThan(numReleaseBuffer));
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartitionTest.java
@@ -280,6 +280,60 @@ class HsResultPartitionTest {
     }
 
     @Test
+    void testBroadcastResultPartition() throws Exception {
+        final int numBuffers = 10;
+        final int numRecords = 10;
+        final int numConsumers = 2;
+        final Random random = new Random();
+
+        BufferPool bufferPool = globalPool.createBufferPool(numBuffers, numBuffers);
+        try (HsResultPartition resultPartition = createHsResultPartition(2, bufferPool, true)) {
+            List<ByteBuffer> dataWritten = new ArrayList<>();
+            for (int i = 0; i < numRecords; i++) {
+                ByteBuffer record = generateRandomData(bufferSize, random);
+                resultPartition.broadcastRecord(record);
+                dataWritten.add(record);
+            }
+            resultPartition.finish();
+
+            Tuple2[] viewAndListeners = createSubpartitionViews(resultPartition, 2);
+
+            List<List<Buffer>> dataRead = new ArrayList<>();
+            for (int i = 0; i < numConsumers; i++) {
+                dataRead.add(new ArrayList<>());
+            }
+            readData(
+                    viewAndListeners,
+                    (buffer, subpartition) -> {
+                        int numBytes = buffer.readableBytes();
+                        if (buffer.isBuffer()) {
+                            MemorySegment segment =
+                                    MemorySegmentFactory.allocateUnpooledSegment(numBytes);
+                            segment.put(0, buffer.getNioBufferReadable(), numBytes);
+                            dataRead.get(subpartition)
+                                    .add(
+                                            new NetworkBuffer(
+                                                    segment,
+                                                    (buf) -> {},
+                                                    buffer.getDataType(),
+                                                    numBytes));
+                        }
+                    });
+
+            for (int i = 0; i < numConsumers; i++) {
+                assertThat(dataWritten).hasSameSizeAs(dataRead.get(i));
+                List<Buffer> readBufferList = dataRead.get(i);
+                for (int j = 0; j < dataWritten.size(); j++) {
+                    ByteBuffer bufferWritten = dataWritten.get(j);
+                    bufferWritten.rewind();
+                    Buffer bufferRead = readBufferList.get(j);
+                    assertThat(bufferRead.getNioBufferReadable()).isEqualTo(bufferWritten);
+                }
+            }
+        }
+    }
+
+    @Test
     void testClose() throws Exception {
         final int numBuffers = 1;
 
@@ -427,6 +481,20 @@ class HsResultPartitionTest {
         }
     }
 
+    @Test
+    void testMetricsUpdateForBroadcastOnlyResultPartition() throws Exception {
+        BufferPool bufferPool = globalPool.createBufferPool(3, 3);
+        try (HsResultPartition partition = createHsResultPartition(2, bufferPool, true)) {
+            partition.broadcastRecord(ByteBuffer.allocate(bufferSize));
+            assertThat(taskIOMetricGroup.getNumBuffersOutCounter().getCount()).isEqualTo(1);
+            assertThat(taskIOMetricGroup.getNumBytesOutCounter().getCount()).isEqualTo(bufferSize);
+            IOMetrics ioMetrics = taskIOMetricGroup.createSnapshot();
+            assertThat(ioMetrics.getNumBytesProducedOfPartitions())
+                    .hasSize(1)
+                    .containsValue((long) bufferSize);
+        }
+    }
+
     private static void recordDataWritten(
             ByteBuffer record,
             Queue<Tuple2<ByteBuffer, Buffer.DataType>>[] dataWritten,
@@ -493,9 +561,25 @@ class HsResultPartitionTest {
 
     private HsResultPartition createHsResultPartition(int numSubpartitions, BufferPool bufferPool)
             throws IOException {
+        return createHsResultPartition(numSubpartitions, bufferPool, false);
+    }
+
+    private HsResultPartition createHsResultPartition(
+            int numSubpartitions,
+            BufferPool bufferPool,
+            HybridShuffleConfiguration hybridShuffleConfiguration)
+            throws IOException {
+        return createHsResultPartition(
+                numSubpartitions, bufferPool, false, hybridShuffleConfiguration);
+    }
+
+    private HsResultPartition createHsResultPartition(
+            int numSubpartitions, BufferPool bufferPool, boolean isBroadcastOnly)
+            throws IOException {
         return createHsResultPartition(
                 numSubpartitions,
                 bufferPool,
+                isBroadcastOnly,
                 HybridShuffleConfiguration.builder(
                                 numSubpartitions, readBufferPool.getNumBuffersPerRequest())
                         .build());
@@ -504,6 +588,7 @@ class HsResultPartitionTest {
     private HsResultPartition createHsResultPartition(
             int numSubpartitions,
             BufferPool bufferPool,
+            boolean isBroadcastOnly,
             HybridShuffleConfiguration hybridShuffleConfiguration)
             throws IOException {
         HsResultPartition hsResultPartition =
@@ -521,6 +606,7 @@ class HsResultPartitionTest {
                         bufferSize,
                         hybridShuffleConfiguration,
                         null,
+                        isBroadcastOnly,
                         () -> bufferPool);
         taskIOMetricGroup =
                 UnregisteredMetricGroups.createUnregisteredTaskMetricGroup().getIOMetricGroup();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionConsumerMemoryDataManagerTest.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.buffer.Buffer;
+import org.apache.flink.runtime.io.network.buffer.ReadOnlySlicedNetworkBuffer;
+import org.apache.flink.runtime.io.network.partition.ResultSubpartition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayDeque;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createBuffer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsSubpartitionConsumerMemoryDataManager}. */
+@SuppressWarnings("FieldAccessNotGuarded")
+class HsSubpartitionConsumerMemoryDataManagerTest {
+
+    private static final int BUFFER_SIZE = Long.BYTES;
+
+    private static final int SUBPARTITION_ID = 0;
+
+    @Test
+    void testPeekNextToConsumeDataTypeNotMeetBufferIndexToConsume() throws Exception {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionConsumerMemoryDataManager subpartitionConsumerMemoryDataManager =
+                createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
+
+        subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(0, false));
+        assertThat(subpartitionConsumerMemoryDataManager.peekNextToConsumeDataType(1))
+                .isEqualTo(Buffer.DataType.NONE);
+    }
+
+    @Test
+    void testPeekNextToConsumeDataTypeTrimHeadingReleasedBuffers() throws Exception {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionConsumerMemoryDataManager subpartitionConsumerMemoryDataManager =
+                createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
+
+        HsBufferContext buffer1 = createBufferContext(0, false);
+        HsBufferContext buffer2 = createBufferContext(1, false);
+        subpartitionConsumerMemoryDataManager.addBuffer(buffer1);
+        subpartitionConsumerMemoryDataManager.addBuffer(buffer2);
+        subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(2, true));
+
+        buffer1.release();
+        buffer2.release();
+
+        assertThat(subpartitionConsumerMemoryDataManager.peekNextToConsumeDataType(2))
+                .isEqualTo(Buffer.DataType.EVENT_BUFFER);
+    }
+
+    @Test
+    void testConsumeBufferFirstUnConsumedBufferIndexNotMeetNextToConsume() throws Exception {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionConsumerMemoryDataManager subpartitionConsumerMemoryDataManager =
+                createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
+
+        subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(0, false));
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(1)).isNotPresent();
+    }
+
+    @Test
+    void testConsumeBufferTrimHeadingReleasedBuffers() throws Exception {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionConsumerMemoryDataManager subpartitionConsumerMemoryDataManager =
+                createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
+
+        HsBufferContext buffer1 = createBufferContext(0, false);
+        HsBufferContext buffer2 = createBufferContext(1, false);
+        subpartitionConsumerMemoryDataManager.addBuffer(buffer1);
+        subpartitionConsumerMemoryDataManager.addBuffer(buffer2);
+        subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(2, true));
+
+        buffer1.release();
+        buffer2.release();
+
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(2)).isPresent();
+    }
+
+    @Test
+    void testConsumeBufferReturnSlice() {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionConsumerMemoryDataManager subpartitionConsumerMemoryDataManager =
+                createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
+
+        subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(0, false));
+
+        Optional<ResultSubpartition.BufferAndBacklog> bufferOpt =
+                subpartitionConsumerMemoryDataManager.consumeBuffer(0);
+        assertThat(bufferOpt)
+                .hasValueSatisfying(
+                        (bufferAndBacklog ->
+                                assertThat(bufferAndBacklog.buffer())
+                                        .isInstanceOf(ReadOnlySlicedNetworkBuffer.class)));
+    }
+
+    @Test
+    void testAddBuffer() {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionConsumerMemoryDataManager subpartitionConsumerMemoryDataManager =
+                createSubpartitionConsumerMemoryDataManager(memoryDataManagerOperation);
+        ArrayDeque<HsBufferContext> initialBuffers = new ArrayDeque<>();
+        initialBuffers.add(createBufferContext(0, false));
+        initialBuffers.add(createBufferContext(1, false));
+        subpartitionConsumerMemoryDataManager.addInitialBuffers(initialBuffers);
+        subpartitionConsumerMemoryDataManager.addBuffer(createBufferContext(2, true));
+
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(0))
+                .hasValueSatisfying(
+                        bufferAndBacklog -> {
+                            assertThat(bufferAndBacklog.getSequenceNumber()).isEqualTo(0);
+                            assertThat(bufferAndBacklog.buffer().getDataType())
+                                    .isEqualTo(Buffer.DataType.DATA_BUFFER);
+                        });
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(1))
+                .hasValueSatisfying(
+                        bufferAndBacklog -> {
+                            assertThat(bufferAndBacklog.getSequenceNumber()).isEqualTo(1);
+                            assertThat(bufferAndBacklog.buffer().getDataType())
+                                    .isEqualTo(Buffer.DataType.DATA_BUFFER);
+                        });
+        assertThat(subpartitionConsumerMemoryDataManager.consumeBuffer(2))
+                .hasValueSatisfying(
+                        bufferAndBacklog -> {
+                            assertThat(bufferAndBacklog.getSequenceNumber()).isEqualTo(2);
+                            assertThat(bufferAndBacklog.buffer().getDataType())
+                                    .isEqualTo(Buffer.DataType.EVENT_BUFFER);
+                        });
+    }
+
+    @Test
+    void testRelease() {
+        CompletableFuture<HsConsumerId> consumerReleasedFuture = new CompletableFuture<>();
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder()
+                        .setOnConsumerReleasedBiConsumer(
+                                (subpartitionId, consumerId) -> {
+                                    consumerReleasedFuture.complete(consumerId);
+                                })
+                        .build();
+        HsConsumerId consumerId = HsConsumerId.newId(null);
+        HsSubpartitionConsumerMemoryDataManager subpartitionConsumerMemoryDataManager =
+                createSubpartitionConsumerMemoryDataManager(consumerId, memoryDataManagerOperation);
+        subpartitionConsumerMemoryDataManager.releaseDataView();
+        assertThat(consumerReleasedFuture).isCompletedWithValue(consumerId);
+    }
+
+    private static HsBufferContext createBufferContext(int bufferIndex, boolean isEvent) {
+        return new HsBufferContext(
+                createBuffer(BUFFER_SIZE, isEvent), bufferIndex, SUBPARTITION_ID);
+    }
+
+    private HsSubpartitionConsumerMemoryDataManager createSubpartitionConsumerMemoryDataManager(
+            HsMemoryDataManagerOperation memoryDataManagerOperation) {
+        return createSubpartitionConsumerMemoryDataManager(
+                HsConsumerId.DEFAULT, memoryDataManagerOperation);
+    }
+
+    private HsSubpartitionConsumerMemoryDataManager createSubpartitionConsumerMemoryDataManager(
+            HsConsumerId consumerId, HsMemoryDataManagerOperation memoryDataManagerOperation) {
+        return new HsSubpartitionConsumerMemoryDataManager(
+                new ReentrantLock(),
+                new ReentrantLock(),
+                // consumerMemoryDataManager is a member of subpartitionMemoryDataManager, using a
+                // fixed subpartition id is enough.
+                SUBPARTITION_ID,
+                consumerId,
+                memoryDataManagerOperation);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
@@ -75,7 +75,7 @@ class HsSubpartitionFileReaderImplTest {
 
     private HsFileDataIndex diskIndex;
 
-    private TestingSubpartitionViewInternalOperation subpartitionOperation;
+    private TestingSubpartitionConsumerInternalOperation subpartitionOperation;
 
     private FileChannel dataFileChannel;
 
@@ -87,7 +87,7 @@ class HsSubpartitionFileReaderImplTest {
         Path dataFilePath = Files.createFile(tempPath.resolve(UUID.randomUUID().toString()));
         dataFileChannel = openFileChannel(dataFilePath);
         diskIndex = new HsFileDataIndexImpl(1);
-        subpartitionOperation = new TestingSubpartitionViewInternalOperation();
+        subpartitionOperation = new TestingSubpartitionConsumerInternalOperation();
         currentFileOffset = 0L;
     }
 
@@ -99,10 +99,10 @@ class HsSubpartitionFileReaderImplTest {
     @Test
     void testReadBuffer() throws Exception {
         diskIndex = new HsFileDataIndexImpl(2);
-        TestingSubpartitionViewInternalOperation viewNotifier1 =
-                new TestingSubpartitionViewInternalOperation();
-        TestingSubpartitionViewInternalOperation viewNotifier2 =
-                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier1 =
+                new TestingSubpartitionConsumerInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier2 =
+                new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl fileReader1 = createSubpartitionFileReader(0, viewNotifier1);
         HsSubpartitionFileReaderImpl fileReader2 = createSubpartitionFileReader(1, viewNotifier2);
 
@@ -142,8 +142,8 @@ class HsSubpartitionFileReaderImplTest {
                 new BufferDecompressor(bufferSize, compressionFactoryName);
 
         diskIndex = new HsFileDataIndexImpl(1);
-        TestingSubpartitionViewInternalOperation viewNotifier =
-                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier =
+                new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl fileReader1 = createSubpartitionFileReader(0, viewNotifier);
 
         writeDataToFile(0, 0, 1, 3, bufferCompressor);
@@ -362,10 +362,10 @@ class HsSubpartitionFileReaderImplTest {
     @Test
     void testCompareTo() throws Exception {
         diskIndex = new HsFileDataIndexImpl(2);
-        TestingSubpartitionViewInternalOperation viewNotifier1 =
-                new TestingSubpartitionViewInternalOperation();
-        TestingSubpartitionViewInternalOperation viewNotifier2 =
-                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier1 =
+                new TestingSubpartitionConsumerInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier2 =
+                new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl fileReader1 = createSubpartitionFileReader(0, viewNotifier1);
         HsSubpartitionFileReaderImpl fileReader2 = createSubpartitionFileReader(1, viewNotifier2);
         assertThat(fileReader1).isEqualByComparingTo(fileReader2);
@@ -390,8 +390,8 @@ class HsSubpartitionFileReaderImplTest {
 
     @Test
     void testConsumeBuffer() throws Throwable {
-        TestingSubpartitionViewInternalOperation viewNotifier =
-                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier =
+                new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl subpartitionFileReader =
                 createSubpartitionFileReader(0, viewNotifier);
 
@@ -428,8 +428,8 @@ class HsSubpartitionFileReaderImplTest {
 
     @Test
     void testPeekNextToConsumeDataTypeOrConsumeBufferThrowException() {
-        TestingSubpartitionViewInternalOperation viewNotifier =
-                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier =
+                new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl subpartitionFileReader =
                 createSubpartitionFileReader(0, viewNotifier);
 
@@ -446,8 +446,8 @@ class HsSubpartitionFileReaderImplTest {
 
     @Test
     void testPeekNextToConsumeDataType() throws Throwable {
-        TestingSubpartitionViewInternalOperation viewNotifier =
-                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier =
+                new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl subpartitionFileReader =
                 createSubpartitionFileReader(0, viewNotifier);
 
@@ -477,8 +477,8 @@ class HsSubpartitionFileReaderImplTest {
      */
     @Test
     void testSubpartitionReaderRegisterMultipleTimes() throws Exception {
-        TestingSubpartitionViewInternalOperation viewNotifier =
-                new TestingSubpartitionViewInternalOperation();
+        TestingSubpartitionConsumerInternalOperation viewNotifier =
+                new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl subpartitionFileReader =
                 createSubpartitionFileReader(0, viewNotifier);
         // mock the scenario that buffer 0 is already read form memory.
@@ -491,7 +491,7 @@ class HsSubpartitionFileReaderImplTest {
         checkData(subpartitionFileReader, 2, 3);
 
         // after failover, new view and subpartitionFileReader will be created.
-        viewNotifier = new TestingSubpartitionViewInternalOperation();
+        viewNotifier = new TestingSubpartitionConsumerInternalOperation();
         subpartitionFileReader = createSubpartitionFileReader(0, viewNotifier);
         subpartitionFileReader.prepareForScheduling();
         memorySegments = createsMemorySegments(3);
@@ -529,7 +529,7 @@ class HsSubpartitionFileReaderImplTest {
     }
 
     private HsSubpartitionFileReaderImpl createSubpartitionFileReader(
-            int targetChannel, HsSubpartitionViewInternalOperations operations) {
+            int targetChannel, HsSubpartitionConsumerInternalOperations operations) {
         return new HsSubpartitionFileReaderImpl(
                 targetChannel,
                 dataFileChannel,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManagerTest.java
@@ -53,6 +53,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatusWithId.ALL_ANY;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatusWithId.fromStatusAndConsumerId;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createBufferBuilder;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createTestingOutputMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -290,40 +292,44 @@ class HsSubpartitionMemoryDataManagerTest {
         subpartitionMemoryDataManager.consumeBuffer(1);
 
         checkBufferIndex(
-                subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.ALL, ConsumeStatus.ALL),
+                subpartitionMemoryDataManager.getBuffersSatisfyStatus(SpillStatus.ALL, ALL_ANY),
                 Arrays.asList(0, 1, 2, 3));
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.ALL, ConsumeStatus.CONSUMED),
+                        SpillStatus.ALL,
+                        fromStatusAndConsumerId(ConsumeStatus.CONSUMED, HsConsumerId.DEFAULT)),
                 Arrays.asList(0, 1));
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.ALL, ConsumeStatus.NOT_CONSUMED),
+                        SpillStatus.ALL,
+                        fromStatusAndConsumerId(ConsumeStatus.NOT_CONSUMED, HsConsumerId.DEFAULT)),
                 Arrays.asList(2, 3));
         checkBufferIndex(
-                subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.SPILL, ConsumeStatus.ALL),
+                subpartitionMemoryDataManager.getBuffersSatisfyStatus(SpillStatus.SPILL, ALL_ANY),
                 Arrays.asList(1, 2));
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.NOT_SPILL, ConsumeStatus.ALL),
+                        SpillStatus.NOT_SPILL, ALL_ANY),
                 Arrays.asList(0, 3));
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.SPILL, ConsumeStatus.NOT_CONSUMED),
+                        SpillStatus.SPILL,
+                        fromStatusAndConsumerId(ConsumeStatus.NOT_CONSUMED, HsConsumerId.DEFAULT)),
                 Collections.singletonList(2));
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.SPILL, ConsumeStatus.CONSUMED),
+                        SpillStatus.SPILL,
+                        fromStatusAndConsumerId(ConsumeStatus.CONSUMED, HsConsumerId.DEFAULT)),
                 Collections.singletonList(1));
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.NOT_SPILL, ConsumeStatus.CONSUMED),
+                        SpillStatus.NOT_SPILL,
+                        fromStatusAndConsumerId(ConsumeStatus.CONSUMED, HsConsumerId.DEFAULT)),
                 Collections.singletonList(0));
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(
-                        SpillStatus.NOT_SPILL, ConsumeStatus.NOT_CONSUMED),
+                        SpillStatus.NOT_SPILL,
+                        fromStatusAndConsumerId(ConsumeStatus.NOT_CONSUMED, HsConsumerId.DEFAULT)),
                 Collections.singletonList(3));
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionMemoryDataManagerTest.java
@@ -28,7 +28,6 @@ import org.apache.flink.runtime.io.network.buffer.Buffer.DataType;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilder;
 import org.apache.flink.runtime.io.network.buffer.BufferCompressor;
 import org.apache.flink.runtime.io.network.buffer.BufferDecompressor;
-import org.apache.flink.runtime.io.network.buffer.ReadOnlySlicedNetworkBuffer;
 import org.apache.flink.runtime.io.network.partition.ResultSubpartition.BufferAndBacklog;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatus;
 import org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.SpillStatus;
@@ -53,11 +52,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsConsumerId.DEFAULT;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatusWithId.ALL_ANY;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HsSpillingInfoProvider.ConsumeStatusWithId.fromStatusAndConsumerId;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createBufferBuilder;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createTestingOutputMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link HsSubpartitionMemoryDataManager}. */
 class HsSubpartitionMemoryDataManagerTest {
@@ -121,98 +123,9 @@ class HsSubpartitionMemoryDataManagerTest {
         assertThat(finishedBuffers).hasValue(2);
     }
 
-    @Test
-    void testPeekNextToConsumeDataTypeNotMeetBufferIndexToConsume() throws Exception {
-        TestingMemoryDataManagerOperation memoryDataManagerOperation =
-                TestingMemoryDataManagerOperation.builder()
-                        .setRequestBufferFromPoolSupplier(() -> createBufferBuilder(RECORD_SIZE))
-                        .build();
-        HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
-                createSubpartitionMemoryDataManager(memoryDataManagerOperation);
-
-        subpartitionMemoryDataManager.append(createRecord(0), DataType.DATA_BUFFER);
-
-        assertThat(subpartitionMemoryDataManager.peekNextToConsumeDataType(1))
-                .isEqualTo(DataType.NONE);
-    }
-
-    @Test
-    void testPeekNextToConsumeDataTypeTrimHeadingReleasedBuffers() throws Exception {
-        TestingMemoryDataManagerOperation memoryDataManagerOperation =
-                TestingMemoryDataManagerOperation.builder()
-                        .setRequestBufferFromPoolSupplier(() -> createBufferBuilder(RECORD_SIZE))
-                        .build();
-        HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
-                createSubpartitionMemoryDataManager(memoryDataManagerOperation);
-
-        subpartitionMemoryDataManager.append(createRecord(0), DataType.DATA_BUFFER);
-        subpartitionMemoryDataManager.append(createRecord(1), DataType.DATA_BUFFER);
-        subpartitionMemoryDataManager.append(createRecord(2), DataType.EVENT_BUFFER);
-
-        List<BufferIndexAndChannel> toRelease =
-                HybridShuffleTestUtils.createBufferIndexAndChannelsList(0, 0, 1);
-        subpartitionMemoryDataManager.releaseSubpartitionBuffers(toRelease);
-
-        assertThat(subpartitionMemoryDataManager.peekNextToConsumeDataType(2))
-                .isEqualTo(DataType.EVENT_BUFFER);
-    }
-
-    @Test
-    void testConsumeBufferFirstUnConsumedBufferIndexNotMeetNextToConsume() throws Exception {
-        TestingMemoryDataManagerOperation memoryDataManagerOperation =
-                TestingMemoryDataManagerOperation.builder()
-                        .setRequestBufferFromPoolSupplier(() -> createBufferBuilder(RECORD_SIZE))
-                        .build();
-        HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
-                createSubpartitionMemoryDataManager(memoryDataManagerOperation);
-
-        subpartitionMemoryDataManager.append(createRecord(0), DataType.DATA_BUFFER);
-
-        assertThat(subpartitionMemoryDataManager.consumeBuffer(1)).isNotPresent();
-    }
-
-    @Test
-    void testConsumeBufferTrimHeadingReleasedBuffers() throws Exception {
-        TestingMemoryDataManagerOperation memoryDataManagerOperation =
-                TestingMemoryDataManagerOperation.builder()
-                        .setRequestBufferFromPoolSupplier(() -> createBufferBuilder(RECORD_SIZE))
-                        .build();
-        HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
-                createSubpartitionMemoryDataManager(memoryDataManagerOperation);
-
-        subpartitionMemoryDataManager.append(createRecord(0), DataType.DATA_BUFFER);
-        subpartitionMemoryDataManager.append(createRecord(1), DataType.DATA_BUFFER);
-        subpartitionMemoryDataManager.append(createRecord(2), DataType.EVENT_BUFFER);
-
-        List<BufferIndexAndChannel> toRelease =
-                HybridShuffleTestUtils.createBufferIndexAndChannelsList(0, 0, 1);
-        subpartitionMemoryDataManager.releaseSubpartitionBuffers(toRelease);
-
-        assertThat(subpartitionMemoryDataManager.consumeBuffer(2)).isPresent();
-    }
-
-    @Test
-    void testConsumeBufferReturnSlice() throws Exception {
-        TestingMemoryDataManagerOperation memoryDataManagerOperation =
-                TestingMemoryDataManagerOperation.builder()
-                        .setRequestBufferFromPoolSupplier(() -> createBufferBuilder(RECORD_SIZE))
-                        .build();
-        HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
-                createSubpartitionMemoryDataManager(memoryDataManagerOperation);
-
-        subpartitionMemoryDataManager.append(createRecord(0), DataType.DATA_BUFFER);
-
-        Optional<BufferAndBacklog> bufferOpt = subpartitionMemoryDataManager.consumeBuffer(0);
-        assertThat(bufferOpt)
-                .hasValueSatisfying(
-                        (bufferAndBacklog ->
-                                assertThat(bufferAndBacklog.buffer())
-                                        .isInstanceOf(ReadOnlySlicedNetworkBuffer.class)));
-    }
-
     @ParameterizedTest
     @ValueSource(strings = {"LZ4", "LZO", "ZSTD", "NULL"})
-    void testConsumeBuffer(String compressionFactoryName) throws Exception {
+    void testCompressBufferAndConsume(String compressionFactoryName) throws Exception {
         final int numDataBuffers = 10;
         final int numRecordsPerBuffer = 10;
         // write numRecordsPerBuffer long record to one buffer, as a single long is
@@ -248,9 +161,11 @@ class HsSubpartitionMemoryDataManagerTest {
         subpartitionMemoryDataManager.append(createRecord(recordValue), DataType.EVENT_BUFFER);
         expectedRecords.add(Tuple2.of(recordValue, DataType.EVENT_BUFFER));
 
+        HsSubpartitionConsumerMemoryDataManager consumer =
+                subpartitionMemoryDataManager.registerNewConsumer(DEFAULT);
         ArrayList<Optional<BufferAndBacklog>> bufferAndBacklogOpts = new ArrayList<>();
         for (int i = 0; i < numDataBuffers + 1; i++) {
-            bufferAndBacklogOpts.add(subpartitionMemoryDataManager.consumeBuffer(i));
+            bufferAndBacklogOpts.add(consumer.consumeBuffer(i));
         }
         checkConsumedBufferAndNextDataType(
                 numRecordsPerBuffer, bufferDecompressor, expectedRecords, bufferAndBacklogOpts);
@@ -276,6 +191,8 @@ class HsSubpartitionMemoryDataManagerTest {
                         .build();
         HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
                 createSubpartitionMemoryDataManager(memoryDataManagerOperation);
+        HsSubpartitionConsumerMemoryDataManager consumer =
+                subpartitionMemoryDataManager.registerNewConsumer(DEFAULT);
         final int numBuffers = 4;
         for (int i = 0; i < numBuffers; i++) {
             subpartitionMemoryDataManager.append(createRecord(i), DataType.DATA_BUFFER);
@@ -288,8 +205,8 @@ class HsSubpartitionMemoryDataManagerTest {
         subpartitionMemoryDataManager.spillSubpartitionBuffers(toStartSpilling, spilledDoneFuture);
 
         // consume buffer 0, 1
-        subpartitionMemoryDataManager.consumeBuffer(0);
-        subpartitionMemoryDataManager.consumeBuffer(1);
+        consumer.consumeBuffer(0);
+        consumer.consumeBuffer(1);
 
         checkBufferIndex(
                 subpartitionMemoryDataManager.getBuffersSatisfyStatus(SpillStatus.ALL, ALL_ANY),
@@ -430,6 +347,33 @@ class HsSubpartitionMemoryDataManagerTest {
                 DataType.EVENT_BUFFER);
         assertThat(metrics.getNumBuffersOut().getCount()).isEqualTo(2);
         assertThat(metrics.getNumBytesOut().getCount()).isEqualTo(recordSize + eventSize);
+    }
+
+    @Test
+    void testConsumerRegisterRepeatedly() {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
+                createSubpartitionMemoryDataManager(memoryDataManagerOperation);
+
+        HsConsumerId consumerId = HsConsumerId.newId(null);
+        subpartitionMemoryDataManager.registerNewConsumer(consumerId);
+        assertThatThrownBy(() -> subpartitionMemoryDataManager.registerNewConsumer(consumerId))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testRegisterAndReleaseConsumer() {
+        TestingMemoryDataManagerOperation memoryDataManagerOperation =
+                TestingMemoryDataManagerOperation.builder().build();
+        HsSubpartitionMemoryDataManager subpartitionMemoryDataManager =
+                createSubpartitionMemoryDataManager(memoryDataManagerOperation);
+
+        HsConsumerId consumerId = HsConsumerId.newId(null);
+        subpartitionMemoryDataManager.registerNewConsumer(consumerId);
+        subpartitionMemoryDataManager.releaseConsumer(consumerId);
+        assertThatNoException()
+                .isThrownBy(() -> subpartitionMemoryDataManager.registerNewConsumer(consumerId));
     }
 
     private static void checkBufferIndex(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
@@ -42,11 +42,11 @@ import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffle
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Tests for {@link HsSubpartitionView}. */
+/** Tests for {@link HsSubpartitionConsumer}. */
 class HsSubpartitionViewTest {
     @Test
     void testGetNextBufferFromDisk() {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
 
         BufferAndBacklog bufferAndBacklog = createBufferAndBacklog(1, DataType.DATA_BUFFER, 0);
         CompletableFuture<Void> consumeBufferFromMemoryFuture = new CompletableFuture<>();
@@ -77,7 +77,7 @@ class HsSubpartitionViewTest {
         final int bufferSize = 16;
         NetworkBufferPool networkBufferPool = new NetworkBufferPool(10, bufferSize);
         BufferPool bufferPool = networkBufferPool.createBufferPool(10, 10);
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
 
         CompletableFuture<Void> acquireWriteLock = new CompletableFuture<>();
 
@@ -102,7 +102,8 @@ class HsSubpartitionViewTest {
                                     } catch (Exception e) {
                                         throw new RuntimeException(e);
                                     }
-                                    spillingInfoProvider.getNextBufferIndexToConsume();
+                                    spillingInfoProvider.getNextBufferIndexToConsume(
+                                            HsConsumerId.DEFAULT);
                                     return HsSpillingStrategy.Decision.NO_ACTION;
                                 })
                         .build();
@@ -117,7 +118,8 @@ class HsSubpartitionViewTest {
                         null,
                         0);
         memoryDataManager.setOutputMetrics(createTestingOutputMetrics());
-        HsDataView hsDataView = memoryDataManager.registerSubpartitionView(0, subpartitionView);
+        HsDataView hsDataView =
+                memoryDataManager.registerNewConsumer(0, HsConsumerId.DEFAULT, subpartitionView);
         subpartitionView.setMemoryDataView(hsDataView);
         subpartitionView.setDiskDataView(TestingHsDataView.NO_OP);
 
@@ -128,7 +130,7 @@ class HsSubpartitionViewTest {
 
     @Test
     void testGetNextBufferFromDiskNextDataTypeIsNone() {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
         BufferAndBacklog bufferAndBacklog = createBufferAndBacklog(0, DataType.NONE, 0);
 
         TestingHsDataView diskDataView =
@@ -158,7 +160,7 @@ class HsSubpartitionViewTest {
 
     @Test
     void testGetNextBufferFromMemory() {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
 
         BufferAndBacklog bufferAndBacklog = createBufferAndBacklog(1, DataType.DATA_BUFFER, 0);
         TestingHsDataView memoryDataView =
@@ -179,7 +181,7 @@ class HsSubpartitionViewTest {
 
     @Test
     void testGetNextBufferThrowException() {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
 
         TestingHsDataView diskDataView =
                 TestingHsDataView.builder()
@@ -200,7 +202,7 @@ class HsSubpartitionViewTest {
 
     @Test
     void testGetNextBufferZeroBacklog() {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
 
         final int diskBacklog = 0;
         final int memoryBacklog = 10;
@@ -236,7 +238,7 @@ class HsSubpartitionViewTest {
     @Test
     void testNotifyDataAvailableNeedNotify() {
         CompletableFuture<Void> notifyAvailableFuture = new CompletableFuture<>();
-        HsSubpartitionView subpartitionView =
+        HsSubpartitionConsumer subpartitionView =
                 createSubpartitionView(() -> notifyAvailableFuture.complete(null));
 
         TestingHsDataView memoryDataView =
@@ -256,7 +258,7 @@ class HsSubpartitionViewTest {
     @Test
     void testNotifyDataAvailableNotNeedNotify() {
         CompletableFuture<Void> notifyAvailableFuture = new CompletableFuture<>();
-        HsSubpartitionView subpartitionView =
+        HsSubpartitionConsumer subpartitionView =
                 createSubpartitionView(() -> notifyAvailableFuture.complete(null));
 
         TestingHsDataView memoryDataView =
@@ -277,7 +279,7 @@ class HsSubpartitionViewTest {
     @Test
     void testGetZeroBacklogNeedNotify() {
         CompletableFuture<Void> notifyAvailableFuture = new CompletableFuture<>();
-        HsSubpartitionView subpartitionView =
+        HsSubpartitionConsumer subpartitionView =
                 createSubpartitionView(() -> notifyAvailableFuture.complete(null));
         subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
         subpartitionView.setDiskDataView(
@@ -294,7 +296,7 @@ class HsSubpartitionViewTest {
 
     @Test
     void testGetAvailabilityAndBacklogPositiveCredit() {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
         subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
 
         final int backlog = 2;
@@ -311,7 +313,7 @@ class HsSubpartitionViewTest {
     void testGetAvailabilityAndBacklogNonPositiveCreditNextIsData() {
         final int backlog = 2;
 
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
         subpartitionView.setMemoryDataView(
                 TestingHsDataView.builder()
                         .setConsumeBufferFunction(
@@ -336,7 +338,7 @@ class HsSubpartitionViewTest {
     void testGetAvailabilityAndBacklogNonPositiveCreditNextIsEvent() {
         final int backlog = 2;
 
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
         subpartitionView.setMemoryDataView(
                 TestingHsDataView.builder()
                         .setConsumeBufferFunction(
@@ -359,23 +361,29 @@ class HsSubpartitionViewTest {
 
     @Test
     void testRelease() throws Exception {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
-        CompletableFuture<Void> releaseDataViewFuture = new CompletableFuture<>();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
+        CompletableFuture<Void> releaseDiskViewFuture = new CompletableFuture<>();
+        CompletableFuture<Void> releaseMemoryViewFuture = new CompletableFuture<>();
         TestingHsDataView diskDataView =
                 TestingHsDataView.builder()
-                        .setReleaseDataViewRunnable(() -> releaseDataViewFuture.complete(null))
+                        .setReleaseDataViewRunnable(() -> releaseDiskViewFuture.complete(null))
+                        .build();
+        TestingHsDataView memoryDataView =
+                TestingHsDataView.builder()
+                        .setReleaseDataViewRunnable(() -> releaseMemoryViewFuture.complete(null))
                         .build();
         subpartitionView.setDiskDataView(diskDataView);
-        subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
+        subpartitionView.setMemoryDataView(memoryDataView);
         subpartitionView.releaseAllResources();
         assertThat(subpartitionView.isReleased()).isTrue();
-        assertThat(releaseDataViewFuture).isCompleted();
+        assertThat(releaseDiskViewFuture).isCompleted();
+        assertThat(releaseMemoryViewFuture).isCompleted();
     }
 
     @Test
     void testGetConsumingOffset() {
         AtomicInteger nextBufferIndex = new AtomicInteger(0);
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
         TestingHsDataView diskDataView =
                 TestingHsDataView.builder()
                         .setConsumeBufferFunction(
@@ -398,7 +406,7 @@ class HsSubpartitionViewTest {
 
     @Test
     void testSetDataViewRepeatedly() {
-        HsSubpartitionView subpartitionView = createSubpartitionView();
+        HsSubpartitionConsumer subpartitionView = createSubpartitionView();
 
         subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP);
         assertThatThrownBy(() -> subpartitionView.setMemoryDataView(TestingHsDataView.NO_OP))
@@ -411,13 +419,13 @@ class HsSubpartitionViewTest {
                 .hasMessageContaining("repeatedly set disk data view is not allowed.");
     }
 
-    private static HsSubpartitionView createSubpartitionView() {
-        return new HsSubpartitionView(new NoOpBufferAvailablityListener());
+    private static HsSubpartitionConsumer createSubpartitionView() {
+        return new HsSubpartitionConsumer(new NoOpBufferAvailablityListener());
     }
 
-    private static HsSubpartitionView createSubpartitionView(
+    private static HsSubpartitionConsumer createSubpartitionView(
             BufferAvailabilityListener bufferAvailabilityListener) {
-        return new HsSubpartitionView(bufferAvailabilityListener);
+        return new HsSubpartitionConsumer(bufferAvailabilityListener);
     }
 
     private static BufferAndBacklog createBufferAndBacklog(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
@@ -73,7 +73,7 @@ public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
     }
 
     @Override
-    public List<Integer> getNextBufferIndexToConsume() {
+    public List<Integer> getNextBufferIndexToConsume(HsConsumerId consumerId) {
         return getNextBufferIndexToConsumeSupplier.get();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSpillingInfoProvider.java
@@ -79,7 +79,7 @@ public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
 
     @Override
     public Deque<BufferIndexAndChannel> getBuffersInOrder(
-            int subpartitionId, SpillStatus spillStatus, ConsumeStatus consumeStatus) {
+            int subpartitionId, SpillStatus spillStatus, ConsumeStatusWithId consumeStatusWithId) {
         Deque<BufferIndexAndChannel> buffersInOrder = new ArrayDeque<>();
 
         List<BufferIndexAndChannel> subpartitionBuffers = allBuffers.get(subpartitionId);
@@ -90,7 +90,7 @@ public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
         for (int i = 0; i < subpartitionBuffers.size(); i++) {
             if (isBufferSatisfyStatus(
                     spillStatus,
-                    consumeStatus,
+                    consumeStatusWithId,
                     spillBufferIndexes
                             .getOrDefault(subpartitionId, Collections.emptySet())
                             .contains(i),
@@ -124,7 +124,7 @@ public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
 
     private static boolean isBufferSatisfyStatus(
             SpillStatus spillStatus,
-            ConsumeStatus consumeStatus,
+            ConsumeStatusWithId consumeStatusWithId,
             boolean isSpill,
             boolean isConsumed) {
         boolean isNeeded = true;
@@ -136,7 +136,7 @@ public class TestingSpillingInfoProvider implements HsSpillingInfoProvider {
                 isNeeded = isSpill;
                 break;
         }
-        switch (consumeStatus) {
+        switch (consumeStatusWithId.status) {
             case NOT_CONSUMED:
                 isNeeded &= !isConsumed;
                 break;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionConsumerInternalOperation.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingSubpartitionConsumerInternalOperation.java
@@ -18,22 +18,29 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid;
 
-/**
- * Operations provided by HsSubpartitionView that are used by other internal components of hybrid
- * result partition.
- */
-public interface HsSubpartitionViewInternalOperations {
+/** Mock {@link HsSubpartitionConsumerInternalOperations} for test. */
+public class TestingSubpartitionConsumerInternalOperation
+        implements HsSubpartitionConsumerInternalOperations {
+    // -1 indicates downstream just start consuming offset.
+    private int consumingOffset = -1;
 
-    /** Callback for new data become available. */
-    void notifyDataAvailable();
+    private Runnable notifyDataAvailableRunnable = () -> {};
 
-    /**
-     * Get the latest consuming offset of the subpartition.
-     *
-     * @param withLock If true, read the consuming offset outside the guarding of lock. This is
-     *     sometimes desired to avoid lock contention, if the caller does not depend on any other
-     *     states to change atomically with the consuming offset.
-     * @return latest consuming offset.
-     */
-    int getConsumingOffset(boolean withLock);
+    @Override
+    public void notifyDataAvailable() {
+        notifyDataAvailableRunnable.run();
+    }
+
+    @Override
+    public int getConsumingOffset(boolean withLock) {
+        return consumingOffset;
+    }
+
+    public void advanceConsumptionProgress() {
+        consumingOffset++;
+    }
+
+    public void setNotifyDataAvailableRunnable(Runnable notifyDataAvailableRunnable) {
+        this.notifyDataAvailableRunnable = notifyDataAvailableRunnable;
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/PartitionDescriptorBuilder.java
@@ -28,6 +28,8 @@ public class PartitionDescriptorBuilder {
     private ResultPartitionType partitionType;
     private int totalNumberOfPartitions = 1;
 
+    private boolean isBroadcast = false;
+
     private PartitionDescriptorBuilder() {
         this.partitionId = new IntermediateResultPartitionID();
         this.partitionType = ResultPartitionType.PIPELINED;
@@ -48,6 +50,11 @@ public class PartitionDescriptorBuilder {
         return this;
     }
 
+    public PartitionDescriptorBuilder setIsBroadcast(boolean isBroadcast) {
+        this.isBroadcast = isBroadcast;
+        return this;
+    }
+
     public PartitionDescriptor build() {
         return new PartitionDescriptor(
                 new IntermediateDataSetID(),
@@ -56,7 +63,7 @@ public class PartitionDescriptorBuilder {
                 partitionType,
                 1,
                 0,
-                false,
+                isBroadcast,
                 true);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

*Hybrid shuffle does not support multiple consumer for single subpartition data. This will bring some defects, such as the inability to support partition reuse, speculative execution. In particular, it cannot support broadcast optimization, that is, hybrid shuffle writes multiple copies of broadcast data, This will cause a waste of memory and disk space and affect the performance of shuffle write phase. Ideally, for the full spilling strategy, any broadcast data (record or event) should only write one piece of data in the memory, and the same is true for the disk.*

## Brief change log

  - *full spilling strategy is no long consider consumer offset*
  - *supports multiple consumer.*
  - *supports broadcast optimize*


## Verifying this change

This change added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
