### PR TITLE
[FLINK-24235][metrics] Only support reporters via factories

### DIFF
--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InstantiateViaFactory.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InstantiateViaFactory.java
@@ -26,14 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for {@link MetricReporter MetricReporters} that support factories but want to maintain
- * backwards-compatibility with existing reflection-based configurations.
- *
- * <p>When an annotated reporter is configured to be used via reflection the given factory will be
- * used instead.
- *
- * <p>Attention: This annotation does not work if the reporter is loaded as a plugin. For these
- * cases, annotate the factory with {@link InterceptInstantiationViaReflection} instead.
+ * This annotation has no effect and is only kept for compatibility reasons.
  *
  * @deprecated Will be removed in a future version. Users should use all reporters as plugins.
  */

--- a/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InterceptInstantiationViaReflection.java
+++ b/flink-metrics/flink-metrics-core/src/main/java/org/apache/flink/metrics/reporter/InterceptInstantiationViaReflection.java
@@ -25,13 +25,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for {@link MetricReporterFactory MetricReporterFactories} that want to maintain
- * backwards-compatibility with existing reflection-based configurations.
+ * This annotation has no effect and is only kept for compatibility reasons.
  *
- * <p>When a reporter is configured to be used via reflection the annotated factory will be used
- * instead.
- *
- * @see InstantiateViaFactory
  * @deprecated Will be removed in a future version. Users should use all reporters as plugins.
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -25,8 +25,6 @@ import org.apache.flink.configuration.DelegatingConfiguration;
 import org.apache.flink.configuration.MetricOptions;
 import org.apache.flink.core.plugin.PluginManager;
 import org.apache.flink.metrics.MetricConfig;
-import org.apache.flink.metrics.reporter.InstantiateViaFactory;
-import org.apache.flink.metrics.reporter.InterceptInstantiationViaReflection;
 import org.apache.flink.metrics.reporter.MetricReporter;
 import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.runtime.metrics.filter.DefaultMetricFilter;
