### PR TITLE
[FLINK-28203] Support Maven 3.3+

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,5 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.2.5/apache-maven-3.2.5-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-wrapper/3.1.0/maven-wrapper-3.1.0.jar

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Prerequisites for building Flink:
 
 * Unix-like environment (we use Linux, Mac OS X, Cygwin, WSL)
 * Git
-* Maven (we recommend version 3.2.5 and require at least 3.1.1)
+* Maven (we recommend version 3.8.6 and require at least 3.1.1)
 * Java 8 or 11 (Java 9 or 10 may work)
 
 ```

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,10 +36,10 @@ trigger:
 
 resources:
   containers:
-  # Container with Maven 3.2.5, SSL to have the same environment everywhere.
-  # see https://github.com/flink-ci/flink-ci-docker
+  # Container with Maven 3.8.6, SSL to have the same environment everywhere.
+  # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17
+    image: chesnay/flink-ci:java_8_11_17_maven_386
     # On AZP provided machines, set this flag to allow writing coredumps in docker
     options: --privileged
 

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -37,8 +37,6 @@ under the License.
 
 还需要准备 **Maven 3** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 8 (deprecated) 或 Java 11** 来进行构建。
 
-*注意：Maven 3.3.x 可以构建 Flink，但是不能正确地屏蔽掉指定的依赖。Maven 3.2.5 可以正确地构建库文件。
-
 输入以下命令从 Git 克隆代码
 
 ```bash
