### PR TITLE
[FLINK-29822] fix wrong description in comments of StreamExecutionEnv…

### DIFF
--- a/docs/layouts/shortcodes/generated/execution_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/execution_config_configuration.html
@@ -47,6 +47,12 @@ Operators that can be disabled include "NestedLoopJoin", "ShuffleHashJoin", "Bro
 By default no operator is disabled.</td>
         </tr>
         <tr>
+            <td><h5>table.exec.interval-join.min-cleanup-interval</h5><br> <span class="label label-primary">Streaming</span></td>
+            <td style="word-wrap: break-word;">0 ms</td>
+            <td>Duration</td>
+            <td>Specifies a minimum time interval for how long cleanup unmatched records in the interval join operator. Before Flink 1.18, the default value of this param was the half of interval duration. Note: Set this option greater than 0 will cause unmatched records in outer joins to be output later than watermark, leading to possible discarding of these records by downstream watermark-dependent operators, such as window operators. The default value is 0, which means it will clean up unmatched records immediately.</td>
+        </tr>
+        <tr>
             <td><h5>table.exec.legacy-cast-behaviour</h5><br> <span class="label label-primary">Batch</span> <span class="label label-primary">Streaming</span></td>
             <td style="word-wrap: break-word;">DISABLED</td>
             <td><p>Enum</p></td>
@@ -177,12 +183,6 @@ By default no operator is disabled.</td>
             <td style="word-wrap: break-word;">100000</td>
             <td>Integer</td>
             <td>Sets the window elements buffer size limit used in group window agg operator.</td>
-        </tr>
-        <tr>
-            <td><h5>table.exec.interval-join.min-cleanup-interval</h5><br> <span class="label label-primary">Streaming</span></td>
-            <td style="word-wrap: break-word;">0 ms</td>
-            <td>Duration</td>
-            <td>Specifies a minimum time interval for how long cleanup unmatched records in the interval join operator. Before Flink 1.18, the default value of this param was the half of interval duration. Note: Set this option greater than 0 will cause unmatched records in outer joins to be output later than watermark, leading to possible discarding of these records by downstream watermark-dependent operators, such as window operators. The default value is 0, which means it will clean up unmatched records immediately.</td>
         </tr>
     </tbody>
 </table>

--- a/docs/layouts/shortcodes/generated/pipeline_configuration.html
+++ b/docs/layouts/shortcodes/generated/pipeline_configuration.html
@@ -90,7 +90,7 @@
             <td><h5>pipeline.max-parallelism</h5></td>
             <td style="word-wrap: break-word;">-1</td>
             <td>Integer</td>
-            <td>The program-wide maximum parallelism used for operators which haven't specified a maximum parallelism. The maximum parallelism specifies the upper limit for dynamic scaling and the number of key groups used for partitioned state. Changing the value explicitly when recovery from original job will lead to state incompatibility.</td>
+            <td>The program-wide maximum parallelism used for operators which haven't specified a maximum parallelism. The maximum parallelism specifies the upper limit for dynamic scaling and the number of key groups used for partitioned state. Changing the value explicitly when recovery from original job will lead to state incompatibility. Must be less than or equal to 32768.</td>
         </tr>
         <tr>
             <td><h5>pipeline.name</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/PipelineOptions.java
@@ -182,7 +182,8 @@ public class PipelineOptions {
                             "The program-wide maximum parallelism used for operators which haven't specified a"
                                     + " maximum parallelism. The maximum parallelism specifies the upper limit for dynamic scaling and"
                                     + " the number of key groups used for partitioned state."
-                                    + " Changing the value explicitly when recovery from original job will lead to state incompatibility.");
+                                    + " Changing the value explicitly when recovery from original job will lead to state incompatibility."
+                                    + " Must be less than or equal to 32768.");
 
     public static final ConfigOption<Boolean> OBJECT_REUSE =
             key("pipeline.object-reuse")

