### PR TITLE
[FLINK-29557] Fix the SinkOperator with OutputFormatFunction is ignor…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/AbstractUdfStreamOperator.java
@@ -47,7 +47,8 @@ import static java.util.Objects.requireNonNull;
  */
 @PublicEvolving
 public abstract class AbstractUdfStreamOperator<OUT, F extends Function>
-        extends AbstractStreamOperator<OUT> implements OutputTypeConfigurable<OUT> {
+        extends AbstractStreamOperator<OUT>
+        implements OutputTypeConfigurable<OUT>, UserFunctionProvider<F> {
 
     private static final long serialVersionUID = 1L;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OutputFormatOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/OutputFormatOperatorFactory.java
@@ -27,7 +27,7 @@ import org.apache.flink.api.common.io.OutputFormat;
  * @param <IN> The input type of the operator.
  */
 @Internal
-public interface OutputFormatOperatorFactory<IN> extends StreamOperatorFactory<Object> {
+public interface OutputFormatOperatorFactory<IN, OUT> extends StreamOperatorFactory<OUT> {
 
     /** @return output format of the operator created by this factory. */
     OutputFormat<IN> getOutputFormat();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOperatorFactory.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.InputTypeConfigurable;
 import org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction;
@@ -45,9 +46,14 @@ public class SimpleOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
                 && ((StreamSource) operator).getUserFunction()
                         instanceof InputFormatSourceFunction) {
             return new SimpleInputFormatOperatorFactory<OUT>((StreamSource) operator);
-        } else if (operator instanceof StreamSink
-                && ((StreamSink) operator).getUserFunction() instanceof OutputFormatSinkFunction) {
-            return new SimpleOutputFormatOperatorFactory<>((StreamSink) operator);
+        } else if (operator instanceof UserFunctionProvider
+                && (((UserFunctionProvider<Function>) operator).getUserFunction()
+                        instanceof OutputFormatSinkFunction)) {
+            return new SimpleOutputFormatOperatorFactory<>(
+                    (((OutputFormatSinkFunction<?>)
+                                    ((UserFunctionProvider<Function>) operator).getUserFunction())
+                            .getFormat()),
+                    operator);
         } else if (operator instanceof AbstractUdfStreamOperator) {
             return new SimpleUdfStreamOperatorFactory<OUT>((AbstractUdfStreamOperator) operator);
         } else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOutputFormatOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SimpleOutputFormatOperatorFactory.java
@@ -19,30 +19,26 @@ package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.io.OutputFormat;
-import org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction;
-
-import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * A simple operator factory which create {@link StreamSink} containing an {@link OutputFormat}.
+ * A simple operator factory which create an operator containing an {@link OutputFormat}.
  *
  * @param <IN> The input type of the operator.
  */
 @Internal
-public class SimpleOutputFormatOperatorFactory<IN> extends SimpleOperatorFactory<Object>
-        implements OutputFormatOperatorFactory<IN> {
+public class SimpleOutputFormatOperatorFactory<IN, OUT> extends SimpleOperatorFactory<OUT>
+        implements OutputFormatOperatorFactory<IN, OUT> {
 
-    private final StreamSink<IN> operator;
+    private final OutputFormat<IN> outputFormat;
 
-    public SimpleOutputFormatOperatorFactory(StreamSink<IN> operator) {
+    public SimpleOutputFormatOperatorFactory(
+            OutputFormat<IN> outputFormat, StreamOperator<OUT> operator) {
         super(operator);
-
-        checkState(operator.getUserFunction() instanceof OutputFormatSinkFunction);
-        this.operator = operator;
+        this.outputFormat = outputFormat;
     }
 
     @Override
     public OutputFormat<IN> getOutputFormat() {
-        return ((OutputFormatSinkFunction<IN>) operator.getUserFunction()).getFormat();
+        return outputFormat;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/UserFunctionProvider.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/UserFunctionProvider.java
@@ -1,0 +1,28 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.operators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.Function;
+
+/** The interface with user function. */
+@Internal
+public interface UserFunctionProvider<F extends Function> {
+
+    F getUserFunction();
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/SinkOperatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sink;
+
+import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.functions.sink.OutputFormatSinkFunction;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.SimpleOutputFormatOperatorFactory;
+import org.apache.flink.table.data.RowData;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link SinkOperator}. */
+public class SinkOperatorTest {
+
+    @Test
+    public void testSinkOperatorWithOutputFormat() {
+        SinkOperator operator =
+                new SinkOperator(
+                        new OutputFormatSinkFunction<>(
+                                new OutputFormat<RowData>() {
+                                    private static final long serialVersionUID = 1L;
+
+                                    @Override
+                                    public void configure(Configuration parameters) {}
+
+                                    @Override
+                                    public void open(int taskNumber, int numTasks) {}
+
+                                    @Override
+                                    public void writeRecord(RowData record) {}
+
+                                    @Override
+                                    public void close() {}
+                                }),
+                        -1);
+        SimpleOperatorFactory<?> factory = SimpleOperatorFactory.of(operator);
+        assertThat(factory).isInstanceOf(SimpleOutputFormatOperatorFactory.class);
+    }
+}


### PR DESCRIPTION
…ed as InputFormatOperator

## What is the purpose of the change

This pr is meant to fix the `SinkOperator` with `OutputFormatFunction` is not recognized as `InputFormatOperator`

## Brief change log

  - Add a new interface `SinkFunctionOperator` and let the `SinkOperator` and `StreamSink` extend from it
  - Check for `SinkFunctionOperator#sinkFunction` in the `SimpleOperatorFactory`


## Verifying this change

This change added tests and can be verified by `SinkOperatorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
