### PR TITLE
[FLINK-27579][client] Make the client.timeout and parallelism.default…

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendDynamicPropertiesTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendDynamicPropertiesTest.java
@@ -33,8 +33,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
-import static org.apache.flink.client.cli.CliFrontendTestUtils.TEST_JAR_MAIN_CLASS;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getTestJarPath;
 import static org.junit.Assert.assertEquals;
 
@@ -83,12 +84,19 @@ public class CliFrontendDynamicPropertiesTest extends CliFrontendTestBase {
             "arg2"
         };
 
-        verifyCliFrontend(
+        Map<String, String> expectedConfigValues = new HashMap<>();
+        expectedConfigValues.put("parallelism.default", "5");
+        expectedConfigValues.put("classloader.resolve-order", "parent-first");
+        verifyCliFrontendWithDynamicProperties(
                 configuration,
                 args,
                 cliUnderTest,
-                "parent-first",
-                ParentFirstClassLoader.class.getName());
+                expectedConfigValues,
+                (configuration, program) -> {
+                    assertEquals(
+                            ParentFirstClassLoader.class.getName(),
+                            program.getUserCodeClassLoader().getClass().getName());
+                });
     }
 
     @Test
@@ -106,12 +114,18 @@ public class CliFrontendDynamicPropertiesTest extends CliFrontendTestBase {
             "arg2"
         };
 
-        verifyCliFrontend(
+        Map<String, String> expectedConfigValues = new HashMap<>();
+        expectedConfigValues.put("parallelism.default", "5");
+        verifyCliFrontendWithDynamicProperties(
                 configuration,
                 args,
                 cliUnderTest,
-                "child-first",
-                ChildFirstClassLoader.class.getName());
+                expectedConfigValues,
+                (configuration, program) -> {
+                    assertEquals(
+                            ChildFirstClassLoader.class.getName(),
+                            program.getUserCodeClassLoader().getClass().getName());
+                });
     }
 
     @Test
@@ -130,56 +144,92 @@ public class CliFrontendDynamicPropertiesTest extends CliFrontendTestBase {
             "arg2"
         };
 
-        verifyCliFrontend(
+        Map<String, String> expectedConfigValues = new HashMap<>();
+        expectedConfigValues.put("parallelism.default", "5");
+        expectedConfigValues.put("classloader.resolve-order", "child-first");
+        verifyCliFrontendWithDynamicProperties(
                 configuration,
                 args,
                 cliUnderTest,
-                "child-first",
-                ChildFirstClassLoader.class.getName());
+                expectedConfigValues,
+                (configuration, program) -> {
+                    assertEquals(
+                            ChildFirstClassLoader.class.getName(),
+                            program.getUserCodeClassLoader().getClass().getName());
+                });
+    }
+
+    @Test
+    public void testDynamicPropertiesWithClientTimeoutAndDefaultParallelism() throws Exception {
+
+        String[] args = {
+            "-e",
+            "test-executor",
+            "-Dclient.timeout=10min",
+            "-Dparallelism.default=12",
+            getTestJarPath(),
+        };
+        Map<String, String> expectedConfigValues = new HashMap<>();
+        expectedConfigValues.put("client.timeout", "10min");
+        expectedConfigValues.put("parallelism.default", "12");
+        verifyCliFrontendWithDynamicProperties(
+                configuration, args, cliUnderTest, expectedConfigValues);
     }
 
     // --------------------------------------------------------------------------------------------
 
-    public static void verifyCliFrontend(
+    public static void verifyCliFrontendWithDynamicProperties(
             Configuration configuration,
             String[] parameters,
             GenericCLI cliUnderTest,
-            String expectedResolveOrderOption,
-            String userCodeClassLoaderClassName)
+            Map<String, String> expectedConfigValues)
             throws Exception {
-        TestingCliFrontend testFrontend =
-                new TestingCliFrontend(
-                        configuration,
-                        cliUnderTest,
-                        expectedResolveOrderOption,
-                        userCodeClassLoaderClassName);
+        verifyCliFrontendWithDynamicProperties(
+                configuration, parameters, cliUnderTest, expectedConfigValues, null);
+    }
+
+    public static void verifyCliFrontendWithDynamicProperties(
+            Configuration configuration,
+            String[] parameters,
+            GenericCLI cliUnderTest,
+            Map<String, String> expectedConfigValues,
+            TestingCliFrontendWithDynamicProperties.CustomTester customTester)
+            throws Exception {
+        TestingCliFrontendWithDynamicProperties testFrontend =
+                new TestingCliFrontendWithDynamicProperties(
+                        configuration, cliUnderTest, expectedConfigValues, customTester);
         testFrontend.run(parameters); // verifies the expected values (see below)
     }
 
-    private static final class TestingCliFrontend extends CliFrontend {
+    private static final class TestingCliFrontendWithDynamicProperties extends CliFrontend {
+        private final Map<String, String> expectedConfigValues;
 
-        private final String expectedResolveOrder;
+        private final CustomTester tester;
 
-        private final String userCodeClassLoaderClassName;
-
-        private TestingCliFrontend(
+        private TestingCliFrontendWithDynamicProperties(
                 Configuration configuration,
-                GenericCLI cliUnderTest,
-                String expectedResolveOrderOption,
-                String userCodeClassLoaderClassName) {
-            super(configuration, Collections.singletonList(cliUnderTest));
-            this.expectedResolveOrder = expectedResolveOrderOption;
-            this.userCodeClassLoaderClassName = userCodeClassLoaderClassName;
+                GenericCLI cli,
+                Map<String, String> expectedConfigValues,
+                CustomTester customTester) {
+            super(configuration, Collections.singletonList(cli));
+            this.expectedConfigValues = expectedConfigValues;
+            this.tester = customTester;
+        }
+
+        @FunctionalInterface
+        private interface CustomTester {
+            void test(Configuration configuration, PackagedProgram program);
         }
 
         @Override
         protected void executeProgram(Configuration configuration, PackagedProgram program) {
-            assertEquals(TEST_JAR_MAIN_CLASS, program.getMainClassName());
-            assertEquals(
-                    expectedResolveOrder, configuration.get(CoreOptions.CLASSLOADER_RESOLVE_ORDER));
-            assertEquals(
-                    userCodeClassLoaderClassName,
-                    program.getUserCodeClassLoader().getClass().getName());
+            expectedConfigValues.forEach(
+                    (key, value) -> {
+                        assertEquals(configuration.toMap().get(key), value);
+                    });
+            if (tester != null) {
+                tester.test(configuration, program);
+            }
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

*backport FLINK-27579 to 1.15*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
