### PR TITLE
[FLINK-30134][runtime][security] Annotate all the public classes for the delegation token framework

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenConverter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenConverter.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
+
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.security.Credentials;
 
@@ -26,6 +28,7 @@ import java.io.DataInputStream;
 import java.io.IOException;
 
 /** Delegation token serializer and deserializer functionality. */
+@Internal
 public class DelegationTokenConverter {
     /** Serializes delegation tokens. */
     public static byte[] serialize(Credentials credentials) throws IOException {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenListener.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenListener.java
@@ -18,12 +18,15 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
+
 /**
  * Listener for delegation tokens state changes in the {@link DelegationTokenManager}.
  *
  * <p>By registering it in the manager one can receive callbacks when events are happening related
  * to delegation tokens.
  */
+@Internal
 public interface DelegationTokenListener {
 
     /** Callback function when new delegation tokens obtained. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenManager.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
+
 import org.apache.hadoop.security.Credentials;
 
 /**
@@ -27,6 +29,7 @@ import org.apache.hadoop.security.Credentials;
  * run without interruption while accessing secured services. It must contact all the configured
  * secure services to obtain delegation tokens to be distributed to the rest of the application.
  */
+@Internal
 public interface DelegationTokenManager {
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenUpdater.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenUpdater.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
+
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
@@ -26,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 /** Delegation token updater functionality. */
+@Internal
 public final class DelegationTokenUpdater {
 
     private static final Logger LOG = LoggerFactory.getLogger(DelegationTokenUpdater.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/HBaseDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/HBaseDelegationTokenProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.Preconditions;
@@ -39,6 +40,7 @@ import java.util.Optional;
  * flink-connector-hbase-base but HBase connection can be made without the connector. All in all I
  * tend to move this but that would be a breaking change.
  */
+@Experimental
 public class HBaseDelegationTokenProvider implements DelegationTokenProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(HBaseDelegationTokenProvider.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManager.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -58,6 +59,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  * with user-provided credentials, and contacts all the configured secure services to obtain
  * delegation tokens to be distributed to the rest of the application.
  */
+@Internal
 public class KerberosDelegationTokenManager implements DelegationTokenManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(KerberosDelegationTokenManager.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosDelegationTokenManagerFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.hadoop.HadoopDependency;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
 /** A factory for {@link KerberosDelegationTokenManager}. */
+@Internal
 public class KerberosDelegationTokenManagerFactory {
 
     private static final Logger LOG =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosLoginProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/KerberosLoginProvider.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.hadoop.HadoopUserUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
@@ -32,6 +33,7 @@ import java.util.Optional;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** Provides Kerberos login functionality. */
+@Internal
 public class KerberosLoginProvider {
 
     private static final Logger LOG = LoggerFactory.getLogger(KerberosLoginProvider.class);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/NoOpDelegationTokenManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/NoOpDelegationTokenManager.java
@@ -18,11 +18,14 @@
 
 package org.apache.flink.runtime.security.token;
 
+import org.apache.flink.annotation.Internal;
+
 import org.apache.hadoop.security.Credentials;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** {@link DelegationTokenManager} implementation which does nothing. */
+@Internal
 public class NoOpDelegationTokenManager implements DelegationTokenManager {
 
     private static final Logger LOG = LoggerFactory.getLogger(NoOpDelegationTokenManager.class);


### PR DESCRIPTION
## What is the purpose of the change

On the discussion thread of the [delegation token framework generalization](https://lists.apache.org/thread/vgg5hbf5jljcxopfhb32w3l0wjoyko4o) popped up that annotations for public classes are missing on several places. In this PR I've added the appropriate annotations for all public delegation token framework classes.

## Brief change log

Added annotations.

## Verifying this change

Trivial rework, not tests needed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
