### PR TITLE
[FLINK-29914][tests][backport] Wait for Kafka topic creation/deletion

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaSinkITCase.java
@@ -99,7 +99,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -445,13 +444,13 @@ public class KafkaSinkITCase extends TestLogger {
                 admin.createTopics(
                         Collections.singletonList(
                                 new NewTopic(topic, numPartitions, replicationFactor)));
-        result.all().get(1, TimeUnit.MINUTES);
+        result.all().get();
     }
 
     private void deleteTestTopic(String topic)
             throws ExecutionException, InterruptedException, TimeoutException {
         final DeleteTopicsResult result = admin.deleteTopics(Collections.singletonList(topic));
-        result.all().get(1, TimeUnit.MINUTES);
+        result.all().get();
     }
 
     private List<ConsumerRecord<byte[], byte[]>> drainAllRecordsFromTopic(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/KafkaSinkExternalContext.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/testutils/KafkaSinkExternalContext.java
@@ -57,7 +57,6 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.streaming.api.CheckpointingMode.EXACTLY_ONCE;
 
@@ -67,7 +66,6 @@ public class KafkaSinkExternalContext implements DataStreamSinkV2ExternalContext
     private static final Logger LOG = LoggerFactory.getLogger(KafkaSinkExternalContext.class);
 
     private static final String TOPIC_NAME_PREFIX = "kafka-single-topic";
-    private static final long DEFAULT_TIMEOUT = 30L;
     private static final int RANDOM_STRING_MAX_LENGTH = 50;
     private static final int NUM_RECORDS_UPPER_BOUND = 500;
     private static final int NUM_RECORDS_LOWER_BOUND = 100;
@@ -100,10 +98,7 @@ public class KafkaSinkExternalContext implements DataStreamSinkV2ExternalContext
                 replicationFactor);
         NewTopic newTopic = new NewTopic(topicName, numPartitions, replicationFactor);
         try {
-            kafkaAdminClient
-                    .createTopics(Collections.singletonList(newTopic))
-                    .all()
-                    .get(DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+            kafkaAdminClient.createTopics(Collections.singletonList(newTopic)).all().get();
         } catch (Exception e) {
             throw new RuntimeException(String.format("Cannot create topic '%s'", topicName), e);
         }
@@ -112,10 +107,7 @@ public class KafkaSinkExternalContext implements DataStreamSinkV2ExternalContext
     private void deleteTopic(String topicName) {
         LOG.debug("Deleting Kafka topic {}", topicName);
         try {
-            kafkaAdminClient
-                    .deleteTopics(Collections.singletonList(topicName))
-                    .all()
-                    .get(DEFAULT_TIMEOUT, TimeUnit.SECONDS);
+            kafkaAdminClient.deleteTopics(Collections.singletonList(topicName)).all().get();
         } catch (Exception e) {
             if (ExceptionUtils.getRootCause(e) instanceof UnknownTopicOrPartitionException) {
                 throw new RuntimeException(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReaderTest.java
@@ -88,8 +88,11 @@ public class KafkaSourceReaderTest extends SourceReaderTestBase<KafkaPartitionSp
     public static void setup() throws Throwable {
         KafkaSourceTestEnv.setup();
         try (AdminClient adminClient = KafkaSourceTestEnv.getAdminClient()) {
-            adminClient.createTopics(
-                    Collections.singleton(new NewTopic(TOPIC, NUM_PARTITIONS, (short) 1)));
+            adminClient
+                    .createTopics(
+                            Collections.singleton(new NewTopic(TOPIC, NUM_PARTITIONS, (short) 1)))
+                    .all()
+                    .get();
             // Use the admin client to trigger the creation of internal __consumer_offsets topic.
             // This makes sure that we won't see unavailable coordinator in the tests.
             waitUtil(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceExternalContext.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/testutils/KafkaSourceExternalContext.java
@@ -204,8 +204,10 @@ public class KafkaSourceExternalContext implements DataStreamSourceExternalConte
                     new TopicPartition(topicName, numPartitions));
         } else {
             LOG.info("Creating topic '{}'", topicName);
-            adminClient.createTopics(
-                    Collections.singletonList(new NewTopic(topicName, 1, (short) 1)));
+            adminClient
+                    .createTopics(Collections.singletonList(new NewTopic(topicName, 1, (short) 1)))
+                    .all()
+                    .get();
             return new KafkaPartitionDataWriter(
                     getKafkaProducerProperties(0), new TopicPartition(topicName, 0));
         }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/FlinkKafkaInternalProducerITCase.java
@@ -204,7 +204,7 @@ public class FlinkKafkaInternalProducerITCase extends KafkaTestBase {
 
     @Test(timeout = 30000L)
     public void testProducerWhenCommitEmptyPartitionsToOutdatedTxnCoordinator() throws Exception {
-        String topic = "flink-kafka-producer-txn-coordinator-changed";
+        String topic = "flink-kafka-producer-txn-coordinator-changed-" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
         Producer<String, String> kafkaProducer = new FlinkKafkaInternalProducer<>(extraProperties);
         try {

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -1253,15 +1253,13 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
                         new RichParallelSourceFunction<Tuple3<Integer, Integer, String>>() {
 
                             @Override
-                            public void run(SourceContext<Tuple3<Integer, Integer, String>> ctx)
-                                    throws Exception {
+                            public void run(SourceContext<Tuple3<Integer, Integer, String>> ctx) {
                                 int partition = getRuntimeContext().getIndexOfThisSubtask();
 
                                 for (int topicId = 0; topicId < numTopics; topicId++) {
                                     for (int i = 0; i < numElements; i++) {
                                         ctx.collect(
-                                                new Tuple3<>(
-                                                        partition, i, topicNamePrefix + topicId));
+                                                new Tuple3<>(partition, i, topics.get(topicId)));
                                     }
                                 }
                             }
@@ -1333,8 +1331,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         tryExecute(env, "Count elements from the topics");
 
         // delete all topics again
-        for (int i = 0; i < numTopics; i++) {
-            final String topic = topicNamePrefix + i;
+        for (String topic : topics) {
             deleteTestTopic(topic);
         }
     }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaConsumerTestBase.java
@@ -805,8 +805,8 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      */
     @RetryOnException(times = 2, exception = NotLeaderForPartitionException.class)
     public void runSimpleConcurrentProducerConsumerTopology() throws Exception {
-        final String topic = "concurrentProducerConsumerTopic_" + UUID.randomUUID().toString();
-        final String additionalEmptyTopic = "additionalEmptyTopic_" + UUID.randomUUID().toString();
+        final String topic = "concurrentProducerConsumerTopic_" + UUID.randomUUID();
+        final String additionalEmptyTopic = "additionalEmptyTopic_" + UUID.randomUUID();
 
         final int parallelism = 3;
         final int elementsPerPartition = 100;
@@ -944,7 +944,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      */
     public void runOneToOneExactlyOnceTest() throws Exception {
 
-        final String topic = "oneToOneTopic";
+        final String topic = "oneToOneTopic-" + UUID.randomUUID();
         final int parallelism = 5;
         final int numElementsPerPartition = 1000;
         final int totalElements = parallelism * numElementsPerPartition;
@@ -992,7 +992,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      * Flink source will read multiple Kafka partitions.
      */
     public void runOneSourceMultiplePartitionsExactlyOnceTest() throws Exception {
-        final String topic = "oneToManyTopic";
+        final String topic = "oneToManyTopic-" + UUID.randomUUID();
         final int numPartitions = 5;
         final int numElementsPerPartition = 1000;
         final int totalElements = numPartitions * numElementsPerPartition;
@@ -1042,7 +1042,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      * means that some Flink sources will read no partitions.
      */
     public void runMultipleSourcesOnePartitionExactlyOnceTest() throws Exception {
-        final String topic = "manyToOneTopic";
+        final String topic = "manyToOneTopic-" + UUID.randomUUID();
         final int numPartitions = 5;
         final int numElementsPerPartition = 1000;
         final int totalElements = numPartitions * numElementsPerPartition;
@@ -1094,7 +1094,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
     /** Tests that the source can be properly canceled when reading full partitions. */
     public void runCancelingOnFullInputTest() throws Exception {
-        final String topic = "cancelingOnFullTopic";
+        final String topic = "cancelingOnFullTopic-" + UUID.randomUUID();
 
         final int parallelism = 3;
         createTestTopic(topic, parallelism, 1);
@@ -1168,7 +1168,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
     /** Tests that the source can be properly canceled when reading empty partitions. */
     public void runCancelingOnEmptyInputTest() throws Exception {
-        final String topic = "cancelingOnEmptyInputTopic";
+        final String topic = "cancelingOnEmptyInputTopic-" + UUID.randomUUID();
 
         final int parallelism = 3;
         createTestTopic(topic, parallelism, 1);
@@ -1238,7 +1238,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
         // create topics with content
         final List<String> topics = new ArrayList<>();
         for (int i = 0; i < numTopics; i++) {
-            final String topic = topicNamePrefix + i;
+            final String topic = topicNamePrefix + i + "-" + UUID.randomUUID();
             topics.add(topic);
             // create topic
             createTestTopic(topic, i + 1 /*partitions*/, 1);
@@ -1343,7 +1343,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      */
     public void runBigRecordTestTopology() throws Exception {
 
-        final String topic = "bigRecordTestTopic";
+        final String topic = "bigRecordTestTopic-" + UUID.randomUUID();
         final int parallelism = 1; // otherwise, the kafka mini clusters may run out of heap space
 
         createTestTopic(topic, parallelism, 1);
@@ -1508,7 +1508,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
     }
 
     public void runKeyValueTest() throws Exception {
-        final String topic = "keyvaluetest";
+        final String topic = "keyvaluetest-" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
         final int elementCount = 5000;
 
@@ -1608,7 +1608,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
      * @throws Exception
      */
     public void runAllDeletesTest() throws Exception {
-        final String topic = "alldeletestest";
+        final String topic = "alldeletestest-" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
         final int elementCount = 300;
 
@@ -1792,7 +1792,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
     public void runMetricsTest() throws Throwable {
 
         // create a stream with 5 topics
-        final String topic = "metricsStream";
+        final String topic = "metricsStream-" + UUID.randomUUID();
         createTestTopic(topic, 5, 1);
 
         final Tuple1<Throwable> error = new Tuple1<>(null);
@@ -2244,7 +2244,7 @@ public abstract class KafkaConsumerTestBase extends KafkaTestBaseWithFlink {
 
         for (int attempt = 1; attempt <= maxNumAttempts; attempt++) {
 
-            final String topicName = baseTopicName + '-' + attempt;
+            final String topicName = baseTopicName + '-' + attempt + '-' + UUID.randomUUID();
 
             LOG.info("Writing attempt #" + attempt);
 

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaITCase.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.UUID;
 
 /** IT cases for Kafka. */
 public class KafkaITCase extends KafkaConsumerTestBase {
@@ -187,7 +188,7 @@ public class KafkaITCase extends KafkaConsumerTestBase {
     @Test(timeout = 60000)
     public void testTimestamps() throws Exception {
 
-        final String topic = "tstopic";
+        final String topic = "tstopic-" + UUID.randomUUID();
         createTestTopic(topic, 3, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaShortRetentionTestBase.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.Properties;
+import java.util.UUID;
 
 import static org.apache.flink.test.util.TestUtils.tryExecute;
 
@@ -128,7 +129,7 @@ public class KafkaShortRetentionTestBase implements Serializable {
     private static boolean stopProducer = false;
 
     public void runAutoOffsetResetTest() throws Exception {
-        final String topic = "auto-offset-reset-test";
+        final String topic = "auto-offset-reset-test-" + UUID.randomUUID();
 
         final int parallelism = 1;
         final int elementsPerPartition = 50000;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/KafkaTestEnvironmentImpl.java
@@ -142,15 +142,11 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
 
     private void tryDelete(AdminClient adminClient, String topic) throws Exception {
         try {
-            adminClient
-                    .deleteTopics(Collections.singleton(topic))
-                    .all()
-                    .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            adminClient.deleteTopics(Collections.singleton(topic)).all().get();
             CommonTestUtils.waitUtil(
                     () -> {
                         try {
-                            return adminClient.listTopics().listings()
-                                    .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS).stream()
+                            return adminClient.listTopics().listings().get().stream()
                                     .map(TopicListing::name)
                                     .noneMatch((name) -> name.equals(topic));
                         } catch (Exception e) {
@@ -164,11 +160,7 @@ public class KafkaTestEnvironmentImpl extends KafkaTestEnvironment {
             LOG.info(
                     "Did not receive delete topic response within {} seconds. Checking if it succeeded",
                     REQUEST_TIMEOUT_SECONDS);
-            if (adminClient
-                    .listTopics()
-                    .names()
-                    .get(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                    .contains(topic)) {
+            if (adminClient.listTopics().names().get().contains(topic)) {
                 throw new Exception("Topic still exists after timeout", e);
             }
         }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleExactlyOnceITCase.java
@@ -31,6 +31,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
+import java.util.UUID;
+
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.IngestionTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.ProcessingTime;
@@ -110,7 +112,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
     private void testKafkaShuffleFailureRecovery(
             int numElementsPerProducer, TimeCharacteristic timeCharacteristic) throws Exception {
 
-        String topic = topic("failure_recovery", timeCharacteristic);
+        String topic = topic("failure_recovery-" + UUID.randomUUID(), timeCharacteristic);
         final int numberOfPartitions = 1;
         final int producerParallelism = 1;
         final int failAfterElements = numElementsPerProducer * numberOfPartitions * 2 / 3;
@@ -150,7 +152,7 @@ public class KafkaShuffleExactlyOnceITCase extends KafkaShuffleTestBase {
      */
     private void testAssignedToPartitionFailureRecovery(
             int numElementsPerProducer, TimeCharacteristic timeCharacteristic) throws Exception {
-        String topic = topic("partition_failure_recovery", timeCharacteristic);
+        String topic = topic("partition_failure_recovery-" + UUID.randomUUID(), timeCharacteristic);
         final int numberOfPartitions = 3;
         final int producerParallelism = 2;
         final int failAfterElements = numElementsPerProducer * producerParallelism * 2 / 3;

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/shuffle/KafkaShuffleITCase.java
@@ -48,6 +48,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 import static org.apache.flink.streaming.api.TimeCharacteristic.EventTime;
 import static org.apache.flink.streaming.api.TimeCharacteristic.IngestionTime;
@@ -181,7 +182,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
         Map<Integer, Collection<ConsumerRecord<byte[], byte[]>>> results =
                 testKafkaShuffleProducer(
-                        topic("test_watermark_broadcast", EventTime),
+                        topic("test_watermark_broadcast-" + UUID.randomUUID(), EventTime),
                         env,
                         numberOfPartitions,
                         producerParallelism,
@@ -250,7 +251,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      */
     private void testKafkaShuffle(int numElementsPerProducer, TimeCharacteristic timeCharacteristic)
             throws Exception {
-        String topic = topic("test_simple", timeCharacteristic);
+        String topic = topic("test_simple-" + UUID.randomUUID(), timeCharacteristic);
         final int numberOfPartitions = 1;
         final int producerParallelism = 1;
 
@@ -287,7 +288,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      */
     private void testAssignedToPartition(
             int numElementsPerProducer, TimeCharacteristic timeCharacteristic) throws Exception {
-        String topic = topic("test_assigned_to_partition", timeCharacteristic);
+        String topic = topic("test_assigned_to_partition-" + UUID.randomUUID(), timeCharacteristic);
         final int numberOfPartitions = 3;
         final int producerParallelism = 2;
 
@@ -331,7 +332,7 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
      */
     private void testWatermarkIncremental(int numElementsPerProducer) throws Exception {
         TimeCharacteristic timeCharacteristic = EventTime;
-        String topic = topic("test_watermark_incremental", timeCharacteristic);
+        String topic = topic("test_watermark_incremental-" + UUID.randomUUID(), timeCharacteristic);
         final int numberOfPartitions = 3;
         final int producerParallelism = 2;
 
@@ -375,7 +376,9 @@ public class KafkaShuffleITCase extends KafkaShuffleTestBase {
         Collection<ConsumerRecord<byte[], byte[]>> records =
                 Iterables.getOnlyElement(
                         testKafkaShuffleProducer(
-                                        topic("test_serde", timeCharacteristic),
+                                        topic(
+                                                "test_serde-" + UUID.randomUUID(),
+                                                timeCharacteristic),
                                         env,
                                         1,
                                         1,

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaTableITCase.java
@@ -49,6 +49,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
@@ -91,7 +92,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     public void testKafkaSourceSink() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
-        final String topic = "tstopic_" + format;
+        final String topic = "tstopic_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
@@ -197,7 +198,10 @@ public class KafkaTableITCase extends KafkaTableTestBase {
         List<String> currencies = Arrays.asList("Euro", "Dollar", "Yen", "Dummy");
         List<String> topics =
                 currencies.stream()
-                        .map(currency -> String.format("%s_%s", currency, format))
+                        .map(
+                                currency ->
+                                        String.format(
+                                                "%s_%s_%s", currency, format, UUID.randomUUID()))
                         .collect(Collectors.toList());
         // Because kafka connector currently doesn't support write data into multiple topic
         // together,
@@ -272,7 +276,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     public void testKafkaSourceSinkWithMetadata() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
-        final String topic = "metadata_topic_" + format;
+        final String topic = "metadata_topic_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
@@ -364,7 +368,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     public void testKafkaSourceSinkWithKeyAndPartialValue() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
-        final String topic = "key_partial_value_topic_" + format;
+        final String topic = "key_partial_value_topic_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
@@ -445,7 +449,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     public void testKafkaSourceSinkWithKeyAndFullValue() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
-        final String topic = "key_full_value_topic_" + format;
+        final String topic = "key_full_value_topic_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
@@ -529,10 +533,11 @@ public class KafkaTableITCase extends KafkaTableTestBase {
 
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
-        final String orderTopic = "temporal_join_topic_order_" + format;
+        final String orderTopic = "temporal_join_topic_order_" + format + "_" + UUID.randomUUID();
         createTestTopic(orderTopic, 1, 1);
 
-        final String productTopic = "temporal_join_topic_product_" + format;
+        final String productTopic =
+                "temporal_join_topic_product_" + format + "_" + UUID.randomUUID();
         createTestTopic(productTopic, 1, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
@@ -665,7 +670,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     public void testPerPartitionWatermarkKafka() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
-        final String topic = "per_partition_watermark_topic_" + format;
+        final String topic = "per_partition_watermark_topic_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 4, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
@@ -755,7 +760,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
     public void testPerPartitionWatermarkWithIdleSource() throws Exception {
         // we always use a different topic name for each parameterized topic,
         // in order to make sure the topic can be created.
-        final String topic = "idle_partition_watermark_topic_" + format;
+        final String topic = "idle_partition_watermark_topic_" + format + "_" + UUID.randomUUID();
         createTestTopic(topic, 4, 1);
 
         // ---------- Produce an event time stream into Kafka -------------------
@@ -968,7 +973,7 @@ public class KafkaTableITCase extends KafkaTableTestBase {
         // in order to make sure the topic can be created.
         final String resetStrategy = "none";
         final String tableName = resetStrategy + "Table";
-        final String topic = "groupOffset_" + format;
+        final String topic = "groupOffset_" + format + "_" + UUID.randomUUID();
         String groupId = resetStrategy + (new Random()).nextInt();
 
         TableResult tableResult = null;

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/main/java/org/apache/flink/tests/util/kafka/KafkaContainerClient.java
@@ -68,8 +68,16 @@ public class KafkaContainerClient {
                 CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, container.getBootstrapServers());
         try (AdminClient admin = AdminClient.create(properties)) {
             admin.createTopics(
-                    Collections.singletonList(
-                            new NewTopic(topic, numPartitions, (short) replicationFactor)));
+                            Collections.singletonList(
+                                    new NewTopic(topic, numPartitions, (short) replicationFactor)))
+                    .all()
+                    .get();
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    String.format(
+                            "Fail to create topic [%s partitions: %d replication factor: %d].",
+                            topic, numPartitions, replicationFactor),
+                    e);
         }
     }
 

--- a/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-common-kafka/src/test/java/org/apache/flink/tests/util/kafka/SmokeKafkaITCase.java
@@ -137,9 +137,11 @@ public class SmokeKafkaITCase {
         // create the required topics
         final short replicationFactor = 1;
         admin.createTopics(
-                Lists.newArrayList(
-                        new NewTopic(inputTopic, 1, replicationFactor),
-                        new NewTopic(outputTopic, 1, replicationFactor)));
+                        Lists.newArrayList(
+                                new NewTopic(inputTopic, 1, replicationFactor),
+                                new NewTopic(outputTopic, 1, replicationFactor)))
+                .all()
+                .get();
 
         producer.send(new ProducerRecord<>(inputTopic, 1));
         producer.send(new ProducerRecord<>(inputTopic, 2));


### PR DESCRIPTION
## What is the purpose of the change

Kafka creation/deletion is an async operation. The API gives back future(s) which must be waited in order to be on the safe side. Additionally the APIs can throw exceptions while waiting to finish. In this PR I've added a more or less consistent Kafka topic creation/deletion behavior to the tests. Namely future wait to all the places where it was missing. This may or may not fix the issue (Kafka itself can be buggy) but I'm pretty sure w/o consistent topic creation/deletion API usage we're in trouble.

## Brief change log

* Wait for Kafka topic creation/deletion.
* Add random to test topic names

## Verifying this change

Existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
