### PR TITLE
[FLINK-29971][HBase] Fix hbase sink will lose data at some extreme case.

### DIFF
--- a/flink-connectors/flink-connector-hbase-base/pom.xml
+++ b/flink-connectors/flink-connector-hbase-base/pom.xml
@@ -168,6 +168,22 @@ under the License.
 			<artifactId>flink-architecture-tests-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-streaming-java</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkFunction.java
+++ b/flink-connectors/flink-connector-hbase-base/src/main/java/org/apache/flink/connector/hbase/sink/HBaseSinkFunction.java
@@ -239,6 +239,7 @@ public class HBaseSinkFunction<T> extends RichSinkFunction<T>
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
+        checkErrorAndRethrow();
         while (numPendingRequests.get() != 0) {
             flush();
         }

--- a/flink-connectors/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/sink/HbaseSinkFunctionTest.java
+++ b/flink-connectors/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/sink/HbaseSinkFunctionTest.java
@@ -19,7 +19,6 @@
 package org.apache.flink.connector.hbase.sink;
 
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
-import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.hbase.util.HBaseTableSchema;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.streaming.api.operators.StreamSink;
@@ -31,8 +30,6 @@ import org.apache.flink.table.data.binary.BinaryStringData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.junit.Test;
-
-import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_ZNODE_PARENT;
 
 /** Test for {@link HBaseSinkFunction}. */
 public class HbaseSinkFunctionTest {
@@ -79,13 +76,6 @@ public class HbaseSinkFunctionTest {
         config.set(HConstants.HBASE_RPC_WRITE_TIMEOUT_KEY, "1000");
         config.set(HConstants.HBASE_CLIENT_META_OPERATION_TIMEOUT, "1000");
         config.set(HConstants.HBASE_CLIENT_RETRIES_NUMBER, "0");
-        return config;
-    }
-
-    private ReadableConfig getHbaseTableConfig() {
-        org.apache.flink.configuration.Configuration config =
-                new org.apache.flink.configuration.Configuration();
-        config.set(ZOOKEEPER_ZNODE_PARENT, ZOOKEEPER_ZNODE_PARENT.defaultValue());
         return config;
     }
 

--- a/flink-connectors/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/sink/HbaseSinkFunctionTest.java
+++ b/flink-connectors/flink-connector-hbase-base/src/test/java/org/apache/flink/connector/hbase/sink/HbaseSinkFunctionTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hbase.sink;
+
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.hbase.util.HBaseTableSchema;
+import org.apache.flink.runtime.checkpoint.CheckpointException;
+import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.binary.BinaryStringData;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.junit.Test;
+
+import static org.apache.flink.connector.hbase.table.HBaseConnectorOptions.ZOOKEEPER_ZNODE_PARENT;
+
+/** Test for {@link HBaseSinkFunction}. */
+public class HbaseSinkFunctionTest {
+
+    /**
+     * To test whether the sink can throw exception when HBaseSinkFunction.numPendingRequests is 0
+     * but HBaseSinkFunction.failureThrowable has exception.
+     */
+    @Test(expected = CheckpointException.class)
+    public void testSnapshotStateWithError() throws Exception {
+        HBaseTableSchema hBaseTableSchema = getHBaseTableSchema();
+
+        HBaseSinkFunction sinkFunction =
+                new HBaseSinkFunction(
+                        "TEST-HBASE",
+                        getHbaseConfig(),
+                        new RowDataToMutationConverter(hBaseTableSchema, "null"),
+                        1000,
+                        1000,
+                        1000);
+        try (OneInputStreamOperatorTestHarness<RowData, Object> testHarness =
+                new OneInputStreamOperatorTestHarness<>(
+                        new StreamSink<>(sinkFunction), IntSerializer.INSTANCE)) {
+            testHarness.setup();
+            testHarness.open();
+            testHarness.processElement(getTestRowData(), 0);
+            // wait the scheduler thread call flush.
+            Thread.sleep(5000);
+            testHarness.snapshot(0, 1);
+        }
+    }
+
+    private HBaseTableSchema getHBaseTableSchema() {
+        HBaseTableSchema hBaseTableSchema = new HBaseTableSchema();
+        hBaseTableSchema.setRowKey("rowkey", Integer.class);
+        hBaseTableSchema.addColumn("TEST-FAMILY", "TEST-QUALIFIER", String.class);
+        return hBaseTableSchema;
+    }
+
+    private Configuration getHbaseConfig() {
+        Configuration config = new Configuration();
+        config.set(HConstants.ZOOKEEPER_QUORUM, "localhost:2181/hbase");
+        config.set(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT, "3000");
+        config.set(HConstants.HBASE_RPC_WRITE_TIMEOUT_KEY, "1000");
+        config.set(HConstants.HBASE_CLIENT_META_OPERATION_TIMEOUT, "1000");
+        config.set(HConstants.HBASE_CLIENT_RETRIES_NUMBER, "0");
+        return config;
+    }
+
+    private ReadableConfig getHbaseTableConfig() {
+        org.apache.flink.configuration.Configuration config =
+                new org.apache.flink.configuration.Configuration();
+        config.set(ZOOKEEPER_ZNODE_PARENT, ZOOKEEPER_ZNODE_PARENT.defaultValue());
+        return config;
+    }
+
+    public RowData getTestRowData() {
+        GenericRowData outsideRow = new GenericRowData(2);
+        outsideRow.setField(0, 1);
+        GenericRowData insideRow = new GenericRowData(1);
+        insideRow.setField(0, new BinaryStringData("TEST-VALUE"));
+        outsideRow.setField(1, insideRow);
+        return outsideRow;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

To fix the hbase sink will lose data at some extreme case.
The bug analysis can refer to https://issues.apache.org/jira/browse/FLINK-29971


## Brief change log

  - Add check error in when hbase sink do the snapthot.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Added test that validates that after the fix the snapshot can action right.
  
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers:  no 
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no
  - The S3 file system connector: no 

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not applicable
