### PR TITLE
[FLINK-29980] Handle partition keys directly in hive bulk format

### DIFF
--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -72,6 +72,13 @@ under the License.
 			<optional>true</optional>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<!-- test dependencies -->
 
 		<dependency>

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/util/RecordMapper.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/util/RecordMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.src.util;
+
+/** Record mapper definition. */
+@FunctionalInterface
+public interface RecordMapper<I, O> {
+    /** Map the record. Both input value and output value are expected to be non-null. */
+    O map(I in);
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/util/RecordMapperWrapperRecordIterator.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/util/RecordMapperWrapperRecordIterator.java
@@ -34,13 +34,6 @@ import java.io.IOException;
  */
 public class RecordMapperWrapperRecordIterator<I, O> implements BulkFormat.RecordIterator<O> {
 
-    /** Record mapper definition. */
-    @FunctionalInterface
-    public interface RecordMapper<I, O> {
-        /** Map the record. Both input value and output value are expected to be non-null. */
-        O map(I in);
-    }
-
     private final BulkFormat.RecordIterator<I> wrapped;
     private final RecordMapper<I, O> mapper;
 

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileInfoExtractor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileInfoExtractor.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.file.table;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.data.util.DataFormatConverters;
+import org.apache.flink.table.types.DataType;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/** A helper class to build the fixed and mutable row index mapping. */
+public class FileInfoExtractor implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<PartitionColumn> partitionColumns;
+    private final int[] extendedRowIndexMapping;
+
+    public FileInfoExtractor(
+            DataType producedDataType,
+            List<String> metadataColumns,
+            List<String> partitionColumns) {
+
+        // Compute index mapping for the extended row and the functions to compute metadata
+        List<DataTypes.Field> producedRowField = DataType.getFields(producedDataType);
+        List<String> producedRowFieldNames =
+                producedRowField.stream()
+                        .map(DataTypes.Field::getName)
+                        .collect(Collectors.toList());
+
+        // Filter out partition columns not in producedDataType
+        final List<String> partitionKeysToExtract =
+                DataType.getFieldNames(producedDataType).stream()
+                        .filter(partitionColumns::contains)
+                        .collect(Collectors.toList());
+
+        List<String> mutableRowFieldNames =
+                producedRowFieldNames.stream()
+                        .filter(
+                                key ->
+                                        !metadataColumns.contains(key)
+                                                && !partitionKeysToExtract.contains(key))
+                        .collect(Collectors.toList());
+
+        List<String> fixedRowFieldNames =
+                Stream.concat(metadataColumns.stream(), partitionKeysToExtract.stream())
+                        .collect(Collectors.toList());
+        this.partitionColumns =
+                partitionKeysToExtract.stream()
+                        .map(
+                                name ->
+                                        new PartitionColumn(
+                                                name,
+                                                producedRowField
+                                                        .get(producedRowFieldNames.indexOf(name))
+                                                        .getDataType()))
+                        .collect(Collectors.toList());
+
+        this.extendedRowIndexMapping =
+                EnrichedRowData.computeIndexMapping(
+                        producedRowFieldNames, mutableRowFieldNames, fixedRowFieldNames);
+    }
+
+    public List<PartitionColumn> getPartitionColumns() {
+        return partitionColumns;
+    }
+
+    public int[] getExtendedRowIndexMapping() {
+        return extendedRowIndexMapping;
+    }
+
+    /** Info of the partition column. */
+    public static class PartitionColumn implements Serializable {
+        private static final long serialVersionUID = 1L;
+        public final String fieldName;
+        public final DataFormatConverters.DataFormatConverter converter;
+        public final DataType dataType;
+
+        public PartitionColumn(String fieldName, DataType dataType) {
+            this.fieldName = fieldName;
+            this.dataType = dataType;
+            this.converter = DataFormatConverters.getConverterForDataType(dataType);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileInfoExtractorBulkFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileInfoExtractorBulkFormat.java
@@ -23,20 +23,15 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.RecordMapperWrapperRecordIterator;
-import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.DataType;
-import org.apache.flink.table.utils.PartitionPathUtils;
 
 import java.io.IOException;
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This {@link BulkFormat} is a wrapper that attaches file information columns to the output
@@ -46,13 +41,10 @@ public class FileInfoExtractorBulkFormat<SplitT extends FileSourceSplit>
         implements BulkFormat<RowData, SplitT> {
 
     private final BulkFormat<RowData, SplitT> wrapped;
-    private final TypeInformation<RowData> producedType;
-
-    private final List<FileSystemTableSource.FileInfoAccessor> metadataColumnsFunctions;
-    private final List<Map.Entry<String, DataType>> partitionColumnTypes;
-    private final int[] extendedRowIndexMapping;
-
-    private final String defaultPartName;
+    private final PartitionFieldExtractor<SplitT> partitionFieldExtractor;
+    private final FileInfoExtractor fileInfoExtractor;
+    public final List<FileSystemTableSource.FileInfoAccessor> metadataColumnsFunctions;
+    public final TypeInformation<RowData> producedType;
 
     public FileInfoExtractorBulkFormat(
             BulkFormat<RowData, SplitT> wrapped,
@@ -60,53 +52,13 @@ public class FileInfoExtractorBulkFormat<SplitT extends FileSourceSplit>
             TypeInformation<RowData> producedTypeInformation,
             Map<String, FileSystemTableSource.FileInfoAccessor> metadataColumns,
             List<String> partitionColumns,
-            String defaultPartName) {
-        this.wrapped = wrapped;
-        this.producedType = producedTypeInformation;
-        this.defaultPartName = defaultPartName;
-
-        // Compute index mapping for the extended row and the functions to compute metadata
-        List<DataTypes.Field> producedRowField = DataType.getFields(producedDataType);
-        List<String> producedRowFieldNames =
-                producedRowField.stream()
-                        .map(DataTypes.Field::getName)
-                        .collect(Collectors.toList());
-
-        // Filter out partition columns not in producedDataType
-        final List<String> partitionKeysToExtract =
-                DataType.getFieldNames(producedDataType).stream()
-                        .filter(partitionColumns::contains)
-                        .collect(Collectors.toList());
-
-        List<String> mutableRowFieldNames =
-                producedRowFieldNames.stream()
-                        .filter(
-                                key ->
-                                        !metadataColumns.containsKey(key)
-                                                && !partitionKeysToExtract.contains(key))
-                        .collect(Collectors.toList());
+            PartitionFieldExtractor<SplitT> partitionFieldExtractor) {
         List<String> metadataFieldNames = new ArrayList<>(metadataColumns.keySet());
-
-        List<String> fixedRowFieldNames =
-                Stream.concat(metadataFieldNames.stream(), partitionKeysToExtract.stream())
-                        .collect(Collectors.toList());
-
-        this.partitionColumnTypes =
-                partitionKeysToExtract.stream()
-                        .map(
-                                fieldName ->
-                                        new SimpleImmutableEntry<>(
-                                                fieldName,
-                                                producedRowField
-                                                        .get(
-                                                                producedRowFieldNames.indexOf(
-                                                                        fieldName))
-                                                        .getDataType()))
-                        .collect(Collectors.toList());
-
-        this.extendedRowIndexMapping =
-                EnrichedRowData.computeIndexMapping(
-                        producedRowFieldNames, mutableRowFieldNames, fixedRowFieldNames);
+        this.wrapped = wrapped;
+        this.partitionFieldExtractor = partitionFieldExtractor;
+        this.producedType = producedTypeInformation;
+        this.fileInfoExtractor =
+                new FileInfoExtractor(producedDataType, metadataFieldNames, partitionColumns);
         this.metadataColumnsFunctions =
                 metadataFieldNames.stream().map(metadataColumns::get).collect(Collectors.toList());
     }
@@ -131,41 +83,38 @@ public class FileInfoExtractorBulkFormat<SplitT extends FileSourceSplit>
         return producedType;
     }
 
-    private Reader<RowData> wrapReader(Reader<RowData> superReader, FileSourceSplit split) {
+    private Reader<RowData> wrapReader(Reader<RowData> superReader, SplitT split) {
         // Fill the metadata + partition columns row
+        List<FileInfoExtractor.PartitionColumn> partitionColumns =
+                fileInfoExtractor.getPartitionColumns();
         final GenericRowData fileInfoRowData =
-                new GenericRowData(metadataColumnsFunctions.size() + partitionColumnTypes.size());
+                new GenericRowData(metadataColumnsFunctions.size() + partitionColumns.size());
         int fileInfoRowIndex = 0;
         for (; fileInfoRowIndex < metadataColumnsFunctions.size(); fileInfoRowIndex++) {
             fileInfoRowData.setField(
                     fileInfoRowIndex,
                     metadataColumnsFunctions.get(fileInfoRowIndex).getValue(split));
         }
-        if (!partitionColumnTypes.isEmpty()) {
-            final LinkedHashMap<String, String> partitionSpec =
-                    PartitionPathUtils.extractPartitionSpecFromPath(split.path());
+        if (!partitionColumns.isEmpty()) {
             for (int partitionFieldIndex = 0;
                     fileInfoRowIndex < fileInfoRowData.getArity();
                     fileInfoRowIndex++, partitionFieldIndex++) {
-                final String fieldName = partitionColumnTypes.get(partitionFieldIndex).getKey();
-                final DataType fieldType = partitionColumnTypes.get(partitionFieldIndex).getValue();
-                if (!partitionSpec.containsKey(fieldName)) {
-                    throw new RuntimeException(
-                            "Cannot find the partition value from path for partition: "
-                                    + fieldName);
-                }
+                FileInfoExtractor.PartitionColumn partition =
+                        partitionColumns.get(partitionFieldIndex);
 
-                String valueStr = partitionSpec.get(fieldName);
-                valueStr = valueStr.equals(defaultPartName) ? null : valueStr;
+                Object partitionValue =
+                        partitionFieldExtractor.extract(
+                                split, partition.fieldName, partition.dataType.getLogicalType());
+
                 fileInfoRowData.setField(
-                        fileInfoRowIndex,
-                        PartitionPathUtils.convertStringToInternalValue(valueStr, fieldType));
+                        fileInfoRowIndex, partition.converter.toInternal(partitionValue));
             }
         }
 
         // This row is going to be reused for every record
         final EnrichedRowData producedRowData =
-                new EnrichedRowData(fileInfoRowData, this.extendedRowIndexMapping);
+                new EnrichedRowData(
+                        fileInfoRowData, fileInfoExtractor.getExtendedRowIndexMapping());
 
         return RecordMapperWrapperRecordIterator.wrapReader(
                 superReader,

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
@@ -300,7 +300,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
 
         if (bulkReaderFormat != null) {
             final BulkFormat<RowData, FileSourceSplit> format =
-                    new FileInfoExtractorBulkFormat(
+                    new FileInfoExtractorBulkFormat<>(
                             bulkReaderFormat.createRuntimeDecoder(
                                     createSourceContext(context), physicalDataType),
                             producedDataType,
@@ -314,7 +314,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
                     deserializationFormat.createRuntimeDecoder(
                             createSourceContext(context), physicalDataType);
             final BulkFormat<RowData, FileSourceSplit> format =
-                    new FileInfoExtractorBulkFormat(
+                    new FileInfoExtractorBulkFormat<>(
                             new DeserializationSchemaAdapter(decoder),
                             producedDataType,
                             context.createTypeInformation(producedDataType),

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSink.java
@@ -307,7 +307,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
                             context.createTypeInformation(producedDataType),
                             Collections.emptyMap(),
                             partitionKeys,
-                            defaultPartName);
+                            PartitionFieldExtractor.forFileSystem(defaultPartName));
             return Optional.of(CompactBulkReader.factory(format));
         } else if (deserializationFormat != null) {
             final DeserializationSchema<RowData> decoder =
@@ -320,7 +320,7 @@ public class FileSystemTableSink extends AbstractFileSystemTable
                             context.createTypeInformation(producedDataType),
                             Collections.emptyMap(),
                             partitionKeys,
-                            defaultPartName);
+                            PartitionFieldExtractor.forFileSystem(defaultPartName));
             return Optional.of(CompactBulkReader.factory(format));
         }
         return Optional.empty();

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -250,7 +250,7 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             bulkFormat =
-                    new FileInfoExtractorBulkFormat(
+                    new FileInfoExtractorBulkFormat<>(
                             bulkFormat,
                             producedDataType,
                             context.createTypeInformation(producedDataType),

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/FileSystemTableSource.java
@@ -256,7 +256,7 @@ public class FileSystemTableSource extends AbstractFileSystemTable
                             context.createTypeInformation(producedDataType),
                             metadataColumns,
                             partitionKeys,
-                            defaultPartName);
+                            PartitionFieldExtractor.forFileSystem(defaultPartName));
         }
         bulkFormat = LimitableBulkFormat.create(bulkFormat, limit);
         return bulkFormat;

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionFieldExtractor.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionFieldExtractor.java
@@ -29,7 +29,7 @@ import java.util.LinkedHashMap;
 /** Interface to extract partition field from split. */
 @FunctionalInterface
 @Internal
-public interface PartitionFieldExtractor<T extends FileSourceSplit> extends Serializable {
+public interface PartitionFieldExtractor<T> extends Serializable {
 
     Object extract(T split, String fieldName, LogicalType fieldType);
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveDynamicTableFactory.java
@@ -23,7 +23,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.file.table.FileSystemConnectorOptions;
 import org.apache.flink.connectors.hive.util.JobConfUtils;
-import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
 import org.apache.flink.table.catalog.hive.HiveCatalogLock;
 import org.apache.flink.table.connector.RequireCatalogLock;
@@ -124,7 +124,8 @@ public class HiveDynamicTableFactory implements DynamicTableSourceFactory, Dynam
             return source;
         }
 
-        final CatalogTable catalogTable = Preconditions.checkNotNull(context.getCatalogTable());
+        final ResolvedCatalogTable catalogTable =
+                Preconditions.checkNotNull(context.getCatalogTable());
 
         final boolean isStreamingSource = configuration.get(STREAMING_SOURCE_ENABLE);
         final boolean includeAllPartition =

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
@@ -264,7 +264,9 @@ public class HiveLookupTableSource extends HiveTableSource implements LookupTabl
                         getProducedTableSchema().getFieldNames(),
                         catalogTable.getPartitionKeys(),
                         projectedFields,
-                        flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER));
+                        flinkConf.get(HiveOptions.TABLE_EXEC_HIVE_FALLBACK_MAPRED_READER),
+                        producedTypes,
+                        defaultPartitionName);
 
         return new FileSystemLookupFunction<>(
                 partitionFetcher,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveLookupTableSource.java
@@ -27,8 +27,8 @@ import org.apache.flink.connectors.hive.read.HiveInputFormatPartitionReader;
 import org.apache.flink.connectors.hive.read.HivePartitionFetcherContextBase;
 import org.apache.flink.connectors.hive.util.HivePartitionUtils;
 import org.apache.flink.connectors.hive.util.JobConfUtils;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.hive.client.HiveShim;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.LookupTableSource;
@@ -79,7 +79,7 @@ public class HiveLookupTableSource extends HiveTableSource implements LookupTabl
             JobConf jobConf,
             ReadableConfig flinkConf,
             ObjectPath tablePath,
-            CatalogTable catalogTable) {
+            ResolvedCatalogTable catalogTable) {
         super(jobConf, flinkConf, tablePath, catalogTable);
         this.configuration = new Configuration();
         catalogTable.getOptions().forEach(configuration::setString);
@@ -99,6 +99,8 @@ public class HiveLookupTableSource extends HiveTableSource implements LookupTabl
         source.projectedFields = projectedFields;
         source.limit = limit;
         source.dynamicFilterPartitionKeys = dynamicFilterPartitionKeys;
+        source.producedTypeInfo = producedTypeInfo;
+        source.producedTypes = producedTypes;
         return source;
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HivePartitionFieldExtractor.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HivePartitionFieldExtractor.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.connector.file.table.PartitionFieldExtractor;
+import org.apache.flink.connectors.hive.read.HiveSourceSplit;
+import org.apache.flink.connectors.hive.read.HiveTableInputSplit;
+import org.apache.flink.connectors.hive.util.HivePartitionUtils;
+import org.apache.flink.table.catalog.hive.client.HiveShim;
+
+/** Partition extractor to extract partition value from {@link HiveSourceSplit}. */
+public class HivePartitionFieldExtractor {
+
+    public static PartitionFieldExtractor<HiveSourceSplit> createForHiveSourceSplit(
+            HiveShim hiveShim, String defaultPartitionName) {
+        return (split, fieldName, fieldType) -> {
+            String valueString = split.getHiveTablePartition().getPartitionSpec().get(fieldName);
+            return HivePartitionUtils.restorePartitionValueFromType(
+                    hiveShim, valueString, fieldType, defaultPartitionName);
+        };
+    }
+
+    public static PartitionFieldExtractor<HiveTableInputSplit> createForHiveTableInputSplit(
+            HiveShim hiveShim, String defaultPartitionName) {
+        return (split, fieldName, fieldType) -> {
+            String valueString = split.getHiveTablePartition().getPartitionSpec().get(fieldName);
+            return HivePartitionUtils.restorePartitionValueFromType(
+                    hiveShim, valueString, fieldType, defaultPartitionName);
+        };
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
@@ -354,7 +354,8 @@ public class HiveSourceBuilder {
                         producedTypeInfo,
                         new HashMap<>(),
                         partitionKeys,
-                        defaultPartitionName);
+                        HivePartitionFieldExtractor.createForHiveSourceSplit(
+                                HiveShimLoader.loadHiveShim(hiveVersion), defaultPartitionName));
 
         return LimitableBulkFormat.create(bulkFormatWithPartitions, limit);
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSource.java
@@ -319,6 +319,8 @@ public class HiveTableSource
         source.projectedFields = projectedFields;
         source.limit = limit;
         source.dynamicFilterPartitionKeys = dynamicFilterPartitionKeys;
+        source.producedTypes = producedTypes;
+        source.producedTypeInfo = producedTypeInfo;
         return source;
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReader.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReader.java
@@ -44,6 +44,8 @@ public class HiveInputFormatPartitionReader
     private final List<String> partitionKeys;
     private final int[] selectedFields;
     private final boolean useMapRedReader;
+    private final DataType producedTypes;
+    private final String defaultPartitionName;
 
     private transient HiveTableInputFormat hiveTableInputFormat;
     private transient HiveTableInputSplit[] inputSplits;
@@ -58,7 +60,9 @@ public class HiveInputFormatPartitionReader
             String[] fieldNames,
             List<String> partitionKeys,
             int[] selectedFields,
-            boolean useMapRedReader) {
+            boolean useMapRedReader,
+            DataType producedType,
+            String defaultPartitionName) {
         this.threadNum = threadNum;
         this.jobConfWrapper = new JobConfWrapper(jobConf);
         this.hiveVersion = hiveVersion;
@@ -68,6 +72,8 @@ public class HiveInputFormatPartitionReader
         this.partitionKeys = partitionKeys;
         this.selectedFields = selectedFields;
         this.useMapRedReader = useMapRedReader;
+        this.producedTypes = producedType;
+        this.defaultPartitionName = defaultPartitionName;
     }
 
     @Override
@@ -83,7 +89,9 @@ public class HiveInputFormatPartitionReader
                         null,
                         this.hiveVersion,
                         this.useMapRedReader,
-                        partitions);
+                        partitions,
+                        producedTypes,
+                        defaultPartitionName);
         inputSplits = hiveTableInputFormat.createInputSplits(1);
         readingSplitId = 0;
         if (inputSplits.length > 0) {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDeserializeExceptionTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDeserializeExceptionTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.catalog.CatalogTableImpl;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.InstantiationUtil;
 
@@ -84,7 +85,9 @@ public class HiveDeserializeExceptionTest {
                         new CatalogTableImpl(
                                 TableSchema.builder().field("i", DataTypes.INT()).build(),
                                 Collections.emptyMap(),
-                                null));
+                                null),
+                        InternalTypeInfo.of(DataTypes.ROW(DataTypes.INT()).getLogicalType()),
+                        DataTypes.ROW(DataTypes.INT()));
         builder.setPartitions(
                 Collections.singletonList(
                         new HiveTablePartition(new StorageDescriptor(), new Properties())));

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableSourceITCase.java
@@ -40,8 +40,8 @@ import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
-import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.exceptions.CatalogException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
@@ -50,7 +50,6 @@ import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.factories.DynamicTableFactory;
-import org.apache.flink.table.factories.TableSourceFactory;
 import org.apache.flink.table.module.CoreModuleFactory;
 import org.apache.flink.table.module.hive.HiveModule;
 import org.apache.flink.table.planner.delegation.PlannerBase;
@@ -854,7 +853,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
 
         doAnswer(
                         invocation -> {
-                            TableSourceFactory.Context context = invocation.getArgument(0);
+                            DynamicTableFactory.Context context = invocation.getArgument(0);
                             assertThat(
                                             context.getConfiguration()
                                                     .get(
@@ -865,7 +864,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
                                     new JobConf(hiveCatalog.getHiveConf()),
                                     context.getConfiguration(),
                                     context.getObjectIdentifier().toObjectPath(),
-                                    context.getTable(),
+                                    context.getCatalogTable(),
                                     inferParallelism);
                         })
                 .when(tableFactorySpy)
@@ -1097,7 +1096,7 @@ public class HiveTableSourceITCase extends BatchAbstractTestBase {
                 JobConf jobConf,
                 ReadableConfig flinkConf,
                 ObjectPath tablePath,
-                CatalogTable catalogTable,
+                ResolvedCatalogTable catalogTable,
                 boolean inferParallelism) {
             super(jobConf, flinkConf, tablePath, catalogTable);
             this.inferParallelism = inferParallelism;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReaderITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/read/HiveInputFormatPartitionReaderITCase.java
@@ -19,6 +19,7 @@ package org.apache.flink.connectors.hive.read;
 
 import org.apache.flink.connectors.hive.HiveOptions;
 import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.connectors.hive.util.JobConfUtils;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableSchema;
@@ -70,7 +71,10 @@ public class HiveInputFormatPartitionReaderITCase {
                         tableSchema.getFieldNames(),
                         Collections.emptyList(),
                         null,
-                        false);
+                        false,
+                        tableSchema.toRowDataType(),
+                        JobConfUtils.getDefaultPartitionName(
+                                new JobConf(hiveCatalog.getHiveConf())));
         Table hiveTable = hiveCatalog.getHiveTable(tablePath);
         // create HiveTablePartition to read from
         HiveTablePartition tablePartition =

--- a/flink-formats/flink-orc-nohive/src/main/java/org/apache/flink/orc/nohive/vector/AbstractOrcNoHiveVector.java
+++ b/flink-formats/flink-orc-nohive/src/main/java/org/apache/flink/orc/nohive/vector/AbstractOrcNoHiveVector.java
@@ -18,25 +18,12 @@
 
 package org.apache.flink.orc.nohive.vector;
 
-import org.apache.flink.table.types.logical.DecimalType;
-import org.apache.flink.table.types.logical.LogicalType;
-
-import org.apache.orc.storage.common.type.HiveDecimal;
 import org.apache.orc.storage.ql.exec.vector.BytesColumnVector;
 import org.apache.orc.storage.ql.exec.vector.ColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DecimalColumnVector;
 import org.apache.orc.storage.ql.exec.vector.DoubleColumnVector;
 import org.apache.orc.storage.ql.exec.vector.LongColumnVector;
 import org.apache.orc.storage.ql.exec.vector.TimestampColumnVector;
-
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import java.sql.Date;
-import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-
-import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 
 /** This column vector is used to adapt hive's ColumnVector to Flink's ColumnVector. */
 public abstract class AbstractOrcNoHiveVector
@@ -69,129 +56,5 @@ public abstract class AbstractOrcNoHiveVector
             throw new UnsupportedOperationException(
                     "Unsupported vector: " + vector.getClass().getName());
         }
-    }
-
-    /** Create flink vector by hive vector from constant. */
-    public static org.apache.flink.table.data.columnar.vector.ColumnVector
-            createFlinkVectorFromConstant(LogicalType type, Object value, int batchSize) {
-        return createFlinkVector(createHiveVectorFromConstant(type, value, batchSize));
-    }
-
-    /**
-     * Create a orc vector from partition spec value. See hive {@code
-     * VectorizedRowBatchCtx#addPartitionColsToBatch}.
-     */
-    private static ColumnVector createHiveVectorFromConstant(
-            LogicalType type, Object value, int batchSize) {
-        switch (type.getTypeRoot()) {
-            case CHAR:
-            case VARCHAR:
-            case BINARY:
-            case VARBINARY:
-                return createBytesVector(batchSize, value);
-            case BOOLEAN:
-                return createLongVector(batchSize, (Boolean) value ? 1 : 0);
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case BIGINT:
-                return createLongVector(batchSize, value);
-            case DECIMAL:
-                DecimalType decimalType = (DecimalType) type;
-                return createDecimalVector(
-                        batchSize, decimalType.getPrecision(), decimalType.getScale(), value);
-            case FLOAT:
-            case DOUBLE:
-                return createDoubleVector(batchSize, value);
-            case DATE:
-                if (value instanceof LocalDate) {
-                    value = Date.valueOf((LocalDate) value);
-                }
-                return createLongVector(batchSize, toInternal((Date) value));
-            case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return createTimestampVector(batchSize, value);
-            default:
-                throw new UnsupportedOperationException("Unsupported type: " + type);
-        }
-    }
-
-    private static LongColumnVector createLongVector(int batchSize, Object value) {
-        LongColumnVector lcv = new LongColumnVector(batchSize);
-        if (value == null) {
-            lcv.noNulls = false;
-            lcv.isNull[0] = true;
-            lcv.isRepeating = true;
-        } else {
-            lcv.fill(((Number) value).longValue());
-            lcv.isNull[0] = false;
-        }
-        return lcv;
-    }
-
-    private static BytesColumnVector createBytesVector(int batchSize, Object value) {
-        BytesColumnVector bcv = new BytesColumnVector(batchSize);
-        if (value == null) {
-            bcv.noNulls = false;
-            bcv.isNull[0] = true;
-            bcv.isRepeating = true;
-        } else {
-            byte[] bytes =
-                    value instanceof byte[]
-                            ? (byte[]) value
-                            : value.toString().getBytes(StandardCharsets.UTF_8);
-            bcv.initBuffer(bytes.length);
-            bcv.fill(bytes);
-            bcv.isNull[0] = false;
-        }
-        return bcv;
-    }
-
-    private static DecimalColumnVector createDecimalVector(
-            int batchSize, int precision, int scale, Object value) {
-        DecimalColumnVector dv = new DecimalColumnVector(batchSize, precision, scale);
-        if (value == null) {
-            dv.noNulls = false;
-            dv.isNull[0] = true;
-            dv.isRepeating = true;
-        } else {
-            dv.set(
-                    0,
-                    value instanceof HiveDecimal
-                            ? (HiveDecimal) value
-                            : HiveDecimal.create((BigDecimal) value));
-            dv.isRepeating = true;
-            dv.isNull[0] = false;
-        }
-        return dv;
-    }
-
-    private static DoubleColumnVector createDoubleVector(int batchSize, Object value) {
-        DoubleColumnVector dcv = new DoubleColumnVector(batchSize);
-        if (value == null) {
-            dcv.noNulls = false;
-            dcv.isNull[0] = true;
-            dcv.isRepeating = true;
-        } else {
-            dcv.fill(((Number) value).doubleValue());
-            dcv.isNull[0] = false;
-        }
-        return dcv;
-    }
-
-    private static TimestampColumnVector createTimestampVector(int batchSize, Object value) {
-        TimestampColumnVector lcv = new TimestampColumnVector(batchSize);
-        if (value == null) {
-            lcv.noNulls = false;
-            lcv.isNull[0] = true;
-            lcv.isRepeating = true;
-        } else {
-            Timestamp timestamp =
-                    value instanceof LocalDateTime
-                            ? Timestamp.valueOf((LocalDateTime) value)
-                            : (Timestamp) value;
-            lcv.fill(timestamp);
-            lcv.isNull[0] = false;
-        }
-        return lcv;
     }
 }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileFormatFactory.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFileFormatFactory.java
