### PR TITLE
[FLINK-29870] [ResourceManager]Split ResourceActions to ResourceAllocator and ResourceEventListener.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/StandaloneResourceManager.java
@@ -27,6 +27,8 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.exceptions.ResourceManagerException;
+import org.apache.flink.runtime.resourcemanager.slotmanager.NonSupportedResourceAllocatorImpl;
+import org.apache.flink.runtime.resourcemanager.slotmanager.ResourceAllocator;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -35,6 +37,7 @@ import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -100,19 +103,8 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
             ApplicationStatus finalStatus, @Nullable String diagnostics) {}
 
     @Override
-    public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
-        return false;
-    }
-
-    @Override
-    public boolean stopWorker(ResourceID resourceID) {
-        // standalone resource manager cannot stop workers
-        return false;
-    }
-
-    @Override
-    protected ResourceID workerStarted(ResourceID resourceID) {
-        return resourceID;
+    protected Optional<ResourceID> getWorkerNodeIfAcceptRegistration(ResourceID resourceID) {
+        return Optional.of(resourceID);
     }
 
     private void startStartupPeriod() {
@@ -131,5 +123,10 @@ public class StandaloneResourceManager extends ResourceManager<ResourceID> {
     @Override
     public CompletableFuture<Void> getReadyToServeFuture() {
         return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    protected ResourceAllocator getResourceAllocator() {
+        return NonSupportedResourceAllocatorImpl.INSTANCE;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -108,7 +108,10 @@ public class FineGrainedSlotManager implements SlotManager {
     @Nullable private Executor mainThreadExecutor;
 
     /** Callbacks for resource (de-)allocations. */
-    @Nullable private ResourceActions resourceActions;
+    @Nullable private ResourceAllocator resourceAllocator;
+
+    /** Callbacks for resource not enough. */
+    @Nullable private ResourceEventListener resourceEventListener;
 
     @Nullable private ScheduledFuture<?> taskManagerTimeoutsCheck;
 
@@ -149,7 +152,8 @@ public class FineGrainedSlotManager implements SlotManager {
         this.maxTotalMem = Preconditions.checkNotNull(slotManagerConfiguration.getMaxTotalMem());
 
         resourceManagerId = null;
-        resourceActions = null;
+        resourceAllocator = null;
+        resourceEventListener = null;
         mainThreadExecutor = null;
         taskManagerTimeoutsCheck = null;
         requirementsCheckFuture = null;
@@ -166,7 +170,7 @@ public class FineGrainedSlotManager implements SlotManager {
 
         if (failUnfulfillableRequest && !unfulfillableJobs.isEmpty()) {
             for (JobID jobId : unfulfillableJobs) {
-                resourceActions.notifyNotEnoughResourcesAvailable(
+                resourceEventListener.notEnoughResourceAvailable(
                         jobId, resourceTracker.getAcquiredResources(jobId));
             }
         }
@@ -186,20 +190,22 @@ public class FineGrainedSlotManager implements SlotManager {
      *
      * @param newResourceManagerId to use for communication with the task managers
      * @param newMainThreadExecutor to use to run code in the ResourceManager's main thread
-     * @param newResourceActions to use for resource (de-)allocations
+     * @param newResourceAllocator to use for resource (de-)allocations
      * @param newBlockedTaskManagerChecker to query whether a task manager is blocked
      */
     @Override
     public void start(
             ResourceManagerId newResourceManagerId,
             Executor newMainThreadExecutor,
-            ResourceActions newResourceActions,
+            ResourceAllocator newResourceAllocator,
+            ResourceEventListener newResourceEventListener,
             BlockedTaskManagerChecker newBlockedTaskManagerChecker) {
         LOG.info("Starting the slot manager.");
 
         resourceManagerId = Preconditions.checkNotNull(newResourceManagerId);
         mainThreadExecutor = Preconditions.checkNotNull(newMainThreadExecutor);
-        resourceActions = Preconditions.checkNotNull(newResourceActions);
+        resourceAllocator = Preconditions.checkNotNull(newResourceAllocator);
+        resourceEventListener = Preconditions.checkNotNull(newResourceEventListener);
         slotStatusSyncer.initialize(
                 taskManagerTracker, resourceTracker, resourceManagerId, mainThreadExecutor);
         blockedTaskManagerChecker = Preconditions.checkNotNull(newBlockedTaskManagerChecker);
@@ -246,7 +252,8 @@ public class FineGrainedSlotManager implements SlotManager {
 
         unfulfillableJobs.clear();
         resourceManagerId = null;
-        resourceActions = null;
+        resourceAllocator = null;
+        resourceEventListener = null;
         started = false;
     }
 
@@ -346,7 +353,7 @@ public class FineGrainedSlotManager implements SlotManager {
                         taskExecutorConnection.getResourceID(),
                         maxTotalCpu,
                         maxTotalMem.toHumanReadableString());
-                resourceActions.releaseResource(
+                resourceAllocator.releaseResource(
                         taskExecutorConnection.getInstanceID(),
                         new FlinkExpectedException(
                                 "The max total resource limitation is reached."));
@@ -571,7 +578,7 @@ public class FineGrainedSlotManager implements SlotManager {
         if (sendNotEnoughResourceNotifications) {
             for (JobID jobId : unfulfillableJobs) {
                 LOG.warn("Could not fulfill resource requirements of job {}.", jobId);
-                resourceActions.notifyNotEnoughResourcesAvailable(
+                resourceEventListener.notEnoughResourceAvailable(
                         jobId, resourceTracker.getAcquiredResources(jobId));
             }
         }
@@ -730,7 +737,7 @@ public class FineGrainedSlotManager implements SlotManager {
     private void releaseIdleTaskExecutor(InstanceID timedOutTaskManagerId) {
         final FlinkExpectedException cause =
                 new FlinkExpectedException("TaskManager exceeded the idle timeout.");
-        resourceActions.releaseResource(timedOutTaskManagerId, cause);
+        resourceAllocator.releaseResource(timedOutTaskManagerId, cause);
     }
 
     private boolean allocateResource(PendingTaskManager pendingTaskManager) {
@@ -743,7 +750,7 @@ public class FineGrainedSlotManager implements SlotManager {
             return false;
         }
 
-        if (!resourceActions.allocateResource(
+        if (!resourceAllocator.allocateResource(
                 WorkerResourceSpec.fromTotalResourceProfile(
                         pendingTaskManager.getTotalResourceProfile(),
                         pendingTaskManager.getNumSlots()))) {
@@ -771,7 +778,8 @@ public class FineGrainedSlotManager implements SlotManager {
         Preconditions.checkState(started, "The slot manager has not been started.");
         Preconditions.checkNotNull(resourceManagerId);
         Preconditions.checkNotNull(mainThreadExecutor);
-        Preconditions.checkNotNull(resourceActions);
+        Preconditions.checkNotNull(resourceAllocator);
+        Preconditions.checkNotNull(resourceEventListener);
     }
 
     private boolean isMaxTotalResourceExceededAfterAdding(ResourceProfile newResource) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
@@ -22,31 +22,27 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
-/** Resource related actions which the {@link SlotManager} can perform. */
-public interface ResourceAllocator {
+/** ResourceAllocator that not support to allocate/release resources. */
+public class NonSupportedResourceAllocatorImpl implements ResourceAllocator {
+    public static final NonSupportedResourceAllocatorImpl INSTANCE =
+            new NonSupportedResourceAllocatorImpl();
 
-    /** Whether allocate/release resources are supported. */
-    boolean isSupported();
+    @Override
+    public boolean isSupported() {
+        return false;
+    }
 
-    /**
-     * Releases the resource with the given instance id.
-     *
-     * @param instanceId identifying which resource to release
-     * @param cause why the resource is released
-     */
-    void releaseResource(InstanceID instanceId, Exception cause);
+    @Override
+    public void releaseResource(InstanceID instanceId, Exception cause) {
+        throw new UnsupportedOperationException();
+    }
 
-    /**
-     * Releases the resource with the given resource id.
-     *
-     * @param resourceID identifying which resource to release
-     */
-    void releaseResource(ResourceID resourceID);
+    @Override
+    public void releaseResource(ResourceID resourceID) {
+        throw new UnsupportedOperationException();
+    }
 
-    /**
-     * Requests to allocate a resource with the given {@link WorkerResourceSpec}.
-     *
-     * @param workerResourceSpec for the to be allocated worker
-     */
-    void allocateResource(WorkerResourceSpec workerResourceSpec);
+    public void allocateResource(WorkerResourceSpec workerResourceSpec) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
@@ -27,6 +27,8 @@ public class NonSupportedResourceAllocatorImpl implements ResourceAllocator {
     public static final NonSupportedResourceAllocatorImpl INSTANCE =
             new NonSupportedResourceAllocatorImpl();
 
+    private NonSupportedResourceAllocatorImpl() {}
+
     @Override
     public boolean isSupported() {
         return false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+
+/** Resource related actions which the {@link SlotManager} can perform. */
+public interface ResourceAllocator {
+
+    /**
+     * Releases the resource with the given instance id.
+     *
+     * @param instanceId identifying which resource to release
+     * @param cause why the resource is released
+     */
+    void releaseResource(InstanceID instanceId, Exception cause);
+
+    /**
+     * Requests to allocate a resource with the given {@link WorkerResourceSpec}.
+     *
+     * @param workerResourceSpec for the to be allocated worker
+     * @return whether the resource can be allocated
+     */
+    boolean allocateResource(WorkerResourceSpec workerResourceSpec);
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceEventListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceEventListener.java
@@ -19,38 +19,16 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.slots.ResourceRequirement;
 
 import java.util.Collection;
 
-/** Resource related actions which the {@link SlotManager} can perform. */
-public interface ResourceActions {
-
+/** Listener for resource events of {@link SlotManager}. */
+@FunctionalInterface
+public interface ResourceEventListener {
     /**
-     * Releases the resource with the given instance id.
-     *
-     * @param instanceId identifying which resource to release
-     * @param cause why the resource is released
-     */
-    void releaseResource(InstanceID instanceId, Exception cause);
-
-    /**
-     * Requests to allocate a resource with the given {@link WorkerResourceSpec}.
-     *
-     * @param workerResourceSpec for the to be allocated worker
-     * @return whether the resource can be allocated
-     */
-    boolean allocateResource(WorkerResourceSpec workerResourceSpec);
-
-    /**
-     * Notifies that not enough resources are available to fulfill the resource requirements of a
-     * job.
-     *
      * @param jobId job for which not enough resources are available
      * @param acquiredResources the resources that have been acquired for the job
      */
-    void notifyNotEnoughResourcesAvailable(
-            JobID jobId, Collection<ResourceRequirement> acquiredResources);
+    void notEnoughResourceAvailable(JobID jobId, Collection<ResourceRequirement> acquiredResources);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -40,7 +40,7 @@ import java.util.concurrent.Executor;
  * their allocation and all pending slot requests. Whenever a new slot is registered or an allocated
  * slot is freed, then it tries to fulfill another pending slot request. Whenever there are not
  * enough slots available the slot manager will notify the resource manager about it via {@link
- * ResourceActions#allocateResource(WorkerResourceSpec)}.
+ * ResourceAllocator#allocateResource(WorkerResourceSpec)}.
  *
  * <p>In order to free resources and avoid resource leaks, idling task managers (task managers whose
  * slots are currently not used) and pending slot requests time out triggering their release and
@@ -56,7 +56,7 @@ public interface SlotManager extends AutoCloseable {
     int getNumberFreeSlotsOf(InstanceID instanceId);
 
     /**
-     * Get number of workers SlotManager requested from {@link ResourceActions} that are not yet
+     * Get number of workers SlotManager requested from {@link ResourceAllocator} that are not yet
      * fulfilled.
      *
      * @return a map whose key set is all the unique resource specs of the pending workers, and the
@@ -79,13 +79,15 @@ public interface SlotManager extends AutoCloseable {
      *
      * @param newResourceManagerId to use for communication with the task managers
      * @param newMainThreadExecutor to use to run code in the ResourceManager's main thread
-     * @param newResourceActions to use for resource (de-)allocations
+     * @param newResourceAllocator to use for resource (de-)allocations
+     * @param resourceEventListener to use for notify resource not enough
      * @param newBlockedTaskManagerChecker to query whether a task manager is blocked
      */
     void start(
             ResourceManagerId newResourceManagerId,
             Executor newMainThreadExecutor,
-            ResourceActions newResourceActions,
+            ResourceAllocator newResourceAllocator,
+            ResourceEventListener resourceEventListener,
             BlockedTaskManagerChecker newBlockedTaskManagerChecker);
 
     /** Suspends the component. This clears the internal state of the slot manager. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
@@ -153,16 +153,15 @@ class TaskExecutorManager implements AutoCloseable {
             SlotReport initialSlotReport,
             ResourceProfile totalResourceProfile,
             ResourceProfile defaultSlotResourceProfile) {
-        if (isMaxSlotNumExceededAfterRegistration(initialSlotReport)) {
-            if (resourceAllocator.isSupported()) {
-                LOG.info(
-                        "The total number of slots exceeds the max limitation {}, releasing the excess task executor.",
-                        maxSlotNum);
-                resourceAllocator.releaseResource(
-                        taskExecutorConnection.getInstanceID(),
-                        new FlinkExpectedException(
-                                "The total number of slots exceeds the max limitation."));
-            }
+        if (resourceAllocator.isSupported()
+                && isMaxSlotNumExceededAfterRegistration(initialSlotReport)) {
+            LOG.info(
+                    "The total number of slots exceeds the max limitation {}, releasing the excess task executor.",
+                    maxSlotNum);
+            resourceAllocator.releaseResource(
+                    taskExecutorConnection.getInstanceID(),
+                    new FlinkExpectedException(
+                            "The total number of slots exceeds the max limitation."));
             return false;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/TestingResourceManagerFactory.java
@@ -30,6 +30,8 @@ import org.apache.flink.runtime.heartbeat.HeartbeatServices;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerFactory;
 import org.apache.flink.runtime.io.network.partition.ResourceManagerPartitionTrackerImpl;
 import org.apache.flink.runtime.metrics.groups.ResourceManagerMetricGroup;
+import org.apache.flink.runtime.resourcemanager.slotmanager.NonSupportedResourceAllocatorImpl;
+import org.apache.flink.runtime.resourcemanager.slotmanager.ResourceAllocator;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
@@ -39,6 +41,7 @@ import org.apache.flink.util.function.TriConsumer;
 
 import javax.annotation.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -219,17 +222,7 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
         }
 
         @Override
-        public boolean startNewWorker(WorkerResourceSpec workerResourceSpec) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        protected ResourceID workerStarted(ResourceID resourceID) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public boolean stopWorker(ResourceID worker) {
+        protected Optional<ResourceID> getWorkerNodeIfAcceptRegistration(ResourceID resourceID) {
             throw new UnsupportedOperationException();
         }
 
@@ -242,6 +235,11 @@ public class TestingResourceManagerFactory extends ResourceManagerFactory<Resour
         @Override
         public CompletableFuture<Void> getReadyToServeFuture() {
             return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        protected ResourceAllocator getResourceAllocator() {
+            return NonSupportedResourceAllocatorImpl.INSTANCE;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -107,18 +107,17 @@ public class ActiveResourceManagerTest extends TestLogger {
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
-                            CompletableFuture<Boolean> startNewWorkerFuture =
+                            CompletableFuture<Void> startNewWorkerFuture =
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                            .requestNewWorker(
+                                                                    WORKER_RESOURCE_SPEC));
                             TaskExecutorProcessSpec taskExecutorProcessSpec =
                                     requestWorkerFromDriverFuture.get(
                                             TIMEOUT_SEC, TimeUnit.SECONDS);
 
-                            assertThat(
-                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    is(true));
+                            startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
                             assertThat(
                                     taskExecutorProcessSpec,
                                     is(
@@ -171,19 +170,18 @@ public class ActiveResourceManagerTest extends TestLogger {
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
-                            CompletableFuture<Boolean> startNewWorkerFuture =
+                            CompletableFuture<Void> startNewWorkerFuture =
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                            .requestNewWorker(
+                                                                    WORKER_RESOURCE_SPEC));
                             TaskExecutorProcessSpec taskExecutorProcessSpec1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
                                             .get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
-                            assertThat(
-                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    is(true));
+                            startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
                             assertThat(
                                     taskExecutorProcessSpec1,
                                     is(
@@ -250,19 +248,18 @@ public class ActiveResourceManagerTest extends TestLogger {
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
-                            CompletableFuture<Boolean> startNewWorkerFuture =
+                            CompletableFuture<Void> startNewWorkerFuture =
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                            .requestNewWorker(
+                                                                    WORKER_RESOURCE_SPEC));
                             TaskExecutorProcessSpec taskExecutorProcessSpec1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
                                             .get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
-                            assertThat(
-                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    is(true));
+                            startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
                             assertThat(
                                     taskExecutorProcessSpec1,
                                     is(
@@ -329,19 +326,18 @@ public class ActiveResourceManagerTest extends TestLogger {
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
-                            CompletableFuture<Boolean> startNewWorkerFuture =
+                            CompletableFuture<Void> startNewWorkerFuture =
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                            .requestNewWorker(
+                                                                    WORKER_RESOURCE_SPEC));
                             TaskExecutorProcessSpec taskExecutorProcessSpec1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
                                             .get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
-                            assertThat(
-                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    is(true));
+                            startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
                             assertThat(
                                     taskExecutorProcessSpec1,
                                     is(
@@ -408,19 +404,18 @@ public class ActiveResourceManagerTest extends TestLogger {
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
-                            CompletableFuture<Boolean> startNewWorkerFuture =
+                            CompletableFuture<Void> startNewWorkerFuture =
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                            .requestNewWorker(
+                                                                    WORKER_RESOURCE_SPEC));
                             TaskExecutorProcessSpec taskExecutorProcessSpec =
                                     requestWorkerFromDriverFutures
                                             .get(0)
                                             .get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
-                            assertThat(
-                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    is(true));
+                            startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
                             assertThat(
                                     taskExecutorProcessSpec,
                                     is(
@@ -482,7 +477,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                             runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC))
+                                                            .requestNewWorker(WORKER_RESOURCE_SPEC))
                                     .thenCompose(
                                             (ignore) ->
                                                     registerTaskExecutor(
@@ -539,18 +534,18 @@ public class ActiveResourceManagerTest extends TestLogger {
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
-                            CompletableFuture<Boolean> startNewWorkerFuture =
+                            CompletableFuture<Void> startNewWorkerFuture =
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                            .requestNewWorker(
+                                                                    WORKER_RESOURCE_SPEC));
                             long t1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
                                             .get(TIMEOUT_SEC, TimeUnit.SECONDS);
-                            assertThat(
-                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    is(true));
+
+                            startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
                             // first worker failed before register, verify requesting another worker
                             // from driver
@@ -619,14 +614,14 @@ public class ActiveResourceManagerTest extends TestLogger {
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
-                            CompletableFuture<Boolean> startNewWorkerFuture =
+                            CompletableFuture<Void> startNewWorkerFuture =
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .startNewWorker(WORKER_RESOURCE_SPEC));
-                            assertThat(
-                                    startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
-                                    is(true));
+                                                            .requestNewWorker(
+                                                                    WORKER_RESOURCE_SPEC));
+
+                            startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
 
                             long t1 =
                                     requestWorkerFromDriverFutures
@@ -745,7 +740,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                             runInMainThread(
                                     () ->
                                             getResourceManager()
-                                                    .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                    .requestNewWorker(WORKER_RESOURCE_SPEC));
 
                             // verify worker is released due to not registered in time
                             assertThat(
@@ -781,7 +776,7 @@ public class ActiveResourceManagerTest extends TestLogger {
                             runInMainThread(
                                     () ->
                                             getResourceManager()
-                                                    .startNewWorker(WORKER_RESOURCE_SPEC));
+                                                    .requestNewWorker(WORKER_RESOURCE_SPEC));
 
                             // resource allocation takes longer than worker registration timeout
                             try {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AbstractFineGrainedSlotManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/AbstractFineGrainedSlotManagerITCase.java
@@ -67,7 +67,7 @@ abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManag
                 new CompletableFuture<>();
         new Context() {
             {
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         allocateResourceFuture::complete);
                 runTest(
                         () -> {
@@ -224,7 +224,7 @@ abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManag
         new Context() {
             {
                 setBlockedTaskManagerChecker(blockedTaskManager::equals);
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         allocateResourceFuture::complete);
                 runTest(
                         () -> {
@@ -259,7 +259,7 @@ abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManag
 
         new Context() {
             {
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         ignored -> {
                             if (allocateResourceFutures.get(0).isDone()) {
                                 allocateResourceFutures.get(1).complete(null);
@@ -430,7 +430,7 @@ abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManag
         final SlotReport slotReport = new SlotReport();
         new Context() {
             {
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         ignored -> allocateResourceFutures.complete(null));
                 runTest(
                         () -> {
@@ -481,7 +481,7 @@ abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManag
         final SlotReport slotReport = new SlotReport();
         new Context() {
             {
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         ignored -> allocateResourceFutures.complete(null));
                 runTest(
                         () -> {
@@ -528,7 +528,7 @@ abstract class AbstractFineGrainedSlotManagerITCase extends FineGrainedSlotManag
 
         new Context() {
             {
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         ignored -> {
                             if (allocateResourceFutures.get(0).isDone()) {
                                 allocateResourceFutures.get(1).complete(null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -170,30 +170,56 @@ public class DeclarativeSlotManagerBuilder {
 
     public DeclarativeSlotManager buildAndStartWithDirectExec() {
         return buildAndStartWithDirectExec(
-                ResourceManagerId.generate(), new TestingResourceActionsBuilder().build());
+                ResourceManagerId.generate(),
+                new TestingResourceAllocatorBuilder().build(),
+                new TestingResourceEventListenerBuilder().build());
     }
 
     public DeclarativeSlotManager buildAndStartWithDirectExec(
-            ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions) {
-        return buildAndStart(resourceManagerId, Executors.directExecutor(), resourceManagerActions);
+            ResourceManagerId resourceManagerId, ResourceAllocator resourceAllocator) {
+        return buildAndStartWithDirectExec(
+                resourceManagerId,
+                resourceAllocator,
+                new TestingResourceEventListenerBuilder().build());
     }
 
-    public DeclarativeSlotManager buildAndStart(
+    public DeclarativeSlotManager buildAndStartWithDirectExec(
             ResourceManagerId resourceManagerId,
-            Executor executor,
-            ResourceActions resourceManagerActions) {
+            ResourceAllocator resourceAllocator,
+            ResourceEventListener resourceEventListener) {
         return buildAndStart(
-                resourceManagerId, executor, resourceManagerActions, resourceID -> false);
+                resourceManagerId,
+                Executors.directExecutor(),
+                resourceAllocator,
+                resourceEventListener);
     }
 
     public DeclarativeSlotManager buildAndStart(
             ResourceManagerId resourceManagerId,
             Executor executor,
-            ResourceActions resourceManagerActions,
+            ResourceAllocator resourceAllocator,
+            ResourceEventListener resourceEventListener) {
+        return buildAndStart(
+                resourceManagerId,
+                executor,
+                resourceAllocator,
+                resourceEventListener,
+                resourceID -> false);
+    }
+
+    public DeclarativeSlotManager buildAndStart(
+            ResourceManagerId resourceManagerId,
+            Executor executor,
+            ResourceAllocator resourceAllocator,
+            ResourceEventListener resourceEventListener,
             BlockedTaskManagerChecker blockedTaskManagerChecker) {
         final DeclarativeSlotManager slotManager = build();
         slotManager.start(
-                resourceManagerId, executor, resourceManagerActions, blockedTaskManagerChecker);
+                resourceManagerId,
+                executor,
+                resourceAllocator,
+                resourceEventListener,
+                blockedTaskManagerChecker);
         return slotManager;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -259,7 +259,7 @@ class DeclarativeSlotManagerTest {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
 
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
-        final ResourceAllocator resourceAllocator = new NonSupportedResourceAllocatorImpl();
+        final ResourceAllocator resourceAllocator = NonSupportedResourceAllocatorImpl.INSTANCE;
 
         try (DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -258,12 +258,8 @@ class DeclarativeSlotManagerTest {
     void testRequirementDeclarationWithResourceAllocationFailure() throws Exception {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
 
-        ResourceAllocator resourceAllocator =
-                new TestingResourceAllocatorBuilder()
-                        .setAllocateResourceFunction(value -> false)
-                        .build();
-
         final ResourceTracker resourceTracker = new DefaultResourceTracker();
+        final ResourceAllocator resourceAllocator = new NonSupportedResourceAllocatorImpl();
 
         try (DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()
@@ -1076,11 +1072,7 @@ class DeclarativeSlotManagerTest {
         final AtomicInteger resourceRequests = new AtomicInteger(0);
         final TestingResourceAllocator testingResourceAllocator =
                 new TestingResourceAllocatorBuilder()
-                        .setAllocateResourceFunction(
-                                ignored -> {
-                                    resourceRequests.incrementAndGet();
-                                    return true;
-                                })
+                        .setAllocateResourceConsumer(ignored -> resourceRequests.incrementAndGet())
                         .build();
 
         try (final DeclarativeSlotManager slotManager =
@@ -1191,10 +1183,6 @@ class DeclarativeSlotManagerTest {
 
         List<Tuple2<JobID, Collection<ResourceRequirement>>> notEnoughResourceNotifications =
                 new ArrayList<>();
-        ResourceAllocator resourceAllocator =
-                new TestingResourceAllocatorBuilder()
-                        .setAllocateResourceFunction(ignored -> false)
-                        .build();
 
         ResourceEventListener resourceEventListener =
                 new TestingResourceEventListenerBuilder()
@@ -1203,6 +1191,8 @@ class DeclarativeSlotManagerTest {
                                         notEnoughResourceNotifications.add(
                                                 Tuple2.of(jobId1, acquiredResources)))
                         .build();
+
+        ResourceAllocator resourceAllocator = NonSupportedResourceAllocatorImpl.INSTANCE;
 
         try (DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -194,13 +194,12 @@ class DeclarativeSlotManagerTest {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
 
         CompletableFuture<WorkerResourceSpec> allocateResourceFuture = new CompletableFuture<>();
-        ResourceActions resourceManagerActions =
-                new TestingResourceActionsBuilder()
+        ResourceAllocator resourceAllocator =
+                new TestingResourceAllocatorBuilder()
                         .setAllocateResourceConsumer(allocateResourceFuture::complete)
                         .build();
 
-        try (SlotManager slotManager =
-                createSlotManager(resourceManagerId, resourceManagerActions)) {
+        try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceAllocator)) {
 
             slotManager.processResourceRequirements(resourceRequirements);
 
@@ -218,8 +217,8 @@ class DeclarativeSlotManagerTest {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
 
         CompletableFuture<WorkerResourceSpec> allocateResourceFuture = new CompletableFuture<>();
-        ResourceActions resourceManagerActions =
-                new TestingResourceActionsBuilder()
+        ResourceAllocator resourceAllocator =
+                new TestingResourceAllocatorBuilder()
                         .setAllocateResourceConsumer(allocateResourceFuture::complete)
                         .build();
 
@@ -230,7 +229,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 resourceManagerId,
                                 Executors.directExecutor(),
-                                resourceManagerActions,
+                                resourceAllocator,
+                                new TestingResourceEventListenerBuilder().build(),
                                 blockedTaskManager::equals)) {
 
             final TaskExecutorGateway taskExecutorGateway =
@@ -258,8 +258,8 @@ class DeclarativeSlotManagerTest {
     void testRequirementDeclarationWithResourceAllocationFailure() throws Exception {
         final ResourceRequirements resourceRequirements = createResourceRequirementsForSingleSlot();
 
-        ResourceActions resourceManagerActions =
-                new TestingResourceActionsBuilder()
+        ResourceAllocator resourceAllocator =
+                new TestingResourceAllocatorBuilder()
                         .setAllocateResourceFunction(value -> false)
                         .build();
 
@@ -269,7 +269,7 @@ class DeclarativeSlotManagerTest {
                 createDeclarativeSlotManagerBuilder()
                         .setResourceTracker(resourceTracker)
                         .buildAndStartWithDirectExec(
-                                ResourceManagerId.generate(), resourceManagerActions)) {
+                                ResourceManagerId.generate(), resourceAllocator)) {
 
             slotManager.processResourceRequirements(resourceRequirements);
 
@@ -347,7 +347,7 @@ class DeclarativeSlotManagerTest {
                 createDeclarativeSlotManagerBuilder()
                         .setSlotTracker(slotTracker)
                         .buildAndStartWithDirectExec(
-                                resourceManagerId, new TestingResourceActionsBuilder().build())) {
+                                resourceManagerId, new TestingResourceAllocatorBuilder().build())) {
 
             if (scenario
                     == RequirementDeclarationScenario
@@ -432,8 +432,8 @@ class DeclarativeSlotManagerTest {
     void testDuplicateResourceRequirementDeclarationAfterSuccessfulAllocation() throws Exception {
         final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
         final AtomicInteger allocateResourceCalls = new AtomicInteger(0);
-        final ResourceActions resourceManagerActions =
-                new TestingResourceActionsBuilder()
+        final ResourceAllocator resourceAllocator =
+                new TestingResourceAllocatorBuilder()
                         .setAllocateResourceConsumer(
                                 ignored -> allocateResourceCalls.incrementAndGet())
                         .build();
@@ -454,7 +454,7 @@ class DeclarativeSlotManagerTest {
         try (DeclarativeSlotManager slotManager =
                 createDeclarativeSlotManagerBuilder()
                         .setSlotTracker(slotTracker)
-                        .buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions)) {
+                        .buildAndStartWithDirectExec(resourceManagerId, resourceAllocator)) {
 
             slotManager.registerTaskManager(
                     taskManagerConnection, slotReport, ResourceProfile.ANY, ResourceProfile.ANY);
@@ -549,14 +549,13 @@ class DeclarativeSlotManagerTest {
     @Test
     void testReceivingUnknownSlotReport() throws Exception {
         final ResourceManagerId resourceManagerId = ResourceManagerId.generate();
-        final ResourceActions resourceManagerActions = new TestingResourceActionsBuilder().build();
+        final ResourceAllocator resourceAllocator = new TestingResourceAllocatorBuilder().build();
 
         final InstanceID unknownInstanceID = new InstanceID();
         final SlotID unknownSlotId = new SlotID(ResourceID.generate(), 0);
         final SlotReport unknownSlotReport = new SlotReport(createFreeSlotStatus(unknownSlotId));
 
-        try (SlotManager slotManager =
-                createSlotManager(resourceManagerId, resourceManagerActions)) {
+        try (SlotManager slotManager = createSlotManager(resourceManagerId, resourceAllocator)) {
             // check that we don't have any slots registered
             assertThat(slotManager.getNumberRegisteredSlots()).isEqualTo(0);
 
@@ -656,7 +655,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 mainThreadExecutor,
-                                new TestingResourceActionsBuilder().build())) {
+                                new TestingResourceAllocatorBuilder().build(),
+                                new TestingResourceEventListenerBuilder().build())) {
 
             CompletableFuture.runAsync(
                             () ->
@@ -790,7 +790,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 mainThreadExecutor,
-                                new TestingResourceActionsBuilder().build())) {
+                                new TestingResourceAllocatorBuilder().build(),
+                                new TestingResourceEventListenerBuilder().build())) {
 
             slotManager.registerTaskManager(
                     taskExecutorConnection, slotReport, ResourceProfile.ANY, ResourceProfile.ANY);
@@ -1073,8 +1074,8 @@ class DeclarativeSlotManagerTest {
     void testRequestNewResources() throws Exception {
         final int numberSlots = 2;
         final AtomicInteger resourceRequests = new AtomicInteger(0);
-        final TestingResourceActions testingResourceActions =
-                new TestingResourceActionsBuilder()
+        final TestingResourceAllocator testingResourceAllocator =
+                new TestingResourceAllocatorBuilder()
                         .setAllocateResourceFunction(
                                 ignored -> {
                                     resourceRequests.incrementAndGet();
@@ -1084,7 +1085,7 @@ class DeclarativeSlotManagerTest {
 
         try (final DeclarativeSlotManager slotManager =
                 createSlotManager(
-                        ResourceManagerId.generate(), testingResourceActions, numberSlots)) {
+                        ResourceManagerId.generate(), testingResourceAllocator, numberSlots)) {
 
             final JobID jobId = new JobID();
 
@@ -1190,10 +1191,14 @@ class DeclarativeSlotManagerTest {
 
         List<Tuple2<JobID, Collection<ResourceRequirement>>> notEnoughResourceNotifications =
                 new ArrayList<>();
-        ResourceActions resourceManagerActions =
-                new TestingResourceActionsBuilder()
+        ResourceAllocator resourceAllocator =
+                new TestingResourceAllocatorBuilder()
                         .setAllocateResourceFunction(ignored -> false)
-                        .setNotEnoughResourcesConsumer(
+                        .build();
+
+        ResourceEventListener resourceEventListener =
+                new TestingResourceEventListenerBuilder()
+                        .setNotEnoughResourceAvailableConsumer(
                                 (jobId1, acquiredResources) ->
                                         notEnoughResourceNotifications.add(
                                                 Tuple2.of(jobId1, acquiredResources)))
@@ -1204,7 +1209,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 new ManuallyTriggeredScheduledExecutor(),
-                                resourceManagerActions)) {
+                                resourceAllocator,
+                                resourceEventListener)) {
 
             if (withNotificationGracePeriod) {
                 // this should disable notifications
@@ -1271,7 +1277,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 executor,
-                                new TestingResourceActionsBuilder().build())) {
+                                new TestingResourceAllocatorBuilder().build(),
+                                new TestingResourceEventListenerBuilder().build())) {
 
             JobID jobId = new JobID();
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 1));
@@ -1318,7 +1325,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 executor,
-                                new TestingResourceActionsBuilder().build())) {
+                                new TestingResourceAllocatorBuilder().build(),
+                                new TestingResourceEventListenerBuilder().build())) {
 
             JobID jobId = new JobID();
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 1));
@@ -1372,7 +1380,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                new TestingResourceActionsBuilder().build())) {
+                                new TestingResourceAllocatorBuilder().build(),
+                                new TestingResourceEventListenerBuilder().build())) {
 
             final TaskExecutorConnection taskExecutionConnection =
                     createTaskExecutorConnection(taskExecutorGateway);
@@ -1422,7 +1431,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                new TestingResourceActionsBuilder().build())) {
+                                new TestingResourceAllocatorBuilder().build(),
+                                new TestingResourceEventListenerBuilder().build())) {
 
             final JobID jobId = new JobID();
 
@@ -1461,7 +1471,7 @@ class DeclarativeSlotManagerTest {
                         .setRequirementCheckDelay(delay)
                         .buildAndStartWithDirectExec(
                                 ResourceManagerId.generate(),
-                                new TestingResourceActionsBuilder()
+                                new TestingResourceAllocatorBuilder()
                                         .setAllocateResourceConsumer(
                                                 workerResourceSpec ->
                                                         allocatedResourceCounter.getAndIncrement())
@@ -1502,7 +1512,8 @@ class DeclarativeSlotManagerTest {
                         .buildAndStart(
                                 ResourceManagerId.generate(),
                                 ComponentMainThreadExecutorServiceAdapter.forMainThread(),
-                                new TestingResourceActionsBuilder().build())) {
+                                new TestingResourceAllocatorBuilder().build(),
+                                new TestingResourceEventListenerBuilder().build())) {
 
             final JobID jobId = new JobID();
 
@@ -1585,19 +1596,19 @@ class DeclarativeSlotManagerTest {
     }
 
     private DeclarativeSlotManager createSlotManager(
-            ResourceManagerId resourceManagerId, ResourceActions resourceManagerActions) {
-        return createSlotManager(resourceManagerId, resourceManagerActions, 1);
+            ResourceManagerId resourceManagerId, ResourceAllocator resourceAllocator) {
+        return createSlotManager(resourceManagerId, resourceAllocator, 1);
     }
 
     private DeclarativeSlotManager createSlotManager(
             ResourceManagerId resourceManagerId,
-            ResourceActions resourceManagerActions,
+            ResourceAllocator resourceAllocator,
             int numSlotsPerWorker) {
         return createDeclarativeSlotManagerBuilder(
                         new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))
                 .setNumSlotsPerWorker(numSlotsPerWorker)
                 .setRedundantTaskManagerNum(0)
-                .buildAndStartWithDirectExec(resourceManagerId, resourceManagerActions);
+                .buildAndStartWithDirectExec(resourceManagerId, resourceAllocator);
     }
 
     private static DeclarativeSlotManagerBuilder createDeclarativeSlotManagerBuilder() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -52,11 +52,8 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
 
         new Context() {
             {
-                resourceAllocatorBuilder.setAllocateResourceFunction(
-                        ignored -> {
-                            resourceRequests.incrementAndGet();
-                            return true;
-                        });
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
+                        ignored -> resourceRequests.incrementAndGet());
                 runTest(
                         () -> {
                             runInMainThread(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -52,7 +52,7 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
 
         new Context() {
             {
-                resourceActionsBuilder.setAllocateResourceFunction(
+                resourceAllocatorBuilder.setAllocateResourceFunction(
                         ignored -> {
                             resourceRequests.incrementAndGet();
                             return true;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -378,7 +378,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         allocateResourceFutures.add(new CompletableFuture<>());
         new Context() {
             {
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         ignored -> {
                             if (allocateResourceFutures.get(0).isDone()) {
                                 allocateResourceFutures.get(1).complete(null);
@@ -445,7 +445,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                                                 pendingTaskManager.getPendingTaskManagerId(),
                                                 DEFAULT_SLOT_RESOURCE_PROFILE)
                                         .build()));
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         ignored -> requestResourceFuture.complete(null));
                 runTest(
                         () -> {
@@ -496,7 +496,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         final CompletableFuture<Void> notifyNotEnoughResourceFuture = new CompletableFuture<>();
         new Context() {
             {
-                resourceActionsBuilder.setNotEnoughResourcesConsumer(
+                resourceEventListenerBuilder.setNotEnoughResourceAvailableConsumer(
                         (jobId1, acquiredResources) -> {
                             notEnoughResourceNotifications.add(
                                     Tuple2.of(jobId1, acquiredResources));
@@ -638,7 +638,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         final InstanceID instanceId = taskExecutionConnection.getInstanceID();
         new Context() {
             {
-                resourceActionsBuilder.setReleaseResourceConsumer(
+                resourceAllocatorBuilder.setReleaseResourceConsumer(
                         (instanceID, e) -> releaseResourceFuture.complete(instanceID));
                 slotManagerConfigurationBuilder.setTaskManagerTimeout(taskManagerTimeout);
                 runTest(
@@ -827,7 +827,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
             {
                 maxTotalResourceSetter.accept(slotManagerConfigurationBuilder);
 
-                resourceActionsBuilder.setAllocateResourceConsumer(
+                resourceAllocatorBuilder.setAllocateResourceConsumer(
                         ignored -> {
                             if (allocateResourceFutures.get(0).isDone()) {
                                 allocateResourceFutures.get(1).complete(null);
@@ -876,7 +876,7 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
             {
                 maxTotalResourceSetter.accept(slotManagerConfigurationBuilder);
 
-                resourceActionsBuilder.setReleaseResourceConsumer(
+                resourceAllocatorBuilder.setReleaseResourceConsumer(
                         (instanceId, ignore) -> releaseResourceFuture.complete(instanceId));
 
                 runTest(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -157,8 +157,11 @@ abstract class FineGrainedSlotManagerTestBase {
         final TestingResourceAllocationStrategy.Builder resourceAllocationStrategyBuilder =
                 TestingResourceAllocationStrategy.newBuilder();
 
-        final TestingResourceActionsBuilder resourceActionsBuilder =
-                new TestingResourceActionsBuilder();
+        final TestingResourceAllocatorBuilder resourceAllocatorBuilder =
+                new TestingResourceAllocatorBuilder();
+
+        final TestingResourceEventListenerBuilder resourceEventListenerBuilder =
+                new TestingResourceEventListenerBuilder();
         final SlotManagerConfigurationBuilder slotManagerConfigurationBuilder =
                 SlotManagerConfigurationBuilder.newBuilder();
 
@@ -221,7 +224,8 @@ abstract class FineGrainedSlotManagerTestBase {
                             slotManager.start(
                                     resourceManagerId,
                                     mainThreadExecutor,
-                                    resourceActionsBuilder.build(),
+                                    resourceAllocatorBuilder.build(),
+                                    resourceEventListenerBuilder.build(),
                                     blockedTaskManagerChecker));
 
             testMethod.run();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
@@ -35,7 +35,7 @@ public class TaskExecutorManagerBuilder {
     private Time taskManagerTimeout = Time.seconds(5);
     private final ScheduledExecutor scheduledExecutor;
     private Executor mainThreadExecutor = Executors.directExecutor();
-    private ResourceActions newResourceActions = new TestingResourceActionsBuilder().build();
+    private ResourceAllocator newResourceAllocator = new TestingResourceAllocatorBuilder().build();
 
     public TaskExecutorManagerBuilder(ScheduledExecutor scheduledExecutor) {
         this.scheduledExecutor = scheduledExecutor;
@@ -78,8 +78,8 @@ public class TaskExecutorManagerBuilder {
         return this;
     }
 
-    public TaskExecutorManagerBuilder setResourceActions(ResourceActions newResourceActions) {
-        this.newResourceActions = newResourceActions;
+    public TaskExecutorManagerBuilder setResourceAllocator(ResourceAllocator newResourceAllocator) {
+        this.newResourceAllocator = newResourceAllocator;
         return this;
     }
 
@@ -93,6 +93,6 @@ public class TaskExecutorManagerBuilder {
                 taskManagerTimeout,
                 scheduledExecutor,
                 mainThreadExecutor,
-                newResourceActions);
+                newResourceAllocator);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
@@ -250,11 +250,7 @@ public class TaskExecutorManagerTest extends TestLogger {
         final AtomicInteger resourceRequests = new AtomicInteger(0);
         ResourceAllocator resourceAllocator =
                 createResourceAllocatorBuilder()
-                        .setAllocateResourceFunction(
-                                ignored -> {
-                                    resourceRequests.incrementAndGet();
-                                    return true;
-                                })
+                        .setAllocateResourceConsumer(ignored -> resourceRequests.incrementAndGet())
                         .build();
 
         try (final TaskExecutorManager taskExecutorManager =
@@ -283,11 +279,7 @@ public class TaskExecutorManagerTest extends TestLogger {
         final AtomicInteger resourceRequests = new AtomicInteger(0);
         ResourceAllocator resourceAllocator =
                 createResourceAllocatorBuilder()
-                        .setAllocateResourceFunction(
-                                ignored -> {
-                                    resourceRequests.incrementAndGet();
-                                    return true;
-                                })
+                        .setAllocateResourceConsumer(ignored -> resourceRequests.incrementAndGet())
                         .build();
 
         try (final TaskExecutorManager taskExecutorManager =
@@ -382,7 +374,7 @@ public class TaskExecutorManagerTest extends TestLogger {
     private static TestingResourceAllocatorBuilder createResourceAllocatorBuilder() {
         return new TestingResourceAllocatorBuilder()
                 // ensures we do something when excess resource are requested
-                .setAllocateResourceFunction(ignored -> true);
+                .setAllocateResourceConsumer(ignored -> {});
     }
 
     private static InstanceID createAndRegisterTaskExecutor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerTest.java
@@ -133,7 +133,7 @@ public class TaskExecutorManagerTest extends TestLogger {
 
     /**
      * Tests that a task manager timeout does not remove the slots from the SlotManager. A timeout
-     * should only trigger the {@link ResourceActions#releaseResource(InstanceID, Exception)}
+     * should only trigger the {@link ResourceAllocator#releaseResource(InstanceID, Exception)}
      * callback. The receiver of the callback can then decide what to do with the TaskManager.
      *
      * <p>See FLINK-7793
@@ -143,8 +143,8 @@ public class TaskExecutorManagerTest extends TestLogger {
         final Time taskManagerTimeout = Time.milliseconds(10L);
 
         final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
-        final ResourceActions resourceActions =
-                createResourceActionsBuilder()
+        final ResourceAllocator resourceAllocator =
+                createResourceAllocatorBuilder()
                         .setReleaseResourceConsumer(
                                 (instanceId, ignored) -> releaseResourceFuture.complete(instanceId))
                         .build();
@@ -154,7 +154,7 @@ public class TaskExecutorManagerTest extends TestLogger {
         try (final TaskExecutorManager taskExecutorManager =
                 createTaskExecutorManagerBuilder()
                         .setTaskManagerTimeout(taskManagerTimeout)
-                        .setResourceActions(resourceActions)
+                        .setResourceAllocator(resourceAllocator)
                         .setMainThreadExecutor(mainThreadExecutor)
                         .createTaskExecutorManager()) {
 
@@ -195,8 +195,8 @@ public class TaskExecutorManagerTest extends TestLogger {
         final Time taskManagerTimeout = Time.milliseconds(50L);
 
         final CompletableFuture<InstanceID> releaseResourceFuture = new CompletableFuture<>();
-        final ResourceActions resourceManagerActions =
-                new TestingResourceActionsBuilder()
+        final ResourceAllocator resourceAllocator =
+                new TestingResourceAllocatorBuilder()
                         .setReleaseResourceConsumer(
                                 (instanceID, e) -> releaseResourceFuture.complete(instanceID))
                         .build();
@@ -207,7 +207,7 @@ public class TaskExecutorManagerTest extends TestLogger {
                 createTaskExecutorManagerBuilder()
                         .setTaskManagerTimeout(taskManagerTimeout)
                         .setDefaultWorkerResourceSpec(workerResourceSpec)
-                        .setResourceActions(resourceManagerActions)
+                        .setResourceAllocator(resourceAllocator)
                         .setMainThreadExecutor(mainThreadExecutor)
                         .createTaskExecutorManager()) {
 
@@ -248,8 +248,8 @@ public class TaskExecutorManagerTest extends TestLogger {
                 ResourceProfile.newBuilder().setCpuCores(numCoresPerWorker + 1).build();
 
         final AtomicInteger resourceRequests = new AtomicInteger(0);
-        ResourceActions resourceActions =
-                createResourceActionsBuilder()
+        ResourceAllocator resourceAllocator =
+                createResourceAllocatorBuilder()
                         .setAllocateResourceFunction(
                                 ignored -> {
                                     resourceRequests.incrementAndGet();
@@ -262,7 +262,7 @@ public class TaskExecutorManagerTest extends TestLogger {
                         .setDefaultWorkerResourceSpec(workerResourceSpec)
                         .setNumSlotsPerWorker(1)
                         .setMaxNumSlots(1)
-                        .setResourceActions(resourceActions)
+                        .setResourceAllocator(resourceAllocator)
                         .createTaskExecutorManager()) {
 
             assertThat(
@@ -281,8 +281,8 @@ public class TaskExecutorManagerTest extends TestLogger {
         final int maxSlotNum = 1;
 
         final AtomicInteger resourceRequests = new AtomicInteger(0);
-        ResourceActions resourceActions =
-                createResourceActionsBuilder()
+        ResourceAllocator resourceAllocator =
+                createResourceAllocatorBuilder()
                         .setAllocateResourceFunction(
                                 ignored -> {
                                     resourceRequests.incrementAndGet();
@@ -294,7 +294,7 @@ public class TaskExecutorManagerTest extends TestLogger {
                 createTaskExecutorManagerBuilder()
                         .setNumSlotsPerWorker(numberSlots)
                         .setMaxNumSlots(maxSlotNum)
-                        .setResourceActions(resourceActions)
+                        .setResourceAllocator(resourceAllocator)
                         .createTaskExecutorManager()) {
 
             assertThat(resourceRequests.get(), is(0));
@@ -317,8 +317,8 @@ public class TaskExecutorManagerTest extends TestLogger {
         final int maxSlotNum = 1;
 
         final CompletableFuture<InstanceID> releasedResourceFuture = new CompletableFuture<>();
-        ResourceActions resourceActions =
-                createResourceActionsBuilder()
+        ResourceAllocator resourceAllocator =
+                createResourceAllocatorBuilder()
                         .setReleaseResourceConsumer(
                                 (instanceID, e) -> releasedResourceFuture.complete(instanceID))
                         .build();
@@ -327,7 +327,7 @@ public class TaskExecutorManagerTest extends TestLogger {
                 createTaskExecutorManagerBuilder()
                         .setNumSlotsPerWorker(numberSlots)
                         .setMaxNumSlots(maxSlotNum)
-                        .setResourceActions(resourceActions)
+                        .setResourceAllocator(resourceAllocator)
                         .createTaskExecutorManager()) {
 
             createAndRegisterTaskExecutor(taskExecutorManager, 1, ResourceProfile.ANY);
@@ -376,11 +376,11 @@ public class TaskExecutorManagerTest extends TestLogger {
     private static TaskExecutorManagerBuilder createTaskExecutorManagerBuilder() {
         return new TaskExecutorManagerBuilder(
                         new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor()))
-                .setResourceActions(createResourceActionsBuilder().build());
+                .setResourceAllocator(createResourceAllocatorBuilder().build());
     }
 
-    private static TestingResourceActionsBuilder createResourceActionsBuilder() {
-        return new TestingResourceActionsBuilder()
+    private static TestingResourceAllocatorBuilder createResourceAllocatorBuilder() {
+        return new TestingResourceAllocatorBuilder()
                 // ensures we do something when excess resource are requested
                 .setAllocateResourceFunction(ignored -> true);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
@@ -18,26 +18,32 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import javax.annotation.Nonnull;
 
 import java.util.function.BiConsumer;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 /** Testing implementation of the {@link ResourceAllocator}. */
 public class TestingResourceAllocator implements ResourceAllocator {
 
     @Nonnull private final BiConsumer<InstanceID, Exception> releaseResourceConsumer;
 
-    @Nonnull private final Function<WorkerResourceSpec, Boolean> allocateResourceFunction;
+    @Nonnull private final Consumer<WorkerResourceSpec> allocateResourceConsumer;
 
     public TestingResourceAllocator(
             @Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
-            @Nonnull Function<WorkerResourceSpec, Boolean> allocateResourceFunction) {
+            @Nonnull Consumer<WorkerResourceSpec> allocateResourceConsumer) {
         this.releaseResourceConsumer = releaseResourceConsumer;
-        this.allocateResourceFunction = allocateResourceFunction;
+        this.allocateResourceConsumer = allocateResourceConsumer;
+    }
+
+    @Override
+    public boolean isSupported() {
+        return true;
     }
 
     @Override
@@ -46,7 +52,12 @@ public class TestingResourceAllocator implements ResourceAllocator {
     }
 
     @Override
-    public boolean allocateResource(WorkerResourceSpec workerResourceSpec) {
-        return allocateResourceFunction.apply(workerResourceSpec);
+    public void releaseResource(ResourceID resourceID) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void allocateResource(WorkerResourceSpec workerResourceSpec) {
+        allocateResourceConsumer.accept(workerResourceSpec);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
@@ -18,37 +18,26 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
-import org.apache.flink.runtime.slots.ResourceRequirement;
 
 import javax.annotation.Nonnull;
 
-import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
-/** Testing implementation of the {@link ResourceActions}. */
-public class TestingResourceActions implements ResourceActions {
+/** Testing implementation of the {@link ResourceAllocator}. */
+public class TestingResourceAllocator implements ResourceAllocator {
 
     @Nonnull private final BiConsumer<InstanceID, Exception> releaseResourceConsumer;
 
     @Nonnull private final Function<WorkerResourceSpec, Boolean> allocateResourceFunction;
 
-    @Nonnull
-    private final BiConsumer<JobID, Collection<ResourceRequirement>>
-            notifyNotEnoughResourcesConsumer;
-
-    public TestingResourceActions(
+    public TestingResourceAllocator(
             @Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
-            @Nonnull Function<WorkerResourceSpec, Boolean> allocateResourceFunction,
-            @Nonnull
-                    BiConsumer<JobID, Collection<ResourceRequirement>>
-                            notifyNotEnoughResourcesConsumer) {
+            @Nonnull Function<WorkerResourceSpec, Boolean> allocateResourceFunction) {
         this.releaseResourceConsumer = releaseResourceConsumer;
         this.allocateResourceFunction = allocateResourceFunction;
-        this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
     }
 
     @Override
@@ -59,11 +48,5 @@ public class TestingResourceActions implements ResourceActions {
     @Override
     public boolean allocateResource(WorkerResourceSpec workerResourceSpec) {
         return allocateResourceFunction.apply(workerResourceSpec);
-    }
-
-    @Override
-    public void notifyNotEnoughResourcesAvailable(
-            JobID jobId, Collection<ResourceRequirement> acquiredResources) {
-        notifyNotEnoughResourcesConsumer.accept(jobId, acquiredResources);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
@@ -23,12 +23,11 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 /** Builder for the {@link TestingResourceAllocator}. */
 public class TestingResourceAllocatorBuilder {
     private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
-    private Function<WorkerResourceSpec, Boolean> allocateResourceFunction = (ignored) -> true;
+    private Consumer<WorkerResourceSpec> allocateResourceConsumer = (ignored) -> {};
 
     public TestingResourceAllocatorBuilder setReleaseResourceConsumer(
             BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
@@ -36,23 +35,13 @@ public class TestingResourceAllocatorBuilder {
         return this;
     }
 
-    public TestingResourceAllocatorBuilder setAllocateResourceFunction(
-            Function<WorkerResourceSpec, Boolean> allocateResourceFunction) {
-        this.allocateResourceFunction = allocateResourceFunction;
-        return this;
-    }
-
     public TestingResourceAllocatorBuilder setAllocateResourceConsumer(
             Consumer<WorkerResourceSpec> allocateResourceConsumer) {
-        this.allocateResourceFunction =
-                workerRequest -> {
-                    allocateResourceConsumer.accept(workerRequest);
-                    return true;
-                };
+        this.allocateResourceConsumer = allocateResourceConsumer;
         return this;
     }
 
     public TestingResourceAllocator build() {
-        return new TestingResourceAllocator(releaseResourceConsumer, allocateResourceFunction);
+        return new TestingResourceAllocator(releaseResourceConsumer, allocateResourceConsumer);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
@@ -18,36 +18,31 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
-import org.apache.flink.runtime.slots.ResourceRequirement;
 
-import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-/** Builder for the {@link TestingResourceActions}. */
-public class TestingResourceActionsBuilder {
+/** Builder for the {@link TestingResourceAllocator}. */
+public class TestingResourceAllocatorBuilder {
     private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
     private Function<WorkerResourceSpec, Boolean> allocateResourceFunction = (ignored) -> true;
-    private BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer =
-            (ignoredA, ignoredB) -> {};
 
-    public TestingResourceActionsBuilder setReleaseResourceConsumer(
+    public TestingResourceAllocatorBuilder setReleaseResourceConsumer(
             BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
         this.releaseResourceConsumer = releaseResourceConsumer;
         return this;
     }
 
-    public TestingResourceActionsBuilder setAllocateResourceFunction(
+    public TestingResourceAllocatorBuilder setAllocateResourceFunction(
             Function<WorkerResourceSpec, Boolean> allocateResourceFunction) {
         this.allocateResourceFunction = allocateResourceFunction;
         return this;
     }
 
-    public TestingResourceActionsBuilder setAllocateResourceConsumer(
+    public TestingResourceAllocatorBuilder setAllocateResourceConsumer(
             Consumer<WorkerResourceSpec> allocateResourceConsumer) {
         this.allocateResourceFunction =
                 workerRequest -> {
@@ -57,16 +52,7 @@ public class TestingResourceActionsBuilder {
         return this;
     }
 
-    public TestingResourceActionsBuilder setNotEnoughResourcesConsumer(
-            BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer) {
-        this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
-        return this;
-    }
-
-    public TestingResourceActions build() {
-        return new TestingResourceActions(
-                releaseResourceConsumer,
-                allocateResourceFunction,
-                notifyNotEnoughResourcesConsumer);
+    public TestingResourceAllocator build() {
+        return new TestingResourceAllocator(releaseResourceConsumer, allocateResourceFunction);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceEventListener.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceEventListener.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+/** Testing implementation of the {@link ResourceEventListener}. */
+public class TestingResourceEventListener implements ResourceEventListener {
+
+    @Nonnull
+    private final BiConsumer<JobID, Collection<ResourceRequirement>>
+            notEnoughResourceAvailableConsumer;
+
+    public TestingResourceEventListener(
+            @Nonnull
+                    BiConsumer<JobID, Collection<ResourceRequirement>>
+                            notEnoughResourceAvailableConsumer) {
+        this.notEnoughResourceAvailableConsumer = notEnoughResourceAvailableConsumer;
+    }
+
+    @Override
+    public void notEnoughResourceAvailable(
+            JobID jobId, Collection<ResourceRequirement> acquiredResources) {
+        notEnoughResourceAvailableConsumer.accept(jobId, acquiredResources);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceEventListenerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceEventListenerBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.slots.ResourceRequirement;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+/** Builder for the {@link TestingResourceEventListener}. */
+public class TestingResourceEventListenerBuilder {
+    private BiConsumer<JobID, Collection<ResourceRequirement>> notEnoughResourceAvailableConsumer =
+            (ignoredA, ignoredB) -> {};
+
+    public TestingResourceEventListenerBuilder setNotEnoughResourceAvailableConsumer(
+            BiConsumer<JobID, Collection<ResourceRequirement>> notEnoughResourceAvailableConsumer) {
+        this.notEnoughResourceAvailableConsumer = notEnoughResourceAvailableConsumer;
+        return this;
+    }
+
+    public TestingResourceEventListener build() {
+        return new TestingResourceEventListener(notEnoughResourceAvailableConsumer);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -114,7 +114,8 @@ public class TestingSlotManager implements SlotManager {
     public void start(
             ResourceManagerId newResourceManagerId,
             Executor newMainThreadExecutor,
-            ResourceActions newResourceActions,
+            ResourceAllocator newResourceAllocator,
+            ResourceEventListener resourceEventListener,
             BlockedTaskManagerChecker newBlockedTaskManagerChecker) {}
 
     @Override


### PR DESCRIPTION

## What is the purpose of the change

SlotManager determines whether a resource can be allocated by the return value of ResourceActions.allocateResource. It can reduce unnecessary waiting by quickly marking the slotRequest as a failure if the resource cannot be allocated.

The new declareResourceNeed function will not return whether resources could be allocated. This will cause useless waiting for SlotRequests.

This PR will split ResourceNotEnoughNotifier from ResourceActions so that we can make ResourceActions only co-works with ActiveResourceManager. And SlotManager cloud determine whether can allocate new resources by ResourceActions is null or not.


## Brief change log
- Extract the notifyNotEnoughResourcesAvailable function from ResourceActions to ResourceNotEnoughNotifier
- Move ResourceActionsImpl from ResourceManager to ActiveResourceManager
- SlotManager determines whether a resource can be allocated by whether the ResourceActions is null or not.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes, ResourceManager)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
    * part of https://docs.google.com/document/d/1lcmf3MKmcmf9tsPc1whaZHMYKurGoGtqOXEep9ngP2k/edit# 
