### PR TITLE
[hotfix] [flink-parquet] avro parquet logical type fix

### DIFF
--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormatTest.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormatTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -349,9 +350,9 @@ class AvroParquetRecordFormatTest {
 
     private static List<Address> createAddressList() {
         return Arrays.asList(
-                new Address(1, "a", "b", "c", "12345"),
-                new Address(2, "p", "q", "r", "12345"),
-                new Address(3, "x", "y", "z", "12345"));
+                new Address(1, "a", "b", "c", "12345", LocalDate.of(2022, 10, 25)),
+                new Address(2, "p", "q", "r", "12345", LocalDate.of(2022, 7, 26)),
+                new Address(3, "x", "y", "z", "12345", LocalDate.of(2022, 2, 13)));
     }
 
     private static List<Datum> createDatumList() {

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetStreamingFileSinkITCase.java
@@ -71,9 +71,9 @@ public class AvroParquetStreamingFileSinkITCase extends AbstractTestBase {
 
         final List<Address> data =
                 Arrays.asList(
-                        new Address(1, "a", "b", "c", "12345"),
-                        new Address(2, "p", "q", "r", "12345"),
-                        new Address(3, "x", "y", "z", "12345"));
+                        new Address(1, "a", "b", "c", "12345", LocalDate.of(2022, 10, 25)),
+                        new Address(2, "p", "q", "r", "12345", LocalDate.of(2022, 7, 26)),
+                        new Address(3, "x", "y", "z", "12345", LocalDate.of(2022, 2, 13)));
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         env.setParallelism(1);

--- a/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetStreamingFileSinkITCase.java
+++ b/flink-formats/flink-parquet/src/test/java/org/apache/flink/formats/parquet/avro/AvroParquetStreamingFileSinkITCase.java
@@ -46,6 +46,7 @@ import org.junit.rules.Timeout;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.time.LocalDate;
 import java.util.AbstractCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -121,8 +122,8 @@ public class AvroParquetStreamingFileSinkITCase extends AbstractTestBase {
 
         List<Address> expected =
                 Arrays.asList(
-                        new Address(1, "a", "b", "c", "12345"),
-                        new Address(2, "x", "y", "z", "98765"));
+                        new Address(1, "a", "b", "c", "12345", LocalDate.of(2022, 10, 25)),
+                        new Address(2, "x", "y", "z", "98765", LocalDate.of(2022, 10, 26));
 
         validateResults(folder, SpecificData.get(), expected);
     }

--- a/flink-formats/flink-parquet/src/test/resources/avro/testdata.avsc
+++ b/flink-formats/flink-parquet/src/test/resources/avro/testdata.avsc
@@ -1,13 +1,15 @@
 [
-{"namespace": "org.apache.flink.formats.parquet.generated",
- "type": "record",
- "name": "Address",
- "fields": [
-     {"name": "num", "type": "int"},
-     {"name": "street", "type": "string"},
-     {"name": "city", "type": "string"},
-     {"name": "state", "type": "string"},
-     {"name": "zip", "type": "string"}
-  ]
-}
+  {
+    "namespace": "org.apache.flink.formats.parquet.generated",
+    "type": "record",
+    "name": "Address",
+    "fields": [
+      {"name": "num", "type": "int"},
+      {"name": "street", "type": "string"},
+      {"name": "city", "type": "string"},
+      {"name": "state", "type": "string"},
+      {"name": "zip", "type": "string"},
+      {"name": "date", "type": { "type": "int", "logicalType": "date"} }
+    ]
+  }
 ]


### PR DESCRIPTION
## What is the purpose of the change

Currently the code doesn't use the specified Avro Model's SpecificData record which means any logicalTypes registered on the avro type are unavailable resulting in an error. This is hot fix since this is an experimental module, and only fixes the current state of things for those that need it.

## Brief change log

 - Remove redundant schema serialization and de-serialization over and over
 - Make it so it uses the specific model as indicated instead of the generic 'SpecificData' model

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is already covered by existing tests, such as the modified two tests (adding a logical type)

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): NO
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: NO
  - The serializers: YES - writer factory. although experimental
  - The runtime per-record code paths (performance sensitive): NO
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: NO
  - The S3 file system connector: NO

## Documentation

  - Does this pull request introduce a new feature? NO
  - If yes, how is the feature documented? NOT APPLICABLE
