### PR TITLE
[FLINK-30084][Runtime] Remove unused method notifyAllocationFailure.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMaster.java
@@ -882,11 +882,6 @@ public class JobMaster extends FencedRpcEndpoint<JobMasterId>
     }
 
     @Override
-    public void notifyAllocationFailure(AllocationID allocationID, Exception cause) {
-        internalFailAllocation(null, allocationID, cause);
-    }
-
-    @Override
     public void notifyNotEnoughResourcesAvailable(
             Collection<ResourceRequirement> acquiredResources) {
         slotPoolService.notifyNotEnoughResourcesAvailable(acquiredResources);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobmaster/JobMasterGateway.java
@@ -257,14 +257,6 @@ public interface JobMasterGateway
             @RpcTimeout final Time timeout);
 
     /**
-     * Notifies that the allocation has failed.
-     *
-     * @param allocationID the failed allocation id.
-     * @param cause the reason that the allocation failed
-     */
-    void notifyAllocationFailure(AllocationID allocationID, Exception cause);
-
-    /**
      * Notifies that not enough resources are available to fulfill the resource requirements of a
      * job.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1350,19 +1350,6 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
         }
 
         @Override
-        public void notifyAllocationFailure(
-                JobID jobId, AllocationID allocationId, Exception cause) {
-            validateRunsInMainThread();
-
-            JobManagerRegistration jobManagerRegistration = jobManagerRegistrations.get(jobId);
-            if (jobManagerRegistration != null) {
-                jobManagerRegistration
-                        .getJobManagerGateway()
-                        .notifyAllocationFailure(allocationId, cause);
-            }
-        }
-
-        @Override
         public void notifyNotEnoughResourcesAvailable(
                 JobID jobId, Collection<ResourceRequirement> acquiredResources) {
             validateRunsInMainThread();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceActions.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.slots.ResourceRequirement;
@@ -44,15 +43,6 @@ public interface ResourceActions {
      * @return whether the resource can be allocated
      */
     boolean allocateResource(WorkerResourceSpec workerResourceSpec);
-
-    /**
-     * Notifies that an allocation failure has occurred.
-     *
-     * @param jobId to which the allocation belonged
-     * @param allocationId identifying the failed allocation
-     * @param cause of the allocation failure
-     */
-    void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause);
 
     /**
      * Notifies that not enough resources are available to fulfill the resource requirements of a

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGateway.java
@@ -68,7 +68,6 @@ import javax.annotation.Nullable;
 import java.net.InetSocketAddress;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -142,8 +141,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
     @Nonnull
     private final TriFunction<String, Boolean, SavepointFormatType, CompletableFuture<String>>
             stopWithSavepointFunction;
-
-    @Nonnull private final BiConsumer<AllocationID, Throwable> notifyAllocationFailureConsumer;
 
     @Nonnull
     private final Consumer<
@@ -246,7 +243,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
             @Nonnull
                     TriFunction<String, Boolean, SavepointFormatType, CompletableFuture<String>>
                             stopWithSavepointFunction,
-            @Nonnull BiConsumer<AllocationID, Throwable> notifyAllocationFailureConsumer,
             @Nonnull
                     Consumer<
                                     Tuple5<
@@ -315,7 +311,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
         this.triggerSavepointFunction = triggerSavepointFunction;
         this.triggerCheckpointFunction = triggerCheckpointFunction;
         this.stopWithSavepointFunction = stopWithSavepointFunction;
-        this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
         this.acknowledgeCheckpointConsumer = acknowledgeCheckpointConsumer;
         this.declineCheckpointConsumer = declineCheckpointConsumer;
         this.fencingTokenSupplier = fencingTokenSupplier;
@@ -430,11 +425,6 @@ public class TestingJobMasterGateway implements JobMasterGateway {
             final boolean terminate,
             final Time timeout) {
         return stopWithSavepointFunction.apply(targetDirectory, terminate, formatType);
-    }
-
-    @Override
-    public void notifyAllocationFailure(AllocationID allocationID, Exception cause) {
-        notifyAllocationFailureConsumer.accept(allocationID, cause);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/utils/TestingJobMasterGatewayBuilder.java
@@ -67,7 +67,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -136,8 +135,6 @@ public class TestingJobMasterGatewayBuilder {
                                     targetDirectory != null
                                             ? targetDirectory
                                             : UUID.randomUUID().toString());
-    private BiConsumer<AllocationID, Throwable> notifyAllocationFailureConsumer =
-            (ignoredA, ignoredB) -> {};
     private Consumer<Tuple5<JobID, ExecutionAttemptID, Long, CheckpointMetrics, TaskStateSnapshot>>
             acknowledgeCheckpointConsumer = ignored -> {};
     private Consumer<DeclineCheckpoint> declineCheckpointConsumer = ignored -> {};
@@ -300,12 +297,6 @@ public class TestingJobMasterGatewayBuilder {
         return this;
     }
 
-    public TestingJobMasterGatewayBuilder setNotifyAllocationFailureConsumer(
-            BiConsumer<AllocationID, Throwable> notifyAllocationFailureConsumer) {
-        this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
-        return this;
-    }
-
     public TestingJobMasterGatewayBuilder setNotifyNotEnoughResourcesConsumer(
             Consumer<Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer) {
         this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
@@ -417,7 +408,6 @@ public class TestingJobMasterGatewayBuilder {
                 triggerSavepointFunction,
                 triggerCheckpointFunction,
                 stopWithSavepointFunction,
-                notifyAllocationFailureConsumer,
                 acknowledgeCheckpointConsumer,
                 declineCheckpointConsumer,
                 fencingTokenSupplier,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActions.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.slots.ResourceRequirement;
@@ -29,7 +27,6 @@ import javax.annotation.Nonnull;
 
 import java.util.Collection;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 /** Testing implementation of the {@link ResourceActions}. */
