### PR TITLE
[FLINK-29975] Let hybrid full spilling strategy supports partition reuse

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/failover/flip1/RestartPipelinedRegionFailoverStrategy.java
@@ -293,8 +293,8 @@ public class RestartPipelinedRegionFailoverStrategy implements FailoverStrategy 
                     && resultPartitionAvailabilityChecker.isAvailable(resultPartitionID)
                     // If the result partition is available in the partition tracker and does not
                     // fail, it will be available if it can be re-consumption, and it may also be
-                    // available for PIPELINED_APPROXIMATE and HYBRID_FULL type.
-                    && isResultPartitionCanBeConsumedRepeatedly(resultPartitionID);
+                    // available for PIPELINED_APPROXIMATE type.
+                    && isResultPartitionIsReConsumableOrPipelinedApproximate(resultPartitionID);
         }
 
         public void markResultPartitionFailed(IntermediateResultPartitionID resultPartitionID) {
@@ -306,14 +306,12 @@ public class RestartPipelinedRegionFailoverStrategy implements FailoverStrategy 
             failedPartitions.remove(resultPartitionID);
         }
 
-        private boolean isResultPartitionCanBeConsumedRepeatedly(
+        private boolean isResultPartitionIsReConsumableOrPipelinedApproximate(
                 IntermediateResultPartitionID resultPartitionID) {
             ResultPartitionType resultPartitionType =
                     resultPartitionTypeRetriever.apply(resultPartitionID);
             return resultPartitionType.isReconsumable()
-                    || resultPartitionType == ResultPartitionType.PIPELINED_APPROXIMATE
-                    // TODO support re-consumable for HYBRID_FULL resultPartitionType.
-                    || resultPartitionType == ResultPartitionType.HYBRID_FULL;
+                    || resultPartitionType == ResultPartitionType.PIPELINED_APPROXIMATE;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -91,16 +91,14 @@ public enum ResultPartitionType {
      *
      * <p>Hybrid partitions can be consumed any time, whether fully produced or not.
      *
-     * <p>HYBRID_FULL partitions can be consumed repeatedly, but it does not support concurrent
-     * consumption. So re-consumable is false, but double calculation can be avoided during
+     * <p>HYBRID_FULL partitions is re-consumable, so double calculation can be avoided during
      * failover.
      */
-    // TODO support re-consumable for HYBRID_FULL resultPartitionType.
-    HYBRID_FULL(false, false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER),
+    HYBRID_FULL(true, false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER),
 
     /**
-     * HYBRID_SELECTIVE partitions are similar to {@link #HYBRID_FULL} partitions, but it cannot be
-     * consumed repeatedly.
+     * HYBRID_SELECTIVE partitions are similar to {@link #HYBRID_FULL} partitions, but it is not
+     * re-consumable.
      */
     HYBRID_SELECTIVE(
             false, false, false, ConsumingConstraint.CAN_BE_PIPELINED, ReleaseBy.SCHEDULER);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/StreamExchangeMode.java
@@ -39,14 +39,14 @@ public enum StreamExchangeMode {
     /**
      * The consumer can start consuming data anytime as long as the producer has started producing.
      *
-     * <p>This exchange mode can be consumed repeatedly.
+     * <p>This exchange mode is re-consumable.
      */
     HYBRID_FULL,
 
     /**
      * The consumer can start consuming data anytime as long as the producer has started producing.
      *
-     * <p>This exchange mode can not be consumed repeatedly.
+     * <p>This exchange mode is not re-consumable.
      */
     HYBRID_SELECTIVE,
 


### PR DESCRIPTION
## What is the purpose of the change

*Partition reuse is a very useful optimization in some topologies. In essence, multiple downstream tasks consume the same subpartition's data. Therefore, hybrid shuffle should also enjoy the benefits it brings. After [FLINK-28889](https://issues.apache.org/jira/browse/FLINK-28889), we are finally able to achieve repeated consumption at the subpartition level for hybrid full spilling strategy, so let's make it better.*

This reverts commit f0a6c0cbd8313de8146c9c2610bb3db98bacaea0.

## Brief change log

  - *Revert "[FLINK-29034] HYBRID_FULL result partition type is not yet reConsumable"*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
