### PR TITLE
[FLINK-29789][tests] Fix flaky test in CheckpointCoordinatorTest

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -1891,7 +1891,7 @@ public class CheckpointCoordinator {
 
     public Map<Long, PendingCheckpoint> getPendingCheckpoints() {
         synchronized (lock) {
-            return new HashMap<>(this.pendingCheckpoints);
+            return new LinkedHashMap<>(this.pendingCheckpoints);
         }
     }
 


### PR DESCRIPTION
This PR aims to solve the issue presented here: https://issues.apache.org/jira/browse/FLINK-29789

## What is the purpose of the change
The fix is to change the HashMap of PendingCheckpoint in CheckpointCoordinator to LinkedHashMap to make the tests more stable (less flaky).

## Brief change log
- Changing the map implementation of PendingCheckpoint in CheckpointCoordinator

## Verifying this change
Existing tests already cover this change, and it can pass them successfully.
The tests are: 
1. org.apache.flink.runtime.checkpoint.CheckpointCoordinatorTest.testTriggerAndDeclineCheckpointComplex

## Does this pull request potentially affect one of the following parts:
* Dependencies (does it add or upgrade a dependency): No
* The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
* The serializers: No
* The runtime per-record code paths (performance sensitive): No
* Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos,, ZooKeeper: No
* The S3 file system connector: No

## Documentation
Does this pull request introduce a new feature? No