### PR TITLE
[BP-1.15][FLINK-29849 & FLINK-29781][table-planner] Fix event time temporal join on an upsert source may produce incorrect execution plan

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkSnapshotConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/FlinkSnapshotConverter.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.calcite;
+
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalCalc;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalSnapshot;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalTableSourceScan;
+import org.apache.flink.table.planner.plan.nodes.logical.FlinkLogicalWatermarkAssigner;
+import org.apache.flink.table.planner.plan.schema.TimeIndicatorRelDataType;
+
+import org.apache.calcite.rel.RelHomogeneousShuttle;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.type.RelDataType;
+
+/**
+ * Traverses a {@link RelNode} tree and update the child node of {@link FlinkLogicalSnapshot} to set
+ * {@link FlinkLogicalTableSourceScan#eventTimeSnapshot} property.
+ *
+ * <p>Note: only snapshot on event time period will update the child {@link
+ * FlinkLogicalTableSourceScan}.
+ */
+public final class FlinkSnapshotConverter extends RelHomogeneousShuttle {
+
+    public static RelNode update(RelNode input) {
+        FlinkSnapshotConverter converter = new FlinkSnapshotConverter();
+        return input.accept(converter);
+    }
+
+    @Override
+    public RelNode visit(RelNode node) {
+        if (node instanceof FlinkLogicalSnapshot) {
+            final FlinkLogicalSnapshot snapshot = (FlinkLogicalSnapshot) node;
+            if (isEventTime(snapshot.getPeriod().getType())) {
+                final RelNode child = snapshot.getInput();
+                final RelNode newChild = transmitSnapshotRequirement(child);
+                if (newChild != child) {
+                    return snapshot.copy(snapshot.getTraitSet(), newChild, snapshot.getPeriod());
+                }
+            }
+            return snapshot;
+        }
+        return super.visit(node);
+    }
+
+    private boolean isEventTime(RelDataType period) {
+        if (period instanceof TimeIndicatorRelDataType) {
+            return ((TimeIndicatorRelDataType) period).isEventTime();
+        }
+        return false;
+    }
+
+    private RelNode transmitSnapshotRequirement(RelNode node) {
+        if (node instanceof FlinkLogicalCalc) {
+            final FlinkLogicalCalc calc = (FlinkLogicalCalc) node;
+            final RelNode child = calc.getInput();
+            final RelNode newChild = transmitSnapshotRequirement(child);
+            if (newChild != child) {
+                return calc.copy(calc.getTraitSet(), newChild, calc.getProgram());
+            }
+            return calc;
+        }
+        if (node instanceof FlinkLogicalWatermarkAssigner) {
+            final FlinkLogicalWatermarkAssigner wma = (FlinkLogicalWatermarkAssigner) node;
+            final RelNode child = wma.getInput();
+            final RelNode newChild = transmitSnapshotRequirement(child);
+            if (newChild != child) {
+                return wma.copy(
+                        wma.getTraitSet(), newChild, wma.rowtimeFieldIndex(), wma.watermarkExpr());
+            }
+            return wma;
+        }
+        if (node instanceof FlinkLogicalTableSourceScan) {
+            final FlinkLogicalTableSourceScan ts = (FlinkLogicalTableSourceScan) node;
+            // update eventTimeSnapshot to true
+            return ts.copy(ts.getTraitSet(), ts.relOptTable(), true);
+        }
+        return node;
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/StreamFilterIntoJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/StreamFilterIntoJoinRule.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.rules.logical;
+
+import org.apache.flink.table.planner.plan.utils.TemporalJoinUtil;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.rules.FilterJoinRule;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexVisitor;
+import org.apache.calcite.rex.RexVisitorImpl;
+import org.apache.calcite.util.Util;
+
+/**
+ * FilterIntoJoinRule for streaming, it doesn't push a filter into join which is a temporal join
+ * using event time.
+ */
+public class StreamFilterIntoJoinRule extends FilterJoinRule<StreamFilterIntoJoinRule.Config> {
+
+    public static final RelOptRule FILTER_INTO_JOIN = Config.DEFAULT.toRule();
+
+    protected StreamFilterIntoJoinRule(Config config) {
+        super(config);
+    }
+
+    @Override
+    public boolean matches(RelOptRuleCall call) {
+        Join join = call.rel(1);
+        boolean existTemporalJoinCondition = existTemporalJoinCondition(join.getCondition());
+        return !existTemporalJoinCondition && super.matches(call);
+    }
+
+    private boolean existTemporalJoinCondition(RexNode joinCondition) {
+        RexVisitor<Void> temporalConditionFinder =
+                new RexVisitorImpl<Void>(true) {
+                    @Override
+                    public Void visitCall(RexCall call) {
+                        if (call.getOperator() == TemporalJoinUtil.INITIAL_TEMPORAL_JOIN_CONDITION()
+                                && TemporalJoinUtil.isInitialRowTimeTemporalTableJoin(call)) {
+                            throw new Util.FoundOne(call);
+                        }
+                        return super.visitCall(call);
+                    }
+                };
+        try {
+            joinCondition.accept(temporalConditionFinder);
+        } catch (Util.FoundOne found) {
+            return true;
+        }
+        return false;
+    }
+
+    public void onMatch(RelOptRuleCall call) {
+        Filter filter = call.rel(0);
+        Join join = call.rel(1);
+        this.perform(call, filter, join);
+    }
+
+    /** Config for StreamFilterIntoJoinRule. */
+    public interface Config extends FilterJoinRule.Config {
+        StreamFilterIntoJoinRule.Config DEFAULT =
+                EMPTY.withOperandSupplier(
+                                b0 ->
+                                        b0.operand(Filter.class)
+                                                .oneInput(b1 -> b1.operand(Join.class).anyInputs()))
+                        .as(FilterJoinRule.Config.class)
+                        .withSmart(true)
+                        .withPredicate((join, joinType, exp) -> true)
+                        .as(StreamFilterIntoJoinRule.Config.class);
+
+        @Override
+        default RelOptRule toRule() {
+            return new StreamFilterIntoJoinRule(this);
+        }
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/logical/FlinkLogicalTableSourceScan.scala
@@ -46,7 +46,8 @@ class FlinkLogicalTableSourceScan(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,
     hints: util.List[RelHint],
-    relOptTable: TableSourceTable)
+    val relOptTable: TableSourceTable,
+    val eventTimeSnapshot: Boolean = false)
   extends TableScan(cluster, traitSet, hints, relOptTable)
   with FlinkLogicalRel {
 
@@ -54,12 +55,29 @@ class FlinkLogicalTableSourceScan(
 
   def copy(
       traitSet: RelTraitSet,
+      tableSourceTable: TableSourceTable,
+      eventTimeSnapshot: Boolean): FlinkLogicalTableSourceScan = {
+    new FlinkLogicalTableSourceScan(
+      cluster,
+      traitSet,
+      getHints,
+      tableSourceTable,
+      eventTimeSnapshot)
+  }
+
+  def copy(
+      traitSet: RelTraitSet,
       tableSourceTable: TableSourceTable): FlinkLogicalTableSourceScan = {
-    new FlinkLogicalTableSourceScan(cluster, traitSet, getHints, tableSourceTable)
+    new FlinkLogicalTableSourceScan(
+      cluster,
+      traitSet,
+      getHints,
+      tableSourceTable,
+      eventTimeSnapshot)
   }
 
   override def copy(traitSet: RelTraitSet, inputs: java.util.List[RelNode]): RelNode = {
-    new FlinkLogicalTableSourceScan(cluster, traitSet, getHints, relOptTable)
+    new FlinkLogicalTableSourceScan(cluster, traitSet, getHints, relOptTable, eventTimeSnapshot)
   }
 
   override def deriveRowType(): RelDataType = {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalChangelogNormalize.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalChangelogNormalize.scala
@@ -58,6 +58,10 @@ class StreamPhysicalChangelogNormalize(
       contextResolvedTable)
   }
 
+  def copy(traitSet: RelTraitSet, input: RelNode, uniqueKeys: Array[Int]): RelNode = {
+    new StreamPhysicalChangelogNormalize(cluster, traitSet, input, uniqueKeys, contextResolvedTable)
+  }
+
   override def explainTerms(pw: RelWriter): RelWriter = {
     val fieldNames = getRowType.getFieldNames
     super

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkChangelogModeInferenceProgram.scala
@@ -30,7 +30,6 @@ import org.apache.flink.table.planner.plan.nodes.physical.stream._
 import org.apache.flink.table.planner.plan.utils._
 import org.apache.flink.table.planner.plan.utils.RankProcessStrategy.{AppendFastStrategy, RetractStrategy, UpdateFastStrategy}
 import org.apache.flink.table.planner.sinks.DataStreamTableSink
-import org.apache.flink.table.planner.utils.JavaScalaConversionUtil.toScala
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType
 import org.apache.flink.table.sinks.{AppendStreamTableSink, RetractStreamTableSink, StreamTableSink, UpsertStreamTableSink}
 import org.apache.flink.types.RowKind
@@ -79,8 +78,12 @@ class FlinkChangelogModeInferenceProgram extends FlinkOptimizeProgram[StreamOpti
     // step3: sanity check and return non-empty root
     if (finalRoot.isEmpty) {
       val plan = FlinkRelOptUtil.toString(root, withChangelogTraits = true)
-      throw new TableException(
-        "Can't generate a valid execution plan for the given query:\n" + plan)
+      val error = s"""
+                     |Can't generate a valid execution plan for the given query:$plan
+                     |Intermediate plan with modify kind:
+                     |${FlinkRelOptUtil.toString(rootWithModifyKindSet, withChangelogTraits = true)}
+              """.stripMargin
+      throw new TableException(error)
     } else {
       finalRoot.head
     }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkSnapshotRequirementProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkSnapshotRequirementProgram.scala
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.table.planner.plan.optimize.program
+
+import org.apache.flink.table.planner.calcite.FlinkSnapshotConverter
+
+import org.apache.calcite.rel.RelNode
+
+/**
+ * A FlinkOptimizeProgram that deals with time.
+ *
+ * @tparam OC
+ *   OptimizeContext
+ */
+class FlinkSnapshotRequirementProgram[OC <: FlinkOptimizeContext] extends FlinkOptimizeProgram[OC] {
+
+  override def optimize(input: RelNode, context: OC): RelNode = {
+//    input
+    FlinkSnapshotConverter.update(input)
+  }
+
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/optimize/program/FlinkStreamProgram.scala
@@ -36,6 +36,7 @@ object FlinkStreamProgram {
   val PROJECT_REWRITE = "project_rewrite"
   val LOGICAL = "logical"
   val LOGICAL_REWRITE = "logical_rewrite"
+  val SNAPSHOT_REQUIREMENT = "snapshot_requirement"
   val TIME_INDICATOR = "time_indicator"
   val PHYSICAL = "physical"
   val PHYSICAL_REWRITE = "physical_rewrite"
@@ -257,6 +258,9 @@ object FlinkStreamProgram {
         .add(FlinkStreamRuleSets.LOGICAL_REWRITE)
         .build()
     )
+
+    // update snapshot requirement to source scan
+    chainedProgram.addLast(SNAPSHOT_REQUIREMENT, new FlinkSnapshotRequirementProgram)
 
     // convert time indicators
     chainedProgram.addLast(TIME_INDICATOR, new FlinkRelTimeIndicatorProgram)

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkStreamRuleSets.scala
@@ -133,8 +133,8 @@ object FlinkStreamRuleSets {
 
   /** RuleSet about filter */
   private val FILTER_RULES: RuleSet = RuleSets.ofList(
-    // push a filter into a join
-    CoreRules.FILTER_INTO_JOIN,
+    // push a filter into a join which isn't a temporal join
+    StreamFilterIntoJoinRule.FILTER_INTO_JOIN,
     // push filter into the children of a join
     CoreRules.JOIN_CONDITION_PUSH,
     // push filter through an aggregation

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/TemporalJoinRewriteWithUniqueKeyRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/TemporalJoinRewriteWithUniqueKeyRule.scala
@@ -64,6 +64,7 @@ class TemporalJoinRewriteWithUniqueKeyRule
     val join = call.rel[FlinkLogicalJoin](0)
     val leftInput = call.rel[FlinkLogicalRel](1)
     val snapshot = call.rel[FlinkLogicalSnapshot](2)
+    val snapshotInput = call.rel[FlinkLogicalRel](3)
 
     val joinCondition = join.getCondition
 
@@ -84,7 +85,8 @@ class TemporalJoinRewriteWithUniqueKeyRule
             }
 
           val rexBuilder = join.getCluster.getRexBuilder
-          val primaryKeyInputRefs = extractPrimaryKeyInputRefs(leftInput, snapshot, rexBuilder)
+          val primaryKeyInputRefs =
+            extractPrimaryKeyInputRefs(leftInput, snapshot, snapshotInput, rexBuilder)
           validateRightPrimaryKey(join, rightJoinKey, primaryKeyInputRefs)
 
           if (TemporalJoinUtil.isInitialRowTimeTemporalTableJoin(call)) {
@@ -161,11 +163,12 @@ class TemporalJoinRewriteWithUniqueKeyRule
   private def extractPrimaryKeyInputRefs(
       leftInput: RelNode,
       snapshot: FlinkLogicalSnapshot,
+      snapshotInput: FlinkLogicalRel,
       rexBuilder: RexBuilder): Option[Seq[RexNode]] = {
     val rightFields = snapshot.getRowType.getFieldList
     val fmq = FlinkRelMetadataQuery.reuseOrCreate(snapshot.getCluster.getMetadataQuery)
 
-    val upsertKeySet = fmq.getUpsertKeys(snapshot.getInput())
+    val upsertKeySet = fmq.getUpsertKeys(snapshotInput)
     val fields = snapshot.getRowType.getFieldList
 
     if (upsertKeySet != null && upsertKeySet.size() > 0) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/physical/stream/StreamPhysicalTableSourceScanRule.scala
@@ -69,8 +69,8 @@ class StreamPhysicalTableSourceScanRule
     val resolvedSchema = table.contextResolvedTable.getResolvedSchema
 
     if (
-      isUpsertSource(resolvedSchema, table.tableSource) ||
-      isSourceChangeEventsDuplicate(resolvedSchema, table.tableSource, config)
+      !scan.eventTimeSnapshot && (isUpsertSource(resolvedSchema, table.tableSource) ||
+        isSourceChangeEventsDuplicate(resolvedSchema, table.tableSource, config))
     ) {
       // generate changelog normalize node
       // primary key has been validated in CatalogSourceTable

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.xml
@@ -44,7 +44,7 @@ Calc(select=[currency2, cnt, w$start AS w_start, w$end AS w_end], changelogMode=
 +- GroupWindowAggregate(groupBy=[currency2], window=[TumblingGroupWindow('w$, currency_time, 5000)], properties=[w$start, w$end, w$rowtime, w$proctime], select=[currency2, COUNT(*) AS cnt, start('w$) AS w$start, end('w$) AS w$end, rowtime('w$) AS w$rowtime, proctime('w$) AS w$proctime], changelogMode=[I])
    +- Exchange(distribution=[hash[currency2]], changelogMode=[I,UB,UA,D])
       +- Calc(select=[currency2, currency_time], changelogMode=[I,UB,UA,D])
-         +- ChangelogNormalize(key=[currency2], changelogMode=[I,UB,UA,D])
+         +- ChangelogNormalize(key=[currency], changelogMode=[I,UB,UA,D])
             +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
                +- WatermarkAssigner(rowtime=[currency_time], watermark=[-(currency_time, 5000:INTERVAL SECOND)], changelogMode=[UA,D])
                   +- Calc(select=[+(currency, 2) AS currency2, TO_TIMESTAMP(c) AS currency_time, currency], changelogMode=[UA,D])
@@ -185,6 +185,47 @@ Calc(select=[currency, cnt, w$start AS w_start, w$end AS w_end], changelogMode=[
          +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
             +- WatermarkAssigner(rowtime=[currency_time], watermark=[-(currency_time, 5000:INTERVAL SECOND)], changelogMode=[UA,D])
                +- TableSourceScan(table=[[default_catalog, default_database, simple_src, project=[currency, currency_time], metadata=[]]], fields=[currency, currency_time], changelogMode=[UA,D])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testPushdownCalcNotAffectChangelogNormalizeKey">
+    <Resource name="sql">
+      <![CDATA[
+SELECT t1.a, t1.b, t2.f
+FROM t1 INNER JOIN t2 FOR SYSTEM_TIME AS OF t1.ingestion_time
+ ON t1.a = t2.a WHERE t2.f = true
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$1], b=[$2], f=[$6])
++- LogicalFilter(condition=[=($6, true)])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 1}])
+      :- LogicalWatermarkAssigner(rowtime=[ingestion_time], watermark=[$0])
+      :  +- LogicalProject(ingestion_time=[CAST($2):TIMESTAMP(3) *ROWTIME*], a=[$0], b=[$1])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, t1]])
+      +- LogicalFilter(condition=[=($cor0.a, $2)])
+         +- LogicalSnapshot(period=[$cor0.ingestion_time])
+            +- LogicalWatermarkAssigner(rowtime=[ingestion_time], watermark=[$1])
+               +- LogicalProject(k=[$0], ingestion_time=[CAST($3):TIMESTAMP(3) *ROWTIME*], a=[$1], f=[$2])
+                  +- LogicalTableScan(table=[[default_catalog, default_database, t2]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+Calc(select=[a, b, f], changelogMode=[I])
++- TemporalJoin(joinType=[InnerJoin], where=[AND(=(a, a0), __TEMPORAL_JOIN_CONDITION(ingestion_time, ingestion_time0, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(a0), __TEMPORAL_JOIN_LEFT_KEY(a), __TEMPORAL_JOIN_RIGHT_KEY(a0)))], select=[ingestion_time, a, b, ingestion_time0, a0, f], changelogMode=[I])
+   :- Exchange(distribution=[hash[a]], changelogMode=[I])
+   :  +- WatermarkAssigner(rowtime=[ingestion_time], watermark=[ingestion_time], changelogMode=[I])
+   :     +- Calc(select=[CAST(ingestion_time AS TIMESTAMP(3) *ROWTIME*) AS ingestion_time, a, b], changelogMode=[I])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, t1]], fields=[a, b, ingestion_time], changelogMode=[I])
+   +- Exchange(distribution=[hash[a]], changelogMode=[I,UB,UA,D])
+      +- Calc(select=[ingestion_time, a, f], where=[f], changelogMode=[I,UB,UA,D])
+         +- ChangelogNormalize(key=[a], changelogMode=[I,UB,UA,D])
+            +- Exchange(distribution=[hash[a]], changelogMode=[I,UA,D])
+               +- WatermarkAssigner(rowtime=[ingestion_time], watermark=[ingestion_time], changelogMode=[I,UA,D])
+                  +- Calc(select=[CAST(ingestion_time AS TIMESTAMP(3) *ROWTIME*) AS ingestion_time, a, f], changelogMode=[I,UA,D])
+                     +- TableSourceScan(table=[[default_catalog, default_database, t2, project=[a, f], metadata=[ts]]], fields=[a, f, ingestion_time], changelogMode=[I,UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -308,11 +308,9 @@ Calc(select=[currency, amount, rate, *(amount, rate) AS EXPR$3], changelogMode=[
    :- Exchange(distribution=[hash[currency]], changelogMode=[I])
    :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I])
    :     +- TableSourceScan(table=[[default_catalog, default_database, orders]], fields=[amount, currency, rowtime], changelogMode=[I])
-   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
-      +- ChangelogNormalize(key=[currency], changelogMode=[I,UA,D])
-         +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
-            +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[UA,D])
-               +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate, rowtime], changelogMode=[UA,D])
+   +- Exchange(distribution=[hash[currency]], changelogMode=[UA,D])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[UA,D])
+         +- TableSourceScan(table=[[default_catalog, default_database, rates_history]], fields=[currency, rate, rowtime], changelogMode=[UA,D])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/join/TemporalJoinTest.xml
@@ -759,4 +759,42 @@ Calc(select=[amount, currency, rowtime, PROCTIME_MATERIALIZE(proctime) AS procti
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testTemporalJoinUpsertSourceWithPostFilter">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalProject(amount=[$0], currency=[$1], rowtime=[$2], proctime=[$3], currency0=[$4], rate=[$5], valid=[$6], rowtime0=[$7])
++- LogicalFilter(condition=[=($6, _UTF-16LE'true')])
+   +- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{1, 2}])
+      :- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$2])
+      :  +- LogicalProject(amount=[$0], currency=[$1], rowtime=[$2], proctime=[PROCTIME()])
+      :     +- LogicalTableScan(table=[[default_catalog, default_database, Orders]])
+      +- LogicalFilter(condition=[=($cor0.currency, $0)])
+         +- LogicalSnapshot(period=[$cor0.rowtime])
+            +- LogicalWatermarkAssigner(rowtime=[rowtime], watermark=[$3])
+               +- LogicalTableScan(table=[[default_catalog, default_database, UpsertRates]])
+
+== Optimized Physical Plan ==
+Calc(select=[amount, currency, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, currency0, rate, CAST(_UTF-16LE'true':VARCHAR(2147483647) CHARACTER SET "UTF-16LE" AS VARCHAR(2147483647) CHARACTER SET "UTF-16LE") AS valid, CAST(rowtime0 AS TIMESTAMP(3)) AS rowtime0], where=[=(valid, _UTF-16LE'true':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")], changelogMode=[I])
++- TemporalJoin(joinType=[InnerJoin], where=[AND(=(currency, currency0), __TEMPORAL_JOIN_CONDITION(rowtime, rowtime0, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0), __TEMPORAL_JOIN_LEFT_KEY(currency), __TEMPORAL_JOIN_RIGHT_KEY(currency0)))], select=[amount, currency, rowtime, proctime, currency0, rate, valid, rowtime0], changelogMode=[I])
+   :- Exchange(distribution=[hash[currency]], changelogMode=[I])
+   :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I])
+   :     +- Calc(select=[amount, currency, rowtime, PROCTIME() AS proctime], changelogMode=[I])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, Orders]], fields=[amount, currency, rowtime], changelogMode=[I])
+   +- Exchange(distribution=[hash[currency]], changelogMode=[I,UA,D])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime], changelogMode=[I,UA,D])
+         +- TableSourceScan(table=[[default_catalog, default_database, UpsertRates]], fields=[currency, rate, valid, rowtime], changelogMode=[I,UA,D])
+
+== Optimized Execution Plan ==
+Calc(select=[amount, currency, rowtime, PROCTIME_MATERIALIZE(proctime) AS proctime, currency0, rate, CAST('true' AS VARCHAR(2147483647)) AS valid, CAST(rowtime0 AS TIMESTAMP(3)) AS rowtime0], where=[(valid = 'true')])
++- TemporalJoin(joinType=[InnerJoin], where=[((currency = currency0) AND __TEMPORAL_JOIN_CONDITION(rowtime, rowtime0, __TEMPORAL_JOIN_CONDITION_PRIMARY_KEY(currency0), __TEMPORAL_JOIN_LEFT_KEY(currency), __TEMPORAL_JOIN_RIGHT_KEY(currency0)))], select=[amount, currency, rowtime, proctime, currency0, rate, valid, rowtime0])
+   :- Exchange(distribution=[hash[currency]])
+   :  +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+   :     +- Calc(select=[amount, currency, rowtime, PROCTIME() AS proctime])
+   :        +- TableSourceScan(table=[[default_catalog, default_database, Orders]], fields=[amount, currency, rowtime])
+   +- Exchange(distribution=[hash[currency]])
+      +- WatermarkAssigner(rowtime=[rowtime], watermark=[rowtime])
+         +- TableSourceScan(table=[[default_catalog, default_database, UpsertRates]], fields=[currency, rate, valid, rowtime])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/physical/stream/WatermarkAssignerChangelogNormalizeTransposeRuleTest.scala
@@ -166,4 +166,40 @@ class WatermarkAssignerChangelogNormalizeTransposeRuleTest extends TableTestBase
         |""".stripMargin
     util.verifyRelPlan(sql, ExplainDetail.CHANGELOG_MODE)
   }
+
+  @Test
+  def testPushdownCalcNotAffectChangelogNormalizeKey(): Unit = {
+    util.addTable("""
+                    |CREATE TABLE t1 (
+                    |  ingestion_time TIMESTAMP(3) METADATA FROM 'ts',
+                    |  a VARCHAR NOT NULL,
+                    |  b VARCHAR NOT NULL,
+                    |  WATERMARK FOR ingestion_time AS ingestion_time
+                    |) WITH (
+                    | 'connector' = 'values',
+                    | 'readable-metadata' = 'ts:TIMESTAMP(3)'
+                    |)
+      """.stripMargin)
+    util.addTable("""
+                    |CREATE TABLE t2 (
+                    |  k VARBINARY,
+                    |  ingestion_time TIMESTAMP(3) METADATA FROM 'ts',
+                    |  a VARCHAR NOT NULL,
+                    |  f BOOLEAN NOT NULL,
+                    |  WATERMARK FOR `ingestion_time` AS `ingestion_time`,
+                    |  PRIMARY KEY (`a`) NOT ENFORCED
+                    |) WITH (
+                    | 'connector' = 'values',
+                    | 'readable-metadata' = 'ts:TIMESTAMP(3)',
+                    | 'changelog-mode' = 'I,UA,D'
+                    |)
+      """.stripMargin)
+    val sql =
+      """
+        |SELECT t1.a, t1.b, t2.f
+        |FROM t1 INNER JOIN t2 FOR SYSTEM_TIME AS OF t1.ingestion_time
+        | ON t1.a = t2.a WHERE t2.f = true
+        |""".stripMargin
+    util.verifyRelPlan(sql, ExplainDetail.CHANGELOG_MODE)
+  }
 }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperatorTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/join/temporal/TemporalRowTimeJoinOperatorTest.java
@@ -189,6 +189,83 @@ public class TemporalRowTimeJoinOperatorTest extends TemporalTimeJoinOperatorTes
         testHarness.close();
     }
 
+    @Test
+    public void testRowTimeTemporalJoinOnUpsertSource() throws Exception {
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(new Watermark(1));
+        expectedOutput.add(new Watermark(2));
+        expectedOutput.add(updateAfterRecord(3L, "k1", "1a3", 2L, "k1", "1a2"));
+        expectedOutput.add(new Watermark(5));
+        expectedOutput.add(insertRecord(6L, "k2", "2a3", 4L, "k2", "2a4"));
+        expectedOutput.add(new Watermark(8));
+        expectedOutput.add(new Watermark(9));
+        expectedOutput.add(insertRecord(11L, "k2", "5a12", 10L, "k2", "2a6"));
+        expectedOutput.add(new Watermark(13));
+
+        testRowTimeTemporalJoinOnUpsertSource(false, expectedOutput);
+    }
+
+    @Test
+    public void testRowTimeLeftTemporalJoinOnUpsertSource() throws Exception {
+        List<Object> expectedOutput = new ArrayList<>();
+        expectedOutput.add(new Watermark(1));
+        expectedOutput.add(insertRecord(1L, "k1", "1a1", null, null, null));
+        expectedOutput.add(new Watermark(2));
+        expectedOutput.add(updateAfterRecord(3L, "k1", "1a3", 2L, "k1", "1a2"));
+        expectedOutput.add(new Watermark(5));
+        expectedOutput.add(insertRecord(6L, "k2", "2a3", 4L, "k2", "2a4"));
+        expectedOutput.add(new Watermark(8));
+        expectedOutput.add(insertRecord(9L, "k2", "5a11", null, null, null));
+        expectedOutput.add(new Watermark(9));
+        expectedOutput.add(insertRecord(11L, "k2", "5a12", 10L, "k2", "2a6"));
+        expectedOutput.add(new Watermark(13));
+
+        testRowTimeTemporalJoinOnUpsertSource(true, expectedOutput);
+    }
+
+    private void testRowTimeTemporalJoinOnUpsertSource(
+            boolean isLeftOuterJoin, List<Object> expectedOutput) throws Exception {
+        TemporalRowTimeJoinOperator joinOperator =
+                new TemporalRowTimeJoinOperator(
+                        rowType, rowType, joinCondition, 0, 0, 0, 0, isLeftOuterJoin);
+        KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData> testHarness =
+                createTestHarness(joinOperator);
+
+        testHarness.open();
+
+        testHarness.processWatermark1(new Watermark(1));
+        testHarness.processWatermark2(new Watermark(1));
+
+        testHarness.processElement1(insertRecord(1L, "k1", "1a1"));
+        testHarness.processElement2(insertRecord(2L, "k1", "1a2"));
+
+        testHarness.processWatermark1(new Watermark(2));
+        testHarness.processWatermark2(new Watermark(2));
+
+        testHarness.processElement1(updateAfterRecord(3L, "k1", "1a3"));
+        testHarness.processElement2(insertRecord(4L, "k2", "2a4"));
+
+        testHarness.processWatermark1(new Watermark(5));
+        testHarness.processWatermark2(new Watermark(5));
+
+        testHarness.processElement1(insertRecord(6L, "k2", "2a3"));
+        testHarness.processElement2(updateAfterRecord(7L, "k2", "2a5"));
+
+        testHarness.processWatermark1(new Watermark(8));
+        testHarness.processWatermark2(new Watermark(9));
+
+        testHarness.processElement1(insertRecord(9L, "k2", "5a11"));
+        testHarness.processElement1(insertRecord(11L, "k2", "5a12"));
+        testHarness.processElement2(deleteRecord(9L, "k2", "2a5"));
+        testHarness.processElement2(insertRecord(10L, "k2", "2a6"));
+
+        testHarness.processWatermark1(new Watermark(13));
+        testHarness.processWatermark2(new Watermark(13));
+
+        assertor.assertOutputEquals("output wrong.", expectedOutput, testHarness.getOutput());
+        testHarness.close();
+    }
+
     private KeyedTwoInputStreamOperatorTestHarness<RowData, RowData, RowData, RowData>
             createTestHarness(TemporalRowTimeJoinOperator temporalJoinOperator) throws Exception {
 


### PR DESCRIPTION
## What is the purpose of the change
this is the backport pr for FLINK-29849 & FLINK-29781

## Brief change log 
for FLINK-29849
* add a new StreamFilterIntoJoinRule for streaming, it doesn't push a filter into join which is a temporal join using event time.
* add a FlinkSnapshotRequirementProgram to update snapshot requirement for its child source to avoid adding the ChangelogNormalize node in such cases

for FLINK-29781
* add the unique key indexes remapping logic for WatermarkAssignerChangelogNormalizeTransposeRule

## Verifying this change
TemporalJoinTest & TemporalRowTimeJoinOperatorTest

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)