### PR TITLE
[FLINK-30079][doc] Stop using deprecated TM options in doc

### DIFF
--- a/docs/content.zh/docs/dev/dataset/local_execution.md
+++ b/docs/content.zh/docs/dev/dataset/local_execution.md
@@ -97,7 +97,7 @@ The `LocalEnvironment` allows also to pass custom configuration values to Flink.
 
 ```java
 Configuration conf = new Configuration();
-conf.setFloat(ConfigConstants.TASK_MANAGER_MEMORY_FRACTION_KEY, 0.5f);
+conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.5f);
 final ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(conf);
 ```
 

--- a/docs/content/docs/dev/dataset/local_execution.md
+++ b/docs/content/docs/dev/dataset/local_execution.md
@@ -97,7 +97,7 @@ The `LocalEnvironment` allows also to pass custom configuration values to Flink.
 
 ```java
 Configuration conf = new Configuration();
-conf.setFloat(ConfigConstants.TASK_MANAGER_MEMORY_FRACTION_KEY, 0.5f);
+conf.setFloat(TaskManagerOptions.MANAGED_MEMORY_FRACTION, 0.5f);
 final ExecutionEnvironment env = ExecutionEnvironment.createLocalEnvironment(conf);
 ```
 


### PR DESCRIPTION
## What is the purpose of the change

The option ConfigConstants.TASK_MANAGER_MEMORY_FRACTION_KEY was deprecated and configuring it should have no effect now. However, in the [documentation](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/dev/dataset/local_execution/#local-environment) we still reference it and show in example code. This can be replaced with TaskManagerOptions.MANAGED_MEMORY_FRACTION.


## Brief change log

This can be replaced with TaskManagerOptions.MANAGED_MEMORY_FRACTION.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
