### PR TITLE
[JavaDoc Typo] Fix the example for HBaseAsyncTableFunction

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncTableFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/AsyncTableFunction.java
@@ -87,8 +87,8 @@ import java.util.concurrent.CompletableFuture;
  *     Get get = new Get(Bytes.toBytes(rowkey));
  *     ListenableFuture<Result> future = hbase.asyncGet(get);
  *     Futures.addCallback(future, new FutureCallback<Result>() {
- *       public void onSuccess(Result result) {
- *         List<Row> ret = process(result);
+ *       public void onSuccess(Result hbaseResult) {
+ *         List<Row> ret = process(hbaseResult);
  *         result.complete(ret);
  *       }
  *       public void onFailure(Throwable thrown) {


### PR DESCRIPTION
## What is the purpose of the change
the example uses the same parameter name in the outer method  `eval(CompletableFuture<Collection<Row>> result, String rowkey)` and in the inner  `public void onSuccess(Result result) {` so the example isn't actually valid functioning code

## Brief change log
- renamed the parameter in the inner method

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Documentation
 - Does this pull request introduce a new feature?  no
