### PR TITLE
[FLINK-30083] Bump maven-shade-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -990,11 +990,6 @@ under the License.
 						</plugin>
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
-							<artifactId>maven-shade-plugin</artifactId>
-							<version>3.4.1</version>
-						</plugin>
-						<plugin>
-							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-surefire-plugin</artifactId>
 							<configuration>
 								<excludedGroups>org.apache.flink.testutils.junit.FailsOnJava11</excludedGroups>

--- a/pom.xml
+++ b/pom.xml
@@ -991,7 +991,7 @@ under the License.
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-shade-plugin</artifactId>
-							<version>3.2.4</version>
+							<version>3.4.0</version>
 						</plugin>
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -991,7 +991,7 @@ under the License.
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-shade-plugin</artifactId>
-							<version>3.4.0</version>
+							<version>3.4.1</version>
 						</plugin>
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
@@ -2070,7 +2070,7 @@ under the License.
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-shade-plugin</artifactId>
-					<version>3.1.1</version>
+					<version>3.4.1</version>
 				</plugin>
 
 				<plugin>


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-24273](https://issues.apache.org/jira/browse/FLINK-24273) proposes to relocate the io.fabric8 dependencies of flink-kubernetes.
This is not possible because of a problem with the maven shade plugin ("mvn install" doesn't work, it needs to be "mvn clean install").
[MSHADE-425](https://issues.apache.org/jira/browse/MSHADE-425) solves this issue, and has been released with maven-shade-plugin 3.4.0.

Upgrading the shade plugin will solve the problem, unblocking the K8s relocation.


## Brief change log
- bump the version.

## Verifying this change

Covered by CI

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**yes** / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

