### PR TITLE
[FLINK-29787][ci] fix ci METHOD_NEW_DEFAULT issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2112,10 +2112,11 @@ under the License.
 								<include>@org.apache.flink.annotation.Public</include>
 								<!-- The following line is un-commented by tools/releasing/update_japicmp_configuration.sh
 								 	as part of the release process -->
-								<include>@org.apache.flink.annotation.PublicEvolving</include>
+								<!--<include>@org.apache.flink.annotation.PublicEvolving</include>-->
 							</includes>
 							<excludes>
 								<exclude>@org.apache.flink.annotation.Experimental</exclude>
+								<exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
 								<exclude>@org.apache.flink.annotation.Internal</exclude>
 								<!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
 								<exclude>org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator#getSideOutput(org.apache.flink.util.OutputTag)</exclude>
@@ -2153,18 +2154,6 @@ under the License.
 							<packagingSupporteds>
 								<packagingSupported>jar</packagingSupported>
 							</packagingSupporteds>
-							<overrideCompatibilityChangeParameters>
-								<overrideCompatibilityChangeParameter>
-									<compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
-									<binaryCompatible>true</binaryCompatible>
-									<sourceCompatible>true</sourceCompatible>
-								</overrideCompatibilityChangeParameter>
-								<overrideCompatibilityChangeParameter>
-									<compatibilityChange>METHOD_ADDED_TO_INTERFACE</compatibilityChange>
-									<binaryCompatible>true</binaryCompatible>
-									<sourceCompatible>true</sourceCompatible>
-								</overrideCompatibilityChangeParameter>
-							</overrideCompatibilityChangeParameters>
 						</parameter>
 						<projectBuildDir>${rootDir}/${japicmp.outputDir}/${project.artifactId}</projectBuildDir>
 						<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -2153,6 +2153,18 @@ under the License.
 							<packagingSupporteds>
 								<packagingSupported>jar</packagingSupported>
 							</packagingSupporteds>
+							<overrideCompatibilityChangeParameters>
+								<overrideCompatibilityChangeParameter>
+									<compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
+									<binaryCompatible>true</binaryCompatible>
+									<sourceCompatible>true</sourceCompatible>
+								</overrideCompatibilityChangeParameter>
+								<overrideCompatibilityChangeParameter>
+									<compatibilityChange>METHOD_ADDED_TO_INTERFACE</compatibilityChange>
+									<binaryCompatible>true</binaryCompatible>
+									<sourceCompatible>true</sourceCompatible>
+								</overrideCompatibilityChangeParameter>
+							</overrideCompatibilityChangeParameters>
 						</parameter>
 						<projectBuildDir>${rootDir}/${japicmp.outputDir}/${project.artifactId}</projectBuildDir>
 						<dependencies>

--- a/tools/releasing/update_japicmp_configuration.sh
+++ b/tools/releasing/update_japicmp_configuration.sh
@@ -36,8 +36,8 @@ fi
 #     - update the master to X.(Y+1)-SNAPSHOT, but keep the reference version intact since X.Y.0 is not released (yet)
 #     - create X.Y-SNAPSHOT branch, but keep the reference version intact since X.Y.0 is not released (yet)
 #     - release X.Y.0
-#     - update the japicmp reference version of both master and X.Y-SNAPSHOT to X.Y.0
-#     - enable stronger compatibility constraints for X.Y-SNAPSHOT to ensure compatibility for PublicEvolving
+#     - update the japicmp reference version of both master and the release branch X.Y-SNAPSHOT to X.Y.0
+#     - enable stronger compatibility constraints for X.Y-SNAPSHOT in the release branch to ensure compatibility for PublicEvolving
 # Scenario B) New minor release X.Y.Z
 #   Premise:
 #     There is a snapshot branch with a version X.Y-SNAPSHOT, with a japicmp reference version of X.Y.(Z-1)


### PR DESCRIPTION
## What is the purpose of the change

`org.apache.flink.api.connector.source.SourceReader` declared a new default function `pauseOrResumeSplits()`, japicmp plugin failed during ci running, we should configure the plugin to make it compatible.

## Brief change log

* configure overrideCompatibilityChangeParameter

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no