### PR TITLE
[hotfix][docs] Fix alias of Kinesis Data Streams/Firehose and add mis…

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/firehose.md
+++ b/docs/content.zh/docs/connectors/datastream/firehose.md
@@ -2,6 +2,7 @@
 title: Firehose
 weight: 5
 type: docs
+  - /zh/dev/connectors/firehose.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content.zh/docs/connectors/table/firehose.md
+++ b/docs/content.zh/docs/connectors/table/firehose.md
@@ -3,7 +3,7 @@ title: Firehose
 weight: 5
 type: docs
 aliases:
-- /dev/table/connectors/firehose.html
+  - /zh/dev/table/connectors/firehose.html
 ---
 
 <!--
@@ -178,6 +178,14 @@ Connector Options
    <td style="word-wrap: break-word;">(none)</td>
    <td>String</td>
    <td>The external ID to use when credential provider type is set to ASSUME_ROLE.</td>
+    </tr>
+    <tr>
+	  <td><h5>aws.credentials.role.stsEndpoint</h5></td>
+	  <td>optional</td>
+      <td>no</td>
+	  <td style="word-wrap: break-word;">(none)</td>
+	  <td>String</td>
+	  <td>The AWS endpoint for STS (derived from the AWS region setting if not set) to use when credential provider type is set to ASSUME_ROLE.</td>
     </tr>
     <tr>
    <td><h5>aws.credentials.role.provider</h5></td>

--- a/docs/content/docs/connectors/datastream/firehose.md
+++ b/docs/content/docs/connectors/datastream/firehose.md
@@ -2,6 +2,8 @@
 title: Firehose
 weight: 5
 type: docs
+aliases:
+  - /dev/connectors/firehose.html
 ---
 <!--
 Licensed to the Apache Software Foundation (ASF) under one

--- a/docs/content/docs/connectors/table/firehose.md
+++ b/docs/content/docs/connectors/table/firehose.md
@@ -3,7 +3,7 @@ title: Firehose
 weight: 5
 type: docs
 aliases:
-- /dev/table/connectors/firehose.html
+  - /dev/table/connectors/firehose.html
 ---
 
 <!--
@@ -178,6 +178,14 @@ Connector Options
    <td style="word-wrap: break-word;">(none)</td>
    <td>String</td>
    <td>The external ID to use when credential provider type is set to ASSUME_ROLE.</td>
+    </tr>
+    <tr>
+	  <td><h5>aws.credentials.role.stsEndpoint</h5></td>
+	  <td>optional</td>
+      <td>no</td>
+	  <td style="word-wrap: break-word;">(none)</td>
+	  <td>String</td>
+	  <td>The AWS endpoint for STS (derived from the AWS region setting if not set) to use when credential provider type is set to ASSUME_ROLE.</td>
     </tr>
     <tr>
    <td><h5>aws.credentials.role.provider</h5></td>


### PR DESCRIPTION
…sing stsEndpoint option for Firehose

## What is the purpose of the change

Docs hotfix

## Brief change log

- Fixed aliases for Kinesis Data Streams/Firehose
- Added missing `stsEndpoint` option for Kinesis Data Firehose added in [FLINK-29496](https://issues.apache.org/jira/browse/FLINK-29496)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
