### PR TITLE
[FLINK-30036][kubernetes] force delete pod when the k8s node is under NotReady state

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -40,7 +40,6 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
-import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.OwnerReference;
@@ -183,8 +182,8 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                                                             .getSpec()
                                                             .getNodeName())
                                             .get());
-                    // When the Ready NodeCondition status is False or Unknown, to force delete the pod
-                    // on it.
+                    // When the Ready NodeCondition status is False or Unknown, to force delete the
+                    // pod on it.
                     this.internalClient
                             .pods()
                             .withName(podName)

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -40,6 +40,7 @@ import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import io.fabric8.kubernetes.api.model.ConfigMap;
+import io.fabric8.kubernetes.api.model.DeletionPropagation;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.OwnerReference;
@@ -323,11 +324,9 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                                             () ->
                                                     new CompletionException(
                                                             new KubernetesException(
-                                                                    "Cannot retry "
-                                                                            + "checkAndUpdateConfigMap with configMap "
+                                                                    "Cannot retry checkAndUpdateConfigMap with configMap "
                                                                             + configMapName
-                                                                            + " because it does "
-                                                                            + "not exist.")));
+                                                                            + " because it does not exist.")));
                     final Optional<KubernetesConfigMap> maybeUpdate =
                             updateFunction.apply(configMap);
                     if (maybeUpdate.isPresent()) {

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -170,18 +170,25 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     public CompletableFuture<Void> stopPod(String podName) {
         return CompletableFuture.runAsync(
                 () -> {
-                    KubernetesNode kubernetesNode = new KubernetesNode(this.internalClient
-                            .nodes()
-                            .withName(this.internalClient
-                                    .pods()
-                                    .withName(podName)
-                                    .get()
-                                    .getSpec()
-                                    .getNodeName()).get());
-                    // When the Ready NodeCondition is False or Unknown, to force delete the pod
+                    KubernetesNode kubernetesNode =
+                            new KubernetesNode(
+                                    this.internalClient
+                                            .nodes()
+                                            .withName(
+                                                    this.internalClient
+                                                            .pods()
+                                                            .withName(podName)
+                                                            .get()
+                                                            .getSpec()
+                                                            .getNodeName())
+                                            .get());
+                    // When the Ready NodeCondition status is False or Unknown, to force delete the pod
                     // on it.
-                    this.internalClient.pods().withName(podName).withGracePeriod(
-                            kubernetesNode.isNodeNotReady() ? 0 : 30).delete();
+                    this.internalClient
+                            .pods()
+                            .withName(podName)
+                            .withGracePeriod(kubernetesNode.isNodeNotReady() ? 0 : 30)
+                            .delete();
                 },
                 kubeClientExecutorService);
     }
@@ -317,8 +324,7 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                                                     new CompletionException(
                                                             new KubernetesException(
                                                                     "Cannot retry "
-                                                                            +
-                                                                            "checkAndUpdateConfigMap with configMap "
+                                                                            + "checkAndUpdateConfigMap with configMap "
                                                                             + configMapName
                                                                             + " because it does "
                                                                             + "not exist.")));
