### PR TITLE
[FLINK-29865][CI] Allow setting the JDK in build-nightly-dist.yml

### DIFF
--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -106,6 +106,7 @@ stages:
           stage_name: cron_snapshot_deployment
           environment: PROFILE=""
           container: flink-build-container
+          jdk: 8
       - template: jobs-template.yml
         parameters:
           stage_name: cron_azure

--- a/tools/azure-pipelines/build-nightly-dist.yml
+++ b/tools/azure-pipelines/build-nightly-dist.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+parameters:
+  jdk: # the jdk version to use
+
 jobs:
   - job: ${{parameters.stage_name}}_binary
     pool:
@@ -28,6 +31,10 @@ jobs:
           restoreKeys: $(CACHE_FALLBACK_KEY)
           path: $(MAVEN_CACHE_FOLDER)
         continueOnError: true
+      - script: |
+          echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+          echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+        displayName: "Set JDK"
       - task: CmdLine@2
         displayName: Build snapshot binary release
         inputs:
@@ -76,6 +83,10 @@ jobs:
           restoreKeys: $(CACHE_FALLBACK_KEY)
           path: $(MAVEN_CACHE_FOLDER)
         continueOnError: true
+      - script: |
+          echo "##vso[task.setvariable variable=JAVA_HOME]$JAVA_HOME_${{parameters.jdk}}_X64"
+          echo "##vso[task.setvariable variable=PATH]$JAVA_HOME_${{parameters.jdk}}_X64/bin:$PATH"
+        displayName: "Set JDK"
       # Upload snapshot
       - task: CmdLine@2
         displayName: Deploy maven snapshot


### PR DESCRIPTION
## What is the purpose of the change

`build-nightly-dist.yml` currently uses the default JDK from https://github.com/flink-ci/flink-ci-docker which happens to be Java 1.8 that we use for releases. We should

1. not rely on this default being set to 1.8 and
2. be able to configure this in the workflows themselves

## Brief change log

- extend `build-nightly-dist.yml`with capabilities to set the JDK just like `jobs-template.yml`

## Verifying this change

This change is a CI-only change that is verified by it as well.
