### PR TITLE
fix(sec): upgrade org.apache.calcite:calcite-core to 1.32.0

### DIFF
--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -76,7 +76,7 @@ under the License.
 	</dependencyManagement>
 
 	<properties>
-		<calcite.version>1.27.0</calcite.version>
+		<calcite.version>1.32.0</calcite.version>
 		<!-- Keep Janino in sync with calcite. -->
 		<janino.version>3.0.11</janino.version>
 		<jsonpath.version>2.6.0</jsonpath.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.calcite:calcite-core 1.27.0
- [CVE-2022-39135](https://www.oscs1024.com/hd/CVE-2022-39135)


### What did I do？
Upgrade org.apache.calcite:calcite-core from 1.27.0 to 1.32.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS
Signed-off-by:pen4<948453219@qq.com>