### PR TITLE
[FLINK-29458][docs-zh]Update "Table API sql queries joins module case

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/joins.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/joins.md
@@ -165,7 +165,7 @@ CREATE TABLE currency_rates (
 SELECT 
      order_id,
      price,
-     currency,
+     orders.currency,
      conversion_rate,
      order_time
 FROM orders

--- a/docs/content/docs/dev/table/sql/queries/joins.md
+++ b/docs/content/docs/dev/table/sql/queries/joins.md
@@ -165,7 +165,7 @@ CREATE TABLE currency_rates (
 SELECT 
      order_id,
      price,
-     currency,
+     orders.currency,
      conversion_rate,
      order_time
 FROM orders


### PR DESCRIPTION

## What is the purpose of the change

*When two tables have the same field, do not specify the table name,Exception will be thrown：SqlValidatorException :Column 'currency' is ambiguous.

The page url is https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/table/sql/queries/joins/*


## Brief change log
  - *The table name is added before the query field，“ orders.currency”*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