@@ -365,8 +363,7 @@ public final class ReporterSetup {
     private static Optional<MetricReporter> loadReporter(
             final String reporterName,
             final Configuration reporterConfig,
-            final Map<String, MetricReporterFactory> reporterFactories)
-            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+            final Map<String, MetricReporterFactory> reporterFactories) {
 
         final String reporterClassName = reporterConfig.get(MetricOptions.REPORTER_CLASS);
         final String factoryClassName = reporterConfig.get(MetricOptions.REPORTER_FACTORY_CLASS);
@@ -378,40 +375,16 @@ public final class ReporterSetup {
 
         if (reporterClassName != null) {
             LOG.warn(
-                    "The reporter configuration of '{}' configures the reporter class, which is a deprecated approach to configure reporters."
-                            + " Please configure a factory class instead: '{}{}.{}: <factoryClass>' to ensure that the configuration"
-                            + " continues to work with future versions.",
+                    "The reporter configuration of '{}' configures the reporter class, which is no a no longer supported approach to configure reporters."
+                            + " Please configure a factory class instead: '{}{}.{}: <factoryClass>'.",
                     reporterName,
                     ConfigConstants.METRICS_REPORTER_PREFIX,
                     reporterName,
                     MetricOptions.REPORTER_FACTORY_CLASS.key());
-
-            final Optional<MetricReporterFactory> interceptingFactory =
-                    reporterFactories.values().stream()
-                            .filter(
-                                    factory -> {
-                                        InterceptInstantiationViaReflection annotation =
-                                                factory.getClass()
-                                                        .getAnnotation(
-                                                                InterceptInstantiationViaReflection
-                                                                        .class);
-                                        return annotation != null
-                                                && annotation
-                                                        .reporterClassName()
-                                                        .equals(reporterClassName);
-                                    })
-                            .findAny();
-
-            if (interceptingFactory.isPresent()) {
-                return loadViaFactory(reporterConfig, interceptingFactory.get());
-            }
-
-            return loadViaReflection(
-                    reporterClassName, reporterName, reporterConfig, reporterFactories);
         }
 
         LOG.warn(
-                "No reporter class nor factory set for reporter {}. Metrics might not be exposed/reported.",
+                "No reporter factory set for reporter {}. Metrics might not be exposed/reported.",
                 reporterName);
         return Optional.empty();
     }
@@ -443,27 +416,5 @@ public final class ReporterSetup {
         reporterConfig.addAllToProperties(metricConfig);
 
         return Optional.of(factory.createMetricReporter(metricConfig));
-    }
-
-    @SuppressWarnings("deprecation")
-    private static Optional<MetricReporter> loadViaReflection(
-            final String reporterClassName,
-            final String reporterName,
-            final Configuration reporterConfig,
-            final Map<String, MetricReporterFactory> reporterFactories)
-            throws ClassNotFoundException, IllegalAccessException, InstantiationException {
-
-        final Class<?> reporterClass = Class.forName(reporterClassName);
-
-        final InstantiateViaFactory alternativeFactoryAnnotation =
-                reporterClass.getAnnotation(InstantiateViaFactory.class);
-        if (alternativeFactoryAnnotation != null) {
-            final String alternativeFactoryClassName =
-                    alternativeFactoryAnnotation.factoryClassName();
-            return loadViaFactory(
-                    alternativeFactoryClassName, reporterName, reporterConfig, reporterFactories);
-        }
-
-        return Optional.of((MetricReporter) reporterClass.newInstance());
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/metrics/JobManagerMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/metrics/JobManagerMetricsITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.core.testutils.CheckedThread;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.reporter.AbstractReporter;
+import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.PrintSinkFunction;
@@ -38,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -138,7 +141,7 @@ public class JobManagerMetricsITCase extends TestLogger {
     private static Configuration getConfiguration() {
         Configuration configuration = new Configuration();
         configuration.setString(
-                "metrics.reporter.test_reporter.class", TestReporter.class.getName());
+                "metrics.reporter.test_reporter.factory.class", TestReporter.class.getName());
         return configuration;
     }
 
@@ -160,7 +163,8 @@ public class JobManagerMetricsITCase extends TestLogger {
     }
 
     /** Test metric reporter that exposes registered metrics. */
-    public static final class TestReporter extends AbstractReporter {
+    public static final class TestReporter extends AbstractReporter
+            implements MetricReporterFactory {
         public static final Set<TestReporter> OPENED_REPORTERS = ConcurrentHashMap.newKeySet();
 
         @Override
@@ -180,6 +184,11 @@ public class JobManagerMetricsITCase extends TestLogger {
 
         public Map<Gauge<?>, String> getGauges() {
             return gauges;
+        }
+
+        @Override
+        public MetricReporter createMetricReporter(Properties properties) {
+            return this;
         }
     }
 }

--- a/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/runtime/metrics/SystemResourcesMetricsITCase.java
@@ -25,6 +25,7 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.MetricConfig;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.reporter.MetricReporter;
+import org.apache.flink.metrics.reporter.MetricReporterFactory;
 import org.apache.flink.runtime.testutils.MiniClusterResource;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.util.TestLogger;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -65,7 +67,7 @@ public class SystemResourcesMetricsITCase extends TestLogger {
         configuration.setString(MetricOptions.SCOPE_NAMING_JM, "jobmanager");
         configuration.setString(MetricOptions.SCOPE_NAMING_TM, "taskmanager");
         configuration.setString(
-                "metrics.reporter.test_reporter.class", TestReporter.class.getName());
+                "metrics.reporter.test_reporter.factory.class", TestReporter.class.getName());
         return configuration;
     }
 
@@ -107,7 +109,7 @@ public class SystemResourcesMetricsITCase extends TestLogger {
     }
 
     /** Test metric reporter that exposes registered metrics. */
-    public static final class TestReporter implements MetricReporter {
+    public static final class TestReporter implements MetricReporter, MetricReporterFactory {
         public static final Set<TestReporter> OPENED_REPORTERS = ConcurrentHashMap.newKeySet();
         private final Map<String, CompletableFuture<Void>> patternFutures =
                 getExpectedPatterns().stream()
@@ -140,5 +142,10 @@ public class SystemResourcesMetricsITCase extends TestLogger {
 
         @Override
         public void notifyOfRemovedMetric(Metric metric, String metricName, MetricGroup group) {}
+
+        @Override
+        public MetricReporter createMetricReporter(Properties properties) {
+            return this;
+        }
     }
 }


### PR DESCRIPTION
Following the deprecation in 1.16 this PR removes the reflection-based code path for instantiating reporters.