### PR TITLE
[FLINK-29927][akka] Use singleton ExtensionId

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaUtils.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/AkkaUtils.java
@@ -518,7 +518,7 @@ class AkkaUtils {
      * @return {@link Address} of the given {@link ActorSystem}
      */
     public static Address getAddress(ActorSystem system) {
-        return new RemoteAddressExtension().apply(system).getAddress();
+        return RemoteAddressExtension.INSTANCE.apply(system).getAddress();
     }
 
     /**

--- a/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/RemoteAddressExtension.java
+++ b/flink-rpc/flink-rpc-akka/src/main/java/org/apache/flink/runtime/rpc/akka/RemoteAddressExtension.java
@@ -29,6 +29,10 @@ import akka.actor.Extension;
 public class RemoteAddressExtension
         extends AbstractExtensionId<RemoteAddressExtension.RemoteAddressExtensionImpl> {
 
+    public static final RemoteAddressExtension INSTANCE = new RemoteAddressExtension();
+
+    private RemoteAddressExtension() {}
+
     @Override
     public RemoteAddressExtensionImpl createExtension(ExtendedActorSystem system) {
         return new RemoteAddressExtensionImpl(system);


### PR DESCRIPTION
Fixes an issue where we're registering a new `ExtensionId` on every call to `RpcUtils#getAddress`, slowly increasing memory usage.

We now use a singleton instance of the `RemoteAddressExtension` to prevent this.
(ExtensionId is basically a factory for Extensions that also identifies extensions via object-identity.)