### PR TITLE
[FLINK-29783][tests] Add some random to KafkaShuffleExactlyOnceITCase topic names

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
@@ -31,6 +31,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.util.UUID;
+
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.IngestionTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.ProcessingTime;
@@ -110,7 +112,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
     private void testKafkaShuffleFailureRecovery(
             int numElementsPerProducer, TimeCharacteristic timeCharacteristic) throws Exception {
 
-        String topic = topic("failure_recovery", timeCharacteristic);
+        String topic = topic("failure_recovery" + UUID.randomUUID(), timeCharacteristic);
         final int numberOfPartitions = 1;
         final int producerParallelism = 1;
         final int failAfterElements = numElementsPerProducer * numberOfPartitions * 2 / 3;
@@ -150,7 +152,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      */
     private void testAssignedToPartitionFailureRecovery(
             int numElementsPerProducer, TimeCharacteristic timeCharacteristic) throws Exception {
-        String topic = topic("partition_failure_recovery", timeCharacteristic);
+        String topic = topic("partition_failure_recovery" + UUID.randomUUID(), timeCharacteristic);
         final int numberOfPartitions = 3;
         final int producerParallelism = 2;
         final int failAfterElements = numElementsPerProducer * producerParallelism * 2 / 3;


### PR DESCRIPTION
## What is the purpose of the change

`KafkaShuffleExactlyOnceITCasetopic.testAssignedToPartitionFailureRecoveryEventTime` fails with the following exception:
```
{code:java}
Oct 27 15:07:54 java.lang.AssertionError: Create test topic : partition_failure_recovery_EventTime failed, org.apache.kafka.common.errors.TopicExistsException: Topic 'partition_failure_recovery_EventTime' already exists.
Oct 27 15:07:54 	at org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironmentImpl.createTestTopic(KafkaTestEnvironmentImpl.java:207)
Oct 27 15:07:54 	at org.apache.flink.streaming.connectors.kafka.KafkaTestEnvironment.createTestTopic(KafkaTestEnvironment.java:97)
Oct 27 15:07:54 	at org.apache.flink.streaming.connectors.kafka.KafkaTestBase.createTestTopic(KafkaTestBase.java:217)
Oct 27 15:07:54 	at org.apache.flink.streaming.connectors.kafka.shuffle.KafkaShuffleExactlyOnceITCase.testAssignedToPartitionFailureRecovery(KafkaShuffleExactlyOnceITCase.java:158)
Oct 27 15:07:54 	at org.apache.flink.streaming.connectors.kafka.shuffle.KafkaShuffleExactlyOnceITCase.testAssignedToPartitionFailureRecoveryEventTime(KafkaShuffleExactlyOnceITCase.java:101)
Oct 27 15:07:54 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
Oct 27 15:07:54 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
Oct 27 15:07:54 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
Oct 27 15:07:54 	at java.lang.reflect.Method.invoke(Method.java:498)
Oct 27 15:07:54 	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
Oct 27 15:07:54 	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
Oct 27 15:07:54 	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
Oct 27 15:07:54 	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
Oct 27 15:07:54 	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
Oct 27 15:07:54 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
Oct 27 15:07:54 	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
Oct 27 15:07:54 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
Oct 27 15:07:54 	at java.lang.Thread.run(Thread.java:748)
{code}
```

I don't see any reason why multiple times the same topic would be created so what I assume is that somehow the test is executed multiple times within the JVM and Kafka instance is class bounded.

In the current PR I've made a quick fix to make this disappear and allow peoples to work on features.

## Brief change log

Added some random to KafkaShuffleExactlyOnceITCasetopic names.

## Verifying this change

Existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
