### PR TITLE
[FLINK-30045][flink-clients] fix too eager check for main class existence

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/FromClasspathEntryClassInformationProviderTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/FromClasspathEntryClassInformationProviderTest.java
@@ -58,10 +58,6 @@ class FromClasspathEntryClassInformationProviderTest {
     ClasspathProviderExtension testJobEntryClassClasspathProvider =
             ClasspathProviderExtension.createWithTestJobOnly();
 
-    @RegisterExtension
-    ClasspathProviderExtension onlyTextFileClasspathProvider =
-            ClasspathProviderExtension.createWithTextFileOnly();
-
     @Test
     void testJobClassOnUserClasspathWithExplicitJobClassName() throws IOException, FlinkException {
         FromClasspathEntryClassInformationProvider testInstance =
@@ -72,19 +68,6 @@ class FromClasspathEntryClassInformationProviderTest {
         assertThat(testInstance.getJobClassName())
                 .contains(singleEntryClassClasspathProvider.getJobClassName());
         assertThat(testInstance.getJarFile()).isEmpty();
-    }
-
-    @Test
-    void testJobClassOnUserClasspathWithOnlyTestFileOnClasspath() {
-        assertThatThrownBy(
-                        () -> {
-                            // we want to check that the right exception is thrown if the user
-                            // classpath is empty
-                            FromClasspathEntryClassInformationProvider.create(
-                                    "SomeJobClassName",
-                                    onlyTextFileClasspathProvider.getURLUserClasspath());
-                        })
-                .isInstanceOf(FlinkException.class);
     }
 
     @Test

--- a/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/program/DefaultPackagedProgramRetrieverTest.java
@@ -50,7 +50,6 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.fail;
 
 /** {@code PackagedProgramRetrieverImplTest} tests {@link DefaultPackagedProgramRetriever}. */
 class DefaultPackagedProgramRetrieverTest {
@@ -278,24 +277,6 @@ class DefaultPackagedProgramRetrieverTest {
     }
 
     @Test
-    void testFailIfJobDirDoesNotHaveEntryClass() {
-        assertThatThrownBy(
-                        () -> {
-                            DefaultPackagedProgramRetriever.create(
-                                    noEntryClassClasspathProvider.getDirectory(),
-                                    testJobEntryClassClasspathProvider.getJobClassName(),
-                                    ClasspathProviderExtension.parametersForTestJob("suffix"),
-                                    new Configuration());
-                            fail("This case should throw exception !");
-                        })
-                .isInstanceOf(FlinkException.class)
-                .hasMessageContaining(
-                        String.format(
-                                "Could not find the provided job class (%s) in the user lib directory.",
-                                testJobEntryClassClasspathProvider.getJobClassName()));
-    }
-
-    @Test
     void testEntryClassNotFoundOnSystemClasspath() {
         assertThatThrownBy(
                         () -> {
@@ -319,14 +300,21 @@ class DefaultPackagedProgramRetrieverTest {
 
     @Test
     void testEntryClassNotFoundOnUserClasspath() {
+        final String jobClassName = "NotExistingClass";
         assertThatThrownBy(
                         () ->
                                 DefaultPackagedProgramRetriever.create(
-                                        noEntryClassClasspathProvider.getDirectory(),
-                                        "NotExistingClass",
-                                        new String[0],
-                                        new Configuration()))
-                .isInstanceOf(FlinkException.class);
+                                                noEntryClassClasspathProvider.getDirectory(),
+                                                jobClassName,
+                                                new String[0],
+                                                new Configuration())
+                                        .getPackagedProgram())
+                .isInstanceOf(FlinkException.class)
+                .hasMessageContaining("Could not load the provided entrypoint class.")
+                .cause()
+                .hasMessageContaining(
+                        "The program's entry point class '%s' was not found in the jar file.",
+                        jobClassName);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Remove a too eager main class check in `StandaloneApplicationClusterEntryPoint` (this is already covered by `PackagedProgram`).

## Brief change log

- remove main class check from `FromClasspathEntryClassInformationProvider` 

## Verifying this change

This change is already covered by existing tests, such as `DefaultPackagedProgramRetrieverTest` which I adapted to get the `PackagedProgram` and fail through that since this is what an EntryPoint has to do.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
