### PR TITLE
[FLINK-30155][streaming] Pretty print MutatedConfigurationException

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/program/MutatedConfigurationException.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/program/MutatedConfigurationException.java
@@ -34,6 +34,15 @@ public class MutatedConfigurationException extends Exception {
     private static final long serialVersionUID = -2417524218857151612L;
 
     public MutatedConfigurationException(Collection<String> errorMessages) {
-        super(String.join("\n", errorMessages));
+        super(prettyFormat(errorMessages));
+    }
+
+    private static String prettyFormat(Collection<String> errorMessages) {
+        StringBuilder builder =
+                new StringBuilder("Not allowed configuration change(s) were detected:");
+        for (String error : errorMessages) {
+            builder.append("\n - " + error);
+        }
+        return builder.toString();
     }
 }


### PR DESCRIPTION
The new message will look like:
```
org.apache.flink.client.program.MutatedConfigurationException: Not allowed configuration change(s) were detected:
 - Configuration execution.sorted-inputs.enabled:true not allowed.
 - Configuration execution.runtime-mode was changed from STREAMING to BATCH.
 - Configuration execution.checkpointing.interval:500 ms not allowed in the configuration object CheckpointConfig.
 - Configuration execution.checkpointing.mode:EXACTLY_ONCE not allowed in the configuration object CheckpointConfig.
 - Configuration pipeline.max-parallelism:1024 not allowed in the configuration object ExecutionConfig.
 - Configuration parallelism.default:25 not allowed in the configuration object ExecutionConfig.

	at org.apache.flink.client.program.StreamContextEnvironment.checkNotAllowedConfigurations(StreamContextEnvironment.java:235)
	at org.apache.flink.client.program.StreamContextEnvironment.executeAsync(StreamContextEnvironment.java:175)
	at org.apache.flink.client.program.StreamContextEnvironment.execute(StreamContextEnvironment.java:115)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.execute(StreamExecutionEnvironment.java:2049)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.execute(StreamExecutionEnvironment.java:2027)
```
Instead of:
```
org.apache.flink.client.program.MutatedConfigurationException: Configuration execution.sorted-inputs.enabled:true not allowed.
Configuration execution.runtime-mode was changed from STREAMING to BATCH.
Configuration execution.checkpointing.interval:500 ms not allowed in the configuration object CheckpointConfig.
Configuration execution.checkpointing.mode:EXACTLY_ONCE not allowed in the configuration object CheckpointConfig.
Configuration pipeline.max-parallelism:1024 not allowed in the configuration object ExecutionConfig.
Configuration parallelism.default:25 not allowed in the configuration object ExecutionConfig.

	at org.apache.flink.client.program.StreamContextEnvironment.checkNotAllowedConfigurations(StreamContextEnvironment.java:235)
	at org.apache.flink.client.program.StreamContextEnvironment.executeAsync(StreamContextEnvironment.java:175)
	at org.apache.flink.client.program.StreamContextEnvironment.execute(StreamContextEnvironment.java:115)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.execute(StreamExecutionEnvironment.java:2049)
	at org.apache.flink.streaming.api.environment.StreamExecutionEnvironment.execute(StreamExecutionEnvironment.java:2027)
```
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
