### PR TITLE
[FLINK-21223][python] Support to specify the output types of Python UDFs via string

### DIFF
--- a/docs/content.zh/docs/dev/python/table/operations/row_based_operations.md
+++ b/docs/content.zh/docs/dev/python/table/operations/row_based_operations.md
@@ -35,7 +35,6 @@ The output will be flattened if the output type is a composite type.
 from pyflink.common import Row
 from pyflink.table import EnvironmentSettings, TableEnvironment
 from pyflink.table.expressions import col
-from pyflink.table.types import DataTypes
 from pyflink.table.udf import udf
 
 env_settings = EnvironmentSettings.in_batch_mode()
@@ -43,8 +42,7 @@ table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi'), (2, 'Hello')], ['id', 'data'])
 
-@udf(result_type=DataTypes.ROW([DataTypes.FIELD("id", DataTypes.BIGINT()),
-                                DataTypes.FIELD("data", DataTypes.STRING())]))
+@udf(result_type='ROW<id BIGINT, data STRING>')
 def func1(id: int, data: str) -> Row:
     return Row(id, data * 2)
 
@@ -62,8 +60,7 @@ table.map(func1(col('id'), col('data'))).execute().print()
 It also supports to take a Row object (containing all the columns of the input table) as input.
 
 ```python
-@udf(result_type=DataTypes.ROW([DataTypes.FIELD("id", DataTypes.BIGINT()),
-                                DataTypes.FIELD("data", DataTypes.STRING())]))
+@udf(result_type='ROW<id BIGINT, data STRING>')
 def func2(data: Row) -> Row:
     return Row(data.id, data.data * 2)
 
@@ -85,9 +82,7 @@ It should be noted that the input type and output type should be pandas.DataFram
 
 ```python
 import pandas as pd
-@udf(result_type=DataTypes.ROW([DataTypes.FIELD("id", DataTypes.BIGINT()),
-                                DataTypes.FIELD("data", DataTypes.STRING())]),
-     func_type='pandas')
+@udf(result_type='ROW<id BIGINT, data STRING>', func_type='pandas')
 def func3(data: pd.DataFrame) -> pd.DataFrame:
     res = pd.concat([data.id, data.data * 2], axis=1)
     return res
@@ -109,14 +104,14 @@ Performs a `flat_map` operation with a python [table function]({{< ref "docs/dev
 ```python
 from pyflink.common import Row
 from pyflink.table.udf import udtf
-from pyflink.table import DataTypes, EnvironmentSettings, TableEnvironment
+from pyflink.table import EnvironmentSettings, TableEnvironment
 
 env_settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(env_settings)
 
 table = table_env.from_elements([(1, 'Hi,Flink'), (2, 'Hello')], ['id', 'data'])
 
-@udtf(result_types=[DataTypes.INT(), DataTypes.STRING()])
+@udtf(result_types=['INT', 'STRING'])
 def split(x: Row) -> Row:
     for s in x.data.split(","):
         yield x.id, s
@@ -154,7 +149,7 @@ Performs an `aggregate` operation with a python [general aggregate function]({{<
 
 ```python
 from pyflink.common import Row
-from pyflink.table import DataTypes, EnvironmentSettings, TableEnvironment
+from pyflink.table import EnvironmentSettings, TableEnvironment
 from pyflink.table.expressions import col
 from pyflink.table.udf import AggregateFunction, udaf
 
@@ -180,14 +175,10 @@ class CountAndSumAggregateFunction(AggregateFunction):
             accumulator[1] += other_acc[1]
 
     def get_accumulator_type(self):
-        return DataTypes.ROW(
-            [DataTypes.FIELD("a", DataTypes.BIGINT()),
-             DataTypes.FIELD("b", DataTypes.BIGINT())])
+        return 'ROW<a BIGINT, b BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.ROW(
-            [DataTypes.FIELD("a", DataTypes.BIGINT()),
-             DataTypes.FIELD("b", DataTypes.BIGINT())])
+        return 'ROW<a BIGINT, b BIGINT>'
 
 function = CountAndSumAggregateFunction()
 agg = udaf(function,
@@ -221,9 +212,7 @@ table_env = TableEnvironment.create(env_settings)
 t = table_env.from_elements([(1, 2), (2, 1), (1, 3)], ['a', 'b'])
 
 pandas_udaf = udaf(lambda pd: (pd.b.mean(), pd.b.max()),
-                   result_type=DataTypes.ROW(
-                       [DataTypes.FIELD("a", DataTypes.FLOAT()),
-                        DataTypes.FIELD("b", DataTypes.INT())]),
+                   result_type='ROW<a FLOAT, b INT>',
                    func_type="pandas")
 t.aggregate(pandas_udaf.alias("a", "b")) \
     .select(col('a'), col('b')).execute().print()
@@ -250,7 +239,7 @@ Similar to `aggregate`, you have to close the `flat_aggregate` with a select sta
 
 ```python
 from pyflink.common import Row
-from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
+from pyflink.table import TableEnvironment, EnvironmentSettings
 from pyflink.table.expressions import col
 from pyflink.table.udf import udtaf, TableAggregateFunction
 
@@ -272,11 +261,10 @@ class Top2(TableAggregateFunction):
                 accumulator[1] = row.a
 
     def get_accumulator_type(self):
-        return DataTypes.ARRAY(DataTypes.BIGINT())
+        return 'ARRAY<BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.ROW(
-            [DataTypes.FIELD("a", DataTypes.BIGINT())])
+        return 'ROW<a BIGINT>'
 
 
 env_settings = EnvironmentSettings.in_streaming_mode()

--- a/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/python_udfs.md
@@ -55,13 +55,13 @@ class HashCode(ScalarFunction):
 settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
-hash_code = udf(HashCode(), result_type=DataTypes.BIGINT())
+hash_code = udf(HashCode(), result_type='BIGINT')
 
 # 在 Python Table API 中使用 Python 自定义函数
 my_table.select(col("string"), col("bigint"), hash_code(col("bigint")), call(hash_code, col("bigint")))
 
 # 在 SQL API 中使用 Python 自定义函数
-table_env.create_temporary_function("hash_code", udf(HashCode(), result_type=DataTypes.BIGINT()))
+table_env.create_temporary_function("hash_code", udf(HashCode(), result_type='BIGINT'))
 table_env.sql_query("SELECT string, bigint, hash_code(bigint) FROM MyTable")
 ```
 
@@ -108,25 +108,25 @@ class Add(ScalarFunction):
 add = udf(Add(), result_type=DataTypes.BIGINT())
 
 # 方式二：普通 Python 函数
-@udf(result_type=DataTypes.BIGINT())
+@udf(result_type='BIGINT')
 def add(i, j):
   return i + j
 
 # 方式三：lambda 函数
-add = udf(lambda i, j: i + j, result_type=DataTypes.BIGINT())
+add = udf(lambda i, j: i + j, result_type='BIGINT')
 
 # 方式四：callable 函数
 class CallableAdd(object):
   def __call__(self, i, j):
     return i + j
 
-add = udf(CallableAdd(), result_type=DataTypes.BIGINT())
+add = udf(CallableAdd(), result_type='BIGINT')
 
 # 方式五：partial 函数
 def partial_add(i, j, k):
   return i + j + k
 
-add = udf(functools.partial(partial_add, k=1), result_type=DataTypes.BIGINT())
+add = udf(functools.partial(partial_add, k=1), result_type='BIGINT')
 
 # 注册 Python 自定义函数
 table_env.create_temporary_function("add", add)
@@ -160,14 +160,14 @@ table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
 # 注册 Python 表值函数
-split = udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()])
+split = udtf(Split(), result_types=['STRING', 'INT'])
 
 # 在 Python Table API 中使用 Python 表值函数
 my_table.join_lateral(split(col("a")).alias("word", "length"))
 my_table.left_outer_join_lateral(split(col("a")).alias("word", "length"))
 
 # 在 SQL API 中使用 Python 表值函数
-table_env.create_temporary_function("split", udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()]))
+table_env.create_temporary_function("split", udtf(Split(), result_types=['STRING', 'INT']))
 table_env.sql_query("SELECT a, word, length FROM MyTable, LATERAL TABLE(split(a)) as T(word, length)")
 table_env.sql_query("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(split(a)) as T(word, length) ON TRUE")
 ```
@@ -219,18 +219,18 @@ table_env.sql_query("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE
 
 ```python
 # 方式一：生成器函数
