### PR TITLE
[FLINK-26037][coordination] TMRunner waits for metric registry shutdown

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -380,7 +380,7 @@ public class TaskManagerRunner implements FatalErrorHandler {
 
             if (metricRegistry != null) {
                 try {
-                    metricRegistry.closeAsync();
+                    terminationFutures.add(metricRegistry.closeAsync());
                 } catch (Exception e) {
                     exception = ExceptionUtils.firstOrSuppressed(e, exception);
                 }


### PR DESCRIPTION
Fix an issue where the TaskManagerRunner shutdown sequence ignored the metric registry shutdown. This could result in the rpc system (and rpc classloader!) being closed while the metrics actor system is still active.