### PR TITLE
[FLINK-30017][build] Remove aggregate-scaladoc profile

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -51,7 +51,6 @@ mvn clean install -B -DskipTests -Dfast -Pskip-webui-build
 # build java/scala docs
 mkdir -p docs/target/api
 mvn javadoc:aggregate -B \
-    -Paggregate-scaladoc \
     -DadditionalJOption="-Xdoclint:none --allow-script-in-comments" \
     -Dmaven.javadoc.failOnError=false \
     -Dcheckstyle.skip=true \

--- a/pom.xml
+++ b/pom.xml
@@ -1215,13 +1215,6 @@ under the License.
 		</profile>
 
 		<profile>
-            <!-- Kept for backwards compatiblity, the doc buildbot expects
-                 this profile to exist.-->
-			<id>aggregate-scaladoc</id>
-		</profile>
-
-
-		<profile>
 			<!-- used for SNAPSHOT and regular releases -->
 			<id>docs-and-source</id>
 			<activation>

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -69,8 +69,8 @@ fi
 
 echo "============ Checking Javadocs ============"
 
-# use the same invocation as on buildbot (https://svn.apache.org/repos/infra/infrastructure/buildbot/aegis/buildmaster/master1/projects/flink.conf)
-run_mvn javadoc:aggregate -Paggregate-scaladoc -DadditionalJOption='-Xdoclint:none' \
+# use the same invocation as .github/workflows/docs.sh
+run_mvn javadoc:aggregate -DadditionalJOption='-Xdoclint:none' \
       -Dmaven.javadoc.failOnError=false -Dcheckstyle.skip=true -Denforcer.skip=true -Dspotless.skip=true \
       -Dheader=someTestHeader > javadoc.out
 EXIT_CODE=$?


### PR DESCRIPTION
Back when we used buildbot we had to keep the set of profiles constant across releases. Now that the docs are build via GHA we no longer need this legacy profile.