### PR TITLE
[hotfix] [docs] fix link URL to DataStream operators

### DIFF
--- a/docs/content/docs/try-flink/local_installation.md
+++ b/docs/content/docs/try-flink/local_installation.md
@@ -141,7 +141,7 @@ You can view the data flow plan for the execution:
 
 Here for the job execution, Flink has two operators. The ﬁrst is the source operator which reads data from the
 collection source. The second operator is the transformation operator which aggregates counts of words. Learn
-more about [DataStream operators]({{< ref "docs/dev/datastream/operators" >}}).
+more about [DataStream operators]({{< ref "docs/dev/datastream/operators/overview" >}}).
 
 You can also look at the timeline of the job execution:
 


### PR DESCRIPTION
## Brief change log

one more URL element has been added to open Overview page. Currently, it opens Operators parent page which is empty.

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
