### PR TITLE
[FLINK-30089][kinesis] Remove dependency promotion

### DIFF
--- a/flink-connectors/flink-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-connector-kinesis/pom.xml
@@ -119,6 +119,40 @@ under the License.
 			</exclusions>
 		</dependency>
 
+		<!-- Transitive dependencies that we explicitly declare again because we
+		     bundle the direct dependencies but not these transitive dependencies.
+		     Without this explicit declaration these dependencies would be lost. -->
+		<dependency>
+			<groupId>joda-time</groupId>
+			<artifactId>joda-time</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-codec</groupId>
+			<artifactId>commons-codec</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-io</groupId>
+			<artifactId>commons-io</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>2.6</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-logging</groupId>
+			<artifactId>commons-logging</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
 		<!-- Other third-party dependencies -->
 		<dependency>
 			<!-- KPL requires jaxb-api for javax.xml.bind.DatatypeConverter -->
@@ -311,7 +345,6 @@ under the License.
 						<configuration>
 							<!-- required for the Kinesis e2e test -->
 							<shadeTestJar>true</shadeTestJar>
-							<promoteTransitiveDependencies>true</promoteTransitiveDependencies>
 							<artifactSet combine.children="append">
 								<includes>
 									<include>org.apache.flink:flink-connector-aws-base:*</include>

--- a/flink-connectors/flink-sql-connector-kinesis/pom.xml
+++ b/flink-connectors/flink-sql-connector-kinesis/pom.xml
@@ -67,17 +67,17 @@ under the License.
 						<configuration>
 							<artifactSet>
 								<includes>
-									<include>org.apache.flink:flink-connector-base</include>
-									<include>org.apache.flink:flink-connector-kinesis</include>
-									<include>joda-time:joda-time</include>
-									<include>commons-codec:commons-codec</include>
-									<include>commons-io:commons-io</include>
-									<include>commons-lang:commons-lang</include>
-									<include>commons-logging:commons-logging</include>
-									<include>org.apache.commons:commons-lang3</include>
-									<include>com.google.guava:guava</include>
-									<include>com.google.guava:failureaccess</include>
+									<include>*:*</include>
 								</includes>
+								<excludes>
+									<!-- Exclude unnecessary dependencies.
+									     This is done here to not change the user-facing dependencies
+									     of flink-connector-kinesis. -->
+									<exclude>com.google.guava:listenablefuture</exclude>
+									<exclude>org.checkerframework:checker-qual</exclude>
+									<exclude>com.google.errorprone:error_prone_annotations</exclude>
+									<exclude>com.google.j2objc:j2objc-annotations</exclude>
+								</excludes>
 							</artifactSet>
 							<filters>
 								<filter>


### PR DESCRIPTION
Remove a special case in our shading setup.
This shouldn't change the contents of the sql-connector-kinesis jar or the total set of dependencies visible to users of flink-connector-kinesis..

@dannycranmer It would be great if you could take a look.