### PR TITLE
[FLINK-30067][conf] DelegatingConfiguration#set returns itself

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/DelegatingConfiguration.java
@@ -351,7 +351,8 @@ public final class DelegatingConfiguration extends Configuration {
 
     @Override
     public <T> Configuration set(ConfigOption<T> option, T value) {
-        return backingConfig.set(prefixOption(option, prefix), value);
+        backingConfig.set(prefixOption(option, prefix), value);
+        return this;
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/DelegatingConfigurationTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.configuration;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.lang.reflect.Method;
@@ -136,5 +137,14 @@ public class DelegatingConfigurationTest {
         }
         // Verification
         assertEquals(properties, mapProperties);
+    }
+
+    @Test
+    public void testSetReturnsDelegatingConfiguration() {
+        final Configuration conf = new Configuration();
+        final DelegatingConfiguration delegatingConf = new DelegatingConfiguration(conf, "prefix.");
+
+        Assertions.assertThat(delegatingConf.set(CoreOptions.DEFAULT_PARALLELISM, 1))
+                .isSameAs(delegatingConf);
     }
 }


### PR DESCRIPTION
Configuration#set is meant to allow setting multiple options in a row, but this doesn't really work for the delegating configuration.
A surprising trap I fell into in FLINK-29993.