### PR TITLE
[FLINK-28082][Connector/Pulsar] Add end-to-end encryption support for Pulsar connector.

### DIFF
--- a/docs/layouts/shortcodes/generated/pulsar_producer_configuration.html
+++ b/docs/layouts/shortcodes/generated/pulsar_producer_configuration.html
@@ -51,10 +51,22 @@
             <td>Message data compression type used by a producer.Available options:<ul><li><a href="LZ4">https://github.com/lz4/lz4</a></li><li><a href="ZLIB">https://zlib.net/</a></li><li><a href="ZSTD">https://facebook.github.io/zstd/</a></li><li><a href="SNAPPY">https://google.github.io/snappy/</a></li></ul><br /><br />Possible values:<ul><li>"NONE"</li><li>"LZ4"</li><li>"ZLIB"</li><li>"ZSTD"</li><li>"SNAPPY"</li></ul></td>
         </tr>
         <tr>
+            <td><h5>pulsar.producer.encryptionKeys</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>List&lt;String&gt;</td>
+            <td>Add public encryption key, used by producer to encrypt the data key.</td>
+        </tr>
+        <tr>
             <td><h5>pulsar.producer.initialSequenceId</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Long</td>
             <td>The sequence id for avoiding the duplication, it's used when Pulsar doesn't have transaction.</td>
+        </tr>
+        <tr>
+            <td><h5>pulsar.producer.producerCryptoFailureAction</h5></td>
+            <td style="word-wrap: break-word;">FAIL</td>
+            <td><p>Enum</p></td>
+            <td>The action the producer will take in case of encryption failures.<br /><br />Possible values:<ul><li>"FAIL"</li><li>"SEND"</li></ul></td>
         </tr>
         <tr>
             <td><h5>pulsar.producer.producerName</h5></td>

--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -294,6 +294,8 @@ under the License.
 						<configuration>
 							<includes>
 								<include>**/testutils/**</include>
+								<include>encrypt/test_ecdsa_privkey.pem</include>
+								<include>encrypt/test_ecdsa_pubkey.pem</include>
 								<include>META-INF/LICENSE</include>
 								<include>META-INF/NOTICE</include>
 							</includes>
@@ -317,6 +319,8 @@ under the License.
 							</archive>
 							<includes>
 								<include>**/testutils/**</include>
+								<include>encrypt/test_ecdsa_privkey.pem</include>
+								<include>encrypt/test_ecdsa_pubkey.pem</include>
 								<include>META-INF/LICENSE</include>
 								<include>META-INF/NOTICE</include>
 							</includes>

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSink.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSink.java
@@ -37,6 +37,10 @@ import org.apache.flink.connector.pulsar.sink.writer.serializer.PulsarSerializat
 import org.apache.flink.connector.pulsar.sink.writer.topic.TopicMetadataListener;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
+import org.apache.pulsar.client.api.CryptoKeyReader;
+
+import javax.annotation.Nullable;
+
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -86,17 +90,21 @@ public class PulsarSink<IN> implements TwoPhaseCommittingSink<IN, PulsarCommitta
     private final MessageDelayer<IN> messageDelayer;
     private final TopicRouter<IN> topicRouter;
 
+    @Nullable private final CryptoKeyReader cryptoKeyReader;
+
     PulsarSink(
             SinkConfiguration sinkConfiguration,
             PulsarSerializationSchema<IN> serializationSchema,
             TopicMetadataListener metadataListener,
             TopicRoutingMode topicRoutingMode,
             TopicRouter<IN> topicRouter,
-            MessageDelayer<IN> messageDelayer) {
+            MessageDelayer<IN> messageDelayer,
+            @Nullable CryptoKeyReader cryptoKeyReader) {
         this.sinkConfiguration = checkNotNull(sinkConfiguration);
         this.serializationSchema = checkNotNull(serializationSchema);
         this.metadataListener = checkNotNull(metadataListener);
         this.messageDelayer = checkNotNull(messageDelayer);
+        this.cryptoKeyReader = cryptoKeyReader;
         checkNotNull(topicRoutingMode);
 
         // Create topic router supplier.
@@ -128,6 +136,7 @@ public class PulsarSink<IN> implements TwoPhaseCommittingSink<IN, PulsarCommitta
                 metadataListener,
                 topicRouter,
                 messageDelayer,
+                cryptoKeyReader,
                 initContext);
     }
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSinkOptions.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/PulsarSinkOptions.java
@@ -29,8 +29,10 @@ import org.apache.flink.connector.pulsar.common.config.PulsarOptions;
 import org.apache.flink.connector.pulsar.sink.writer.router.MessageKeyHash;
 
 import org.apache.pulsar.client.api.CompressionType;
+import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 import static java.util.Collections.emptyMap;
@@ -287,4 +289,20 @@ public final class PulsarSinkOptions {
                                     .text(
                                             " When getting a topic stats, associate this metadata with the consumer stats for easier identification.")
                                     .build());
+
+    public static final ConfigOption<ProducerCryptoFailureAction>
+            PULSAR_PRODUCER_CRYPTO_FAILURE_ACTION =
+                    ConfigOptions.key(PRODUCER_CONFIG_PREFIX + "producerCryptoFailureAction")
+                            .enumType(ProducerCryptoFailureAction.class)
+                            .defaultValue(ProducerCryptoFailureAction.FAIL)
+                            .withDescription(
+                                    "The action the producer will take in case of encryption failures.");
+
+    public static final ConfigOption<List<String>> PULSAR_ENCRYPTION_KEYS =
+            ConfigOptions.key(PRODUCER_CONFIG_PREFIX + "encryptionKeys")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Add public encryption key, used by producer to encrypt the data key.");
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/config/PulsarSinkConfigUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/config/PulsarSinkConfigUtils.java
@@ -43,9 +43,11 @@ import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_BA
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_BATCHING_PARTITION_SWITCH_FREQUENCY_BY_PUBLISH_DELAY;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_CHUNKING_ENABLED;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_COMPRESSION_TYPE;
+import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_ENCRYPTION_KEYS;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_INITIAL_SEQUENCE_ID;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_MAX_PENDING_MESSAGES;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_MAX_PENDING_MESSAGES_ACROSS_PARTITIONS;
+import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_PRODUCER_CRYPTO_FAILURE_ACTION;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_PRODUCER_NAME;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_PRODUCER_PROPERTIES;
 import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_SEND_TIMEOUT_MS;
@@ -96,6 +98,11 @@ public final class PulsarSinkConfigUtils {
         configuration.useOption(PULSAR_CHUNKING_ENABLED, builder::enableChunking);
         configuration.useOption(PULSAR_COMPRESSION_TYPE, builder::compressionType);
         configuration.useOption(PULSAR_INITIAL_SEQUENCE_ID, builder::initialSequenceId);
+        configuration.useOption(
+                PULSAR_PRODUCER_CRYPTO_FAILURE_ACTION, builder::cryptoFailureAction);
+        // Add the encryption keys.
+        configuration.useOption(
+                PULSAR_ENCRYPTION_KEYS, keys -> keys.forEach(builder::addEncryptionKey));
 
         // Set producer properties
         Map<String, String> properties = configuration.getProperties(PULSAR_PRODUCER_PROPERTIES);

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriter.java
@@ -39,10 +39,13 @@ import org.apache.flink.util.FlinkRuntimeException;
 
 import org.apache.flink.shaded.guava30.com.google.common.base.Strings;
 
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.TypedMessageBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -93,6 +96,7 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
             TopicMetadataListener metadataListener,
             TopicRouter<IN> topicRouter,
             MessageDelayer<IN> messageDelayer,
+            @Nullable CryptoKeyReader cryptoKeyReader,
             InitContext initContext) {
         checkNotNull(sinkConfiguration);
         this.serializationSchema = checkNotNull(serializationSchema);
@@ -122,7 +126,7 @@ public class PulsarWriter<IN> implements PrecommittingSinkWriter<IN, PulsarCommi
         }
 
         // Create this producer register after opening serialization schema!
-        this.producerRegister = new TopicProducerRegister(sinkConfiguration);
+        this.producerRegister = new TopicProducerRegister(sinkConfiguration, cryptoKeyReader);
         this.mailboxExecutor = initContext.getMailboxExecutor();
     }
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSource.java
@@ -43,6 +43,10 @@ import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitSerializer;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 
+import org.apache.pulsar.client.api.CryptoKeyReader;
+
+import javax.annotation.Nullable;
+
 /**
  * The Source implementation of Pulsar. Please use a {@link PulsarSourceBuilder} to construct a
  * {@link PulsarSource}. The following example shows how to create a PulsarSource emitting records
@@ -86,8 +90,10 @@ public final class PulsarSource<OUT>
 
     private final Boundedness boundedness;
 
-    /** The pulsar deserialization schema used for deserializing message. */
+    /** The pulsar deserialization schema is used for deserializing message. */
     private final PulsarDeserializationSchema<OUT> deserializationSchema;
