### PR TITLE
[FLINK-29938][Connectors/Base] Add open() Method to AsyncSink ElementConverter

### DIFF
--- a/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkElementConverter.java
+++ b/flink-connectors/flink-connector-aws-kinesis-firehose/src/main/java/org/apache/flink/connector/firehose/sink/KinesisFirehoseSinkElementConverter.java
@@ -19,6 +19,7 @@ package org.apache.flink.connector.firehose.sink;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.metrics.MetricGroup;
@@ -39,7 +40,8 @@ import software.amazon.awssdk.services.firehose.model.Record;
 @Internal
 public class KinesisFirehoseSinkElementConverter<InputT>
         implements ElementConverter<InputT, Record> {
-    private boolean schemaOpened = false;
+
+    private static final long serialVersionUID = 1L;
 
     /** A serialization schema to specify how the input element should be serialized. */
     private final SerializationSchema<InputT> serializationSchema;
@@ -49,34 +51,31 @@ public class KinesisFirehoseSinkElementConverter<InputT>
     }
 
     @Override
+    public void open(Sink.InitContext context) {
+        try {
+            serializationSchema.open(
+                    new SerializationSchema.InitializationContext() {
+                        @Override
+                        public MetricGroup getMetricGroup() {
+                            return new UnregisteredMetricsGroup();
+                        }
+
+                        @Override
+                        public UserCodeClassLoader getUserCodeClassLoader() {
+                            return SimpleUserCodeClassLoader.create(
+                                    KinesisFirehoseSinkElementConverter.class.getClassLoader());
+                        }
+                    });
+        } catch (Exception e) {
+            throw new FlinkRuntimeException("Failed to initialize serialization schema.", e);
+        }
+    }
+
+    @Override
     public Record apply(InputT element, SinkWriter.Context context) {
-        checkOpened();
         return Record.builder()
                 .data(SdkBytes.fromByteArray(serializationSchema.serialize(element)))
                 .build();
-    }
-
-    private void checkOpened() {
-        if (!schemaOpened) {
-            try {
-                serializationSchema.open(
-                        new SerializationSchema.InitializationContext() {
-                            @Override
-                            public MetricGroup getMetricGroup() {
-                                return new UnregisteredMetricsGroup();
-                            }
-
-                            @Override
-                            public UserCodeClassLoader getUserCodeClassLoader() {
-                                return SimpleUserCodeClassLoader.create(
-                                        KinesisFirehoseSinkElementConverter.class.getClassLoader());
-                            }
-                        });
-                schemaOpened = true;
-            } catch (Exception e) {
-                throw new FlinkRuntimeException("Failed to initialize serialization schema.", e);
-            }
-        }
     }
 
     public static <InputT> Builder<InputT> builder() {

--- a/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkElementConverterTest.java
+++ b/flink-connectors/flink-connector-aws-kinesis-streams/src/test/java/org/apache/flink/connector/kinesis/sink/KinesisStreamsSinkElementConverterTest.java
@@ -15,51 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.flink.connector.firehose.sink;
+package org.apache.flink.connector.kinesis.sink;
 
 import org.apache.flink.api.common.serialization.SerializationSchema;
-import org.apache.flink.api.common.serialization.SimpleStringSchema;
-import org.apache.flink.connector.base.sink.writer.ElementConverter;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import software.amazon.awssdk.core.SdkBytes;
-import software.amazon.awssdk.services.firehose.model.Record;
+
+import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Covers construction and sanity checking of {@link KinesisFirehoseSinkElementConverter}. */
-class KinesisFirehoseSinkElementConverterTest {
-
-    @Test
-    void elementConverterWillComplainASerializationSchemaIsNotSetIfBuildIsCalledWithoutIt() {
-        Assertions.assertThatExceptionOfType(NullPointerException.class)
-                .isThrownBy(() -> KinesisFirehoseSinkElementConverter.<String>builder().build())
-                .withMessageContaining(
-                        "No SerializationSchema was supplied to the KinesisFirehoseSink builder.");
-    }
-
-    @Test
-    void elementConverterUsesProvidedSchemaToSerializeRecord() {
-        ElementConverter<String, Record> elementConverter =
-                KinesisFirehoseSinkElementConverter.<String>builder()
-                        .setSerializationSchema(new SimpleStringSchema())
-                        .build();
-
-        String testString = "{many hands make light work;";
-
-        Record serializedRecord = elementConverter.apply(testString, null);
-        byte[] serializedString = (new SimpleStringSchema()).serialize(testString);
-        assertThat(serializedRecord.data()).isEqualTo(SdkBytes.fromByteArray(serializedString));
-    }
+class KinesisStreamsSinkElementConverterTest {
 
     @Test
     void elementConverterOpenInvokesSerializationSchemaOpen() {
         OpenTestingSerializationSchema serializationSchema = new OpenTestingSerializationSchema();
 
-        KinesisFirehoseSinkElementConverter.<String>builder()
+        KinesisStreamsSinkElementConverter.<String>builder()
                 .setSerializationSchema(serializationSchema)
+                .setPartitionKeyGenerator(record -> UUID.randomUUID().toString())
                 .build()
                 .open(null);
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/AsyncSinkWriter.java
@@ -303,6 +303,7 @@ public abstract class AsyncSinkWriter<InputT, RequestEntryT extends Serializable
                                 },
                                 "A fatal exception occurred in the sink that cannot be recovered from or should not be retried.");
 
+        elementConverter.open(context);
         initializeState(states);
     }
 

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/ElementConverter.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/sink/writer/ElementConverter.java
@@ -18,6 +18,7 @@
 package org.apache.flink.connector.base.sink.writer;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 
 import java.io.Serializable;
@@ -33,4 +34,8 @@ import java.io.Serializable;
 @PublicEvolving
 public interface ElementConverter<InputT, RequestEntryT> extends Serializable {
     RequestEntryT apply(InputT element, SinkWriter.Context context);
+
+    default void open(Sink.InitContext context) {
+        // No-op default implementation
+    }
 }

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestElementConverter.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/sink/writer/TestElementConverter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.sink.writer;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+
+/** A test implementation of {@link ElementConverter} used to verify the open() method. */
+public class TestElementConverter implements ElementConverter<String, Integer> {
+
+    private static final long serialVersionUID = 1L;
+    private int openCallCount;
+
+    @Override
+    public void open(Sink.InitContext context) {
+        openCallCount++;
+    }
+
+    @Override
+    public Integer apply(String element, SinkWriter.Context context) {
+        return openCallCount;
+    }
+
+    public int getOpenCallCount() {
+        return openCallCount;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add an `open()` method to the `ElementConverter` used with `AsyncSink`. This gives element converters a hook to use for construction on TM without serializing the local fields

## Brief change log

- Add `open()` to `ElementConverter`
- Invoke `open()` from `AsyncSinkWriter` constructor 
- Update Kinesis Data Streams/Firehose element converter to use the new mechanism
- Added unit test

## Verifying this change

This change added tests and can be verified as follows:

- Added test to `AsyncSinkWriterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