@@ -40,9 +37,6 @@ public class TestingResourceActions implements ResourceActions {
     @Nonnull private final Function<WorkerResourceSpec, Boolean> allocateResourceFunction;
 
     @Nonnull
-    private final Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer;
-
-    @Nonnull
     private final BiConsumer<JobID, Collection<ResourceRequirement>>
             notifyNotEnoughResourcesConsumer;
 
@@ -50,14 +44,10 @@ public class TestingResourceActions implements ResourceActions {
             @Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
             @Nonnull Function<WorkerResourceSpec, Boolean> allocateResourceFunction,
             @Nonnull
-                    Consumer<Tuple3<JobID, AllocationID, Exception>>
-                            notifyAllocationFailureConsumer,
-            @Nonnull
                     BiConsumer<JobID, Collection<ResourceRequirement>>
                             notifyNotEnoughResourcesConsumer) {
         this.releaseResourceConsumer = releaseResourceConsumer;
         this.allocateResourceFunction = allocateResourceFunction;
-        this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
         this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
     }
 
@@ -69,11 +59,6 @@ public class TestingResourceActions implements ResourceActions {
     @Override
     public boolean allocateResource(WorkerResourceSpec workerResourceSpec) {
         return allocateResourceFunction.apply(workerResourceSpec);
-    }
-
-    @Override
-    public void notifyAllocationFailure(JobID jobId, AllocationID allocationId, Exception cause) {
-        notifyAllocationFailureConsumer.accept(Tuple3.of(jobId, allocationId, cause));
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceActionsBuilder.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.api.java.tuple.Tuple3;
-import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.slots.ResourceRequirement;
@@ -34,8 +32,6 @@ import java.util.function.Function;
 public class TestingResourceActionsBuilder {
     private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
     private Function<WorkerResourceSpec, Boolean> allocateResourceFunction = (ignored) -> true;
-    private Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer =
-            (ignored) -> {};
     private BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer =
             (ignoredA, ignoredB) -> {};
 
@@ -61,12 +57,6 @@ public class TestingResourceActionsBuilder {
         return this;
     }
 
-    public TestingResourceActionsBuilder setNotifyAllocationFailureConsumer(
-            Consumer<Tuple3<JobID, AllocationID, Exception>> notifyAllocationFailureConsumer) {
-        this.notifyAllocationFailureConsumer = notifyAllocationFailureConsumer;
-        return this;
-    }
-
     public TestingResourceActionsBuilder setNotEnoughResourcesConsumer(
             BiConsumer<JobID, Collection<ResourceRequirement>> notifyNotEnoughResourcesConsumer) {
         this.notifyNotEnoughResourcesConsumer = notifyNotEnoughResourcesConsumer;
@@ -77,7 +67,6 @@ public class TestingResourceActionsBuilder {
         return new TestingResourceActions(
                 releaseResourceConsumer,
                 allocateResourceFunction,
-                notifyAllocationFailureConsumer,
                 notifyNotEnoughResourcesConsumer);
     }
 }


### PR DESCRIPTION

## What is the purpose of the change

The methods ResourceActions#notifyAllocationFailure and JobMasterGateway#notifyAllocationFailure are not used and should be removed.


## Brief change log
Remove ResourceActions#notifyAllocationFailure and JobMasterGateway#notifyAllocationFailure and the related unit tests.


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)
