### PR TITLE
[hotfix][flink-java] Refactor DataSetUtils apply java 8 features

### DIFF
--- a/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/utils/DataSetUtils.java
@@ -323,15 +323,19 @@ public final class DataSetUtils {
         final TupleTypeInfoBase<?> inType = (TupleTypeInfoBase<?>) input.getType();
         DataSet<TupleSummaryAggregator<R>> result =
                 input.mapPartition(
-                                (MapPartitionFunction<T, TupleSummaryAggregator<R>>)
-                                        (values, out) -> {
-                                            TupleSummaryAggregator<R> aggregator =
-                                                    SummaryAggregatorFactory.create(inType);
-                                            for (Tuple value : values) {
-                                                aggregator.aggregate(value);
-                                            }
-                                            out.collect(aggregator);
-                                        })
+                                new MapPartitionFunction<T, TupleSummaryAggregator<R>>() {
+                                    @Override
+                                    public void mapPartition(
+                                            Iterable<T> values,
+                                            Collector<TupleSummaryAggregator<R>> out) {
+                                        TupleSummaryAggregator<R> aggregator =
+                                                SummaryAggregatorFactory.create(inType);
+                                        for (Tuple value : values) {
+                                            aggregator.aggregate(value);
+                                        }
+                                        out.collect(aggregator);
+                                    }
+                                })
                         .reduce(
                                 (ReduceFunction<TupleSummaryAggregator<R>>)
                                         (agg1, agg2) -> {


### PR DESCRIPTION
## What is the purpose of the change

This PR contains just little refactoring.
Refactor DataSetUtils to get rid of redundant code, also apply some java 8 features, lambda functions in particular to substitute anonymous classes and shorten the code and make it more readable...


## Brief change log

  - DataSetUtils: get rid of redundant code, like throw Exception in anonymous classes...
  - DataSetUtils: apply some java 8 features to shorten the code and make it more readable.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
