### PR TITLE
[FLINK-29973][docs] connector_artifact appends Minor version

### DIFF
--- a/docs/layouts/shortcodes/connector_artifact.html
+++ b/docs/layouts/shortcodes/connector_artifact.html
@@ -31,7 +31,7 @@ under the License.
 <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
     <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
     <span class="nt">&ltartifactId&gt</span>{{- $artifactId -}}<span class="nt">&lt/artifactId&gt</span>
-    <span class="nt">&ltversion&gt</span>{{- $version -}}<span class="nt">&lt/version&gt</span>
+    <span class="nt">&ltversion&gt</span>{{- $version -}}-{{- site.Params.VersionTitle -}}<span class="nt">&lt/version&gt</span>
 <span class="nt">&lt/dependency&gt</span></code></pre></div>
 <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
   Copied to clipboard!


### PR DESCRIPTION

Flink side needs to inject the Flink minor version since branches are not Flink version-specific.
This does mean that the master branch docs references dependencies that don't exist, but I can live with that. It's snapshot docs after all.