### PR TITLE
[FLINK-29427] Fix unstable test LookupJoinITCase by compiling Projection class in advance using userCodeClassLoader

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/CachingLookupFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/CachingLookupFunction.java
@@ -111,7 +111,7 @@ public class CachingLookupFunction extends LookupFunction {
         cache.open(cacheMetricGroup);
         if (cache instanceof LookupFullCache) {
             // TODO add Configuration into FunctionContext
-            ((LookupFullCache) cache).open(new Configuration());
+            ((LookupFullCache) cache).open(new Configuration(), context.getUserCodeClassLoader());
         }
         if (delegate != null) {
             delegate.open(context);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/CacheLoader.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/CacheLoader.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.table.runtime.functions.table.lookup.fullcache;
 
-import org.apache.flink.api.common.functions.AbstractRichFunction;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.ThreadSafeSimpleCounter;
@@ -42,7 +41,7 @@ import static org.apache.flink.runtime.metrics.groups.InternalCacheMetricGroup.U
 /**
  * Abstract task that loads data in Full cache from source provided by {@link ScanRuntimeProvider}.
  */
-public abstract class CacheLoader extends AbstractRichFunction implements Runnable, Serializable {
+public abstract class CacheLoader implements Runnable, Serializable, AutoCloseable {
     private static final Logger LOG = LoggerFactory.getLogger(CacheLoader.class);
 
     protected transient volatile ConcurrentHashMap<RowData, Collection<RowData>> cache;
@@ -61,8 +60,7 @@ public abstract class CacheLoader extends AbstractRichFunction implements Runnab
 
     protected abstract void reloadCache() throws Exception;
 
-    @Override
-    public void open(Configuration parameters) throws Exception {
+    public void open(Configuration parameters, ClassLoader classLoader) throws Exception {
         firstLoadLatch = new CountDownLatch(1);
     }
 

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/LookupFullCache.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/LookupFullCache.java
@@ -60,9 +60,10 @@ public class LookupFullCache implements LookupCache {
         cacheLoader.open(metricGroup);
     }
 
-    public synchronized void open(Configuration parameters) throws Exception {
+    public synchronized void open(Configuration parameters, ClassLoader classLoader)
+            throws Exception {
         if (reloadTriggerContext == null) {
-            cacheLoader.open(parameters);
+            cacheLoader.open(parameters, classLoader);
             reloadTriggerContext =
                     new ReloadTriggerContext(
                             cacheLoader,

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/inputformat/InputFormatCacheLoader.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/inputformat/InputFormatCacheLoader.java
@@ -64,10 +64,11 @@ public class InputFormatCacheLoader extends CacheLoader {
     }
 
     @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
+    public void open(Configuration parameters, ClassLoader classLoader) throws Exception {
+        super.open(parameters, classLoader);
         this.parameters = parameters;
         this.initialInputFormat.configure(parameters);
+        this.keySelector.compileProjection(classLoader);
     }
 
     @Override
@@ -131,8 +132,10 @@ public class InputFormatCacheLoader extends CacheLoader {
             InputFormat<RowData, InputSplit> inputFormat =
                     InstantiationUtil.clone(initialInputFormat);
             inputFormat.configure(parameters);
+            GenericRowDataKeySelector keySelectorCopy = keySelector.copy();
+            keySelectorCopy.open();
             return new InputSplitCacheLoadTask(
-                    newCache, keySelector.copy(), cacheEntriesSerializer, inputFormat, inputSplit);
+                    newCache, keySelectorCopy, cacheEntriesSerializer, inputFormat, inputSplit);
         } catch (Exception e) {
             throw new RuntimeException("Failed to create InputFormatCacheLoadTask", e);
         }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/inputformat/InputSplitCacheLoadTask.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/inputformat/InputSplitCacheLoadTask.java
@@ -57,7 +57,6 @@ public class InputSplitCacheLoadTask implements Runnable {
         this.inputFormat = inputFormat;
         this.cacheEntriesSerializer = cacheEntriesSerializer;
         this.inputSplit = inputSplit;
-        keySelector.open();
     }
 
     @Override

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/keyselector/GenericRowDataKeySelector.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/keyselector/GenericRowDataKeySelector.java
@@ -44,7 +44,23 @@ public class GenericRowDataKeySelector implements RowDataKeySelector {
         this.keySerializer = keySerializer;
     }
 
-    public void open() {
+    /**
+     * Compiles projection class in advance using provided classloader.
+     *
+     * <p>Note: this method should be called only from main Flink thread.
+     */
+    public void compileProjection(ClassLoader classLoader) {
+        generatedProjection.compile(classLoader);
+    }
+
+    /**
+     * Creates projection instance in advance.
+     *
+     * <p>Note: if projection was already compiled by {@link this#compileProjection(ClassLoader)},
+     * {@code Class<Projection>} should be already cached inside {@link GeneratedProjection}, so no
+     * compilation or another interaction with contex classLoader will happen.
+     */
+    public void open() throws Exception {
         ClassLoader cl = Thread.currentThread().getContextClassLoader();
         //noinspection unchecked
         projection = generatedProjection.newInstance(cl);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/LookupFullCacheTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/LookupFullCacheTest.java
@@ -164,7 +164,9 @@ public class LookupFullCacheTest {
                                 ThrowingRunnable.unchecked(
                                         () -> {
                                             cache.open(metricGroup);
-                                            cache.open(new Configuration());
+                                            cache.open(
+                                                    new Configuration(),
+                                                    this.getClass().getClassLoader());
                                         }),
                                 executor);
                 futures.add(future);
@@ -207,7 +209,7 @@ public class LookupFullCacheTest {
         fullCache.open(metricGroup);
         assertThat(cacheLoader.isAwaitTriggered()).isFalse();
         assertThat(cacheLoader.getNumLoads()).isZero();
-        fullCache.open(new Configuration());
+        fullCache.open(new Configuration(), this.getClass().getClassLoader());
         assertThat(cacheLoader.isAwaitTriggered()).isTrue();
         assertThat(cacheLoader.getNumLoads()).isEqualTo(1);
         assertThat(cacheLoader.getCache()).isEqualTo(TestCacheLoader.DATA);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/inputformat/InputFormatCacheLoaderTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/inputformat/InputFormatCacheLoaderTest.java
@@ -209,6 +209,12 @@ class InputFormatCacheLoaderTest {
         // noinspection rawtypes
         GeneratedProjection generatedProjection =
                 new GeneratedProjection("", "", new Object[0]) {
+
+                    @Override
+                    public Class<Projection> compile(ClassLoader classLoader) {
+                        return Projection.class;
+                    }
+
                     @Override
                     public Projection newInstance(ClassLoader classLoader) {
                         return row -> {
@@ -224,7 +230,7 @@ class InputFormatCacheLoaderTest {
                         generatedProjection);
         InputFormatCacheLoader cacheLoader =
                 new InputFormatCacheLoader(inputFormat, keySelector, rightRowSerializer);
-        cacheLoader.open(new Configuration());
+        cacheLoader.open(new Configuration(), this.getClass().getClassLoader());
         return cacheLoader;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull-request *tries to fix* unstable test `LookupJoinITCase` (error was not succeeded to be reproduced locally). An error contains the message 'Trying to access closed classloader'. However, test configured in the way that it loads cache only one time, and we wait until the end of this load in `LookupFullCache#open`. So `LookupFullCache#close` shouldn't somehow affect on cache load thread, if we assume that `close` is called only after `open`. 

During debugging it was found out that in `GenericRowDataKeySelector#open`, which executes inside separate reload thread, call of `Thread.currentThread().getContextClassLoader()` returns `SubmoduleClassLoader` rather than `FlinkUserCodeClassLoader`, which is being returned from the same method inside main thread. *Probably*, this ClassLoader should not be there, and this is the core of the problem. Also it closely relates to the problem about classloader leak, described in option `CoreOptions#CHECK_LEAKED_CLASSLOADER`, to which error points out. 

This change prevents from compiling a class in another separate thread, but rather do it just one time in main thread in `LookupFullCache#open` using provided userCodeClassLoader. Subsequent calls of `GeneratedProjection#newInstance` will end up with creating an instance from cached `Class<Projection>` without compilation or another interaction with context classloader. Note, that provided classloader is not stored anywhere, so classloader leak problem can't occur anymore.


## Brief change log

  - Compile Projection Class in main thread in `LookupFullCache#open` to avoid classloader leak


## Verifying this change

 - This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
