### PR TITLE
[FLINK-28617][SQL Gateway] Support stop job statement in SqlGatewayService

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -460,7 +460,7 @@ public class OperationExecutor {
                                     } catch (Exception e) {
                                         throw new FlinkException(
                                                 "Could not stop job "
-                                                        + stopJobOperation
+                                                        + stopJobOperation.getJobId()
                                                         + " in session "
                                                         + operationHandle.getIdentifier()
                                                         + ".",

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/utils/Constants.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/utils/Constants.java
@@ -25,4 +25,6 @@ public class Constants {
     public static final String SET_KEY = "key";
     public static final String SET_VALUE = "value";
     public static final String COMPLETION_HINTS = "hints";
+
+    public static final String SAVEPOINT_PATH = "savepoint_path";
 }

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -444,7 +444,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
             Path savepointPath = Paths.get(savepoint);
             assertThat(savepointPath.getFileName().toString()).startsWith("savepoint-");
         } else {
-            assertThat(stopResults.get(0).getString(0).toString()).isEmpty();
+            assertThat(stopResults.get(0).getString(0).toString()).isEqualTo("OK");
         }
     }
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -309,7 +309,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                 "Failed to wait operation finish.");
 
         List<RowData> expectedData = getDefaultResultSet().getData();
-        List<RowData> actualData = fetchAllResultRows(sessionHandle, operationHandle);
+        List<RowData> actualData = fetchAllResults(sessionHandle, operationHandle);
         assertThat(actualData).isEqualTo(expectedData);
 
         service.closeOperation(sessionHandle, operationHandle);
@@ -389,7 +389,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                         -1,
                         Configuration.fromMap(Collections.singletonMap(key, value)));
 
