### PR TITLE
[hotfix][connectors][kafka] Remove unused private classes and methods

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -67,11 +67,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.DeleteTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -425,18 +421,6 @@ public class KafkaSinkITCase extends TestLogger {
         standardProps.put("zookeeper.session.timeout.ms", ZK_TIMEOUT_MILLIS);
         standardProps.put("zookeeper.connection.timeout.ms", ZK_TIMEOUT_MILLIS);
         return standardProps;
-    }
-
-    private static Consumer<byte[], byte[]> createTestConsumer(
-            String topic, Properties properties) {
-        final Properties consumerConfig = new Properties();
-        consumerConfig.putAll(properties);
-        consumerConfig.put("key.deserializer", ByteArrayDeserializer.class.getName());
-        consumerConfig.put("value.deserializer", ByteArrayDeserializer.class.getName());
-        consumerConfig.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
-        final KafkaConsumer<byte[], byte[]> kafkaConsumer = new KafkaConsumer<>(consumerConfig);
-        kafkaConsumer.subscribe(Collections.singletonList(topic));
-        return kafkaConsumer;
     }
 
     private void createTestTopic(String topic, int numPartitions, short replicationFactor)

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -558,23 +558,4 @@ public class KafkaEnumeratorTest {
             context.runNextOneTimeCallable();
         }
     }
-
-    // -------------- private class ----------------
-
-    private static class BlockingClosingContext
-            extends MockSplitEnumeratorContext<KafkaPartitionSplit> {
-
-        public BlockingClosingContext(int parallelism) {
-            super(parallelism);
-        }
-
-        @Override
-        public void close() {
-            try {
-                Thread.sleep(Long.MAX_VALUE);
-            } catch (InterruptedException e) {
-                // let it go.
-            }
-        }
-    }
 }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaProducerTestBase.java
@@ -23,15 +23,10 @@ import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.serialization.SerializationSchema;
 import org.apache.flink.api.common.serialization.TypeInformationSerializationSchema;
-import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.FunctionInitializationContext;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
@@ -61,8 +56,6 @@ import static org.assertj.core.api.Assertions.fail;
 /** Abstract test base for all Kafka producer tests. */
 @SuppressWarnings("serial")
 public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
-
-    private static final long KAFKA_READ_TIMEOUT = 60_000L;
 
     /**
      * This tests verifies that custom partitioning works correctly, with a default topic and
@@ -399,83 +392,6 @@ public abstract class KafkaProducerTestBase extends KafkaTestBaseWithFlink {
             if (!missing) {
                 throw new SuccessException();
             }
-        }
-    }
-
-    private static class BrokerRestartingMapper<T> extends RichMapFunction<T, T>
-            implements CheckpointedFunction, CheckpointListener {
-
-        private static final long serialVersionUID = 6334389850158707313L;
-
-        public static volatile boolean triggeredShutdown;
-        public static volatile int lastSnapshotedElementBeforeShutdown;
-        public static volatile Runnable shutdownAction;
-
-        private final int failCount;
-        private int numElementsTotal;
-
-        private boolean failer;
-
-        public static void resetState(Runnable shutdownAction) {
-            triggeredShutdown = false;
-            lastSnapshotedElementBeforeShutdown = 0;
-            BrokerRestartingMapper.shutdownAction = shutdownAction;
-        }
-
-        public BrokerRestartingMapper(int failCount) {
-            this.failCount = failCount;
-        }
-
-        @Override
-        public void open(Configuration parameters) {
-            failer = getRuntimeContext().getIndexOfThisSubtask() == 0;
-        }
-
-        @Override
-        public T map(T value) throws Exception {
-            numElementsTotal++;
-            Thread.sleep(10);
-
-            if (!triggeredShutdown && failer && numElementsTotal >= failCount) {
-                // shut down a Kafka broker
-                triggeredShutdown = true;
-                shutdownAction.run();
-            }
-            return value;
-        }
-
-        @Override
-        public void notifyCheckpointComplete(long checkpointId) {}
-
-        @Override
-        public void notifyCheckpointAborted(long checkpointId) {}
-
-        @Override
-        public void snapshotState(FunctionSnapshotContext context) throws Exception {
-            if (!triggeredShutdown) {
-                lastSnapshotedElementBeforeShutdown = numElementsTotal;
-            }
-        }
-
-        @Override
-        public void initializeState(FunctionInitializationContext context) throws Exception {}
-    }
-
-    private static final class InfiniteIntegerSource implements SourceFunction<Integer> {
-
-        private volatile boolean running = true;
-        private int counter = 0;
-
-        @Override
-        public void run(SourceContext<Integer> ctx) throws Exception {
-            while (running) {
-                ctx.collect(counter++);
-            }
-        }
-
-        @Override
-        public void cancel() {
-            running = false;
         }
     }
 }


### PR DESCRIPTION

## What is the purpose of the change
Remove unused private method/classes
_org.apache.flink.connector.kafka.sink.KafkaSinkITCase#createTestConsumer_ became unused after
https://github.com/apache/flink/commit/ade011ec139f8258db356abd65e6e83601cd22e1

_org.apache.flink.connector.kafka.source.enumerator.KafkaEnumeratorTest.BlockingClosingContext_ is unused since beginning

_org.apache.flink.streaming.connectors.kafka.KafkaProducerTestBase.BrokerRestartingMapper_ became unused after https://github.com/apache/flink/commit/5f5cab2f9a1175fa396833299c313c2de6d1dae3


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
