### PR TITLE
[FLINK-29767] Adaptive batch scheduler supports hybrid shuffle

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
@@ -99,7 +99,8 @@ public class EdgeManagerBuildUtil {
                         .map(ExecutionVertex::getID)
                         .collect(Collectors.toList());
         ConsumerVertexGroup consumerVertexGroup =
-                ConsumerVertexGroup.fromMultipleVertices(consumerVertices);
+                ConsumerVertexGroup.fromMultipleVertices(
+                        consumerVertices, intermediateResult.getResultType());
         for (IntermediateResultPartition partition : intermediateResult.getPartitions()) {
             partition.addConsumers(consumerVertexGroup);
         }
@@ -117,7 +118,8 @@ public class EdgeManagerBuildUtil {
                 IntermediateResultPartition partition = intermediateResult.getPartitions()[i];
 
                 ConsumerVertexGroup consumerVertexGroup =
-                        ConsumerVertexGroup.fromSingleVertex(executionVertex.getID());
+                        ConsumerVertexGroup.fromSingleVertex(
+                                executionVertex.getID(), intermediateResult.getResultType());
                 partition.addConsumers(consumerVertexGroup);
 
                 ConsumedPartitionGroup consumedPartitionGroup =
@@ -132,7 +134,8 @@ public class EdgeManagerBuildUtil {
 
                 ExecutionVertex executionVertex = taskVertices[index];
                 ConsumerVertexGroup consumerVertexGroup =
-                        ConsumerVertexGroup.fromSingleVertex(executionVertex.getID());
+                        ConsumerVertexGroup.fromSingleVertex(
+                                executionVertex.getID(), intermediateResult.getResultType());
 
                 int start = index * sourceCount / targetCount;
                 int end = (index + 1) * sourceCount / targetCount;
@@ -173,7 +176,8 @@ public class EdgeManagerBuildUtil {
                 }
 
                 ConsumerVertexGroup consumerVertexGroup =
-                        ConsumerVertexGroup.fromMultipleVertices(consumers);
+                        ConsumerVertexGroup.fromMultipleVertices(
+                                consumers, intermediateResult.getResultType());
                 partition.addConsumers(consumerVertexGroup);
             }
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
@@ -27,6 +27,7 @@ import org.apache.flink.util.Preconditions;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -131,5 +132,16 @@ public class ConsumedPartitionGroup implements Iterable<IntermediateResultPartit
 
     public ResultPartitionType getResultPartitionType() {
         return resultPartitionType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                resultPartitions, intermediateDataSetID, resultPartitionType, numConsumers);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
@@ -27,7 +27,6 @@ import org.apache.flink.util.Preconditions;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -132,16 +131,5 @@ public class ConsumedPartitionGroup implements Iterable<IntermediateResultPartit
 
     public ResultPartitionType getResultPartitionType() {
         return resultPartitionType;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        return this == o;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(
-                resultPartitions, intermediateDataSetID, resultPartitionType, numConsumers);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumerVertexGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumerVertexGroup.java
@@ -18,24 +18,37 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 /** Group of consumer {@link ExecutionVertexID}s. */
 public class ConsumerVertexGroup implements Iterable<ExecutionVertexID> {
     private final List<ExecutionVertexID> vertices;
 
-    private ConsumerVertexGroup(List<ExecutionVertexID> vertices) {
+    private final ResultPartitionType resultPartitionType;
+
+    private ConsumerVertexGroup(
+            List<ExecutionVertexID> vertices, ResultPartitionType resultPartitionType) {
         this.vertices = vertices;
+        this.resultPartitionType = resultPartitionType;
     }
 
-    public static ConsumerVertexGroup fromMultipleVertices(List<ExecutionVertexID> vertices) {
-        return new ConsumerVertexGroup(vertices);
+    public static ConsumerVertexGroup fromMultipleVertices(
+            List<ExecutionVertexID> vertices, ResultPartitionType resultPartitionType) {
+        return new ConsumerVertexGroup(vertices, resultPartitionType);
     }
 
-    public static ConsumerVertexGroup fromSingleVertex(ExecutionVertexID vertex) {
-        return new ConsumerVertexGroup(Collections.singletonList(vertex));
+    public static ConsumerVertexGroup fromSingleVertex(
+            ExecutionVertexID vertex, ResultPartitionType resultPartitionType) {
+        return new ConsumerVertexGroup(Collections.singletonList(vertex), resultPartitionType);
+    }
+
+    public ResultPartitionType getResultPartitionType() {
+        return resultPartitionType;
     }
 
     @Override
@@ -53,5 +66,23 @@ public class ConsumerVertexGroup implements Iterable<ExecutionVertexID> {
 
     public ExecutionVertexID getFirst() {
         return iterator().next();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ConsumerVertexGroup that = (ConsumerVertexGroup) o;
+        return Objects.equals(vertices, that.vertices)
+                && resultPartitionType == that.resultPartitionType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(vertices, resultPartitionType);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumerVertexGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumerVertexGroup.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 
 /** Group of consumer {@link ExecutionVertexID}s. */
 public class ConsumerVertexGroup implements Iterable<ExecutionVertexID> {
@@ -66,23 +65,5 @@ public class ConsumerVertexGroup implements Iterable<ExecutionVertexID> {
 
     public ExecutionVertexID getFirst() {
         return iterator().next();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        ConsumerVertexGroup that = (ConsumerVertexGroup) o;
-        return Objects.equals(vertices, that.vertices)
-                && resultPartitionType == that.resultPartitionType;
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(vertices, resultPartitionType);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
@@ -34,31 +34,25 @@ import java.util.function.Function;
  * <p>For canBePipelined consumed partition group: whether all result partitions in the group are
  * scheduled.
  */
-public class DefaultInputConsumableDecider implements InputConsumableDecider {
-    private final Function<ExecutionVertexID, SchedulingExecutionVertex> executionVertexRetriever;
-
+class DefaultInputConsumableDecider implements InputConsumableDecider {
     private final Function<IntermediateResultPartitionID, SchedulingResultPartition>
             resultPartitionRetriever;
 
     private final Function<ExecutionVertexID, Boolean> scheduledVertexRetriever;
 
-    public DefaultInputConsumableDecider(
+    DefaultInputConsumableDecider(
             Function<ExecutionVertexID, Boolean> scheduledVertexRetriever,
-            Function<ExecutionVertexID, SchedulingExecutionVertex> executionVertexRetriever,
             Function<IntermediateResultPartitionID, SchedulingResultPartition>
                     resultPartitionRetriever) {
         this.scheduledVertexRetriever = scheduledVertexRetriever;
-        this.executionVertexRetriever = executionVertexRetriever;
         this.resultPartitionRetriever = resultPartitionRetriever;
     }
 
     @Override
     public boolean isInputConsumable(
-            ExecutionVertexID executionVertexID,
+            SchedulingExecutionVertex executionVertex,
             Set<ExecutionVertexID> verticesToSchedule,
             Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
-        SchedulingExecutionVertex executionVertex =
-                executionVertexRetriever.apply(executionVertexID);
         for (ConsumedPartitionGroup consumedPartitionGroup :
                 executionVertex.getConsumedPartitionGroups()) {
 
@@ -107,9 +101,7 @@ public class DefaultInputConsumableDecider implements InputConsumableDecider {
                 SchedulingTopology schedulingTopology,
                 Function<ExecutionVertexID, Boolean> scheduledVertexRetriever) {
             return new DefaultInputConsumableDecider(
-                    scheduledVertexRetriever,
-                    schedulingTopology::getVertex,
-                    schedulingTopology::getResultPartition);
+                    scheduledVertexRetriever, schedulingTopology::getResultPartition);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Default implementation of {@link InputConsumableDecider}. This decider will judge whether the
+ * executionVertex's inputs are consumable as follows:
+ *
+ * <p>For blocking consumed partition group: Whether all result partitions in the group are
+ * finished.
+ *
+ * <p>For canBePipelined consumed partition group: whether all result partitions in the group are
+ * scheduled.
+ */
+public class DefaultInputConsumableDecider implements InputConsumableDecider {
+    private final Function<ExecutionVertexID, SchedulingExecutionVertex> executionVertexRetriever;
+
+    private final Function<IntermediateResultPartitionID, SchedulingResultPartition>
+            resultPartitionRetriever;
+
+    private final Function<ExecutionVertexID, Boolean> scheduledVertexRetriever;
+
+    public DefaultInputConsumableDecider(
+            Function<ExecutionVertexID, Boolean> scheduledVertexRetriever,
+            Function<ExecutionVertexID, SchedulingExecutionVertex> executionVertexRetriever,
+            Function<IntermediateResultPartitionID, SchedulingResultPartition>
+                    resultPartitionRetriever) {
+        this.scheduledVertexRetriever = scheduledVertexRetriever;
+        this.executionVertexRetriever = executionVertexRetriever;
+        this.resultPartitionRetriever = resultPartitionRetriever;
+    }
+
+    @Override
+    public boolean isInputConsumable(
+            ExecutionVertexID executionVertexID,
+            Set<ExecutionVertexID> verticesToSchedule,
+            Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
+        SchedulingExecutionVertex executionVertex =
+                executionVertexRetriever.apply(executionVertexID);
+        for (ConsumedPartitionGroup consumedPartitionGroup :
+                executionVertex.getConsumedPartitionGroups()) {
+
+            if (!consumableStatusCache.computeIfAbsent(
+                    consumedPartitionGroup,
+                    (group) -> isConsumedPartitionGroupConsumable(group, verticesToSchedule))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isConsumedPartitionGroupConsumable(
+            final ConsumedPartitionGroup consumedPartitionGroup,
+            final Set<ExecutionVertexID> verticesToSchedule) {
+        if (consumedPartitionGroup.getResultPartitionType().canBePipelinedConsumed()) {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                ExecutionVertexID producerVertex =
+                        resultPartitionRetriever.apply(partitionId).getProducer().getId();
+                if (!verticesToSchedule.contains(producerVertex)
+                        && !scheduledVertexRetriever.apply(producerVertex)) {
+                    return false;
+                }
+            }
+        } else {
+            for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
+                if (resultPartitionRetriever.apply(partitionId).getState()
+                        != ResultPartitionState.CONSUMABLE) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /** Factory for {@link DefaultInputConsumableDecider}. */
+    public static class Factory implements InputConsumableDecider.Factory {
+
+        public static final InputConsumableDecider.Factory INSTANCE = new Factory();
+
+        // disable public instantiation.
+        private Factory() {}
+
+        @Override
+        public InputConsumableDecider createInstance(
+                SchedulingTopology schedulingTopology,
+                Function<ExecutionVertexID, Boolean> scheduledVertexRetriever) {
+            return new DefaultInputConsumableDecider(
+                    scheduledVertexRetriever,
+                    schedulingTopology::getVertex,
+                    schedulingTopology::getResultPartition);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputConsumableDecider.java
@@ -18,28 +18,26 @@
 
 package org.apache.flink.runtime.scheduler.strategy;
 
-import org.apache.flink.runtime.executiongraph.ExecutionVertex;
-
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
 /**
- * {@link InputConsumableDecider} is responsible for determining weather the input of an
+ * {@link InputConsumableDecider} is responsible for determining whether the input of an
  * executionVertex is consumable.
  */
 public interface InputConsumableDecider {
     /**
-     * Determining weather the input of an execution vertex is consumable.
+     * Determining whether the input of an execution vertex is consumable.
      *
-     * @param executionVertexID identifier of this {@link ExecutionVertex}.
-     * @param verticesToSchedule vertices that are not yet scheduled by already decided to be
+     * @param executionVertex to be determined whether it's input is consumable.
+     * @param verticesToSchedule vertices that are not yet scheduled but already decided to be
      *     scheduled.
      * @param consumableStatusCache a cache for {@link ConsumedPartitionGroup} consumable status.
      *     This is to avoid repetitive computation.
      */
     boolean isInputConsumable(
-            ExecutionVertexID executionVertexID,
+            SchedulingExecutionVertex executionVertex,
             Set<ExecutionVertexID> verticesToSchedule,
             Map<ConsumedPartitionGroup, Boolean> consumableStatusCache);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/InputConsumableDecider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * {@link InputConsumableDecider} is responsible for determining weather the input of an
+ * executionVertex is consumable.
+ */
+public interface InputConsumableDecider {
+    /**
+     * Determining weather the input of an execution vertex is consumable.
+     *
+     * @param executionVertexID identifier of this {@link ExecutionVertex}.
+     * @param verticesToSchedule vertices that are not yet scheduled by already decided to be
+     *     scheduled.
+     * @param consumableStatusCache a cache for {@link ConsumedPartitionGroup} consumable status.
+     *     This is to avoid repetitive computation.
+     */
+    boolean isInputConsumable(
+            ExecutionVertexID executionVertexID,
+            Set<ExecutionVertexID> verticesToSchedule,
+            Map<ConsumedPartitionGroup, Boolean> consumableStatusCache);
+
+    /** Factory for {@link InputConsumableDecider}. */
+    interface Factory {
+        InputConsumableDecider createInstance(
+                SchedulingTopology schedulingTopology,
+                Function<ExecutionVertexID, Boolean> scheduledVertexRetriever);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
@@ -133,9 +133,7 @@ public class VertexwiseSchedulingStrategy
                                             schedulingTopology.getVertex(vertexId);
                                     checkState(vertex.getState() == ExecutionState.CREATED);
                                     return inputConsumableDecider.isInputConsumable(
-                                            vertexId,
-                                            Collections.emptySet(),
-                                            consumableStatusCache);
+                                            vertex, Collections.emptySet(), consumableStatusCache);
                                 })
                         .collect(Collectors.toSet());
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
@@ -38,9 +38,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 
 /**
  * {@link SchedulingStrategy} instance which schedules tasks in granularity of vertex (which
- * indicates this strategy only supports ALL_EDGES_BLOCKING batch jobs). Note that this strategy
- * implements {@link SchedulingTopologyListener}, so it can handle the updates of scheduling
- * topology.
+ * indicates this strategy only supports batch jobs). Note that this strategy implements {@link
+ * SchedulingTopologyListener}, so it can handle the updates of scheduling topology.
  */
 public class VertexwiseSchedulingStrategy
         implements SchedulingStrategy, SchedulingTopologyListener {
@@ -114,8 +113,6 @@ public class VertexwiseSchedulingStrategy
     }
 
     private void maybeScheduleVertices(final Set<ExecutionVertexID> vertices) {
-        final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache = new HashMap<>();
-
         Set<ExecutionVertexID> allCandidates;
         if (newVertices.isEmpty()) {
             allCandidates = vertices;
@@ -125,31 +122,73 @@ public class VertexwiseSchedulingStrategy
             newVertices.clear();
         }
 
-        final Set<ExecutionVertexID> verticesToDeploy =
-                allCandidates.stream()
-                        .filter(
-                                vertexId -> {
-                                    SchedulingExecutionVertex vertex =
-                                            schedulingTopology.getVertex(vertexId);
-                                    checkState(vertex.getState() == ExecutionState.CREATED);
-                                    return inputConsumableDecider.isInputConsumable(
-                                            vertex, Collections.emptySet(), consumableStatusCache);
-                                })
-                        .collect(Collectors.toSet());
+        final Set<ExecutionVertexID> verticesToSchedule = new HashSet<>();
 
-        scheduleVerticesOneByOne(verticesToDeploy);
-        scheduledVertices.addAll(verticesToDeploy);
+        Set<ExecutionVertexID> nextVertices = allCandidates;
+        while (!nextVertices.isEmpty()) {
+            nextVertices = addToScheduleAndGetVertices(nextVertices, verticesToSchedule);
+        }
+
+        scheduleVerticesOneByOne(verticesToSchedule);
+        scheduledVertices.addAll(verticesToSchedule);
     }
 
-    private void scheduleVerticesOneByOne(final Set<ExecutionVertexID> verticesToDeploy) {
-        if (verticesToDeploy.isEmpty()) {
+    private Set<ExecutionVertexID> addToScheduleAndGetVertices(
+            Set<ExecutionVertexID> currentVertices, Set<ExecutionVertexID> verticesToSchedule) {
+        Set<ExecutionVertexID> nextVertices = new HashSet<>();
+        // cache consumedPartitionGroup's consumable status to avoid compute repeatedly.
+        final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache = new HashMap<>();
+        final Set<ConsumerVertexGroup> visitedConsumerVertexGroup = new HashSet<>();
+
+        for (ExecutionVertexID currentVertex : currentVertices) {
+            if (isVertexSchedulable(currentVertex, consumableStatusCache, verticesToSchedule)) {
+                verticesToSchedule.add(currentVertex);
+                Set<ConsumerVertexGroup> canBePipelinedConsumerVertexGroups =
+                        IterableUtils.toStream(
+                                        schedulingTopology
+                                                .getVertex(currentVertex)
+                                                .getProducedResults())
+                                .map(SchedulingResultPartition::getConsumerVertexGroups)
+                                .flatMap(Collection::stream)
+                                .filter(
+                                        (consumerVertexGroup) ->
+                                                consumerVertexGroup
+                                                        .getResultPartitionType()
+                                                        .canBePipelinedConsumed())
+                                .collect(Collectors.toSet());
+                for (ConsumerVertexGroup consumerVertexGroup : canBePipelinedConsumerVertexGroups) {
+                    if (!visitedConsumerVertexGroup.contains(consumerVertexGroup)) {
+                        visitedConsumerVertexGroup.add(consumerVertexGroup);
+                        nextVertices.addAll(
+                                canBePipelinedConsumerVertexGroups.stream()
+                                        .flatMap(IterableUtils::toStream)
+                                        .collect(Collectors.toSet()));
+                    }
+                }
+            }
+        }
+        return nextVertices;
+    }
+
+    private boolean isVertexSchedulable(
+            final ExecutionVertexID vertex,
+            final Map<ConsumedPartitionGroup, Boolean> consumableStatusCache,
+            final Set<ExecutionVertexID> verticesToSchedule) {
+        return !verticesToSchedule.contains(vertex)
+                && !scheduledVertices.contains(vertex)
+                && inputConsumableDecider.isInputConsumable(
+                        vertex, verticesToSchedule, consumableStatusCache);
+    }
+
+    private void scheduleVerticesOneByOne(final Set<ExecutionVertexID> verticesToSchedule) {
+        if (verticesToSchedule.isEmpty()) {
             return;
         }
-        final List<ExecutionVertexID> sortedVerticesToDeploy =
+        final List<ExecutionVertexID> sortedVerticesToSchedule =
                 SchedulingStrategyUtils.sortExecutionVerticesInTopologicalOrder(
-                        schedulingTopology, verticesToDeploy);
+                        schedulingTopology, verticesToSchedule);
 
-        sortedVerticesToDeploy.forEach(
+        sortedVerticesToSchedule.forEach(
                 id -> schedulerOperations.allocateSlotsAndDeploy(Collections.singletonList(id)));
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategy.java
@@ -51,12 +51,20 @@ public class VertexwiseSchedulingStrategy
 
     private final Set<ExecutionVertexID> newVertices = new HashSet<>();
 
+    private final Set<ExecutionVertexID> scheduledVertices = new HashSet<>();
+
+    private final InputConsumableDecider inputConsumableDecider;
+
     public VertexwiseSchedulingStrategy(
             final SchedulerOperations schedulerOperations,
-            final SchedulingTopology schedulingTopology) {
+            final SchedulingTopology schedulingTopology,
+            final InputConsumableDecider.Factory inputConsumableDeciderFactory) {
 
         this.schedulerOperations = checkNotNull(schedulerOperations);
         this.schedulingTopology = checkNotNull(schedulingTopology);
+        this.inputConsumableDecider =
+                inputConsumableDeciderFactory.createInstance(
+                        schedulingTopology, scheduledVertices::contains);
         schedulingTopology.registerSchedulingTopologyListener(this);
     }
 
@@ -73,6 +81,7 @@ public class VertexwiseSchedulingStrategy
 
     @Override
     public void restartTasks(Set<ExecutionVertexID> verticesToRestart) {
+        scheduledVertices.removeAll(verticesToRestart);
         maybeScheduleVertices(verticesToRestart);
     }
 
@@ -123,12 +132,15 @@ public class VertexwiseSchedulingStrategy
                                     SchedulingExecutionVertex vertex =
                                             schedulingTopology.getVertex(vertexId);
                                     checkState(vertex.getState() == ExecutionState.CREATED);
-                                    return areVertexInputsAllConsumable(
-                                            vertex, consumableStatusCache);
+                                    return inputConsumableDecider.isInputConsumable(
+                                            vertexId,
+                                            Collections.emptySet(),
+                                            consumableStatusCache);
                                 })
                         .collect(Collectors.toSet());
 
         scheduleVerticesOneByOne(verticesToDeploy);
+        scheduledVertices.addAll(verticesToDeploy);
     }
 
     private void scheduleVerticesOneByOne(final Set<ExecutionVertexID> verticesToDeploy) {
@@ -143,37 +155,16 @@ public class VertexwiseSchedulingStrategy
                 id -> schedulerOperations.allocateSlotsAndDeploy(Collections.singletonList(id)));
     }
 
-    private boolean areVertexInputsAllConsumable(
-            SchedulingExecutionVertex vertex,
-            Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
-        for (ConsumedPartitionGroup consumedPartitionGroup : vertex.getConsumedPartitionGroups()) {
-
-            if (!consumableStatusCache.computeIfAbsent(
-                    consumedPartitionGroup, this::isConsumedPartitionGroupConsumable)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean isConsumedPartitionGroupConsumable(
-            final ConsumedPartitionGroup consumedPartitionGroup) {
-        for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
-            if (schedulingTopology.getResultPartition(partitionId).getState()
-                    != ResultPartitionState.CONSUMABLE) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /** The factory for creating {@link VertexwiseSchedulingStrategy}. */
     public static class Factory implements SchedulingStrategyFactory {
         @Override
         public SchedulingStrategy createInstance(
                 final SchedulerOperations schedulerOperations,
                 final SchedulingTopology schedulingTopology) {
-            return new VertexwiseSchedulingStrategy(schedulerOperations, schedulingTopology);
+            return new VertexwiseSchedulingStrategy(
+                    schedulerOperations,
+                    schedulingTopology,
+                    DefaultInputConsumableDecider.Factory.INSTANCE);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultResultPartitionTest.java
@@ -86,7 +86,9 @@ class DefaultResultPartitionTest {
         ExecutionVertexID executionVertexId = new ExecutionVertexID(new JobVertexID(), 0);
         consumerVertexGroups.put(
                 resultPartition.getId(),
-                Collections.singletonList(ConsumerVertexGroup.fromSingleVertex(executionVertexId)));
+                Collections.singletonList(
+                        ConsumerVertexGroup.fromSingleVertex(
+                                executionVertexId, resultPartition.getResultType())));
         assertThat(resultPartition.getConsumerVertexGroups()).isNotEmpty();
         assertThat(resultPartition.getConsumerVertexGroups().get(0)).contains(executionVertexId);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
@@ -52,11 +52,11 @@ class DefaultInputConsumableDeciderTest {
 
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                                consumer.get(0), Collections.emptySet(), new HashMap<>()))
                 .isFalse();
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(1).getId(), Collections.emptySet(), new HashMap<>()))
+                                consumer.get(1), Collections.emptySet(), new HashMap<>()))
                 .isFalse();
     }
 
@@ -80,11 +80,11 @@ class DefaultInputConsumableDeciderTest {
 
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                                consumer.get(0), Collections.emptySet(), new HashMap<>()))
                 .isTrue();
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(1).getId(), Collections.emptySet(), new HashMap<>()))
+                                consumer.get(1), Collections.emptySet(), new HashMap<>()))
                 .isTrue();
     }
 
@@ -108,11 +108,11 @@ class DefaultInputConsumableDeciderTest {
 
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                                consumer.get(0), Collections.emptySet(), new HashMap<>()))
                 .isFalse();
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(1).getId(), Collections.emptySet(), new HashMap<>()))
+                                consumer.get(1), Collections.emptySet(), new HashMap<>()))
                 .isFalse();
     }
 
@@ -140,11 +140,11 @@ class DefaultInputConsumableDeciderTest {
 
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(0).getId(), vertexToDeploy, new HashMap<>()))
+                                consumer.get(0), vertexToDeploy, new HashMap<>()))
                 .isTrue();
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(1).getId(), vertexToDeploy, new HashMap<>()))
+                                consumer.get(1), vertexToDeploy, new HashMap<>()))
                 .isTrue();
     }
 
@@ -177,15 +177,13 @@ class DefaultInputConsumableDeciderTest {
 
         assertThat(
                         inputConsumableDecider.isInputConsumable(
-                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                                consumer.get(0), Collections.emptySet(), new HashMap<>()))
                 .isFalse();
     }
 
     private DefaultInputConsumableDecider createDefaultInputConsumableDecider(
             Set<ExecutionVertexID> scheduledVertices, SchedulingTopology schedulingTopology) {
         return new DefaultInputConsumableDecider(
-                scheduledVertices::contains,
-                schedulingTopology::getVertex,
-                schedulingTopology::getResultPartition);
+                scheduledVertices::contains, schedulingTopology::getResultPartition);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link DefaultInputConsumableDecider}. */
+class DefaultInputConsumableDeciderTest {
+    @Test
+    void testNotFinishedBlockingInput() {
+        final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+        final List<TestingSchedulingExecutionVertex> producers =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        final List<TestingSchedulingExecutionVertex> consumer =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        topology.connectAllToAll(producers, consumer)
+                .withResultPartitionState(ResultPartitionState.CREATED)
+                .withResultPartitionType(ResultPartitionType.BLOCKING)
+                .finish();
+
+        DefaultInputConsumableDecider inputConsumableDecider =
+                createDefaultInputConsumableDecider(Collections.emptySet(), topology);
+
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                .isFalse();
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(1).getId(), Collections.emptySet(), new HashMap<>()))
+                .isFalse();
+    }
+
+    @Test
+    void testAllFinishedBlockingInput() {
+        final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+        final List<TestingSchedulingExecutionVertex> producers =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        final List<TestingSchedulingExecutionVertex> consumer =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        topology.connectAllToAll(producers, consumer)
+                .withResultPartitionState(ResultPartitionState.CONSUMABLE)
+                .withResultPartitionType(ResultPartitionType.BLOCKING)
+                .finish();
+
+        DefaultInputConsumableDecider inputConsumableDecider =
+                createDefaultInputConsumableDecider(Collections.emptySet(), topology);
+
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                .isTrue();
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(1).getId(), Collections.emptySet(), new HashMap<>()))
+                .isTrue();
+    }
+
+    @Test
+    void testUpstreamNotScheduledHybridInput() {
+        final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+        final List<TestingSchedulingExecutionVertex> producers =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        final List<TestingSchedulingExecutionVertex> consumer =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        topology.connectAllToAll(producers, consumer)
+                .withResultPartitionState(ResultPartitionState.CREATED)
+                .withResultPartitionType(ResultPartitionType.HYBRID_FULL)
+                .finish();
+
+        DefaultInputConsumableDecider inputConsumableDecider =
+                createDefaultInputConsumableDecider(Collections.emptySet(), topology);
+
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                .isFalse();
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(1).getId(), Collections.emptySet(), new HashMap<>()))
+                .isFalse();
+    }
+
+    @Test
+    void testUpstreamAllScheduledHybridInput() {
+        final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+        final List<TestingSchedulingExecutionVertex> producers =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        final List<TestingSchedulingExecutionVertex> consumer =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        topology.connectAllToAll(producers, consumer)
+                .withResultPartitionState(ResultPartitionState.CREATED)
+                .withResultPartitionType(ResultPartitionType.HYBRID_FULL)
+                .finish();
+
+        HashSet<ExecutionVertexID> scheduledVertices = new HashSet<>();
+        DefaultInputConsumableDecider inputConsumableDecider =
+                createDefaultInputConsumableDecider(scheduledVertices, topology);
+        scheduledVertices.add(producers.get(0).getId());
+        HashSet<ExecutionVertexID> vertexToDeploy = new HashSet<>();
+        vertexToDeploy.add(producers.get(1).getId());
+
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(0).getId(), vertexToDeploy, new HashMap<>()))
+                .isTrue();
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(1).getId(), vertexToDeploy, new HashMap<>()))
+                .isTrue();
+    }
+
+    @Test
+    void testHybridAndBlockingInputButBlockingInputNotFinished() {
+        final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+        final List<TestingSchedulingExecutionVertex> producers1 =
+                topology.addExecutionVertices().withParallelism(1).finish();
+
+        final List<TestingSchedulingExecutionVertex> producers2 =
+                topology.addExecutionVertices().withParallelism(1).finish();
+
+        final List<TestingSchedulingExecutionVertex> consumer =
+                topology.addExecutionVertices().withParallelism(1).finish();
+
+        topology.connectAllToAll(producers1, consumer)
+                .withResultPartitionState(ResultPartitionState.CREATED)
+                .withResultPartitionType(ResultPartitionType.BLOCKING)
+                .finish();
+
+        topology.connectAllToAll(producers2, consumer)
+                .withResultPartitionState(ResultPartitionState.CREATED)
+                .withResultPartitionType(ResultPartitionType.HYBRID_FULL)
+                .finish();
+
+        DefaultInputConsumableDecider inputConsumableDecider =
+                createDefaultInputConsumableDecider(
+                        Collections.singleton(producers2.get(0).getId()), topology);
+
+        assertThat(
+                        inputConsumableDecider.isInputConsumable(
+                                consumer.get(0).getId(), Collections.emptySet(), new HashMap<>()))
+                .isFalse();
+    }
+
+    private DefaultInputConsumableDecider createDefaultInputConsumableDecider(
+            Set<ExecutionVertexID> scheduledVertices, SchedulingTopology schedulingTopology) {
+        return new DefaultInputConsumableDecider(
+                scheduledVertices::contains,
+                schedulingTopology::getVertex,
+                schedulingTopology::getResultPartition);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingInputConsumableDecider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingInputConsumableDecider.java
@@ -26,31 +26,31 @@ import java.util.Set;
 /** Mock {@link InputConsumableDecider} for testing. */
 public class TestingInputConsumableDecider implements InputConsumableDecider {
 
-    private final Set<ExecutionVertexID> inputConsumableExecutionVertices = new HashSet<>();
+    private final Set<SchedulingExecutionVertex> inputConsumableExecutionVertices = new HashSet<>();
 
-    private final Set<ExecutionVertexID> sourceVertices = new HashSet<>();
+    private final Set<SchedulingExecutionVertex> sourceVertices = new HashSet<>();
 
-    private ExecutionVertexID lastExecutionToDecideInputConsumable;
+    private SchedulingExecutionVertex lastExecutionToDecideInputConsumable;
 
     @Override
     public boolean isInputConsumable(
-            ExecutionVertexID executionVertexID,
+            SchedulingExecutionVertex executionVertex,
             Set<ExecutionVertexID> verticesToDeploy,
             Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
-        lastExecutionToDecideInputConsumable = executionVertexID;
-        return sourceVertices.contains(executionVertexID)
-                || inputConsumableExecutionVertices.contains(executionVertexID);
+        lastExecutionToDecideInputConsumable = executionVertex;
+        return sourceVertices.contains(executionVertex)
+                || inputConsumableExecutionVertices.contains(executionVertex);
     }
 
-    public void setInputConsumable(ExecutionVertexID executionVertex) {
+    public void setInputConsumable(SchedulingExecutionVertex executionVertex) {
         inputConsumableExecutionVertices.add(executionVertex);
     }
 
-    public void addSourceVertices(Collection<ExecutionVertexID> sourceVertices) {
+    public void addSourceVertices(Collection<SchedulingExecutionVertex> sourceVertices) {
         this.sourceVertices.addAll(sourceVertices);
     }
 
-    public ExecutionVertexID getLastExecutionToDecideInputConsumable() {
+    public SchedulingExecutionVertex getLastExecutionToDecideInputConsumable() {
         return lastExecutionToDecideInputConsumable;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingInputConsumableDecider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingInputConsumableDecider.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.strategy;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/** Mock {@link InputConsumableDecider} for testing. */
+public class TestingInputConsumableDecider implements InputConsumableDecider {
+
+    private final Set<ExecutionVertexID> inputConsumableExecutionVertices = new HashSet<>();
+
+    private final Set<ExecutionVertexID> sourceVertices = new HashSet<>();
+
+    private ExecutionVertexID lastExecutionToDecideInputConsumable;
+
+    @Override
+    public boolean isInputConsumable(
+            ExecutionVertexID executionVertexID,
+            Set<ExecutionVertexID> verticesToDeploy,
+            Map<ConsumedPartitionGroup, Boolean> consumableStatusCache) {
+        lastExecutionToDecideInputConsumable = executionVertexID;
+        return sourceVertices.contains(executionVertexID)
+                || inputConsumableExecutionVertices.contains(executionVertexID);
+    }
+
+    public void setInputConsumable(ExecutionVertexID executionVertex) {
+        inputConsumableExecutionVertices.add(executionVertex);
+    }
+
+    public void addSourceVertices(Collection<ExecutionVertexID> sourceVertices) {
+        this.sourceVertices.addAll(sourceVertices);
+    }
+
+    public ExecutionVertexID getLastExecutionToDecideInputConsumable() {
+        return lastExecutionToDecideInputConsumable;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -102,14 +102,17 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
         return Collections.unmodifiableList(consumedPartitionGroups);
     }
 
-    void addConsumerGroup(Collection<TestingSchedulingExecutionVertex> consumerVertices) {
+    void addConsumerGroup(
+            Collection<TestingSchedulingExecutionVertex> consumerVertices,
+            ResultPartitionType resultPartitionType) {
         checkState(this.consumerVertexGroup == null);
 
         final ConsumerVertexGroup consumerVertexGroup =
                 ConsumerVertexGroup.fromMultipleVertices(
                         consumerVertices.stream()
                                 .map(TestingSchedulingExecutionVertex::getId)
-                                .collect(Collectors.toList()));
+                                .collect(Collectors.toList()),
+                        resultPartitionType);
 
         this.consumerVertexGroup = consumerVertexGroup;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -194,7 +194,8 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                         .withResultPartitionType(resultPartitionType)
                         .build();
 
-        resultPartition.addConsumerGroup(Collections.singleton(consumer));
+        resultPartition.addConsumerGroup(
+                Collections.singleton(consumer), resultPartition.getResultType());
         resultPartition.setProducer(producer);
 
         producer.addProducedPartition(resultPartition);
@@ -304,7 +305,8 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                 resultPartition.setProducer(producer);
                 producer.addProducedPartition(resultPartition);
                 consumer.addConsumedPartition(resultPartition);
-                resultPartition.addConsumerGroup(Collections.singleton(consumer));
+                resultPartition.addConsumerGroup(
+                        Collections.singleton(consumer), resultPartitionType);
                 resultPartitions.add(resultPartition);
             }
 
@@ -344,7 +346,7 @@ public class TestingSchedulingTopology implements SchedulingTopology {
                 resultPartition.setProducer(producer);
                 producer.addProducedPartition(resultPartition);
 
-                resultPartition.addConsumerGroup(consumers);
+                resultPartition.addConsumerGroup(consumers, resultPartitionType);
                 resultPartitions.add(resultPartition);
             }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategyTest.java
@@ -185,6 +185,43 @@ class VertexwiseSchedulingStrategyTest {
     }
 
     @Test
+    void testScheduleDownstreamOfHybridEdge() {
+        final TestingSchedulingTopology topology = new TestingSchedulingTopology();
+
+        final List<TestingSchedulingExecutionVertex> producers =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        final List<TestingSchedulingExecutionVertex> consumers =
+                topology.addExecutionVertices().withParallelism(2).finish();
+
+        // add consumers to scheduling strategy.
+        topology.connectAllToAll(producers, consumers)
+                .withResultPartitionType(ResultPartitionType.HYBRID_FULL)
+                .finish();
+
+        final VertexwiseSchedulingStrategy schedulingStrategy = createSchedulingStrategy(topology);
+        inputConsumableDecider.addSourceVertices(
+                producers.stream()
+                        .map(TestingSchedulingExecutionVertex::getId)
+                        .collect(Collectors.toSet()));
+
+        inputConsumableDecider.setInputConsumable(consumers.get(0).getId());
+        inputConsumableDecider.setInputConsumable(consumers.get(1).getId());
+
+        schedulingStrategy.startScheduling();
+
+        // consumers are properly scheduled indicates that the consuming relationship and
+        // correlation are successfully built
+        assertLatestScheduledVerticesAreEqualTo(
+                Arrays.asList(
+                        Collections.singletonList(producers.get(0)),
+                        Collections.singletonList(producers.get(1)),
+                        Collections.singletonList(consumers.get(0)),
+                        Collections.singletonList(consumers.get(1))),
+                testingSchedulerOperation);
+    }
+
+    @Test
     void testUpdateStrategyWithAllToAll() {
         testUpdateStrategyOnTopologyUpdate(true);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategyTest.java
@@ -21,22 +21,22 @@ package org.apache.flink.runtime.scheduler.strategy;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.apache.flink.runtime.scheduler.strategy.StrategyTestUtil.assertLatestScheduledVerticesAreEqualTo;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit tests for {@link VertexwiseSchedulingStrategy}. */
-public class VertexwiseSchedulingStrategyTest {
+class VertexwiseSchedulingStrategyTest {
 
     private TestingSchedulerOperations testingSchedulerOperation;
 
@@ -50,8 +50,8 @@ public class VertexwiseSchedulingStrategyTest {
 
     private List<TestingSchedulingExecutionVertex> sink;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         testingSchedulerOperation = new TestingSchedulerOperations();
 
         buildTopology();
@@ -89,20 +89,20 @@ public class VertexwiseSchedulingStrategyTest {
     }
 
     @Test
-    public void testStartScheduling() {
+    void testStartScheduling() {
         startScheduling(testingSchedulingTopology);
 
         final List<List<TestingSchedulingExecutionVertex>> expectedScheduledVertices =
                 new ArrayList<>();
-        expectedScheduledVertices.add(Arrays.asList(source.get(0)));
-        expectedScheduledVertices.add(Arrays.asList(source.get(1)));
+        expectedScheduledVertices.add(Collections.singletonList(source.get(0)));
+        expectedScheduledVertices.add(Collections.singletonList(source.get(1)));
 
         assertLatestScheduledVerticesAreEqualTo(
                 expectedScheduledVertices, testingSchedulerOperation);
     }
 
     @Test
-    public void testRestartTasks() {
+    void testRestartTasks() {
         final VertexwiseSchedulingStrategy schedulingStrategy =
                 startScheduling(testingSchedulingTopology);
 
@@ -116,66 +116,66 @@ public class VertexwiseSchedulingStrategyTest {
 
         final List<List<TestingSchedulingExecutionVertex>> expectedScheduledVertices =
                 new ArrayList<>();
-        expectedScheduledVertices.add(Arrays.asList(source.get(0)));
-        expectedScheduledVertices.add(Arrays.asList(source.get(1)));
+        expectedScheduledVertices.add(Collections.singletonList(source.get(0)));
+        expectedScheduledVertices.add(Collections.singletonList(source.get(1)));
         assertLatestScheduledVerticesAreEqualTo(
                 expectedScheduledVertices, testingSchedulerOperation);
     }
 
     @Test
-    public void testOnExecutionStateChangeToFinished() {
+    void testOnExecutionStateChangeToFinished() {
         // trigger source1, source2 scheduled.
         final VertexwiseSchedulingStrategy schedulingStrategy =
                 startScheduling(testingSchedulingTopology);
-        assertThat(testingSchedulerOperation.getScheduledVertices(), hasSize(2));
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(2);
 
         // trigger map1 scheduled
         final TestingSchedulingExecutionVertex source1 = source.get(0);
         source1.getProducedResults().iterator().next().setState(ResultPartitionState.CONSUMABLE);
         schedulingStrategy.onExecutionStateChange(source1.getId(), ExecutionState.FINISHED);
-        assertThat(testingSchedulerOperation.getScheduledVertices(), hasSize(3));
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(3);
 
         // trigger map2 scheduled
         final TestingSchedulingExecutionVertex source2 = source.get(1);
         source2.getProducedResults().iterator().next().setState(ResultPartitionState.CONSUMABLE);
         schedulingStrategy.onExecutionStateChange(source2.getId(), ExecutionState.FINISHED);
-        assertThat(testingSchedulerOperation.getScheduledVertices(), hasSize(4));
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(4);
 
         // sinks' inputs are not all consumable yet so they are not scheduled
         final TestingSchedulingExecutionVertex map1 = map.get(0);
         map1.getProducedResults().iterator().next().setState(ResultPartitionState.CONSUMABLE);
         schedulingStrategy.onExecutionStateChange(map1.getId(), ExecutionState.FINISHED);
-        assertThat(testingSchedulerOperation.getScheduledVertices(), hasSize(4));
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(4);
 
         // trigger sink1, sink2 scheduled
         final TestingSchedulingExecutionVertex map2 = map.get(1);
         map2.getProducedResults().iterator().next().setState(ResultPartitionState.CONSUMABLE);
         schedulingStrategy.onExecutionStateChange(map2.getId(), ExecutionState.FINISHED);
-        assertThat(testingSchedulerOperation.getScheduledVertices(), hasSize(6));
+        assertThat(testingSchedulerOperation.getScheduledVertices()).hasSize(6);
 
         final List<List<TestingSchedulingExecutionVertex>> expectedScheduledVertices =
                 new ArrayList<>();
-        expectedScheduledVertices.add(Arrays.asList(source.get(0)));
-        expectedScheduledVertices.add(Arrays.asList(source.get(1)));
-        expectedScheduledVertices.add(Arrays.asList(map.get(0)));
-        expectedScheduledVertices.add(Arrays.asList(map.get(1)));
-        expectedScheduledVertices.add(Arrays.asList(sink.get(0)));
-        expectedScheduledVertices.add(Arrays.asList(sink.get(1)));
+        expectedScheduledVertices.add(Collections.singletonList(source.get(0)));
+        expectedScheduledVertices.add(Collections.singletonList(source.get(1)));
+        expectedScheduledVertices.add(Collections.singletonList(map.get(0)));
+        expectedScheduledVertices.add(Collections.singletonList(map.get(1)));
+        expectedScheduledVertices.add(Collections.singletonList(sink.get(0)));
+        expectedScheduledVertices.add(Collections.singletonList(sink.get(1)));
         assertLatestScheduledVerticesAreEqualTo(
                 expectedScheduledVertices, testingSchedulerOperation);
     }
 
     @Test
-    public void testUpdateStrategyWithAllToAll() {
+    void testUpdateStrategyWithAllToAll() {
         testUpdateStrategyOnTopologyUpdate(true);
     }
 
     @Test
-    public void testUpdateStrategyWithPointWise() {
+    void testUpdateStrategyWithPointWise() {
         testUpdateStrategyOnTopologyUpdate(false);
     }
 
-    public void testUpdateStrategyOnTopologyUpdate(boolean allToAll) {
+    private void testUpdateStrategyOnTopologyUpdate(boolean allToAll) {
         final TestingSchedulingTopology topology = new TestingSchedulingTopology();
 
         final List<TestingSchedulingExecutionVertex> producers =
@@ -216,10 +216,10 @@ public class VertexwiseSchedulingStrategyTest {
         // correlation are successfully built
         assertLatestScheduledVerticesAreEqualTo(
                 Arrays.asList(
-                        Arrays.asList(producers.get(0)),
-                        Arrays.asList(producers.get(1)),
-                        Arrays.asList(consumers.get(0)),
-                        Arrays.asList(consumers.get(1))),
+                        Collections.singletonList(producers.get(0)),
+                        Collections.singletonList(producers.get(1)),
+                        Collections.singletonList(consumers.get(0)),
+                        Collections.singletonList(consumers.get(1))),
                 testingSchedulerOperation);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/VertexwiseSchedulingStrategyTest.java
@@ -200,13 +200,10 @@ class VertexwiseSchedulingStrategyTest {
                 .finish();
 
         final VertexwiseSchedulingStrategy schedulingStrategy = createSchedulingStrategy(topology);
-        inputConsumableDecider.addSourceVertices(
-                producers.stream()
-                        .map(TestingSchedulingExecutionVertex::getId)
-                        .collect(Collectors.toSet()));
+        inputConsumableDecider.addSourceVertices(new HashSet<>(producers));
 
-        inputConsumableDecider.setInputConsumable(consumers.get(0).getId());
-        inputConsumableDecider.setInputConsumable(consumers.get(1).getId());
+        inputConsumableDecider.setInputConsumable(consumers.get(0));
+        inputConsumableDecider.setInputConsumable(consumers.get(1));
 
         schedulingStrategy.startScheduling();
 


### PR DESCRIPTION
## What is the purpose of the change

*`SpeculativeScheduler` reuses the ability of `AdaptiveBatchScheduler` to schedule tasks, but the current `AdaptiveBatchScheduler` only supports `ALL_ EDGES_BLOCKING` batch jobs, so we should make it also support hybrid shuffle mode.*


## Brief change log

  - *Introduce InputConsumableDecider and using it to decide are input all consumable for VertexwiseSchedulingStrategy.*
  - *VertexwiseSchedulingStrategy supports hybrid shuffle edge.*


## Verifying this change

This change added unit tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
