### PR TITLE
[FLINK-25546][flink-connector-base][JUnit5 Migration] Module: flink-connector-base

### DIFF
--- a/flink-connectors/flink-connector-base/pom.xml
+++ b/flink-connectors/flink-connector-base/pom.xml
@@ -113,6 +113,12 @@
 						<goals>
 							<goal>test-jar</goal>
 						</goals>
+						<configuration>
+							<excludes>
+								<!-- test-jar is still used by JUnit4 modules -->
+								<exclude>META-INF/services/org.junit.jupiter.api.extension.Extension</exclude>
+							</excludes>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Integration tests of a baseline generic sink that implements the AsyncSinkBase. */
 @ExtendWith(TestLoggerExtension.class)
-public class AsyncSinkBaseITCase {
+class AsyncSinkBaseITCase {
 
     @RegisterExtension
     private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
@@ -45,13 +45,13 @@ public class AsyncSinkBaseITCase {
     final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
 
     @Test
-    public void testWriteTwentyThousandRecordsToGenericSink() throws Exception {
+    void testWriteTwentyThousandRecordsToGenericSink() throws Exception {
         env.fromSequence(1, 20000).map(Object::toString).sinkTo(new ArrayListAsyncSink());
         env.execute("Integration Test: AsyncSinkBaseITCase").getJobExecutionResult();
     }
 
     @Test
-    public void testFailuresOnPersistingToDestinationAreCaughtAndRaised() {
+    void testFailuresOnPersistingToDestinationAreCaughtAndRaised() {
         env.fromSequence(999_999, 1_000_100)
                 .map(Object::toString)
                 .sinkTo(new ArrayListAsyncSink(1, 1, 2, 10, 1000, 10));
@@ -63,7 +63,7 @@ public class AsyncSinkBaseITCase {
     }
 
     @Test
-    public void testThatNoIssuesOccurWhenCheckpointingIsEnabled() throws Exception {
+    void testThatNoIssuesOccurWhenCheckpointingIsEnabled() throws Exception {
         env.enableCheckpointing(20);
         RestartStrategyUtils.configureFixedDelayRestartStrategy(env, 1, 200);
         env.fromSequence(1, 10_000).map(Object::toString).sinkTo(new ArrayListAsyncSink());

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/AsyncSinkBaseITCase.java
@@ -22,16 +22,13 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
 import org.apache.flink.test.junit5.MiniClusterExtension;
-import org.apache.flink.util.TestLoggerExtension;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Integration tests of a baseline generic sink that implements the AsyncSinkBase. */
-@ExtendWith(TestLoggerExtension.class)
 class AsyncSinkBaseITCase {
 
     @RegisterExtension

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/throwable/FatalExceptionClassifierTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/throwable/FatalExceptionClassifierTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 /** Tests the FatalExceptionClassifier of the Async Sink Writer. */
-public class FatalExceptionClassifierTest {
+class FatalExceptionClassifierTest {
 
     private static Integer nullReference;
 
@@ -51,7 +51,7 @@ public class FatalExceptionClassifierTest {
                                     err));
 
     @Test
-    public void exceptionsAreWrappedInTheContainingExceptionWhenAMatchIsFound() {
+    void exceptionsAreWrappedInTheContainingExceptionWhenAMatchIsFound() {
         AtomicReference<Exception> caughtExceptionReference = new AtomicReference<>();
 
         ARITHMETIC_EXCEPTION_STRATEGY.isFatal(
@@ -63,7 +63,7 @@ public class FatalExceptionClassifierTest {
     }
 
     @Test
-    public void noExceptionIsThrownIfTheExceptionDoesNotMatchTheOneExpected() {
+    void noExceptionIsThrownIfTheExceptionDoesNotMatchTheOneExpected() {
         AtomicReference<Exception> caughtException = new AtomicReference<>();
         try {
             System.out.print(nullReference.toString());
@@ -74,7 +74,7 @@ public class FatalExceptionClassifierTest {
     }
 
     @Test
-    public void chainedFatalExceptionClassifierAcceptExceptionsOnTheFirstItemOfChain() {
+    void chainedFatalExceptionClassifierAcceptExceptionsOnTheFirstItemOfChain() {
         FatalExceptionClassifier fatalExceptionClassifier =
                 FatalExceptionClassifier.createChain(
                         ARITHMETIC_EXCEPTION_STRATEGY, NULL_POINTER_EXCEPTION_STRATEGY);
@@ -89,7 +89,7 @@ public class FatalExceptionClassifierTest {
     }
 
     @Test
-    public void chainedFatalExceptionClassifierAcceptExceptionsOnTheLastItemOfChain() {
+    void chainedFatalExceptionClassifierAcceptExceptionsOnTheLastItemOfChain() {
         FatalExceptionClassifier fatalExceptionClassifier =
                 FatalExceptionClassifier.createChain(
                         ARITHMETIC_EXCEPTION_STRATEGY, NULL_POINTER_EXCEPTION_STRATEGY);
@@ -107,7 +107,7 @@ public class FatalExceptionClassifierTest {
     }
 
     @Test
-    public void circularChainedFatalExceptionClassifierThrowsException() {
+    void circularChainedFatalExceptionClassifierThrowsException() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(
                         () ->
@@ -120,7 +120,7 @@ public class FatalExceptionClassifierTest {
     }
 
     @Test
-    public void emptyChainedFatalExceptionClassifierThrowsException() {
+    void emptyChainedFatalExceptionClassifierThrowsException() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(FatalExceptionClassifier::createChain)
                 .withMessageContaining("Cannot create empty classifier chain.");

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterStateSerializerTest.java
@@ -18,7 +18,7 @@
 
 package org.apache.flink.connector.base.sink.writer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
@@ -29,10 +29,10 @@ import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUti
 import static org.apache.flink.connector.base.sink.writer.AsyncSinkWriterTestUtils.getTestState;
 
 /** Test class for {@link AsyncSinkWriterStateSerializer}. */
-public class AsyncSinkWriterStateSerializerTest {
+class AsyncSinkWriterStateSerializerTest {
 
     @Test
-    public void testSerializeAndDeSerialize() throws IOException {
+    void testSerializeAndDeSerialize() throws IOException {
         AsyncSinkWriterStateSerializerImpl stateSerializer =
                 new AsyncSinkWriterStateSerializerImpl();
         BufferedRequestState<String> state =

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
@@ -50,14 +50,14 @@ import static org.assertj.core.api.Assertions.fail;
  * Unit Tests the functionality of AsyncSinkWriter without any assumptions of what a concrete
  * implementation might do.
  */
-public class AsyncSinkWriterTest {
+class AsyncSinkWriterTest {
 
     private final List<Integer> res = new ArrayList<>();
     private TestSinkInitContext sinkInitContext;
     private TestSinkInitContextAnyThreadMailbox sinkInitContextAnyThreadMailbox;
 
     @BeforeEach
-    public void before() {
+    void before() {
         res.clear();
         sinkInitContext = new TestSinkInitContext();
         sinkInitContextAnyThreadMailbox = new TestSinkInitContextAnyThreadMailbox();
@@ -73,7 +73,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testElementConvertOpenIsInvoked() {
+    void testElementConvertOpenIsInvoked() {
         TestElementConverter elementConverter = new TestElementConverter();
         assertThat(elementConverter.getOpenCallCount()).isEqualTo(0);
 
@@ -87,7 +87,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testNumberOfRecordsIsAMultipleOfBatchSizeResultsInThatNumberOfRecordsBeingWritten()
+    void testNumberOfRecordsIsAMultipleOfBatchSizeResultsInThatNumberOfRecordsBeingWritten()
             throws IOException, InterruptedException {
         performNormalWriteOfEightyRecordsToMock();
 
@@ -95,7 +95,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testMetricsGroupHasLoggedNumberOfRecordsAndNumberOfBytesCorrectly()
+    void testMetricsGroupHasLoggedNumberOfRecordsAndNumberOfBytesCorrectly()
             throws IOException, InterruptedException {
         performNormalWriteOfEightyRecordsToMock();
 
@@ -107,7 +107,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void checkLoggedSendTimesAreWithinBounds() throws IOException, InterruptedException {
+    void checkLoggedSendTimesAreWithinBounds() throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -128,7 +128,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatUnwrittenRecordsInBufferArePersistedWhenSnapshotIsTaken()
+    void testThatUnwrittenRecordsInBufferArePersistedWhenSnapshotIsTaken()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
@@ -141,8 +141,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void sinkToAllowBatchSizesEqualToByteWiseLimit()
-            throws IOException, InterruptedException {
+    void sinkToAllowBatchSizesEqualToByteWiseLimit() throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -157,7 +156,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testPreparingCommitAtSnapshotTimeEnsuresBufferedRecordsArePersistedToDestination()
+    void testPreparingCommitAtSnapshotTimeEnsuresBufferedRecordsArePersistedToDestination()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
@@ -170,7 +169,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatMailboxYieldDoesNotBlockWhileATimerIsRegisteredAndHasYetToElapse()
+    void testThatMailboxYieldDoesNotBlockWhileATimerIsRegisteredAndHasYetToElapse()
             throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
@@ -181,7 +180,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatSnapshotsAreTakenOfBufferCorrectlyBeforeAndAfterAutomaticFlush()
+    void testThatSnapshotsAreTakenOfBufferCorrectlyBeforeAndAfterAutomaticFlush()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder().context(sinkInitContext).maxBatchSize(3).build();
@@ -215,7 +214,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatSnapshotsAreTakenOfBufferCorrectlyBeforeAndAfterManualFlush()
+    void testThatSnapshotsAreTakenOfBufferCorrectlyBeforeAndAfterManualFlush()
             throws IOException, InterruptedException {
         writeFiveRecordsWithOneFailingThenCallPrepareCommitWithFlushing();
 
@@ -223,7 +222,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void metricsAreLoggedEachTimeSubmitRequestEntriesIsCalled()
+    void metricsAreLoggedEachTimeSubmitRequestEntriesIsCalled()
             throws IOException, InterruptedException {
         writeFiveRecordsWithOneFailingThenCallPrepareCommitWithFlushing();
 
@@ -232,7 +231,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testRuntimeErrorsInSubmitRequestEntriesEndUpAsIOExceptionsWithNumOfFailedRequests()
+    void testRuntimeErrorsInSubmitRequestEntriesEndUpAsIOExceptionsWithNumOfFailedRequests()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -254,7 +253,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testRetryableErrorsDoNotViolateAtLeastOnceSemanticsDueToRequeueOfFailures()
+    void testRetryableErrorsDoNotViolateAtLeastOnceSemanticsDueToRequeueOfFailures()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -328,9 +327,8 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void
-            testFailedEntriesAreRetriedInTheNextPossiblePersistRequestIfPrepareCommitIsTriggered()
-                    throws IOException, InterruptedException {
+    void testFailedEntriesAreRetriedInTheNextPossiblePersistRequestIfPrepareCommitIsTriggered()
+            throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -341,7 +339,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testFailedEntriesAreRetriedInTheNextPossiblePersistRequestIfBufferFillsToFull()
+    void testFailedEntriesAreRetriedInTheNextPossiblePersistRequestIfBufferFillsToFull()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -379,7 +377,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatMaxBufferSizeOfSinkShouldBeStrictlyGreaterThanMaxSizeOfEachBatch() {
+    void testThatMaxBufferSizeOfSinkShouldBeStrictlyGreaterThanMaxSizeOfEachBatch() {
         assertThatThrownBy(
                         () ->
                                 new AsyncSinkWriterImplBuilder()
@@ -393,7 +391,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void maxRecordSizeSetMustBeSmallerThanOrEqualToMaxBatchSize() {
+    void maxRecordSizeSetMustBeSmallerThanOrEqualToMaxBatchSize() {
         assertThatThrownBy(
                         () ->
                                 new AsyncSinkWriterImplBuilder()
@@ -409,7 +407,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void recordsWrittenToTheSinkMustBeSmallerOrEqualToMaxRecordSizeInBytes() {
+    void recordsWrittenToTheSinkMustBeSmallerOrEqualToMaxRecordSizeInBytes() {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -436,7 +434,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testFlushThresholdMetBeforeBatchLimitWillCreateASmallerBatchOfSizeAboveThreshold()
+    void testFlushThresholdMetBeforeBatchLimitWillCreateASmallerBatchOfSizeAboveThreshold()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -457,7 +455,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void prepareCommitDoesNotFlushElementsIfFlushIsSetToFalse() throws Exception {
+    void prepareCommitDoesNotFlushElementsIfFlushIsSetToFalse() throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder().context(sinkInitContext).build();
         sink.write(String.valueOf(0));
@@ -469,7 +467,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatWhenNumberOfItemAndSizeOfRecordThresholdsAreMetSimultaneouslyAFlushOccurs()
+    void testThatWhenNumberOfItemAndSizeOfRecordThresholdsAreMetSimultaneouslyAFlushOccurs()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -493,7 +491,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatIntermittentlyFailingEntriesAreEnqueuedOnToTheBufferWithCorrectSize()
+    void testThatIntermittentlyFailingEntriesAreEnqueuedOnToTheBufferWithCorrectSize()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -521,7 +519,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatIntermittentlyFailingEntriesAreEnqueuedOnToTheBufferWithCorrectOrder()
+    void testThatIntermittentlyFailingEntriesAreEnqueuedOnToTheBufferWithCorrectOrder()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -552,8 +550,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatABatchWithSizeSmallerThanMaxBatchSizeIsFlushedOnTimeoutExpiry()
-            throws Exception {
+    void testThatABatchWithSizeSmallerThanMaxBatchSizeIsFlushedOnTimeoutExpiry() throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -581,8 +578,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatTimeBasedBatchPicksUpAllRelevantItemsUpUntilExpiryOfTimer()
-            throws Exception {
+    void testThatTimeBasedBatchPicksUpAllRelevantItemsUpUntilExpiryOfTimer() throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -606,8 +602,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void prepareCommitFlushesInflightElementsAndDoesNotFlushIfFlushIsSetToFalse()
-            throws Exception {
+    void prepareCommitFlushesInflightElementsAndDoesNotFlushIfFlushIsSetToFalse() throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -634,7 +629,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatIntermittentlyFailingEntriesAreEnqueuedOnToTheBufferAfterSnapshot()
+    void testThatIntermittentlyFailingEntriesAreEnqueuedOnToTheBufferAfterSnapshot()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -670,7 +665,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatRecordOfSizeBiggerThanMaximumFailsSinkInitialization()
+    void testThatRecordOfSizeBiggerThanMaximumFailsSinkInitialization()
             throws IOException, InterruptedException {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -694,7 +689,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testRestoreFromMultipleStates() throws IOException {
+    void testRestoreFromMultipleStates() throws IOException {
         List<BufferedRequestState<Integer>> states =
                 Arrays.asList(
                         new BufferedRequestState<>(
@@ -727,7 +722,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testWriterInitializedWithStateHasCallbackRegistered() throws Exception {
+    void testWriterInitializedWithStateHasCallbackRegistered() throws Exception {
         AsyncSinkWriterImpl initialSinkWriter =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -763,7 +758,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatOneAndOnlyOneCallbackIsEverRegistered() throws Exception {
+    void testThatOneAndOnlyOneCallbackIsEverRegistered() throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -795,7 +790,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatIntermittentlyFailingEntriesShouldBeFlushedWithMainBatchInTimeBasedFlush()
+    void testThatIntermittentlyFailingEntriesShouldBeFlushedWithMainBatchInTimeBasedFlush()
             throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
@@ -822,7 +817,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatFlushingAnEmptyBufferDoesNotResultInErrorOrFailure() throws Exception {
+    void testThatFlushingAnEmptyBufferDoesNotResultInErrorOrFailure() throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -844,7 +839,7 @@ public class AsyncSinkWriterTest {
     }
 
     @Test
-    public void testThatOnExpiryOfAnOldTimeoutANewOneMayBeRegisteredImmediately() throws Exception {
+    void testThatOnExpiryOfAnOldTimeoutANewOneMayBeRegisteredImmediately() throws Exception {
         AsyncSinkWriterImpl sink =
                 new AsyncSinkWriterImplBuilder()
                         .context(sinkInitContext)
@@ -884,7 +879,7 @@ public class AsyncSinkWriterTest {
      * thread if it enters {@code mailbox.tryYield()}.
      */
     @Test
-    public void testThatInterleavingThreadsMayBlockEachOtherButDoNotCauseRaceConditions()
+    void testThatInterleavingThreadsMayBlockEachOtherButDoNotCauseRaceConditions()
             throws Exception {
         CountDownLatch blockedWriteLatch = new CountDownLatch(1);
         CountDownLatch delayedStartLatch = new CountDownLatch(1);
@@ -915,7 +910,7 @@ public class AsyncSinkWriterTest {
      * thread if it enters {@code mailbox.tryYield()}.
      */
     @Test
-    public void testThatIfOneInterleavedThreadIsBlockedTheOtherThreadWillContinueAndCorrectlyWrite()
+    void testThatIfOneInterleavedThreadIsBlockedTheOtherThreadWillContinueAndCorrectlyWrite()
             throws Exception {
         CountDownLatch blockedWriteLatch = new CountDownLatch(1);
         CountDownLatch delayedStartLatch = new CountDownLatch(1);
@@ -978,7 +973,7 @@ public class AsyncSinkWriterTest {
      * immediately fail.
      */
     @Test
-    public void ifTheNumberOfUncompletedInFlightRequestsIsTooManyThenBlockInFlushMethod()
+    void ifTheNumberOfUncompletedInFlightRequestsIsTooManyThenBlockInFlushMethod()
             throws Exception {
         CountDownLatch blockedWriteLatch = new CountDownLatch(1);
         CountDownLatch delayedStartLatch = new CountDownLatch(1);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterThrottlingTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterThrottlingTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.connector.base.sink.writer.config.AsyncSinkWriterConfiguration;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -33,10 +33,10 @@ import java.util.List;
 import java.util.Queue;
 
 /** Test class for rate limiting functionalities of {@link AsyncSinkWriter}. */
-public class AsyncSinkWriterThrottlingTest {
+class AsyncSinkWriterThrottlingTest {
 
     @Test
-    public void testSinkThroughputShouldThrottleToHalfBatchSize() throws Exception {
+    void testSinkThroughputShouldThrottleToHalfBatchSize() throws Exception {
         int maxBatchSize = 32;
         int maxInFlightRequest = 10;
         int numberOfBatchesToSend = 1000;

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTimeoutTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTimeoutTest.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /** Test for timeout functionalities of {@link AsyncSinkWriter}. */
-public class AsyncSinkWriterTimeoutTest {
+class AsyncSinkWriterTimeoutTest {
 
     private final ExecutorService executorService = Executors.newFixedThreadPool(5);
     private final List<Long> destination = new ArrayList<>();

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/config/AsyncSinkWriterConfigurationBuilderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/config/AsyncSinkWriterConfigurationBuilderTest.java
@@ -25,9 +25,9 @@ import static org.apache.flink.connector.base.sink.writer.config.AsyncSinkWriter
 import static org.apache.flink.connector.base.sink.writer.config.AsyncSinkWriterConfiguration.DEFAULT_REQUEST_TIMEOUT_MS;
 
 /** Tests for {@link AsyncSinkWriterConfiguration#builder()}. */
-public class AsyncSinkWriterConfigurationBuilderTest {
+class AsyncSinkWriterConfigurationBuilderTest {
     @Test
-    public void testBuilderSetsValueForTimeoutAndFailOnTimeout() {
+    void testBuilderSetsValueForTimeoutAndFailOnTimeout() {
         AsyncSinkWriterConfiguration configuration =
                 AsyncSinkWriterConfiguration.builder()
                         .setMaxBatchSize(1)
@@ -44,7 +44,7 @@ public class AsyncSinkWriterConfigurationBuilderTest {
     }
 
     @Test
-    public void testBuilderSetsDefaultValuesForTimeoutAndFailOnTimeout() {
+    void testBuilderSetsDefaultValuesForTimeoutAndFailOnTimeout() {
         AsyncSinkWriterConfiguration configuration =
                 AsyncSinkWriterConfiguration.builder()
                         .setMaxBatchSize(1)

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/strategy/NoOpScalingStrategyTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/strategy/NoOpScalingStrategyTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test class for {@link NoOpScalingStrategy}. */
-public class NoOpScalingStrategyTest {
+class NoOpScalingStrategyTest {
     @Test
     void testScaleUpNoOp() {
         NoOpScalingStrategy scalingStrategy = new NoOpScalingStrategy();

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceReaderTest.java
@@ -35,7 +35,7 @@ import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
 import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.mock.Whitebox;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.Collections;
@@ -46,10 +46,10 @@ import java.util.function.Supplier;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link HybridSourceReader}. */
-public class HybridSourceReaderTest {
+class HybridSourceReaderTest {
 
     @Test
-    public void testReader() throws Exception {
+    void testReader() throws Exception {
         TestingReaderContext readerContext = new TestingReaderContext();
         TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
         MockBaseSource source = new MockBaseSource(1, 1, Boundedness.BOUNDED);
@@ -128,7 +128,7 @@ public class HybridSourceReaderTest {
     }
 
     @Test
-    public void testAvailabilityFutureSwitchover() throws Exception {
+    void testAvailabilityFutureSwitchover() throws Exception {
         TestingReaderContext readerContext = new TestingReaderContext();
         TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
         MockBaseSource source = new MockBaseSource(1, 1, Boundedness.BOUNDED);
@@ -242,7 +242,7 @@ public class HybridSourceReaderTest {
     }
 
     @Test
-    public void testReaderRecovery() throws Exception {
+    void testReaderRecovery() throws Exception {
         TestingReaderContext readerContext = new TestingReaderContext();
         TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
         MockBaseSource source = new MockBaseSource(1, 1, Boundedness.BOUNDED);
@@ -282,7 +282,7 @@ public class HybridSourceReaderTest {
     }
 
     @Test
-    public void testDefaultMethodDelegation() throws Exception {
+    void testDefaultMethodDelegation() throws Exception {
         TestingReaderContext readerContext = new TestingReaderContext();
         TestingReaderOutput<Integer> readerOutput = new TestingReaderOutput<>();
         MockBaseSource source =

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitEnumeratorTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitEnumerator;
 import org.apache.flink.mock.Whitebox;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link HybridSourceSplitEnumerator}. */
-public class HybridSourceSplitEnumeratorTest {
+class HybridSourceSplitEnumeratorTest {
 
     private static final int SUBTASK0 = 0;
     private static final int SUBTASK1 = 1;
@@ -89,7 +89,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testHighCardinalitySources() {
+    void testHighCardinalitySources() {
         context = new MockSplitEnumeratorContext<>(2);
         HybridSource.HybridSourceBuilder<Integer, MockSplitEnumerator> hybridSourceBuilder =
                 HybridSource.builder(MOCK_SOURCE);
@@ -145,7 +145,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testRegisterReaderAfterSwitchAndReaderReset() {
+    void testRegisterReaderAfterSwitchAndReaderReset() {
         setupEnumeratorAndTriggerSourceSwitch();
 
         // add split of previous source back (simulates reader reset during recovery)
@@ -176,7 +176,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testHandleSplitRequestAfterSwitchAndReaderReset() {
+    void testHandleSplitRequestAfterSwitchAndReaderReset() {
         setupEnumeratorAndTriggerSourceSwitch();
 
         UnderlyingEnumeratorWrapper underlyingEnumeratorWrapper =
@@ -212,7 +212,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testRestoreEnumerator() throws Exception {
+    void testRestoreEnumerator() throws Exception {
         setupEnumeratorAndTriggerSourceSwitch();
         enumerator = (HybridSourceSplitEnumerator) source.createEnumerator(context);
         enumerator.start();
@@ -233,7 +233,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testRestoreEnumeratorAfterFirstSourceWithoutRestoredSplits() throws Exception {
+    void testRestoreEnumeratorAfterFirstSourceWithoutRestoredSplits() throws Exception {
         setupEnumeratorAndTriggerSourceSwitch();
         HybridSourceEnumeratorState enumeratorState = enumerator.snapshotState(0);
         MockSplitEnumerator underlyingEnumerator = getCurrentEnumerator(enumerator);
@@ -254,7 +254,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testDefaultMethodDelegation() throws Exception {
+    void testDefaultMethodDelegation() throws Exception {
         setupEnumeratorAndTriggerSourceSwitch();
         SplitEnumerator<MockSourceSplit, Object> underlyingEnumeratorSpy =
                 Mockito.spy((SplitEnumerator) getCurrentEnumerator(enumerator));
@@ -272,7 +272,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testInterceptNoMoreSplitEvent() {
+    void testInterceptNoMoreSplitEvent() {
         context = new MockSplitEnumeratorContext<>(2);
         source = HybridSource.builder(MOCK_SOURCE).addSource(MOCK_SOURCE).build();
 
@@ -309,7 +309,7 @@ public class HybridSourceSplitEnumeratorTest {
     }
 
     @Test
-    public void testMultiSubtaskSwitchEnumerator() {
+    void testMultiSubtaskSwitchEnumerator() {
         context = new MockSplitEnumeratorContext<>(2);
         source =
                 HybridSource.builder(MOCK_SOURCE)

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceSplitSerializerTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.connector.base.source.hybrid;
 import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -31,10 +31,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link HybridSourceSplitSerializer}. */
-public class HybridSourceSplitSerializerTest {
+class HybridSourceSplitSerializerTest {
 
     @Test
-    public void testSerialization() throws Exception {
+    void testSerialization() throws Exception {
         Map<Integer, Source> switchedSources = new HashMap<>();
         switchedSources.put(0, new MockSource(null, 0));
         byte[] splitBytes = {1, 2, 3};

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/hybrid/HybridSourceTest.java
@@ -25,7 +25,7 @@ import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.connector.base.source.reader.mocks.MockBaseSource;
 import org.apache.flink.connector.base.source.reader.mocks.MockSplitEnumerator;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -33,10 +33,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link HybridSource}. */
-public class HybridSourceTest {
+class HybridSourceTest {
 
     @Test
-    public void testBoundedness() {
+    void testBoundedness() {
         HybridSource<Integer> source;
 
         source =
@@ -64,7 +64,7 @@ public class HybridSourceTest {
     }
 
     @Test
-    public void testBuilderWithSourceFactory() {
+    void testBuilderWithSourceFactory() {
         HybridSource.SourceFactory<Integer, Source<Integer, ?, ?>, MockSplitEnumerator>
                 sourceFactory =
                         new HybridSource.SourceFactory<
@@ -94,7 +94,7 @@ public class HybridSourceTest {
     }
 
     @Test
-    public void testBuilderWithEnumeratorSuperclass() {
+    void testBuilderWithEnumeratorSuperclass() {
         HybridSource.SourceFactory<Integer, Source<Integer, ?, ?>, MockSplitEnumerator>
                 sourceFactory =
                         (HybridSource.SourceFactory<

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/AlignedWatermarksITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/AlignedWatermarksITCase.java
@@ -59,7 +59,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * it should never increase any further, but gradually decrease to the configured threshold, as the
  * slower source catches up.
  */
-public class AlignedWatermarksITCase {
+class AlignedWatermarksITCase {
     public static final String SLOW_SOURCE_NAME = "SlowNumberSequenceSource";
     public static final String FAST_SOURCE_NAME = "FastNumberSequenceSource";
     private static final Duration UPDATE_INTERVAL = Duration.ofMillis(100);
@@ -80,7 +80,7 @@ public class AlignedWatermarksITCase {
                             .build());
 
     @Test
-    public void testAlignment(@InjectMiniCluster MiniCluster miniCluster) throws Exception {
+    void testAlignment(@InjectMiniCluster MiniCluster miniCluster) throws Exception {
         final JobGraph jobGraph = getJobGraph();
         final CompletableFuture<JobSubmissionResult> submission = miniCluster.submitJob(jobGraph);
         final JobID jobID = submission.get().getJobID();

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceITCase.java
@@ -32,10 +32,10 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.legacy.RichSinkFunction;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
-import org.apache.flink.test.util.AbstractTestBaseJUnit4;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.FlinkRuntimeException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 
@@ -46,10 +46,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT case for the {@link Source} with a coordinator. */
-public class CoordinatedSourceITCase extends AbstractTestBaseJUnit4 {
+class CoordinatedSourceITCase extends AbstractTestBase {
 
     @Test
-    public void testEnumeratorReaderCommunication() throws Exception {
+    void testEnumeratorReaderCommunication() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         MockBaseSource source = new MockBaseSource(2, 10, Boundedness.BOUNDED);
         DataStream<Integer> stream =
@@ -58,7 +58,7 @@ public class CoordinatedSourceITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
-    public void testMultipleSources() throws Exception {
+    void testMultipleSources() throws Exception {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         MockBaseSource source1 = new MockBaseSource(2, 10, Boundedness.BOUNDED);
         MockBaseSource source2 = new MockBaseSource(2, 10, 20, Boundedness.BOUNDED);
@@ -70,7 +70,7 @@ public class CoordinatedSourceITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
-    public void testEnumeratorCreationFails() throws Exception {
+    void testEnumeratorCreationFails() throws Exception {
         OnceFailingToCreateEnumeratorSource.reset();
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -83,7 +83,7 @@ public class CoordinatedSourceITCase extends AbstractTestBaseJUnit4 {
     }
 
     @Test
-    public void testEnumeratorRestoreFails() throws Exception {
+    void testEnumeratorRestoreFails() throws Exception {
         OnceFailingToRestoreEnumeratorSource.reset();
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceRescaleITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/CoordinatedSourceRescaleITCase.java
@@ -30,13 +30,11 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.legacy.SinkFunction;
 import org.apache.flink.streaming.util.RestartStrategyUtils;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 
@@ -53,31 +51,29 @@ import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStor
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests if the coordinator handles up and downscaling. */
-public class CoordinatedSourceRescaleITCase extends TestLogger {
+class CoordinatedSourceRescaleITCase {
 
     public static final String CREATED_CHECKPOINT = "successfully created checkpoint";
     public static final String RESTORED_CHECKPOINT = "successfully restored checkpoint";
 
-    @ClassRule
-    public static final MiniClusterWithClientResource MINI_CLUSTER =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    private static final MiniClusterExtension miniClusterResource =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(7)
                             .build());
 
-    @Rule public final TemporaryFolder temp = new TemporaryFolder();
-
     @Test
-    public void testDownscaling() throws Exception {
-        final File checkpointDir = temp.newFolder();
+    void testDownscaling(@TempDir Path tempDir) throws Exception {
+        final File checkpointDir = tempDir.toFile();
         final File lastCheckpoint = generateCheckpoint(checkpointDir, 7);
         resumeCheckpoint(checkpointDir, lastCheckpoint, 3);
     }
 
     @Test
-    public void testUpscaling() throws Exception {
-        final File checkpointDir = temp.newFolder();
+    void testUpscaling(@TempDir Path temp) throws Exception {
+        final File checkpointDir = temp.toFile();
         final File lastCheckpoint = generateCheckpoint(checkpointDir, 3);
         resumeCheckpoint(checkpointDir, lastCheckpoint, 7);
     }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceMetricsITCase.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceMetricsITCase.java
@@ -40,14 +40,12 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.v2.DiscardingSink;
-import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.apache.flink.testutils.junit.SharedObjects;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.testutils.junit.SharedObjectsExtension;
 import org.apache.flink.testutils.junit.SharedReference;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.time.Duration;
 import java.util.List;
@@ -59,7 +57,7 @@ import static org.apache.flink.metrics.testutils.MetricAssertions.assertThatGaug
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests whether all provided metrics of a {@link Source} are of the expected values (FLIP-33). */
-public class SourceMetricsITCase extends TestLogger {
+class SourceMetricsITCase {
     private static final int DEFAULT_PARALLELISM = 4;
     // since integration tests depend on wall clock time, use huge lags
     private static final long EVENTTIME_LAG = Duration.ofDays(100).toMillis();
@@ -67,12 +65,12 @@ public class SourceMetricsITCase extends TestLogger {
     private static final long EVENTTIME_EPSILON = Duration.ofDays(20).toMillis();
     // this basically is the time a build is allowed to be frozen before the test fails
     private static final long WATERMARK_EPSILON = Duration.ofHours(6).toMillis();
-    @Rule public final SharedObjects sharedObjects = SharedObjects.create();
+    @RegisterExtension SharedObjectsExtension sharedObjects = SharedObjectsExtension.create();
     private static final InMemoryReporter reporter = InMemoryReporter.createWithRetainedMetrics();
 
-    @ClassRule
-    public static final MiniClusterWithClientResource MINI_CLUSTER_RESOURCE =
-            new MiniClusterWithClientResource(
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_RESOURCE =
+            new MiniClusterExtension(
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
@@ -80,7 +78,7 @@ public class SourceMetricsITCase extends TestLogger {
                             .build());
 
     @Test
-    public void testMetricsWithTimestamp() throws Exception {
+    void testMetricsWithTimestamp() throws Exception {
         long baseTime = System.currentTimeMillis() - EVENTTIME_LAG;
         WatermarkStrategy<Integer> strategy =
                 WatermarkStrategy.forGenerator(
@@ -91,7 +89,7 @@ public class SourceMetricsITCase extends TestLogger {
     }
 
     @Test
-    public void testMetricsWithoutTimestamp() throws Exception {
+    void testMetricsWithoutTimestamp() throws Exception {
         testMetrics(WatermarkStrategy.noWatermarks(), false);
     }
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/SourceReaderBaseTest.java
@@ -71,7 +71,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** A unit test class for {@link SourceReaderBase}. */
-public class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
+class SourceReaderBaseTest extends SourceReaderTestBase<MockSourceSplit> {
 
     private static final Logger LOG = LoggerFactory.getLogger(SourceReaderBaseTest.class);
 

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManagerTest.java
@@ -31,7 +31,8 @@ import org.apache.flink.connector.base.source.reader.splitreader.SplitsChange;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.core.testutils.OneShotLatch;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -39,6 +40,7 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Queue;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.test.util.TestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,22 +48,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 /** Unit tests for the {@link SplitFetcherManager}. */
-public class SplitFetcherManagerTest {
+class SplitFetcherManagerTest {
 
     @Test
-    public void testExceptionPropagationFirstFetch() throws Exception {
+    void testExceptionPropagationFirstFetch() throws Exception {
         testExceptionPropagation();
     }
 
     @Test
-    public void testExceptionPropagationSuccessiveFetch() throws Exception {
+    void testExceptionPropagationSuccessiveFetch() throws Exception {
         testExceptionPropagation(
                 new TestingRecordsWithSplitIds<>("testSplit", 1, 2, 3, 4),
                 new TestingRecordsWithSplitIds<>("testSplit", 5, 6, 7, 8));
     }
 
     @Test
-    public void testCloseFetcherWithException() throws Exception {
+    void testCloseFetcherWithException() throws Exception {
         TestingSplitReader<Object, TestingSourceSplit> reader = new TestingSplitReader<>();
         reader.setCloseWithException();
         SplitFetcherManager<Object, TestingSourceSplit> fetcherManager =
@@ -72,7 +74,8 @@ public class SplitFetcherManagerTest {
     }
 
     @Test
-    public void testCloseCleansUpPreviouslyClosedFetcher() throws Exception {
+    @Timeout(value = 30000, unit = TimeUnit.MILLISECONDS)
+    void testCloseCleansUpPreviouslyClosedFetcher() throws Exception {
         final String splitId = "testSplit";
         // Set the queue capacity to 1 to make sure in this case the
         // fetcher shutdown won't block on putting the batches into the queue.
@@ -98,7 +101,7 @@ public class SplitFetcherManagerTest {
     }
 
     @Test
-    public void testIdleShutdownSplitFetcherWaitsUntilRecordProcessed() throws Exception {
+    void testIdleShutdownSplitFetcherWaitsUntilRecordProcessed() throws Exception {
         final String splitId = "testSplit";
         final AwaitingReader<Integer, TestingSourceSplit> reader =
                 new AwaitingReader<>(

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherPauseResumeSplitReaderTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherPauseResumeSplitReaderTest.java
@@ -53,7 +53,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Tests {@link SplitFetcher} integration to pause or resume {@link SplitReader} based on {@link
  * SourceReader} output.
  */
-public class SplitFetcherPauseResumeSplitReaderTest {
+class SplitFetcherPauseResumeSplitReaderTest {
 
     /**
      * Tests if pause or resume shows expected behavior which requires creation and execution of
@@ -61,7 +61,7 @@ public class SplitFetcherPauseResumeSplitReaderTest {
      */
     @ParameterizedTest(name = "Individual reader per split: {0}")
     @ValueSource(booleans = {false, true})
-    public void testPauseResumeSplitReaders(boolean individualReader) throws Exception {
+    void testPauseResumeSplitReaders(boolean individualReader) throws Exception {
         final AtomicInteger numSplitReaders = new AtomicInteger();
         final MockSplitReader.Builder readerBuilder =
                 SteppingSourceReaderTestHarness.createSplitReaderBuilder();
@@ -105,7 +105,7 @@ public class SplitFetcherPauseResumeSplitReaderTest {
      */
     @ParameterizedTest(name = "Allow unaligned source splits: {0}")
     @ValueSource(booleans = {true, false})
-    public void testPauseResumeUnsupported(boolean allowUnalignedSourceSplits) throws Exception {
+    void testPauseResumeUnsupported(boolean allowUnalignedSourceSplits) throws Exception {
         final AtomicInteger numSplitReaders = new AtomicInteger();
         final Configuration configuration = new Configuration();
         configuration.set(ALLOW_UNALIGNED_SOURCE_SPLITS, allowUnalignedSourceSplits);

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherTest.java
@@ -29,7 +29,7 @@ import org.apache.flink.connector.base.source.reader.synchronization.FutureCompl
 import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.util.ExceptionUtils;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -46,17 +46,17 @@ import static org.apache.flink.test.util.TestUtils.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for {@link SplitFetcher}. */
-public class SplitFetcherTest {
+class SplitFetcherTest {
 
     @Test
-    public void testNewFetcherIsIdle() {
+    void testNewFetcherIsIdle() {
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
                 createFetcher(new TestingSplitReader<>());
         assertThat(fetcher.isIdle()).isTrue();
     }
 
     @Test
-    public void testFetcherNotIdleAfterSplitAdded() {
+    void testFetcherNotIdleAfterSplitAdded() {
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
                 createFetcher(new TestingSplitReader<>());
         final TestingSourceSplit split = new TestingSourceSplit("test-split");
@@ -73,7 +73,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testIdleAfterFinishedSplitsEnqueued() {
+    void testIdleAfterFinishedSplitsEnqueued() {
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
                 createFetcherWithSplit(
                         "test-split", new TestingSplitReader<>(finishedSplitFetch("test-split")));
@@ -85,7 +85,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testNotifiesWhenGoingIdle() {
+    void testNotifiesWhenGoingIdle() {
         final FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
                 new FutureCompletingBlockingQueue<>();
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
@@ -102,7 +102,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testNotifiesOlderFutureWhenGoingIdle() {
+    void testNotifiesOlderFutureWhenGoingIdle() {
         final FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
                 new FutureCompletingBlockingQueue<>();
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
@@ -121,7 +121,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testNotifiesWhenGoingIdleConcurrent() throws Exception {
+    void testNotifiesWhenGoingIdleConcurrent() throws Exception {
         final FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
                 new FutureCompletingBlockingQueue<>();
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
@@ -146,7 +146,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testNotifiesOlderFutureWhenGoingIdleConcurrent() throws Exception {
+    void testNotifiesOlderFutureWhenGoingIdleConcurrent() throws Exception {
         final FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
                 new FutureCompletingBlockingQueue<>();
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
@@ -167,7 +167,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testWakeup() throws InterruptedException {
+    void testWakeup() throws InterruptedException {
         final int numSplits = 3;
         final int numRecordsPerSplit = 10_000;
         final int wakeupRecordsInterval = 10;
@@ -251,7 +251,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testClose() {
+    void testClose() {
         TestingSplitReader<Object, TestingSourceSplit> splitReader = new TestingSplitReader<>();
         final SplitFetcher<Object, TestingSourceSplit> fetcher = createFetcher(splitReader);
         fetcher.shutdown();
@@ -260,7 +260,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testCloseAfterPause() throws InterruptedException {
+    void testCloseAfterPause() throws InterruptedException {
         final FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
                 new FutureCompletingBlockingQueue<>();
         final SplitFetcher<Object, TestingSourceSplit> fetcher =
@@ -279,7 +279,7 @@ public class SplitFetcherTest {
     }
 
     @Test
-    public void testShutdownWaitingForRecordsProcessing() throws Exception {
+    void testShutdownWaitingForRecordsProcessing() throws Exception {
         TestingSplitReader<Object, TestingSourceSplit> splitReader = new TestingSplitReader<>();
         FutureCompletingBlockingQueue<RecordsWithSplitIds<Object>> queue =
                 new FutureCompletingBlockingQueue<>();

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/synchronization/FutureCompletingBlockingQueueTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.connector.base.source.reader.synchronization;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
 import org.apache.flink.runtime.io.AvailabilityProvider;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.BitSet;
@@ -34,12 +34,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 /** The unit test for {@link FutureCompletingBlockingQueue}. */
-public class FutureCompletingBlockingQueueTest {
+class FutureCompletingBlockingQueueTest {
 
     private static final int DEFAULT_CAPACITY = 2;
 
     @Test
-    public void testBasics() throws InterruptedException {
+    void testBasics() throws InterruptedException {
         FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>(5);
 
         CompletableFuture<Void> future = queue.getAvailabilityFuture();
@@ -62,7 +62,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testPoll() throws InterruptedException {
+    void testPoll() throws InterruptedException {
         FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>();
         queue.put(0, 1234);
         Integer value = queue.poll();
@@ -71,7 +71,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testPollEmptyQueue() throws InterruptedException {
+    void testPollEmptyQueue() throws InterruptedException {
         FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>();
         queue.put(0, 1234);
 
@@ -81,7 +81,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testWakeUpPut() throws InterruptedException {
+    void testWakeUpPut() throws InterruptedException {
         FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>(1);
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -103,7 +103,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testConcurrency() throws InterruptedException {
+    void testConcurrency() throws InterruptedException {
         FutureCompletingBlockingQueue<Integer> queue = new FutureCompletingBlockingQueue<>(5);
         final int numValuesPerThread = 10000;
         final int numPuttingThreads = 5;
@@ -156,7 +156,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testSpecifiedQueueCapacity() {
+    void testSpecifiedQueueCapacity() {
         final int capacity = 8_000;
         final FutureCompletingBlockingQueue<Object> queue =
                 new FutureCompletingBlockingQueue<>(capacity);
@@ -164,7 +164,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testQueueDefaultCapacity() {
+    void testQueueDefaultCapacity() {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         assertThat(queue.remainingCapacity()).isEqualTo(DEFAULT_CAPACITY);
         assertThat(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY.defaultValue().intValue())
@@ -172,20 +172,20 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testUnavailableWhenEmpty() {
+    void testUnavailableWhenEmpty() {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         assertThat(queue.getAvailabilityFuture().isDone()).isFalse();
     }
 
     @Test
-    public void testImmediatelyAvailableAfterPut() throws InterruptedException {
+    void testImmediatelyAvailableAfterPut() throws InterruptedException {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         queue.put(0, new Object());
         assertThat(queue.getAvailabilityFuture().isDone()).isTrue();
     }
 
     @Test
-    public void testFutureBecomesAvailableAfterPut() throws InterruptedException {
+    void testFutureBecomesAvailableAfterPut() throws InterruptedException {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         final CompletableFuture<?> future = queue.getAvailabilityFuture();
         queue.put(0, new Object());
@@ -193,7 +193,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testUnavailableWhenBecomesEmpty() throws InterruptedException {
+    void testUnavailableWhenBecomesEmpty() throws InterruptedException {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         queue.put(0, new Object());
         queue.poll();
@@ -201,14 +201,14 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testAvailableAfterNotifyAvailable() throws InterruptedException {
+    void testAvailableAfterNotifyAvailable() throws InterruptedException {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         queue.notifyAvailable();
         assertThat(queue.getAvailabilityFuture().isDone()).isTrue();
     }
 
     @Test
-    public void testFutureBecomesAvailableAfterNotifyAvailable() throws InterruptedException {
+    void testFutureBecomesAvailableAfterNotifyAvailable() throws InterruptedException {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         final CompletableFuture<?> future = queue.getAvailabilityFuture();
         queue.notifyAvailable();
@@ -216,7 +216,7 @@ public class FutureCompletingBlockingQueueTest {
     }
 
     @Test
-    public void testPollResetsAvailability() throws InterruptedException {
+    void testPollResetsAvailability() throws InterruptedException {
         final FutureCompletingBlockingQueue<Object> queue = new FutureCompletingBlockingQueue<>();
         queue.notifyAvailable();
 
@@ -234,7 +234,7 @@ public class FutureCompletingBlockingQueueTest {
      * scope does not.
      */
     @Test
-    public void testQueueUsesShortCircuitFuture() {
+    void testQueueUsesShortCircuitFuture() {
         assertThat(FutureCompletingBlockingQueue.AVAILABLE)
                 .isSameAs(AvailabilityProvider.AVAILABLE);
     }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/utils/SerdeUtilsTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/utils/SerdeUtilsTest.java
@@ -21,7 +21,7 @@ package org.apache.flink.connector.base.source.utils;
 import org.apache.flink.connector.base.source.reader.mocks.TestingSourceSplit;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -33,13 +33,13 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link SerdeUtils}. */
-public class SerdeUtilsTest {
+class SerdeUtilsTest {
 
     private static final int READER0 = 0;
     private static final int READER1 = 1;
 
     @Test
-    public void testSerdeSplitAssignments() throws IOException {
+    void testSerdeSplitAssignments() throws IOException {
         final Map<Integer, Set<TestingSourceSplit>> splitAssignments = new HashMap<>();
 
         final HashSet<TestingSourceSplit> splitsForReader0 = new HashSet<>();

--- a/flink-connectors/flink-connector-base/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension 
+++ b/flink-connectors/flink-connector-base/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension 
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION


## What is the purpose of the change

Migrate flink-connector-base module to AssertJ and JUnit 5 following the [JUnit 5 Migration Guide](https://docs.google.com/document/d/1514Wa_aNB9bJUen4xm5uiuXOooOJTtXqS_Jqk9KJitU/edit)

## Brief change log
Use JUnit5 and AssertJ in tests instead of JUnit4 and Hamcrest


## Verifying this change
This change is a code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
