### PR TITLE
[FLINK-29733][hotfix] fix test error in flink-connector-hive

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/module/hive/HiveModuleTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.table.module.hive;
 
+import org.apache.flink.table.HiveVersionTestUtil;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.catalog.hive.HiveTestUtils;
@@ -37,8 +38,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.flink.table.catalog.hive.client.HiveShimLoader.HIVE_VERSION_V2_3_9;
-import static org.apache.flink.table.catalog.hive.client.HiveShimLoader.HIVE_VERSION_V3_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -72,15 +71,12 @@ public class HiveModuleTest {
     }
 
     private void verifyNumBuiltInFunctions(String hiveVersion, HiveModule hiveModule) {
-        switch (hiveVersion) {
-            case HIVE_VERSION_V2_3_9:
-                assertThat(hiveModule.listFunctions()).hasSize(277);
-                break;
-            case HIVE_VERSION_V3_1_1:
-                assertThat(hiveModule.listFunctions()).hasSize(296);
-                break;
-            default:
-                fail("Unknown test version " + hiveVersion);
+        if (HiveVersionTestUtil.HIVE_310_OR_LATER) {
+            assertThat(hiveModule.listFunctions()).hasSize(296);
+        } else if (HiveVersionTestUtil.HIVE_230_OR_LATER) {
+            assertThat(hiveModule.listFunctions()).hasSize(277);
+        } else {
+            fail("Unknown test version " + hiveVersion);
         }
     }
 


### PR DESCRIPTION

## What is the purpose of the change
This is a quick fix missed in FLINK-29478.


## Brief change log
adds 3.1.3 hive-connector-shim to run in test

## Verifying this change

Test related change 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 
