### PR TITLE
[hotfix][doc] `FlinkKafkaConsumer` is deprecated and will be removed with Flink 1.17 instead of 1.15

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -327,7 +327,7 @@ Kafka source 的源读取器扩展了 ```SourceReaderBase```，并使用单线�
 
 ## Kafka SourceFunction
 {{< hint warning >}}
-`FlinkKafkaConsumer` 已被弃用并将在 Flink 1.15 中移除，请改用 ```KafkaSource```。
+`FlinkKafkaConsumer` 已被弃用并将在 Flink 1.17 中移除，请改用 ```KafkaSource```。
 {{< /hint >}}
 
 如需参考，请参阅 Flink 1.13 [文档](https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/connectors/datastream/kafka/#kafka-sourcefunction)。

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -381,7 +381,7 @@ when the record is emitted downstream.
 
 ## Kafka SourceFunction
 {{< hint warning >}}
-`FlinkKafkaConsumer` is deprecated and will be removed with Flink 1.15, please use `KafkaSource` instead.
+`FlinkKafkaConsumer` is deprecated and will be removed with Flink 1.17, please use `KafkaSource` instead.
 {{< /hint >}}
 
 For older references you can look at the Flink 1.13 <a href="https://nightlies.apache.org/flink/flink-docs-release-1.13/docs/connectors/datastream/kafka/#kafka-sourcefunction">documentation</a>.


### PR DESCRIPTION
## What is the purpose of the change

Doc should be updated: `FlinkKafkaConsumer` is deprecated and will be removed with Flink 1.17 instead of 1.15 since Flink 1.16 has code freeze and will be released soon.


## Brief change log

  - kafka.md
  - zh kafka.md


## Verifying this change

This change is a trivial doc update without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
