### PR TITLE
[FLINK-27341][runtime] Remove LOOPBACK from TaskManager findConnectingAddress.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/ConnectionUtils.java
@@ -58,7 +58,6 @@ public class ConnectionUtils {
      * state failed to determine the address.
      */
     private enum AddressDetectionState {
-        LOOPBACK(100),
         /** Connect from interface returned by InetAddress.getLocalHost(). * */
         LOCAL_HOST(200),
         /** Detect own IP address based on the target IP address. Look for common prefix */
@@ -116,7 +115,6 @@ public class ConnectionUtils {
         final List<AddressDetectionState> strategies =
                 Collections.unmodifiableList(
                         Arrays.asList(
-                                AddressDetectionState.LOOPBACK,
                                 AddressDetectionState.LOCAL_HOST,
                                 AddressDetectionState.ADDRESS,
                                 AddressDetectionState.FAST_CONNECT,
@@ -227,18 +225,6 @@ public class ConnectionUtils {
     private static InetAddress findAddressUsingStrategy(
             AddressDetectionState strategy, InetSocketAddress targetAddress, boolean logging)
             throws IOException {
-        if (strategy == AddressDetectionState.LOOPBACK) {
-            InetAddress loopback = InetAddress.getLoopbackAddress();
-
-            if (tryToConnect(loopback, targetAddress, strategy.getTimeout(), logging)) {
-                LOG.debug(
-                        "Using InetAddress.getLoopbackAddress() immediately for connecting address");
-                return loopback;
-            } else {
-                return null;
-            }
-        }
-
         // try LOCAL_HOST strategy independent of the network interfaces
         if (strategy == AddressDetectionState.LOCAL_HOST) {
             InetAddress localhostName;
@@ -446,7 +432,7 @@ public class ConnectionUtils {
                     }
 
                     if (targetAddress != null) {
-                        AddressDetectionState strategy = AddressDetectionState.LOOPBACK;
+                        AddressDetectionState strategy = AddressDetectionState.LOCAL_HOST;
 
                         boolean logging = elapsedTimeMillis >= startLoggingAfter.toMillis();
                         if (logging) {
@@ -463,9 +449,6 @@ public class ConnectionUtils {
 
                             // pick the next strategy
                             switch (strategy) {
-                                case LOOPBACK:
-                                    strategy = AddressDetectionState.LOCAL_HOST;
-                                    break;
                                 case LOCAL_HOST:
                                     strategy = AddressDetectionState.ADDRESS;
                                     break;


### PR DESCRIPTION

## What is the purpose of the change

If JobManager and TaskManager run in same host, the previous logic will use LOOPBACK interface for TaskManager, thus other TaskManagers in different host can not connect with the TaskManager.

## Brief change log

- Remove LOOPBACK related logic in findConnectingAddress.


## Verifying this change

This change is already covered by existing tests, such as ConnectionUtilsTest. 
  - Manually verified the change by running 1 JobManager and 2 taskmanagers in these deployment target. TaskManager can connect with JobManager and TaskManager in different host can community.
    - *Kubernetes cluster*
    - *Docker cluster*
    - *Standalone cluster*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