@@ -162,7 +162,6 @@ public class OrcFileFormatFactory implements BulkReaderFormatFactory, BulkWriter
                     getOrcConfiguration(formatOptions),
                     (RowType) producedDataType.getLogicalType(),
                     Collections.emptyList(),
-                    null,
                     Projection.of(projections).toTopLevelIndexes(),
                     orcPredicates,
                     VectorizedColumnBatch.DEFAULT_SIZE,

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/TimestampUtil.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/TimestampUtil.java
@@ -19,7 +19,6 @@
 package org.apache.flink.orc;
 
 import org.apache.flink.orc.vector.OrcLegacyTimestampColumnVector;
-import org.apache.flink.orc.vector.OrcTimestampColumnVector;
 
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.slf4j.Logger;
@@ -49,14 +48,5 @@ public class TimestampUtil {
     // whether a ColumnVector is the new TimestampColumnVector
     public static boolean isHiveTimestampColumnVector(ColumnVector vector) {
         return hiveTSColVectorClz != null && hiveTSColVectorClz.isAssignableFrom(vector.getClass());
-    }
-
-    // creates a Hive ColumnVector of constant timestamp value
-    public static ColumnVector createVectorFromConstant(int batchSize, Object value) {
-        if (hiveTSColVectorClz != null) {
-            return OrcTimestampColumnVector.createFromConstant(batchSize, value);
-        } else {
-            return OrcLegacyTimestampColumnVector.createFromConstant(batchSize, value);
-        }
     }
 }

