### PR TITLE
[FLINK-12130][clients] : Allow dynamic loading of kerberos keytab from client end 

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/cli/CommandLineOptions.java
@@ -26,15 +26,19 @@ import static org.apache.flink.client.cli.CliFrontendParser.HELP_OPTION;
  * Base class for all options parsed from the command line. Contains options for printing help and
  * the JobManager address.
  */
-public abstract class CommandLineOptions {
+public class CommandLineOptions {
 
-    private final boolean printHelp;
+    private final CommandLine commandLine;
 
     protected CommandLineOptions(CommandLine line) {
-        this.printHelp = line.hasOption(HELP_OPTION.getOpt());
+        this.commandLine = line;
+    }
+
+    public CommandLine getCommandLine() {
+        return commandLine;
     }
 
     public boolean isPrintHelp() {
-        return printHelp;
+        return commandLine.hasOption(HELP_OPTION.getOpt());
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendPackageProgramTest.java
@@ -30,10 +30,11 @@ import org.apache.flink.optimizer.costs.DefaultCostEstimator;
 import org.apache.flink.runtime.jobgraph.SavepointRestoreSettings;
 
 import org.apache.commons.cli.CommandLine;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.FileNotFoundException;
 import java.net.URL;
@@ -43,69 +44,78 @@ import static org.apache.flink.client.cli.CliFrontendTestUtils.TEST_JAR_CLASSLOA
 import static org.apache.flink.client.cli.CliFrontendTestUtils.TEST_JAR_MAIN_CLASS;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getNonJarFilePath;
 import static org.apache.flink.client.cli.CliFrontendTestUtils.getTestJarPath;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /** Tests for the RUN command with {@link PackagedProgram PackagedPrograms}. */
-class CliFrontendPackageProgramTest {
+public class CliFrontendPackageProgramTest extends CliFrontendTestBase {
 
     private CliFrontend frontend;
 
-    @BeforeAll
-    static void init() {
+    @BeforeClass
+    public static void init() {
         CliFrontendTestUtils.pipeSystemOutToNull();
     }
 
-    @AfterAll
-    static void shutdown() {
+    @AfterClass
+    public static void shutdown() {
         CliFrontendTestUtils.restoreSystemOut();
     }
 
-    @BeforeEach
-    void setup() {
+    @Before
+    public void setup() throws Exception {
         final Configuration configuration = new Configuration();
         frontend = new CliFrontend(configuration, Collections.singletonList(new DefaultCLI()));
     }
 
     @Test
-    void testNonExistingJarFile() {
+    public void testNonExistingJarFile() throws Exception {
         ProgramOptions programOptions = mock(ProgramOptions.class);
         when(programOptions.getJarFilePath()).thenReturn("/some/none/existing/path");
 
-        assertThatThrownBy(() -> frontend.buildProgram(programOptions))
-                .isInstanceOf(FileNotFoundException.class);
+        try {
+            frontend.buildProgram(programOptions);
+            fail("should throw an exception");
+        } catch (FileNotFoundException e) {
+            // that's what we want
+        }
     }
 
     @Test
-    void testFileNotJarFile() {
+    public void testFileNotJarFile() throws Exception {
         ProgramOptions programOptions = mock(ProgramOptions.class);
         when(programOptions.getJarFilePath()).thenReturn(getNonJarFilePath());
         when(programOptions.getProgramArgs()).thenReturn(new String[0]);
         when(programOptions.getSavepointRestoreSettings())
                 .thenReturn(SavepointRestoreSettings.none());
 
-        assertThatThrownBy(() -> frontend.buildProgram(programOptions))
-                .isInstanceOf(ProgramInvocationException.class);
+        try {
+            frontend.buildProgram(programOptions);
+            fail("should throw an exception");
+        } catch (ProgramInvocationException e) {
+            // that's what we want
+        }
     }
 
     @Test
-    void testVariantWithExplicitJarAndArgumentsOption() throws Exception {
+    public void testVariantWithExplicitJarAndArgumentsOption() throws Exception {
         String[] arguments = {
-            "--classpath",
-            "file:///tmp/foo",
-            "--classpath",
-            "file:///tmp/bar",
-            "-j",
-            getTestJarPath(),
-            "-a",
-            "--debug",
-            "true",
-            "arg1",
-            "arg2"
+                "--classpath",
+                "file:///tmp/foo",
+                "--classpath",
+                "file:///tmp/bar",
+                "-j",
+                getTestJarPath(),
+                "-a",
+                "--debug",
+                "true",
+                "arg1",
+                "arg2"
         };
         URL[] classpath = new URL[] {new URL("file:///tmp/foo"), new URL("file:///tmp/bar")};
         String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
@@ -114,29 +124,29 @@ class CliFrontendPackageProgramTest {
                 CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
         ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
-        assertThat(programOptions.getJarFilePath()).isEqualTo(getTestJarPath());
-        assertThat(programOptions.getClasspaths().toArray()).isEqualTo(classpath);
-        assertThat(programOptions.getProgramArgs()).isEqualTo(reducedArguments);
+        assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+        assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
+        assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
         PackagedProgram prog = frontend.buildProgram(programOptions);
 
-        assertThat(prog.getArguments()).isEqualTo(reducedArguments);
-        assertThat(prog.getMainClassName()).isEqualTo(TEST_JAR_MAIN_CLASS);
+        Assert.assertArrayEquals(reducedArguments, prog.getArguments());
+        Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
     }
 
     @Test
-    void testVariantWithExplicitJarAndNoArgumentsOption() throws Exception {
+    public void testVariantWithExplicitJarAndNoArgumentsOption() throws Exception {
         String[] arguments = {
-            "--classpath",
-            "file:///tmp/foo",
-            "--classpath",
-            "file:///tmp/bar",
-            "-j",
-            getTestJarPath(),
-            "--debug",
-            "true",
-            "arg1",
-            "arg2"
+                "--classpath",
+                "file:///tmp/foo",
+                "--classpath",
+                "file:///tmp/bar",
+                "-j",
+                getTestJarPath(),
+                "--debug",
+                "true",
+                "arg1",
+                "arg2"
         };
         URL[] classpath = new URL[] {new URL("file:///tmp/foo"), new URL("file:///tmp/bar")};
         String[] reducedArguments = new String[] {"--debug", "true", "arg1", "arg2"};
@@ -145,28 +155,28 @@ class CliFrontendPackageProgramTest {
                 CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
         ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
-        assertThat(programOptions.getJarFilePath()).isEqualTo(getTestJarPath());
-        assertThat(programOptions.getClasspaths().toArray()).isEqualTo(classpath);
-        assertThat(programOptions.getProgramArgs()).isEqualTo(reducedArguments);
+        assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+        assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
+        assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
         PackagedProgram prog = frontend.buildProgram(programOptions);
 
-        assertThat(prog.getArguments()).isEqualTo(reducedArguments);
-        assertThat(prog.getMainClassName()).isEqualTo(TEST_JAR_MAIN_CLASS);
+        Assert.assertArrayEquals(reducedArguments, prog.getArguments());
+        Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
     }
 
     @Test
-    void testValidVariantWithNoJarAndNoArgumentsOption() throws Exception {
+    public void testValidVariantWithNoJarAndNoArgumentsOption() throws Exception {
         String[] arguments = {
-            "--classpath",
-            "file:///tmp/foo",
-            "--classpath",
-            "file:///tmp/bar",
-            getTestJarPath(),
-            "--debug",
-            "true",
-            "arg1",
-            "arg2"
+                "--classpath",
+                "file:///tmp/foo",
+                "--classpath",
+                "file:///tmp/bar",
+                getTestJarPath(),
+                "--debug",
+                "true",
+                "arg1",
+                "arg2"
         };
         URL[] classpath = new URL[] {new URL("file:///tmp/foo"), new URL("file:///tmp/bar")};
         String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
@@ -175,33 +185,33 @@ class CliFrontendPackageProgramTest {
                 CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
         ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
-        assertThat(programOptions.getJarFilePath()).isEqualTo(getTestJarPath());
-        assertThat(programOptions.getClasspaths().toArray()).isEqualTo(classpath);
-        assertThat(programOptions.getProgramArgs()).isEqualTo(reducedArguments);
+        assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+        assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
+        assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
         PackagedProgram prog = frontend.buildProgram(programOptions);
 
-        assertThat(prog.getArguments()).isEqualTo(reducedArguments);
-        assertThat(prog.getMainClassName()).isEqualTo(TEST_JAR_MAIN_CLASS);
+        Assert.assertArrayEquals(reducedArguments, prog.getArguments());
+        Assert.assertEquals(TEST_JAR_MAIN_CLASS, prog.getMainClassName());
+    }
+
+    @Test(expected = CliArgsException.class)
+    public void testNoJarNoArgumentsAtAll() throws Exception {
+        testAction(frontend, frontend.new ActionRun(), new String[0]);
     }
 
     @Test
-    void testNoJarNoArgumentsAtAll() {
-        assertThatThrownBy(() -> frontend.run(new String[0])).isInstanceOf(CliArgsException.class);
-    }
-
-    @Test
-    void testNonExistingFileWithArguments() throws Exception {
+    public void testNonExistingFileWithArguments() throws Exception {
         String[] arguments = {
-            "--classpath",
-            "file:///tmp/foo",
-            "--classpath",
-            "file:///tmp/bar",
-            "/some/none/existing/path",
-            "--debug",
-            "true",
-            "arg1",
-            "arg2"
+                "--classpath",
+                "file:///tmp/foo",
+                "--classpath",
+                "file:///tmp/bar",
+                "/some/none/existing/path",
+                "--debug",
+                "true",
+                "arg1",
+                "arg2"
         };
         URL[] classpath = new URL[] {new URL("file:///tmp/foo"), new URL("file:///tmp/bar")};
         String[] reducedArguments = {"--debug", "true", "arg1", "arg2"};
@@ -210,24 +220,28 @@ class CliFrontendPackageProgramTest {
                 CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
         ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
-        assertThat(programOptions.getJarFilePath()).isEqualTo(arguments[4]);
-        assertThat(programOptions.getClasspaths().toArray()).isEqualTo(classpath);
-        assertThat(programOptions.getProgramArgs()).isEqualTo(reducedArguments);
+        assertEquals(arguments[4], programOptions.getJarFilePath());
+        assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
+        assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
-        assertThatThrownBy(() -> frontend.buildProgram(programOptions))
-                .isInstanceOf(FileNotFoundException.class);
+        try {
+            frontend.buildProgram(programOptions);
+            fail("Should fail with an exception");
+        } catch (FileNotFoundException e) {
+            // that's what we want
+        }
     }
 
     @Test
-    void testNonExistingFileWithoutArguments() throws Exception {
+    public void testNonExistingFileWithoutArguments() throws Exception {
         String[] arguments = {"/some/none/existing/path"};
 
         CommandLine commandLine =
                 CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
         ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
-        assertThat(programOptions.getJarFilePath()).isEqualTo(arguments[0]);
-        assertThat(programOptions.getProgramArgs()).isEqualTo(new String[0]);
+        assertEquals(arguments[0], programOptions.getJarFilePath());
+        assertArrayEquals(new String[0], programOptions.getProgramArgs());
 
         try {
             frontend.buildProgram(programOptions);
@@ -271,23 +285,23 @@ class CliFrontendPackageProgramTest {
      * </ul>
      */
     @Test
-    void testPlanWithExternalClass() throws Exception {
+    public void testPlanWithExternalClass() throws Exception {
         final boolean[] callme = {
-            false
+                false
         }; // create a final object reference, to be able to change its val later
 
         try {
             String[] arguments = {
-                "--classpath",
-                "file:///tmp/foo",
-                "--classpath",
-                "file:///tmp/bar",
-                "-c",
-                TEST_JAR_CLASSLOADERTEST_CLASS,
-                getTestJarPath(),
-                "true",
-                "arg1",
-                "arg2"
+                    "--classpath",
+                    "file:///tmp/foo",
+                    "--classpath",
+                    "file:///tmp/bar",
+                    "-c",
+                    TEST_JAR_CLASSLOADERTEST_CLASS,
+                    getTestJarPath(),
+                    "true",
+                    "arg1",
+                    "arg2"
             };
             URL[] classpath = new URL[] {new URL("file:///tmp/foo"), new URL("file:///tmp/bar")};
             String[] reducedArguments = {"true", "arg1", "arg2"};
@@ -296,11 +310,10 @@ class CliFrontendPackageProgramTest {
                     CliFrontendParser.parse(CliFrontendParser.RUN_OPTIONS, arguments, true);
             ProgramOptions programOptions = ProgramOptions.create(commandLine);
 
-            assertThat(programOptions.getJarFilePath()).isEqualTo(getTestJarPath());
-            assertThat(programOptions.getClasspaths().toArray()).isEqualTo(classpath);
-            assertThat(programOptions.getEntryPointClassName())
-                    .isEqualTo(TEST_JAR_CLASSLOADERTEST_CLASS);
-            assertThat(programOptions.getProgramArgs()).isEqualTo(reducedArguments);
+            assertEquals(getTestJarPath(), programOptions.getJarFilePath());
+            assertArrayEquals(classpath, programOptions.getClasspaths().toArray());
+            assertEquals(TEST_JAR_CLASSLOADERTEST_CLASS, programOptions.getEntryPointClassName());
+            assertArrayEquals(reducedArguments, programOptions.getProgramArgs());
 
             PackagedProgram prog = spy(frontend.buildProgram(programOptions));
 
@@ -318,25 +331,22 @@ class CliFrontendPackageProgramTest {
                     };
             when(prog.getUserCodeClassLoader()).thenReturn(testClassLoader);
 
-            assertThat(prog.getMainClassName()).isEqualTo(TEST_JAR_CLASSLOADERTEST_CLASS);
-            assertThat(prog.getArguments()).isEqualTo(reducedArguments);
+            assertEquals(TEST_JAR_CLASSLOADERTEST_CLASS, prog.getMainClassName());
+            assertArrayEquals(reducedArguments, prog.getArguments());
 
             Configuration c = new Configuration();
             Optimizer compiler = new Optimizer(new DataStatistics(), new DefaultCostEstimator(), c);
 
             // we expect this to fail with a "ClassNotFoundException"
             Pipeline pipeline = PackagedProgramUtils.getPipelineFromProgram(prog, c, 666, true);
-            FlinkPipelineTranslationUtil.translateToJSONExecutionPlan(
-                    prog.getUserCodeClassLoader(), pipeline);
+            FlinkPipelineTranslationUtil.translateToJSONExecutionPlan(pipeline);
             fail("Should have failed with a ClassNotFoundException");
         } catch (ProgramInvocationException e) {
             if (!(e.getCause() instanceof ClassNotFoundException)) {
                 e.printStackTrace();
                 fail("Program didn't throw ClassNotFoundException");
             }
-            if (!callme[0]) {
-                fail("Classloader was not called");
-            }
+            assertTrue("Classloader was not called", callme[0]);
         }
     }
 }

--- a/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/cli/CliFrontendTestBase.java
@@ -31,4 +31,18 @@ public abstract class CliFrontendTestBase {
     static AbstractCustomCommandLine getCli() {
         return new DefaultCLI();
     }
+
+    static void testAction(
+            CliFrontend cliFrontend, CliFrontend.CommandAction commandAction, String[] parameters)
+            throws Exception {
+        final CommandLineOptions commandLineOptions = commandAction.parse(parameters);
+
+        final CustomCommandLine activeCommandLine =
+                cliFrontend.validateAndGetActiveCommandLine(commandLineOptions.getCommandLine());
+
+        final Configuration effectiveConfiguration =
+                commandAction.getConfiguration(commandLineOptions, activeCommandLine);
+
+        commandAction.runAction(commandLineOptions, effectiveConfiguration);
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change
This change allows users to dynamically pass kerberos keytab and principal name when submitting a flink job. 

Ex: flink run -m yarn-cluster -yD security.kerberos.login.keytab=/path/to/kerb.keytab -yD security.kerberos.login.principal=kerbprincipalname /path/to/my.jar


## Brief change log
- Continuation to this PR: https://github.com/apache/flink/pull/8166 by [jiasheng55](https://github.com/jiasheng55)
- Make applyCommandLineOptionsToConfiguration(CommandLine commandLine) a method of interface
- CustomCommandLine and change it to applyCommandLineOptionsToConfiguration(Configuration configuration, CommandLine commandLine), as suggested by @aljoscha
- Make org.apache.flink.client.cli.CliFrontend#parseParameters return parsed CommandLine
- Apply command line options to configuration before installing security modules


## Verifying this change

This change is already covered by existing tests, such as org.apache.flink.client.cli.CliFrontend...*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) - no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) - no
  - The serializers: (yes / no / don't know) - no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) - no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) - Yes, deployment
  - The S3 file system connector: (yes / no / don't know) - no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) - no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) - n/a
