### PR TITLE
[FLINK-29830][Connector/Pulsar] Create the topic with schema before consuming messages in PulsarSinkITCase

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/PulsarSinkITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/sink/PulsarSinkITCase.java
@@ -51,6 +51,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphabetic;
 import static org.apache.flink.connector.pulsar.sink.writer.serializer.PulsarSerializationSchema.flinkSchema;
+import static org.apache.pulsar.client.api.Schema.STRING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for using PulsarSink writing to a Pulsar cluster. */
@@ -104,6 +105,7 @@ class PulsarSinkITCase {
             // A random topic with partition 4.
             String topic = randomAlphabetic(8);
             operator().createTopic(topic, 4);
+            operator().createSchema(topic, STRING);
             int counts = ThreadLocalRandom.current().nextInt(100, 200);
 
             ControlSource source =

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/PulsarRuntimeOperator.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/testutils/runtime/PulsarRuntimeOperator.java
@@ -180,6 +180,10 @@ public class PulsarRuntimeOperator implements Closeable {
         }
     }
 
+    public void createSchema(String topic, Schema<?> schema) {
+        sneakyAdmin(() -> admin().schemas().createSchema(topic, schema.getSchemaInfo()));
+    }
+
     /**
      * Increase the partition number of the topic.
      *


### PR DESCRIPTION
## What is the purpose of the change

The tests in `PulsarSinkITCase` may failed with some error logs like below. This is caused by we may consume messages on a blank topic with no schema. Pulsar topic's schema is define by the first message sent to it. Or you can create schema on topic manually.

```
Failed to subscribe for topic [persistent://public/default/bCQuHnEp] in topics consumer, subscribe error: org.apache.pulsar.client.api.PulsarClientException$IncompatibleSchemaException: {"errorMsg":"Topic does not have schema to check","reqId":2052942634743575747, "remote":"localhost/127.0.0.1:44835", "local":"/127.0.0.1:41334"}
```

In this test, we will manually create the topic schema before the test which fixes this race condition.

## Brief change log

- Create schema in `PulsarSinkITCase`.
- Log all the exceptions in `ControlSource` for better debugging.

## Verifying this change

This change is already covered by existing tests, such as:

- PulsarSinkITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
