### PR TITLE
[hotfix][table] Fix misleading state cleared message in SinkUpsertMaterializer

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/SinkUpsertMaterializer.java
@@ -67,8 +67,9 @@ public class SinkUpsertMaterializer extends TableStreamOperator<RowData>
     private static final Logger LOG = LoggerFactory.getLogger(SinkUpsertMaterializer.class);
 
     private static final String STATE_CLEARED_WARN_MSG =
-            "The state is cleared because of state ttl. This will result in incorrect result. "
-                    + "You can increase the state ttl to avoid this.";
+            "A delete or retract message is dropped, which may lead to wrong results. "
+                    + "You can try to increase the state TTL or ensure that "
+                    + "no non-deterministic functions or metadata fields are used.";
 
     private final StateTtlConfig ttlConfig;
     private final GeneratedRecordEqualiser generatedRecordEqualiser;


### PR DESCRIPTION
## What is the purpose of the change

When non-deterministic functions (like `UUID()`) or some special metadata fields (like `op_type`) are used in the source or sink fields, the `SinkUpsertMaterializer` may fail to match the `-U` or `-D` record with existing states, making the delete or retract record being erroneously dropped.

In this case, the error message in the log is misleading, as it only says it is the statel ttl that caused this issue, which is untrue as user may have not enabled state TTL at all.

## Brief change log

Enrich the error message to tell users more potential reasons.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no