+
+    @Nullable private final CryptoKeyReader cryptoKeyReader;
 
     /**
      * The constructor for PulsarSource, it's package protected for forcing using {@link
@@ -100,7 +106,8 @@ public final class PulsarSource<OUT>
             StartCursor startCursor,
             StopCursor stopCursor,
             Boundedness boundedness,
-            PulsarDeserializationSchema<OUT> deserializationSchema) {
+            PulsarDeserializationSchema<OUT> deserializationSchema,
+            @Nullable CryptoKeyReader cryptoKeyReader) {
         this.sourceConfiguration = sourceConfiguration;
         this.subscriber = subscriber;
         this.rangeGenerator = rangeGenerator;
@@ -108,6 +115,7 @@ public final class PulsarSource<OUT>
         this.stopCursor = stopCursor;
         this.boundedness = boundedness;
         this.deserializationSchema = deserializationSchema;
+        this.cryptoKeyReader = cryptoKeyReader;
     }
 
     /**
@@ -134,7 +142,7 @@ public final class PulsarSource<OUT>
         deserializationSchema.open(initializationContext, sourceConfiguration);
 
         return PulsarSourceReaderFactory.create(
-                readerContext, deserializationSchema, sourceConfiguration);
+                readerContext, deserializationSchema, sourceConfiguration, cryptoKeyReader);
     }
 
     @Internal

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/PulsarSourceBuilder.java
@@ -36,11 +36,14 @@ import org.apache.flink.connector.pulsar.source.enumerator.topic.range.RangeGene
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.SplitRangeGenerator;
 import org.apache.flink.connector.pulsar.source.reader.deserializer.PulsarDeserializationSchema;
 
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.RegexSubscriptionMode;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
@@ -129,6 +132,7 @@ public final class PulsarSourceBuilder<OUT> {
     private StopCursor stopCursor;
     private Boundedness boundedness;
     private PulsarDeserializationSchema<OUT> deserializationSchema;
+    @Nullable private CryptoKeyReader cryptoKeyReader;
 
     // private builder constructor.
     PulsarSourceBuilder() {
@@ -374,6 +378,18 @@ public final class PulsarSourceBuilder<OUT> {
     }
 
     /**
+     * Sets a {@link CryptoKeyReader}. Configure the key reader to be used to decrypt the message
+     * payloads.
+     *
+     * @param cryptoKeyReader CryptoKeyReader object
+     * @return this PulsarSourceBuilder.
+     */
+    public PulsarSourceBuilder<OUT> setCryptoKeyReader(CryptoKeyReader cryptoKeyReader) {
+        this.cryptoKeyReader = checkNotNull(cryptoKeyReader);
+        return this;
+    }
+
+    /**
      * Configure the authentication provider to use in the Pulsar client instance.
      *
      * @param authPluginClassName name of the Authentication-Plugin you want to use
@@ -529,7 +545,8 @@ public final class PulsarSourceBuilder<OUT> {
                 startCursor,
                 stopCursor,
                 boundedness,
-                deserializationSchema);
+                deserializationSchema,
+                cryptoKeyReader);
     }
 
     // ------------- private helpers  --------------

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderFactory.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/PulsarSourceReaderFactory.java
@@ -33,10 +33,13 @@ import org.apache.flink.connector.pulsar.source.reader.split.PulsarUnorderedPart
 import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.api.transaction.TransactionCoordinatorClient;
 import org.apache.pulsar.client.impl.PulsarClientImpl;
+
+import javax.annotation.Nullable;
 
 import java.util.function.Supplier;
 
@@ -44,8 +47,8 @@ import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactor
 import static org.apache.flink.connector.pulsar.common.config.PulsarClientFactory.createClient;
 
 /**
- * This factory class is used for creating different types of source reader for different
- * subscription type.
+ * This factory class is used for creating different types of source reader for the different
+ * subscription types.
  *
  * <ol>
  *   <li>Failover, Exclusive: We would create {@link PulsarOrderedSourceReader}.
@@ -63,7 +66,8 @@ public final class PulsarSourceReaderFactory {
     public static <OUT> SourceReader<OUT, PulsarPartitionSplit> create(
             SourceReaderContext readerContext,
             PulsarDeserializationSchema<OUT> deserializationSchema,
-            SourceConfiguration sourceConfiguration) {
+            SourceConfiguration sourceConfiguration,
+            @Nullable CryptoKeyReader cryptoKeyReader) {
 
         PulsarClient pulsarClient = createClient(sourceConfiguration);
         PulsarAdmin pulsarAdmin = createAdmin(sourceConfiguration);
@@ -84,7 +88,8 @@ public final class PulsarSourceReaderFactory {
                                     pulsarClient,
                                     pulsarAdmin,
                                     sourceConfiguration,
-                                    deserializationSchema);
+                                    deserializationSchema,
+                                    cryptoKeyReader);
 
             return new PulsarOrderedSourceReader<>(
                     elementsQueue,
@@ -109,6 +114,7 @@ public final class PulsarSourceReaderFactory {
                                     pulsarAdmin,
                                     sourceConfiguration,
                                     deserializationSchema,
+                                    cryptoKeyReader,
                                     coordinatorClient);
 
             return new PulsarUnorderedSourceReader<>(

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarOrderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarOrderedPartitionSplitReader.java
@@ -27,12 +27,15 @@ import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplit;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.admin.PulsarAdminException;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
 
 import java.time.Duration;
 import java.util.List;
@@ -57,8 +60,14 @@ public class PulsarOrderedPartitionSplitReader<OUT> extends PulsarPartitionSplit
             PulsarClient pulsarClient,
             PulsarAdmin pulsarAdmin,
             SourceConfiguration sourceConfiguration,
-            PulsarDeserializationSchema<OUT> deserializationSchema) {
-        super(pulsarClient, pulsarAdmin, sourceConfiguration, deserializationSchema);
+            PulsarDeserializationSchema<OUT> deserializationSchema,
+            @Nullable CryptoKeyReader cryptoKeyReader) {
+        super(
+                pulsarClient,
+                pulsarAdmin,
+                sourceConfiguration,
+                deserializationSchema,
+                cryptoKeyReader);
     }
 
     @Override

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReader.java
@@ -27,6 +27,7 @@ import org.apache.flink.connector.pulsar.source.split.PulsarPartitionSplitState;
 
 import org.apache.pulsar.client.admin.PulsarAdmin;
 import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.CryptoKeyReader;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
@@ -69,8 +70,14 @@ public class PulsarUnorderedPartitionSplitReader<OUT> extends PulsarPartitionSpl
             PulsarAdmin pulsarAdmin,
             SourceConfiguration sourceConfiguration,
             PulsarDeserializationSchema<OUT> deserializationSchema,
+            @Nullable CryptoKeyReader cryptoKeyReader,
             TransactionCoordinatorClient coordinatorClient) {
-        super(pulsarClient, pulsarAdmin, sourceConfiguration, deserializationSchema);
+        super(
+                pulsarClient,
+                pulsarAdmin,
+                sourceConfiguration,
+                deserializationSchema,
+                cryptoKeyReader);
 
         this.coordinatorClient = coordinatorClient;
     }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/PulsarSinkITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/PulsarSinkITCase.java
@@ -25,8 +25,9 @@ import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestSuiteBase;
 import org.apache.flink.connector.pulsar.testutils.function.ControlSource;
 import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntime;
-import org.apache.flink.connector.pulsar.testutils.sink.PulsarSinkTestContext;
 import org.apache.flink.connector.pulsar.testutils.sink.PulsarSinkTestSuiteBase;
+import org.apache.flink.connector.pulsar.testutils.sink.cases.PulsarEncryptSinkContext;
+import org.apache.flink.connector.pulsar.testutils.sink.cases.PulsarSinkTestContext;
 import org.apache.flink.connector.testframe.environment.MiniClusterTestEnvironment;
 import org.apache.flink.connector.testframe.junit.annotations.TestContext;
 import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
@@ -75,6 +76,25 @@ class PulsarSinkITCase {
         @TestContext
         PulsarTestContextFactory<String, PulsarSinkTestContext> sinkContext =
                 new PulsarTestContextFactory<>(pulsar, PulsarSinkTestContext::new);
+    }
+
+    @Nested
+    class ProducerEncryptionTest extends PulsarSinkTestSuiteBase {
+
+        @TestEnv MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
+
+        @TestExternalSystem
+        PulsarTestEnvironment pulsar = new PulsarTestEnvironment(PulsarRuntime.mock());
+
+        @TestSemantics
+        CheckpointingMode[] semantics =
+                new CheckpointingMode[] {
+                    CheckpointingMode.EXACTLY_ONCE, CheckpointingMode.AT_LEAST_ONCE
+                };
+
+        @TestContext
+        PulsarTestContextFactory<String, PulsarEncryptSinkContext> sinkContext =
+                new PulsarTestContextFactory<>(pulsar, PulsarEncryptSinkContext::new);
     }
 
     /** Tests for using PulsarSink writing to a Pulsar cluster. */

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/PulsarWriterTest.java
@@ -78,7 +78,8 @@ class PulsarWriterTest extends PulsarTestSuiteBase {
         MockInitContext initContext = new MockInitContext();
 
         PulsarWriter<String> writer =
-                new PulsarWriter<>(configuration, schema, listener, router, delayer, initContext);
+                new PulsarWriter<>(
+                        configuration, schema, listener, router, delayer, null, initContext);
 
         writer.flush(false);
         writer.prepareCommit();

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicProducerRegisterTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/writer/topic/TopicProducerRegisterTest.java
@@ -49,7 +49,7 @@ class TopicProducerRegisterTest extends PulsarTestSuiteBase {
         operator().createTopic(topic, 8);
 
         SinkConfiguration configuration = sinkConfiguration(deliveryGuarantee);
-        TopicProducerRegister register = new TopicProducerRegister(configuration);
+        TopicProducerRegister register = new TopicProducerRegister(configuration, null);
 
         String message = randomAlphabetic(10);
         register.createMessageBuilder(topic, Schema.STRING).value(message).send();
@@ -76,7 +76,7 @@ class TopicProducerRegisterTest extends PulsarTestSuiteBase {
         operator().createTopic(topic, 8);
 
         SinkConfiguration configuration = sinkConfiguration(deliveryGuarantee);
-        TopicProducerRegister register = new TopicProducerRegister(configuration);
+        TopicProducerRegister register = new TopicProducerRegister(configuration, null);
 
         String message = randomAlphabetic(10);
         register.createMessageBuilder(topic, Schema.STRING).value(message).sendAsync();

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarSourceITCase.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.pulsar.source;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestContextFactory;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
 import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntime;
+import org.apache.flink.connector.pulsar.testutils.source.cases.ConsumeEncryptMessagesContext;
 import org.apache.flink.connector.pulsar.testutils.source.cases.MultipleTopicConsumingContext;
 import org.apache.flink.connector.pulsar.testutils.source.cases.SingleTopicConsumingContext;
 import org.apache.flink.connector.testframe.environment.MiniClusterTestEnvironment;
@@ -32,6 +33,7 @@ import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
 /**
@@ -39,26 +41,49 @@ import org.junit.jupiter.api.Tag;
  * subscription.
  */
 @Tag("org.apache.flink.testutils.junit.FailsOnJava11")
-class PulsarSourceITCase extends SourceTestSuiteBase<String> {
+class PulsarSourceITCase {
 
-    // Defines test environment on Flink MiniCluster
-    @TestEnv MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
+    @Nested
+    class IntegrationTest extends SourceTestSuiteBase<String> {
 
-    // Defines pulsar running environment
-    @TestExternalSystem
-    PulsarTestEnvironment pulsar = new PulsarTestEnvironment(PulsarRuntime.mock());
+        // Defines test environment on Flink MiniCluster
+        @TestEnv MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
 
-    // This field is preserved, we don't support the semantics in source currently.
-    @TestSemantics
-    CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
+        // Defines pulsar running environment
+        @TestExternalSystem
+        PulsarTestEnvironment pulsar = new PulsarTestEnvironment(PulsarRuntime.mock());
 
-    // Defines an external context Factories,
-    // so test cases will be invoked using these external contexts.
-    @TestContext
-    PulsarTestContextFactory<String, SingleTopicConsumingContext> singleTopic =
-            new PulsarTestContextFactory<>(pulsar, SingleTopicConsumingContext::new);
+        // This field is preserved, we don't support the semantics in source currently.
+        @TestSemantics
+        CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
 
-    @TestContext
-    PulsarTestContextFactory<String, MultipleTopicConsumingContext> multipleTopic =
-            new PulsarTestContextFactory<>(pulsar, MultipleTopicConsumingContext::new);
+        // Defines an external context Factories,
+        // so test cases will be invoked using these external contexts.
+        @TestContext
+        PulsarTestContextFactory<String, SingleTopicConsumingContext> singleTopic =
+                new PulsarTestContextFactory<>(pulsar, SingleTopicConsumingContext::new);
+
+        @TestContext
+        PulsarTestContextFactory<String, MultipleTopicConsumingContext> multipleTopic =
+                new PulsarTestContextFactory<>(pulsar, MultipleTopicConsumingContext::new);
+    }
+
+    @Nested
+    class ConsumerEncryptionTest extends SourceTestSuiteBase<String> {
+
+        // Defines test environment on Flink MiniCluster
+        @TestEnv MiniClusterTestEnvironment flink = new MiniClusterTestEnvironment();
+
+        // Defines pulsar running environment
+        @TestExternalSystem
+        PulsarTestEnvironment pulsar = new PulsarTestEnvironment(PulsarRuntime.mock());
+
+        // This field is preserved, we don't support the semantics in source currently.
+        @TestSemantics
+        CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
+
+        @TestContext
+        PulsarTestContextFactory<String, ConsumeEncryptMessagesContext> encryptMessages =
+                new PulsarTestContextFactory<>(pulsar, ConsumeEncryptMessagesContext::new);
+    }
 }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StopCursorTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/enumerator/cursor/StopCursorTest.java
@@ -59,7 +59,8 @@ class StopCursorTest extends PulsarTestSuiteBase {
                         operator().client(),
                         operator().admin(),
                         sourceConfig(),
-                        flinkSchema(new SimpleStringSchema()));
+                        flinkSchema(new SimpleStringSchema()),
+                        null);
         // send the first message and set the stopCursor to filter any late stopCursor
         operator()
                 .sendMessage(

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/source/PulsarSourceReaderTestBase.java
@@ -150,7 +150,7 @@ abstract class PulsarSourceReaderTestBase extends PulsarTestSuiteBase {
         SourceConfiguration sourceConfiguration = new SourceConfiguration(configuration);
         return (PulsarSourceReaderBase<Integer>)
                 PulsarSourceReaderFactory.create(
-                        context, deserializationSchema, sourceConfiguration);
+                        context, deserializationSchema, sourceConfiguration, null);
     }
 
     public class PulsarSourceReaderInvocationContextProvider

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderTestBase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarPartitionSplitReaderTestBase.java
@@ -347,13 +347,15 @@ abstract class PulsarPartitionSplitReaderTestBase extends PulsarTestSuiteBase {
                     operator().client(),
                     operator().admin(),
                     sourceConfig(),
-                    flinkSchema(new SimpleStringSchema()));
+                    flinkSchema(new SimpleStringSchema()),
+                    null);
         } else {
             return new PulsarUnorderedPartitionSplitReader<>(
                     operator().client(),
                     operator().admin(),
                     sourceConfig(),
                     flinkSchema(new SimpleStringSchema()),
+                    null,
                     null);
         }
     }

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarTestKeyReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/PulsarTestKeyReader.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils;
+
+import org.apache.flink.connector.pulsar.testutils.source.cases.ConsumeEncryptMessagesContext;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.EncryptionKeyInfo;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A default key reader for the Pulsar client. We would load the pre-generated key file and validate
+ * it.
+ */
+public class PulsarTestKeyReader implements CryptoKeyReader {
+    private static final long serialVersionUID = -7488297938196049791L;
+
+    public static final String DEFAULT_KEY = "flink";
+    public static final String DEFAULT_PUBKEY = "/encrypt/test_ecdsa_pubkey.pem";
+    public static final String DEFAULT_PRIVKEY = "/encrypt/test_ecdsa_privkey.pem";
+
+    private static final String APPLICATION_X_PEM_FILE = "application/x-pem-file";
+
+    private final String encryptKey;
+    private final byte[] publicKey;
+    private final byte[] privateKey;
+
+    public PulsarTestKeyReader(String encryptKey, String pubkeyRes, String privkeyRes) {
+        this.encryptKey = checkNotNull(encryptKey);
+        this.publicKey = loadKey(pubkeyRes);
+        this.privateKey = loadKey(privkeyRes);
+    }
+
+    @Override
+    public EncryptionKeyInfo getPublicKey(String keyName, Map<String, String> metadata) {
+        EncryptionKeyInfo info = new EncryptionKeyInfo();
+        if (encryptKey.equals(keyName)) {
+            info.setKey(copyKey(publicKey));
+        }
+
+        return info;
+    }
+
+    @Override
+    public EncryptionKeyInfo getPrivateKey(String keyName, Map<String, String> metadata) {
+        EncryptionKeyInfo info = new EncryptionKeyInfo();
+        if (encryptKey.equals(keyName)) {
+            info.setKey(copyKey(privateKey));
+        }
+
+        return info;
+    }
+
+    private byte[] copyKey(byte[] key) {
+        // The byte array is not immutable. Duplicate it for safety.
+        byte[] k = new byte[key.length];
+        System.arraycopy(key, 0, k, 0, key.length);
+
+        return k;
+    }
+
+    private byte[] loadKey(String resourcePath) {
+        URL fileURL = ConsumeEncryptMessagesContext.class.getResource(resourcePath);
+        checkNotNull(fileURL, "Failed to load resource file: " + resourcePath);
+
+        try {
+            URLConnection urlConnection = fileURL.openConnection();
+            try {
+                String protocol = fileURL.getProtocol();
+                String contentType = urlConnection.getContentType();
+
+                if ("data".equals(protocol) && !APPLICATION_X_PEM_FILE.equals(contentType)) {
+                    throw new IllegalArgumentException("Unsupported format: " + contentType);
+                }
+                return IOUtils.toByteArray(urlConnection);
+            } finally {
+                IOUtils.close(urlConnection);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/sink/cases/PulsarEncryptSinkContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/sink/cases/PulsarEncryptSinkContext.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils.sink.cases;
+
+import org.apache.flink.connector.pulsar.sink.PulsarSinkBuilder;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader;
+import org.apache.flink.connector.pulsar.testutils.sink.reader.PulsarEncryptDataReader;
+import org.apache.flink.connector.testframe.external.ExternalSystemDataReader;
+import org.apache.flink.connector.testframe.external.sink.TestingSinkSettings;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
+
+import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_PRODUCER_CRYPTO_FAILURE_ACTION;
+import static org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader.DEFAULT_KEY;
+import static org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader.DEFAULT_PRIVKEY;
+import static org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader.DEFAULT_PUBKEY;
+import static org.apache.pulsar.client.api.ProducerCryptoFailureAction.FAIL;
+import static org.apache.pulsar.client.api.Schema.STRING;
+
+/** The sink context for supporting producing messages which are encrypted. */
+public class PulsarEncryptSinkContext extends PulsarSinkTestContext {
+
+    private final CryptoKeyReader cryptoKeyReader =
+            new PulsarTestKeyReader(DEFAULT_KEY, DEFAULT_PUBKEY, DEFAULT_PRIVKEY);
+
+    public PulsarEncryptSinkContext(PulsarTestEnvironment environment) {
+        super(environment);
+    }
+
+    @Override
+    protected void setSinkBuilder(PulsarSinkBuilder<String> builder) {
+        super.setSinkBuilder(builder);
+
+        builder.setEncryptionKeys(DEFAULT_KEY);
+        builder.setCryptoKeyReader(cryptoKeyReader);
+        builder.setConfig(PULSAR_PRODUCER_CRYPTO_FAILURE_ACTION, FAIL);
+    }
+
+    @Override
+    public ExternalSystemDataReader<String> createSinkDataReader(TestingSinkSettings sinkSettings) {
+        PulsarEncryptDataReader<String> reader =
+                new PulsarEncryptDataReader<>(operator, topicName, STRING, cryptoKeyReader);
+        closer.register(reader);
+
+        return reader;
+    }
+
+    @Override
+    protected String displayName() {
+        return "write messages into one topic by End-to-end encryption";
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/sink/reader/PulsarEncryptDataReader.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/sink/reader/PulsarEncryptDataReader.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils.sink.reader;
+
+import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntimeOperator;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.Schema;
+
+/** The data reader for reading encrypted messages from Pulsar. */
+public class PulsarEncryptDataReader<T> extends PulsarPartitionDataReader<T> {
+
+    public PulsarEncryptDataReader(
+            PulsarRuntimeOperator operator,
+            String fullTopicName,
+            Schema<T> schema,
+            CryptoKeyReader cryptoKeyReader) {
+        super(operator, fullTopicName, schema, cryptoKeyReader);
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/PulsarSourceTestContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/PulsarSourceTestContext.java
@@ -27,6 +27,7 @@ import org.apache.flink.connector.pulsar.source.PulsarSourceBuilder;
 import org.apache.flink.connector.pulsar.source.enumerator.cursor.StopCursor;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestContext;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
+import org.apache.flink.connector.pulsar.testutils.source.writer.PulsarPartitionDataWriter;
 import org.apache.flink.connector.testframe.external.ExternalSystemSplitDataWriter;
 import org.apache.flink.connector.testframe.external.source.DataStreamSourceExternalContext;
 import org.apache.flink.connector.testframe.external.source.TestingSourceSettings;

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/cases/ConsumeEncryptMessagesContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/cases/ConsumeEncryptMessagesContext.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils.source.cases;
+
+import org.apache.flink.connector.pulsar.source.PulsarSourceBuilder;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
+import org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader;
+import org.apache.flink.connector.pulsar.testutils.source.writer.PulsarEncryptDataWriter;
+import org.apache.flink.connector.testframe.external.ExternalSystemSplitDataWriter;
+import org.apache.flink.connector.testframe.external.source.TestingSourceSettings;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.SubscriptionType;
+
+import static org.apache.flink.connector.pulsar.source.PulsarSourceOptions.PULSAR_CRYPTO_FAILURE_ACTION;
+import static org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader.DEFAULT_KEY;
+import static org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader.DEFAULT_PRIVKEY;
+import static org.apache.flink.connector.pulsar.testutils.PulsarTestKeyReader.DEFAULT_PUBKEY;
+import static org.apache.pulsar.client.api.ConsumerCryptoFailureAction.FAIL;
+
+/** We will use this context for producing messages with encryption support. */
+public class ConsumeEncryptMessagesContext extends MultipleTopicConsumingContext {
+
+    private final CryptoKeyReader cryptoKeyReader =
+            new PulsarTestKeyReader(DEFAULT_KEY, DEFAULT_PUBKEY, DEFAULT_PRIVKEY);
+
+    public ConsumeEncryptMessagesContext(PulsarTestEnvironment environment) {
+        super(environment);
+    }
+
+    @Override
+    protected void setSourceBuilder(PulsarSourceBuilder<String> builder) {
+        super.setSourceBuilder(builder);
+
+        // Set CryptoKeyReader for the Pulsar source.
+        builder.setCryptoKeyReader(cryptoKeyReader);
+        builder.setConfig(PULSAR_CRYPTO_FAILURE_ACTION, FAIL);
+    }
+
+    @Override
+    public ExternalSystemSplitDataWriter<String> createSourceSplitDataWriter(
+            TestingSourceSettings sourceSettings) {
+        String partitionName = generatePartitionName();
+        return new PulsarEncryptDataWriter<>(
+                operator, partitionName, schema, DEFAULT_KEY, cryptoKeyReader);
+    }
+
+    @Override
+    protected String displayName() {
+        return "consume messages by End-to-end encryption";
+    }
+
+    @Override
+    protected String subscriptionName() {
+        return "pulsar-encryption-subscription";
+    }
+
+    @Override
+    protected SubscriptionType subscriptionType() {
+        return SubscriptionType.Exclusive;
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/cases/KeySharedSubscriptionContext.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/cases/KeySharedSubscriptionContext.java
@@ -21,7 +21,7 @@ package org.apache.flink.connector.pulsar.testutils.source.cases;
 import org.apache.flink.connector.pulsar.source.PulsarSourceBuilder;
 import org.apache.flink.connector.pulsar.source.enumerator.topic.range.FixedKeysRangeGenerator;
 import org.apache.flink.connector.pulsar.testutils.PulsarTestEnvironment;
-import org.apache.flink.connector.pulsar.testutils.source.KeyedPulsarPartitionDataWriter;
+import org.apache.flink.connector.pulsar.testutils.source.writer.KeyedPulsarPartitionDataWriter;
 import org.apache.flink.connector.testframe.external.ExternalSystemSplitDataWriter;
 import org.apache.flink.connector.testframe.external.source.TestingSourceSettings;
 

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/writer/PulsarEncryptDataWriter.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/source/writer/PulsarEncryptDataWriter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.pulsar.testutils.source.writer;
+
+import org.apache.flink.connector.pulsar.testutils.runtime.PulsarRuntimeOperator;
+import org.apache.flink.connector.testframe.external.ExternalSystemSplitDataWriter;
+
+import org.apache.pulsar.client.api.CryptoKeyReader;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.ProducerBuilder;
+import org.apache.pulsar.client.api.ProducerCryptoFailureAction;
+import org.apache.pulsar.client.api.Schema;
+
+import java.util.List;
+
+import static org.apache.flink.connector.pulsar.common.utils.PulsarExceptionUtils.sneakyClient;
+import static org.apache.pulsar.client.api.ProducerAccessMode.Shared;
+
+/** Encrypt the messages with the given public key and send the message to Pulsar. */
+public class PulsarEncryptDataWriter<T> implements ExternalSystemSplitDataWriter<T> {
+
+    private final Producer<T> producer;
+
+    public PulsarEncryptDataWriter(
+            PulsarRuntimeOperator operator,
+            String fullTopicName,
+            Schema<T> schema,
+            String encryptKey,
+            CryptoKeyReader cryptoKeyReader) {
+        ProducerBuilder<T> builder =
+                operator.client()
+                        .newProducer(schema)
+                        .topic(fullTopicName)
+                        .enableBatching(false)
+                        .enableMultiSchema(true)
+                        .accessMode(Shared)
+                        .addEncryptionKey(encryptKey)
+                        .cryptoFailureAction(ProducerCryptoFailureAction.FAIL)
+                        .cryptoKeyReader(cryptoKeyReader);
+        this.producer = sneakyClient(builder::create);
+    }
+
+    @Override
+    public void writeRecords(List<T> records) {
+        for (T record : records) {
+            sneakyClient(() -> producer.newMessage().value(record).send());
+        }
+        sneakyClient(producer::flush);
+    }
+
+    @Override
+    public void close() throws Exception {
+        producer.close();
+    }
+}

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/encrypt/test_ecdsa_privkey.pem
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/encrypt/test_ecdsa_privkey.pem
@@ -1,0 +1,29 @@
+-----BEGIN EC PARAMETERS-----
+MIIBwgIBATBNBgcqhkjOPQEBAkIB////////////////////////////////////
+//////////////////////////////////////////////////8wgZ4EQgH/////
+////////////////////////////////////////////////////////////////
+/////////////////ARBUZU+uWGOHJofkpohoLaFQO6i2nJbmbMV87i0iZGO8Qnh
+Vhk5Uex+k3sWUsC9O7G/BzVz34g9LDTx70Uf1GtQPwADFQDQnogAKRy4U5bMZxc5
+MoSqoNpkugSBhQQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5BT+1Ifgor2BrTT26oUte
+d+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYBGDkpaniaO8AEXIpftCx9G9mY
+9URJV5tEaBevvRcnPmYsl+5ymV70JkDFULkBP60HYTU8cIaicsJAiL6Udp/RZlAC
+QgH///////////////////////////////////////////pRhoeDvy+Wa3/MAUj3
+CaXQO7XJuImcR667b7cekThkCQIBAQ==
+-----END EC PARAMETERS-----
+-----BEGIN EC PRIVATE KEY-----
+MIICnQIBAQRCAZ+PML9ogJ3M4nBsOC6X4wTHOKEBQuBzNCqvR/p5oyG/XqmpwXnj
+jEo/avN+Nyk8DS0vQoBvC/q8gsxK+1vM6vSIoIIBxjCCAcICAQEwTQYHKoZIzj0B
+AQJCAf//////////////////////////////////////////////////////////
+////////////////////////////MIGeBEIB////////////////////////////
+//////////////////////////////////////////////////////////wEQVGV
+PrlhjhyaH5KaIaC2hUDuotpyW5mzFfO4tImRjvEJ4VYZOVHsfpN7FlLAvTuxvwc1
+c9+IPSw08e9FH9RrUD8AAxUA0J6IACkcuFOWzGcXOTKEqqDaZLoEgYUEAMaFjga3
+BATpzZ4+y2YjlbRCnGSBOQU/tSH4KK9ga009uqFLXnfv51ko/h3BJ6L/qN4zSLPB
+hWpCm/l+fjHC5b1mARg5KWp4mjvABFyKX7QsfRvZmPVESVebRGgXr70XJz5mLJfu
+cple9CZAxVC5AT+tB2E1PHCGonLCQIi+lHaf0WZQAkIB////////////////////
+///////////////////////6UYaHg78vlmt/zAFI9wml0Du1ybiJnEeuu2+3HpE4
+ZAkCAQGhgYkDgYYABABjn0TWCOZ2AlU48+ozPwJw/Mu8oFksIiHTNLoE0ni0KnZg
+mEoiaOfJEyLN+fbRwtydKi6uejOOVBScXcVsxcfLFwH4bKovdOuhqeB3IaRvy43I
+4wilm5nf+NfirZVa2Y9aFW+ko550CrgAQK3at9qmQXR5CzD6t+Xh00+lHl+xTjMC
+Yw==
+-----END EC PRIVATE KEY-----

--- a/flink-connectors/flink-connector-pulsar/src/test/resources/encrypt/test_ecdsa_pubkey.pem
+++ b/flink-connectors/flink-connector-pulsar/src/test/resources/encrypt/test_ecdsa_pubkey.pem
@@ -1,0 +1,15 @@
+-----BEGIN PUBLIC KEY-----
+MIICXDCCAc8GByqGSM49AgEwggHCAgEBME0GByqGSM49AQECQgH/////////////
+////////////////////////////////////////////////////////////////
+/////////zCBngRCAf//////////////////////////////////////////////
+///////////////////////////////////////8BEFRlT65YY4cmh+SmiGgtoVA
+7qLacluZsxXzuLSJkY7xCeFWGTlR7H6TexZSwL07sb8HNXPfiD0sNPHvRR/Ua1A/
+AAMVANCeiAApHLhTlsxnFzkyhKqg2mS6BIGFBADGhY4GtwQE6c2ePstmI5W0Qpxk
+gTkFP7Uh+CivYGtNPbqhS1537+dZKP4dwSei/6jeM0izwYVqQpv5fn4xwuW9ZgEY
+OSlqeJo7wARcil+0LH0b2Zj1RElXm0RoF6+9Fyc+ZiyX7nKZXvQmQMVQuQE/rQdh
+NTxwhqJywkCIvpR2n9FmUAJCAf//////////////////////////////////////
+////+lGGh4O/L5Zrf8wBSPcJpdA7tcm4iZxHrrtvtx6ROGQJAgEBA4GGAAQAY59E
+1gjmdgJVOPPqMz8CcPzLvKBZLCIh0zS6BNJ4tCp2YJhKImjnyRMizfn20cLcnSou
+rnozjlQUnF3FbMXHyxcB+GyqL3TroangdyGkb8uNyOMIpZuZ3/jX4q2VWtmPWhVv
+pKOedAq4AECt2rfapkF0eQsw+rfl4dNPpR5fsU4zAmM=
+-----END PUBLIC KEY-----

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/PulsarEncryptionE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/PulsarEncryptionE2ECase.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tests.util.pulsar;
+
+import org.apache.flink.connector.pulsar.testutils.PulsarTestContextFactory;
+import org.apache.flink.connector.pulsar.testutils.sink.PulsarSinkTestSuiteBase;
+import org.apache.flink.connector.pulsar.testutils.sink.cases.PulsarEncryptSinkContext;
+import org.apache.flink.connector.pulsar.testutils.source.cases.ConsumeEncryptMessagesContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestContext;
+import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
+import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem;
+import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
+import org.apache.flink.connector.testframe.testsuites.SourceTestSuiteBase;
+import org.apache.flink.streaming.api.CheckpointingMode;
+import org.apache.flink.tests.util.pulsar.common.FlinkContainerWithPulsarEnvironment;
+import org.apache.flink.tests.util.pulsar.common.PulsarContainerTestEnvironment;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * The test will produce and consume messages by Pulsar connector with the End-to-end encryption
+ * support.
+ */
+@SuppressWarnings("unused")
+@Tag("org.apache.flink.testutils.junit.FailsOnJava11")
+public class PulsarEncryptionE2ECase {
+
+    @Nested
+    class EncryptionSource extends SourceTestSuiteBase<String> {
+
+        // Defines the Semantic.
+        @TestSemantics
+        CheckpointingMode[] semantics = new CheckpointingMode[] {CheckpointingMode.EXACTLY_ONCE};
+
+        // Defines TestEnvironment.
+        @TestEnv
+        FlinkContainerWithPulsarEnvironment flink = new FlinkContainerWithPulsarEnvironment(1, 6);
+
+        // Defines ConnectorExternalSystem.
+        @TestExternalSystem
+        PulsarContainerTestEnvironment pulsar = new PulsarContainerTestEnvironment(flink);
+
+        @TestContext
+        PulsarTestContextFactory<String, ConsumeEncryptMessagesContext> encryptMessages =
+                new PulsarTestContextFactory<>(pulsar, ConsumeEncryptMessagesContext::new);
+    }
+
+    @Nested
+    class EncryptionSink extends PulsarSinkTestSuiteBase {
+
+        // Defines the Semantic.
+        @TestSemantics
+        CheckpointingMode[] semantics =
+                new CheckpointingMode[] {
+                    CheckpointingMode.EXACTLY_ONCE, CheckpointingMode.AT_LEAST_ONCE
+                };
+
+        // Defines TestEnvironment
+        @TestEnv
+        FlinkContainerWithPulsarEnvironment flink = new FlinkContainerWithPulsarEnvironment(1, 6);
+
+        // Defines ConnectorExternalSystem.
+        @TestExternalSystem
+        PulsarContainerTestEnvironment pulsar = new PulsarContainerTestEnvironment(flink);
+
+        @TestContext
+        PulsarTestContextFactory<String, PulsarEncryptSinkContext> sinkContext =
+                new PulsarTestContextFactory<>(pulsar, PulsarEncryptSinkContext::new);
+    }
+}

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/PulsarSinkE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/PulsarSinkE2ECase.java
@@ -19,8 +19,8 @@
 package org.apache.flink.tests.util.pulsar;
 
 import org.apache.flink.connector.pulsar.testutils.PulsarTestContextFactory;
-import org.apache.flink.connector.pulsar.testutils.sink.PulsarSinkTestContext;
 import org.apache.flink.connector.pulsar.testutils.sink.PulsarSinkTestSuiteBase;
+import org.apache.flink.connector.pulsar.testutils.sink.cases.PulsarSinkTestContext;
 import org.apache.flink.connector.testframe.junit.annotations.TestContext;
 import org.apache.flink.connector.testframe.junit.annotations.TestEnv;
 import org.apache.flink.connector.testframe.junit.annotations.TestExternalSystem;
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Tag;
 @Tag("org.apache.flink.testutils.junit.FailsOnJava11")
 public class PulsarSinkE2ECase extends PulsarSinkTestSuiteBase {
 
+    // Defines the Semantic.
     @TestSemantics
     CheckpointingMode[] semantics =
             new CheckpointingMode[] {


### PR DESCRIPTION
## What is the purpose of the change

Add the end-to-end encryption support for Pulsar.

## Brief change log

Add the `CryptoKeyReader` for both Pulsar source and sink. Add encryption config options to Pulsar sink and source.

## Verifying this change

This change added tests and can be verified as follows:

- PulsarSinkITCase
- PulsarSourceITCase
- PulsarEncryptionE2ECase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduces a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
