### PR TITLE
[hotfix] fix syntax errors 

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -468,7 +468,7 @@ public class StreamGraph implements Pipeline {
                 outSerializer);
 
         if (taskOperatorFactory.isOutputTypeConfigurable()) {
-            // sets the output type which must be know at StreamGraph creation time
+            // sets the output type which must be known at StreamGraph creation time
             taskOperatorFactory.setOutputType(outTypeInfo, executionConfig);
         }
 
@@ -499,7 +499,7 @@ public class StreamGraph implements Pipeline {
         setSerializers(vertexID, inTypeInfos, createSerializer(outTypeInfo));
 
         if (operatorFactory.isOutputTypeConfigurable()) {
-            // sets the output type which must be know at StreamGraph creation time
+            // sets the output type which must be known at StreamGraph creation time
             operatorFactory.setOutputType(outTypeInfo, executionConfig);
         }
 


### PR DESCRIPTION
## What is the purpose of the change

Fix syntax errors in  org.apache.flink.streaming.api.graph.StreamGraph.
The past participle is required after "must be". 



## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
