### PR TITLE
[FLINK-30085][tests] Lower YARN client timeout to speed-up negative tests

### DIFF
--- a/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
+++ b/flink-yarn-tests/src/test/java/org/apache/flink/yarn/YarnTestBase.java
@@ -225,6 +225,9 @@ public abstract class YarnTestBase {
         YARN_CONFIGURATION.setFloat(
                 YarnConfiguration.NM_MAX_PER_DISK_UTILIZATION_PERCENTAGE, 99.0F);
         YARN_CONFIGURATION.set(YarnConfiguration.YARN_APPLICATION_CLASSPATH, getYarnClasspath());
+        YARN_CONFIGURATION.setInt(
+                YarnConfiguration.RESOURCEMANAGER_CONNECT_RETRY_INTERVAL_MS, 1000);
+        YARN_CONFIGURATION.setInt(YarnConfiguration.RESOURCEMANAGER_CONNECT_MAX_WAIT_MS, 5000);
     }
 
     /**


### PR DESCRIPTION
## What is the purpose of the change

Tests like `YARNSessionCapacitySchedulerITCase.testNonexistingQueueWARNmessage` are negative tests in a way that they try to test error handling. This is fine but YARN installs a shutdown hook for all failed to submit applications. The mentioned hook tries to kill the application and do some cleanup at JVM exit time. Since in tests the YARN cluster is already shut down the application kill is timing out which is 15 minutes by default. All in all we're wasting 15 minutes for each JVM stop when we execute such negative tests. In this PR I've lowered the timeout to 5 seconds with 1 second retry to speedup CI and spare our nerves.

## Brief change log

Lowered YARN client timeout.

## Verifying this change

Existing unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
