### PR TITLE
[FLINK-29962] Exclude jamon 2.3.1 from dependencies

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -696,6 +696,10 @@ under the License.
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
+					<groupId>org.jamon</groupId>
+					<artifactId>jamon-runtime</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>org.apache.hive</groupId>
 					<artifactId>hive-exec</artifactId>
 				</exclusion>
@@ -782,6 +786,10 @@ under the License.
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
+					<groupId>org.jamon</groupId>
+					<artifactId>jamon-runtime</artifactId>
+				</exclusion>
+				<exclusion>
 					<groupId>org.apache.hive</groupId>
 					<artifactId>hive-exec</artifactId>
 				</exclusion>
@@ -834,6 +842,10 @@ under the License.
 			<version>${hive.version}</version>
 			<scope>test</scope>
 			<exclusions>
+				<exclusion>
+					<groupId>org.jamon</groupId>
+					<artifactId>jamon-runtime</artifactId>
+				</exclusion>
 				<exclusion>
 					<groupId>jdk.tools</groupId>
 					<artifactId>jdk.tools</artifactId>
@@ -944,6 +956,10 @@ under the License.
 			<version>${hive.version}</version>
 			<scope>test</scope>
 			<exclusions>
+				<exclusion>
+					<groupId>org.jamon</groupId>
+					<artifactId>jamon-runtime</artifactId>
+				</exclusion>
 				<exclusion>
 					<groupId>log4j</groupId>
 					<artifactId>log4j</artifactId>

--- a/flink-end-to-end-tests/flink-sql-gateway-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-gateway-test/pom.xml
@@ -63,6 +63,10 @@ under the License.
             <version>${hive.version}</version>
             <scope>test</scope>
             <exclusions>
+				<exclusion>
+					<groupId>org.jamon</groupId>
+					<artifactId>jamon-runtime</artifactId>
+				</exclusion>
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes a transitive dependency on `jamon-runtime:2.3.1`, which has a malformed pom.xml file. Flink already has a transitive dependency on `jamon-runtime:2.4.1`, which has a valid pom, so we just wind up using that one instead.

This fixes the build for me, since my Maven mirror rejects jamon-runtime:2.3.1 (due to the malformed pom). Note that this transitive dependency is via Hive, and we already exclude a bunch of other problematic transitive dependencies from the hive dependencies.

## Brief change log

  - exclude jamon-runtime from the direct dependencies that transitively import 2.3.1
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

- Run `./mvnw dependency:tree -Dincludes=org.jamon`
- Examine the results to verify that we only transitively depend on 2.4.1

Since I can't build Flink against my Maven mirror (due to the malformed pom), a secondary verification is just that I can build it now. But that's not repeatable unless you also have the same problem.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): it's hard to say. Since we already had transitive dependencies on both 2.3.1 and 2.4.1, Maven (or the classloader) would wind up picking one of them at runtime according to a complex set of rules that are different for different people. It's possible that some Flink processes were using 2.3.1 before, and now they will use 2.4.1. On the other hand, it was never well specified.
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable