### PR TITLE
[FLINK-29653][sql-client]Change ResultStore as [sessionId, [resultId, result]].

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliTableResultView.java
@@ -296,7 +296,10 @@ public class CliTableResultView extends CliResultView<CliTableResultView.ResultT
         try {
             rows =
                     client.getExecutor()
-                            .retrieveResultPage(resultDescriptor.getResultId(), retrievalPage);
+                            .retrieveResultPage(
+                                    resultDescriptor.getSessionId(),
+                                    resultDescriptor.getResultId(),
+                                    retrievalPage);
         } catch (SqlExecutionException e) {
             close(e);
             return;

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/Executor.java
@@ -129,11 +129,16 @@ public interface Executor {
     TypedResult<Integer> snapshotResult(String sessionId, String resultId, int pageSize)
             throws SqlExecutionException;
 
+    /** @deprecated. remove later. */
+    @Deprecated
+    List<RowData> retrieveResultPage(String resultId, int page) throws SqlExecutionException;
+
     /**
      * Returns the rows that are part of the current page or throws an exception if the snapshot has
      * been expired.
      */
-    List<RowData> retrieveResultPage(String resultId, int page) throws SqlExecutionException;
+    List<RowData> retrieveResultPage(String sessionId, String resultId, int page)
+            throws SqlExecutionException;
 
     /**
      * Cancels a table program and stops the result retrieval. Blocking until cancellation command

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ResultDescriptor.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/gateway/ResultDescriptor.java
@@ -31,23 +31,46 @@ import static org.apache.flink.table.client.config.SqlClientOptions.EXECUTION_RE
 /** Describes a result to be expected from a table program. */
 public class ResultDescriptor {
 
+    private final String sessionId;
     private final String resultId;
     private final ResolvedSchema resultSchema;
     private final boolean isMaterialized;
     private final ReadableConfig config;
     private final RowDataToStringConverter rowDataToStringConverter;
 
+    /** @deprecated. remove later. */
+    @Deprecated
     public ResultDescriptor(
             String resultId,
             ResolvedSchema resultSchema,
             boolean isMaterialized,
             ReadableConfig config,
             RowDataToStringConverter rowDataToStringConverter) {
+        this.sessionId = "";
         this.resultId = resultId;
         this.resultSchema = resultSchema;
         this.isMaterialized = isMaterialized;
         this.config = config;
         this.rowDataToStringConverter = rowDataToStringConverter;
+    }
+
+    public ResultDescriptor(
+            String sessionId,
+            String resultId,
+            ResolvedSchema resultSchema,
+            boolean isMaterialized,
+            ReadableConfig config,
+            RowDataToStringConverter rowDataToStringConverter) {
+        this.sessionId = sessionId;
+        this.resultId = resultId;
+        this.resultSchema = resultSchema;
+        this.isMaterialized = isMaterialized;
+        this.config = config;
+        this.rowDataToStringConverter = rowDataToStringConverter;
+    }
+
+    public String getSessionId() {
+        return sessionId;
     }
 
     public String getResultId() {

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliClientTest.java
@@ -545,8 +545,16 @@ public class CliClientTest extends TestLogger {
             return null;
         }
 
+        /** @deprecated. remove later. */
+        @Deprecated
         @Override
         public List<RowData> retrieveResultPage(String resultId, int page)
+                throws SqlExecutionException {
+            return null;
+        }
+
+        @Override
+        public List<RowData> retrieveResultPage(String sessionId, String resultId, int page)
                 throws SqlExecutionException {
             return null;
         }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliResultViewTest.java
@@ -103,6 +103,7 @@ public class CliResultViewTest {
                 ResolvedSchema.of(Column.physical("Null Field", DataTypes.STRING()));
         final ResultDescriptor descriptor =
                 new ResultDescriptor(
+                        "session-id",
                         "result-id",
                         schema,
                         false,
@@ -225,8 +226,16 @@ public class CliResultViewTest {
             return (TypedResult<Integer>) typedResult;
         }
 
+        /** @deprecated. remove later. */
+        @Deprecated
         @Override
         public List<RowData> retrieveResultPage(String resultId, int page)
+                throws SqlExecutionException {
+            return Collections.singletonList(new GenericRowData(1));
+        }
+
+        @Override
+        public List<RowData> retrieveResultPage(String sessionId, String resultId, int page)
                 throws SqlExecutionException {
             return Collections.singletonList(new GenericRowData(1));
         }

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/CliTableauResultViewTest.java
@@ -178,7 +178,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.BATCH);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()
@@ -232,7 +232,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.BATCH);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()
@@ -274,7 +274,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.BATCH);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()
@@ -301,7 +301,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.BATCH);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()
@@ -332,7 +332,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()
@@ -395,7 +395,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()
@@ -427,7 +427,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()
@@ -482,7 +482,7 @@ public class CliTableauResultViewTest {
         testConfig.set(EXECUTION_RESULT_MODE, ResultMode.TABLEAU);
         testConfig.set(RUNTIME_MODE, RuntimeExecutionMode.STREAMING);
         ResultDescriptor resultDescriptor =
-                new ResultDescriptor("", schema, true, testConfig, rowDataToStringConverter);
+                new ResultDescriptor("", "", schema, true, testConfig, rowDataToStringConverter);
 
         TestingExecutor mockExecutor =
                 new TestingExecutorBuilder()

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/cli/TestingExecutor.java
@@ -89,8 +89,18 @@ class TestingExecutor implements Executor {
                 .get();
     }
 
+    /** @deprecated. remove later. */
+    @Deprecated
     @Override
     public List<RowData> retrieveResultPage(String resultId, int page)
+            throws SqlExecutionException {
+        return resultPages
+                .get(Math.min(numRetrieveResultPageCalls++, resultPages.size() - 1))
+                .get();
+    }
+
+    @Override
+    public List<RowData> retrieveResultPage(String sessionId, String resultId, int page)
             throws SqlExecutionException {
         return resultPages
                 .get(Math.min(numRetrieveResultPageCalls++, resultPages.size() - 1))

--- a/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
+++ b/flink-table/flink-sql-client/src/test/java/org/apache/flink/table/client/gateway/local/LocalExecutorITCase.java
@@ -497,7 +497,8 @@ public class LocalExecutorITCase extends TestLogger {
                         .forEach(
                                 (page) -> {
                                     for (RowData row :
-                                            executor.retrieveResultPage(resultID, page)) {
+                                            executor.retrieveResultPage(
+                                                    sessionId, resultID, page)) {
                                         actualResults.add(
                                                 StringUtils.arrayAwareToString(
                                                         rowDataToStringConverter.convert(row)));


### PR DESCRIPTION

## What is the purpose of the change

This pull request constructs result in ResultStore in format of [sessionId, [resultId, result]].


## Brief change log

  - Construct results in ResultStore.java as [sessionId, [resultId, result]].
  - Add new variable sessionId in ResultDescriptor.java
  - Get and put result into ResultStore through param sessionId and resultId, if sessionId is empty, empty string will be default value.
  - Mark some methods without sessionId as deprecated and do not delete them. Maybe remove them later in a new flink version.


## Verifying this change

This change is already covered by existing tests, such as CliClientTest/CliResultViewTest/CliTableauResultViewTest/TestingExecutor/LocalExecutorITCase.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)