### PR TITLE
[FLINK-28695][network] Fix the bug of old netty client isn't closed when netty server closes channel and no input channel

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
@@ -124,22 +124,18 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
 
     @Override
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
-        // Unexpected close. In normal operation, the client closes the connection after all input
-        // channels have been removed. This indicates a problem with the remote task manager.
-        if (!inputChannels.isEmpty()) {
-            final SocketAddress remoteAddr = ctx.channel().remoteAddress();
+        final SocketAddress remoteAddr = ctx.channel().remoteAddress();
 
-            notifyAllChannelsOfErrorAndClose(
-                    new RemoteTransportException(
-                            "Connection unexpectedly closed by remote task manager '"
-                                    + remoteAddr
-                                    + " [ "
-                                    + connectionID.getResourceID().getStringWithMetadata()
-                                    + " ] "
-                                    + "'. "
-                                    + "This might indicate that the remote task manager was lost.",
-                            remoteAddr));
-        }
+        notifyAllChannelsOfErrorAndClose(
+                new RemoteTransportException(
+                        "Connection unexpectedly closed by remote task manager '"
+                                + remoteAddr
+                                + " [ "
+                                + connectionID.getResourceID().getStringWithMetadata()
+                                + " ] "
+                                + "'. "
+                                + "This might indicate that the remote task manager was lost.",
+                        remoteAddr));
 
         super.channelInactive(ctx);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java
@@ -275,7 +275,7 @@ class CreditBasedPartitionRequestClientHandler extends ChannelInboundHandlerAdap
         }
     }
 