-@udtf(result_types=DataTypes.BIGINT())
+@udtf(result_types='BIGINT')
 def generator_func(x):
       yield 1
       yield 2
 
 # 方式二：返回迭代器
-@udtf(result_types=DataTypes.BIGINT())
+@udtf(result_types='BIGINT')
 def iterator_func(x):
       return range(5)
 
 # 方式三：返回可迭代子类
-@udtf(result_types=DataTypes.BIGINT())
+@udtf(result_types='BIGINT')
 def iterable_func(x):
       result = [1, 2, 3]
       return result
@@ -300,12 +300,10 @@ class WeightedAvg(AggregateFunction):
         accumulator[1] -= weight
         
     def get_result_type(self):
-        return DataTypes.BIGINT()
+        return 'BIGINT'
         
     def get_accumulator_type(self):
-        return DataTypes.ROW([
-            DataTypes.FIELD("f0", DataTypes.BIGINT()), 
-            DataTypes.FIELD("f1", DataTypes.BIGINT())])
+        return 'ROW<f0 BIGINT, f1 BIGINT>'
 
 
 env_settings = EnvironmentSettings.in_streaming_mode()
@@ -475,11 +473,10 @@ class Top2(TableAggregateFunction):
                 accumulator[1] = row[0]
 
     def get_accumulator_type(self):
-        return DataTypes.ARRAY(DataTypes.BIGINT())
+        return 'ARRAY<BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.ROW(
-            [DataTypes.FIELD("a", DataTypes.BIGINT())])
+        return 'ROW<a BIGINT>'
 
 
 env_settings = EnvironmentSettings.in_streaming_mode()

--- a/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content.zh/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -49,11 +49,11 @@ under the License.
 以下示例显示了如何定义自己的向量化 Python 标量函数，该函数计算两列的总和，并在查询中使用它：
 
 ```python
-from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
+from pyflink.table import TableEnvironment, EnvironmentSettings
 from pyflink.table.expressions import col
 from pyflink.table.udf import udf
 
-@udf(result_type=DataTypes.BIGINT(), func_type="pandas")
+@udf(result_type='BIGINT', func_type="pandas")
 def add(i, j):
   return i + j
 
@@ -85,12 +85,12 @@ table_env.sql_query("SELECT add(bigint, bigint) FROM MyTable")
 and `Over Window Aggregation` 使用它:
 
 ```python
