### PR TITLE
[FLINK-29679][table] Migrate to new schema framework & show column comment

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -132,11 +132,11 @@ table_env.execute_sql("DESC Orders").print()
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> CREATE TABLE Orders (
->  `user` BIGINT NOT NULl,
+>  `user` BIGINT NOT NULl comment 'this is primary key',
 >  product VARCHAR(32),
 >  amount INT,
->  ts TIMESTAMP(3),
->  ptime AS PROCTIME(),
+>  ts TIMESTAMP(3) comment 'notice: watermark',
+>  ptime AS PROCTIME() comment 'this is a computed column',
 >  PRIMARY KEY(`user`) NOT ENFORCED,
 >  WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS
 > ) with (
@@ -156,15 +156,15 @@ Flink SQL> DESC Orders;
 {{< tab "Java" >}}
 ```text
 
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    name |                             type |  null |       key | computed column |                  watermark |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    user |                           BIGINT | false | PRI(user) |                 |                            |
-| product |                      VARCHAR(32) |  true |           |                 |                            |
-|  amount |                              INT |  true |           |                 |                            |
-|      ts |           TIMESTAMP(3) *ROWTIME* |  true |           |                 | `ts` - INTERVAL '1' SECOND |
-|   ptime | TIMESTAMP(3) NOT NULL *PROCTIME* | false |           |      PROCTIME() |                            |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
 
 ```
@@ -172,15 +172,15 @@ Flink SQL> DESC Orders;
 {{< tab "Scala" >}}
 ```text
 
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    name |                             type |  null |       key | computed column |                  watermark |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    user |                           BIGINT | false | PRI(user) |                 |                            |
-| product |                      VARCHAR(32) |  true |           |                 |                            |
-|  amount |                              INT |  true |           |                 |                            |
-|      ts |           TIMESTAMP(3) *ROWTIME* |  true |           |                 | `ts` - INTERVAL '1' SECOND |
-|   ptime | TIMESTAMP(3) NOT NULL *PROCTIME* | false |           |      PROCTIME() |                            |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
 
 ```
@@ -188,15 +188,15 @@ Flink SQL> DESC Orders;
 {{< tab "Python" >}}
 ```text
 
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    name |                             type |  null |       key | computed column |                  watermark |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    user |                           BIGINT | false | PRI(user) |                 |                            |
-| product |                      VARCHAR(32) |  true |           |                 |                            |
-|  amount |                              INT |  true |           |                 |                            |
-|      ts |           TIMESTAMP(3) *ROWTIME* |  true |           |                 | `ts` - INTERVAL '1' SECOND |
-|   ptime | TIMESTAMP(3) NOT NULL *PROCTIME* | false |           |      PROCTIME() |                            |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
 
 ```
@@ -205,11 +205,11 @@ Flink SQL> DESC Orders;
 ```text
 
 root
- |-- user: BIGINT NOT NULL
+ |-- user: BIGINT NOT NULL COMMENT 'this is primary key'
  |-- product: VARCHAR(32)
  |-- amount: INT
- |-- ts: TIMESTAMP(3) *ROWTIME*
- |-- ptime: TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME()
+ |-- ts: TIMESTAMP(3) *ROWTIME* COMMENT 'notice: watermark'
+ |-- ptime: TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME() COMMENT 'this is a computed column'
  |-- WATERMARK FOR ts AS `ts` - INTERVAL '1' SECOND
  |-- CONSTRAINT PK_3599338 PRIMARY KEY (user)
 

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -131,11 +131,11 @@ table_env.execute_sql("DESC Orders").print()
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> CREATE TABLE Orders (
->  `user` BIGINT NOT NULl,
+>  `user` BIGINT NOT NULl comment 'this is primary key',
 >  product VARCHAR(32),
 >  amount INT,
->  ts TIMESTAMP(3),
->  ptime AS PROCTIME(),
+>  ts TIMESTAMP(3) comment 'notice: watermark',
+>  ptime AS PROCTIME() comment 'this is a computed column',
 >  PRIMARY KEY(`user`) NOT ENFORCED,
 >  WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS
 > ) with (
@@ -155,15 +155,15 @@ The result of the above example is:
 {{< tab "Java" >}}
 ```text
 
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    name |                             type |  null |       key | computed column |                  watermark |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    user |                           BIGINT | false | PRI(user) |                 |                            |
-| product |                      VARCHAR(32) |  true |           |                 |                            |
-|  amount |                              INT |  true |           |                 |                            |
-|      ts |           TIMESTAMP(3) *ROWTIME* |  true |           |                 | `ts` - INTERVAL '1' SECOND |
-|   ptime | TIMESTAMP(3) NOT NULL *PROCTIME* | false |           |      PROCTIME() |                            |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
 
 ```
@@ -171,15 +171,15 @@ The result of the above example is:
 {{< tab "Scala" >}}
 ```text
 
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    name |                             type |  null |       key | computed column |                  watermark |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    user |                           BIGINT | false | PRI(user) |                 |                            |
-| product |                      VARCHAR(32) |  true |           |                 |                            |
-|  amount |                              INT |  true |           |                 |                            |
-|      ts |           TIMESTAMP(3) *ROWTIME* |  true |           |                 | `ts` - INTERVAL '1' SECOND |
-|   ptime | TIMESTAMP(3) NOT NULL *PROCTIME* | false |           |      PROCTIME() |                            |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
 
 ```
@@ -187,15 +187,15 @@ The result of the above example is:
 {{< tab "Python" >}}
 ```text
 
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    name |                             type |  null |       key | computed column |                  watermark |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
-|    user |                           BIGINT | false | PRI(user) |                 |                            |
-| product |                      VARCHAR(32) |  true |           |                 |                            |
-|  amount |                              INT |  true |           |                 |                            |
-|      ts |           TIMESTAMP(3) *ROWTIME* |  true |           |                 | `ts` - INTERVAL '1' SECOND |
-|   ptime | TIMESTAMP(3) NOT NULL *PROCTIME* | false |           |      PROCTIME() |                            |
-+---------+----------------------------------+-------+-----------+-----------------+----------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                   comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |       this is primary key |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                           |
+|  amount |                         INT |  TRUE |           |               |                            |                           |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |         notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | this is a computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+---------------------------+
 5 rows in set
 
 ```
@@ -204,11 +204,11 @@ The result of the above example is:
 ```text
 
 root
- |-- user: BIGINT NOT NULL
+ |-- user: BIGINT NOT NULL COMMENT 'this is primary key'
  |-- product: VARCHAR(32)
  |-- amount: INT
- |-- ts: TIMESTAMP(3) *ROWTIME*
- |-- ptime: TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME()
+ |-- ts: TIMESTAMP(3) *ROWTIME* COMMENT 'notice: watermark'
+ |-- ptime: TIMESTAMP(3) NOT NULL *PROCTIME* AS PROCTIME() COMMENT 'this is a computed column'
  |-- WATERMARK FOR ts AS `ts` - INTERVAL '1' SECOND
  |-- CONSTRAINT PK_3599338 PRIMARY KEY (user)
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableFactory.java
@@ -19,14 +19,12 @@
 package org.apache.flink.connectors.hive;
 
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.factories.TableFactoryUtil;
 import org.apache.flink.table.factories.TableSinkFactory;
 import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.TableSource;
-import org.apache.flink.util.Preconditions;
 
 import java.util.List;
 import java.util.Map;
@@ -49,7 +47,6 @@ public class HiveTableFactory implements TableSourceFactory, TableSinkFactory {
     @Override
     public TableSource createTableSource(TableSourceFactory.Context context) {
         CatalogTable table = checkNotNull(context.getTable());
-        Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
         boolean isHiveTable = HiveCatalog.isHiveTable(table.getOptions());
 
@@ -65,7 +62,6 @@ public class HiveTableFactory implements TableSourceFactory, TableSinkFactory {
     @Override
     public TableSink createTableSink(TableSinkFactory.Context context) {
         CatalogTable table = checkNotNull(context.getTable());
-        Preconditions.checkArgument(table instanceof CatalogTableImpl);
 
         boolean isHiveTable = HiveCatalog.isHiveTable(table.getOptions());
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
@@ -2099,7 +2099,7 @@ public class HiveParserBaseSemanticAnalyzer {
                                         String.format(
                                                 "Table %s doesn't exist.",
                                                 tableIdentifier.asSummaryString())))
-                .getTable();
+                .getResolvedTable();
     }
 
     /** Counterpart of hive's BaseSemanticAnalyzer.TableSpec. */

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSemanticAnalyzer.java
@@ -2103,7 +2103,7 @@ public class HiveParserSemanticAnalyzer {
                 return null;
             }
         } else {
-            return optionalTab.get().getTable();
+            return optionalTab.get().getResolvedTable();
         }
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/parse/HiveParserDDLSemanticAnalyzer.java
@@ -2192,7 +2192,7 @@ public class HiveParserDDLSemanticAnalyzer {
             throw new ValidationException(
                     String.format("Table or View %s is temporary.", tableIdentifier.toString()));
         }
-        return optionalCatalogTable.get().getTable();
+        return optionalCatalogTable.get().getResolvedTable();
     }
 
     /**

--- a/flink-table/flink-sql-client/src/test/resources/sql/table.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/table.q
@@ -527,6 +527,52 @@ Empty set
 !ok
 
 # ==========================================================================
+# test describe table with comment
+# ==========================================================================
+
+CREATE TABLE `default_catalog`.`default_database`.`orders3` (
+  `user` BIGINT NOT NULL comment 'this is the first column',
+  `product` VARCHAR(32),
+  `amount` INT,
+  `ts` TIMESTAMP(3) comment 'notice: watermark',
+  `ptime` AS PROCTIME() comment 'notice: computed column',
+  WATERMARK FOR `ts` AS `ts` - INTERVAL '1' SECOND,
+  CONSTRAINT `PK_3599338` PRIMARY KEY (`user`) NOT ENFORCED
+) WITH (
+  'connector' = 'kafka',
+  'scan.startup.mode' = 'earliest-offset'
+);
+[INFO] Execute statement succeed.
+!info
+
+describe orders3;
++---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                  comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            | this is the first column |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                          |
+|  amount |                         INT |  TRUE |           |               |                            |                          |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |        notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            |  notice: computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
+5 rows in set
+!ok
+
+# test desc table
+desc orders3;
++---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                  comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            | this is the first column |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                          |
+|  amount |                         INT |  TRUE |           |               |                            |                          |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |        notice: watermark |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            |  notice: computed column |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
+5 rows in set
+!ok
+
+# ==========================================================================
 # test explain
 # ==========================================================================
 

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -1624,31 +1624,27 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                 .map(
                         (c) -> {
                             final LogicalType logicalType = c.getDataType().getLogicalType();
-                            if (nonComments) {
-                                return new Object[] {
-                                    c.getName(),
-                                    logicalType.copy(true).asSummaryString(),
-                                    logicalType.isNullable(),
-                                    fieldToPrimaryKey.getOrDefault(c.getName(), null),
-                                    c.explainExtras().orElse(null),
-                                    fieldToWatermark.getOrDefault(c.getName(), null)
-                                };
+                            final ArrayList<Object> result =
+                                    new ArrayList<>(
+                                            Arrays.asList(
+                                                    c.getName(),
+                                                    logicalType.copy(true).asSummaryString(),
+                                                    logicalType.isNullable(),
+                                                    fieldToPrimaryKey.getOrDefault(
+                                                            c.getName(), null),
+                                                    c.explainExtras().orElse(null),
+                                                    fieldToWatermark.getOrDefault(
+                                                            c.getName(), null)));
+                            if (!nonComments) {
+                                result.add(c.getComment().orElse(null));
                             }
-                            return new Object[] {
-                                c.getName(),
-                                logicalType.copy(true).asSummaryString(),
-                                logicalType.isNullable(),
-                                fieldToPrimaryKey.getOrDefault(c.getName(), null),
-                                c.explainExtras().orElse(null),
-                                fieldToWatermark.getOrDefault(c.getName(), null),
-                                c.getComment().orElse(null)
-                            };
+                            return result.toArray();
                         })
                 .toArray(Object[][]::new);
     }
 
     private boolean isSchemaNonColumnComments(ResolvedSchema schema) {
-        return schema.getColumns().stream().noneMatch(col -> col.getComment().isPresent());
+        return schema.getColumns().stream().map(Column::getComment).noneMatch(Optional::isPresent);
     }
 
     private TableResultInternal buildResult(String[] headers, DataType[] types, Object[][] rows) {

--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/api/TableEnvironmentTest.java
@@ -67,7 +67,7 @@ class TableEnvironmentTest {
                 tEnv.getCatalogManager().getTable(ObjectIdentifier.of(catalog, database, "T"));
         assertThat(lookupResult.isPresent()).isTrue();
 
-        final CatalogBaseTable catalogTable = lookupResult.get().getTable();
+        final CatalogBaseTable catalogTable = lookupResult.get().getResolvedTable();
         assertThat(catalogTable instanceof CatalogTable).isTrue();
         assertThat(catalogTable.getUnresolvedSchema()).isEqualTo(schema);
         assertThat(catalogTable.getOptions().get("connector")).isEqualTo("fake");
@@ -120,7 +120,7 @@ class TableEnvironmentTest {
                         crs -> {
                             assertThat(crs.isAnonymous()).isTrue();
                             assertThat(crs.getIdentifier().toList()).hasSize(1);
-                            assertThat(crs.getTable().getOptions())
+                            assertThat(crs.getResolvedTable().getOptions())
                                     .containsEntry("connector", "fake");
                         });
 
@@ -196,7 +196,7 @@ class TableEnvironmentTest {
                 tEnv.getCatalogManager().getTable(identifier);
         assertThat(lookupResult.isPresent()).isTrue();
 
-        final CatalogBaseTable catalogTable = lookupResult.get().getTable();
+        final CatalogBaseTable catalogTable = lookupResult.get().getResolvedTable();
         assertThat(catalogTable instanceof CatalogTable).isTrue();
         assertThat(catalogTable.getUnresolvedSchema()).isEqualTo(schema);
         assertThat(catalogTable.getOptions().get("a")).isEqualTo("Test");

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -314,36 +314,7 @@ public class TableSchema {
 
     /** Helps to migrate to the new {@link Schema} class. */
     public Schema toSchema() {
-        final Schema.Builder builder = Schema.newBuilder();
-
-        columns.forEach(
-                column -> {
-                    if (column instanceof PhysicalColumn) {
-                        final PhysicalColumn c = (PhysicalColumn) column;
-                        builder.column(c.getName(), c.getType());
-                    } else if (column instanceof MetadataColumn) {
-                        final MetadataColumn c = (MetadataColumn) column;
-                        builder.columnByMetadata(
-                                c.getName(),
-                                c.getType(),
-                                c.getMetadataAlias().orElse(null),
-                                c.isVirtual());
-                    } else if (column instanceof ComputedColumn) {
-                        final ComputedColumn c = (ComputedColumn) column;
-                        builder.columnByExpression(c.getName(), c.getExpression());
-                    } else {
-                        throw new IllegalArgumentException("Unsupported column type: " + column);
-                    }
-                });
-
-        watermarkSpecs.forEach(
-                spec -> builder.watermark(spec.getRowtimeAttribute(), spec.getWatermarkExpr()));
-
-        if (primaryKey != null) {
-            builder.primaryKeyNamed(primaryKey.getName(), primaryKey.getColumns());
-        }
-
-        return builder.build();
+        return toSchema(Collections.emptyMap());
     }
 
     /** Helps to migrate to the new {@link Schema} class, retain comments when needed. */

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/TableSchema.java
@@ -368,7 +368,10 @@ public class TableSchema {
                     } else {
                         throw new IllegalArgumentException("Unsupported column type: " + column);
                     }
-                    builder.withComment(comments.get(column.getName()));
+                    String colName = column.getName();
+                    if (comments.containsKey(colName)) {
+                        builder.withComment(comments.get(colName));
+                    }
                 });
 
         watermarkSpecs.forEach(

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/typeutils/TimeIndicatorTypeInfo.java
@@ -22,7 +22,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.typeinfo.SqlTimeTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.base.LongSerializer;
+import org.apache.flink.api.common.typeutils.base.LocalDateTimeSerializer;
 import org.apache.flink.api.common.typeutils.base.SqlTimestampComparator;
 import org.apache.flink.api.common.typeutils.base.SqlTimestampSerializer;
 import org.apache.flink.table.api.DataTypes;
@@ -30,8 +30,7 @@ import org.apache.flink.table.api.DataTypes;
 import java.sql.Timestamp;
 
 /**
- * Type information for indicating event or processing time. However, it behaves like a regular SQL
- * timestamp but is serialized as Long.
+ * Type information for indicating event or processing time.
  *
  * @deprecated This class will be removed in future versions as it is used for the old type system.
  *     It is recommended to use {@link DataTypes} instead. Please make sure to use either the old or
@@ -62,13 +61,10 @@ public class TimeIndicatorTypeInfo extends SqlTimeTypeInfo<Timestamp> {
         this.isEventTime = isEventTime;
     }
 
-    // this replaces the effective serializer by a LongSerializer
-    // it is a hacky but efficient solution to keep the object creation overhead low but still
-    // be compatible with the corresponding SqlTimestampTypeInfo
     @Override
     @SuppressWarnings("unchecked")
     public TypeSerializer<Timestamp> createSerializer(ExecutionConfig executionConfig) {
-        return (TypeSerializer) LongSerializer.INSTANCE;
+        return (TypeSerializer) LocalDateTimeSerializer.INSTANCE;
     }
 
     public boolean isEventTime() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/catalog/CatalogSchemaTable.java
@@ -154,14 +154,14 @@ public class CatalogSchemaTable extends AbstractTable implements TemporalTable {
     private Optional<TableSource<?>> findAndCreateTableSource() {
         Optional<TableSource<?>> tableSource = Optional.empty();
         try {
-            if (contextResolvedTable.getTable() instanceof CatalogTable) {
+            if (contextResolvedTable.getResolvedTable() instanceof CatalogTable) {
                 // Use an empty config for TableSourceFactoryContextImpl since we can't fetch the
                 // actual TableConfig here. And currently the empty config do not affect the logic.
                 ReadableConfig config = new Configuration();
                 TableSourceFactory.Context context =
                         new TableSourceFactoryContextImpl(
                                 contextResolvedTable.getIdentifier(),
-                                contextResolvedTable.getTable(),
+                                contextResolvedTable.getResolvedTable(),
                                 config,
                                 contextResolvedTable.isTemporary());
                 TableSource<?> source = TableFactoryUtil.findAndCreateTableSource(context);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -419,7 +419,7 @@ public class SqlToOperationConverter {
                             "View %s doesn't exist or is a temporary view.",
                             viewIdentifier.toString()));
         }
-        CatalogBaseTable baseTable = optionalCatalogTable.get().getTable();
+        CatalogBaseTable baseTable = optionalCatalogTable.get().getResolvedTable();
         if (baseTable instanceof CatalogTable) {
             throw new ValidationException("ALTER VIEW for a table is not allowed");
         }
@@ -476,7 +476,7 @@ public class SqlToOperationConverter {
                     String.format(
                             "Table %s doesn't exist or is a temporary table.", tableIdentifier));
         }
-        CatalogBaseTable baseTable = optionalCatalogTable.get().getTable();
+        CatalogBaseTable baseTable = optionalCatalogTable.get().getResolvedTable();
         if (baseTable instanceof CatalogView) {
             throw new ValidationException("ALTER TABLE for a view is not allowed");
         }
@@ -1293,7 +1293,7 @@ public class SqlToOperationConverter {
                     String.format(
                             "Table %s doesn't exist or is a temporary table.", tableIdentifier));
         }
-        CatalogBaseTable baseTable = optionalCatalogTable.get().getTable();
+        CatalogBaseTable baseTable = optionalCatalogTable.get().getResolvedTable();
         if (baseTable instanceof CatalogView) {
             throw new ValidationException("ANALYZE TABLE for a view is not allowed.");
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/FlinkCalciteCatalogReader.java
@@ -199,7 +199,7 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
                     names,
                     rowType,
                     schemaTable,
-                    schemaTable.getContextResolvedTable().getTable());
+                    schemaTable.getContextResolvedTable().getResolvedTable());
         } else {
             return new CatalogSourceTable(relOptSchema, names, rowType, schemaTable);
         }
@@ -209,7 +209,8 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
     private static boolean isLegacySourceOptions(CatalogSchemaTable schemaTable) {
         // normalize option keys
         DescriptorProperties properties = new DescriptorProperties(true);
-        properties.putProperties(schemaTable.getContextResolvedTable().getTable().getOptions());
+        properties.putProperties(
+                schemaTable.getContextResolvedTable().getResolvedTable().getOptions());
         if (properties.containsKey(ConnectorDescriptorValidator.CONNECTOR_TYPE)) {
             return true;
         } else {
@@ -219,7 +220,7 @@ public class FlinkCalciteCatalogReader extends CalciteCatalogReader {
                 TableFactoryUtil.findAndCreateTableSource(
                         schemaTable.getContextResolvedTable().getCatalog().orElse(null),
                         schemaTable.getContextResolvedTable().getIdentifier(),
-                        schemaTable.getContextResolvedTable().getTable(),
+                        schemaTable.getContextResolvedTable().getResolvedTable(),
                         new Configuration(),
                         schemaTable.isTemporary());
                 // success, then we will use the legacy factories

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushPartitionIntoTableSourceScanRule.java
@@ -100,7 +100,7 @@ public class PushPartitionIntoTableSourceScanRule extends RelOptRule {
         if (!(dynamicTableSource instanceof SupportsPartitionPushDown)) {
             return false;
         }
-        CatalogTable catalogTable = tableSourceTable.contextResolvedTable().getTable();
+        CatalogTable catalogTable = tableSourceTable.contextResolvedTable().getResolvedTable();
         if (!catalogTable.isPartitioned() || catalogTable.getPartitionKeys().isEmpty()) {
             return false;
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/DynamicPartitionPruningUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/DynamicPartitionPruningUtils.java
@@ -150,7 +150,7 @@ public class DynamicPartitionPruningUtils {
                 factSideFactors.isSuitableFactScanSource = false;
                 return;
             }
-            CatalogTable catalogTable = tableSourceTable.contextResolvedTable().getTable();
+            CatalogTable catalogTable = tableSourceTable.contextResolvedTable().getResolvedTable();
             List<String> partitionKeys = catalogTable.getPartitionKeys();
             if (partitionKeys.isEmpty()) {
                 factSideFactors.isSuitableFactScanSource = false;
@@ -257,7 +257,7 @@ public class DynamicPartitionPruningUtils {
                     }
                 }
             }
-            CatalogTable catalogTable = table.contextResolvedTable().getTable();
+            CatalogTable catalogTable = table.contextResolvedTable().getResolvedTable();
             dimSideFactors.hasNonPartitionedScan = !catalogTable.isPartitioned();
         } else if (rel instanceof HepRelVertex) {
             visitDimSide(((HepRelVertex) rel).getCurrentRel(), dimSideFactors);

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -409,14 +409,14 @@ abstract class PlannerBase(
             tableConfig,
             isStreamingMode,
             objectIdentifier,
-            resolvedTable.getOrigin,
+            resolvedTable,
             isTemporary
           )
         ) {
           val tableSink = TableFactoryUtil.findAndCreateTableSink(
             catalog.orNull,
             objectIdentifier,
-            tableToFind.getOrigin,
+            tableToFind,
             getTableConfig,
             isStreamingMode,
             isTemporary)

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -1939,6 +1939,131 @@ class TableEnvironmentTest {
   }
 
   @Test
+  def testDescribeTableWithComment(): Unit = {
+    val sourceDDL =
+      """
+        |CREATE TABLE T1(
+        |  c0 char(10) comment 'this is the first column',
+        |  c1 varchar(10) comment 'this is the second column',
+        |  c2 string,
+        |  c3 BOOLEAN,
+        |  c4 BINARY(10),
+        |  c5 VARBINARY(10),
+        |  c6 BYTES,
+        |  c7 DECIMAL(10, 3),
+        |  c8 TINYINT,
+        |  c9 SMALLINT,
+        |  c10 INTEGER,
+        |  c11 BIGINT,
+        |  c12 FLOAT,
+        |  c13 DOUBLE,
+        |  c14 DATE,
+        |  c15 TIME,
+        |  c16 TIMESTAMP,
+        |  c17 TIMESTAMP(3),
+        |  c18 TIMESTAMP WITHOUT TIME ZONE,
+        |  c19 TIMESTAMP(3) WITH LOCAL TIME ZONE,
+        |  c20 TIMESTAMP WITH LOCAL TIME ZONE,
+        |  c21 ARRAY<INT>,
+        |  c22 MAP<INT, STRING>,
+        |  c23 ROW<f0 INT, f1 STRING>,
+        |  c24 int not null comment 'this is c24 and part of pk',
+        |  c25 varchar not null,
+        |  c26 row<f0 int not null, f1 int> not null comment 'this is c26 and part of pk',
+        |  c27 AS LOCALTIME,
+        |  c28 AS CURRENT_TIME,
+        |  c29 AS LOCALTIMESTAMP,
+        |  c30 AS CURRENT_TIMESTAMP comment 'notice: computed column',
+        |  c31 AS CURRENT_ROW_TIMESTAMP(),
+        |  ts AS to_timestamp(c25) comment 'notice: watermark',
+        |  PRIMARY KEY(c24, c26) NOT ENFORCED,
+        |  WATERMARK FOR ts AS ts - INTERVAL '1' SECOND
+        |) with (
+        |  'connector' = 'COLLECTION'
+        |)
+      """.stripMargin
+
+    tableEnv.executeSql(sourceDDL)
+
+    val expectedResult1 = util.Arrays.asList(
+      Row.of("c0", "CHAR(10)", Boolean.box(true), null, null, null, "this is the first column"),
+      Row.of("c1", "VARCHAR(10)", Boolean.box(true), null, null, null, "this is the second column"),
+      Row.of("c2", "STRING", Boolean.box(true), null, null, null, null),
+      Row.of("c3", "BOOLEAN", Boolean.box(true), null, null, null, null),
+      Row.of("c4", "BINARY(10)", Boolean.box(true), null, null, null, null),
+      Row.of("c5", "VARBINARY(10)", Boolean.box(true), null, null, null, null),
+      Row.of("c6", "BYTES", Boolean.box(true), null, null, null, null),
+      Row.of("c7", "DECIMAL(10, 3)", Boolean.box(true), null, null, null, null),
+      Row.of("c8", "TINYINT", Boolean.box(true), null, null, null, null),
+      Row.of("c9", "SMALLINT", Boolean.box(true), null, null, null, null),
+      Row.of("c10", "INT", Boolean.box(true), null, null, null, null),
+      Row.of("c11", "BIGINT", Boolean.box(true), null, null, null, null),
+      Row.of("c12", "FLOAT", Boolean.box(true), null, null, null, null),
+      Row.of("c13", "DOUBLE", Boolean.box(true), null, null, null, null),
+      Row.of("c14", "DATE", Boolean.box(true), null, null, null, null),
+      Row.of("c15", "TIME(0)", Boolean.box(true), null, null, null, null),
+      Row.of("c16", "TIMESTAMP(6)", Boolean.box(true), null, null, null, null),
+      Row.of("c17", "TIMESTAMP(3)", Boolean.box(true), null, null, null, null),
+      Row.of("c18", "TIMESTAMP(6)", Boolean.box(true), null, null, null, null),
+      Row.of("c19", "TIMESTAMP_LTZ(3)", Boolean.box(true), null, null, null, null),
+      Row.of("c20", "TIMESTAMP_LTZ(6)", Boolean.box(true), null, null, null, null),
+      Row.of("c21", "ARRAY<INT>", Boolean.box(true), null, null, null, null),
+      Row.of("c22", "MAP<INT, STRING>", Boolean.box(true), null, null, null, null),
+      Row.of("c23", "ROW<`f0` INT, `f1` STRING>", Boolean.box(true), null, null, null, null),
+      Row.of(
+        "c24",
+        "INT",
+        Boolean.box(false),
+        "PRI(c24, c26)",
+        null,
+        null,
+        "this is c24 and part of pk"),
+      Row.of("c25", "STRING", Boolean.box(false), null, null, null, null),
+      Row.of(
+        "c26",
+        "ROW<`f0` INT NOT NULL, `f1` INT>",
+        Boolean.box(false),
+        "PRI(c24, c26)",
+        null,
+        null,
+        "this is c26 and part of pk"),
+      Row.of("c27", "TIME(0)", Boolean.box(false), null, "AS LOCALTIME", null, null),
+      Row.of("c28", "TIME(0)", Boolean.box(false), null, "AS CURRENT_TIME", null, null),
+      Row.of("c29", "TIMESTAMP(3)", Boolean.box(false), null, "AS LOCALTIMESTAMP", null, null),
+      Row.of(
+        "c30",
+        "TIMESTAMP_LTZ(3)",
+        Boolean.box(false),
+        null,
+        "AS CURRENT_TIMESTAMP",
+        null,
+        "notice: computed column"),
+      Row.of(
+        "c31",
+        "TIMESTAMP_LTZ(3)",
+        Boolean.box(false),
+        null,
+        "AS CURRENT_ROW_TIMESTAMP()",
+        null,
+        null),
+      Row.of(
+        "ts",
+        "TIMESTAMP(3) *ROWTIME*",
+        Boolean.box(true),
+        null,
+        "AS TO_TIMESTAMP(`c25`)",
+        "`ts` - INTERVAL '1' SECOND",
+        "notice: watermark")
+    )
+    val tableResult1 = tableEnv.executeSql("describe T1")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult1.getResultKind)
+    checkData(expectedResult1.iterator(), tableResult1.collect())
+    val tableResult2 = tableEnv.executeSql("desc T1")
+    assertEquals(ResultKind.SUCCESS_WITH_CONTENT, tableResult2.getResultKind)
+    checkData(expectedResult1.iterator(), tableResult2.collect())
+  }
+
+  @Test
   def testTemporaryOperationListener(): Unit = {
     val listener = new ListenerCatalog("listener_cat")
     val currentCat = tableEnv.getCurrentCatalog

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.scala
@@ -18,7 +18,7 @@
 package org.apache.flink.table.planner.plan.stream.sql
 
 import org.apache.flink.core.testutils.FlinkMatchers.containsMessage
-import org.apache.flink.table.api.TableException
+import org.apache.flink.table.api.ValidationException
 import org.apache.flink.table.planner.utils._
 
 import org.junit.Test
@@ -100,7 +100,7 @@ class TableSourceTest extends TableTestBase {
 
   @Test
   def testProctimeOnWatermarkSpec(): Unit = {
-    thrown.expect(classOf[TableException])
+    thrown.expect(classOf[ValidationException])
     thrown.expect(
       containsMessage("A watermark can not be defined for a processing-time attribute."))
     val ddl =

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/table/TableSourceTest.scala
@@ -170,7 +170,7 @@ class TableSourceTest extends TableTestBase {
 
   @Test
   def testProctimeOnWatermarkSpec(): Unit = {
-    thrown.expect(classOf[TableException])
+    thrown.expect(classOf[ValidationException])
     thrown.expect(
       containsMessage("A watermark can not be defined for a processing-time attribute."))
 


### PR DESCRIPTION
## What is the purpose of the change

Migrate created table to new schema framework,  so we can make all flink tables including hive table to have new version schema, would bring a lot of benefits like get column comments which make results user-friendly, such as help analysts write sql adaptive to corresponding business logics.

## Brief change log

* Migrate to new schema framework then get comment from ResolvedSchema.

## Verifying this change

This change added tests and can be verified as follows:

flink-table/flink-sql-client/src/test/resources/sql/table.q
TableEnvironmentTest#testDescribeTableWithComment()

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? yes