### PR TITLE
[FLINK-29652][sql-client]Fix materializedTable size to avoid retrieve duplicate/missing result.

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/config/SqlClientOptions.java
@@ -32,7 +32,7 @@ public class SqlClientOptions {
     public static final ConfigOption<Integer> EXECUTION_MAX_TABLE_RESULT_ROWS =
             ConfigOptions.key("sql-client.execution.max-table-result.rows")
                     .intType()
-                    .defaultValue(1000_000)
+                    .defaultValue(10_000)
                     .withDescription(
                             "The number of rows to cache when in the table mode. If the number of rows exceeds the "
                                     + "specified value, it retries the row in the FIFO style.");

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectResultBase.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectResultBase.java
@@ -56,22 +56,22 @@ public abstract class MaterializedCollectResultBase extends CollectResultBase
      * Materialized table that is continuously updated by inserts and deletes. Deletes at the
      * beginning are lazily cleaned up when the threshold is reached.
      */
-    protected final List<RowData> materializedTable;
+    protected List<RowData> materializedTable;
 
     /** Counter for deleted rows to be deleted at the beginning of the materialized table. */
     protected int validRowPosition;
 
     /** Current snapshot of the materialized table. */
-    private final List<RowData> snapshot;
+    protected final List<RowData> snapshot;
 
     /** Page count of the snapshot (always >= 1). */
-    private int pageCount;
+    protected int pageCount;
 
     /** Page size of the snapshot (always >= 1). */
-    private int pageSize;
+    protected int pageSize;
 
     /** Indicator that this is the last snapshot possible (EOS afterwards). */
-    private boolean isLastSnapshot;
+    protected boolean isLastSnapshot;
 
     public MaterializedCollectResultBase(
             TableResultInternal tableResult, int maxRowCount, int overcommitThreshold) {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResultTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/result/MaterializedCollectBatchResultTest.java
@@ -57,7 +57,7 @@ public class MaterializedCollectBatchResultTest extends BaseMaterializedResultTe
         try (TestMaterializedCollectBatchResult result =
                 new TestMaterializedCollectBatchResult(
                         new TestTableResult(ResultKind.SUCCESS_WITH_CONTENT, schema),
-                        Integer.MAX_VALUE,
+                        10_000,
                         createInternalBinaryRowDataConverter(schema.toPhysicalRowDataType()))) {
 
             result.isRetrieving = true;
@@ -86,29 +86,13 @@ public class MaterializedCollectBatchResultTest extends BaseMaterializedResultTe
                     result.retrievePage(4),
                     rowConverter);
 
-            result.processRecord(Row.of("A", 1));
+            result.processRecord(Row.of("D", 10));
 
-            assertEquals(TypedResult.payload(5), result.snapshot(1));
+            assertEquals(TypedResult.payload(1), result.snapshot(1));
 
             assertRowEquals(
-                    Collections.singletonList(Row.of("A", 1)),
+                    Collections.singletonList(Row.of("D", 10)),
                     result.retrievePage(1),
-                    rowConverter);
-            assertRowEquals(
-                    Collections.singletonList(Row.of("B", 1)),
-                    result.retrievePage(2),
-                    rowConverter);
-            assertRowEquals(
-                    Collections.singletonList(Row.of("A", 1)),
-                    result.retrievePage(3),
-                    rowConverter);
-            assertRowEquals(
-                    Collections.singletonList(Row.of("C", 2)),
-                    result.retrievePage(4),
-                    rowConverter);
-            assertRowEquals(
-                    Collections.singletonList(Row.of("A", 1)),
-                    result.retrievePage(5),
                     rowConverter);
         }
     }
@@ -136,19 +120,20 @@ public class MaterializedCollectBatchResultTest extends BaseMaterializedResultTe
 
             result.processRecord(Row.of("D", 1));
             result.processRecord(Row.of("A", 1));
+            // only first maxRowCount rows will be stored.
+            // rows blew will be discarded.
             result.processRecord(Row.of("B", 1));
             result.processRecord(Row.of("A", 1));
 
             assertRowEquals(
-                    Arrays.asList(
-                            null, null, Row.of("B", 1), Row.of("A", 1)), // two over-committed rows
+                    Arrays.asList(Row.of("D", 1), Row.of("A", 1)), // two over-committed rows
                     result.getMaterializedTable(),
                     rowConverter);
 
             assertEquals(TypedResult.payload(2), result.snapshot(1));
 
             assertRowEquals(
-                    Collections.singletonList(Row.of("B", 1)),
+                    Collections.singletonList(Row.of("D", 1)),
                     result.retrievePage(1),
                     rowConverter);
             assertRowEquals(
@@ -159,14 +144,16 @@ public class MaterializedCollectBatchResultTest extends BaseMaterializedResultTe
             result.processRecord(Row.of("C", 1));
 
             assertRowEquals(
-                    Arrays.asList(Row.of("A", 1), Row.of("C", 1)), // limit clean up has taken place
+                    Arrays.asList(
+                            Row.of("D", 1),
+                            Row.of("A", 1)), // clean up was removed, so result is not changed
                     result.getMaterializedTable(),
                     rowConverter);
 
             result.processRecord(Row.of("A", 1));
 
             assertRowEquals(
-                    Arrays.asList(null, Row.of("C", 1), Row.of("A", 1)),
+                    Arrays.asList(Row.of("D", 1), Row.of("A", 1)),
                     result.getMaterializedTable(),
                     rowConverter);
         }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the problem that user may get duplicate row records occasionally even if querying from a hive/hudi table which contains only one record.

## Brief change log

  - Fix materializedTable size in MaterializedCollectBatchResult as maxRowCount, rows exceed maxRowCount will be discarded.
  - Override snapshot method.
  - Remove cleanUp method because materializedTable table size was fixed.
  - Variable validRowPosition indicates the position of rows where snapshot method has been processed.


## Verifying this change

This change is already covered by existing tests, such as MaterializedCollectBatchResultTest.testLimitedSnapshot(), MaterializedCollectBatchResultTest.testSnapshot().


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)