@@ -399,7 +405,7 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
                                         service -> {
                                             final Service updatedService =
                                                     new ServiceBuilder(
-                                                            service.getInternalResource())
+                                                                    service.getInternalResource())
                                                             .editSpec()
                                                             .editMatchingPort(
                                                                     servicePortBuilder ->

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.kubernetes.kubeclient.resources;
 
-import org.apache.flink.annotation.VisibleForTesting;
-
 import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeCondition;
 
@@ -42,8 +40,7 @@ public class KubernetesNode extends KubernetesResource<Node> {
         return false;
     }
 
-    @VisibleForTesting
-    enum NodeConditions {
+    public enum NodeConditions {
         /**
          * True if the node is healthy and ready to accept pods, False if the node is not healthy
          * and is not accepting pods, and Unknown if the node controller has not heard from the node
@@ -69,8 +66,7 @@ public class KubernetesNode extends KubernetesResource<Node> {
         NetworkUnavailable
     }
 
-    @VisibleForTesting
-    enum NodeConditionStatus {
+    public enum NodeConditionStatus {
         /** The NodeCondition is normal. */
         True,
         /** The NodeCondition is out of whack. */

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.Node;
 import io.fabric8.kubernetes.api.model.NodeCondition;
 
 import java.util.List;
+import java.util.Objects;
 
 /** Represent KubernetesNode resource in kubernetes. */
 public class KubernetesNode extends KubernetesResource<Node> {
@@ -31,15 +32,21 @@ public class KubernetesNode extends KubernetesResource<Node> {
 
     public boolean isNodeNotReady() {
         List<NodeCondition> nodeConditions = this.getInternalResource().getStatus().getConditions();
-        for (NodeCondition nodeCondition : nodeConditions) {
-            if (NodeConditions.Ready.name().equals(nodeCondition.getType())) {
-                return NodeConditionStatus.False.name().equals(nodeCondition.getStatus())
-                        || NodeConditionStatus.Unknown.name().equals(nodeCondition.getStatus());
-            }
+        if (Objects.nonNull(nodeConditions) && !nodeConditions.isEmpty()) {
+            return nodeConditions.stream()
+                    .anyMatch(
+                            e ->
+                                    NodeConditions.Ready.name().equals(e.getType())
+                                            && (NodeConditionStatus.False.name()
+                                                            .equals(e.getStatus())
+                                                    || NodeConditionStatus.Unknown.name()
+                                                            .equals(e.getStatus())));
         }
+
         return false;
     }
 
+    /** Conditions for node. */
     public enum NodeConditions {
         /**
          * True if the node is healthy and ready to accept pods, False if the node is not healthy
@@ -66,6 +73,7 @@ public class KubernetesNode extends KubernetesResource<Node> {
         NetworkUnavailable
     }
 
+    /** Condition status for node. */
     public enum NodeConditionStatus {
         /** The NodeCondition is normal. */
         True,

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.resources;
+
+import org.apache.flink.annotation.VisibleForTesting;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeCondition;
+
+import java.util.List;
+
+/** Represent KubernetesNode resource in kubernetes. */
+public class KubernetesNode extends KubernetesResource<Node> {
+    public KubernetesNode(Node internalResource) {
+        super(internalResource);
+    }
+
+    public boolean isNodeNotReady() {
+        List<NodeCondition> nodeConditions = this.getInternalResource().getStatus().getConditions();
+        for (NodeCondition nodeCondition : nodeConditions) {
+            if (NodeConditions.Ready.name().equals(nodeCondition.getType())) {
+                return NodeConditionStatus.False.name().equals(nodeCondition.getStatus())
+                        || NodeConditionStatus.Unknown.name().equals(nodeCondition.getStatus());
+            }
+        }
+        return false;
+    }
+
+    @VisibleForTesting
+    enum NodeConditions {
+        /**
+         * True if the node is healthy and ready to accept pods, False if the node is not healthy
+         * and is not accepting pods, and Unknown if the node controller has not heard from the node
+         * in the last node-monitor-grace-period (default is 40 seconds)
+         */
+        Ready,
+        /**
+         * True if pressure exists on the disk size—that is, if the disk capacity is low; otherwise
+         * False
+         */
+        DiskPressure,
+        /**
+         * True if pressure exists on the node memory—that is, if the node memory is low; otherwise
+         * False
+         */
+        MemoryPressure,
+        /**
+         * True if pressure exists on the processes—that is, if there are too many processes on the
+         * node; otherwise False
+         */
+        PIDPressure,
+        /**
+         * True if the network for the node is not correctly configured, otherwise False
+         */
+        NetworkUnavailable
+    }
+
+    @VisibleForTesting
+    enum NodeConditionStatus {
+        /**
+         * The NodeCondition is normal.
+         */
+        True,
+        /**
+         * The NodeCondition is out of whack.
+         */
+        False,
+        /**
+         * The NodeCondition is unknown.
+         */
+        Unknown
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
@@ -47,25 +47,25 @@ public class KubernetesNode extends KubernetesResource<Node> {
         /**
          * True if the node is healthy and ready to accept pods, False if the node is not healthy
          * and is not accepting pods, and Unknown if the node controller has not heard from the node
-         * in the last node-monitor-grace-period (default is 40 seconds)
+         * in the last node-monitor-grace-period (default is 40 seconds).
          */
         Ready,
         /**
          * True if pressure exists on the disk size—that is, if the disk capacity is low; otherwise
-         * False
+         * False.
          */
         DiskPressure,
         /**
          * True if pressure exists on the node memory—that is, if the node memory is low; otherwise
-         * False
+         * False.
          */
         MemoryPressure,
         /**
          * True if pressure exists on the processes—that is, if there are too many processes on the
-         * node; otherwise False
+         * node; otherwise False.
          */
         PIDPressure,
-        /** True if the network for the node is not correctly configured, otherwise False */
+        /** True if the network for the node is not correctly configured, otherwise False. */
         NetworkUnavailable
     }
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNode.java
@@ -65,25 +65,17 @@ public class KubernetesNode extends KubernetesResource<Node> {
          * node; otherwise False
          */
         PIDPressure,
-        /**
-         * True if the network for the node is not correctly configured, otherwise False
-         */
+        /** True if the network for the node is not correctly configured, otherwise False */
         NetworkUnavailable
     }
 
     @VisibleForTesting
     enum NodeConditionStatus {
-        /**
-         * The NodeCondition is normal.
-         */
+        /** The NodeCondition is normal. */
         True,
-        /**
-         * The NodeCondition is out of whack.
-         */
+        /** The NodeCondition is out of whack. */
         False,
-        /**
-         * The NodeCondition is unknown.
-         */
+        /** The NodeCondition is unknown. */
         Unknown
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNodeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNodeTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.kubernetes.kubeclient.resources;
 
 import org.apache.flink.kubernetes.kubeclient.resources.KubernetesNode.NodeConditionStatus;

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNodeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNodeTest.java
@@ -16,31 +16,40 @@ public class KubernetesNodeTest {
     @Test
     void testIsNodeNotReady() {
         final Node node = new NodeBuilder().build();
-        node.setStatus(new NodeStatusBuilder().withConditions(new NodeConditionBuilder()
-                .withType(
-                        NodeConditions.Ready.name())
-                .withMessage("kubelet is posting ready status")
-                .withStatus(NodeConditionStatus.True.name())
-                .withReason("KubeletReady")
-                .build()).build());
+        node.setStatus(
+                new NodeStatusBuilder()
+                        .withConditions(
+                                new NodeConditionBuilder()
+                                        .withType(NodeConditions.Ready.name())
+                                        .withMessage("kubelet is posting ready status")
+                                        .withStatus(NodeConditionStatus.True.name())
+                                        .withReason("KubeletReady")
+                                        .build())
+                        .build());
         assertThat(new KubernetesNode(node).isNodeNotReady()).isFalse();
 
-        node.setStatus(new NodeStatusBuilder().withConditions(new NodeConditionBuilder()
-                .withType(
-                        NodeConditions.Ready.name())
-                .withMessage("kubelet is posting not ready status")
-                .withStatus(NodeConditionStatus.False.name())
-                .withReason("KubeletNotReady")
-                .build()).build());
+        node.setStatus(
+                new NodeStatusBuilder()
+                        .withConditions(
+                                new NodeConditionBuilder()
+                                        .withType(NodeConditions.Ready.name())
+                                        .withMessage("kubelet is posting not ready status")
+                                        .withStatus(NodeConditionStatus.False.name())
+                                        .withReason("KubeletNotReady")
+                                        .build())
+                        .build());
         assertThat(new KubernetesNode(node).isNodeNotReady()).isTrue();
 
-        node.setStatus(new NodeStatusBuilder().withConditions(new NodeConditionBuilder()
-                .withType(
-                        NodeConditions.Ready.name())
-                .withMessage("kubelet is posting unknown status")
-                .withStatus(NodeConditionStatus.Unknown.name())
-                .withReason("KubeletUnknown")
-                .build()).build());
+        node.setStatus(
+                new NodeStatusBuilder()
+                        .withConditions(
+                                new NodeConditionBuilder()
+                                        .withType(NodeConditions.Ready.name())
+                                        .withMessage("kubelet is posting unknown status")
+                                        .withStatus(NodeConditionStatus.Unknown.name())
+                                        .withReason("KubeletUnknown")
+                                        .build())
+                        .build());
         assertThat(new KubernetesNode(node).isNodeNotReady()).isTrue();
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNodeTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/resources/KubernetesNodeTest.java
@@ -1,0 +1,46 @@
+package org.apache.flink.kubernetes.kubeclient.resources;
+
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesNode.NodeConditionStatus;
+import org.apache.flink.kubernetes.kubeclient.resources.KubernetesNode.NodeConditions;
+
+import io.fabric8.kubernetes.api.model.Node;
+import io.fabric8.kubernetes.api.model.NodeBuilder;
+import io.fabric8.kubernetes.api.model.NodeConditionBuilder;
+import io.fabric8.kubernetes.api.model.NodeStatusBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link KubernetesNode}. */
+public class KubernetesNodeTest {
+    @Test
+    void testIsNodeNotReady() {
+        final Node node = new NodeBuilder().build();
+        node.setStatus(new NodeStatusBuilder().withConditions(new NodeConditionBuilder()
+                .withType(
+                        NodeConditions.Ready.name())
+                .withMessage("kubelet is posting ready status")
+                .withStatus(NodeConditionStatus.True.name())
+                .withReason("KubeletReady")
+                .build()).build());
+        assertThat(new KubernetesNode(node).isNodeNotReady()).isFalse();
+
+        node.setStatus(new NodeStatusBuilder().withConditions(new NodeConditionBuilder()
+                .withType(
+                        NodeConditions.Ready.name())
+                .withMessage("kubelet is posting not ready status")
+                .withStatus(NodeConditionStatus.False.name())
+                .withReason("KubeletNotReady")
+                .build()).build());
+        assertThat(new KubernetesNode(node).isNodeNotReady()).isTrue();
+
+        node.setStatus(new NodeStatusBuilder().withConditions(new NodeConditionBuilder()
+                .withType(
+                        NodeConditions.Ready.name())
+                .withMessage("kubelet is posting unknown status")
+                .withStatus(NodeConditionStatus.Unknown.name())
+                .withReason("KubeletUnknown")
+                .build()).build());
+        assertThat(new KubernetesNode(node).isNodeNotReady()).isTrue();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This pull request check whether the node where the pod resides is in the NotReady state. If yes, delete the pod forcibly.


## Brief change log

  -  Add KubernetesNode resource defination
  -  Before deleting a pod, check whether the status of the node where the pod resides is normal. If no, delete the pod forcibly.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:
  - Added Unit test to  test the node NotReady status get is right.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
