### PR TITLE
[hotfix][docs] Update the missing parts of this fault_tolerance Chinese documentation.

### DIFF
--- a/docs/content.zh/docs/learn-flink/fault_tolerance.md
+++ b/docs/content.zh/docs/learn-flink/fault_tolerance.md
@@ -94,32 +94,31 @@ Flink 管理的状态存储在 _state backend_ 中。Flink 有两种 state backe
 
 ## Checkpoint Storage
 
-Flink periodically takes persistent snapshots of all the state in every operator and copies these snapshots somewhere more durable, such as a distributed file system. In the event of the failure, Flink can restore the complete state of your application and resume
-processing as though nothing had gone wrong.
+Flink 定期对每个算子的所有状态进行持久化快照，并将这些快照复制到更持久的地方，例如分布式文件系统。 如果发生故障，Flink 可以恢复应用程序的完整状态并恢复处理，就好像没有出现任何问题一样。
 
-The location where these snapshots are stored is defined via the jobs _checkpoint storage_.
-Two implementations of checkpoint storage are available - one that persists its state snapshots
-to a distributed file system, and another that users the JobManager's heap.
+这些快照的存储位置是通过作业_checkpoint storage_定义的。
+有两种可用检查点存储实现：一种持久保存其状态快照
+到一个分布式文件系统，另一种是使用 JobManager 的堆。
 
 <center>
   <table class="table table-bordered">
     <thead>
       <tr class="book-hint info">
-        <th class="text-left">Name</th>
-        <th class="text-left">State Backup</th>
+        <th class="text-left">名称</th>
+        <th class="text-left">状态备份</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th class="text-left">FileSystemCheckpointStorage</th>
-        <td class="text-left">Distributed file system</td>
+        <td class="text-left">分布式文件系统</td>
       </tr>
       <tr>
         <td colspan="4" class="text-left">
           <ul>
-            <li>Supports very large state size</li>
-            <li>Highly durable</li>
-            <li>Recommended for production deployments</li>
+            <li>支持非常大的状态大小</li>
+            <li>高度可靠</li>
+            <li>推荐用于生产部署</li>
           </ul>
         </td>
       </tr>
@@ -130,7 +129,7 @@ to a distributed file system, and another that users the JobManager's heap.
       <tr>
         <td colspan="4" class="text-left">
           <ul>
-            <li>Good for testing and experimentation with small state (locally)</li>
+            <li>适合小状态（本地）的测试和实验</li>
           </ul>
         </td>
       </tr>

--- a/docs/content.zh/docs/learn-flink/fault_tolerance.md
+++ b/docs/content.zh/docs/learn-flink/fault_tolerance.md
@@ -92,6 +92,54 @@ Flink 管理的状态存储在 _state backend_ 中。Flink 有两种 state backe
 
 {{< top >}}
 
+## Checkpoint Storage
+
+Flink periodically takes persistent snapshots of all the state in every operator and copies these snapshots somewhere more durable, such as a distributed file system. In the event of the failure, Flink can restore the complete state of your application and resume
+processing as though nothing had gone wrong.
+
+The location where these snapshots are stored is defined via the jobs _checkpoint storage_.
+Two implementations of checkpoint storage are available - one that persists its state snapshots
+to a distributed file system, and another that users the JobManager's heap.
+
+<center>
+  <table class="table table-bordered">
+    <thead>
+      <tr class="book-hint info">
+        <th class="text-left">Name</th>
+        <th class="text-left">State Backup</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <th class="text-left">FileSystemCheckpointStorage</th>
+        <td class="text-left">Distributed file system</td>
+      </tr>
+      <tr>
+        <td colspan="4" class="text-left">
+          <ul>
+            <li>Supports very large state size</li>
+            <li>Highly durable</li>
+            <li>Recommended for production deployments</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <th class="text-left">JobManagerCheckpointStorage</th>
+        <td class="text-left">JobManager JVM Heap</td>
+      </tr>
+      <tr>
+        <td colspan="4" class="text-left">
+          <ul>
+            <li>Good for testing and experimentation with small state (locally)</li>
+          </ul>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</center>
+
+{{< top >}}
+
 ## 状态快照
 
 ### 定义

--- a/docs/content/docs/learn-flink/fault_tolerance.md
+++ b/docs/content/docs/learn-flink/fault_tolerance.md
@@ -91,7 +91,7 @@ processing as though nothing had gone wrong.
 
 The location where these snapshots are stored is defined via the jobs _checkpoint storage_.
 Two implementations of checkpoint storage are available - one that persists its state snapshots
-to a distributed file system, and another that users the JobManager's heap. 
+to a distributed file system, and another that uses the JobManager's heap. 
 
 <center>
   <table class="table table-bordered">


### PR DESCRIPTION

## What is the purpose of the change

- Update the missing parts of this fault_tolerance Chinese documentation.


## Brief change log

- Update the missing parts of this fault_tolerance Chinese documentation.

## Verifying this change

- No need to test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
