### PR TITLE
[FLINK-29969][checkpoint] Show the root cause when exceeded checkpoint tolerable failure threshold

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointFailureManager.java
@@ -203,8 +203,13 @@ public class CheckpointFailureManager {
             checkFailureCounter(exception, checkpointId);
             if (continuousFailureCounter.get() > tolerableCpFailureNumber) {
                 clearCount();
-                errorHandler.accept(
-                        new FlinkRuntimeException(EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE));
+                String exceptionMessage =
+                        String.format(
+                                "%s The latest checkpoint failed due to %s, view the Checkpoint History tab"
+                                        + " or the Job Manager log to find out why continuous checkpoints failed.",
+                                EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE,
+                                exception.getCheckpointFailureReason().message());
+                errorHandler.accept(new FlinkRuntimeException(exceptionMessage));
             }
         }
     }

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/CheckpointFailureManagerITCase.java
@@ -264,7 +264,10 @@ public class CheckpointFailureManagerITCase extends TestLogger {
 
     private boolean isCheckpointFailure(JobExecutionException jobException) {
         return ExceptionUtils.findThrowable(jobException, FlinkRuntimeException.class)
-                .filter(ex -> ex.getMessage().equals(EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE))
+                .filter(
+                        ex ->
+                                ex.getMessage()
+                                        .startsWith(EXCEEDED_CHECKPOINT_TOLERABLE_FAILURE_MESSAGE))
                 .isPresent();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add the root cause when exceeded checkpoint tolerable failure threshold, it's helpful during troubleshooting.

After change:

<img width="1297" alt="image" src="https://user-images.githubusercontent.com/38427477/200990319-1f1211ff-b46a-4d0e-9e65-0fd5aca50752.png">


## Brief change log

Add the root cause when exceeded checkpoint tolerable failure threshold.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