-    private void decodeMsg(Object msg) throws Throwable {
+    private void decodeMsg(Object msg) {
         final Class<?> msgClazz = msg.getClass();
 
         // ---- Buffer --------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -131,29 +131,26 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                         inputChannel.getInitialCredit());
 
         final ChannelFutureListener listener =
-                new ChannelFutureListener() {
-                    @Override
-                    public void operationComplete(ChannelFuture future) {
-                        if (!future.isSuccess()) {
-                            clientHandler.removeInputChannel(inputChannel);
-                            inputChannel.onError(
-                                    new LocalTransportException(
-                                            String.format(
-                                                    "Sending the partition request to '%s [%s] (#%d)' failed.",
-                                                    connectionId.getAddress(),
-                                                    connectionId
-                                                            .getResourceID()
-                                                            .getStringWithMetadata(),
-                                                    connectionId.getConnectionIndex()),
-                                            future.channel().localAddress(),
-                                            future.cause()));
-                            sendToChannel(
-                                    new ConnectionErrorMessage(
-                                            future.cause() == null
-                                                    ? new RuntimeException(
-                                                            "Cannot send partition request.")
-                                                    : future.cause()));
-                        }
+                future -> {
+                    if (!future.isSuccess()) {
+                        clientHandler.removeInputChannel(inputChannel);
+                        inputChannel.onError(
+                                new LocalTransportException(
+                                        String.format(
+                                                "Sending the partition request to '%s [%s] (#%d)' failed.",
+                                                connectionId.getAddress(),
+                                                connectionId
+                                                        .getResourceID()
+                                                        .getStringWithMetadata(),
+                                                connectionId.getConnectionIndex()),
+                                        future.channel().localAddress(),
+                                        future.cause()));
+                        sendToChannel(
+                                new ConnectionErrorMessage(
+                                        future.cause() == null
+                                                ? new RuntimeException(
+                                                        "Cannot send partition request.")
+                                                : future.cause()));
                     }
                 };
 
@@ -165,12 +162,9 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
             tcpChannel
                     .eventLoop()
                     .schedule(
-                            new Runnable() {
-                                @Override
-                                public void run() {
-                                    f[0] = tcpChannel.writeAndFlush(request);
-                                    f[0].addListener(listener);
-                                }
+                            () -> {
+                                f[0] = tcpChannel.writeAndFlush(request);
+                                f[0].addListener(listener);
                             },
                             delayMs,
                             TimeUnit.MILLISECONDS);
@@ -194,30 +188,28 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                 .writeAndFlush(
                         new TaskEventRequest(event, partitionId, inputChannel.getInputChannelId()))
                 .addListener(
-                        new ChannelFutureListener() {
-                            @Override
-                            public void operationComplete(ChannelFuture future) {
-                                if (!future.isSuccess()) {
-                                    inputChannel.onError(
-                                            new LocalTransportException(
-                                                    String.format(
-                                                            "Sending the task event to '%s [%s] (#%d)' failed.",
-                                                            connectionId.getAddress(),
-                                                            connectionId
-                                                                    .getResourceID()
-                                                                    .getStringWithMetadata(),
-                                                            connectionId.getConnectionIndex()),
-                                                    future.channel().localAddress(),
-                                                    future.cause()));
-                                    sendToChannel(
-                                            new ConnectionErrorMessage(
-                                                    future.cause() == null
-                                                            ? new RuntimeException(
-                                                                    "Cannot send task event.")
-                                                            : future.cause()));
-                                }
-                            }
-                        });
+                        (ChannelFutureListener)
+                                future -> {
+                                    if (!future.isSuccess()) {
+                                        inputChannel.onError(
+                                                new LocalTransportException(
+                                                        String.format(
+                                                                "Sending the task event to '%s [%s] (#%d)' failed.",
+                                                                connectionId.getAddress(),
+                                                                connectionId
+                                                                        .getResourceID()
+                                                                        .getStringWithMetadata(),
+                                                                connectionId.getConnectionIndex()),
+                                                        future.channel().localAddress(),
+                                                        future.cause()));
+                                        sendToChannel(
+                                                new ConnectionErrorMessage(
+                                                        future.cause() == null
+                                                                ? new RuntimeException(
+                                                                        "Cannot send task event.")
+                                                                : future.cause()));
+                                    }
+                                });
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -133,7 +133,7 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
         final ChannelFutureListener listener =
                 new ChannelFutureListener() {
                     @Override
-                    public void operationComplete(ChannelFuture future) throws Exception {
+                    public void operationComplete(ChannelFuture future) {
                         if (!future.isSuccess()) {
                             clientHandler.removeInputChannel(inputChannel);
                             inputChannel.onError(
@@ -196,7 +196,7 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                 .addListener(
                         new ChannelFutureListener() {
                             @Override
-                            public void operationComplete(ChannelFuture future) throws Exception {
+                            public void operationComplete(ChannelFuture future) {
                                 if (!future.isSuccess()) {
                                     inputChannel.onError(
                                             new LocalTransportException(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -81,8 +82,7 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
             factory.createPartitionRequestClient(
                     nettyServerAndClient.getConnectionID(RESOURCE_ID, 0));
         } finally {
-            nettyServerAndClient.client().shutdown();
-            nettyServerAndClient.server().shutdown();
+            shutdown(nettyServerAndClient);
         }
     }
 
@@ -125,8 +125,7 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
 
             factory.createPartitionRequestClient(connectionID);
         } finally {
-            nettyServerAndClient.client().shutdown();
-            nettyServerAndClient.server().shutdown();
+            shutdown(nettyServerAndClient);
         }
     }
 
@@ -139,8 +138,7 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
             checkReuseNettyPartitionRequestClient(nettyServerAndClient, 5);
             checkReuseNettyPartitionRequestClient(nettyServerAndClient, 10);
         } finally {
-            nettyServerAndClient.client().shutdown();
-            nettyServerAndClient.server().shutdown();
+            shutdown(nettyServerAndClient);
         }
     }
 
@@ -176,8 +174,7 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
 
         factory.createPartitionRequestClient(serverAndClient.getConnectionID(RESOURCE_ID, 0));
 
-        serverAndClient.client().shutdown();
-        serverAndClient.server().shutdown();
+        shutdown(serverAndClient);
     }
 
     // see https://issues.apache.org/jira/browse/FLINK-18821
@@ -218,14 +215,12 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
                             unstableNettyClient, 2, 1, connectionReuseEnabled);
 
             assertThatThrownBy(
-                            () -> {
-                                factory.createPartitionRequestClient(
-                                        serverAndClient.getConnectionID(RESOURCE_ID, 0));
-                            })
+                            () ->
+                                    factory.createPartitionRequestClient(
+                                            serverAndClient.getConnectionID(RESOURCE_ID, 0)))
                     .isInstanceOf(IOException.class);
         } finally {
-            serverAndClient.client().shutdown();
-            serverAndClient.server().shutdown();
+            shutdown(serverAndClient);
         }
     }
 
@@ -274,8 +269,7 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
                 });
 
         threadPoolExecutor.shutdown();
-        serverAndClient.client().shutdown();
-        serverAndClient.server().shutdown();
+        shutdown(serverAndClient);
     }
 
     private NettyTestUtil.NettyServerAndClient createNettyServerAndClient() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -182,7 +182,7 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
 
     // see https://issues.apache.org/jira/browse/FLINK-18821
     @TestTemplate
-    void testFailureReportedToSubsequentRequests() throws Exception {
+    void testFailureReportedToSubsequentRequests() {
         PartitionRequestClientFactory factory =
                 new PartitionRequestClientFactory(
                         new FailingNettyClient(), 2, 1, connectionReuseEnabled);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -27,9 +27,12 @@ import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTe
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.TestLogger;
 
+import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelException;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelFuture;
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandler;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelHandlerContext;
+import org.apache.flink.shaded.netty4.io.netty.channel.ChannelInboundHandlerAdapter;
 
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,6 +51,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -160,6 +164,56 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
             set.add(factory.createPartitionRequestClient(connectionID));
         }
         assertThat(set.size()).isLessThanOrEqualTo(maxNumberOfConnections);
+    }
+
+    /**
+     * Verify that the netty client reuse when the netty server closes the channel and there is no
+     * input channel.
+     */
+    @TestTemplate
+    void testConnectionReuseWhenRemoteCloseAndNoInputChannel() throws Exception {
+        CompletableFuture<Void> inactiveFuture = new CompletableFuture<>();
+        CompletableFuture<Channel> serverChannelFuture = new CompletableFuture<>();
+        NettyProtocol protocol =
+                new NettyProtocol(null, null) {
+                    @Override
+                    public ChannelHandler[] getServerChannelHandlers() {
+                        return new ChannelHandler[] {
+                            // Close on read
+                            new ChannelInboundHandlerAdapter() {
+                                @Override
+                                public void channelRegistered(ChannelHandlerContext ctx)
+                                        throws Exception {
+                                    super.channelRegistered(ctx);
+                                    serverChannelFuture.complete(ctx.channel());
+                                }
+                            }
+                        };
+                    }
+
+                    @Override
+                    public ChannelHandler[] getClientChannelHandlers() {
+                        return new ChannelHandler[] {
+                            new ChannelInactiveFutureHandler(inactiveFuture)
+                        };
+                    }
+                };
+        NettyTestUtil.NettyServerAndClient serverAndClient = initServerAndClient(protocol);
+
+        PartitionRequestClientFactory factory =
+                new PartitionRequestClientFactory(
+                        serverAndClient.client(), 2, 1, connectionReuseEnabled);
+
+        ConnectionID connectionID = serverAndClient.getConnectionID(RESOURCE_ID, 0);
+        NettyPartitionRequestClient oldClient = factory.createPartitionRequestClient(connectionID);
+
+        // close server channel
+        Channel channel = serverChannelFuture.get();
+        channel.close();
+        inactiveFuture.get();
+        NettyPartitionRequestClient newClient = factory.createPartitionRequestClient(connectionID);
+        assertThat(newClient).as("Factory should create a new client.").isNotSameAs(oldClient);
+        shutdown(serverAndClient);
     }
 
     @TestTemplate
@@ -342,6 +396,26 @@ public class PartitionRequestClientFactoryTest extends TestLogger {
             } catch (Exception exception) {
                 throw new RuntimeException(exception);
             }
+        }
+    }
+
+    private static class ChannelInactiveFutureHandler
+            extends CreditBasedPartitionRequestClientHandler {
+
+        private final CompletableFuture<Void> inactiveFuture;
+
+        private ChannelInactiveFutureHandler(CompletableFuture<Void> inactiveFuture) {
+            this.inactiveFuture = inactiveFuture;
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+            super.channelInactive(ctx);
+            inactiveFuture.complete(null);
+        }
+
+        public CompletableFuture<Void> getInactiveFuture() {
+            return inactiveFuture;
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Fix the bug of old netty client isn't closed when netty server closes channel and no input channel.

`CreditBasedPartitionRequestClientHandler#channelInactive`  doesn't call the `notifyAllChannelsOfErrorAndClose` when  the `inputChannels.isEmpty()`.

https://github.com/apache/flink/blob/d745f5b3f7a64445854c735668afa9b72edb3fee/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandler.java#L126

![image](https://user-images.githubusercontent.com/38427477/202892039-7692b054-e502-4b3f-9de6-4f67c6b04f6f.png)


FLINK-15455 enables TCP connection reuse across multiple jobs. That means `CreditBasedPartitionRequestClientHandler#channelInactive` doesn't call the `notifyAllChannelsOfErrorAndClose` when  after old job stop and before new job start. If the tcp connection is disconnected during this period, the new job should create a new tcp connection. However, the `PartitionRequestClientFactory` doesn't know that the tcp connection is broken, so the new job reuses the failed connection.


## Brief change log

Close the old netty client when netty server closes channel and no input channel


## Verifying this change

This change added tests and can be verified as follows:

  - *PartitionRequestClientFactoryTest#testConnectionReuseWhenRemoteCloseAndNoInputChannel*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