--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/vector/AbstractOrcColumnVector.java
@@ -20,13 +20,11 @@ package org.apache.flink.orc.vector;
 
 import org.apache.flink.orc.TimestampUtil;
 import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.DecimalType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
 
-import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
@@ -35,13 +33,6 @@ import org.apache.hadoop.hive.ql.exec.vector.ListColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.MapColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
-
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import java.sql.Date;
-import java.time.LocalDate;
-
-import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 
 /** This column vector is used to adapt hive's ColumnVector to Flink's ColumnVector. */
 public abstract class AbstractOrcColumnVector
@@ -84,112 +75,5 @@ public abstract class AbstractOrcColumnVector
             throw new UnsupportedOperationException(
                     "Unsupported vector: " + vector.getClass().getName());
         }
-    }
-
-    /** Create flink vector by hive vector from constant. */
-    public static org.apache.flink.table.data.columnar.vector.ColumnVector
-            createFlinkVectorFromConstant(LogicalType type, Object value, int batchSize) {
-        return createFlinkVector(createHiveVectorFromConstant(type, value, batchSize), type);
-    }
-
-    /**
-     * Create a orc vector from partition spec value. See hive {@code
-     * VectorizedRowBatchCtx#addPartitionColsToBatch}.
-     */
-    private static ColumnVector createHiveVectorFromConstant(
-            LogicalType type, Object value, int batchSize) {
-        switch (type.getTypeRoot()) {
-            case CHAR:
-            case VARCHAR:
-            case BINARY:
-            case VARBINARY:
-                return createBytesVector(batchSize, value);
-            case BOOLEAN:
-                return createLongVector(batchSize, (Boolean) value ? 1 : 0);
-            case TINYINT:
-            case SMALLINT:
-            case INTEGER:
-            case BIGINT:
-                return createLongVector(batchSize, value);
-            case DECIMAL:
-                DecimalType decimalType = (DecimalType) type;
-                return createDecimalVector(
-                        batchSize, decimalType.getPrecision(), decimalType.getScale(), value);
-            case FLOAT:
-            case DOUBLE:
-                return createDoubleVector(batchSize, value);
-            case DATE:
-                if (value instanceof LocalDate) {
-                    value = Date.valueOf((LocalDate) value);
-                }
-                return createLongVector(batchSize, toInternal((Date) value));
-            case TIMESTAMP_WITHOUT_TIME_ZONE:
-                return TimestampUtil.createVectorFromConstant(batchSize, value);
-            default:
-                throw new UnsupportedOperationException("Unsupported type: " + type);
-        }
-    }
-
-    private static LongColumnVector createLongVector(int batchSize, Object value) {
-        LongColumnVector lcv = new LongColumnVector(batchSize);
-        if (value == null) {
-            lcv.noNulls = false;
-            lcv.isNull[0] = true;
-            lcv.isRepeating = true;
-        } else {
-            lcv.fill(((Number) value).longValue());
-            lcv.isNull[0] = false;
-        }
-        return lcv;
-    }
-
-    private static BytesColumnVector createBytesVector(int batchSize, Object value) {
-        BytesColumnVector bcv = new BytesColumnVector(batchSize);
-        if (value == null) {
-            bcv.noNulls = false;
-            bcv.isNull[0] = true;
-            bcv.isRepeating = true;
-        } else {
-            byte[] bytes =
-                    value instanceof byte[]
-                            ? (byte[]) value
-                            : value.toString().getBytes(StandardCharsets.UTF_8);
-            bcv.initBuffer(bytes.length);
-            bcv.fill(bytes);
-            bcv.isNull[0] = false;
-        }
-        return bcv;
-    }
-
-    private static DecimalColumnVector createDecimalVector(
-            int batchSize, int precision, int scale, Object value) {
-        DecimalColumnVector dv = new DecimalColumnVector(batchSize, precision, scale);
-        if (value == null) {
-            dv.noNulls = false;
-            dv.isNull[0] = true;
-            dv.isRepeating = true;
-        } else {
-            dv.set(
-                    0,
-                    value instanceof HiveDecimal
-                            ? (HiveDecimal) value
-                            : HiveDecimal.create((BigDecimal) value));
-            dv.isRepeating = true;
-            dv.isNull[0] = false;
-        }
-        return dv;
-    }
-
-    private static DoubleColumnVector createDoubleVector(int batchSize, Object value) {
-        DoubleColumnVector dcv = new DoubleColumnVector(batchSize);
-        if (value == null) {
-            dcv.noNulls = false;
-            dcv.isNull[0] = true;
-            dcv.isRepeating = true;
-        } else {
-            dcv.fill(((Number) value).doubleValue());
-            dcv.isNull[0] = false;
-        }
-        return dcv;
     }
 }

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetFileFormatFactory.java
@@ -143,7 +143,6 @@ public class ParquetFileFormatFactory implements BulkReaderFormatFactory, BulkWr
                     (RowType) Projection.of(projections).project(producedDataType).getLogicalType(),
                     sourceContext.createTypeInformation(producedDataType),
                     Collections.emptyList(),
