### PR TITLE
[FLINK-29957][docs] Rework connector docs integration

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -112,7 +112,7 @@ pygmentsUseClasses = true
 
 [module]
 [[module.imports]]
-  path = 'github.com/apache/flink-connector-elasticsearch/docs'
+  path = 'connectors'
 [[module.imports.mounts]]
   source = 'content'
   target = 'content'

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -44,16 +44,16 @@ function integrate_connector_docs {
   rsync -a flink-connector-${connector}/docs/content* "${theme_dir}/"
 }
 
-if [[ ! "$currentBranch" =~ ^release- ]] || [[ -z "$currentBranch" ]]; then
-  rm -rf themes/connectors/*
-  rm -rf tmp
-  mkdir tmp
-  cd tmp
+# Integrate the connector documentation
 
-  # Since there's no documentation yet available for a release branch,
-  # we only get the documentation from the main branch
-  integrate_connector_docs elasticsearch main
+rm -rf themes/connectors/*
+rm -rf tmp
+mkdir tmp
+cd tmp
 
-  cd ..
-  rm -rf tmp
-fi
+# Since there's no documentation yet available for a release branch,
+# we only get the documentation from the main branch
+integrate_connector_docs elasticsearch main
+
+cd ..
+rm -rf tmp

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -50,6 +50,8 @@ if [[ ! "$currentBranch" =~ ^release- ]] || [[ -z "$currentBranch" ]]; then
   mkdir tmp
   cd tmp
 
+  # Since there's no documentation yet available for a release branch,
+  # we only get the documentation from the main branch
   integrate_connector_docs elasticsearch main
 
   cd ..

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -35,9 +35,23 @@ echo "Created temporary file" $goModFileLocation/go.mod
 # Make Hugo retrieve modules which are used for externally hosted documentation
 currentBranch=$(git rev-parse --abbrev-ref HEAD)
 
+function integrate_connector_docs {
+  connector=$1
+  ref=$2
+  git clone --single-branch --branch ${ref} https://github.com/apache/flink-connector-${connector}
+  theme_dir="../themes/connectors"
+  mkdir -p "${theme_dir}"
+  rsync -a flink-connector-${connector}/docs/content* "${theme_dir}/"
+}
+
 if [[ ! "$currentBranch" =~ ^release- ]] || [[ -z "$currentBranch" ]]; then
-  # If the current branch is master or not provided, get the documentation from the main branch
-  $(command -v hugo) mod get -u github.com/apache/flink-connector-elasticsearch/docs@main
-  # Since there's no documentation yet available for a release branch,
-  # we only get the documentation from the main branch
+  rm -rf themes/connectors/*
+  rm -rf tmp
+  mkdir tmp
+  cd tmp
+
+  integrate_connector_docs elasticsearch main
+
+  cd ..
+  rm -rf tmp
 fi

--- a/docs/themes/.gitignore
+++ b/docs/themes/.gitignore
@@ -1,0 +1,1 @@
+connectors/


### PR DESCRIPTION
Rework the connector integration to not rely on go modules.
Instead we clone the relevant repos at the right branch/tag and merge the content directories into a pseudo hugo module that we put into the /themes directory.

On the connector side we can then remove the go.mod and config.toml.