### PR TITLE
[FLINK-29860][Connector/Pulsar] Remove the InlineElement for all Pulsar enums.

### DIFF
--- a/docs/layouts/shortcodes/generated/pulsar_sink_configuration.html
+++ b/docs/layouts/shortcodes/generated/pulsar_sink_configuration.html
@@ -28,9 +28,9 @@
         </tr>
         <tr>
             <td><h5>pulsar.sink.messageKeyHash</h5></td>
-            <td style="word-wrap: break-word;">murmur-3-32-hash</td>
+            <td style="word-wrap: break-word;">MURMUR3_32_HASH</td>
             <td><p>Enum</p></td>
-            <td>The hash policy for routing message by calculating the hash code of message key.<br /><br />Possible values:<ul><li>"java-hash": This hash would use <code class="highlighter-rouge">String.hashCode()</code> to calculate the message key string's hash code.</li><li>"murmur-3-32-hash": This hash would calculate message key's hash code by using <a href="https://en.wikipedia.org/wiki/MurmurHash">Murmur3</a> algorithm.</li></ul></td>
+            <td>The hash policy for routing message by calculating the hash code of message key.<br /><br />Possible values:<ul><li>"JAVA_HASH"</li><li>"MURMUR3_32_HASH"</li></ul></td>
         </tr>
         <tr>
             <td><h5>pulsar.sink.topicMetadataRefreshInterval</h5></td>

--- a/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
+++ b/docs/layouts/shortcodes/generated/pulsar_source_configuration.html
@@ -54,7 +54,7 @@
             <td><h5>pulsar.source.verifyInitialOffsets</h5></td>
             <td style="word-wrap: break-word;">WARN_ON_MISMATCH</td>
             <td><p>Enum</p></td>
-            <td>Upon (re)starting the source, check whether the expected message can be read. If failure is enabled, the application fails. Otherwise, it logs a warning. A possible solution is to adjust the retention settings in Pulsar or ignoring the check result.<br /><br />Possible values:<ul><li>"FAIL_ON_MISMATCH": Fail the consuming from Pulsar when we don't find the related cursor.</li><li>"WARN_ON_MISMATCH": Print a warn message and start consuming from the valid offset.</li></ul></td>
+            <td>Upon (re)starting the source, check whether the expected message can be read. If failure is enabled, the application fails. Otherwise, it logs a warning. A possible solution is to adjust the retention settings in Pulsar or ignoring the check result.<br /><br />Possible values:<ul><li>"FAIL_ON_MISMATCH"</li><li>"WARN_ON_MISMATCH"</li></ul></td>
         </tr>
     </tbody>
 </table>

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/MessageKeyHash.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/MessageKeyHash.java
@@ -20,27 +20,17 @@ package org.apache.flink.connector.pulsar.sink.writer.router;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.DescribedEnum;
-import org.apache.flink.configuration.description.InlineElement;
 
 import org.apache.pulsar.client.impl.Hash;
 import org.apache.pulsar.client.impl.JavaStringHash;
 import org.apache.pulsar.client.impl.Murmur3Hash32;
 
-import static org.apache.flink.configuration.description.LinkElement.link;
-import static org.apache.flink.configuration.description.TextElement.code;
-import static org.apache.flink.configuration.description.TextElement.text;
-
 /** Predefined the available hash function for routing the message. */
 @PublicEvolving
