### PR TITLE
[FLINK-29379][streaming] Migrate CheckpointConfig to use Configuration field and ConfigOption

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/CheckpointConfig.java
@@ -129,16 +129,6 @@ public class CheckpointConfig implements java.io.Serializable {
     private final Configuration configuration;
 
     /**
-     * Task would not fail if there is an error in their checkpointing.
-     *
-     * <p>{@link ExecutionCheckpointingOptions#TOLERABLE_FAILURE_NUMBER} would always overrule this
-     * deprecated field if they have conflicts.
-     *
-     * @deprecated Use {@link ExecutionCheckpointingOptions#TOLERABLE_FAILURE_NUMBER}.
-     */
-    @Deprecated private boolean failOnCheckpointingErrors = true;
-
-    /**
      * The checkpoint storage for this application. This field is marked as transient because it may
      * contain user-code.
      *
@@ -380,7 +370,7 @@ public class CheckpointConfig implements java.io.Serializable {
      */
     @Deprecated
     public boolean isFailOnCheckpointingErrors() {
-        return failOnCheckpointingErrors;
+        return getTolerableCheckpointFailureNumber() == 0;
     }
 
     /**
@@ -409,7 +399,6 @@ public class CheckpointConfig implements java.io.Serializable {
                     getTolerableCheckpointFailureNumber());
             return;
         }
-        this.failOnCheckpointingErrors = failOnCheckpointingErrors;
         if (failOnCheckpointingErrors) {
             setTolerableCheckpointFailureNumber(0);
         } else {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/ExecutionCheckpointingOptions.java
@@ -18,7 +18,9 @@
 
 package org.apache.flink.streaming.api.environment;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.annotation.docs.Documentation;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
@@ -28,6 +30,7 @@ import org.apache.flink.streaming.api.CheckpointingMode;
 
 import java.time.Duration;
 
+import static org.apache.flink.configuration.ConfigOptions.key;
 import static org.apache.flink.configuration.description.LinkElement.link;
 
 /**
@@ -252,4 +255,29 @@ public class ExecutionCheckpointingOptions {
                                                     "{{.Site.BaseURL}}{{.Site.LanguagePrefix}}/docs/dev/datastream/fault-tolerance/checkpointing/#checkpointing-with-parts-of-the-graph-finished-beta",
                                                     "the important considerations"))
                                     .build());
+
+    /**
+     * Access to this option is officially only supported via {@link
+     * CheckpointConfig#setForceCheckpointing(boolean)}, but there is no good reason behind this.
+     *
+     * @deprecated This will be removed once iterations properly participate in checkpointing.
+     */
+    @Internal @Deprecated @Documentation.ExcludeFromDocumentation
+    public static final ConfigOption<Boolean> FORCE_CHECKPOINTING =
+            key("execution.checkpointing.force")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Flag to force checkpointing in iterative jobs.");
+
+    /**
+     * Access to this option is officially only supported via {@link
+     * CheckpointConfig#enableApproximateLocalRecovery(boolean)}, but there is no good reason behind
+     * this.
+     */
+    @Internal @Documentation.ExcludeFromDocumentation
+    public static final ConfigOption<Boolean> APPROXIMATE_LOCAL_RECOVERY =
+            key("execution.checkpointing.approximate-local-recovery")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("Flag to enable approximate local recovery.");
 }


### PR DESCRIPTION

## What is the purpose of the change

This PR refactors `CheckpointConfig` to use `Configuration` class

## Brief change log

Please check individual commits.

## Verifying this change

This is only a refactor that's covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**yes** / no)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / no ****/ don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
