### PR TITLE
[hotfix] Fix some typo in HiveOptions.

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveOptions.java
@@ -100,7 +100,7 @@ public class HiveOptions {
             key("table.exec.hive.calculate-partition-size.thread-num")
                     .intType()
                     .defaultValue(3)
-                    .withDeprecatedKeys("The thread number to calculate partition's size.");
+                    .withDescription("The thread number to calculate partition's size.");
 
     public static final ConfigOption<Boolean> TABLE_EXEC_HIVE_DYNAMIC_GROUPING_ENABLED =
             key("table.exec.hive.sink.sort-by-dynamic-partition.enable")
@@ -156,7 +156,7 @@ public class HiveOptions {
                     key("table.exec.hive.sink.statistic-auto-gather.thread-num")
                             .intType()
                             .defaultValue(3)
-                            .withDeprecatedKeys(
+                            .withDescription(
                                     "The number of threads used to gather statistic during writing Hive Table"
                                             + " when the table is stored as ORC or Parquet format."
                                             + " The default value is 3.");


### PR DESCRIPTION
## What is the purpose of the change

*Fix some typo in HiveOptions.*


## Brief change log

  - *Using `withDescription` instead of `withDeprecatedKeys` for some config options.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
