### PR TITLE
[FLINK-29495][Connector/Pulsar] Bump the Pulsar to latest 2.10.2

### DIFF
--- a/flink-connectors/flink-connector-pulsar/pom.xml
+++ b/flink-connectors/flink-connector-pulsar/pom.xml
@@ -36,14 +36,15 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<pulsar.version>2.10.0</pulsar.version>
+		<pulsar.version>2.10.2</pulsar.version>
 
 		<!-- Test Libraries -->
 		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 		<os-maven-plugin.version>1.7.0</os-maven-plugin.version>
 		<pulsar-commons-lang3.version>3.11</pulsar-commons-lang3.version>
-		<pulsar-netty.version>4.1.74.Final</pulsar-netty.version>
-		<pulsar-grpc.version>1.42.1</pulsar-grpc.version>
+		<pulsar-netty.version>4.1.77.Final</pulsar-netty.version>
+		<pulsar-grpc.version>1.45.1</pulsar-grpc.version>
+		<pulsar-caffeine.version>2.9.1</pulsar-caffeine.version>
 	</properties>
 
 	<dependencies>
@@ -151,6 +152,13 @@ under the License.
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
 			<version>${pulsar-commons-lang3.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<version>${pulsar-caffeine.version}</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchema.java
@@ -155,6 +155,9 @@ public final class PulsarSchema<T> implements Serializable {
             oos.writeUTF(entry.getKey());
             oos.writeUTF(entry.getValue());
         }
+
+        // Timestamp
+        oos.writeLong(schemaInfo.getTimestamp());
     }
 
     private void readObject(ObjectInputStream ois) throws ClassNotFoundException, IOException {
@@ -177,7 +180,17 @@ public final class PulsarSchema<T> implements Serializable {
             properties.put(ois.readUTF(), ois.readUTF());
         }
 
-        this.schemaInfo = new SchemaInfoImpl(name, schemaBytes, type, properties);
+        // Timestamp
+        long timestamp = ois.readLong();
+
+        this.schemaInfo =
+                SchemaInfoImpl.builder()
+                        .name(name)
+                        .schema(schemaBytes)
+                        .type(type)
+                        .properties(properties)
+                        .timestamp(timestamp)
+                        .build();
         this.schema = createSchema(schemaInfo);
     }
 

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/common/schema/PulsarSchemaUtils.java
@@ -181,8 +181,13 @@ public final class PulsarSchemaUtils {
         Map<String, String> properties = new HashMap<>(schemaInfo.getProperties());
         properties.put(CLASS_INFO_PLACEHOLDER, typeClass.getName());
 
-        return new SchemaInfoImpl(
-                schemaInfo.getName(), schemaInfo.getSchema(), schemaInfo.getType(), properties);
+        return SchemaInfoImpl.builder()
+                .name(schemaInfo.getName())
+                .schema(schemaInfo.getSchema())
+                .type(schemaInfo.getType())
+                .properties(properties)
+                .timestamp(schemaInfo.getTimestamp())
+                .build();
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
+++ b/flink-connectors/flink-sql-connector-pulsar/src/main/resources/META-INF/NOTICE
@@ -6,10 +6,10 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.pulsar:bouncy-castle-bc:pkg:2.10.0
-- org.apache.pulsar:pulsar-client-admin-api:2.10.0
-- org.apache.pulsar:pulsar-client-all:2.10.0
-- org.apache.pulsar:pulsar-client-api:2.10.0
+- org.apache.pulsar:bouncy-castle-bc:pkg:2.10.2
+- org.apache.pulsar:pulsar-client-admin-api:2.10.2
+- org.apache.pulsar:pulsar-client-all:2.10.2
+- org.apache.pulsar:pulsar-client-api:2.10.2
 - org.slf4j:jul-to-slf4j:1.7.32
 
 This project bundles the following dependencies under the Bouncy Castle license.

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/pom.xml
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/pom.xml
@@ -31,7 +31,7 @@ under the License.
 	<name>Flink : E2E Tests : Pulsar</name>
 
 	<properties>
-		<pulsar.version>2.10.0</pulsar.version>
+		<pulsar.version>2.10.2</pulsar.version>
 		<bouncycastle.version>1.69</bouncycastle.version>
 		<jaxb-api.version>2.3.1</jaxb-api.version>
 	</properties>

--- a/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
+++ b/flink-test-utils-parent/flink-test-utils-junit/src/main/java/org/apache/flink/util/DockerImageVersions.java
@@ -42,7 +42,7 @@ public class DockerImageVersions {
 
     public static final String LOCALSTACK = "localstack/localstack:0.13.3";
 
-    public static final String PULSAR = "apachepulsar/pulsar:2.10.0";
+    public static final String PULSAR = "apachepulsar/pulsar:2.10.2";
 
     public static final String CASSANDRA_3 = "cassandra:3.0";
 


### PR DESCRIPTION
## What is the purpose of the change

Bump the pulsar-client-all to 2.10.2 which fixes the `NullPointerException`. This issue cause the test hang in Flink CI.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (yes)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
