### PR TITLE
HadoopConfigLoader should consider Hadoop configuration files

### DIFF
--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopConfigLoader.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/util/HadoopConfigLoader.java
@@ -94,7 +94,7 @@ public class HadoopConfigLoader {
     // add additional config entries from the Flink config to the Hadoop config
     private org.apache.hadoop.conf.Configuration loadHadoopConfigFromFlink() {
         org.apache.hadoop.conf.Configuration hadoopConfig =
-                new org.apache.hadoop.conf.Configuration();
+                HadoopUtils.getHadoopConfiguration(flinkConfig);
         for (String key : flinkConfig.keySet()) {
             for (String prefix : flinkConfigPrefixes) {
                 if (key.startsWith(prefix)) {

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/fs/hdfs/HadoopConfigLoadingTest.java
@@ -28,12 +28,11 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.apache.flink.runtime.util.ConfigurationFileUtil.printConfig;
+import static org.apache.flink.runtime.util.ConfigurationFileUtil.printConfigs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -302,26 +301,5 @@ public class HadoopConfigLoadingTest {
 
         // also contains classpath defaults
         assertEquals(IN_CP_CONFIG_VALUE, hadoopConf.get(IN_CP_CONFIG_KEY, null));
-    }
-
-    private static void printConfig(File file, String key, String value) throws IOException {
-        Map<String, String> map = new HashMap<>(1);
-        map.put(key, value);
-        printConfigs(file, map);
-    }
-
-    private static void printConfigs(File file, Map<String, String> properties) throws IOException {
-        try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
-            out.println("<?xml version=\"1.0\"?>");
-            out.println("<?xml-stylesheet type=\"text/xsl\" href=\"configuration.xsl\"?>");
-            out.println("<configuration>");
-            for (Map.Entry<String, String> entry : properties.entrySet()) {
-                out.println("\t<property>");
-                out.println("\t\t<name>" + entry.getKey() + "</name>");
-                out.println("\t\t<value>" + entry.getValue() + "</value>");
-                out.println("\t</property>");
-            }
-            out.println("</configuration>");
-        }
     }
 }

--- a/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/ConfigurationFileUtil.java
+++ b/flink-filesystems/flink-hadoop-fs/src/test/java/org/apache/flink/runtime/util/ConfigurationFileUtil.java
@@ -1,0 +1,34 @@
+package org.apache.flink.runtime.util;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.Map;
+
+/** Utility class for generating configuration file for tests. */
+public class ConfigurationFileUtil {
+    private ConfigurationFileUtil() {}
+
+    public static void printConfig(File file, String key, String value) throws IOException {
+        Map<String, String> map = new HashMap<>(1);
+        map.put(key, value);
+        printConfigs(file, map);
+    }
+
+    public static void printConfigs(File file, Map<String, String> properties) throws IOException {
+        try (PrintStream out = new PrintStream(new FileOutputStream(file))) {
+            out.println("<?xml version=\"1.0\"?>");
+            out.println("<?xml-stylesheet type=\"text/xsl\" href=\"configuration.xsl\"?>");
+            out.println("<configuration>");
+            for (Map.Entry<String, String> entry : properties.entrySet()) {
+                out.println("\t<property>");
+                out.println("\t\t<name>" + entry.getKey() + "</name>");
+                out.println("\t\t<value>" + entry.getValue() + "</value>");
+                out.println("\t</property>");
+            }
+            out.println("</configuration>");
+        }
+    }
+}

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -52,6 +52,12 @@ under the License.
 			</dependency>
 
 			<dependency>
+				<groupId>org.apache.hadoop</groupId>
+				<artifactId>hadoop-hdfs-client</artifactId>
+				<version>${fs.hadoopshaded.version}</version>
+			</dependency>
+
+			<dependency>
 				<!-- Bumped for security purposes -->
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
@@ -129,6 +135,12 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.hadoop</groupId>
+			<artifactId>hadoop-hdfs-client</artifactId>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
## What is the purpose of the change

Make sure that `HadoopConfigLoader` considers every Hadoop configuration which are set.

## Brief change log

* Changed `HadoopConfigLoader` to use `HadoopUtils.getHadoopConfiguration` instead of just creating a new `Configuration` object
* Created a new unit test for the case: `HadoopS3FileSystemTest.testConfigKeysFromHadoopConfig`
* Refactored the config file generating test utils from `HadoopConfigLoadingTest` to `ConfigurationFileUtil.java`, and reused them in the new test
* Added `hadoop-hdfs-client` test dependency to `flink-s3-fs-hadoop` project - **This is something which should be checked by more experienced Flink developers**

## Verifying this change

This change added tests and can be verified as follows:
 * Added a new unit test for the case: `HadoopS3FileSystemTest.testConfigKeysFromHadoopConfig` which reads the files and check the priority of the configs

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **yes**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **yes** - checkpointing will use the provided Hadoop configurations as well
  - The S3 file system connector: yes - but only the configuration loading

## Documentation

  - Does this pull request introduce a new feature? no - I think this is a bug
  - If yes, how is the feature documented? not applicable