@@ -116,29 +114,6 @@ python -m pip install apache-flink-libraries/dist/*.tar.gz
 ```bash
 python -m pip install dist/*.whl
 ```
-
-## 依赖屏蔽
-
-Flink [屏蔽](https://maven.apache.org/plugins/maven-shade-plugin/)了一些它使用的包，这样做是为了避免与程序员自己引入的包的存在的可能的版本冲突。屏蔽掉的包包括 *Google Guava*,*Asm*,*Apache Curator*,*Apache HTTP Components*,*Netty* 等。
-
-这种依赖屏蔽机制最近在 Maven 中有所改变。需要用户根据 Maven 的的不同版本来执行不同的命令。
-
-**对于Maven 3.1.x and 3.2.x**
-直接在 Flink 源码根目录执行命令 `mvn clean install -DskipTests` 就足够了。
-
-**Maven 3.3.x**
-如下的构建需要两步走：第一步需要在基础目录下执行编译构建；第二步需要在编译后的 flink-dist 目录下执行：
-
-```bash
-mvn clean install -DskipTests
-cd flink-dist
-mvn clean install
-```
-
-*注意:* 运行 `mvn --version` 以查看Maven的版本。
-
-{{< top >}}
-
 
 ## Scala 版本
 

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -35,8 +35,6 @@ In order to build Flink you need the source code. Either [download the source of
 
 In addition you need **Maven 3** and a **JDK** (Java Development Kit). Flink requires **Java 8 (deprecated) or Java 11** to build.
 
-*NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.2.5 creates the libraries properly.*
-
 To clone from git, enter:
 
 ```bash
@@ -114,39 +112,6 @@ The sdist and wheel packages of `apache-flink` will be found under `./flink-pyth
 ```bash
 python -m pip install dist/*.whl
 ```
-
-## Dependency Shading
-
-Flink [shades away](https://maven.apache.org/plugins/maven-shade-plugin/) some of the libraries it uses, in order to avoid version clashes with user programs that use different versions of these libraries. Among the shaded libraries are *Google Guava*, *Asm*, *Apache Curator*, *Apache HTTP Components*, *Netty*, and others.
-
-The dependency shading mechanism was recently changed in Maven and requires users to build Flink slightly differently, depending on their Maven version:
-
-**Maven and 3.2.x**
-It is sufficient to call `mvn clean install -DskipTests` in the root directory of Flink code base.
-
-**Maven 3.3.x**
-The build has to be done in two steps: First in the base directory, then in shaded modules, such as the distribution and the filesystems:
-
-```bash
-# build overall project
-mvn clean install -DskipTests
-
-# build shaded modules used in dist again, for example:
-cd flink-filesystems/flink-s3-fs-presto/
-mvn clean install -DskipTests
-# ... and other modules
-
-# build dist again to include shaded modules
-cd flink-dist
-mvn clean install
-```
-
-*Note:* To check your Maven version, run `mvn --version`.
-
-*Note:* We recommend using the latest Maven 3.2.x version for building production-grade Flink distributions, as this is the version the Flink developers are using for the official releases and testing.
-
-{{< top >}}
-
 
 ## Scala Versions
 

--- a/flink-connectors/flink-connector-files/pom.xml
+++ b/flink-connectors/flink-connector-files/pom.xml
@@ -55,6 +55,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>

--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -232,12 +232,14 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-compatibility_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-bulk</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
@@ -252,6 +254,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-orc</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.orc</groupId>
@@ -264,6 +267,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-orc-nohive</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.orc</groupId>
@@ -276,6 +280,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-parquet</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- File systems -->
@@ -284,6 +289,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-fs</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Hadoop -->

--- a/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-1.4/pom.xml
@@ -41,6 +41,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-hbase-1.4</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
+++ b/flink-connectors/flink-sql-connector-hbase-2.2/pom.xml
@@ -41,6 +41,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-hbase-2.2</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-connectors/flink-sql-connector-hive-2.3.9/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-2.3.9/pom.xml
@@ -43,12 +43,14 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-hive_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-exec</artifactId>
 			<version>2.3.9</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>log4j</groupId>
@@ -82,6 +84,7 @@ under the License.
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr-runtime</artifactId>
 			<version>3.5.2</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
@@ -89,6 +89,7 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-mapreduce-client-core</artifactId>
 			<version>3.1.0</version>
+			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
 					<groupId>log4j</groupId>

--- a/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
+++ b/flink-connectors/flink-sql-connector-hive-3.1.3/pom.xml
@@ -43,12 +43,14 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-hive_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hive</groupId>
 			<artifactId>hive-exec</artifactId>
 			<version>3.1.3</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>log4j</groupId>
@@ -82,6 +84,7 @@ under the License.
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr-runtime</artifactId>
 			<version>3.5.2</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- hadoop dependency to make the copied code compile -->
@@ -122,6 +125,7 @@ under the License.
 			<groupId>org.apache.thrift</groupId>
 			<artifactId>libfb303</artifactId>
 			<version>0.9.3</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- avro is included in hive-exec. we use the same dependencies but with a different version -->
@@ -129,6 +133,7 @@ under the License.
 			<groupId>org.apache.avro</groupId>
 			<artifactId>avro</artifactId>
 			<version>1.8.2</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
@@ -136,6 +141,7 @@ under the License.
 			<artifactId>avro-mapred</artifactId>
 			<classifier>hadoop2</classifier>
 			<version>1.8.2</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.mortbay.jetty</groupId>

--- a/flink-connectors/flink-sql-connector-kafka/pom.xml
+++ b/flink-connectors/flink-sql-connector-kafka/pom.xml
@@ -43,6 +43,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-kafka</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-dist-scala/pom.xml
+++ b/flink-dist-scala/pom.xml
@@ -40,6 +40,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<!-- transitive Flink dependencies are provided at runtime -->
@@ -52,6 +53,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<!-- transitive Flink dependencies are provided at runtime -->

--- a/flink-dist/pom.xml
+++ b/flink-dist/pom.xml
@@ -51,84 +51,98 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-java</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-runtime-web</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-optimizer</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-clients</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-metrics-core</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-container</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-statebackend-rocksdb</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-statebackend-changelog</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
         <dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-dstl-dfs</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
         </dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-kubernetes</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-yarn</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.hadoop</groupId>
@@ -141,6 +155,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Default file system support. The Hadoop dependency			   -->
@@ -150,6 +165,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-fs</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Concrete logging framework - we add this only here (and not in the 
@@ -454,6 +470,18 @@ under the License.
 			<!-- this entry exists to prevent a compile dependency from slipping through -->
 			<scope>provided</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>1.3.9</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
 
 		<!-- test dependencies -->
 
@@ -479,6 +507,12 @@ under the License.
 				<artifactId>flink-streaming-scala_${scala.binary.version}</artifactId>
 				<version>${project.version}</version>
 				<scope>provided</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.objenesis</groupId>
+				<artifactId>objenesis</artifactId>
+				<version>2.1</version>
+				<optional>${flink.markBundledAsOptional}</optional>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/flink-end-to-end-tests/flink-sql-client-test/pom.xml
+++ b/flink-end-to-end-tests/flink-sql-client-test/pom.xml
@@ -91,6 +91,8 @@ under the License.
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
+						<!-- Use a special execution id to be ignored by license/optional checks -->
+						<id>e2e-dependencies</id>
 						<phase>package</phase>
 						<goals>
 							<goal>shade</goal>

--- a/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
+++ b/flink-examples/flink-examples-build-helper/flink-examples-streaming-state-machine/pom.xml
@@ -36,6 +36,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-examples-streaming</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -51,18 +51,21 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-fs</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-fs-hadoop-shaded</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-azure</artifactId>
 			<version>${fs.hadoopshaded.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.hadoop</groupId>

--- a/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
+++ b/flink-filesystems/flink-fs-hadoop-shaded/pom.xml
@@ -52,6 +52,7 @@ under the License.
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-common</artifactId>
 			<version>${fs.hadoopshaded.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>jdk.tools</groupId>

--- a/flink-filesystems/flink-gs-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-gs-fs-hadoop/pom.xml
@@ -53,18 +53,21 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-fs</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-fs-hadoop-shaded</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>com.google.cloud</groupId>
 			<artifactId>google-cloud-storage</artifactId>
 			<version>${fs.gs.sdk.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<!-- the following conflict with flink-fs-hadoop-shaded so exclude here -->
 				<exclusion>
@@ -99,6 +102,7 @@ under the License.
 			<groupId>com.google.cloud.bigdataoss</groupId>
 			<artifactId>gcs-connector</artifactId>
 			<version>${fs.gs.connector.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<!-- the following conflict with flink-fs-hadoop-shaded so exclude here -->
 				<exclusion>

--- a/flink-filesystems/flink-oss-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-oss-fs-hadoop/pom.xml
@@ -44,18 +44,21 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-hadoop-fs</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-fs-hadoop-shaded</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
 			<artifactId>hadoop-aliyun</artifactId>
 			<version>${fs.hadoopshaded.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>com.aliyun.oss</groupId>
@@ -81,6 +84,7 @@ under the License.
 			<groupId>com.aliyun.oss</groupId>
 			<artifactId>aliyun-sdk-oss</artifactId>
 			<version>${fs.oss.sdk.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>javax.xml.bind</groupId>

--- a/flink-filesystems/flink-s3-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-s3-fs-hadoop/pom.xml
@@ -74,6 +74,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-s3-fs-base</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>

--- a/flink-filesystems/flink-s3-fs-presto/pom.xml
+++ b/flink-filesystems/flink-s3-fs-presto/pom.xml
@@ -45,6 +45,14 @@ under the License.
 			<scope>provided</scope>
 		</dependency>
 
+		<!-- S3 base (bundled) -->
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-s3-fs-base</artifactId>
+			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
+		</dependency>
+
 		<!-- for the HAJobRunOnPrestoS3FileSystemITCase -->
 		<dependency>
 			<groupId>org.apache.flink</groupId>
@@ -89,18 +97,12 @@ under the License.
 			</exclusions>
 		</dependency>
 
-		<!-- S3 base (bundled) -->
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-s3-fs-base</artifactId>
-			<version>${project.version}</version>
-		</dependency>
-
 		<!-- Presto's S3 file system (bundled) -->
 		<dependency>
 			<groupId>com.facebook.presto</groupId>
 			<artifactId>presto-hive</artifactId>
 			<version>${presto.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<!-- Exclude AWS dependencies which we provide ourselves (and in more recent versions). -->
 				<exclusion>
@@ -317,6 +319,7 @@ under the License.
 			<groupId>com.facebook.presto.hadoop</groupId>
 			<artifactId>hadoop-apache2</artifactId>
 			<version>2.7.4-9</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
@@ -352,6 +355,7 @@ under the License.
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-common</artifactId>
 				<version>${fs.hadoopshaded.version}</version>
+				<optional>${flink.markBundledAsOptional}</optional>
 				<exclusions>
 					<exclusion>
 						<groupId>jdk.tools</groupId>
@@ -379,6 +383,7 @@ under the License.
 				<groupId>org.apache.hadoop</groupId>
 				<artifactId>hadoop-hdfs</artifactId>
 				<version>${fs.hadoopshaded.version}</version>
+				<optional>${flink.markBundledAsOptional}</optional>
 				<exclusions>
 					<exclusion>
 						<groupId>jdk.tools</groupId>
@@ -408,6 +413,7 @@ under the License.
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
 				<version>1.9.4</version>
+				<optional>${flink.markBundledAsOptional}</optional>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/flink-formats/flink-csv/pom.xml
+++ b/flink-formats/flink-csv/pom.xml
@@ -39,6 +39,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-format-common</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- core dependencies -->

--- a/flink-formats/flink-json/pom.xml
+++ b/flink-formats/flink-json/pom.xml
@@ -39,6 +39,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-format-common</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- core dependencies -->

--- a/flink-formats/flink-sql-avro-confluent-registry/pom.xml
+++ b/flink-formats/flink-sql-avro-confluent-registry/pom.xml
@@ -49,6 +49,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro-confluent-registry</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-formats/flink-sql-avro/pom.xml
+++ b/flink-formats/flink-sql-avro/pom.xml
@@ -42,6 +42,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-avro</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>

--- a/flink-formats/flink-sql-csv/pom.xml
+++ b/flink-formats/flink-sql-csv/pom.xml
@@ -42,6 +42,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-csv</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-formats/flink-sql-json/pom.xml
+++ b/flink-formats/flink-sql-json/pom.xml
@@ -42,6 +42,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-json</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-formats/flink-sql-orc/pom.xml
+++ b/flink-formats/flink-sql-orc/pom.xml
@@ -42,6 +42,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-orc</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-formats/flink-sql-parquet/pom.xml
+++ b/flink-formats/flink-sql-parquet/pom.xml
@@ -42,12 +42,14 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-parquet</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.parquet</groupId>
 			<artifactId>parquet-avro</artifactId>
 			<version>${flink.format.parquet.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.hadoop</groupId>

--- a/flink-formats/flink-sql-protobuf/pom.xml
+++ b/flink-formats/flink-sql-protobuf/pom.xml
@@ -42,6 +42,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-protobuf</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -62,6 +62,7 @@ under the License.
 			<groupId>io.fabric8</groupId>
 			<artifactId>kubernetes-client</artifactId>
 			<version>${kubernetes.client.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-metrics/flink-metrics-datadog/pom.xml
+++ b/flink-metrics/flink-metrics-datadog/pom.xml
@@ -55,6 +55,7 @@ under the License.
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>okhttp</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>

--- a/flink-metrics/flink-metrics-graphite/pom.xml
+++ b/flink-metrics/flink-metrics-graphite/pom.xml
@@ -50,18 +50,21 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-metrics-dropwizard</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
 			<artifactId>metrics-core</artifactId>
 			<version>${dropwizard.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>io.dropwizard.metrics</groupId>
 			<artifactId>metrics-graphite</artifactId>
 			<version>${dropwizard.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-metrics/flink-metrics-influxdb/pom.xml
+++ b/flink-metrics/flink-metrics-influxdb/pom.xml
@@ -50,6 +50,7 @@ under the License.
 			<groupId>org.influxdb</groupId>
 			<artifactId>influxdb-java</artifactId>
 			<version>2.17</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-metrics/flink-metrics-prometheus/pom.xml
+++ b/flink-metrics/flink-metrics-prometheus/pom.xml
@@ -61,18 +61,21 @@ under the License.
 			<groupId>io.prometheus</groupId>
 			<artifactId>simpleclient</artifactId>
 			<version>${prometheus.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>simpleclient_httpserver</artifactId>
 			<version>${prometheus.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>io.prometheus</groupId>
 			<artifactId>simpleclient_pushgateway</artifactId>
 			<version>${prometheus.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -95,6 +95,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.beam</groupId>
 			<artifactId>beam-runners-java-fn-execution</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.beam</groupId>
@@ -110,6 +111,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.beam</groupId>
 			<artifactId>beam-runners-core-java</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- PemJa dependencies -->
@@ -117,6 +119,7 @@ under the License.
 			<groupId>com.alibaba</groupId>
 			<artifactId>pemja</artifactId>
 			<version>0.3.0</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Protobuf dependencies -->
@@ -124,6 +127,7 @@ under the License.
 		<dependency>
 			<groupId>com.google.protobuf</groupId>
 			<artifactId>protobuf-java</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Python API dependencies -->
@@ -131,11 +135,13 @@ under the License.
 		<dependency>
 			<groupId>net.sf.py4j</groupId>
 			<artifactId>py4j</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>net.razorvine</groupId>
 			<artifactId>pyrolite</artifactId>
 			<version>4.13</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>net.razorvine</groupId>
@@ -150,6 +156,7 @@ under the License.
 			<groupId>org.apache.arrow</groupId>
 			<artifactId>arrow-vector</artifactId>
 			<version>${arrow.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>commons-codec</groupId>
@@ -161,6 +168,7 @@ under the License.
 			<groupId>org.apache.arrow</groupId>
 			<artifactId>arrow-memory-netty</artifactId>
 			<version>${arrow.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-rpc/flink-rpc-akka/pom.xml
+++ b/flink-rpc/flink-rpc-akka/pom.xml
@@ -62,22 +62,26 @@ under the License.
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-library</artifactId>
 			<scope>compile</scope>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.scala-lang</groupId>
 			<artifactId>scala-compiler</artifactId>
 			<scope>compile</scope>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-actor_${scala.binary.version}</artifactId>
 			<version>${akka.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-remote_${scala.binary.version}</artifactId>
 			<version>${akka.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<!-- optional dependency for UDP transport which we don't need -->
@@ -95,11 +99,13 @@ under the License.
 			<groupId>com.typesafe.akka</groupId>
 			<artifactId>akka-slf4j_${scala.binary.version}</artifactId>
 			<version>${akka.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.netty</groupId>
 			<artifactId>netty</artifactId>
 			<version>3.10.6.Final</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>

--- a/flink-runtime/pom.xml
+++ b/flink-runtime/pom.xml
@@ -205,6 +205,7 @@ under the License.
 			<groupId>io.airlift</groupId>
 			<artifactId>aircompressor</artifactId>
 			<version>0.21</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- test dependencies -->

--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -70,12 +70,14 @@ under the License.
 			<groupId>org.jline</groupId>
 			<artifactId>jline-terminal</artifactId>
 			<version>3.21.0</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-reader</artifactId>
 			<version>3.21.0</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- configuration -->
@@ -187,6 +189,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-parser</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.calcite</groupId>

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -47,6 +47,7 @@
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-sql-gateway-api</artifactId>
             <version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>

--- a/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
+++ b/flink-table/flink-sql-jdbc-driver-bundle/pom.xml
@@ -39,31 +39,37 @@
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-jdbc-driver</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-client</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-gateway-api</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-gateway</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-common</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-annotations</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Used to create Executor in connection. TODO jdbc driver should get rid of flink-core which is a big module. -->
@@ -71,6 +77,7 @@
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-table/flink-table-api-java-uber/pom.xml
+++ b/flink-table/flink-table-api-java-uber/pom.xml
@@ -40,26 +40,31 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-common</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-java</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-bridge-base</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-java-bridge</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-gateway-api</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-table/flink-table-code-splitter/pom.xml
+++ b/flink-table/flink-table-code-splitter/pom.xml
@@ -47,6 +47,7 @@ under the License.
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4-runtime</artifactId>
 			<version>${antlr4.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>

--- a/flink-table/flink-table-planner-loader-bundle/pom.xml
+++ b/flink-table/flink-table-planner-loader-bundle/pom.xml
@@ -44,6 +44,7 @@
 			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
 			<version>${project.version}</version>
 			<scope>runtime</scope>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 	</dependencies>
 

--- a/flink-table/flink-table-planner/pom.xml
+++ b/flink-table/flink-table-planner/pom.xml
@@ -42,6 +42,7 @@ under the License.
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.checkerframework</groupId>
@@ -92,6 +93,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-parser</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.calcite</groupId>
@@ -109,6 +111,7 @@ under the License.
 			<groupId>org.checkerframework</groupId>
 			<artifactId>checker-qual</artifactId>
 			<version>3.10.0</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Table Runtime (not included in the uber) -->
@@ -124,6 +127,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-calcite-bridge</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/flink-table/flink-table-runtime/pom.xml
+++ b/flink-table/flink-table-runtime/pom.xml
@@ -59,6 +59,7 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-code-splitter</artifactId>
 			<version>${project.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Flink dependencies -->
@@ -72,10 +73,12 @@ under the License.
 		<dependency>
 			<groupId>org.codehaus.janino</groupId>
 			<artifactId>janino</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.codehaus.janino</groupId>
 			<artifactId>commons-compiler</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- JsonPath -->
@@ -84,6 +87,7 @@ under the License.
 			<groupId>com.jayway.jsonpath</groupId>
 			<artifactId>json-path</artifactId>
 			<version>${jsonpath.version}</version>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Test dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -1336,8 +1336,7 @@ under the License.
 								<configuration>
 									<rules>
 										<requireMavenVersion>
-											<!-- maven version must be lower than 3.3. See FLINK-3158 -->
-											<version>(,3.3)</version>
+											<version>3.8.6</version>
 										</requireMavenVersion>
 										<requireJavaVersion>
 											<version>1.8.0</version>
@@ -1593,8 +1592,6 @@ under the License.
 						<exclude>tools/japicmp-output/**</exclude>
 						<!-- artifacts created during release process -->
 						<exclude>tools/releasing/release/**</exclude>
-						<!-- manually installed version on travis -->
-						<exclude>apache-maven-3.2.5/**</exclude>
 						<!-- PyCharm -->
 						<exclude>**/.idea/**</exclude>
 						<!-- Generated code via Avro -->

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,7 @@ under the License.
 		<flink.surefire.baseArgLine>-XX:+UseG1GC -Xms256m</flink.surefire.baseArgLine>
 		<flink.shaded.version>16.1</flink.shaded.version>
 		<flink.shaded.jackson.version>2.13.4</flink.shaded.jackson.version>
+		<flink.markBundledAsOptional>true</flink.markBundledAsOptional>
 		<target.java.version>1.8</target.java.version>
 		<slf4j.version>1.7.36</slf4j.version>
 		<log4j.version>2.17.1</log4j.version>
@@ -206,6 +207,7 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-shaded-force-shading</artifactId>
+			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<!-- Root dependencies for all projects -->
@@ -938,6 +940,20 @@ under the License.
 	</dependencyManagement>
 
 	<profiles>
+		<profile>
+			<id>intellij</id>
+			<activation>
+				<property>
+					<name>idea.version</name>
+				</property>
+			</activation>
+			<properties>
+				<!-- Set to false so that all required dependencies are put on the classpath,
+				     since IntelliJ does not work against jars produced by the shade plugin
+				     (which may bundled said classes). -->
+				<flink.markBundledAsOptional>false</flink.markBundledAsOptional>
+			</properties>
+		</profile>
 		<profile>
 			<id>scala-2.12</id>
 			<properties>

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -36,10 +36,10 @@ trigger:
 
 resources:
   containers:
-  # Container with Maven 3.2.5, SSL to have the same environment everywhere.
-  # see https://github.com/flink-ci/flink-ci-docker
+  # Container with Maven 3.8.6, SSL to have the same environment everywhere.
+  # see https://github.com/apache/flink-connector-shared-utils/tree/ci_utils
   - container: flink-build-container
-    image: chesnay/flink-ci:java_8_11_17
+    image: chesnay/flink-ci:java_8_11_17_maven_386
 
 variables:
   MAVEN_CACHE_FOLDER: $(Pipeline.Workspace)/.m2/repository

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -90,6 +90,10 @@ if [ $EXIT_CODE != 0 ] ; then
   exit $EXIT_CODE
 fi
 
+echo "============ Checking bundled dependencies marked as optional ============"
+
+${CI_DIR}/verify_bundled_optional.sh $MVN_CLEAN_COMPILE_OUT "$CI_DIR" "$(pwd)" || exit $?
+
 echo "============ Checking scala suffixes ============"
 
 ${CI_DIR}/verify_scala_suffixes.sh "$CI_DIR" "$(pwd)" || exit $?

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/optional/ShadeOptionalChecker.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/optional/ShadeOptionalChecker.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tools.ci.optional;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.tools.ci.utils.dependency.DependencyParser;
+import org.apache.flink.tools.ci.utils.shade.ShadeParser;
+import org.apache.flink.tools.ci.utils.shared.Dependency;
+import org.apache.flink.tools.ci.utils.shared.DependencyTree;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Verifies that all dependencies bundled with the shade-plugin are marked as optional in the pom.
+ * This ensures compatibility with later maven versions and in general simplifies dependency
+ * management as transitivity is no longer dependent on the shade-plugin.
+ *
+ * <p>In Maven 3.3 the dependency tree was made immutable at runtime, and thus can no longer be
+ * changed by the shade plugin. The plugin would usually remove a dependency from the tree when it
+ * is being bundled (known as dependency reduction). While dependency reduction still works for the
+ * published poms (== what users consume) since it can still change the content of the final pom,
+ * while developing Flink it no longer works. This breaks plenty of things, since suddenly a bunch
+ * of dependencies are still visible to downstream modules that weren't before.
+ *
+ * <p>To workaround this we mark all dependencies that we bundle as optional; this makes them
+ * non-transitive. To a downstream module, behavior-wise a non-transitive dependency is identical to
+ * a removed dependency.
+ *
+ * <p>This checker analyzes the bundled dependencies (based on the shade-plugin output) and the set
+ * of dependencies (based on the dependency plugin) to detect cases where a dependency is not marked
+ * as optional as it should.
+ *
+ * <p>The enforced rule is rather simple: Any dependency that is bundled, or any of its parents,
+ * must show up as optional in the dependency tree. The parent clause is required to cover cases
+ * where a module has 2 paths to a bundled dependency. If a module depends on A1/A2, each depending
+ * on B, with A1 and B being bundled, then even if A1 is marked as optional B is still shown as a
+ * non-optional dependency (because the non-optional A2 still needs it!).
+ */
+public class ShadeOptionalChecker {
+    private static final Logger LOG = LoggerFactory.getLogger(ShadeOptionalChecker.class);
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 2) {
+            System.out.println(
+                    "Usage: ShadeOptionalChecker <pathShadeBuildOutput> <pathMavenDependencyOutput>");
+            System.exit(1);
+        }
+
+        final Path shadeOutputPath = Paths.get(args[0]);
+        final Path dependencyOutputPath = Paths.get(args[1]);
+
+        final Map<String, Set<Dependency>> bundledDependenciesByModule =
+                ShadeParser.parseShadeOutput(shadeOutputPath);
+        final Map<String, DependencyTree> dependenciesByModule =
+                DependencyParser.parseDependencyTreeOutput(dependencyOutputPath);
+
+        final Map<String, Set<Dependency>> violations =
+                checkOptionalFlags(bundledDependenciesByModule, dependenciesByModule);
+
+        if (!violations.isEmpty()) {
+            LOG.error(
+                    "{} modules bundle in total {} dependencies without them being marked as optional in the pom.",
+                    violations.keySet().size(),
+                    violations.values().stream().mapToInt(Collection::size).sum());
+            LOG.error(
+                    "\tIn order for shading to properly work within Flink we require all bundled dependencies to be marked as optional in the pom.");
+            LOG.error(
+                    "\tFor verification purposes we require the dependency tree from the dependency-plugin to show the dependency as either:");
+            LOG.error("\t\ta) an optional dependency,");
+            LOG.error("\t\tb) a transitive dependency of another optional dependency.");
+            LOG.error(
+                    "\tIn most cases adding '<optional>${flink.markBundledAsOptional}</optional>' to the bundled dependency is sufficient.");
+            LOG.error(
+                    "\tThere are some edge cases where a transitive dependency might be associated with the \"wrong\" dependency in the tree, for example if a test dependency also requires it.");
+            LOG.error(
+                    "\tIn such cases you need to adjust the poms so that the dependency shows up in the right spot. This may require adding an explicit dependency (Management) entry, excluding dependencies, or at times even reordering dependencies in the pom.");
+            LOG.error(
+                    "\tSee the Dependencies page in the wiki for details: https://cwiki.apache.org/confluence/display/FLINK/Dependencies");
+
+            for (String moduleWithViolations : violations.keySet()) {
+                final Collection<Dependency> dependencyViolations =
+                        violations.get(moduleWithViolations);
+                LOG.error(
+                        "\tModule {} ({} violation{}):",
+                        moduleWithViolations,
+                        dependencyViolations.size(),
+                        dependencyViolations.size() == 1 ? "" : "s");
+                for (Dependency dependencyViolation : dependencyViolations) {
+                    LOG.error("\t\t{}", dependencyViolation);
+                }
+            }
+
+            System.exit(1);
+        }
+    }
+
+    private static Map<String, Set<Dependency>> checkOptionalFlags(
+            Map<String, Set<Dependency>> bundledDependenciesByModule,
+            Map<String, DependencyTree> dependenciesByModule) {
+
+        final Map<String, Set<Dependency>> allViolations = new HashMap<>();
+
+        for (String module : bundledDependenciesByModule.keySet()) {
+            LOG.debug("Checking module '{}'.", module);
+            if (!dependenciesByModule.containsKey(module)) {
+                throw new IllegalStateException(
+                        String.format(
+                                "Module %s listed by shade-plugin, but not dependency-plugin.",
+                                module));
+            }
+
+            final Collection<Dependency> bundledDependencies =
+                    bundledDependenciesByModule.get(module);
+            final DependencyTree dependencyTree = dependenciesByModule.get(module);
+
+            final Set<Dependency> violations =
+                    checkOptionalFlags(module, bundledDependencies, dependencyTree);
+
+            if (violations.isEmpty()) {
+                LOG.info("OK: {}", module);
+            } else {
+                allViolations.put(module, violations);
+            }
+        }
+
+        return allViolations;
+    }
+
+    @VisibleForTesting
+    static Set<Dependency> checkOptionalFlags(
+            String module,
+            Collection<Dependency> bundledDependencies,
+            DependencyTree dependencyTree) {
+
+        bundledDependencies =
+                bundledDependencies.stream()
+                        // force-shading isn't relevant for this check but breaks some shortcuts
+                        .filter(
+                                dependency ->
+                                        !dependency
+                                                .getArtifactId()
+                                                .equals("flink-shaded-force-shading"))
+                        .collect(Collectors.toSet());
+
+        final Set<Dependency> violations = new HashSet<>();
+
+        if (bundledDependencies.isEmpty()) {
+            LOG.debug("\tModule is not bundling any dependencies.");
+            return violations;
+        }
+
+        // The set of dependencies that the module directly depends on and which downstream modules
+        // would pull in transitively.
+        //
+        // If this set is empty we do not need to check anything.
+        // This allows us to avoid some edge-cases:
+        //
+        // Assume module M has the following (full) dependency tree, bundling dependency 1 and 2:
+        //
+        // +- dependency1 (compile/optional)",
+        // |  \- dependency2 (compile) (implicitly optional because dependency1 is optional)
+        // \- dependency3 (test)
+        //    \- dependency2 (compile)
+        //
+        // However, in the dependency plugin output a dependency can only show up once, so Maven may
+        // return this:
+        //
+        // +- dependency1 (compile/optional)",
+        // \- dependency3 (test)
+        //    \- dependency2 (compile)
+        //
+        // Given this tree, and knowing that dependency2 is bundled, we would draw the conclusion
+        // that dependency2 is missing the optional flag.
+        //
+        // However, because dependency 1/3 are optional/test dependencies they are not transitive.
+        // Without any direct transitive dependency nothing can leak through to downstream modules,
+        // removing the need to check dependency 2 at all (and in turn, saving us from having to
+        // resolve this problem).
+        final List<Dependency> directTransitiveDependencies =
+                dependencyTree.getDirectDependencies().stream()
+                        .filter(
+                                dependency ->
+                                        !(isOptional(dependency)
+                                                || hasProvidedScope(dependency)
+                                                || hasTestScope(dependency)
+                                                || isCommonCompileDependency(dependency)))
+                        .collect(Collectors.toList());
+
+        // if nothing would be exposed to downstream modules we exit early to reduce noise on CI
+        if (directTransitiveDependencies.isEmpty()) {
+            LOG.debug(
+                    "Skipping deep-check of module {} because all direct dependencies are not transitive.",
+                    module);
+            return violations;
+        }
+        LOG.debug(
+                "Running deep-check of module {} because there are direct dependencies that are transitive: {}",
+                module,
+                directTransitiveDependencies);
+
+        for (Dependency bundledDependency : bundledDependencies) {
+            LOG.debug("\tChecking dependency '{}'.", bundledDependency);
+
+            final List<Dependency> dependencyPath = dependencyTree.getPathTo(bundledDependency);
+
+            final boolean isOptional =
+                    dependencyPath.stream().anyMatch(parent -> parent.isOptional().orElse(false));
+
+            if (!isOptional) {
+                violations.add(bundledDependency);
+            }
+        }
+
+        return violations;
+    }
+
+    private static boolean isOptional(Dependency dependency) {
+        return dependency.isOptional().orElse(false);
+    }
+
+    private static boolean hasProvidedScope(Dependency dependency) {
+        return "provided".equals(dependency.getScope().orElse(null));
+    }
+
+    private static boolean hasTestScope(Dependency dependency) {
+        return "test".equals(dependency.getScope().orElse(null));
+    }
+
+    /**
+     * These are compile dependencies that are set up in the root pom. We do not require modules to
+     * mark these as optional because all modules depend on them anyway; whether they leak through
+     * or not is therefore irrelevant.
+     */
+    private static boolean isCommonCompileDependency(Dependency dependency) {
+        return "flink-shaded-force-shading".equals(dependency.getArtifactId())
+                || "jsr305".equals(dependency.getArtifactId())
+                || "slf4j-api".equals(dependency.getArtifactId());
+    }
+}

