### PR TITLE
[FLINK-29730][checkpoint] Do not support concurrent unaligned checkpoints in the ChannelStateWriteRequestDispatcherImpl

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateCheckpointWriter.java
@@ -73,7 +73,7 @@ class ChannelStateCheckpointWriter {
     private boolean allOutputsReceived = false;
     private final RunnableWithException onComplete;
     private final int subtaskIndex;
-    private String taskName;
+    private final String taskName;
 
     ChannelStateCheckpointWriter(
             String taskName,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImpl.java
@@ -17,14 +17,14 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
+import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.state.CheckpointStorageWorkerView;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashMap;
-import java.util.Map;
-
+import static org.apache.flink.runtime.checkpoint.CheckpointFailureReason.CHECKPOINT_DECLINED_SUBSUMED;
+import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -36,12 +36,30 @@ final class ChannelStateWriteRequestDispatcherImpl implements ChannelStateWriteR
     private static final Logger LOG =
             LoggerFactory.getLogger(ChannelStateWriteRequestDispatcherImpl.class);
 
-    private final Map<Long, ChannelStateCheckpointWriter>
-            writers; // limited indirectly by results max size
     private final CheckpointStorageWorkerView streamFactoryResolver;
     private final ChannelStateSerializer serializer;
     private final int subtaskIndex;
     private final String taskName;
+
+    /**
+     * It is the checkpointId corresponding to writer. And It should be always update with {@link
+     * #writer}.
+     */
+    private long ongoingCheckpointId;
+
+    /**
+     * The checkpoint that checkpointId is less than or equal to maxAbortedCheckpointId should be
+     * aborted.
+     */
+    private long maxAbortedCheckpointId;
+
+    /** The aborted cause of the maxAbortedCheckpointId. */
+    private Throwable abortedCause;
+
+    /**
+     * The channelState writer of ongoing checkpointId, it can be null when the writer is finished.
+     */
+    private ChannelStateCheckpointWriter writer;
 
     ChannelStateWriteRequestDispatcherImpl(
             String taskName,
@@ -50,9 +68,10 @@ final class ChannelStateWriteRequestDispatcherImpl implements ChannelStateWriteR
             ChannelStateSerializer serializer) {
         this.taskName = taskName;
         this.subtaskIndex = subtaskIndex;
-        this.writers = new HashMap<>();
         this.streamFactoryResolver = checkNotNull(streamFactoryResolver);
         this.serializer = checkNotNull(serializer);
+        this.ongoingCheckpointId = -1;
+        this.maxAbortedCheckpointId = -1;
     }
 
     @Override
@@ -71,22 +90,66 @@ final class ChannelStateWriteRequestDispatcherImpl implements ChannelStateWriteR
     }
 
     private void dispatchInternal(ChannelStateWriteRequest request) throws Exception {
+        if (isAbortedCheckpoint(request.getCheckpointId())) {
+            if (request.getCheckpointId() == maxAbortedCheckpointId) {
+                request.cancel(abortedCause);
+            } else {
+                request.cancel(new CheckpointException(CHECKPOINT_DECLINED_SUBSUMED));
+            }
+            return;
+        }
+
         if (request instanceof CheckpointStartRequest) {
             checkState(
-                    !writers.containsKey(request.getCheckpointId()),
-                    "writer not found for request " + request);
-            writers.put(request.getCheckpointId(), buildWriter((CheckpointStartRequest) request));
+                    request.getCheckpointId() > ongoingCheckpointId,
+                    String.format(
+                            "Checkpoint must be incremented, ongoingCheckpointId is %s, but the request is %s.",
+                            ongoingCheckpointId, request));
+            failAndClearWriter(
+                    new IllegalStateException(
+                            String.format(
+                                    "Task[name=%s, subtaskIndex=%s] has uncompleted channelState writer of checkpointId=%s, "
+                                            + "but it received a new checkpoint start request of checkpointId=%s, it maybe "
+                                            + "a bug due to currently not supported concurrent unaligned checkpoint.",
+                                    taskName,
+                                    subtaskIndex,
+                                    ongoingCheckpointId,
+                                    request.getCheckpointId())));
+            this.writer = buildWriter((CheckpointStartRequest) request);
+            this.ongoingCheckpointId = request.getCheckpointId();
         } else if (request instanceof CheckpointInProgressRequest) {
-            ChannelStateCheckpointWriter writer = writers.get(request.getCheckpointId());
             CheckpointInProgressRequest req = (CheckpointInProgressRequest) request;
-            if (writer == null) {
-                req.onWriterMissing();
-            } else {
-                req.execute(writer);
+            checkArgument(
+                    ongoingCheckpointId == req.getCheckpointId() && writer != null,
+                    "writer not found while processing request: " + req);
+            req.execute(writer);
+        } else if (request instanceof CheckpointAbortRequest) {
+            CheckpointAbortRequest req = (CheckpointAbortRequest) request;
+            if (request.getCheckpointId() > maxAbortedCheckpointId) {
+                this.maxAbortedCheckpointId = req.getCheckpointId();
+                this.abortedCause = req.getThrowable();
+            }
+
+            if (req.getCheckpointId() == ongoingCheckpointId) {
+                failAndClearWriter(req.getThrowable());
+            } else if (request.getCheckpointId() > ongoingCheckpointId) {
+                failAndClearWriter(new CheckpointException(CHECKPOINT_DECLINED_SUBSUMED));
             }
         } else {
             throw new IllegalArgumentException("unknown request type: " + request);
         }
+    }
+
+    private boolean isAbortedCheckpoint(long checkpointId) {
+        return checkpointId < ongoingCheckpointId || checkpointId <= maxAbortedCheckpointId;
+    }
+
+    private void failAndClearWriter(Throwable e) {
+        if (writer == null) {
+            return;
+        }
+        writer.fail(e);
+        writer = null;
     }
 
     private ChannelStateCheckpointWriter buildWriter(CheckpointStartRequest request)
@@ -98,18 +161,26 @@ final class ChannelStateWriteRequestDispatcherImpl implements ChannelStateWriteR
                 streamFactoryResolver.resolveCheckpointStorageLocation(
                         request.getCheckpointId(), request.getLocationReference()),
                 serializer,
-                () -> writers.remove(request.getCheckpointId()));
+                () -> {
+                    checkState(
+                            request.getCheckpointId() == ongoingCheckpointId,
+                            "The ongoingCheckpointId[%s] was changed when clear writer of checkpoint[%s], it might be a bug.",
+                            ongoingCheckpointId,
+                            request.getCheckpointId());
+                    this.writer = null;
+                });
     }
 
     @Override
     public void fail(Throwable cause) {
-        for (ChannelStateCheckpointWriter writer : writers.values()) {
-            try {
-                writer.fail(cause);
-            } catch (Exception ex) {
-                LOG.warn("unable to fail write channel state writer", cause);
-            }
+        if (writer == null) {
+            return;
         }
-        writers.clear();
+        try {
+            writer.fail(cause);
+        } catch (Exception ex) {
+            LOG.warn("unable to fail write channel state writer", cause);
+        }
+        writer = null;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImpl.java
@@ -41,7 +41,7 @@ final class ChannelStateWriteRequestDispatcherImpl implements ChannelStateWriteR
     private final CheckpointStorageWorkerView streamFactoryResolver;
     private final ChannelStateSerializer serializer;
     private final int subtaskIndex;
-    private String taskName;
+    private final String taskName;
 
     ChannelStateWriteRequestDispatcherImpl(
             String taskName,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
@@ -39,6 +39,7 @@ import static org.apache.flink.util.CloseableIterator.ofElements;
 import static org.apache.flink.util.ExceptionUtils.findThrowable;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /** {@link ChannelStateWriterImpl} lifecycle tests. */
 public class ChannelStateWriterImplTest {
@@ -118,6 +119,33 @@ public class ChannelStateWriterImplTest {
     @Test
     public void testAbortIgnoresMissing() throws Exception {
         runWithSyncWorker(this::callAbort);
+    }
+
+    @Test
+    public void testAbortOldAndStartNewCheckpoint() throws Exception {
+        runWithSyncWorker(
+                (writer, worker) -> {
+                    int checkpoint42 = 42;
+                    int checkpoint43 = 43;
+                    writer.start(
+                            checkpoint42, CheckpointOptions.forCheckpointWithDefaultLocation());
+                    writer.abort(checkpoint42, new TestException(), false);
+                    writer.start(
+                            checkpoint43, CheckpointOptions.forCheckpointWithDefaultLocation());
+                    worker.processAllRequests();
+
+                    ChannelStateWriteResult result42 = writer.getAndRemoveWriteResult(checkpoint42);
+                    assertTrue(result42.isDone());
+                    try {
+                        result42.getInputChannelStateHandles().get();
+                        fail("The result should have failed.");
+                    } catch (Throwable throwable) {
+                        assertTrue(findThrowable(throwable, TestException.class).isPresent());
+                    }
+
+                    ChannelStateWriteResult result43 = writer.getAndRemoveWriteResult(checkpoint43);
+                    assertFalse(result43.isDone());
+                });
     }
 
     @Test(expected = TestException.class)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/CheckpointInProgressRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/CheckpointInProgressRequestTest.java
@@ -67,8 +67,7 @@ public class CheckpointInProgressRequestTest {
                 unused -> {
                     cancelCounter.incrementAndGet();
                     await(cb);
-                },
-                false);
+                });
     }
 
     private void await(CyclicBarrier cb) {


### PR DESCRIPTION
## What is the purpose of the change

 Simplify the ChannelStateWriteRequestDispatcherImpl due to not supported concurrent unaligned checkpoint

## Brief change log

The `Map<Long, ChannelStateCheckpointWriter> writers;` can be simplified to `long ongoingCheckpointId` and `ChannelStateCheckpointWriter writer`.


## Verifying this change

This change added tests and can be verified as follows:

  - *ChannelStateWriteRequestDispatcherImplTest.testConcurrentUnalignedCheckpoint()*
  - *ChannelStateWriterImplTest.testAbortOldAndStartNewCheckpoint()*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  not documented
