### PR TITLE
[BP-1.15][FLINK-29539][Deployment/Kubernetes] dnsPolicy in FlinkPod is not overridable

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/Constants.java
@@ -25,8 +25,8 @@ public class Constants {
     public static final String API_VERSION = "v1";
     public static final String APPS_API_VERSION = "apps/v1";
 
-    public static final String DNS_PLOICY_DEFAULT = "ClusterFirst";
-    public static final String DNS_PLOICY_HOSTNETWORK = "ClusterFirstWithHostNet";
+    public static final String DNS_POLICY_DEFAULT = "ClusterFirst";
+    public static final String DNS_POLICY_HOSTNETWORK = "ClusterFirstWithHostNet";
 
     public static final String CONFIG_FILE_LOGBACK_NAME = "logback-console.xml";
     public static final String CONFIG_FILE_LOG4J_NAME = "log4j-console.properties";

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/utils/KubernetesUtils.java
@@ -84,6 +84,8 @@ import java.util.stream.Collectors;
 
 import static org.apache.flink.kubernetes.utils.Constants.CHECKPOINT_ID_KEY_PREFIX;
 import static org.apache.flink.kubernetes.utils.Constants.COMPLETED_CHECKPOINT_FILE_SUFFIX;
+import static org.apache.flink.kubernetes.utils.Constants.DNS_POLICY_DEFAULT;
+import static org.apache.flink.kubernetes.utils.Constants.DNS_POLICY_HOSTNETWORK;
 import static org.apache.flink.kubernetes.utils.Constants.JOB_GRAPH_STORE_KEY_PREFIX;
 import static org.apache.flink.kubernetes.utils.Constants.LABEL_CONFIGMAP_TYPE_HIGH_AVAILABILITY;
 import static org.apache.flink.kubernetes.utils.Constants.LEADER_ADDRESS_KEY;
@@ -484,6 +486,24 @@ public class KubernetesUtils {
             resolvedValue = valueOfConfigOptionOrDefault;
         }
         return resolvedValue;
+    }
+
+    /**
+     * Resolve the DNS policy defined value. Return DNS_POLICY_HOSTNETWORK if host network enabled.
+     * If not, check whether there is a DNS policy overridden in pod template.
+     *
+     * @param dnsPolicy DNS policy defined in pod template spec
+     * @param hostNetworkEnabled Host network enabled or not
+     * @return the resolved value
+     */
+    public static String resolveDNSPolicy(String dnsPolicy, boolean hostNetworkEnabled) {
+        if (hostNetworkEnabled) {
+            return DNS_POLICY_HOSTNETWORK;
+        }
+        if (!StringUtils.isNullOrWhitespaceOnly(dnsPolicy)) {
+            return dnsPolicy;
+        }
+        return DNS_POLICY_DEFAULT;
     }
 
     /**

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/DecoratorWithPodTemplateTestBase.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/DecoratorWithPodTemplateTestBase.java
@@ -232,4 +232,25 @@ public abstract class DecoratorWithPodTemplateTestBase extends KubernetesPodTest
     public void testMainContainerImagePullPolicyOverwritten() {
         assertThat(this.resultPod.getMainContainer().getImagePullPolicy(), is(IMAGE_PULL_POLICY));
     }
+
+    @Test
+    public void testDNSPolicyWithPodTemplate() {
+        assertThat(
+                this.resultPod.getPodWithoutMainContainer().getSpec().getDnsPolicy(), is("None"));
+    }
+
+    @Test
+    public void testDNSPolicyOverwritten() throws Exception {
+        flinkConfig.set(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED, true);
+        final FlinkPod podTemplate =
+                KubernetesUtils.loadPodFromTemplateFile(
+                        flinkKubeClient,
+                        KubernetesPodTemplateTestUtils.getPodTemplateFile(),
+                        KubernetesPodTemplateTestUtils.TESTING_MAIN_CONTAINER_NAME);
+        final FlinkPod newResultPod = getResultPod(podTemplate);
+        assertThat(
+                newResultPod.getPodWithoutMainContainer().getSpec().getDnsPolicy(),
+                is(Constants.DNS_POLICY_HOSTNETWORK));
+        flinkConfig.set(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED, false);
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -230,4 +230,9 @@ public class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
                                                         .equals(USER_DEFINED_FLINK_LOG_DIR)),
                 is(true));
     }
+
+    @Test
+    public void testDNSPolicyDefaultValue() {
+        assertThat(this.resultPod.getSpec().getDnsPolicy(), is(Constants.DNS_POLICY_DEFAULT));
+    }
 }

--- a/flink-kubernetes/src/test/resources/testing-pod-template.yaml
+++ b/flink-kubernetes/src/test/resources/testing-pod-template.yaml
@@ -94,3 +94,4 @@ spec:
       emptyDir: { }
     - name: flink-logs
       emptyDir: { }
+  dnsPolicy: None


### PR DESCRIPTION
This PR is a backport of PR https://github.com/apache/flink/pull/20982 that relates to [FLINK-29539](https://issues.apache.org/jira/browse/FLINK-29539)