### PR TITLE
[FLINK-29827][Connectors/Base] Registering callback for AsyncWriter on restore from state

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
@@ -441,27 +441,28 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
     }
 
     private void addEntryToBuffer(RequestEntryT entry, boolean insertAtHead) {
+        addEntryToBuffer(new RequestEntryWrapper<>(entry, getSizeInBytes(entry)), insertAtHead);
+    }
+
+    private void addEntryToBuffer(RequestEntryWrapper<RequestEntryT> entry, boolean insertAtHead) {
         if (bufferedRequestEntries.isEmpty() && !existsActiveTimerCallback) {
             registerCallback();
         }
 
-        RequestEntryWrapper<RequestEntryT> wrappedEntry =
-                new RequestEntryWrapper<>(entry, getSizeInBytes(entry));
-
-        if (wrappedEntry.getSize() > maxRecordSizeInBytes) {
+        if (entry.getSize() > maxRecordSizeInBytes) {
             throw new IllegalArgumentException(
                     String.format(
                             "The request entry sent to the buffer was of size [%s], when the maxRecordSizeInBytes was set to [%s].",
-                            wrappedEntry.getSize(), maxRecordSizeInBytes));
+                            entry.getSize(), maxRecordSizeInBytes));
         }
 
         if (insertAtHead) {
-            bufferedRequestEntries.addFirst(wrappedEntry);
+            bufferedRequestEntries.addFirst(entry);
         } else {
-            bufferedRequestEntries.add(wrappedEntry);
+            bufferedRequestEntries.add(entry);
         }
 
-        bufferedRequestEntriesTotalSizeInBytes += wrappedEntry.getSize();
+        bufferedRequestEntriesTotalSizeInBytes += entry.getSize();
     }
 
     /**
@@ -501,23 +502,10 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
 
     private void initializeState(Collection<BufferedRequestState<RequestEntryT>> states) {
         for (BufferedRequestState<RequestEntryT> state : states) {
-            initializeState(state);
-        }
-    }
-
-    private void initializeState(BufferedRequestState<RequestEntryT> state) {
-        this.bufferedRequestEntries.addAll(state.getBufferedRequestEntries());
-
-        for (RequestEntryWrapper<RequestEntryT> wrapper : bufferedRequestEntries) {
-            if (wrapper.getSize() > maxRecordSizeInBytes) {
-                throw new IllegalStateException(
-                        String.format(
-                                "State contains record of size %d which exceeds sink maximum record size %d.",
-                                wrapper.getSize(), maxRecordSizeInBytes));
+            for (RequestEntryWrapper<RequestEntryT> wrapper : state.getBufferedRequestEntries()) {
+                addEntryToBuffer(wrapper, false);
             }
         }
-
-        this.bufferedRequestEntriesTotalSizeInBytes += state.getStateSize();
     }
 
     @Override

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriterTest.java
@@ -665,7 +665,7 @@ public class AsyncSinkWriterTest {
         sink.write(String.valueOf(225)); // Buffer: 100/110B; 1/10 elements; 0 inflight
         sink.flush(false);
         List<BufferedRequestState<Integer>> states = sink.snapshotState(1);
-        assertThatExceptionOfType(IllegalStateException.class)
+        assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(
                         () ->
                                 new AsyncSinkWriterImplBuilder()
@@ -673,7 +673,7 @@ public class AsyncSinkWriterTest {
                                         .maxRecordSizeInBytes(15)
                                         .buildWithState(states))
                 .withMessageContaining(
-                        "State contains record of size 100 which exceeds sink maximum record size 15.");
+                        "The request entry sent to the buffer was of size [100], when the maxRecordSizeInBytes was set to [15].");
     }
 
     @Test
@@ -707,6 +707,42 @@ public class AsyncSinkWriterTest {
                                 .map(RequestEntryWrapper::getRequestEntry)
                                 .collect(Collectors.toList()))
                 .containsExactlyInAnyOrder(1, 2, 3, 4, 5, 6);
+    }
+
+    @Test
+    public void testWriterInitializedWithStateHasCallbackRegistered() throws Exception {
+        AsyncSinkWriterImpl initialSinkWriter =
+                new AsyncSinkWriterImplBuilder()
+                        .context(sinkInitContext)
+                        .maxBatchSize(10)
+                        .maxInFlightRequests(20)
+                        .maxBatchSizeInBytes(10_000)
+                        .maxTimeInBufferMS(100)
+                        .maxRecordSizeInBytes(10_000)
+                        .simulateFailures(true)
+                        .build();
+        assertThat(res.size()).isEqualTo(0);
+        TestProcessingTimeService tpts = sinkInitContext.getTestProcessingTimeService();
+        tpts.setCurrentTime(0L);
+        initialSinkWriter.write("1");
+        initialSinkWriter.write("2");
+        initialSinkWriter.write("3");
+        tpts.setCurrentTime(10L);
+
+        AsyncSinkWriterImpl restoredSinkWriter =
+                new AsyncSinkWriterImplBuilder()
+                        .context(sinkInitContext)
+                        .maxBatchSize(10)
+                        .maxInFlightRequests(20)
+                        .maxBatchSizeInBytes(10_000)
+                        .maxTimeInBufferMS(10)
+                        .maxRecordSizeInBytes(10_000)
+                        .simulateFailures(true)
+                        .buildWithState(initialSinkWriter.snapshotState(1));
+        restoredSinkWriter.write("4");
+
+        tpts.setCurrentTime(30L);
+        assertThat(res.size()).isEqualTo(4);
     }
 
     @Test


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This is a bug fix, where `AsyncSinkWriter` doesn't register callback on state restoration causing records to reside in buffer more than assigned `maxTimeInBufferMS`


## Brief change log
  
  - Added callback registration on state restoration for async sink writer if needed.
  - Added unit tests for respective change


## Verifying this change

  - Added unit tests in `AsyncSinkWriterTest`
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable)