-                    null,
                     VectorizedColumnBatch.DEFAULT_SIZE,
                     formatOptions.get(UTC_TIMEZONE),
                     true);

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/vector/ParquetSplitReaderUtil.java
@@ -34,8 +34,6 @@ import org.apache.flink.formats.parquet.vector.reader.MapColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.RowColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.ShortColumnReader;
 import org.apache.flink.formats.parquet.vector.reader.TimestampColumnReader;
-import org.apache.flink.table.data.DecimalData;
-import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.data.columnar.vector.ColumnVector;
 import org.apache.flink.table.data.columnar.vector.VectorizedColumnBatch;
 import org.apache.flink.table.data.columnar.vector.heap.HeapArrayVector;
@@ -53,14 +51,10 @@ import org.apache.flink.table.data.columnar.vector.heap.HeapTimestampVector;
 import org.apache.flink.table.data.columnar.vector.writable.WritableColumnVector;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.ArrayType;
-import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.DecimalType;
-import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
-import org.apache.flink.table.types.logical.VarBinaryType;
-import org.apache.flink.util.Preconditions;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.ParquetRuntimeException;
@@ -73,18 +67,12 @@ import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import java.sql.Date;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.table.utils.DateTimeUtils.toInternal;
 import static org.apache.parquet.Preconditions.checkArgument;
 
 /** Util for generating {@link ParquetColumnarRowSplitReader}. */
