### PR TITLE
[FLINK-28786][python] Fix the NoneType error on MacOS with M1 Chip

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -33,4 +33,4 @@ grpcio>=1.29.0,<=1.46.3
 grpcio-tools>=1.29.0,<=1.46.3
 pemja==0.2.4; python_version >= '3.7' and platform_system != 'Windows'
 httplib2>=0.19.0,<=0.20.4
-protobuf<=3.21
+protobuf>=3.19.0,<=3.21

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -311,7 +311,7 @@ try:
     install_requires = ['py4j==0.10.9.3', 'python-dateutil==2.8.0', 'apache-beam==2.38.0',
                         'cloudpickle==2.1.0', 'avro-python3>=1.8.1,!=1.9.2,<1.10.0',
                         'pytz>=2018.3', 'fastavro>=1.1.0,<1.4.8', 'requests>=2.26.0',
-                        'protobuf<3.18',
+                        'protobuf>=3.19.0,<=3.21',
                         'pemja==0.2.6;'
                         'python_full_version >= "3.7" and platform_system != "Windows"',
                         'httplib2>=0.19.0,<=0.20.4', apache_flink_libraries_dependency]


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will  fix the NoneType error on MacOS with M1 Chip*

## Brief change log

  - *Upgrade protobuf to 3.20.3 to fix this problem https://github.com/protocolbuffers/protobuf/issues/10075 *

## Verifying this change

 - *Manual tests in M1/M2 chip*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
