### PR TITLE
[FLINK-15633][build] Fix building Javadocs on JDK 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -992,6 +992,7 @@ under the License.
 							<configuration>
 								<additionalJOptions>
 									<additionalJOption>--add-exports=java.base/sun.net.util=ALL-UNNAMED</additionalJOption>
+									<additionalJOption>--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED</additionalJOption>
 								</additionalJOptions>
 							</configuration>
 						</plugin>


### PR DESCRIPTION
## What is the purpose of the change

Javadocs won't build when building for Java 11, e.g. like this:

```
./mvnw clean package javadoc:jar -Pjava11 -Pjava11-target -pl flink-dist -am -Drat.skip=true -Dcheckstyle.skip=true -Dspotless.apply.skip -DskipTests
```

## Brief change log

- add missing `add-exports` for `java.rmi/sun.rmi.registry` to make it work

## Verifying this change

Verified with the build command from above

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
