### PR TITLE
[FLINK-29430] Add sanity check when setCurrentKeyGroupIndex

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/InternalKeyContextImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/InternalKeyContextImpl.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.state.heap;
 
 import org.apache.flink.runtime.state.KeyGroupRange;
+import org.apache.flink.runtime.state.KeyGroupRangeOffsets;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -72,6 +73,10 @@ public class InternalKeyContextImpl<K> implements InternalKeyContext<K> {
 
     @Override
     public void setCurrentKeyGroupIndex(int currentKeyGroupIndex) {
+        if (!keyGroupRange.contains(currentKeyGroupIndex)) {
+            throw KeyGroupRangeOffsets.newIllegalKeyGroupException(
+                    currentKeyGroupIndex, keyGroupRange);
+        }
         this.currentKeyGroupIndex = currentKeyGroupIndex;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/InternalKeyContextImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/heap/InternalKeyContextImplTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.runtime.state.heap;
+
+import org.apache.flink.runtime.state.KeyGroupRange;
+
+import org.junit.Test;
+
+/** Tests for {@link InternalKeyContextImpl}. */
+public class InternalKeyContextImplTest {
+
+    @Test
+    public void testSetKeyGroupIndexWithinRange() {
+        InternalKeyContextImpl<Integer> integerInternalKeyContext =
+                new InternalKeyContextImpl<>(KeyGroupRange.of(0, 128), 4096);
+        // There will be no exception thrown since the key group index is within the range.
+        integerInternalKeyContext.setCurrentKeyGroupIndex(64);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testSetKeyGroupIndexOutOfRange() {
+        InternalKeyContextImpl<Integer> integerInternalKeyContext =
+                new InternalKeyContextImpl<>(KeyGroupRange.of(0, 128), 4096);
+        // There will be an IllegalArgumentException thrown since the key group index is out of the
+        // range.
+        integerInternalKeyContext.setCurrentKeyGroupIndex(2048);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Currently the HeapStateBackend check whether the current key group index is a valid one while the RocksDBStateBackend will not.
This PR do this check in InternalKeyContextImpl#setCurrentKeyGroupIndex, to expose the data correctness problem immediately when using RocksDB as well as heap.

## Brief change log

* Add the checking logic in InternalKeyContextImpl#setCurrentKeyGroupIndex.
* Add a test for the new logic.
* Change some test code in CoBroadcastWithKeyedOperatorTest, since it fails after adding the check.

## Verifying this change

This change added a new test class InternalKeyContextImplTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): **yes**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
