### PR TITLE
[BP-1.15][FLINK-29639][runtime] Print resourceId of remote taskmanager when encounter transport exception.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkClientHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NetworkClientHandler.java
@@ -39,6 +39,8 @@ public interface NetworkClientHandler extends ChannelHandler {
 
     void cancelRequestFor(InputChannelID inputChannelId);
 
+    void setConnectionId(ConnectionID connectionId);
+
     /**
      * Return whether there is channel error.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClient.java
@@ -77,6 +77,7 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
         this.clientHandler = checkNotNull(clientHandler);
         this.connectionId = checkNotNull(connectionId);
         this.clientFactory = checkNotNull(clientFactory);
+        clientHandler.setConnectionId(connectionId);
     }
 
     boolean canBeDisposed() {
@@ -138,8 +139,11 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                             inputChannel.onError(
                                     new LocalTransportException(
                                             String.format(
-                                                    "Sending the partition request to '%s (#%d)' failed.",
+                                                    "Sending the partition request to '%s [%s] (#%d)' failed.",
                                                     connectionId.getAddress(),
+                                                    connectionId
+                                                            .getResourceID()
+                                                            .getStringWithMetadata(),
                                                     connectionId.getConnectionIndex()),
                                             future.channel().localAddress(),
                                             future.cause()));
@@ -197,8 +201,11 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
                                     inputChannel.onError(
                                             new LocalTransportException(
                                                     String.format(
-                                                            "Sending the task event to '%s (#%d)' failed.",
+                                                            "Sending the task event to '%s [%s] (#%d)' failed.",
                                                             connectionId.getAddress(),
+                                                            connectionId
+                                                                    .getResourceID()
+                                                                    .getStringWithMetadata(),
                                                             connectionId.getConnectionIndex()),
                                                     future.channel().localAddress(),
                                                     future.cause()));
@@ -275,7 +282,10 @@ public class NettyPartitionRequestClient implements PartitionRequestClient {
             final SocketAddress localAddr = tcpChannel.localAddress();
             final SocketAddress remoteAddr = tcpChannel.remoteAddress();
             throw new LocalTransportException(
-                    String.format("Channel to '%s' closed.", remoteAddr), localAddr);
+                    String.format(
+                            "Channel to '%s [%s]' closed.",
+                            remoteAddr, connectionId.getResourceID().getStringWithMetadata()),
+                    localAddr);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactory.java
@@ -80,6 +80,7 @@ class PartitionRequestClientFactory {
         // We map the input ConnectionID to a new value to restrict the number of tcp connections
         connectionId =
                 new ConnectionID(
+                        connectionId.getResourceID(),
                         connectionId.getAddress(),
                         connectionId.getConnectionIndex() % maxNumberOfConnections);
         while (true) {
@@ -164,6 +165,9 @@ class PartitionRequestClientFactory {
             throw new RemoteTransportException(
                     "Connecting to remote task manager '"
                             + connectionId.getAddress()
+                            + " [ "
+                            + connectionId.getResourceID().getStringWithMetadata()
+                            + " ] "
                             + "' has failed. This might indicate that the remote task "
                             + "manager has been lost.",
                     connectionId.getAddress(),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -66,7 +66,8 @@ class ResultPartitionDeploymentDescriptorTest {
 
     private static final ResourceID producerLocation = new ResourceID("producerLocation");
     private static final InetSocketAddress address = new InetSocketAddress("localhost", 10000);
-    private static final ConnectionID connectionID = new ConnectionID(address, connectionIndex);
+    private static final ConnectionID connectionID =
+            new ConnectionID(producerLocation, address, connectionIndex);
 
     /** Tests simple de/serialization with {@link UnknownShuffleDescriptor}. */
     @Test
@@ -85,7 +86,7 @@ class ResultPartitionDeploymentDescriptorTest {
         ShuffleDescriptor shuffleDescriptor =
                 new NettyShuffleDescriptor(
                         producerLocation,
-                        new NetworkPartitionConnectionInfo(connectionID),
+                        new NetworkPartitionConnectionInfo(address, connectionIndex),
                         resultPartitionID);
 
         ResultPartitionDeploymentDescriptor copy =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ResultPartitionDeploymentDescriptorTest.java
@@ -31,19 +31,16 @@ import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor.NetworkPartitionC
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.UnknownShuffleDescriptor;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for the {@link ResultPartitionDeploymentDescriptor}. */
-public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
+class ResultPartitionDeploymentDescriptorTest {
     private static final IntermediateDataSetID resultId = new IntermediateDataSetID();
     private static final int numberOfPartitions = 5;
 
@@ -73,18 +70,18 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 
     /** Tests simple de/serialization with {@link UnknownShuffleDescriptor}. */
     @Test
-    public void testSerializationOfUnknownShuffleDescriptor() throws IOException {
+    void testSerializationOfUnknownShuffleDescriptor() throws IOException {
         ShuffleDescriptor shuffleDescriptor = new UnknownShuffleDescriptor(resultPartitionID);
         ShuffleDescriptor shuffleDescriptorCopy =
                 CommonTestUtils.createCopySerializable(shuffleDescriptor);
-        assertThat(shuffleDescriptorCopy, instanceOf(UnknownShuffleDescriptor.class));
-        assertThat(shuffleDescriptorCopy.getResultPartitionID(), is(resultPartitionID));
-        assertThat(shuffleDescriptorCopy.isUnknown(), is(true));
+        assertThat(shuffleDescriptorCopy).isInstanceOf(UnknownShuffleDescriptor.class);
+        assertThat(resultPartitionID).isEqualTo(shuffleDescriptorCopy.getResultPartitionID());
+        assertThat(shuffleDescriptorCopy.isUnknown()).isTrue();
     }
 
     /** Tests simple de/serialization with {@link NettyShuffleDescriptor}. */
     @Test
-    public void testSerializationWithNettyShuffleDescriptor() throws IOException {
+    void testSerializationWithNettyShuffleDescriptor() throws IOException {
         ShuffleDescriptor shuffleDescriptor =
                 new NettyShuffleDescriptor(
                         producerLocation,
@@ -94,13 +91,13 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
         ResultPartitionDeploymentDescriptor copy =
                 createCopyAndVerifyResultPartitionDeploymentDescriptor(shuffleDescriptor);
 
-        assertThat(copy.getShuffleDescriptor(), instanceOf(NettyShuffleDescriptor.class));
+        assertThat(copy.getShuffleDescriptor()).isInstanceOf(NettyShuffleDescriptor.class);
         NettyShuffleDescriptor shuffleDescriptorCopy =
                 (NettyShuffleDescriptor) copy.getShuffleDescriptor();
-        assertThat(shuffleDescriptorCopy.getResultPartitionID(), is(resultPartitionID));
-        assertThat(shuffleDescriptorCopy.isUnknown(), is(false));
-        assertThat(shuffleDescriptorCopy.isLocalTo(producerLocation), is(true));
-        assertThat(shuffleDescriptorCopy.getConnectionId(), is(connectionID));
+        assertThat(resultPartitionID).isEqualTo(shuffleDescriptorCopy.getResultPartitionID());
+        assertThat(shuffleDescriptorCopy.isUnknown()).isFalse();
+        assertThat(shuffleDescriptorCopy.isLocalTo(producerLocation)).isTrue();
+        assertThat(connectionID).isEqualTo(shuffleDescriptorCopy.getConnectionId());
     }
 
     private static ResultPartitionDeploymentDescriptor
@@ -116,11 +113,11 @@ public class ResultPartitionDeploymentDescriptorTest extends TestLogger {
 
     private static void verifyResultPartitionDeploymentDescriptorCopy(
             ResultPartitionDeploymentDescriptor copy) {
-        assertThat(copy.getResultId(), is(resultId));
-        assertThat(copy.getTotalNumberOfPartitions(), is(numberOfPartitions));
-        assertThat(copy.getPartitionId(), is(partitionId));
-        assertThat(copy.getPartitionType(), is(partitionType));
-        assertThat(copy.getNumberOfSubpartitions(), is(numberOfSubpartitions));
-        assertThat(copy.notifyPartitionDataAvailable(), is(true));
+        assertThat(resultId).isEqualTo(copy.getResultId());
+        assertThat(numberOfPartitions).isEqualTo(copy.getTotalNumberOfPartitions());
+        assertThat(partitionId).isEqualTo(copy.getPartitionId());
+        assertThat(partitionType).isEqualTo(copy.getPartitionType());
+        assertThat(numberOfSubpartitions).isEqualTo(copy.getNumberOfSubpartitions());
+        assertThat(copy.notifyPartitionDataAvailable()).isTrue();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/deployment/ShuffleDescriptorTest.java
@@ -66,9 +66,10 @@ public class ShuffleDescriptorTest extends TestLogger {
                             jobID, localPartitionId, consumerResourceID);
 
             ResultPartitionID remotePartitionId = new ResultPartitionID();
+            ResourceID remoteResourceID = ResourceID.generate();
             ResultPartitionDeploymentDescriptor remotePartition =
                     createResultPartitionDeploymentDescriptor(
-                            jobID, remotePartitionId, ResourceID.generate());
+                            jobID, remotePartitionId, remoteResourceID);
 
             ResultPartitionID unknownPartitionId = new ResultPartitionID();
 
@@ -118,7 +119,15 @@ public class ShuffleDescriptorTest extends TestLogger {
                         remotePartitionId);
                 nettyShuffleDescriptor = (NettyShuffleDescriptor) remoteShuffleDescriptor;
                 assertThat(nettyShuffleDescriptor.isLocalTo(consumerResourceID), is(false));
-                assertThat(nettyShuffleDescriptor.getConnectionId(), is(STUB_CONNECTION_ID));
+                assertThat(
+                        nettyShuffleDescriptor.getConnectionId().getAddress(),
+                        is(STUB_CONNECTION_ID.getAddress()));
+                assertThat(
+                        nettyShuffleDescriptor.getConnectionId().getConnectionIndex(),
+                        is(STUB_CONNECTION_ID.getConnectionIndex()));
+                assertThat(
+                        nettyShuffleDescriptor.getConnectionId().getResourceID(),
+                        is(remoteResourceID));
             } else {
                 // Unknown (lazy deployment allowed)
                 verifyShuffleDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -40,7 +40,7 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelOutboundHandlerAda
 import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
 import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
@@ -52,11 +52,8 @@ import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.createConfig;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doAnswer;
@@ -67,14 +64,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class ClientTransportErrorHandlingTest {
+class ClientTransportErrorHandlingTest {
 
     /**
      * Verifies that failed client requests via {@link PartitionRequestClient} are correctly
      * attributed to the respective {@link RemoteInputChannel}.
      */
     @Test
-    public void testExceptionOnWrite() throws Exception {
+    void testExceptionOnWrite() throws Exception {
 
         NettyProtocol protocol =
                 new NettyProtocol(
@@ -146,14 +143,13 @@ public class ClientTransportErrorHandlingTest {
 
         // Second request is *not* successful
         requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[1], 0);
-
         // Wait for the notification and it could confirm all the request operations are done
-        if (!sync.await(TestingUtils.TESTING_DURATION.toMillis(), TimeUnit.MILLISECONDS)) {
-            fail(
-                    "Timed out after waiting for "
-                            + TestingUtils.TESTING_DURATION.toMillis()
-                            + " ms to be notified about the channel error.");
-        }
+        assertThat(sync.await(TestingUtils.TESTING_DURATION.toMillis(), TimeUnit.MILLISECONDS))
+                .withFailMessage(
+                        "Timed out after waiting for "
+                                + TestingUtils.TESTING_DURATION.toMillis()
+                                + " ms to be notified about the channel error.")
+                .isTrue();
 
         // Only the second channel should be notified about the error
         verify(rich[0], times(0)).onError(any(LocalTransportException.class));
@@ -166,7 +162,7 @@ public class ClientTransportErrorHandlingTest {
      * RemoteTransportException} instances.
      */
     @Test
-    public void testWrappingOfRemoteErrorMessage() throws Exception {
+    void testWrappingOfRemoteErrorMessage() throws Exception {
         EmbeddedChannel ch = createEmbeddedChannel();
 
         NetworkClientHandler handler = getClientHandler(ch);
@@ -187,14 +183,12 @@ public class ClientTransportErrorHandlingTest {
                                 new RuntimeException("Expected test exception"),
                                 rich[0].getInputChannelId()));
 
-        try {
-            // Exception should not reach end of pipeline...
-            ch.checkException();
-        } catch (Exception e) {
-            fail(
-                    "The exception reached the end of the pipeline and "
-                            + "was not handled correctly by the last handler.");
-        }
+        // Exception should not reach end of pipeline...
+        assertThatNoException()
+                .describedAs(
+                        "The exception reached the end of the pipeline and "
+                                + "was not handled correctly by the last handler.")
+                .isThrownBy(ch::checkException);
 
         verify(rich[0], times(1)).onError(isA(RemoteTransportException.class));
         verify(rich[1], never()).onError(any(Throwable.class));
@@ -205,14 +199,12 @@ public class ClientTransportErrorHandlingTest {
                         new NettyMessage.ErrorResponse(
                                 new RuntimeException("Expected test exception")));
 
-        try {
-            // Exception should not reach end of pipeline...
-            ch.checkException();
-        } catch (Exception e) {
-            fail(
-                    "The exception reached the end of the pipeline and "
-                            + "was not handled correctly by the last handler.");
-        }
+        // Exception should not reach end of pipeline...
+        assertThatNoException()
+                .describedAs(
+                        "The exception reached the end of the pipeline and "
+                                + "was not handled correctly by the last handler.")
+                .isThrownBy(ch::checkException);
 
         verify(rich[0], times(2)).onError(isA(RemoteTransportException.class));
         verify(rich[1], times(1)).onError(isA(RemoteTransportException.class));
@@ -223,7 +215,7 @@ public class ClientTransportErrorHandlingTest {
      * RemoteTransportException}.
      */
     @Test
-    public void testExceptionOnRemoteClose() throws Exception {
+    void testExceptionOnRemoteClose() throws Exception {
 
         NettyProtocol protocol =
                 new NettyProtocol(
@@ -275,12 +267,12 @@ public class ClientTransportErrorHandlingTest {
         ch.writeAndFlush(Unpooled.buffer().writerIndex(16));
 
         // Wait for the notification
-        if (!sync.await(TestingUtils.TESTING_DURATION.toMillis(), TimeUnit.MILLISECONDS)) {
-            fail(
-                    "Timed out after waiting for "
-                            + TestingUtils.TESTING_DURATION.toMillis()
-                            + " ms to be notified about remote connection close.");
-        }
+        assertThat(sync.await(TestingUtils.TESTING_DURATION.toMillis(), TimeUnit.MILLISECONDS))
+                .withFailMessage(
+                        "Timed out after waiting for "
+                                + TestingUtils.TESTING_DURATION.toMillis()
+                                + " ms to be notified about remote connection close.")
+                .isTrue();
 
         // All the registered channels should be notified.
         for (RemoteInputChannel r : rich) {
@@ -292,7 +284,7 @@ public class ClientTransportErrorHandlingTest {
 
     /** Verifies that fired Exceptions are handled correctly by the pipeline. */
     @Test
-    public void testExceptionCaught() throws Exception {
+    void testExceptionCaught() throws Exception {
         EmbeddedChannel ch = createEmbeddedChannel();
 
         NetworkClientHandler handler = getClientHandler(ch);
@@ -308,14 +300,12 @@ public class ClientTransportErrorHandlingTest {
 
         ch.pipeline().fireExceptionCaught(new Exception());
 
-        try {
-            // Exception should not reach end of pipeline...
-            ch.checkException();
-        } catch (Exception e) {
-            fail(
-                    "The exception reached the end of the pipeline and "
-                            + "was not handled correctly by the last handler.");
-        }
+        // Exception should not reach end of pipeline...
+        assertThatNoException()
+                .describedAs(
+                        "The exception reached the end of the pipeline and "
+                                + "was not handled correctly by the last handler.")
+                .isThrownBy(ch::checkException);
 
         // ...but all the registered channels should be notified.
         for (RemoteInputChannel r : rich) {
@@ -328,7 +318,7 @@ public class ClientTransportErrorHandlingTest {
      * instance of {@link RemoteTransportException}.
      */
     @Test
-    public void testConnectionResetByPeer() throws Throwable {
+    void testConnectionResetByPeer() throws Throwable {
         EmbeddedChannel ch = createEmbeddedChannel();
 
         NetworkClientHandler handler = getClientHandler(ch);
@@ -345,13 +335,13 @@ public class ClientTransportErrorHandlingTest {
                                 Throwable cause = (Throwable) invocation.getArguments()[0];
 
                                 try {
-                                    assertEquals(RemoteTransportException.class, cause.getClass());
-                                    assertNotEquals("Connection reset by peer", cause.getMessage());
+                                    assertThat(cause).isInstanceOf(RemoteTransportException.class);
+                                    assertThat(cause)
+                                            .hasMessageNotContaining("Connection reset by peer");
 
-                                    assertEquals(IOException.class, cause.getCause().getClass());
-                                    assertEquals(
-                                            "Connection reset by peer",
-                                            cause.getCause().getMessage());
+                                    assertThat(cause.getCause()).isInstanceOf(IOException.class);
+                                    assertThat(cause.getCause())
+                                            .hasMessage("Connection reset by peer");
                                 } catch (Throwable t) {
                                     error[0] = t;
                                 }
@@ -364,12 +354,12 @@ public class ClientTransportErrorHandlingTest {
 
         ch.pipeline().fireExceptionCaught(new IOException("Connection reset by peer"));
 
-        assertNull(error[0]);
+        assertThat(error[0]).isNull();
     }
 
     /** Verifies that the channel is closed if there is an error *during* error notification. */
     @Test
-    public void testChannelClosedOnExceptionDuringErrorNotification() throws Exception {
+    void testChannelClosedOnExceptionDuringErrorNotification() throws Exception {
         EmbeddedChannel ch = createEmbeddedChannel();
 
         NetworkClientHandler handler = getClientHandler(ch);
@@ -382,7 +372,7 @@ public class ClientTransportErrorHandlingTest {
 
         ch.pipeline().fireExceptionCaught(new Exception());
 
-        assertFalse(ch.isActive());
+        assertThat(ch.isActive()).isFalse();
     }
 
     // ---------------------------------------------------------------------------------------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/CreditBasedPartitionRequestClientHandlerTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.metrics.SimpleCounter;
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
 import org.apache.flink.runtime.io.network.TestingConnectionManager;
@@ -60,6 +61,7 @@ import org.junit.Assume;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
 
 import static org.apache.flink.runtime.io.network.netty.PartitionRequestQueueTest.blockChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
@@ -652,6 +654,8 @@ public class CreditBasedPartitionRequestClientHandlerTest {
             Class<? extends TransportException> expectedClass, Exception cause) {
         CreditBasedPartitionRequestClientHandler handler =
                 new CreditBasedPartitionRequestClientHandler();
+        handler.setConnectionId(
+                new ConnectionID(ResourceID.generate(), new InetSocketAddress("localhost", 0), 0));
         EmbeddedChannel embeddedChannel =
                 new EmbeddedChannel(
                         // A test handler to trigger the exception.

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyPartitionRequestClientTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.NetworkClientHandler;
 import org.apache.flink.runtime.io.network.PartitionRequestClient;
@@ -287,7 +288,8 @@ public class NettyPartitionRequestClientTest {
         try (NetUtils.Port availablePort = NetUtils.getAvailablePort()) {
             int port = availablePort.getPort();
             ConnectionID connectionID =
-                    new ConnectionID(new InetSocketAddress("localhost", port), 0);
+                    new ConnectionID(
+                            ResourceID.generate(), new InetSocketAddress("localhost", port), 0);
             NettyConfig config =
                     new NettyConfig(InetAddress.getLocalHost(), port, 1024, 1, new Configuration());
             NettyClient nettyClient = new NettyClient(config);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.netty;
 
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.util.NetUtils;
 
@@ -224,8 +225,9 @@ public class NettyTestUtil {
             return client;
         }
 
-        ConnectionID getConnectionID(int connectionIndex) {
+        ConnectionID getConnectionID(ResourceID resourceID, int connectionIndex) {
             return new ConnectionID(
+                    resourceID,
                     new InetSocketAddress(
                             server.getConfig().getServerAddress(),
                             server.getConfig().getServerPort()),

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/PartitionRequestClientFactoryTest.java
@@ -199,7 +199,7 @@ public class PartitionRequestClientFactoryTest {
                 new PartitionRequestClientFactory(
                         serverAndClient.client(), 2, 1, connectionReuseEnabled);
 
-        ConnectionID connectionID = serverAndClient.getConnectionID(0);
+        ConnectionID connectionID = serverAndClient.getConnectionID(ResourceID.generate(), 0);
         NettyPartitionRequestClient oldClient = factory.createPartitionRequestClient(connectionID);
 
         // close server channel

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/InputChannelBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.io.network.partition.consumer;
 
 import org.apache.flink.runtime.checkpoint.channel.ChannelStateWriter;
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.ConnectionManager;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
@@ -38,7 +39,7 @@ import static org.apache.flink.runtime.io.network.partition.consumer.SingleInput
 /** Builder for various {@link InputChannel} types. */
 public class InputChannelBuilder {
     public static final ConnectionID STUB_CONNECTION_ID =
-            new ConnectionID(new InetSocketAddress("localhost", 5000), 0);
+            new ConnectionID(ResourceID.generate(), new InetSocketAddress("localhost", 5000), 0);
 
     private int channelIndex = 0;
     private ResultPartitionID partitionId = new ResultPartitionID();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
@@ -71,10 +71,11 @@ public class NettyShuffleDescriptorBuilder {
     }
 
     public NettyShuffleDescriptor buildRemote() {
-        ConnectionID connectionID =
-                new ConnectionID(new InetSocketAddress(address, dataPort), connectionIndex);
         return new NettyShuffleDescriptor(
-                producerLocation, new NetworkPartitionConnectionInfo(connectionID), id);
+                producerLocation,
+                new NetworkPartitionConnectionInfo(
+                        new InetSocketAddress(address, dataPort), connectionIndex),
+                id);
     }
 
     public NettyShuffleDescriptor buildLocal() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/util/NettyShuffleDescriptorBuilder.java
@@ -20,7 +20,6 @@ package org.apache.flink.runtime.util;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
-import org.apache.flink.runtime.io.network.ConnectionID;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.shuffle.NettyShuffleDescriptor;


### PR DESCRIPTION
## What is the purpose of the change

*backport FLINK-29639 to 1.15*
