### PR TITLE
[FLINK-29888][streaming] Reimplement checkNotAllowedConfigurations using refactored CheckpointConfig and ExecutionConfig

### DIFF
--- a/docs/layouts/shortcodes/generated/deployment_configuration.html
+++ b/docs/layouts/shortcodes/generated/deployment_configuration.html
@@ -30,7 +30,7 @@
             <td><h5>execution.program-config.wildcards</h5></td>
             <td style="word-wrap: break-word;"></td>
             <td>List&lt;String&gt;</td>
-            <td>List of configuration keys that are allowed to be set in a user program regardless whether program configuration is enabled or not.<br /><br />Currently, this list is limited to 'pipeline.global-job-parameters' only.</td>
+            <td>List of configuration keys that are allowed to be set in a user program regardless whether program configuration is enabled or not.<br /><br />Currently changes that are not backed by the Configuration class are always allowed.</td>
         </tr>
         <tr>
             <td><h5>execution.shutdown-on-application-finish</h5></td>

--- a/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/StreamContextEnvironment.java
@@ -295,8 +295,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
                 .forEach(
                         (k, v) ->
                                 errors.add(
-                                        ConfigurationNotAllowedMessage.ofConfigurationKeyAndValue(
-                                                k, v)));
+                                        ConfigurationNotAllowedMessage.ofConfigurationAdded(k, v)));
         diff.entriesOnlyOnLeft()
                 .forEach(
                         (k, v) ->
@@ -307,7 +306,7 @@ public class StreamContextEnvironment extends StreamExecutionEnvironment {
                 .forEach(
                         (k, v) ->
                                 errors.add(
-                                        ConfigurationNotAllowedMessage.ofConfigurationChange(
+                                        ConfigurationNotAllowedMessage.ofConfigurationChanged(
                                                 k, v)));
 
         final Configuration enrichedClusterConfig = new Configuration(clusterConfiguration);

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -765,6 +765,20 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         }
     }
 
+    /**
+     * Removes given key from the configuration.
+     *
+     * @param key key of a config option to remove
+     * @return true is config has been removed, false otherwise
+     */
+    public boolean removeKey(String key) {
+        synchronized (this.confData) {
+            boolean removed = this.confData.remove(key) != null;
+            removed |= removePrefixMap(confData, key);
+            return removed;
+        }
+    }
+
     // --------------------------------------------------------------------------------------------
 
     <T> void setValueInternal(String key, T value, boolean canBePrefixMap) {

--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -325,6 +325,11 @@ public final class DelegatingConfiguration extends Configuration {
     }
 
     @Override
+    public boolean removeKey(String key) {
+        return backingConfig.removeKey(key);
+    }
+
+    @Override
     public boolean containsKey(String key) {
         return backingConfig.containsKey(prefix + key);
     }

--- a/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DeploymentOptions.java
@@ -119,9 +119,7 @@ public class DeploymentOptions {
                                     .linebreak()
                                     .linebreak()
                                     .text(
-                                            "Currently, this list is limited to '%s' only.",
-                                            TextElement.text(
-                                                    PipelineOptions.GLOBAL_JOB_PARAMETERS.key()))
+                                            "Currently changes that are not backed by the Configuration class are always allowed.")
                                     .build());
 
     @Experimental

--- a/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/ConfigurationTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -312,6 +313,25 @@ public class ConfigurationTest extends TestLogger {
         assertTrue("Expected 'existedOption' is removed", cfg.removeConfig(deprecatedOption));
         assertEquals("Wrong expectation about size", cfg.keySet().size(), 0);
         assertFalse("Expected 'unexistedOption' is not removed", cfg.removeConfig(unexistedOption));
+    }
+
+    @Test
+    public void testRemoveKey() {
+        Configuration cfg = new Configuration();
+        String key1 = "a.b";
+        String key2 = "c.d";
+        cfg.setInteger(key1, 42);
+        cfg.setInteger(key2, 44);
+        cfg.setInteger(key2 + ".f1", 44);
+        cfg.setInteger(key2 + ".f2", 44);
+        cfg.setInteger("e.f", 1337);
+
+        assertFalse(cfg.removeKey("not-existing-key"));
+        assertTrue(cfg.removeKey(key1));
+        assertFalse(cfg.containsKey(key1));
+
+        assertTrue(cfg.removeKey(key2));
+        assertThat(cfg.keySet(), containsInAnyOrder("e.f"));
     }
 
     @Test

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
@@ -32,19 +32,19 @@ public class ConfigurationNotAllowedMessage {
 
     private ConfigurationNotAllowedMessage() {}
 
-    public static String ofConfigurationKeyAndValue(String configkey, String configValue) {
-        return String.format("Configuration %s:%s not allowed.", configkey, configValue);
+    public static String ofConfigurationAdded(String configKey, String configValue) {
+        return String.format("Configuration %s:%s not allowed.", configKey, configValue);
     }
 
-    public static String ofConfigurationRemoved(String configkey, String configValue) {
-        return String.format("Configuration %s:%s was removed.", configkey, configValue);
+    public static String ofConfigurationRemoved(String configKey, String configValue) {
+        return String.format("Configuration %s:%s was removed.", configKey, configValue);
     }
 
-    public static String ofConfigurationChange(
-            String configkey, MapDifference.ValueDifference<String> change) {
+    public static String ofConfigurationChanged(
+            String configKey, MapDifference.ValueDifference<String> change) {
         return String.format(
                 "Configuration %s was changed from %s to %s.",
-                configkey, change.leftValue(), change.rightValue());
+                configKey, change.leftValue(), change.rightValue());
     }
 
     public static String ofConfigurationObject(String configurationObject) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
@@ -66,4 +66,9 @@ public class ConfigurationNotAllowedMessage {
                 "Configuration %s:%s was removed from the configuration object %s.",
                 configKey, configValue, configurationObject);
     }
+
+    public static String ofConfigurationObjectSetterUsed(
+            String configurationObject, String setter) {
+        return String.format("Setter %s#%s has been used", configurationObject, setter);
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/ConfigurationNotAllowedMessage.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.dispatcher;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.DeploymentOptions;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.MapDifference;
+import org.apache.flink.shaded.guava30.com.google.common.collect.MapDifference.ValueDifference;
 
 /**
  * If {@link DeploymentOptions#PROGRAM_CONFIG_ENABLED} is disabled, this error denotes the not
@@ -40,14 +40,30 @@ public class ConfigurationNotAllowedMessage {
         return String.format("Configuration %s:%s was removed.", configKey, configValue);
     }
 
-    public static String ofConfigurationChanged(
-            String configKey, MapDifference.ValueDifference<String> change) {
+    public static String ofConfigurationChanged(String configKey, ValueDifference<String> change) {
         return String.format(
                 "Configuration %s was changed from %s to %s.",
                 configKey, change.leftValue(), change.rightValue());
     }
 
-    public static String ofConfigurationObject(String configurationObject) {
-        return String.format("Configuration object %s changed.", configurationObject);
+    public static String ofConfigurationObjectAdded(
+            String configurationObject, String configKey, String configValue) {
+        return String.format(
+                "Configuration %s:%s not allowed in the configuration object %s.",
+                configKey, configValue, configurationObject);
+    }
+
+    public static String ofConfigurationObjectChanged(
+            String configurationObject, String configKey, ValueDifference<String> change) {
+        return String.format(
+                "Configuration %s was changed from %s to %s in the configuration object %s.",
+                configKey, change.leftValue(), change.rightValue(), configurationObject);
+    }
+
+    public static String ofConfigurationObjectRemoved(
+            String configurationObject, String configKey, String configValue) {
+        return String.format(
+                "Configuration %s:%s was removed from the configuration object %s.",
+                configKey, configValue, configurationObject);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/storage/ExternalizedSnapshotLocation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/storage/ExternalizedSnapshotLocation.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.fs.Path;
 import javax.annotation.Nullable;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -153,5 +154,23 @@ class ExternalizedSnapshotLocation implements Serializable {
                                         e);
                             }
                         });
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(baseCheckpointPath, baseSavepointPath);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        ExternalizedSnapshotLocation that = (ExternalizedSnapshotLocation) other;
+        return Objects.equals(baseCheckpointPath, that.baseCheckpointPath)
+                && Objects.equals(baseSavepointPath, that.baseSavepointPath);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/storage/FileSystemCheckpointStorage.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/storage/FileSystemCheckpointStorage.java
@@ -40,6 +40,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.Objects;
 
 import static org.apache.flink.configuration.CheckpointingOptions.FS_SMALL_FILE_THRESHOLD;
 import static org.apache.flink.util.Preconditions.checkArgument;
@@ -370,5 +371,24 @@ public class FileSystemCheckpointStorage
         return writeBufferSize >= 0
                 ? writeBufferSize
                 : CheckpointingOptions.FS_WRITE_BUFFER_SIZE.defaultValue();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(location, fileStateThreshold, writeBufferSize);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || getClass() != other.getClass()) {
+            return false;
+        }
+        FileSystemCheckpointStorage that = (FileSystemCheckpointStorage) other;
+        return Objects.equals(location, that.location)
+                && Objects.equals(fileStateThreshold, that.fileStateThreshold)
+                && Objects.equals(writeBufferSize, that.writeBufferSize);
     }
 }


### PR DESCRIPTION
This PR depends on FLINK-29379, so please ignore a couple of first commits that are being reviewed in https://github.com/apache/flink/pull/21245

After FLINK-29379 we can re-implement checkNotAllowedConfigurations to produce better exception messages.
Instead of a generic "Configuration object ExecutionConfig changed", without a hint of what has been modified,
we can report what ConfigOption has been changed.

## Verifying this change

This change is partially covered by existing tests but also expands `StreamContextEnvironmentTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
