### PR TITLE
[FLINK-29929][table] Correct conversions from ResolvedSchema to TableSchema

### DIFF
--- a/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
+++ b/flink-table/flink-table-api-java/src/test/java/org/apache/flink/table/catalog/CatalogBaseTableResolutionTest.java
@@ -269,6 +269,31 @@ class CatalogBaseTableResolutionTest {
         return catalogManager;
     }
 
+    @Test
+    void testWatermarkOnTimestampEqualityWithConverted() {
+        TableSchema tableSchema =
+                TableSchema.builder()
+                        .field("ts", DataTypes.TIMESTAMP(3))
+                        .field(
+                                "f1",
+                                DataTypes.ROW(
+                                        DataTypes.FIELD("q1", DataTypes.STRING()),
+                                        DataTypes.FIELD("q2", DataTypes.TIMESTAMP_LTZ(3))))
+                        .watermark("ts", "ts - INTERVAL '5' SECOND", DataTypes.TIMESTAMP(3))
+                        .build();
+        ResolvedSchema resolvedSchema =
+                catalogManager()
+                        .resolveCatalogTable(
+                                CatalogTable.of(
+                                        tableSchema.toSchema(),
+                                        "",
+                                        Collections.emptyList(),
+                                        Collections.emptyMap()))
+                        .getResolvedSchema();
+        TableSchema result = TableSchema.fromResolvedSchema(resolvedSchema);
+        assertThat(result.toString()).isEqualTo(tableSchema.toString());
+    }
+
     private static <T extends CatalogBaseTable> T resolveCatalogBaseTable(
             Class<T> expectedClass, CatalogBaseTable table) {
         final CatalogManager catalogManager = catalogManager();


### PR DESCRIPTION
## What is the purpose of the change

Previously, conversions from ResolvedSchema to TableSchema generate wrong Timestamp DataType.

## Brief change log

* remove time attribute addition.

## Verifying this change

This change added tests and can be verified as follows:

CatalogBaseTableResolutionTest#testWatermarkOnTimestampEqualityWithConverted

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no