### PR TITLE
[hotfix][docs] Makes the japicmp script documentation more consistent after the change in cb442936.

### DIFF
--- a/tools/releasing/update_japicmp_configuration.sh
+++ b/tools/releasing/update_japicmp_configuration.sh
@@ -34,18 +34,18 @@ fi
 #     There is a master branch with a version X.Y-SNAPSHOT, with a japicmp reference version of X.(Y-1).0 .
 #   Release flow:
 #     - update the master to X.(Y+1)-SNAPSHOT, but keep the reference version intact since X.Y.0 is not released (yet)
-#     - create X.Y-SNAPSHOT branch, but keep the reference version intact since X.Y.0 is not released (yet)
+#     - create snapshot branch for X.Y-SNAPSHOT (i.e. release-X.Y), but keep the reference version intact since X.Y.0 is not released (yet)
 #     - release X.Y.0
-#     - update the japicmp reference version of both master and the release branch X.Y-SNAPSHOT to X.Y.0
-#     - enable stronger compatibility constraints for X.Y-SNAPSHOT in the release branch to ensure compatibility for PublicEvolving
+#     - update the japicmp reference version of both master and the snapshot branch for X.Y-SNAPSHOT to X.Y.0
+#     - enable stronger compatibility constraints for X.Y-SNAPSHOT in the snapshot branch to ensure compatibility for PublicEvolving
 # Scenario B) New minor release X.Y.Z
 #   Premise:
-#     There is a snapshot branch with a version X.Y-SNAPSHOT, with a japicmp reference version of X.Y.(Z-1)
+#     There is a snapshot branch release-X.Y having a version X.Y-SNAPSHOT, with a japicmp reference version of X.Y.(Z-1)
 #   Release flow:
-#     - create X.Y.Z-rc branch
+#     - create X.Y.Z-rc* branch
 #     - update the japicmp reference version of X.Y.Z to X.Y.(Z-1)
 #     - release X.Y.Z
-#     - update the japicmp reference version of X.Y-SNAPSHOT to X.Y.Z
+#     - update the japicmp reference version of X.Y-SNAPSHOT (in the snapshot branch release-X.Y) to X.Y.Z
 
 POM=../pom.xml
 function enable_public_evolving_compatibility_checks() {


### PR DESCRIPTION
## What is the purpose of the change

PR #21184 updated the documentation a bit leaving it in a kind of inconsistent state. This hotfix PR fixes this issue. Reading the previous version of the comment was confusing because of the snapshot version being used for specifying the reference version but also for refering to the snapshot branch. I tried to make this more explicit now with that PR.

## Brief change log

* Updates docs in script

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