-public enum MessageKeyHash implements DescribedEnum {
+public enum MessageKeyHash {
 
     /** Use regular <code>String.hashCode()</code>. */
-    JAVA_HASH(
-            "java-hash",
-            text(
-                    "This hash would use %s to calculate the message key string's hash code.",
-                    code("String.hashCode()"))) {
+    JAVA_HASH {
         @Override
         public Hash getHash() {
             return JavaStringHash.getInstance();
@@ -50,36 +40,13 @@ public enum MessageKeyHash implements DescribedEnum {
      * Use Murmur3 hashing function. <a
      * href="https://en.wikipedia.org/wiki/MurmurHash">https://en.wikipedia.org/wiki/MurmurHash</a>
      */
-    MURMUR3_32_HASH(
-            "murmur-3-32-hash",
-            text(
-                    "This hash would calculate message key's hash code by using %s algorithm.",
-                    link("https://en.wikipedia.org/wiki/MurmurHash", "Murmur3"))) {
+    MURMUR3_32_HASH {
         @Override
         public Hash getHash() {
             return Murmur3Hash32.getInstance();
         }
     };
 
-    private final String name;
-    private final InlineElement desc;
-
-    MessageKeyHash(String name, InlineElement desc) {
-        this.name = name;
-        this.desc = desc;
-    }
-
     @Internal
     public abstract Hash getHash();
-
-    @Override
-    public String toString() {
-        return name;
-    }
-
-    @Internal
-    @Override
-    public InlineElement getDescription() {
-        return desc;
-    }
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/TopicRoutingMode.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/sink/writer/router/TopicRoutingMode.java
@@ -18,70 +18,29 @@
 
 package org.apache.flink.connector.pulsar.sink.writer.router;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.DescribedEnum;
-import org.apache.flink.configuration.description.InlineElement;
-
-import static org.apache.flink.configuration.description.TextElement.code;
-import static org.apache.flink.configuration.description.TextElement.text;
-import static org.apache.flink.connector.pulsar.sink.PulsarSinkOptions.PULSAR_BATCHING_MAX_MESSAGES;
 
 /** The routing policy for choosing the desired topic by the given message. */
 @PublicEvolving
-public enum TopicRoutingMode implements DescribedEnum {
+public enum TopicRoutingMode {
 
     /**
      * The producer will publish messages across all partitions in a round-robin fashion to achieve
      * maximum throughput. Please note that round-robin is not done per individual message but
      * rather it's set to the same boundary of batching delay, to ensure batching is effective.
      */
-    ROUND_ROBIN(
-            "round-robin",
-            text(
-                    "The producer will publish messages across all partitions in a round-robin fashion to achieve maximum throughput."
-                            + " Please note that round-robin is not done per individual message"
-                            + " but rather it's set to the same boundary of %s, to ensure batching is effective.",
-                    code(PULSAR_BATCHING_MAX_MESSAGES.key()))),
+    ROUND_ROBIN,
 
     /**
      * If no key is provided, The partitioned producer will randomly pick one single topic partition
      * and publish all the messages into that partition. If a key is provided on the message, the
      * partitioned producer will hash the key and assign the message to a particular partition.
      */
-    MESSAGE_KEY_HASH(
-            "message-key-hash",
-            text(
-                    "If no key is provided, The partitioned producer will randomly pick one single topic partition"
-                            + " and publish all the messages into that partition. If a key is provided on the message,"
-                            + " the partitioned producer will hash the key and assign the message to a particular partition.")),
+    MESSAGE_KEY_HASH,
 
     /**
      * Use custom topic router implementation that will be called to determine the partition for a
      * particular message.
      */
-    CUSTOM(
-            "custom",
-            text(
-                    "Use custom %s implementation that will be called to determine the partition for a particular message.",
-                    code(TopicRouter.class.getSimpleName())));
-
-    private final String name;
-    private final InlineElement desc;
-
-    TopicRoutingMode(String name, InlineElement desc) {
-        this.name = name;
-        this.desc = desc;
-    }
-
-    @Internal
-    @Override
-    public InlineElement getDescription() {
-        return desc;
-    }
-
-    @Override
-    public String toString() {
-        return name;
-    }
+    CUSTOM;
 }

--- a/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/CursorVerification.java
+++ b/flink-connectors/flink-connector-pulsar/src/main/java/org/apache/flink/connector/pulsar/source/config/CursorVerification.java
@@ -18,32 +18,15 @@
 
 package org.apache.flink.connector.pulsar.source.config;
 
-import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.PublicEvolving;
-import org.apache.flink.configuration.DescribedEnum;
-import org.apache.flink.configuration.description.InlineElement;
-
-import static org.apache.flink.configuration.description.TextElement.text;
 
 /** The enum class for defining the cursor verify behavior. */
 @PublicEvolving
-public enum CursorVerification implements DescribedEnum {
+public enum CursorVerification {
 
     /** We would just fail the consuming. */
-    FAIL_ON_MISMATCH(text("Fail the consuming from Pulsar when we don't find the related cursor.")),
+    FAIL_ON_MISMATCH,
 
     /** Print a warn message and start consuming from the valid offset. */
-    WARN_ON_MISMATCH(text("Print a warn message and start consuming from the valid offset."));
-
-    private final InlineElement desc;
-
-    CursorVerification(InlineElement desc) {
-        this.desc = desc;
-    }
-
-    @Internal
-    @Override
-    public InlineElement getDescription() {
-        return desc;
-    }
+    WARN_ON_MISMATCH;
 }


### PR DESCRIPTION
## What is the purpose of the change

Remove the use of `DescribedEnum` for passing the `ClosureCleaner` check in HybirdSource.

## Brief change log

Remove the `DescribedEnum` in `TopicRoutingMode`, `MessageKeyHash` and `CursorVerification`.

## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
