### PR TITLE
[FLINK-30165][runtime][JUnit5 Migration] Migrate unaligned checkpoint related tests under flink-runtime module to junit5

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateChunkReaderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateChunkReaderTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
@@ -34,32 +34,38 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
-import static org.apache.flink.util.Preconditions.checkState;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
 /** {@link ChannelStateChunkReader} test. */
-public class ChannelStateChunkReaderTest {
+class ChannelStateChunkReaderTest {
 
-    @Test(expected = TestException.class)
-    public void testBufferRecycledOnFailure() throws IOException, InterruptedException {
+    @Test
+    void testBufferRecycledOnFailure() throws IOException {
         FailingChannelStateSerializer serializer = new FailingChannelStateSerializer();
         TestRecoveredChannelStateHandler handler = new TestRecoveredChannelStateHandler();
 
         try (FSDataInputStream stream = getStream(serializer, 10)) {
-            new ChannelStateChunkReader(serializer)
-                    .readChunk(stream, serializer.getHeaderLength(), handler, "channelInfo", 0);
-        } finally {
-            checkState(serializer.failed);
-            checkState(!handler.requestedBuffers.isEmpty());
-            assertTrue(
-                    handler.requestedBuffers.stream()
-                            .allMatch(TestChannelStateByteBuffer::isRecycled));
+            assertThatThrownBy(
+                            () ->
+                                    new ChannelStateChunkReader(serializer)
+                                            .readChunk(
+                                                    stream,
+                                                    serializer.getHeaderLength(),
+                                                    handler,
+                                                    "channelInfo",
+                                                    0))
+                    .isInstanceOf(TestException.class);
+            assertThat(serializer.failed).isTrue();
+            assertThat(handler.requestedBuffers)
+                    .isNotEmpty()
+                    .allMatch(TestChannelStateByteBuffer::isRecycled);
         }
     }
 
     @Test
-    public void testBufferRecycledOnSuccess() throws IOException, InterruptedException {
+    void testBufferRecycledOnSuccess() throws IOException, InterruptedException {
         ChannelStateSerializer serializer = new ChannelStateSerializerImpl();
         TestRecoveredChannelStateHandler handler = new TestRecoveredChannelStateHandler();
 
@@ -67,15 +73,14 @@ public class ChannelStateChunkReaderTest {
             new ChannelStateChunkReader(serializer)
                     .readChunk(stream, serializer.getHeaderLength(), handler, "channelInfo", 0);
         } finally {
-            checkState(!handler.requestedBuffers.isEmpty());
-            assertTrue(
-                    handler.requestedBuffers.stream()
-                            .allMatch(TestChannelStateByteBuffer::isRecycled));
+            assertThat(handler.requestedBuffers)
+                    .isNotEmpty()
+                    .allMatch(TestChannelStateByteBuffer::isRecycled);
         }
     }
 
     @Test
-    public void testBuffersNotRequestedForEmptyStream() throws IOException, InterruptedException {
+    void testBuffersNotRequestedForEmptyStream() throws IOException, InterruptedException {
         ChannelStateSerializer serializer = new ChannelStateSerializerImpl();
         TestRecoveredChannelStateHandler handler = new TestRecoveredChannelStateHandler();
 
@@ -83,12 +88,12 @@ public class ChannelStateChunkReaderTest {
             new ChannelStateChunkReader(serializer)
                     .readChunk(stream, serializer.getHeaderLength(), handler, "channelInfo", 0);
         } finally {
-            assertTrue(handler.requestedBuffers.isEmpty());
+            assertThat(handler.requestedBuffers).isEmpty();
         }
     }
 
     @Test
-    public void testNoSeekUnnecessarily() throws IOException, InterruptedException {
+    void testNoSeekUnnecessarily() throws IOException, InterruptedException {
         final int offset = 123;
         final FSDataInputStream stream =
                 new FSDataInputStream() {
@@ -99,7 +104,7 @@ public class ChannelStateChunkReaderTest {
 
                     @Override
                     public void seek(long ignored) {
-                        fail();
+                        fail("It shouldn't be called.");
                     }
 
                     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriteRequestDispatcherImplTest.java
@@ -26,20 +26,19 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
 import org.apache.flink.runtime.state.memory.MemoryBackendCheckpointStorageAccess;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.function.Function;
 
 import static org.apache.flink.runtime.state.ChannelPersistenceITCase.getStreamFactoryFactory;
 import static org.apache.flink.util.CloseableIterator.ofElements;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** {@link ChannelStateWriteRequestDispatcherImpl} test. */
-public class ChannelStateWriteRequestDispatcherImplTest {
+class ChannelStateWriteRequestDispatcherImplTest {
 
     @Test
-    public void testPartialInputChannelStateWrite() throws Exception {
+    void testPartialInputChannelStateWrite() throws Exception {
         testBuffersRecycled(
                 buffers ->
                         ChannelStateWriteRequest.write(
@@ -49,7 +48,7 @@ public class ChannelStateWriteRequestDispatcherImplTest {
     }
 
     @Test
-    public void testPartialResultSubpartitionStateWrite() throws Exception {
+    void testPartialResultSubpartitionStateWrite() throws Exception {
         testBuffersRecycled(
                 buffers ->
                         ChannelStateWriteRequest.write(
@@ -57,7 +56,7 @@ public class ChannelStateWriteRequestDispatcherImplTest {
     }
 
     @Test
-    public void testConcurrentUnalignedCheckpoint() throws Exception {
+    void testConcurrentUnalignedCheckpoint() throws Exception {
         ChannelStateWriteRequestDispatcher processor =
                 new ChannelStateWriteRequestDispatcherImpl(
                         "dummy task",
@@ -68,16 +67,16 @@ public class ChannelStateWriteRequestDispatcherImplTest {
         processor.dispatch(
                 ChannelStateWriteRequest.start(
                         1L, result, CheckpointStorageLocationReference.getDefault()));
-        assertFalse(result.isDone());
+        assertThat(result.isDone()).isFalse();
 
         processor.dispatch(
                 ChannelStateWriteRequest.start(
                         2L,
                         new ChannelStateWriteResult(),
                         CheckpointStorageLocationReference.getDefault()));
-        assertTrue(result.isDone());
-        assertTrue(result.getInputChannelStateHandles().isCompletedExceptionally());
-        assertTrue(result.getResultSubpartitionStateHandles().isCompletedExceptionally());
+        assertThat(result.isDone()).isTrue();
+        assertThat(result.getInputChannelStateHandles()).isCompletedExceptionally();
+        assertThat(result.getResultSubpartitionStateHandles()).isCompletedExceptionally();
     }
 
     private void testBuffersRecycled(
@@ -98,9 +97,7 @@ public class ChannelStateWriteRequestDispatcherImplTest {
 
         NetworkBuffer[] buffers = new NetworkBuffer[] {buffer(), buffer()};
         dispatcher.dispatch(requestBuilder.apply(buffers));
-        for (NetworkBuffer buffer : buffers) {
-            assertTrue(buffer.isRecycled());
-        }
+        assertThat(buffers).allMatch(NetworkBuffer::isRecycled);
     }
 
     private NetworkBuffer buffer() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
@@ -182,10 +182,7 @@ class ChannelStateWriterImplTest {
 
     @Test
     void testAddDataNotStarted() {
-        assertThatThrownBy(
-                        () ->
-                                executeCallbackAndProcessWithSyncWorker(
-                                        (Consumer<ChannelStateWriter>) this::callAddInputData))
+        assertThatThrownBy(() -> executeCallbackAndProcessWithSyncWorker(this::callAddInputData))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriterImplTest.java
@@ -24,9 +24,8 @@ import org.apache.flink.runtime.io.network.buffer.Buffer;
 import org.apache.flink.runtime.io.network.buffer.FreeingBufferRecycler;
 import org.apache.flink.runtime.io.network.buffer.NetworkBuffer;
 import org.apache.flink.util.function.BiConsumerWithException;
-import org.apache.flink.util.function.RunnableWithException;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayDeque;
@@ -36,78 +35,74 @@ import java.util.function.Consumer;
 
 import static org.apache.flink.runtime.state.ChannelPersistenceITCase.getStreamFactoryFactory;
 import static org.apache.flink.util.CloseableIterator.ofElements;
-import static org.apache.flink.util.ExceptionUtils.findThrowable;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** {@link ChannelStateWriterImpl} lifecycle tests. */
-public class ChannelStateWriterImplTest {
+class ChannelStateWriterImplTest {
     private static final long CHECKPOINT_ID = 42L;
     private static final String TASK_NAME = "test";
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testAddEventBuffer() throws Exception {
+    @Test
+    void testAddEventBuffer() throws Exception {
 
         NetworkBuffer dataBuf = getBuffer();
         NetworkBuffer eventBuf = getBuffer();
         eventBuf.setDataType(Buffer.DataType.EVENT_BUFFER);
-        try {
-            runWithSyncWorker(
-                    writer -> {
-                        callStart(writer);
-                        writer.addInputData(
-                                CHECKPOINT_ID,
-                                new InputChannelInfo(1, 1),
-                                1,
-                                ofElements(Buffer::recycleBuffer, eventBuf, dataBuf));
-                    });
-        } finally {
-            assertTrue(dataBuf.isRecycled());
-        }
+
+        executeCallbackWithSyncWorker(
+                (writer, worker) -> {
+                    callStart(writer);
+                    callAddInputData(writer, eventBuf, dataBuf);
+                    assertThatThrownBy(worker::processAllRequests)
+                            .isInstanceOf(IllegalArgumentException.class);
+                });
+        assertThat(dataBuf.isRecycled()).isTrue();
     }
 
     @Test
-    public void testResultCompletion() throws IOException {
+    void testResultCompletion() throws IOException {
         ChannelStateWriteResult result;
         try (ChannelStateWriterImpl writer = openWriter()) {
             callStart(writer);
             result = writer.getAndRemoveWriteResult(CHECKPOINT_ID);
-            assertFalse(result.resultSubpartitionStateHandles.isDone());
-            assertFalse(result.inputChannelStateHandles.isDone());
+            assertThat(result.resultSubpartitionStateHandles).isNotDone();
+            assertThat(result.inputChannelStateHandles).isNotDone();
         }
-        assertTrue(result.inputChannelStateHandles.isDone());
-        assertTrue(result.resultSubpartitionStateHandles.isDone());
+        assertThat(result.inputChannelStateHandles).isDone();
+        assertThat(result.resultSubpartitionStateHandles).isDone();
     }
 
     @Test
-    public void testAbort() throws Exception {
+    void testAbort() throws Exception {
         NetworkBuffer buffer = getBuffer();
-        runWithSyncWorker(
+        executeCallbackWithSyncWorker(
                 (writer, worker) -> {
                     callStart(writer);
                     ChannelStateWriteResult result = writer.getAndRemoveWriteResult(CHECKPOINT_ID);
                     callAddInputData(writer, buffer);
                     callAbort(writer);
                     worker.processAllRequests();
-                    assertTrue(result.isDone());
-                    assertTrue(buffer.isRecycled());
-                });
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testAbortClearsResults() throws Exception {
-        runWithSyncWorker(
-                (writer, worker) -> {
-                    callStart(writer);
-                    writer.abort(CHECKPOINT_ID, new TestException(), true);
-                    writer.getAndRemoveWriteResult(CHECKPOINT_ID);
+                    assertThat(result.isDone()).isTrue();
+                    assertThat(buffer.isRecycled()).isTrue();
                 });
     }
 
     @Test
-    public void testAbortDoesNotClearsResults() throws Exception {
-        runWithSyncWorker(
+    void testAbortClearsResults() throws Exception {
+        executeCallbackWithSyncWorker(
+                (writer, worker) -> {
+                    callStart(writer);
+                    writer.abort(CHECKPOINT_ID, new TestException(), true);
+
+                    assertThatThrownBy(() -> writer.getAndRemoveWriteResult(CHECKPOINT_ID))
+                            .isInstanceOf(IllegalArgumentException.class);
+                });
+    }
+
+    @Test
+    void testAbortDoesNotClearsResults() throws Exception {
+        executeCallbackWithSyncWorker(
                 (writer, worker) -> {
                     callStart(writer);
                     callAbort(writer);
@@ -117,13 +112,13 @@ public class ChannelStateWriterImplTest {
     }
 
     @Test
-    public void testAbortIgnoresMissing() throws Exception {
-        runWithSyncWorker(this::callAbort);
+    void testAbortIgnoresMissing() throws Exception {
+        executeCallbackAndProcessWithSyncWorker(this::callAbort);
     }
 
     @Test
-    public void testAbortOldAndStartNewCheckpoint() throws Exception {
-        runWithSyncWorker(
+    void testAbortOldAndStartNewCheckpoint() throws Exception {
+        executeCallbackWithSyncWorker(
                 (writer, worker) -> {
                     int checkpoint42 = 42;
                     int checkpoint43 = 43;
@@ -135,100 +130,99 @@ public class ChannelStateWriterImplTest {
                     worker.processAllRequests();
 
                     ChannelStateWriteResult result42 = writer.getAndRemoveWriteResult(checkpoint42);
-                    assertTrue(result42.isDone());
-                    try {
-                        result42.getInputChannelStateHandles().get();
-                        fail("The result should have failed.");
-                    } catch (Throwable throwable) {
-                        assertTrue(findThrowable(throwable, TestException.class).isPresent());
-                    }
+                    assertThat(result42.isDone()).isTrue();
+                    assertThatThrownBy(() -> result42.getInputChannelStateHandles().get())
+                            .as("The result should have failed.")
+                            .hasCauseInstanceOf(TestException.class);
 
                     ChannelStateWriteResult result43 = writer.getAndRemoveWriteResult(checkpoint43);
-                    assertFalse(result43.isDone());
-                });
-    }
-
-    @Test(expected = TestException.class)
-    public void testBuffersRecycledOnError() throws Exception {
-        unwrappingError(
-                TestException.class,
-                () -> {
-                    NetworkBuffer buffer = getBuffer();
-                    try (ChannelStateWriterImpl writer =
-                            new ChannelStateWriterImpl(
-                                    TASK_NAME, new ConcurrentHashMap<>(), failingWorker(), 5)) {
-                        writer.open();
-                        callAddInputData(writer, buffer);
-                    } finally {
-                        assertTrue(buffer.isRecycled());
-                    }
+                    assertThat(result43.isDone()).isFalse();
                 });
     }
 
     @Test
-    public void testBuffersRecycledOnClose() throws Exception {
+    void testBuffersRecycledOnError() throws IOException {
         NetworkBuffer buffer = getBuffer();
-        runWithSyncWorker(
+        try (ChannelStateWriterImpl writer =
+                new ChannelStateWriterImpl(
+                        TASK_NAME, new ConcurrentHashMap<>(), failingWorker(), 5)) {
+            writer.open();
+            assertThatThrownBy(() -> callAddInputData(writer, buffer))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasCauseInstanceOf(TestException.class);
+            assertThat(buffer.isRecycled()).isTrue();
+        }
+    }
+
+    @Test
+    void testBuffersRecycledOnClose() throws Exception {
+        NetworkBuffer buffer = getBuffer();
+        executeCallbackAndProcessWithSyncWorker(
                 writer -> {
                     callStart(writer);
                     callAddInputData(writer, buffer);
-                    assertFalse(buffer.isRecycled());
+                    assertThat(buffer.isRecycled()).isFalse();
                 });
-        assertTrue(buffer.isRecycled());
+        assertThat(buffer.isRecycled()).isTrue();
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testNoAddDataAfterFinished() throws Exception {
-        unwrappingError(
-                IllegalArgumentException.class,
-                () ->
-                        runWithSyncWorker(
-                                writer -> {
-                                    callStart(writer);
-                                    callFinish(writer);
-                                    callAddInputData(writer);
-                                }));
+    @Test
+    void testNoAddDataAfterFinished() throws Exception {
+        executeCallbackWithSyncWorker(
+                (writer, worker) -> {
+                    callStart(writer);
+                    callFinish(writer);
+                    worker.processAllRequests();
+
+                    callAddInputData(writer);
+                    assertThatThrownBy(worker::processAllRequests)
+                            .isInstanceOf(IllegalArgumentException.class);
+                });
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testAddDataNotStarted() throws Exception {
-        unwrappingError(
-                IllegalArgumentException.class,
-                () -> runWithSyncWorker((Consumer<ChannelStateWriter>) this::callAddInputData));
+    @Test
+    void testAddDataNotStarted() {
+        assertThatThrownBy(
+                        () ->
+                                executeCallbackAndProcessWithSyncWorker(
+                                        (Consumer<ChannelStateWriter>) this::callAddInputData))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFinishNotStarted() throws Exception {
-        unwrappingError(IllegalArgumentException.class, () -> runWithSyncWorker(this::callFinish));
+    @Test
+    void testFinishNotStarted() {
+        assertThatThrownBy(() -> executeCallbackAndProcessWithSyncWorker(this::callFinish))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testRethrowOnClose() throws Exception {
-        unwrappingError(
-                IllegalArgumentException.class,
-                () ->
-                        runWithSyncWorker(
-                                writer -> {
-                                    try {
-                                        callFinish(writer);
-                                    } catch (IllegalArgumentException e) {
-                                        // ignore here - should rethrow in close
-                                    }
-                                }));
+    @Test
+    void testRethrowOnClose() {
+        assertThatThrownBy(
+                        () ->
+                                executeCallbackAndProcessWithSyncWorker(
+                                        writer -> {
+                                            try {
+                                                callFinish(writer);
+                                            } catch (IllegalArgumentException e) {
+                                                // ignore here - should rethrow in
+                                                // close
+                                            }
+                                        }))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @Test(expected = TestException.class)
-    public void testRethrowOnNextCall() throws Exception {
+    @Test
+    void testRethrowOnNextCall() {
         SyncChannelStateWriteRequestExecutor worker = new SyncChannelStateWriteRequestExecutor();
         ChannelStateWriterImpl writer =
                 new ChannelStateWriterImpl(TASK_NAME, new ConcurrentHashMap<>(), worker, 5);
         writer.open();
         worker.setThrown(new TestException());
-        unwrappingError(TestException.class, () -> callStart(writer));
+        assertThatThrownBy(() -> callStart(writer)).hasCauseInstanceOf(TestException.class);
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testLimit() throws IOException {
+    @Test
+    void testLimit() throws IOException {
         int maxCheckpoints = 3;
         try (ChannelStateWriterImpl writer =
                 new ChannelStateWriterImpl(
@@ -237,52 +231,42 @@ public class ChannelStateWriterImplTest {
             for (int i = 0; i < maxCheckpoints; i++) {
                 writer.start(i, CheckpointOptions.forCheckpointWithDefaultLocation());
             }
-            writer.start(maxCheckpoints, CheckpointOptions.forCheckpointWithDefaultLocation());
+            assertThatThrownBy(
+                            () ->
+                                    writer.start(
+                                            maxCheckpoints,
+                                            CheckpointOptions.forCheckpointWithDefaultLocation()))
+                    .isInstanceOf(IllegalStateException.class);
         }
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testStartNotOpened() throws Exception {
-        unwrappingError(
-                IllegalStateException.class,
-                () -> {
-                    try (ChannelStateWriterImpl writer =
-                            new ChannelStateWriterImpl(TASK_NAME, 0, getStreamFactoryFactory())) {
-                        callStart(writer);
-                    }
-                });
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testNoStartAfterClose() throws Exception {
-        unwrappingError(
-                IllegalStateException.class,
-                () -> {
-                    ChannelStateWriterImpl writer = openWriter();
-                    writer.close();
-                    writer.start(42, CheckpointOptions.forCheckpointWithDefaultLocation());
-                });
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testNoAddDataAfterClose() throws Exception {
-        unwrappingError(
-                IllegalStateException.class,
-                () -> {
-                    ChannelStateWriterImpl writer = openWriter();
-                    callStart(writer);
-                    writer.close();
-                    callAddInputData(writer);
-                });
-    }
-
-    private static <T extends Throwable> void unwrappingError(
-            Class<T> clazz, RunnableWithException r) throws Exception {
-        try {
-            r.run();
-        } catch (Exception e) {
-            throw findThrowable(e, clazz).map(te -> (Exception) te).orElse(e);
+    @Test
+    void testStartNotOpened() throws IOException {
+        try (ChannelStateWriterImpl writer =
+                new ChannelStateWriterImpl(TASK_NAME, 0, getStreamFactoryFactory())) {
+            assertThatThrownBy(() -> callStart(writer))
+                    .hasCauseInstanceOf(IllegalStateException.class);
         }
+    }
+
+    @Test
+    void testNoStartAfterClose() throws IOException {
+        ChannelStateWriterImpl writer = openWriter();
+        writer.close();
+        assertThatThrownBy(
+                        () ->
+                                writer.start(
+                                        42, CheckpointOptions.forCheckpointWithDefaultLocation()))
+                .hasCauseInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void testNoAddDataAfterClose() throws IOException {
+        ChannelStateWriterImpl writer = openWriter();
+        callStart(writer);
+        writer.close();
+        assertThatThrownBy(() -> callAddInputData(writer))
+                .hasCauseInstanceOf(IllegalStateException.class);
     }
 
     private NetworkBuffer getBuffer() {
@@ -311,13 +295,16 @@ public class ChannelStateWriterImplTest {
         };
     }
 
-    private void runWithSyncWorker(Consumer<ChannelStateWriter> writerConsumer) throws Exception {
-        runWithSyncWorker(
-                (channelStateWriter, syncChannelStateWriterWorker) ->
-                        writerConsumer.accept(channelStateWriter));
+    private void executeCallbackAndProcessWithSyncWorker(
+            Consumer<ChannelStateWriter> writerConsumer) throws Exception {
+        executeCallbackWithSyncWorker(
+                (channelStateWriter, syncChannelStateWriterWorker) -> {
+                    writerConsumer.accept(channelStateWriter);
+                    syncChannelStateWriterWorker.processAllRequests();
+                });
     }
 
-    private void runWithSyncWorker(
+    private void executeCallbackWithSyncWorker(
             BiConsumerWithException<
                             ChannelStateWriter, SyncChannelStateWriteRequestExecutor, Exception>
                     testFn)
@@ -329,7 +316,6 @@ public class ChannelStateWriterImplTest {
                                 TASK_NAME, new ConcurrentHashMap<>(), worker, 5)) {
             writer.open();
             testFn.accept(writer, worker);
-            worker.processAllRequests();
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/CheckpointInProgressRequestTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/CheckpointInProgressRequestTest.java
@@ -17,23 +17,23 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /** {@link CheckpointInProgressRequest} test. */
-public class CheckpointInProgressRequestTest {
+class CheckpointInProgressRequestTest {
 
     /**
      * Tests that a request can only be cancelled once. This is important for requests to write data
      * to prevent double recycling of their buffers.
      */
     @Test
-    public void testNoCancelTwice() throws Exception {
+    void testNoCancelTwice() throws Exception {
         AtomicInteger counter = new AtomicInteger();
         CyclicBarrier barrier = new CyclicBarrier(10);
         CheckpointInProgressRequest request = cancelCountingRequest(counter, barrier);
@@ -55,7 +55,7 @@ public class CheckpointInProgressRequestTest {
             threads[i].join();
         }
 
-        assertEquals(1, counter.get());
+        assertThat(counter).hasValue(1);
     }
 
     private CheckpointInProgressRequest cancelCountingRequest(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecordingChannelStateWriter.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecordingChannelStateWriter.java
@@ -31,9 +31,9 @@ import static org.apache.flink.util.ExceptionUtils.rethrow;
 /** A simple {@link ChannelStateWriter} used to write unit tests. */
 public class RecordingChannelStateWriter extends MockChannelStateWriter {
     private long lastStartedCheckpointId = -1;
-    private long lastFinishedCheckpointId = -1;
-    private ListMultimap<InputChannelInfo, Buffer> addedInput = LinkedListMultimap.create();
-    private ListMultimap<ResultSubpartitionInfo, Buffer> addedOutput = LinkedListMultimap.create();
+    private final ListMultimap<InputChannelInfo, Buffer> addedInput = LinkedListMultimap.create();
+    private final ListMultimap<ResultSubpartitionInfo, Buffer> addedOutput =
+            LinkedListMultimap.create();
 
     public RecordingChannelStateWriter() {
         super(false);
@@ -41,7 +41,6 @@ public class RecordingChannelStateWriter extends MockChannelStateWriter {
 
     public void reset() {
         lastStartedCheckpointId = -1;
-        lastFinishedCheckpointId = -1;
         addedInput.values().forEach(Buffer::recycleBuffer);
         addedInput.clear();
         addedOutput.values().forEach(Buffer::recycleBuffer);
@@ -78,10 +77,6 @@ public class RecordingChannelStateWriter extends MockChannelStateWriter {
 
     public long getLastStartedCheckpointId() {
         return lastStartedCheckpointId;
-    }
-
-    public long getLastFinishedCheckpointId() {
-        return lastFinishedCheckpointId;
     }
 
     public ListMultimap<InputChannelInfo, Buffer> getAddedInput() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/RecoveredChannelStateHandlerTest.java
@@ -18,17 +18,17 @@
 
 package org.apache.flink.runtime.checkpoint.channel;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base class which contains all tests which should be implemented for every implementation of
  * {@link InputChannelRecoveredStateHandler}.
  */
-public abstract class RecoveredChannelStateHandlerTest {
+abstract class RecoveredChannelStateHandlerTest {
 
     @Test
-    public abstract void testRecycleBufferBeforeRecoverWasCalled() throws Exception;
+    abstract void testRecycleBufferBeforeRecoverWasCalled() throws Exception;
 
     @Test
-    public abstract void testRecycleBufferAfterRecoverWasCalled() throws Exception;
+    abstract void testRecycleBufferAfterRecoverWasCalled() throws Exception;
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/ResultSubpartitionRecoveredStateHandlerTest.java
@@ -26,24 +26,24 @@ import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionBuilder;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.HashSet;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test of different implementation of {@link ResultSubpartitionRecoveredStateHandler}. */
-public class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChannelStateHandlerTest {
+class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChannelStateHandlerTest {
     private static final int preAllocatedSegments = 3;
     private NetworkBufferPool networkBufferPool;
     private ResultPartition partition;
     private ResultSubpartitionRecoveredStateHandler rstHandler;
     private ResultSubpartitionInfo channelInfo;
 
-    @Before
-    public void setUp() throws IOException {
+    @BeforeEach
+    void setUp() throws IOException {
         // given: Segment provider with defined number of allocated segments.
         channelInfo = new ResultSubpartitionInfo(0, 0);
 
@@ -74,7 +74,7 @@ public class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChanne
     }
 
     @Test
-    public void testRecycleBufferBeforeRecoverWasCalled() throws Exception {
+    void testRecycleBufferBeforeRecoverWasCalled() throws Exception {
         // when: Request the buffer.
         RecoveredChannelStateHandler.BufferWithContext<BufferBuilder> bufferWithContext =
                 rstHandler.getBuffer(new ResultSubpartitionInfo(0, 0));
@@ -86,11 +86,12 @@ public class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChanne
         partition.close();
 
         // then: All pre-allocated segments should be successfully recycled.
-        assertEquals(preAllocatedSegments, networkBufferPool.getNumberOfAvailableMemorySegments());
+        assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
+                .isEqualTo(preAllocatedSegments);
     }
 
     @Test
-    public void testRecycleBufferAfterRecoverWasCalled() throws Exception {
+    void testRecycleBufferAfterRecoverWasCalled() throws Exception {
         // when: Request the buffer.
         RecoveredChannelStateHandler.BufferWithContext<BufferBuilder> bufferWithContext =
                 rstHandler.getBuffer(channelInfo);
@@ -102,6 +103,7 @@ public class ResultSubpartitionRecoveredStateHandlerTest extends RecoveredChanne
         partition.close();
 
         // then: All pre-allocated segments should be successfully recycled.
-        assertEquals(preAllocatedSegments, networkBufferPool.getNumberOfAvailableMemorySegments());
+        assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
+                .isEqualTo(preAllocatedSegments);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/channel/SequentialChannelStateReaderImplTest.java
@@ -40,18 +40,22 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.state.InputChannelStateHandle;
 import org.apache.flink.runtime.state.ResultSubpartitionStateHandle;
 import org.apache.flink.runtime.state.memory.ByteStreamStateHandle;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameter;
+import org.apache.flink.testutils.junit.extensions.parameterized.ParameterizedTestExtension;
+import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -65,49 +69,49 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.IntStream.range;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** {@link SequentialChannelStateReaderImpl} Test. */
-@RunWith(Parameterized.class)
+@ExtendWith(ParameterizedTestExtension.class)
 public class SequentialChannelStateReaderImplTest {
 
-    @Parameterized.Parameters(
+    @Parameters(
             name =
                     "{0}: stateParLevel={1}, statePartsPerChannel={2}, stateBytesPerPart={3},  parLevel={4}, bufferSize={5}")
-    public static Object[][] parameters() {
-        return new Object[][] {
-            {"NoStateAndNoChannels", 0, 0, 0, 0, 0},
-            {"NoState", 0, 10, 10, 10, 10},
-            {"ReadPermutedStateWithEqualBuffer", 10, 10, 10, 10, 10},
-            {"ReadPermutedStateWithReducedBuffer", 10, 10, 10, 20, 10},
-            {"ReadPermutedStateWithIncreasedBuffer", 10, 10, 10, 10, 20},
-        };
+    public static List<Object[]> parameters() {
+        return Arrays.asList(
+                new Object[] {"NoStateAndNoChannels", 0, 0, 0, 0, 0},
+                new Object[] {"NoState", 0, 10, 10, 10, 10},
+                new Object[] {"ReadPermutedStateWithEqualBuffer", 10, 10, 10, 10, 10},
+                new Object[] {"ReadPermutedStateWithReducedBuffer", 10, 10, 10, 20, 10},
+                new Object[] {"ReadPermutedStateWithIncreasedBuffer", 10, 10, 10, 10, 20});
     }
 
-    private final ChannelStateSerializer serializer;
-    private final Random random;
-    private final int parLevel;
-    private final int statePartsPerChannel;
-    private final int stateBytesPerPart;
-    private final int bufferSize;
-    private final int stateParLevel;
-    private final int buffersPerChannel;
+    @Parameter public String desc;
 
-    public SequentialChannelStateReaderImplTest(
-            String desc,
-            int stateParLevel,
-            int statePartsPerChannel,
-            int stateBytesPerPart,
-            int parLevel,
-            int bufferSize) {
+    @Parameter(value = 1)
+    public int stateParLevel;
+
+    @Parameter(value = 2)
+    public int statePartsPerChannel;
+
+    @Parameter(value = 3)
+    public int stateBytesPerPart;
+
+    @Parameter(value = 4)
+    public int parLevel;
+
+    @Parameter(value = 5)
+    public int bufferSize;
+
+    private ChannelStateSerializer serializer;
+    private Random random;
+    private int buffersPerChannel;
+
+    @BeforeEach
+    void before() {
         serializer = new ChannelStateSerializerImpl();
         random = new Random();
-        this.parLevel = parLevel;
-        this.statePartsPerChannel = statePartsPerChannel;
-        this.stateBytesPerPart = stateBytesPerPart;
-        this.bufferSize = bufferSize;
-        this.stateParLevel = stateParLevel;
         // will read without waiting for consumption
         buffersPerChannel =
                 Math.max(
@@ -118,8 +122,8 @@ public class SequentialChannelStateReaderImplTest {
                                         : stateBytesPerPart / bufferSize));
     }
 
-    @Test
-    public void testReadPermutedState() throws Exception {
+    @TestTemplate
+    void testReadPermutedState() throws Exception {
         Map<InputChannelInfo, List<byte[]>> inputChannelsData =
                 generateState(InputChannelInfo::new);
         Map<ResultSubpartitionInfo, List<byte[]>> resultPartitionsData =
@@ -184,7 +188,7 @@ public class SequentialChannelStateReaderImplTest {
     private void assertConsumed(InputGate[] gates)
             throws InterruptedException, java.util.concurrent.ExecutionException {
         for (InputGate gate : gates) {
-            assertTrue(gate.getStateConsumedFuture().isDone());
+            assertThat(gate.getStateConsumedFuture()).isDone();
             gate.getStateConsumedFuture().get();
         }
     }
@@ -218,8 +222,8 @@ public class SequentialChannelStateReaderImplTest {
                 }
                 action.accept(gates);
             }
-            assertEquals(
-                    segmentsToAllocate, networkBufferPool.getNumberOfAvailableMemorySegments());
+            assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
+                    .isEqualTo(segmentsToAllocate);
         }
     }
 
@@ -247,8 +251,8 @@ public class SequentialChannelStateReaderImplTest {
                 resultPartition.close();
             }
             try {
-                assertEquals(
-                        segmentsToAllocate, networkBufferPool.getNumberOfAvailableMemorySegments());
+                assertThat(networkBufferPool.getNumberOfAvailableMemorySegments())
+                        .isEqualTo(segmentsToAllocate);
             } finally {
                 networkBufferPool.destroyAllBufferPools();
                 networkBufferPool.destroy();
@@ -363,9 +367,8 @@ public class SequentialChannelStateReaderImplTest {
     private <T> void assertBuffersEquals(
             Map<T, List<byte[]>> expected, Map<T, List<Buffer>> actual) {
         try {
-            assertEquals(
-                    mapValues(expected, this::concat),
-                    mapValues(actual, buffers -> concat(toBytes(buffers))));
+            assertThat(mapValues(actual, buffers -> concat(toBytes(buffers))))
+                    .isEqualTo(mapValues(expected, this::concat));
         } finally {
             actual.values().stream().flatMap(List::stream).forEach(Buffer::recycleBuffer);
         }


### PR DESCRIPTION
## What is the purpose of the change

Migrate unaligned checkpoint related tests under flink-runtime module to junit5

## Brief change log

Migrate unaligned checkpoint related tests under flink-runtime module to junit5

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
