### PR TITLE
[FLINK-29829][table-planner] align explain results in different platforms

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodePlanDumper.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodePlanDumper.java
@@ -193,7 +193,7 @@ public class ExecNodePlanDumper {
 
         if (sb.length() > 0) {
             // delete last line separator
-            sb.deleteCharAt(sb.length() - 1);
+            sb.replace(sb.lastIndexOf(System.getProperty("line.separator")), sb.length(), "");
         }
         return sb.toString();
     }


### PR DESCRIPTION
## What is the purpose of the change

align explain results in different platforms.

## Brief change log

* use jdk line separator instead of last charactor

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no