--- a/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/shared/DependencyTree.java
+++ b/tools/ci/flink-ci-tools/src/main/java/org/apache/flink/tools/ci/utils/shared/DependencyTree.java
@@ -28,6 +28,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -41,25 +42,30 @@ public class DependencyTree {
     private final Map<String, Node> lookup = new LinkedHashMap<>();
     private final List<Node> directDependencies = new ArrayList<>();
 
-    public void addDirectDependency(Dependency dependency) {
+    public DependencyTree addDirectDependency(Dependency dependency) {
         final String key = getKey(dependency);
         if (lookup.containsKey(key)) {
-            return;
+            return this;
         }
         final Node node = new Node(dependency, null);
 
         lookup.put(key, node);
         directDependencies.add(node);
+
+        return this;
     }
 
-    public void addTransitiveDependencyTo(Dependency transitiveDependency, Dependency parent) {
+    public DependencyTree addTransitiveDependencyTo(
+            Dependency transitiveDependency, Dependency parent) {
         final String key = getKey(transitiveDependency);
         if (lookup.containsKey(key)) {
-            return;
+            return this;
         }
         final Node node = lookup.get(getKey(parent)).addTransitiveDependency(transitiveDependency);
 
         lookup.put(key, node);
+
+        return this;
     }
 
     private static final class Node {
@@ -81,6 +87,12 @@ public class DependencyTree {
         private boolean isRoot() {
             return parent == null;
         }
+    }
+
+    public List<Dependency> getDirectDependencies() {
+        return directDependencies.stream()
+                .map(node -> node.dependency)
+                .collect(Collectors.toList());
     }
 
     public List<Dependency> getPathTo(Dependency dependency) {

--- a/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/optional/ShadeOptionalCheckerTest.java
+++ b/tools/ci/flink-ci-tools/src/test/java/org/apache/flink/tools/ci/optional/ShadeOptionalCheckerTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.tools.ci.optional;
+
+import org.apache.flink.tools.ci.utils.shared.Dependency;
+import org.apache.flink.tools.ci.utils.shared.DependencyTree;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShadeOptionalCheckerTest {
+    private static final String MODULE = "module";
+
+    @Test
+    void testNonBundledDependencyIsIgnored() {
+        final Dependency dependency = createMandatoryDependency("a");
+        final Set<Dependency> bundled = Collections.emptySet();
+        final DependencyTree dependencyTree = new DependencyTree().addDirectDependency(dependency);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void testNonBundledDependencyIsIgnoredEvenIfOthersAreBundled() {
+        final Dependency dependencyA = createMandatoryDependency("a");
+        final Dependency dependencyB = createMandatoryDependency("B");
+        final Set<Dependency> bundled = Collections.singleton(dependencyB);
+        final DependencyTree dependencyTree =
+                new DependencyTree()
+                        .addDirectDependency(dependencyA)
+                        .addDirectDependency(dependencyB);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).containsExactly(dependencyB);
+    }
+
+    @Test
+    void testDirectBundledOptionalDependencyIsAccepted() {
+        final Dependency dependency = createOptionalDependency("a");
+        final Set<Dependency> bundled = Collections.singleton(dependency);
+        final DependencyTree dependencyTree = new DependencyTree().addDirectDependency(dependency);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void testDirectBundledDependencyMustBeOptional() {
+        final Dependency dependency = createMandatoryDependency("a");
+        final Set<Dependency> bundled = Collections.singleton(dependency);
+        final DependencyTree dependencyTree = new DependencyTree().addDirectDependency(dependency);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).containsExactly(dependency);
+    }
+
+    @Test
+    void testTransitiveBundledOptionalDependencyIsAccepted() {
+        final Dependency dependencyA = createMandatoryDependency("a");
+        final Dependency dependencyB = createOptionalDependency("b");
+        final Set<Dependency> bundled = Collections.singleton(dependencyB);
+        final DependencyTree dependencyTree =
+                new DependencyTree()
+                        .addDirectDependency(dependencyA)
+                        .addTransitiveDependencyTo(dependencyB, dependencyA);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void testTransitiveBundledDependencyMustBeOptional() {
+        final Dependency dependencyA = createMandatoryDependency("a");
+        final Dependency dependencyB = createMandatoryDependency("b");
+        final Set<Dependency> bundled = Collections.singleton(dependencyB);
+        final DependencyTree dependencyTree =
+                new DependencyTree()
+                        .addDirectDependency(dependencyA)
+                        .addTransitiveDependencyTo(dependencyB, dependencyA);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).containsExactly(dependencyB);
+    }
+
+    @Test
+    void testTransitiveBundledDependencyMayNotBeOptionalIfParentIsOptional() {
+        final Dependency dependencyA = createOptionalDependency("a");
+        final Dependency dependencyB = createMandatoryDependency("b");
+        final Set<Dependency> bundled = Collections.singleton(dependencyB);
+        final DependencyTree dependencyTree =
+                new DependencyTree()
+                        .addDirectDependency(dependencyA)
+                        .addTransitiveDependencyTo(dependencyB, dependencyA);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void testTransitiveBundledDependencyMayNotBeOptionalIfParentHasTestScope() {
+        final Dependency dependencyA = createTestDependency("a");
+        final Dependency dependencyB = createMandatoryDependency("b");
+        final Set<Dependency> bundled = Collections.singleton(dependencyB);
+        final DependencyTree dependencyTree =
+                new DependencyTree()
+                        .addDirectDependency(dependencyA)
+                        .addTransitiveDependencyTo(dependencyB, dependencyA);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void testTransitiveBundledDependencyMayNotBeOptionalIfParentHasProvidedScope() {
+        final Dependency dependencyA = createProvidedDependency("a");
+        final Dependency dependencyB = createMandatoryDependency("b");
+        final Set<Dependency> bundled = Collections.singleton(dependencyB);
+        final DependencyTree dependencyTree =
+                new DependencyTree()
+                        .addDirectDependency(dependencyA)
+                        .addTransitiveDependencyTo(dependencyB, dependencyA);
+
+        final Set<Dependency> violations =
+                ShadeOptionalChecker.checkOptionalFlags(MODULE, bundled, dependencyTree);
+
+        assertThat(violations).isEmpty();
+    }
+
+    private static Dependency createMandatoryDependency(String artifactId) {
+        return Dependency.create("groupId", artifactId, "version", null);
+    }
+
+    private static Dependency createOptionalDependency(String artifactId) {
+        return Dependency.create("groupId", artifactId, "version", null, "compile", true);
+    }
+
+    private static Dependency createProvidedDependency(String artifactId) {
+        return Dependency.create("groupId", artifactId, "version", null, "provided", false);
+    }
+
+    private static Dependency createTestDependency(String artifactId) {
+        return Dependency.create("groupId", artifactId, "version", null, "test", false);
+    }
+}

--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -83,7 +83,7 @@ function collect_coredumps {
 
 CI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-MAVEN_VERSION="3.2.5"
+MAVEN_VERSION="3.8.6"
 MAVEN_CACHE_DIR=${HOME}/maven_cache
 MAVEN_VERSIONED_DIR=${MAVEN_CACHE_DIR}/apache-maven-${MAVEN_VERSION}
 

--- a/tools/ci/verify_bundled_optional.sh
+++ b/tools/ci/verify_bundled_optional.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+## Checks that all bundled dependencies are marked as optional in the poms
+MVN_CLEAN_COMPILE_OUT=$1
+CI_DIR=$2
+FLINK_ROOT=$3
+
+source "${CI_DIR}/maven-utils.sh"
+
+cd "$FLINK_ROOT" || exit
+
+dependency_plugin_output=${CI_DIR}/optional_dep.txt
+
+run_mvn dependency:tree -B > "${dependency_plugin_output}"
+
+cat "${dependency_plugin_output}"
+
+cd "${CI_DIR}/flink-ci-tools/" || exit
+
+run_mvn exec:java -Dexec.mainClass=org.apache.flink.tools.ci.optional.ShadeOptionalChecker -Dexec.args=\""${MVN_CLEAN_COMPILE_OUT}" "${dependency_plugin_output}"\"
+EXIT_CODE=$?
+
+if [ $EXIT_CODE != 0 ]; then
+    echo "=============================================================================="
+    echo "Optional Check failed. See previous output for details."
+    echo "=============================================================================="
+    exit 1
+fi
+
+exit 0
+


### PR DESCRIPTION
Based on #21346 (for test stability).

This PR sets up our build system to support Maven 3.3+ and our CI system to run with Maven 3.8.6.


In Maven 3.3 the dependency tree was made immutable at runtime, and thus can no longer be changed by the shade plugin. The plugin would usually remove a dependency from the tree when it is being bundled (known as dependency reduction).
While dependency reduction still works for the published poms (== what users consume) since it can still change the content of the final pom, while developing Flink it no longer works. This breaks plenty of things, since suddenly a whole bunch of dependencies are still visible to downstream modules that weren't before.
To workaround this we now mark _all_ dependencies that we bundle as _optional_; this makes them non-transitive.
Behavior-wise a non-transitive dependency is identical to a removed dependency.

To also make this work in the IDE (which never interacts with jars within a project, in contrast to Maven) the optional flag is modeled as a property that defaults to `true`, but is set to `false` by a special profile when the module is imported into IntelliJ.

Naturally, requiring all dependencies that are bundled to be marked as optional is prone too errors. To that end the `ShadeOptionalChecker` is being introduced, which analyzes the bundled dependencies (based on the shade-plugin output) and the set of dependencies (based on the dependency plugin) to detect cases where a dependency is not marked as optional as it should.
The enforced rule is rather simple: Any dependency that is bundled, or any of it's parents, must show up as optional in the dependency tree.
The parent clause is required to cover cases where a module has 2 paths to a bundled dependency.
If a module depends on A1/A2, each depending on B, with A1 and B being bundled, then even if A1 is marked as optional B is still shown as a non-optional dependency (because the non-optional A2 still needs it!).

This has the caveat that going forward we may, at times, have to add/exclude dependencies purely for things to show up correctly in the dependency tree.

TODO: The ShadeOptionalChecker needs tests.
