### PR TITLE
[FLINK-29757][connector-files]ContinuousFileSplitEnumerator skip unprocessed splits when the file is splittable

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplit.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/FileSourceSplit.java
@@ -293,6 +293,14 @@ public class FileSourceSplit implements SourceSplit, Serializable {
                 id, filePath, offset, length, fileModificationTime, fileSize, hostnames, position);
     }
 
+    /**
+     * Gets a combined string of path, offset and length. Used to determine whether this split has
+     * been processed.
+     */
+    public String pathAndOffset() {
+        return String.format("%s [%d, %d)", filePath, offset, length);
+    }
+
     // ------------------------------------------------------------------------
     //  utils
     // ------------------------------------------------------------------------

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpoint.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/PendingSplitsCheckpoint.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.file.src;
 
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.core.fs.Path;
 
 import javax.annotation.Nullable;
 
@@ -40,10 +39,10 @@ public class PendingSplitsCheckpoint<SplitT extends FileSourceSplit> {
     private final Collection<SplitT> splits;
 
     /**
-     * The paths that are no longer in the enumerator checkpoint, but have been processed before and
-     * should this be ignored. Relevant only for sources in continuous monitoring mode.
+     * The splits that are no longer in the enumerator checkpoint, but have been processed before
+     * and should this be ignored. Relevant only for sources in continuous monitoring mode.
      */
-    private final Collection<Path> alreadyProcessedPaths;
+    private final Collection<String> alreadyProcessedSplits;
 
     /**
      * The cached byte representation from the last serialization step. This helps to avoid paying
@@ -53,9 +52,9 @@ public class PendingSplitsCheckpoint<SplitT extends FileSourceSplit> {
     @Nullable byte[] serializedFormCache;
 
     protected PendingSplitsCheckpoint(
-            Collection<SplitT> splits, Collection<Path> alreadyProcessedPaths) {
+            Collection<SplitT> splits, Collection<String> alreadyProcessedSplits) {
         this.splits = Collections.unmodifiableCollection(splits);
-        this.alreadyProcessedPaths = Collections.unmodifiableCollection(alreadyProcessedPaths);
+        this.alreadyProcessedSplits = Collections.unmodifiableCollection(alreadyProcessedSplits);
     }
 
     // ------------------------------------------------------------------------
@@ -64,8 +63,8 @@ public class PendingSplitsCheckpoint<SplitT extends FileSourceSplit> {
         return splits;
     }
 
-    public Collection<Path> getAlreadyProcessedPaths() {
-        return alreadyProcessedPaths;
+    public Collection<String> getAlreadyProcessedSplits() {
+        return alreadyProcessedSplits;
     }
 
     // ------------------------------------------------------------------------
@@ -77,7 +76,7 @@ public class PendingSplitsCheckpoint<SplitT extends FileSourceSplit> {
                 + splits
                 + '\n'
                 + "\t\t Processed Paths: "
-                + alreadyProcessedPaths
+                + alreadyProcessedSplits
                 + '\n';
     }
 
@@ -95,18 +94,18 @@ public class PendingSplitsCheckpoint<SplitT extends FileSourceSplit> {
     }
 
     public static <T extends FileSourceSplit> PendingSplitsCheckpoint<T> fromCollectionSnapshot(
-            final Collection<T> splits, final Collection<Path> alreadyProcessedPaths) {
+            final Collection<T> splits, final Collection<String> alreadyProcessedSplits) {
         checkNotNull(splits);
 
         // create a copy of the collection to make sure this checkpoint is immutable
         final Collection<T> splitsCopy = new ArrayList<>(splits);
-        final Collection<Path> pathsCopy = new ArrayList<>(alreadyProcessedPaths);
+        final Collection<String> processedSplitsCopy = new ArrayList<>(alreadyProcessedSplits);
 
-        return new PendingSplitsCheckpoint<>(splitsCopy, pathsCopy);
+        return new PendingSplitsCheckpoint<>(splitsCopy, processedSplitsCopy);
     }
 
     static <T extends FileSourceSplit> PendingSplitsCheckpoint<T> reusingCollection(
-            final Collection<T> splits, final Collection<Path> alreadyProcessedPaths) {
-        return new PendingSplitsCheckpoint<>(splits, alreadyProcessedPaths);
+            final Collection<T> splits, final Collection<String> alreadyProcessedSplits) {
+        return new PendingSplitsCheckpoint<>(splits, alreadyProcessedSplits);
     }
 }

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/ContinuousFileSplitEnumerator.java
@@ -41,6 +41,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -59,7 +60,7 @@ public class ContinuousFileSplitEnumerator
 
     private final FileEnumerator enumerator;
 
-    private final HashSet<Path> pathsAlreadyProcessed;
+    private final Set<String> splitsAlreadyProcessed;
 
     private final LinkedHashMap<Integer, String> readersAwaitingSplit;
 
@@ -74,7 +75,7 @@ public class ContinuousFileSplitEnumerator
             FileEnumerator enumerator,
             FileSplitAssigner splitAssigner,
             Path[] paths,
-            Collection<Path> alreadyDiscoveredPaths,
+            Collection<String> splitsAlreadyProcessed,
             long discoveryInterval) {
 
         checkArgument(discoveryInterval > 0L);
@@ -83,7 +84,7 @@ public class ContinuousFileSplitEnumerator
         this.splitAssigner = checkNotNull(splitAssigner);
         this.paths = paths;
         this.discoveryInterval = discoveryInterval;
-        this.pathsAlreadyProcessed = new HashSet<>(alreadyDiscoveredPaths);
+        this.splitsAlreadyProcessed = new HashSet<>(splitsAlreadyProcessed);
         this.readersAwaitingSplit = new LinkedHashMap<>();
     }
 
@@ -128,7 +129,7 @@ public class ContinuousFileSplitEnumerator
             throws Exception {
         final PendingSplitsCheckpoint<FileSourceSplit> checkpoint =
                 PendingSplitsCheckpoint.fromCollectionSnapshot(
-                        splitAssigner.remainingSplits(), pathsAlreadyProcessed);
+                        splitAssigner.remainingSplits(), splitsAlreadyProcessed);
 
         LOG.debug("Source Checkpoint is {}", checkpoint);
         return checkpoint;
@@ -144,7 +145,7 @@ public class ContinuousFileSplitEnumerator
 
         final Collection<FileSourceSplit> newSplits =
                 splits.stream()
-                        .filter((split) -> pathsAlreadyProcessed.add(split.path()))
+                        .filter(split -> splitsAlreadyProcessed.add(split.pathAndOffset()))
                         .collect(Collectors.toList());
         splitAssigner.addSplits(newSplits);
 

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/PendingSplitsCheckpointSerializerTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/PendingSplitsCheckpointSerializerTest.java
@@ -64,9 +64,9 @@ class PendingSplitsCheckpointSerializerTest {
                 PendingSplitsCheckpoint.fromCollectionSnapshot(
                         Arrays.asList(testSplit1(), testSplit2(), testSplit3()),
                         Arrays.asList(
-                                new Path("file:/some/path"),
-                                new Path("s3://bucket/key/and/path"),
-                                new Path("hdfs://namenode:12345/path")));
+                                "file:/some/path",
+                                "s3://bucket/key/and/path",
+                                "hdfs://namenode:12345/path"));
 
         final PendingSplitsCheckpoint<FileSourceSplit> deSerialized =
                 serializeAndDeserialize(checkpoint);
@@ -148,8 +148,8 @@ class PendingSplitsCheckpointSerializerTest {
                 actual.getSplits(),
                 FileSourceSplitSerializerTest::assertSplitsEqual);
 
-        assertThat(actual.getAlreadyProcessedPaths())
-                .containsExactlyElementsOf(expected.getAlreadyProcessedPaths());
+        assertThat(actual.getAlreadyProcessedSplits())
+                .containsExactlyElementsOf(expected.getAlreadyProcessedSplits());
     }
 
     private static <E> void assertOrderedCollectionEquals(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHivePendingSplitsCheckpointSerializer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/ContinuousHivePendingSplitsCheckpointSerializer.java
@@ -72,7 +72,7 @@ public class ContinuousHivePendingSplitsCheckpointSerializer
                 (ContinuousHivePendingSplitsCheckpoint) checkpoint;
         PendingSplitsCheckpoint<HiveSourceSplit> superCP =
                 PendingSplitsCheckpoint.fromCollectionSnapshot(
-                        hiveCheckpoint.getSplits(), hiveCheckpoint.getAlreadyProcessedPaths());
+                        hiveCheckpoint.getSplits(), hiveCheckpoint.getAlreadyProcessedSplits());
         byte[] superBytes = superSerDe.serialize(superCP);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

ContinuousFileSplitEnumerator use a HashSet<Path> to store processed splits. This works fine when process a file as a single split, once the file is splittable it will make unprocessed splits skipped. I think we should use a combined string of path, offset and length instead of just path to track processed splits.


## Brief change log

  -  Use a combined string of path, offset and length instead of just path to track processed splits.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - *Added a unit test for a single file with multiple splits to track*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? JavaDocs
