### PR TITLE
[FLINK-30023][changelog] increase timeout in ChangelogStorageMetricsT…

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
@@ -260,8 +260,8 @@ public class ChangelogStorageMetricsTest {
 
     @Test
     void testTotalAttemptsPerUpload() throws Exception {
-        int numUploads = 20, maxAttempts = 3;
-        long timeout = 20;
+        int numUploads = 10, maxAttempts = 3;
+        long timeout = 50;
         int numUploadThreads = 4; // must bigger or equal than maxAttempts
 
         ChangelogStorageMetricGroup metrics =


### PR DESCRIPTION
…est#testTotalAttemptsPerUpload for improving stability

## What is the purpose of the change

As the title said, increase timeout in ChangelogStorageMetricsTest#testTotalAttemptsPerUpload for improving stability. Previously shorter timeouts had a chance to cause the test to fail, such as [FLINK-30023](https://issues.apache.org/jira/browse/FLINK-30023) showed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
