### PR TITLE
[FLINK-26890][Connector/Kinesis] Handle invalid shards in DynamoDB

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxyTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/proxy/DynamoDBStreamsProxyTest.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.proxy;
+
+import org.apache.flink.streaming.connectors.kinesis.model.StreamShardHandle;
+import org.apache.flink.streaming.connectors.kinesis.testutils.FakeKinesisClientFactory;
+import org.apache.flink.streaming.connectors.kinesis.testutils.TestUtils;
+
+import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.model.Shard;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for methods in the {@link DynamoDBStreamsProxy} class. */
+class DynamoDBStreamsProxyTest {
+
+    private static final String FAKE_STREAM_NAME = "fake-stream";
+
+    private static final List<String> SHARD_IDS =
+            Arrays.asList(
+                    "shardId-000000000000",
+                    "shardId-000000000001",
+                    "shardId-000000000002",
+                    "shardId-000000000003");
+
+    @Test
+    void testGetShardIterator() throws Exception {
+
+        String invalidShardId = "shardId-000000000004";
+
+        DynamoDBStreamsProxy ddbStreamsProxy = new TestableDynamoDBStreamsProxy();
+
+        for (String shardId : SHARD_IDS) {
+            String shardIterator =
+                    ddbStreamsProxy.getShardIterator(getStreamShardHandle(shardId), "LATEST", null);
+
+            assertThat(shardIterator).isEqualTo("fakeShardIterator");
+        }
+
+        String invalidShardIterator =
+                ddbStreamsProxy.getShardIterator(
+                        getStreamShardHandle(invalidShardId), "LATEST", null);
+
+        assertThat(invalidShardIterator).isNull();
+    }
+
+    private StreamShardHandle getStreamShardHandle(String shardId) {
+        return new StreamShardHandle(FAKE_STREAM_NAME, new Shard().withShardId(shardId));
+    }
+
+    private static class TestableDynamoDBStreamsProxy extends DynamoDBStreamsProxy {
+
+        private TestableDynamoDBStreamsProxy() {
+            super(TestUtils.getStandardProperties());
+        }
+
+        protected AmazonKinesis createKinesisClient(Properties configProps) {
+            return FakeKinesisClientFactory.resourceNotFoundWhenGettingShardIterator(
+                    FAKE_STREAM_NAME, SHARD_IDS);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisClientFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/testutils/FakeKinesisClientFactory.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.connectors.kinesis.testutils;
+
+import org.apache.flink.streaming.connectors.kinesis.proxy.KinesisProxyInterface;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.ResponseMetadata;
+import com.amazonaws.regions.Region;
+import com.amazonaws.services.kinesis.AmazonKinesis;
+import com.amazonaws.services.kinesis.model.AddTagsToStreamRequest;
+import com.amazonaws.services.kinesis.model.AddTagsToStreamResult;
+import com.amazonaws.services.kinesis.model.CreateStreamRequest;
+import com.amazonaws.services.kinesis.model.CreateStreamResult;
+import com.amazonaws.services.kinesis.model.DecreaseStreamRetentionPeriodRequest;
+import com.amazonaws.services.kinesis.model.DecreaseStreamRetentionPeriodResult;
+import com.amazonaws.services.kinesis.model.DeleteStreamRequest;
+import com.amazonaws.services.kinesis.model.DeleteStreamResult;
+import com.amazonaws.services.kinesis.model.DeregisterStreamConsumerRequest;
+import com.amazonaws.services.kinesis.model.DeregisterStreamConsumerResult;
+import com.amazonaws.services.kinesis.model.DescribeLimitsRequest;
+import com.amazonaws.services.kinesis.model.DescribeLimitsResult;
+import com.amazonaws.services.kinesis.model.DescribeStreamConsumerRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamConsumerResult;
+import com.amazonaws.services.kinesis.model.DescribeStreamRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamResult;
+import com.amazonaws.services.kinesis.model.DescribeStreamSummaryRequest;
+import com.amazonaws.services.kinesis.model.DescribeStreamSummaryResult;
+import com.amazonaws.services.kinesis.model.DisableEnhancedMonitoringRequest;
+import com.amazonaws.services.kinesis.model.DisableEnhancedMonitoringResult;
+import com.amazonaws.services.kinesis.model.EnableEnhancedMonitoringRequest;
+import com.amazonaws.services.kinesis.model.EnableEnhancedMonitoringResult;
+import com.amazonaws.services.kinesis.model.GetRecordsRequest;
+import com.amazonaws.services.kinesis.model.GetRecordsResult;
+import com.amazonaws.services.kinesis.model.GetShardIteratorRequest;
+import com.amazonaws.services.kinesis.model.GetShardIteratorResult;
+import com.amazonaws.services.kinesis.model.IncreaseStreamRetentionPeriodRequest;
+import com.amazonaws.services.kinesis.model.IncreaseStreamRetentionPeriodResult;
+import com.amazonaws.services.kinesis.model.ListShardsRequest;
+import com.amazonaws.services.kinesis.model.ListShardsResult;
+import com.amazonaws.services.kinesis.model.ListStreamConsumersRequest;
+import com.amazonaws.services.kinesis.model.ListStreamConsumersResult;
+import com.amazonaws.services.kinesis.model.ListStreamsRequest;
+import com.amazonaws.services.kinesis.model.ListStreamsResult;
+import com.amazonaws.services.kinesis.model.ListTagsForStreamRequest;
+import com.amazonaws.services.kinesis.model.ListTagsForStreamResult;
+import com.amazonaws.services.kinesis.model.MergeShardsRequest;
+import com.amazonaws.services.kinesis.model.MergeShardsResult;
+import com.amazonaws.services.kinesis.model.PutRecordRequest;
+import com.amazonaws.services.kinesis.model.PutRecordResult;
+import com.amazonaws.services.kinesis.model.PutRecordsRequest;
+import com.amazonaws.services.kinesis.model.PutRecordsResult;
+import com.amazonaws.services.kinesis.model.RegisterStreamConsumerRequest;
+import com.amazonaws.services.kinesis.model.RegisterStreamConsumerResult;
+import com.amazonaws.services.kinesis.model.RemoveTagsFromStreamRequest;
+import com.amazonaws.services.kinesis.model.RemoveTagsFromStreamResult;
+import com.amazonaws.services.kinesis.model.ResourceNotFoundException;
+import com.amazonaws.services.kinesis.model.SplitShardRequest;
+import com.amazonaws.services.kinesis.model.SplitShardResult;
+import com.amazonaws.services.kinesis.model.StartStreamEncryptionRequest;
+import com.amazonaws.services.kinesis.model.StartStreamEncryptionResult;
+import com.amazonaws.services.kinesis.model.StopStreamEncryptionRequest;
+import com.amazonaws.services.kinesis.model.StopStreamEncryptionResult;
+import com.amazonaws.services.kinesis.model.UpdateShardCountRequest;
+import com.amazonaws.services.kinesis.model.UpdateShardCountResult;
+import com.amazonaws.services.kinesis.model.UpdateStreamModeRequest;
+import com.amazonaws.services.kinesis.model.UpdateStreamModeResult;
+import com.amazonaws.services.kinesis.waiters.AmazonKinesisWaiters;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+
+/**
+ * Factory for different kinds of fake Amazon Kinesis Client behaviours using the {@link
+ * KinesisProxyInterface} interface.
+ */
+public class FakeKinesisClientFactory {
+
+    public static AmazonKinesis resourceNotFoundWhenGettingShardIterator(
+            String streamName, List<String> shardIds) {
+        return new AmazonKinesis() {
+
+            @Override
+            public GetShardIteratorResult getShardIterator(
+                    GetShardIteratorRequest getShardIteratorRequest) {
+                if (getShardIteratorRequest.getStreamName().equals(streamName)
+                        && shardIds.contains(getShardIteratorRequest.getShardId())) {
+                    return new GetShardIteratorResult().withShardIterator("fakeShardIterator");
+                }
+
+                final ResourceNotFoundException ex =
+                        new ResourceNotFoundException(
+                                "Requested resource not found: Shard does not exist");
+                ex.setErrorType(AmazonServiceException.ErrorType.Client);
+
+                throw ex;
+            }
+
+            @Override
+            public void setEndpoint(String s) {}
+
+            @Override
+            public void setRegion(Region region) {}
+
+            @Override
+            public AddTagsToStreamResult addTagsToStream(
+                    AddTagsToStreamRequest addTagsToStreamRequest) {
+                return null;
+            }
+
+            @Override
+            public CreateStreamResult createStream(CreateStreamRequest createStreamRequest) {
+                return null;
+            }
+
+            @Override
+            public CreateStreamResult createStream(String s, Integer integer) {
+                return null;
+            }
+
+            @Override
+            public DecreaseStreamRetentionPeriodResult decreaseStreamRetentionPeriod(
+                    DecreaseStreamRetentionPeriodRequest decreaseStreamRetentionPeriodRequest) {
+                return null;
+            }
+
+            @Override
+            public DeleteStreamResult deleteStream(DeleteStreamRequest deleteStreamRequest) {
+                return null;
+            }
+
+            @Override
+            public DeleteStreamResult deleteStream(String s) {
+                return null;
+            }
+
+            @Override
+            public DeregisterStreamConsumerResult deregisterStreamConsumer(
+                    DeregisterStreamConsumerRequest deregisterStreamConsumerRequest) {
+                return null;
+            }
+
+            @Override
+            public DescribeLimitsResult describeLimits(
+                    DescribeLimitsRequest describeLimitsRequest) {
+                return null;
+            }
+
+            @Override
+            public DescribeStreamResult describeStream(
+                    DescribeStreamRequest describeStreamRequest) {
+                return null;
+            }
+
+            @Override
+            public DescribeStreamResult describeStream(String s) {
+                return null;
+            }
+
+            @Override
+            public DescribeStreamResult describeStream(String s, String s1) {
+                return null;
+            }
+
+            @Override
+            public DescribeStreamResult describeStream(String s, Integer integer, String s1) {
+                return null;
+            }
+
+            @Override
+            public DescribeStreamConsumerResult describeStreamConsumer(
+                    DescribeStreamConsumerRequest describeStreamConsumerRequest) {
+                return null;
+            }
+
+            @Override
+            public DescribeStreamSummaryResult describeStreamSummary(
+                    DescribeStreamSummaryRequest describeStreamSummaryRequest) {
+                return null;
+            }
+
+            @Override
+            public DisableEnhancedMonitoringResult disableEnhancedMonitoring(
+                    DisableEnhancedMonitoringRequest disableEnhancedMonitoringRequest) {
+                return null;
+            }
+
+            @Override
+            public EnableEnhancedMonitoringResult enableEnhancedMonitoring(
+                    EnableEnhancedMonitoringRequest enableEnhancedMonitoringRequest) {
+                return null;
+            }
+
+            @Override
+            public GetRecordsResult getRecords(GetRecordsRequest getRecordsRequest) {
+                return null;
+            }
+
+            @Override
+            public GetShardIteratorResult getShardIterator(String s, String s1, String s2) {
+                return null;
+            }
+
+            @Override
+            public GetShardIteratorResult getShardIterator(
+                    String s, String s1, String s2, String s3) {
+                return null;
+            }
+
+            @Override
+            public IncreaseStreamRetentionPeriodResult increaseStreamRetentionPeriod(
+                    IncreaseStreamRetentionPeriodRequest increaseStreamRetentionPeriodRequest) {
+                return null;
+            }
+
+            @Override
+            public ListShardsResult listShards(ListShardsRequest listShardsRequest) {
+                return null;
+            }
+
+            @Override
+            public ListStreamConsumersResult listStreamConsumers(
+                    ListStreamConsumersRequest listStreamConsumersRequest) {
+                return null;
+            }
+
+            @Override
+            public ListStreamsResult listStreams(ListStreamsRequest listStreamsRequest) {
+                return null;
+            }
+
+            @Override
+            public ListStreamsResult listStreams() {
+                return null;
+            }
+
+            @Override
+            public ListStreamsResult listStreams(String s) {
+                return null;
+            }
+
+            @Override
+            public ListStreamsResult listStreams(Integer integer, String s) {
+                return null;
+            }
+
+            @Override
+            public ListTagsForStreamResult listTagsForStream(
+                    ListTagsForStreamRequest listTagsForStreamRequest) {
+                return null;
+            }
+
+            @Override
+            public MergeShardsResult mergeShards(MergeShardsRequest mergeShardsRequest) {
+                return null;
+            }
+
+            @Override
+            public MergeShardsResult mergeShards(String s, String s1, String s2) {
+                return null;
+            }
+
+            @Override
+            public PutRecordResult putRecord(PutRecordRequest putRecordRequest) {
+                return null;
+            }
+
+            @Override
+            public PutRecordResult putRecord(String s, ByteBuffer byteBuffer, String s1) {
+                return null;
+            }
+
+            @Override
+            public PutRecordResult putRecord(
+                    String s, ByteBuffer byteBuffer, String s1, String s2) {
+                return null;
+            }
+
+            @Override
+            public PutRecordsResult putRecords(PutRecordsRequest putRecordsRequest) {
+                return null;
+            }
+
+            @Override
+            public RegisterStreamConsumerResult registerStreamConsumer(
+                    RegisterStreamConsumerRequest registerStreamConsumerRequest) {
+                return null;
+            }
+
+            @Override
+            public RemoveTagsFromStreamResult removeTagsFromStream(
+                    RemoveTagsFromStreamRequest removeTagsFromStreamRequest) {
+                return null;
+            }
+
+            @Override
+            public SplitShardResult splitShard(SplitShardRequest splitShardRequest) {
+                return null;
+            }
+
+            @Override
+            public SplitShardResult splitShard(String s, String s1, String s2) {
+                return null;
+            }
+
+            @Override
+            public StartStreamEncryptionResult startStreamEncryption(
+                    StartStreamEncryptionRequest startStreamEncryptionRequest) {
+                return null;
+            }
+
+            @Override
+            public StopStreamEncryptionResult stopStreamEncryption(
+                    StopStreamEncryptionRequest stopStreamEncryptionRequest) {
+                return null;
+            }
+
+            @Override
+            public UpdateShardCountResult updateShardCount(
+                    UpdateShardCountRequest updateShardCountRequest) {
+                return null;
+            }
+
+            @Override
+            public UpdateStreamModeResult updateStreamMode(
+                    UpdateStreamModeRequest updateStreamModeRequest) {
+                return null;
+            }
+
+            @Override
+            public void shutdown() {}
+
+            @Override
+            public ResponseMetadata getCachedResponseMetadata(
+                    AmazonWebServiceRequest amazonWebServiceRequest) {
+                return null;
+            }
+
+            @Override
+            public AmazonKinesisWaiters waiters() {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request makes the Kinesis DynamoDB Streams Consumer close shards that are no longer valid rather than throwing an irrecoverable exceptions. This is because the `DescribeStream` API can return shards that are no longer valid and expects the client to handle them.


## Brief change log

  - `ResourceNotFoundException` thrown in `getShardIterator` for DynamoDB streams consumer is now swallowed
  - A `null` `shardIterator` is returned which is an existing signal to close a shard
  - Added  an `INFO` log to explain that the shard has been closed


## Verifying this change

This change added tests and can be verified as follows:

  - Added a unit test that validates that a `ResourceNotFoundException` thrown in `getShardIterator` is caught and a `null` is returned
  - Manually verified the change by running the ConsumeFromDyanamoDB example, updating records in a DDB table every 10 ms and pausing for updates to re-produce a shard that is no longer valid. Shards that threw a `NoResourceFoundException` were closed.

```python
dyn_resource = boto3.resource('dynamodb')
users = Users(dyn_resource)
users.table = dyn_resource.Table("UsersExample")
while True:
	users.update_user(random.randint(0, 999), names.get_first_name())
	time.sleep(1)
```

  - Manually introduced random failures by changing the last digit of a `shardId` to a 0 and this also resulted in a `NoResourceFoundException` that was handled correctly

```java
public String getShardIterator(
		StreamShardHandle shard, String shardIteratorType, @Nullable Object startingMarker)
		throws InterruptedException {
	...
	if (random.nextInt(10) == 0) {
		char[] shardIdChars = shard.getShard().getShardId().toCharArray();
		shardIdChars[shardIdChars.length - 1] = '0';
		shard =
				new StreamShardHandle(
						shard.getStreamName(),
						new Shard().withShardId(new String(shardIdChars)));
	}
	...
}
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
