### PR TITLE
[Flink 29492] Return Kafka producer to the pool when the Kafka sink is not the end of the chain

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterITCase.java
@@ -494,6 +494,11 @@ public class KafkaWriterITCase {
         public <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
             return Optional.ofNullable((Consumer<MetaT>) metadataConsumer);
         }
+
+        @Override
+        public boolean isChainEnd() {
+            return false;
+        }
     }
 
     private class DummyRecordSerializer implements KafkaRecordSerializationSchema<Integer> {

--- a/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/sink2/Sink.java
@@ -121,5 +121,13 @@ public interface Sink<InputT> extends Serializable {
         default <MetaT> Optional<Consumer<MetaT>> metadataConsumer() {
             return Optional.empty();
         }
+
+        /**
+         * Returns whether the {@link SinkWriter} is the end of a chain.
+         */
+        @Experimental
+        default boolean isChainEnd() {
+            throw new UnsupportedOperationException();
+        }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).

## Brief change log
  -  Add isChainEnd to the InitContext of Sink
  - Change KafkaWriter to return Kafka producers to the pool when the Kafka sink is not the end of the chain

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change will add tests later.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