-        List<RowData> settings = fetchAllResultRows(sessionHandle, operationHandle);
+        List<RowData> settings = fetchAllResults(sessionHandle, operationHandle);
 
         assertThat(settings)
                 .contains(
@@ -420,7 +420,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
         OperationHandle insertOperationHandle =
                 service.executeStatement(sessionHandle, insertSql, -1, configuration);
 
-        List<RowData> results = fetchAllResultRows(sessionHandle, insertOperationHandle);
+        List<RowData> results = fetchAllResults(sessionHandle, insertOperationHandle);
         assertThat(results.size()).isEqualTo(1);
         String jobId = results.get(0).getString(0).toString();
 
@@ -431,7 +431,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
         OperationHandle stopOperationHandle =
                 service.executeStatement(sessionHandle, stopSql, -1, configuration);
 
-        List<RowData> stopResults = fetchAllResultRows(sessionHandle, stopOperationHandle);
+        List<RowData> stopResults = fetchAllResults(sessionHandle, stopOperationHandle);
         assertThat(stopResults.size()).isEqualTo(1);
         if (hasSavepoint) {
             String savepoint = stopResults.get(0).getString(0).toString();
@@ -1117,7 +1117,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                 .isEqualTo(expectedCompletionHints);
     }
 
-    private List<RowData> fetchAllResultRows(
+    private List<RowData> fetchAllResults(
             SessionHandle sessionHandle, OperationHandle operationHandle) {
         Long token = 0L;
         List<RowData> results = new ArrayList<>();

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.gateway.service;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
@@ -431,7 +432,7 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
         assertThat(results.size()).isEqualTo(1);
         String jobId = results.get(0).getString(0).toString();
 
-        TestUtils.waitUntilJobIsRunning(restClusterClient);
+        TestUtils.waitUntilAllTasksAreRunning(restClusterClient, JobID.fromHexString(jobId));
 
         String stopSql = String.format(stopSqlTemplate, jobId, option);
         OperationHandle stopOperationHandle =

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -125,8 +125,6 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
     public static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
             new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
 
-    @TempDir File tmpDir;
-
     private static SessionManager sessionManager;
     private static SqlGatewayServiceImpl service;
 
@@ -401,8 +399,8 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
 
     @ParameterizedTest
     @CsvSource({"WITH SAVEPOINT,true", "WITH SAVEPOINT WITH DRAIN,true", "'',false"})
-    public void testStopJobStatementWithSavepoint(String option, boolean hasSavepoint)
-            throws InterruptedException {
+    public void testStopJobStatementWithSavepoint(
+            String option, boolean hasSavepoint, @TempDir File tmpDir) throws InterruptedException {
         Configuration configuration = new Configuration(MINI_CLUSTER.getClientConfiguration());
         configuration.setBoolean(TableConfigOptions.TABLE_DML_SYNC, false);
         File savepointDir = new File(tmpDir, "savepoints");

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.table.gateway.service;
 
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.CommonTestUtils;
 import org.apache.flink.core.testutils.FlinkAssertions;
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.TableConfigOptions;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
@@ -55,6 +58,7 @@ import org.apache.flink.table.planner.plan.utils.JavaUserDefinedAggFunctions;
 import org.apache.flink.table.planner.runtime.batch.sql.TestModule;
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions;
 import org.apache.flink.table.planner.utils.TableFunc0;
+import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.UserClassLoaderJarTestUtils;
@@ -64,11 +68,16 @@ import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -97,7 +106,6 @@ import static org.apache.flink.table.utils.UserDefinedFunctions.GENERATED_LOWER_
 import static org.apache.flink.types.RowKind.DELETE;
 import static org.apache.flink.types.RowKind.INSERT;
 import static org.apache.flink.types.RowKind.UPDATE_AFTER;
-import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
@@ -105,8 +113,19 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 public class SqlGatewayServiceITCase extends AbstractTestBase {
 
     @RegisterExtension
+    @Order(1)
+    public static final MiniClusterExtension MINI_CLUSTER =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .build());
+
+    @RegisterExtension
+    @Order(2)
     public static final SqlGatewayServiceExtension SQL_GATEWAY_SERVICE_EXTENSION =
-            new SqlGatewayServiceExtension();
+            new SqlGatewayServiceExtension(MINI_CLUSTER::getClientConfiguration);
+
+    @TempDir File tmpDir;
 
     private static SessionManager sessionManager;
     private static SqlGatewayServiceImpl service;
@@ -291,15 +310,8 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                 Duration.ofSeconds(10),
                 "Failed to wait operation finish.");
 
-        Long token = 0L;
         List<RowData> expectedData = getDefaultResultSet().getData();
-        List<RowData> actualData = new ArrayList<>();
-        while (token != null) {
-            ResultSet currentResult =
-                    service.fetchResults(sessionHandle, operationHandle, token, 1);
-            actualData.addAll(checkNotNull(currentResult.getData()));
-            token = currentResult.getNextToken();
-        }
+        List<RowData> actualData = fetchAllResultRows(sessionHandle, operationHandle);
         assertThat(actualData).isEqualTo(expectedData);
 
         service.closeOperation(sessionHandle, operationHandle);
@@ -379,19 +391,57 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
                         -1,
                         Configuration.fromMap(Collections.singletonMap(key, value)));
 
-        Long token = 0L;
-        List<RowData> settings = new ArrayList<>();
-        while (token != null) {
-            ResultSet result =
-                    service.fetchResults(sessionHandle, operationHandle, token, Integer.MAX_VALUE);
-            settings.addAll(result.getData());
-            token = result.getNextToken();
-        }
+        List<RowData> settings = fetchAllResultRows(sessionHandle, operationHandle);
 
         assertThat(settings)
                 .contains(
                         GenericRowData.of(
                                 StringData.fromString(key), StringData.fromString(value)));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"WITH SAVEPOINT,true", "WITH SAVEPOINT WITH DRAIN,true", "'',false"})
+    public void testStopJobStatementWithSavepoint(String option, boolean hasSavepoint)
+            throws InterruptedException {
+        Configuration configuration = new Configuration(MINI_CLUSTER.getClientConfiguration());
+        configuration.setBoolean(TableConfigOptions.TABLE_DML_SYNC, false);
+        File savepointDir = new File(tmpDir, "savepoints");
+        configuration.set(
+                CheckpointingOptions.SAVEPOINT_DIRECTORY, savepointDir.toURI().toString());
+
+        SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
+
+        String sourceDdl = "CREATE TABLE source (a STRING) WITH ('connector'='datagen');";
+        String sinkDdl = "CREATE TABLE sink (a STRING) WITH ('connector'='blackhole');";
+        String insertSql = "INSERT INTO sink SELECT * FROM source;";
+        String stopSqlTemplate = "STOP JOB '%s' %s;";
+
+        service.executeStatement(sessionHandle, sourceDdl, -1, configuration);
+        service.executeStatement(sessionHandle, sinkDdl, -1, configuration);
+
+        OperationHandle insertOperationHandle =
+                service.executeStatement(sessionHandle, insertSql, -1, configuration);
+
+        List<RowData> results = fetchAllResultRows(sessionHandle, insertOperationHandle);
+        assertThat(results.size()).isEqualTo(1);
+        String jobId = results.get(0).getString(0).toString();
+
+        // wait till the job turns into running status
+        Thread.sleep(2_000L);
+
+        String stopSql = String.format(stopSqlTemplate, jobId, option);
+        OperationHandle stopOperationHandle =
+                service.executeStatement(sessionHandle, stopSql, -1, configuration);
+
+        List<RowData> stopResults = fetchAllResultRows(sessionHandle, stopOperationHandle);
+        assertThat(stopResults.size()).isEqualTo(1);
+        if (hasSavepoint) {
+            String savepoint = stopResults.get(0).getString(0).toString();
+            Path savepointPath = Paths.get(savepoint);
+            assertThat(savepointPath.getFileName().toString()).startsWith("savepoint-");
+        } else {
+            assertThat(stopResults.get(0).getString(0).toString()).isEmpty();
+        }
     }
 
     @Test
@@ -1067,5 +1117,18 @@ public class SqlGatewayServiceITCase extends AbstractTestBase {
             List<String> expectedCompletionHints) {
         assertThat(service.completeStatement(sessionHandle, incompleteSql, incompleteSql.length()))
                 .isEqualTo(expectedCompletionHints);
+    }
+
+    private List<RowData> fetchAllResultRows(
+            SessionHandle sessionHandle, OperationHandle operationHandle) {
+        Long token = 0L;
+        List<RowData> results = new ArrayList<>();
+        while (token != null) {
+            ResultSet result =
+                    service.fetchResults(sessionHandle, operationHandle, token, Integer.MAX_VALUE);
+            results.addAll(result.getData());
+            token = result.getNextToken();
+        }
+        return results;
     }
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
@@ -22,14 +22,19 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.client.program.ClusterClient;
+import org.apache.flink.client.program.rest.RestClusterClient;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.checkpoint.Checkpoints;
 import org.apache.flink.runtime.checkpoint.metadata.CheckpointMetadata;
-import org.apache.flink.runtime.client.JobStatusMessage;
+import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.minicluster.MiniCluster;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.JobMessageParameters;
+import org.apache.flink.runtime.rest.messages.job.JobDetailsHeaders;
 import org.apache.flink.runtime.state.CompletedCheckpointStorageLocation;
 import org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess;
+import org.apache.flink.runtime.testutils.CommonTestUtils;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.util.ExceptionUtils;
@@ -42,13 +47,10 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess.CHECKPOINT_DIR_PREFIX;
 import static org.apache.flink.runtime.state.filesystem.AbstractFsCheckpointStorageAccess.METADATA_FILE_NAME;
@@ -188,22 +190,38 @@ public class TestUtils {
     }
 
     /**
-     * Wait util at least one job turns into RUNNING status in the cluster. Applicable for single
-     * job scenarios.
+     * Wait util all task of a job turns into RUNNING state.
      *
-     * @param client ClusterClient which could be {@link
+     * @param restClusterClient RestClusterClient which could be {@link
      *     org.apache.flink.test.junit5.InjectClusterClient}.
      */
-    public static void waitUntilJobIsRunning(ClusterClient<?> client) throws Exception {
-        List<JobID> runningJobs = new ArrayList<>();
-        while (runningJobs.isEmpty()) {
-            Thread.sleep(50);
-            Collection<JobStatusMessage> statusMessages = client.listJobs().get();
-            runningJobs =
-                    statusMessages.stream()
-                            .filter(status -> status.getJobState().equals(JobStatus.RUNNING))
-                            .map(JobStatusMessage::getJobId)
-                            .collect(Collectors.toList());
-        }
+    public static void waitUntilAllTasksAreRunning(
+            RestClusterClient<?> restClusterClient, JobID jobId) throws Exception {
+        // access the REST endpoint of the cluster to determine the state of each ExecutionVertex
+        final JobDetailsHeaders detailsHeaders = JobDetailsHeaders.getInstance();
+        final JobMessageParameters params = detailsHeaders.getUnresolvedMessageParameters();
+        params.jobPathParameter.resolve(jobId);
+
+        CommonTestUtils.waitUntilCondition(
+                () ->
+                        restClusterClient
+                                .sendRequest(detailsHeaders, params, EmptyRequestBody.getInstance())
+                                .thenApply(
+                                        detailsInfo ->
+                                                allVerticesRunning(
+                                                        detailsInfo.getJobVerticesPerState()))
+                                .get());
+    }
+
+    private static boolean allVerticesRunning(Map<ExecutionState, Integer> states) {
+        return states.entrySet().stream()
+                .allMatch(
+                        entry -> {
+                            if (entry.getKey() == ExecutionState.RUNNING) {
+                                return entry.getValue() > 0;
+                            } else {
+                                return entry.getValue() == 0; // no vertices in non-running state.
+                            }
+                        });
     }
 }

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
@@ -195,10 +195,10 @@ public class TestUtils {
      *     org.apache.flink.test.junit5.InjectClusterClient}.
      */
     public static void waitUntilJobIsRunning(ClusterClient<?> client) throws Exception {
-        Collection<JobStatusMessage> statusMessages = client.listJobs().get();
         List<JobID> runningJobs = new ArrayList<>();
         while (runningJobs.isEmpty()) {
             Thread.sleep(50);
+            Collection<JobStatusMessage> statusMessages = client.listJobs().get();
             runningJobs =
                     statusMessages.stream()
                             .filter(status -> status.getJobState().equals(JobStatus.RUNNING))

--- a/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
+++ b/flink-test-utils-parent/flink-test-utils/src/main/java/org/apache/flink/test/util/TestUtils.java
@@ -201,7 +201,7 @@ public class TestUtils {
             Thread.sleep(50);
             runningJobs =
                     statusMessages.stream()
-                            .filter(status -> !status.getJobState().equals(JobStatus.RUNNING))
+                            .filter(status -> status.getJobState().equals(JobStatus.RUNNING))
                             .map(JobStatusMessage::getJobId)
                             .collect(Collectors.toList());
         }


### PR DESCRIPTION
## What is the purpose of the change

Support stop job statement in SqlGatewayService. Subtask of FLIP-222.


## Brief change log

  - *Support stop job statement in SqlGatewayService*
  - *Extend SqlGatewayServiceExtension to include a mini cluster for statement execution*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing


This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for stop job statements.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