--- a/flink-python/pyflink/datastream/stream_execution_environment.py
+++ b/flink-python/pyflink/datastream/stream_execution_environment.py
@@ -93,13 +93,13 @@ class StreamExecutionEnvironment(object):
     def set_max_parallelism(self, max_parallelism: int) -> 'StreamExecutionEnvironment':
         """
         Sets the maximum degree of parallelism defined for the program. The upper limit (inclusive)
-        is 32767.
+        is 32768.
 
         The maximum degree of parallelism specifies the upper limit for dynamic scaling. It also
         defines the number of key groups used for partitioned state.
 
         :param max_parallelism: Maximum degree of parallelism to be used for the program,
-                                with 0 < maxParallelism <= 2^15 - 1.
+                                with 0 < maxParallelism <= 2^15.
         :return: This object.
         """
         self._j_stream_execution_environment = \

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -343,7 +343,7 @@ public class JobVertex implements java.io.Serializable {
      * Sets the maximum parallelism for the task.
      *
      * @param maxParallelism The maximum parallelism to be set. must be between 1 and
-     *     Short.MAX_VALUE.
+     *     Short.MAX_VALUE + 1.
      */
     public void setMaxParallelism(int maxParallelism) {
         this.maxParallelism = maxParallelism;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java
@@ -80,9 +80,9 @@ public final class KeyGroupRangeAssignment {
      * Computes the range of key-groups that are assigned to a given operator under the given
      * parallelism and maximum parallelism.
      *
-     * <p>IMPORTANT: maxParallelism must be <= Short.MAX_VALUE to avoid rounding problems in this
-     * method. If we ever want to go beyond this boundary, this method must perform arithmetic on
-     * long values.
+     * <p>IMPORTANT: maxParallelism must be <= Short.MAX_VALUE + 1 to avoid rounding problems in
+     * this method. If we ever want to go beyond this boundary, this method must perform arithmetic
+     * on long values.
      *
      * @param maxParallelism Maximal parallelism that the job was initially created with.
      * @param parallelism The current parallelism under which the job runs. Must be <=
@@ -109,12 +109,12 @@ public final class KeyGroupRangeAssignment {
      * Computes the index of the operator to which a key-group belongs under the given parallelism
      * and maximum parallelism.
      *
-     * <p>IMPORTANT: maxParallelism must be <= Short.MAX_VALUE to avoid rounding problems in this
-     * method. If we ever want to go beyond this boundary, this method must perform arithmetic on
-     * long values.
+     * <p>IMPORTANT: maxParallelism must be <= Short.MAX_VALUE + 1 to avoid rounding problems in
+     * this method. If we ever want to go beyond this boundary, this method must perform arithmetic
+     * on long values.
      *
      * @param maxParallelism Maximal parallelism that the job was initially created with. 0 <
-     *     parallelism <= maxParallelism <= Short.MAX_VALUE must hold.
+     *     parallelism <= maxParallelism <= Short.MAX_VALUE + 1 must hold.
      * @param parallelism The current parallelism under which the job runs. Must be <=
      *     maxParallelism.
      * @param keyGroupId Id of a key-group. 0 <= keyGroupID < maxParallelism.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -353,13 +353,13 @@ public class StreamExecutionEnvironment implements AutoCloseable {
 
     /**
      * Sets the maximum degree of parallelism defined for the program. The upper limit (inclusive)
-     * is Short.MAX_VALUE.
+     * is Short.MAX_VALUE + 1.
      *
      * <p>The maximum degree of parallelism specifies the upper limit for dynamic scaling. It also
      * defines the number of key groups used for partitioned state.
      *
      * @param maxParallelism Maximum degree of parallelism to be used for the program., with {@code
-     *     0 < maxParallelism <= 2^15 - 1}.
+     *     0 < maxParallelism <= 2^15}.
      */
     public StreamExecutionEnvironment setMaxParallelism(int maxParallelism) {
         Preconditions.checkArgument(


### PR DESCRIPTION
…ironment#setMaxParallelism()

## What is the purpose of the change

As the [issue](https://issues.apache.org/jira/browse/FLINK-29822) said, fix wrong description in comments of StreamExecutionEnvironment#setMaxParallelism().


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