@@ -120,15 +108,10 @@ public class ParquetSplitReaderUtil {
         ParquetColumnarRowSplitReader.ColumnBatchGenerator gen =
                 readVectors -> {
                     // create and initialize the row batch
-                    ColumnVector[] vectors = new ColumnVector[selectedFields.length];
+                    ColumnVector[] vectors = new ColumnVector[selParquetFields.length];
                     for (int i = 0; i < vectors.length; i++) {
-                        String name = fullFieldNames[selectedFields[i]];
-                        LogicalType type = fullFieldTypes[selectedFields[i]].getLogicalType();
-                        vectors[i] =
-                                partitionSpec.containsKey(name)
-                                        ? createVectorFromConstant(
-                                                type, partitionSpec.get(name), batchSize)
-                                        : readVectors[selNonPartNames.indexOf(name)];
+                        String name = nonPartNames.get(selParquetFields[i]);
+                        vectors[i] = readVectors[selNonPartNames.indexOf(name)];
                     }
                     return new VectorizedColumnBatch(vectors);
                 };
@@ -146,129 +129,6 @@ public class ParquetSplitReaderUtil {
                 new org.apache.hadoop.fs.Path(path.toUri()),
                 splitStart,
                 splitLength);
-    }
-
-    public static ColumnVector createVectorFromConstant(
-            LogicalType type, Object value, int batchSize) {
-        switch (type.getTypeRoot()) {
-            case CHAR:
-            case VARCHAR:
-            case BINARY:
-            case VARBINARY:
-                HeapBytesVector bsv = new HeapBytesVector(batchSize);
-                if (value == null) {
-                    bsv.fillWithNulls();
-                } else {
-                    bsv.fill(
-                            value instanceof byte[]
-                                    ? (byte[]) value
-                                    : value.toString().getBytes(StandardCharsets.UTF_8));
-                }
-                return bsv;
-            case BOOLEAN:
-                HeapBooleanVector bv = new HeapBooleanVector(batchSize);
-                if (value == null) {
-                    bv.fillWithNulls();
-                } else {
-                    bv.fill((boolean) value);
-                }
-                return bv;
-            case TINYINT:
-                HeapByteVector byteVector = new HeapByteVector(batchSize);
-                if (value == null) {
-                    byteVector.fillWithNulls();
-                } else {
-                    byteVector.fill(((Number) value).byteValue());
-                }
-                return byteVector;
-            case SMALLINT:
-                HeapShortVector sv = new HeapShortVector(batchSize);
-                if (value == null) {
-                    sv.fillWithNulls();
-                } else {
-                    sv.fill(((Number) value).shortValue());
-                }
-                return sv;
-            case INTEGER:
-                HeapIntVector iv = new HeapIntVector(batchSize);
-                if (value == null) {
-                    iv.fillWithNulls();
-                } else {
-                    iv.fill(((Number) value).intValue());
-                }
-                return iv;
-            case BIGINT:
-                HeapLongVector lv = new HeapLongVector(batchSize);
-                if (value == null) {
-                    lv.fillWithNulls();
-                } else {
-                    lv.fill(((Number) value).longValue());
-                }
-                return lv;
-            case DECIMAL:
-                DecimalType decimalType = (DecimalType) type;
-                int precision = decimalType.getPrecision();
-                int scale = decimalType.getScale();
-                DecimalData decimal =
-                        value == null
-                                ? null
-                                : Preconditions.checkNotNull(
-                                        DecimalData.fromBigDecimal(
-                                                (BigDecimal) value, precision, scale));
-                ColumnVector internalVector;
-                if (ParquetSchemaConverter.is32BitDecimal(precision)) {
-                    internalVector =
-                            createVectorFromConstant(
-                                    new IntType(),
-                                    decimal == null ? null : (int) decimal.toUnscaledLong(),
-                                    batchSize);
-                } else if (ParquetSchemaConverter.is64BitDecimal(precision)) {
-                    internalVector =
-                            createVectorFromConstant(
-                                    new BigIntType(),
-                                    decimal == null ? null : decimal.toUnscaledLong(),
-                                    batchSize);
-                } else {
-                    internalVector =
-                            createVectorFromConstant(
-                                    new VarBinaryType(),
-                                    decimal == null ? null : decimal.toUnscaledBytes(),
-                                    batchSize);
-                }
-                return new ParquetDecimalVector(internalVector);
-            case FLOAT:
-                HeapFloatVector fv = new HeapFloatVector(batchSize);
-                if (value == null) {
-                    fv.fillWithNulls();
-                } else {
-                    fv.fill(((Number) value).floatValue());
-                }
-                return fv;
-            case DOUBLE:
-                HeapDoubleVector dv = new HeapDoubleVector(batchSize);
-                if (value == null) {
-                    dv.fillWithNulls();
-                } else {
-                    dv.fill(((Number) value).doubleValue());
-                }
-                return dv;
-            case DATE:
-                if (value instanceof LocalDate) {
-                    value = Date.valueOf((LocalDate) value);
-                }
-                return createVectorFromConstant(
-                        new IntType(), value == null ? null : toInternal((Date) value), batchSize);
-            case TIMESTAMP_WITHOUT_TIME_ZONE:
-                HeapTimestampVector tv = new HeapTimestampVector(batchSize);
-                if (value == null) {
-                    tv.fillWithNulls();
-                } else {
-                    tv.fill(TimestampData.fromLocalDateTime((LocalDateTime) value));
-                }
-                return tv;
-            default:
-                throw new UnsupportedOperationException("Unsupported type: " + type);
-        }
     }
 
     private static List<ColumnDescriptor> getAllColumnDescriptorByType(


### PR DESCRIPTION
## What is the purpose of the change

This is meant to leverage the `EnrichedRowData` to handle partition keys logic in the hive connectors. After this it will not depend on the parquet/orc formats to make up the rowdata with partition keys. Also, the formats module do not have to care about make up the partition keys.

> At the first try, I want to handle the partition keys in the hive. But I found that can not finish in a single PR without touching the parquet/orc format's code. So I mix the PR with two commits as you can see.

## Brief change log

- wrap the HiveInputFormat with FileInfoExtractorBulkFormat
- decorate the HiveTableInputFormat's records with the record mapping  


## Verifying this change

This change is already covered by existing tests: `HiveSourceITCase` and `HiveTableSourceITCase`
