### PR TITLE
[FLINK-30003][rpc] Wait the scheduler future is done before check

### DIFF
--- a/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
+++ b/flink-rpc/flink-rpc-akka/src/test/java/org/apache/flink/runtime/rpc/akka/ContextClassLoadingSettingTest.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.concurrent.akka.ClassLoadingUtils.runWithContextClassLoader;
@@ -92,7 +91,7 @@ class ContextClassLoadingSettingTest {
     }
 
     @AfterEach
-    void shutdown() throws InterruptedException, ExecutionException, TimeoutException {
+    void shutdown() throws InterruptedException, ExecutionException {
         final CompletableFuture<Void> rpcTerminationFuture = akkaRpcService.closeAsync();
         final CompletableFuture<Terminated> actorSystemTerminationFuture =
                 AkkaFutureUtils.toJava(actorSystem.terminate());


### PR DESCRIPTION
## What is the purpose of the change

CI fails due to main thread didn't wait the future is done. The contextClassLoaders may be empty when checking.

https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=43092&view=logs&j=0da23115-68bb-5dcd-192c-bd4c8adebde1&t=24c3384f-1bcb-57b3-224f-51bf973bbee8&s=ae4f8708-9994-57d3-c2d7-b892156e7812

![image](https://user-images.githubusercontent.com/38427477/201473174-91bef2a7-df57-4469-bbf2-66b5cfd0fafd.png)


## Brief change log

Wait the scheduler future is done before check


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
