### PR TITLE
[hotfix][flink-runtime] Fix the typo of RecordingChannelStateWriter class.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecordingChannelStateWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecordingChannelStateWriter.java
@@ -33,7 +33,7 @@ public class RecordingChannelStateWriter extends MockChannelStateWriter {
     private long lastStartedCheckpointId = -1;
     private long lastFinishedCheckpointId = -1;
     private ListMultimap<InputChannelInfo, Buffer> addedInput = LinkedListMultimap.create();
-    private ListMultimap<ResultSubpartitionInfo, Buffer> adedOutput = LinkedListMultimap.create();
+    private ListMultimap<ResultSubpartitionInfo, Buffer> addedOutput = LinkedListMultimap.create();
 
     public RecordingChannelStateWriter() {
         super(false);
@@ -44,8 +44,8 @@ public class RecordingChannelStateWriter extends MockChannelStateWriter {
         lastFinishedCheckpointId = -1;
         addedInput.values().forEach(Buffer::recycleBuffer);
         addedInput.clear();
-        adedOutput.values().forEach(Buffer::recycleBuffer);
-        adedOutput.clear();
+        addedOutput.values().forEach(Buffer::recycleBuffer);
+        addedOutput.clear();
     }
 
     @Override
@@ -73,7 +73,7 @@ public class RecordingChannelStateWriter extends MockChannelStateWriter {
     public void addOutputData(
             long checkpointId, ResultSubpartitionInfo info, int startSeqNum, Buffer... data) {
         checkCheckpointId(checkpointId);
-        adedOutput.putAll(info, Arrays.asList(data));
+        addedOutput.putAll(info, Arrays.asList(data));
     }
 
     public long getLastStartedCheckpointId() {
@@ -89,6 +89,6 @@ public class RecordingChannelStateWriter extends MockChannelStateWriter {
     }
 
     public ListMultimap<ResultSubpartitionInfo, Buffer> getAddedOutput() {
-        return adedOutput;
+        return addedOutput;
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

- Fix the typo of RecordingChannelStateWriter class.


## Brief change log

- Fix the typo of RecordingChannelStateWriter class.


## Verifying this change

- This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