-from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
+from pyflink.table import TableEnvironment, EnvironmentSettings
 from pyflink.table.expressions import col, lit
 from pyflink.table.udf import udaf
 from pyflink.table.window import Tumble
 
-@udaf(result_type=DataTypes.FLOAT(), func_type="pandas")
+@udaf(result_type='FLOAT', func_type="pandas")
 def mean_udaf(v):
     return v.mean()
 
@@ -126,7 +126,6 @@ table_env.sql_query("""
 以下示例显示了多种定义向量化 Python 聚合函数的方式。该函数需要两个类型为 bigint 的参数作为输入参数，并返回它们的最大值的和作为结果。
 
 ```python
-from pyflink.table import DataTypes
 from pyflink.table.udf import AggregateFunction, udaf
 
 # 方式一：扩展基类 `AggregateFunction`
@@ -152,26 +151,26 @@ class MaxAdd(AggregateFunction):
             result += arg.max()
         accumulator.append(result)
 
-max_add = udaf(MaxAdd(), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(MaxAdd(), result_type='BIGINT', func_type="pandas")
 
 # 方式二：普通 Python 函数
-@udaf(result_type=DataTypes.BIGINT(), func_type="pandas")
+@udaf(result_type='BIGINT', func_type="pandas")
 def max_add(i, j):
   return i.max() + j.max()
 
 # 方式三：lambda 函数
-max_add = udaf(lambda i, j: i.max() + j.max(), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(lambda i, j: i.max() + j.max(), result_type='BIGINT', func_type="pandas")
 
 # 方式四：callable 函数
 class CallableMaxAdd(object):
   def __call__(self, i, j):
     return i.max() + j.max()
 
-max_add = udaf(CallableMaxAdd(), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(CallableMaxAdd(), result_type='BIGINT', func_type="pandas")
 
 # 方式五：partial 函数
 def partial_max_add(i, j, k):
   return i.max() + j.max() + k
   
-max_add = udaf(functools.partial(partial_max_add, k=1), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(functools.partial(partial_max_add, k=1), result_type='BIGINT', func_type="pandas")
 ```

--- a/docs/content/docs/dev/python/table/udfs/python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/python_udfs.md
@@ -55,13 +55,13 @@ class HashCode(ScalarFunction):
 settings = EnvironmentSettings.in_batch_mode()
 table_env = TableEnvironment.create(settings)
 
-hash_code = udf(HashCode(), result_type=DataTypes.BIGINT())
+hash_code = udf(HashCode(), result_type='BIGINT')
 
 # use the Python function in Python Table API
 my_table.select(col("string"), col("bigint"), hash_code(col("bigint")), call(hash_code, col("bigint")))
 
 # use the Python function in SQL API
-table_env.create_temporary_function("hash_code", udf(HashCode(), result_type=DataTypes.BIGINT()))
+table_env.create_temporary_function("hash_code", udf(HashCode(), result_type='BIGINT'))
 table_env.sql_query("SELECT string, bigint, hash_code(bigint) FROM MyTable")
 ```
 
@@ -109,25 +109,25 @@ class Add(ScalarFunction):
 add = udf(Add(), result_type=DataTypes.BIGINT())
 
 # option 2: Python function
-@udf(result_type=DataTypes.BIGINT())
+@udf(result_type='BIGINT')
 def add(i, j):
   return i + j
 
 # option 3: lambda function
-add = udf(lambda i, j: i + j, result_type=DataTypes.BIGINT())
+add = udf(lambda i, j: i + j, result_type='BIGINT')
 
 # option 4: callable function
 class CallableAdd(object):
   def __call__(self, i, j):
     return i + j
 
-add = udf(CallableAdd(), result_type=DataTypes.BIGINT())
+add = udf(CallableAdd(), result_type='BIGINT')
 
 # option 5: partial function
 def partial_add(i, j, k):
   return i + j + k
 
-add = udf(functools.partial(partial_add, k=1), result_type=DataTypes.BIGINT())
+add = udf(functools.partial(partial_add, k=1), result_type='BIGINT')
 
 # register the Python function
 table_env.create_temporary_function("add", add)
@@ -162,14 +162,14 @@ table_env = TableEnvironment.create(env_settings)
 my_table = ...  # type: Table, table schema: [a: String]
 
 # register the Python Table Function
-split = udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()])
+split = udtf(Split(), result_types=['STRING', 'INT'])
 
 # use the Python Table Function in Python Table API
 my_table.join_lateral(split(col("a")).alias("word", "length"))
 my_table.left_outer_join_lateral(split(col("a")).alias("word", "length"))
 
 # use the Python Table function in SQL API
-table_env.create_temporary_function("split", udtf(Split(), result_types=[DataTypes.STRING(), DataTypes.INT()]))
+table_env.create_temporary_function("split", udtf(Split(), result_types=['STRING', 'INT']))
 table_env.sql_query("SELECT a, word, length FROM MyTable, LATERAL TABLE(split(a)) as T(word, length)")
 table_env.sql_query("SELECT a, word, length FROM MyTable LEFT JOIN LATERAL TABLE(split(a)) as T(word, length) ON TRUE")
 
@@ -222,18 +222,18 @@ Like Python scalar functions, you can use the above five ways to define Python T
 
 ```python
 # option 1: generator function
-@udtf(result_types=DataTypes.BIGINT())
+@udtf(result_types='BIGINT')
 def generator_func(x):
       yield 1
       yield 2
 
 # option 2: return iterator
-@udtf(result_types=DataTypes.BIGINT())
+@udtf(result_types='BIGINT')
 def iterator_func(x):
       return range(5)
 
 # option 3: return iterable
-@udtf(result_types=DataTypes.BIGINT())
+@udtf(result_types='BIGINT')
 def iterable_func(x):
       result = [1, 2, 3]
       return result
@@ -302,12 +302,10 @@ class WeightedAvg(AggregateFunction):
         accumulator[1] -= weight
         
     def get_result_type(self):
-        return DataTypes.BIGINT()
+        return 'BIGINT'
         
     def get_accumulator_type(self):
-        return DataTypes.ROW([
-            DataTypes.FIELD("f0", DataTypes.BIGINT()), 
-            DataTypes.FIELD("f1", DataTypes.BIGINT())])
+        return 'ROW<f0 BIGINT, f1 BIGINT>'
 
 
 env_settings = EnvironmentSettings.in_streaming_mode()
@@ -477,11 +475,10 @@ class Top2(TableAggregateFunction):
                 accumulator[1] = row[0]
 
     def get_accumulator_type(self):
-        return DataTypes.ARRAY(DataTypes.BIGINT())
+        return 'ARRAY<BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.ROW(
-            [DataTypes.FIELD("a", DataTypes.BIGINT())])
+        return 'ROW<a BIGINT>'
 
 
 env_settings = EnvironmentSettings.in_streaming_mode()

--- a/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
+++ b/docs/content/docs/dev/python/table/udfs/vectorized_python_udfs.md
@@ -49,11 +49,11 @@ The following example shows how to define your own vectorized Python scalar func
 and use it in a query:
 
 ```python
-from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
+from pyflink.table import TableEnvironment, EnvironmentSettings
 from pyflink.table.expressions import col
 from pyflink.table.udf import udf
 
-@udf(result_type=DataTypes.BIGINT(), func_type="pandas")
+@udf(result_type='BIGINT', func_type="pandas")
 def add(i, j):
   return i + j
 
@@ -84,12 +84,12 @@ The following example shows how to define your own vectorized Python aggregate f
 and use it in `GroupBy Aggregation`, `GroupBy Window Aggregation` and `Over Window Aggregation`:
 
 ```python
-from pyflink.table import DataTypes, TableEnvironment, EnvironmentSettings
+from pyflink.table import TableEnvironment, EnvironmentSettings
 from pyflink.table.expressions import col, lit
 from pyflink.table.udf import udaf
 from pyflink.table.window import Tumble
 
-@udaf(result_type=DataTypes.FLOAT(), func_type="pandas")
+@udaf(result_type='FLOAT', func_type="pandas")
 def mean_udaf(v):
     return v.mean()
 
@@ -126,7 +126,6 @@ The following examples show the different ways to define a vectorized Python agg
 which takes two columns of bigint as the inputs and returns the sum of the maximum of them as the result.
 
 ```python
-from pyflink.table import DataTypes
 from pyflink.table.udf import AggregateFunction, udaf
 
 # option 1: extending the base class `AggregateFunction`
@@ -152,27 +151,27 @@ class MaxAdd(AggregateFunction):
             result += arg.max()
         accumulator.append(result)
 
-max_add = udaf(MaxAdd(), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(MaxAdd(), result_type='BIGINT', func_type="pandas")
 
 # option 2: Python function
-@udaf(result_type=DataTypes.BIGINT(), func_type="pandas")
+@udaf(result_type='BIGINT', func_type="pandas")
 def max_add(i, j):
   return i.max() + j.max()
 
 # option 3: lambda function
-max_add = udaf(lambda i, j: i.max() + j.max(), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(lambda i, j: i.max() + j.max(), result_type='BIGINT', func_type="pandas")
 
 # option 4: callable function
 class CallableMaxAdd(object):
   def __call__(self, i, j):
     return i.max() + j.max()
 
-max_add = udaf(CallableMaxAdd(), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(CallableMaxAdd(), result_type='BIGINT', func_type="pandas")
 
 # option 5: partial function
 def partial_max_add(i, j, k):
   return i.max() + j.max() + k
   
-max_add = udaf(functools.partial(partial_max_add, k=1), result_type=DataTypes.BIGINT(), func_type="pandas")
+max_add = udaf(functools.partial(partial_max_add, k=1), result_type='BIGINT', func_type="pandas")
 
 ```

--- a/flink-python/pyflink/table/tests/test_pandas_udaf.py
+++ b/flink-python/pyflink/table/tests/test_pandas_udaf.py
@@ -343,7 +343,7 @@ class StreamPandasUDAFITTests(PyFlinkStreamTableTestCase):
         super(StreamPandasUDAFITTests, cls).setUpClass()
         cls.t_env.create_temporary_system_function("mean_udaf", mean_udaf)
         max_add_min_udaf = udaf(lambda a: a.max() + a.min(),
-                                result_type=DataTypes.SMALLINT(),
+                                result_type='SMALLINT',
                                 func_type='pandas')
         cls.t_env.create_temporary_system_function("max_add_min_udaf", max_add_min_udaf)
 

--- a/flink-python/pyflink/table/tests/test_udaf.py
+++ b/flink-python/pyflink/table/tests/test_udaf.py
@@ -56,10 +56,10 @@ class CountAggregateFunction(AggregateFunction):
             accumulator[0] = accumulator[0] + other_acc[0]
 
     def get_accumulator_type(self):
-        return DataTypes.ARRAY(DataTypes.BIGINT())
+        return 'ARRAY<BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.BIGINT()
+        return 'BIGINT'
 
 
 class SumAggregateFunction(AggregateFunction):
@@ -81,10 +81,10 @@ class SumAggregateFunction(AggregateFunction):
             accumulator[0] = accumulator[0] + other_acc[0]
 
     def get_accumulator_type(self):
-        return DataTypes.ARRAY(DataTypes.BIGINT())
+        return 'ARRAY<BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.BIGINT()
+        return 'BIGINT'
 
 
 class ConcatAggregateFunction(AggregateFunction):
@@ -107,12 +107,10 @@ class ConcatAggregateFunction(AggregateFunction):
             accumulator[0].remove(args[0])
 
     def get_accumulator_type(self):
-        return DataTypes.ROW([
-            DataTypes.FIELD("f0", DataTypes.ARRAY(DataTypes.STRING())),
-            DataTypes.FIELD("f1", DataTypes.BIGINT())])
+        return 'ROW<f0 STRING, f1 BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.STRING()
+        return 'STRING'
 
 
 class ListViewConcatAggregateFunction(AggregateFunction):
@@ -169,12 +167,10 @@ class CountDistinctAggregateFunction(AggregateFunction):
             accumulator[0][input_str] = None
 
     def get_accumulator_type(self):
-        return DataTypes.ROW([
-            DataTypes.FIELD("f0", DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING())),
-            DataTypes.FIELD("f1", DataTypes.BIGINT())])
+        return 'ROW<f0 MAP<STRING, STRING>, f1 BIGINT>'
 
     def get_result_type(self):
-        return DataTypes.BIGINT()
+        return 'BIGINT'
 
 
 class CustomIterateAggregateFunction(AggregateFunction):

--- a/flink-python/pyflink/table/tests/test_udtf.py
+++ b/flink-python/pyflink/table/tests/test_udtf.py
@@ -152,7 +152,7 @@ class MultiEmit(TableFunction, unittest.TestCase):
             yield x, i
 
 
-@udtf(result_types=[DataTypes.BIGINT()])
+@udtf(result_types=['bigint'])
 def identity(x):
     if x is not None:
         from pyflink.common import Row

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
@@ -27,6 +27,8 @@ import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.utils.TypeConversions;
 
+import java.util.Arrays;
+
 /** The wrapper of user defined python aggregate function. */
 @Internal
 public class PythonAggregateFunction extends AggregateFunction implements PythonFunction {
@@ -35,12 +37,13 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
 
     private final String name;
     private final byte[] serializedAggregateFunction;
-    private final DataType[] inputTypes;
     private final PythonFunctionKind pythonFunctionKind;
     private final boolean deterministic;
     private final PythonEnv pythonEnv;
     private final boolean takesRowAsInput;
 
+    private DataType[] inputTypes;
+    private String[] inputTypesString;
     private DataType resultType;
     private String resultTypeString;
     private DataType accumulatorType;
@@ -59,11 +62,11 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
         this(
                 name,
                 serializedAggregateFunction,
-                inputTypes,
                 pythonFunctionKind,
                 deterministic,
                 takesRowAsInput,
                 pythonEnv);
+        this.inputTypes = inputTypes;
         this.resultType = resultType;
         this.accumulatorType = accumulatorType;
     }
@@ -71,7 +74,7 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
     public PythonAggregateFunction(
             String name,
             byte[] serializedAggregateFunction,
-            DataType[] inputTypes,
+            String[] inputTypesString,
             String resultTypeString,
             String accumulatorTypeString,
             PythonFunctionKind pythonFunctionKind,
@@ -81,11 +84,11 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
         this(
                 name,
                 serializedAggregateFunction,
-                inputTypes,
                 pythonFunctionKind,
                 deterministic,
                 takesRowAsInput,
                 pythonEnv);
+        this.inputTypesString = inputTypesString;
         this.resultTypeString = resultTypeString;
         this.accumulatorTypeString = accumulatorTypeString;
     }
@@ -93,14 +96,12 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
     public PythonAggregateFunction(
             String name,
             byte[] serializedAggregateFunction,
-            DataType[] inputTypes,
             PythonFunctionKind pythonFunctionKind,
             boolean deterministic,
             boolean takesRowAsInput,
             PythonEnv pythonEnv) {
         this.name = name;
         this.serializedAggregateFunction = serializedAggregateFunction;
-        this.inputTypes = inputTypes;
         this.pythonFunctionKind = pythonFunctionKind;
         this.deterministic = deterministic;
         this.pythonEnv = pythonEnv;
@@ -149,17 +150,34 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
 
     @Override
     public TypeInformation getResultType() {
+        if (resultType == null && resultTypeString != null) {
+            throw new RuntimeException(
+                    "String format result type is not supported in old type system.");
+        }
         return TypeConversions.fromDataTypeToLegacyInfo(resultType);
     }
 
     @Override
     public TypeInformation getAccumulatorType() {
+        if (accumulatorType == null && accumulatorTypeString != null) {
+            throw new RuntimeException(
+                    "String format accumulator type is not supported in old type system.");
+        }
         return TypeConversions.fromDataTypeToLegacyInfo(accumulatorType);
     }
 
     @Override
     public TypeInference getTypeInference(DataTypeFactory typeFactory) {
         TypeInference.Builder builder = TypeInference.newBuilder();
+
+        if (inputTypesString != null) {
+            inputTypes =
+                    (DataType[])
+                            Arrays.stream(inputTypesString)
+                                    .map(typeFactory::createDataType)
+                                    .toArray();
+        }
+
         if (inputTypes != null) {
             builder.typedArguments(inputTypes);
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonAggregateFunction.java
@@ -36,12 +36,15 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
     private final String name;
     private final byte[] serializedAggregateFunction;
     private final DataType[] inputTypes;
-    private final DataType resultType;
-    private final DataType accumulatorType;
     private final PythonFunctionKind pythonFunctionKind;
     private final boolean deterministic;
     private final PythonEnv pythonEnv;
     private final boolean takesRowAsInput;
+
+    private DataType resultType;
+    private String resultTypeString;
+    private DataType accumulatorType;
+    private String accumulatorTypeString;
 
     public PythonAggregateFunction(
             String name,
@@ -53,11 +56,51 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
             boolean deterministic,
             boolean takesRowAsInput,
             PythonEnv pythonEnv) {
+        this(
+                name,
+                serializedAggregateFunction,
+                inputTypes,
+                pythonFunctionKind,
+                deterministic,
+                takesRowAsInput,
+                pythonEnv);
+        this.resultType = resultType;
+        this.accumulatorType = accumulatorType;
+    }
+
+    public PythonAggregateFunction(
+            String name,
+            byte[] serializedAggregateFunction,
+            DataType[] inputTypes,
+            String resultTypeString,
+            String accumulatorTypeString,
+            PythonFunctionKind pythonFunctionKind,
+            boolean deterministic,
+            boolean takesRowAsInput,
+            PythonEnv pythonEnv) {
+        this(
+                name,
+                serializedAggregateFunction,
+                inputTypes,
+                pythonFunctionKind,
+                deterministic,
+                takesRowAsInput,
+                pythonEnv);
+        this.resultTypeString = resultTypeString;
+        this.accumulatorTypeString = accumulatorTypeString;
+    }
+
+    public PythonAggregateFunction(
+            String name,
+            byte[] serializedAggregateFunction,
+            DataType[] inputTypes,
+            PythonFunctionKind pythonFunctionKind,
+            boolean deterministic,
+            boolean takesRowAsInput,
+            PythonEnv pythonEnv) {
         this.name = name;
         this.serializedAggregateFunction = serializedAggregateFunction;
         this.inputTypes = inputTypes;
-        this.resultType = resultType;
-        this.accumulatorType = accumulatorType;
         this.pythonFunctionKind = pythonFunctionKind;
         this.deterministic = deterministic;
         this.pythonEnv = pythonEnv;
@@ -120,6 +163,15 @@ public class PythonAggregateFunction extends AggregateFunction implements Python
         if (inputTypes != null) {
             builder.typedArguments(inputTypes);
         }
+
+        if (resultType == null) {
+            resultType = typeFactory.createDataType(resultTypeString);
+        }
+
+        if (accumulatorType == null) {
+            accumulatorType = typeFactory.createDataType(accumulatorTypeString);
+        }
+
         return builder.outputTypeStrategy(TypeStrategies.explicit(resultType))
                 .accumulatorTypeStrategy(TypeStrategies.explicit(accumulatorType))
                 .build();

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonScalarFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonScalarFunction.java
@@ -40,11 +40,13 @@ public class PythonScalarFunction extends ScalarFunction implements PythonFuncti
     private final String name;
     private final byte[] serializedScalarFunction;
     private final DataType[] inputTypes;
-    private final DataType resultType;
     private final PythonFunctionKind pythonFunctionKind;
     private final boolean deterministic;
     private final PythonEnv pythonEnv;
     private final boolean takesRowAsInput;
+
+    private DataType resultType;
+    private String resultTypeString;
 
     public PythonScalarFunction(
             String name,
@@ -55,10 +57,48 @@ public class PythonScalarFunction extends ScalarFunction implements PythonFuncti
             boolean deterministic,
             boolean takesRowAsInput,
             PythonEnv pythonEnv) {
+        this(
+                name,
+                serializedScalarFunction,
+                inputTypes,
+                pythonFunctionKind,
+                deterministic,
+                takesRowAsInput,
+                pythonEnv);
+        this.resultType = resultType;
+    }
+
+    public PythonScalarFunction(
+            String name,
+            byte[] serializedScalarFunction,
+            DataType[] inputTypes,
+            String resultTypeString,
+            PythonFunctionKind pythonFunctionKind,
+            boolean deterministic,
+            boolean takesRowAsInput,
+            PythonEnv pythonEnv) {
+        this(
+                name,
+                serializedScalarFunction,
+                inputTypes,
+                pythonFunctionKind,
+                deterministic,
+                takesRowAsInput,
+                pythonEnv);
+        this.resultTypeString = resultTypeString;
+    }
+
+    public PythonScalarFunction(
+            String name,
+            byte[] serializedScalarFunction,
+            DataType[] inputTypes,
+            PythonFunctionKind pythonFunctionKind,
+            boolean deterministic,
+            boolean takesRowAsInput,
+            PythonEnv pythonEnv) {
         this.name = name;
         this.serializedScalarFunction = serializedScalarFunction;
         this.inputTypes = inputTypes;
-        this.resultType = resultType;
         this.pythonFunctionKind = pythonFunctionKind;
         this.deterministic = deterministic;
         this.pythonEnv = pythonEnv;
@@ -117,6 +157,11 @@ public class PythonScalarFunction extends ScalarFunction implements PythonFuncti
                     Stream.of(inputTypes).collect(Collectors.toList());
             builder.typedArguments(argumentDataTypes);
         }
+
+        if (resultType == null) {
+            resultType = typeFactory.createDataType(resultTypeString);
+        }
+
         return builder.outputTypeStrategy(TypeStrategies.explicit(resultType)).build();
     }
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonScalarFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonScalarFunction.java
@@ -27,6 +27,7 @@ import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.utils.TypeConversions;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,12 +40,13 @@ public class PythonScalarFunction extends ScalarFunction implements PythonFuncti
 
     private final String name;
     private final byte[] serializedScalarFunction;
-    private final DataType[] inputTypes;
     private final PythonFunctionKind pythonFunctionKind;
     private final boolean deterministic;
     private final PythonEnv pythonEnv;
     private final boolean takesRowAsInput;
 
+    private DataType[] inputTypes;
+    private String[] inputTypesString;
     private DataType resultType;
     private String resultTypeString;
 
@@ -60,18 +62,18 @@ public class PythonScalarFunction extends ScalarFunction implements PythonFuncti
         this(
                 name,
                 serializedScalarFunction,
-                inputTypes,
                 pythonFunctionKind,
                 deterministic,
                 takesRowAsInput,
                 pythonEnv);
+        this.inputTypes = inputTypes;
         this.resultType = resultType;
     }
 
     public PythonScalarFunction(
             String name,
             byte[] serializedScalarFunction,
-            DataType[] inputTypes,
+            String[] inputTypesString,
             String resultTypeString,
             PythonFunctionKind pythonFunctionKind,
             boolean deterministic,
@@ -80,25 +82,23 @@ public class PythonScalarFunction extends ScalarFunction implements PythonFuncti
         this(
                 name,
                 serializedScalarFunction,
-                inputTypes,
                 pythonFunctionKind,
                 deterministic,
                 takesRowAsInput,
                 pythonEnv);
+        this.inputTypesString = inputTypesString;
         this.resultTypeString = resultTypeString;
     }
 
     public PythonScalarFunction(
             String name,
             byte[] serializedScalarFunction,
-            DataType[] inputTypes,
             PythonFunctionKind pythonFunctionKind,
             boolean deterministic,
             boolean takesRowAsInput,
             PythonEnv pythonEnv) {
         this.name = name;
         this.serializedScalarFunction = serializedScalarFunction;
-        this.inputTypes = inputTypes;
         this.pythonFunctionKind = pythonFunctionKind;
         this.deterministic = deterministic;
         this.pythonEnv = pythonEnv;
@@ -146,12 +146,25 @@ public class PythonScalarFunction extends ScalarFunction implements PythonFuncti
 
     @Override
     public TypeInformation getResultType(Class[] signature) {
+        if (resultType == null && resultTypeString != null) {
+            throw new RuntimeException(
+                    "String format result type is not supported in old type system.");
+        }
         return TypeConversions.fromDataTypeToLegacyInfo(resultType);
     }
 
     @Override
     public TypeInference getTypeInference(DataTypeFactory typeFactory) {
         TypeInference.Builder builder = TypeInference.newBuilder();
+
+        if (inputTypesString != null) {
+            inputTypes =
+                    (DataType[])
+                            Arrays.stream(inputTypesString)
+                                    .map(typeFactory::createDataType)
+                                    .toArray();
+        }
+
         if (inputTypes != null) {
             final List<DataType> argumentDataTypes =
                     Stream.of(inputTypes).collect(Collectors.toList());

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonTableAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonTableAggregateFunction.java
@@ -27,6 +27,8 @@ import org.apache.flink.table.types.inference.TypeInference;
 import org.apache.flink.table.types.inference.TypeStrategies;
 import org.apache.flink.table.types.utils.TypeConversions;
 
+import java.util.Arrays;
+
 /** The wrapper of user defined python table aggregate function. */
 @Internal
 public class PythonTableAggregateFunction extends TableAggregateFunction implements PythonFunction {
@@ -35,12 +37,13 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
 
     private final String name;
     private final byte[] serializedTableAggregateFunction;
-    private final DataType[] inputTypes;
     private final PythonFunctionKind pythonFunctionKind;
     private final boolean deterministic;
     private final PythonEnv pythonEnv;
     private final boolean takesRowAsInput;
 
+    private DataType[] inputTypes;
+    private String[] inputTypesString;
     private DataType resultType;
     private String resultTypeString;
     private DataType accumulatorType;
@@ -59,11 +62,11 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
         this(
                 name,
                 serializedTableAggregateFunction,
-                inputTypes,
                 pythonFunctionKind,
                 deterministic,
                 takesRowAsInput,
                 pythonEnv);
+        this.inputTypes = inputTypes;
         this.resultType = resultType;
         this.accumulatorType = accumulatorType;
     }
@@ -71,7 +74,7 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
     public PythonTableAggregateFunction(
             String name,
             byte[] serializedTableAggregateFunction,
-            DataType[] inputTypes,
+            String[] inputTypesString,
             String resultTypeString,
             String accumulatorTypeString,
             PythonFunctionKind pythonFunctionKind,
@@ -81,11 +84,11 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
         this(
                 name,
                 serializedTableAggregateFunction,
-                inputTypes,
                 pythonFunctionKind,
                 deterministic,
                 takesRowAsInput,
                 pythonEnv);
+        this.inputTypesString = inputTypesString;
         this.resultTypeString = resultTypeString;
         this.accumulatorTypeString = accumulatorTypeString;
     }
@@ -93,14 +96,12 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
     public PythonTableAggregateFunction(
             String name,
             byte[] serializedTableAggregateFunction,
-            DataType[] inputTypes,
             PythonFunctionKind pythonFunctionKind,
             boolean deterministic,
             boolean takesRowAsInput,
             PythonEnv pythonEnv) {
         this.name = name;
         this.serializedTableAggregateFunction = serializedTableAggregateFunction;
-        this.inputTypes = inputTypes;
         this.pythonFunctionKind = pythonFunctionKind;
         this.deterministic = deterministic;
         this.pythonEnv = pythonEnv;
@@ -149,17 +150,33 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
 
     @Override
     public TypeInformation getResultType() {
+        if (resultType == null && resultTypeString != null) {
+            throw new RuntimeException(
+                    "String format result type is not supported in old type system.");
+        }
         return TypeConversions.fromDataTypeToLegacyInfo(resultType);
     }
 
     @Override
     public TypeInformation getAccumulatorType() {
+        if (accumulatorType == null && accumulatorTypeString != null) {
+            throw new RuntimeException(
+                    "String format accumulator type is not supported in old type system.");
+        }
         return TypeConversions.fromDataTypeToLegacyInfo(accumulatorType);
     }
 
     @Override
     public TypeInference getTypeInference(DataTypeFactory typeFactory) {
         TypeInference.Builder builder = TypeInference.newBuilder();
+        if (inputTypesString != null) {
+            inputTypes =
+                    (DataType[])
+                            Arrays.stream(inputTypesString)
+                                    .map(typeFactory::createDataType)
+                                    .toArray();
+        }
+
         if (inputTypes != null) {
             builder.typedArguments(inputTypes);
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonTableAggregateFunction.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/python/PythonTableAggregateFunction.java
@@ -36,12 +36,15 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
     private final String name;
     private final byte[] serializedTableAggregateFunction;
     private final DataType[] inputTypes;
-    private final DataType resultType;
-    private final DataType accumulatorType;
     private final PythonFunctionKind pythonFunctionKind;
     private final boolean deterministic;
     private final PythonEnv pythonEnv;
     private final boolean takesRowAsInput;
+
+    private DataType resultType;
+    private String resultTypeString;
+    private DataType accumulatorType;
+    private String accumulatorTypeString;
 
     public PythonTableAggregateFunction(
             String name,
@@ -53,11 +56,51 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
             boolean deterministic,
             boolean takesRowAsInput,
             PythonEnv pythonEnv) {
+        this(
+                name,
+                serializedTableAggregateFunction,
+                inputTypes,
+                pythonFunctionKind,
+                deterministic,
+                takesRowAsInput,
+                pythonEnv);
+        this.resultType = resultType;
+        this.accumulatorType = accumulatorType;
+    }
+
+    public PythonTableAggregateFunction(
+            String name,
+            byte[] serializedTableAggregateFunction,
+            DataType[] inputTypes,
+            String resultTypeString,
+            String accumulatorTypeString,
+            PythonFunctionKind pythonFunctionKind,
+            boolean deterministic,
+            boolean takesRowAsInput,
+            PythonEnv pythonEnv) {
+        this(
+                name,
+                serializedTableAggregateFunction,
+                inputTypes,
+                pythonFunctionKind,
+                deterministic,
+                takesRowAsInput,
+                pythonEnv);
+        this.resultTypeString = resultTypeString;
+        this.accumulatorTypeString = accumulatorTypeString;
+    }
+
+    public PythonTableAggregateFunction(
+            String name,
+            byte[] serializedTableAggregateFunction,
+            DataType[] inputTypes,
+            PythonFunctionKind pythonFunctionKind,
+            boolean deterministic,
+            boolean takesRowAsInput,
+            PythonEnv pythonEnv) {
         this.name = name;
         this.serializedTableAggregateFunction = serializedTableAggregateFunction;
         this.inputTypes = inputTypes;
-        this.resultType = resultType;
-        this.accumulatorType = accumulatorType;
         this.pythonFunctionKind = pythonFunctionKind;
         this.deterministic = deterministic;
         this.pythonEnv = pythonEnv;
@@ -120,6 +163,15 @@ public class PythonTableAggregateFunction extends TableAggregateFunction impleme
         if (inputTypes != null) {
             builder.typedArguments(inputTypes);
         }
+
+        if (resultType == null) {
+            resultType = typeFactory.createDataType(resultTypeString);
+        }
+
+        if (accumulatorType == null) {
+            accumulatorType = typeFactory.createDataType(accumulatorTypeString);
+        }
+
         return builder.outputTypeStrategy(TypeStrategies.explicit(resultType))
                 .accumulatorTypeStrategy(TypeStrategies.explicit(accumulatorType))
                 .build();


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will support to specify the output types of Python UDFs via string*

## Brief change log

  - *Support to specify the output types of Python UDFs via string*

## Verifying this change

This change added tests and can be verified as follows:

  - *`test_all_data_types_string` and orginal tests in `test_udtf` and `test_udaf`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
