### PR TITLE
[hotfix][docs] Add missing columns for Kinesis Data Streams Table API…

### DIFF
--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -124,11 +124,12 @@ Connector Options
 <table class="table table-bordered">
     <thead>
     <tr>
-      <th class="text-left" style="width: 25%">Option</th>
-      <th class="text-center" style="width: 8%">Required</th>
-      <th class="text-center" style="width: 7%">Default</th>
-      <th class="text-center" style="width: 10%">Type</th>
-      <th class="text-center" style="width: 50%">Description</th>
+        <th class="text-left" style="width: 25%">Option</th>
+        <th class="text-center" style="width: 8%">Required</th>
+        <th class="text-center" style="width: 8%">Forwarded</th>
+        <th class="text-center" style="width: 7%">Default</th>
+        <th class="text-center" style="width: 10%">Type</th>
+        <th class="text-center" style="width: 42%">Description</th>
     </tr>
     <tr>
       <th colspan="5" class="text-left" style="width: 100%">Common Options</th>
@@ -138,6 +139,7 @@ Connector Options
     <tr>
       <td><h5>connector</h5></td>
       <td>required</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>Specify what connector to use. For Kinesis use <code>'kinesis'</code>.</td>
@@ -145,6 +147,7 @@ Connector Options
     <tr>
       <td><h5>stream</h5></td>
       <td>required</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>Name of the Kinesis data stream backing this table.</td>
@@ -152,6 +155,7 @@ Connector Options
     <tr>
       <td><h5>format</h5></td>
       <td>required</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>The format used to deserialize and serialize Kinesis data stream records. See <a href="#data-type-mapping">Data Type Mapping</a> for details.</td>
@@ -159,6 +163,7 @@ Connector Options
     <tr>
       <td><h5>aws.region</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>The AWS region where the stream is defined. Either this or <code>aws.endpoint</code> are required.</td>
@@ -166,6 +171,7 @@ Connector Options
     <tr>
       <td><h5>aws.endpoint</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>The AWS endpoint for Kinesis (derived from the AWS region setting if not set). Either this or <code>aws.region</code> are required.</td>
@@ -173,6 +179,7 @@ Connector Options
     <tr>
       <td><h5>aws.trust.all.certificates</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
       <td>If true accepts all SSL certificates.</td>
@@ -187,6 +194,7 @@ Connector Options
     <tr>
       <td><h5>aws.credentials.provider</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">AUTO</td>
       <td>String</td>
       <td>A credentials provider to use when authenticating against the Kinesis endpoint. See <a href="#authentication">Authentication</a> for details.</td>
@@ -194,6 +202,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.basic.accesskeyid</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The AWS access key ID to use when setting credentials provider type to BASIC.</td>
@@ -201,6 +210,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.basic.secretkey</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The AWS secret key to use when setting credentials provider type to BASIC.</td>
@@ -208,6 +218,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.profile.path</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>Optional configuration for profile path if credential provider type is set to be PROFILE.</td>
@@ -215,6 +226,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.profile.name</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>Optional configuration for profile name if credential provider type is set to be PROFILE.</td>
@@ -222,6 +234,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.role.arn</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The role ARN to use when credential provider type is set to ASSUME_ROLE or WEB_IDENTITY_TOKEN.</td>
@@ -229,6 +242,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.role.sessionName</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The role session name to use when credential provider type is set to ASSUME_ROLE or WEB_IDENTITY_TOKEN.</td>
@@ -236,6 +250,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.role.externalId</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The external ID to use when credential provider type is set to ASSUME_ROLE.</td>
@@ -251,6 +266,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.role.provider</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The credentials provider that provides credentials for assuming the role when credential provider type is set to ASSUME_ROLE. Roles can be nested, so this value can again be set to ASSUME_ROLE</td>
@@ -258,6 +274,7 @@ Connector Options
     <tr>
 	  <td><h5>aws.credentials.webIdentityToken.file</h5></td>
 	  <td>optional</td>
+      <td>no</td>
 	  <td style="word-wrap: break-word;">(none)</td>
 	  <td>String</td>
 	  <td>The absolute path to the web identity token file that should be used if provider type is set to WEB_IDENTITY_TOKEN.</td>
@@ -272,6 +289,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.initpos</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">LATEST</td>
       <td>String</td>
       <td>Initial position to be used when reading from the table. See <a href="#start-reading-position">Start Reading Position</a> for details.</td>
@@ -279,6 +297,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.initpos-timestamp</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>The initial timestamp to start reading Kinesis stream from (when <code>scan.stream.initpos</code> is AT_TIMESTAMP). See <a href="#start-reading-position">Start Reading Position</a> for details.</td>
@@ -286,6 +305,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.initpos-timestamp-format</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">yyyy-MM-dd'T'HH:mm:ss.SSSXXX</td>
       <td>String</td>
       <td>The date format of initial timestamp to start reading Kinesis stream from (when <code>scan.stream.initpos</code> is AT_TIMESTAMP). See <a href="#start-reading-position">Start Reading Position</a> for details.</td>
@@ -293,6 +313,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.recordpublisher</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">POLLING</td>
       <td>String</td>
       <td>The <code>RecordPublisher</code> type to use for sources. See <a href="#enhanced-fan-out">Enhanced Fan-Out</a> for details.</td>
@@ -300,6 +321,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.efo.consumername</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>The name of the EFO consumer to register with KDS. See <a href="#enhanced-fan-out">Enhanced Fan-Out</a> for details.</td>
@@ -307,6 +329,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.efo.registration</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">LAZY</td>
       <td>String</td>
       <td>Determine how and when consumer de-/registration is performed (LAZY|EAGER|NONE). See <a href="#enhanced-fan-out">Enhanced Fan-Out</a> for details.</td>
@@ -314,6 +337,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.efo.consumerarn</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td>String</td>
       <td>The prefix of consumer ARN for a given stream. See <a href="#enhanced-fan-out">Enhanced Fan-Out</a> for details.</td>
@@ -321,6 +345,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.efo.http-client.max-concurrency</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10000</td>
       <td>Integer</td>
       <td>Maximum number of allowed concurrent requests for the EFO client. See <a href="#enhanced-fan-out">Enhanced Fan-Out</a> for details.</td>
@@ -328,6 +353,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describe.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">50</td>
       <td>Integer</td>
       <td>The maximum number of <code>describeStream</code> attempts if we get a recoverable exception.</td>
@@ -335,6 +361,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describe.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">2000</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between each <code>describeStream</code> attempt (for consuming from DynamoDB streams).</td>
@@ -342,6 +369,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describe.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">5000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds)  between each <code>describeStream</code> attempt (for consuming from DynamoDB streams).</td>
@@ -349,6 +377,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describe.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>describeStream</code> attempt (for consuming from DynamoDB streams).</td>
@@ -356,6 +385,7 @@ Connector Options
     <tr>
       <td><h5>scan.list.shards.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10</td>
       <td>Integer</td>
       <td>The maximum number of <code>listShards</code> attempts if we get a recoverable exception.</td>
@@ -363,6 +393,7 @@ Connector Options
     <tr>
       <td><h5>scan.list.shards.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1000</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between each <code>listShards</code> attempt.</td>
@@ -370,6 +401,7 @@ Connector Options
     <tr>
       <td><h5>scan.list.shards.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">5000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds) between each <code>listShards</code> attempt.</td>
@@ -377,6 +409,7 @@ Connector Options
     <tr>
       <td><h5>scan.list.shards.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>listShards</code> attempt.</td>
@@ -384,6 +417,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describestreamconsumer.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">50</td>
       <td>Integer</td>
       <td>The maximum number of <code>describeStreamConsumer</code> attempts if we get a recoverable exception.</td>
@@ -391,6 +425,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describestreamconsumer.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">2000</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between each <code>describeStreamConsumer</code> attempt.</td>
@@ -398,6 +433,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describestreamconsumer.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">5000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds) between each <code>describeStreamConsumer</code> attempt.</td>
@@ -405,6 +441,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.describestreamconsumer.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>describeStreamConsumer</code> attempt.</td>
@@ -412,6 +449,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.registerstreamconsumer.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10</td>
       <td>Integer</td>
       <td>The maximum number of <code>registerStream</code> attempts if we get a recoverable exception.</td>
@@ -419,6 +457,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.registerstreamconsumer.timeout</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">60</td>
       <td>Integer</td>
       <td>The maximum time in seconds to wait for a stream consumer to become active before giving up.</td>
@@ -426,6 +465,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.registerstreamconsumer.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">500</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between each <code>registerStream</code> attempt.</td>
@@ -433,6 +473,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.registerstreamconsumer.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">2000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds) between each <code>registerStream</code> attempt.</td>
@@ -440,6 +481,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.registerstreamconsumer.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>registerStream</code> attempt.</td>
@@ -447,6 +489,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.deregisterstreamconsumer.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10</td>
       <td>Integer</td>
       <td>The maximum number of <code>deregisterStream</code> attempts if we get a recoverable exception.</td>
@@ -454,6 +497,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.deregisterstreamconsumer.timeout</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">60</td>
       <td>Integer</td>
       <td>The maximum time in seconds to wait for a stream consumer to deregister before giving up.</td>
@@ -461,6 +505,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.deregisterstreamconsumer.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">500</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between each <code>deregisterStream</code> attempt.</td>
@@ -468,6 +513,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.deregisterstreamconsumer.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">2000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds) between each <code>deregisterStream</code> attempt.</td>
@@ -475,6 +521,7 @@ Connector Options
     <tr>
       <td><h5>scan.stream.deregisterstreamconsumer.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>deregisterStream</code> attempt.</td>
@@ -482,6 +529,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.subscribetoshard.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10</td>
       <td>Integer</td>
       <td>The maximum number of <code>subscribeToShard</code> attempts if we get a recoverable exception.</td>
@@ -489,6 +537,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.subscribetoshard.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1000</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between each <code>subscribeToShard</code> attempt.</td>
@@ -496,6 +545,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.subscribetoshard.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">2000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds) between each <code>subscribeToShard</code> attempt.</td>
@@ -503,6 +553,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.subscribetoshard.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>subscribeToShard</code> attempt.</td>
@@ -510,6 +561,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getrecords.maxrecordcount</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10000</td>
       <td>Integer</td>
       <td>The maximum number of records to try to get each time we fetch records from a AWS Kinesis shard.</td>
@@ -517,6 +569,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getrecords.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">3</td>
       <td>Integer</td>
       <td>The maximum number of <code>getRecords</code> attempts if we get a recoverable exception.</td>
@@ -524,6 +577,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getrecords.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">300</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between <code>getRecords</code> attempts if we get a ProvisionedThroughputExceededException.</td>
@@ -531,6 +585,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getrecords.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds) between <code>getRecords</code> attempts if we get a ProvisionedThroughputExceededException.</td>
@@ -538,6 +593,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getrecords.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>getRecords</code> attempt.</td>
@@ -545,6 +601,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getrecords.intervalmillis</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">200</td>
       <td>Long</td>
       <td>The interval (in milliseconds) between each <code>getRecords</code> request to a AWS Kinesis shard in milliseconds.</td>
@@ -552,6 +609,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getiterator.maxretries</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">3</td>
       <td>Integer</td>
       <td>The maximum number of <code>getShardIterator</code> attempts if we get ProvisionedThroughputExceededException.</td>
@@ -559,6 +617,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getiterator.backoff.base</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">300</td>
       <td>Long</td>
       <td>The base backoff time (in milliseconds) between <code>getShardIterator</code> attempts if we get a ProvisionedThroughputExceededException.</td>
@@ -566,6 +625,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getiterator.backoff.max</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1000</td>
       <td>Long</td>
       <td>The maximum backoff time (in milliseconds) between <code>getShardIterator</code> attempts if we get a ProvisionedThroughputExceededException.</td>
@@ -573,6 +633,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.getiterator.backoff.expconst</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">1.5</td>
       <td>Double</td>
       <td>The power constant for exponential backoff between each <code>getShardIterator</code> attempt.</td>
@@ -580,6 +641,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.discovery.intervalmillis</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10000</td>
       <td>Integer</td>
       <td>The interval between each attempt to discover new shards.</td>
@@ -587,6 +649,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.adaptivereads</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
       <td>The config to turn on adaptive reads from a shard. See the <code>AdaptivePollingRecordPublisher</code> documentation for details.</td>
@@ -594,6 +657,7 @@ Connector Options
     <tr>
       <td><h5>scan.shard.idle.interval</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">-1</td>
       <td>Long</td>
       <td>The interval (in milliseconds) after which to consider a shard idle for purposes of watermark generation. A positive value will allow the watermark to progress even when some shards don't receive new records.</td>
@@ -601,6 +665,7 @@ Connector Options
     <tr>
       <td><h5>scan.watermark.sync.interval</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">30000</td>
       <td>Long</td>
       <td>The interval (in milliseconds) for periodically synchronizing the shared watermark state.</td>
@@ -608,6 +673,7 @@ Connector Options
     <tr>
       <td><h5>scan.watermark.lookahead.millis</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">0</td>
       <td>Long</td>
       <td>The maximum delta (in milliseconds) allowed for the reader to advance ahead of the shared global watermark.</td>
@@ -615,6 +681,7 @@ Connector Options
     <tr>
       <td><h5>scan.watermark.sync.queue.capacity</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">100</td>
       <td>Integer</td>
       <td>The maximum number of records that will be buffered before suspending consumption of a shard.</td>
@@ -629,6 +696,7 @@ Connector Options
     <tr>
       <td><h5>sink.partitioner</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">random or row-based</td>
       <td>String</td>
       <td>Optional output partitioning from Flink's partitions into Kinesis shards. See <a href="#sink-partitioning">Sink Partitioning</a> for details.</td>
@@ -636,6 +704,7 @@ Connector Options
     <tr>
       <td><h5>sink.partitioner-field-delimiter</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">|</td>
       <td>String</td>
       <td>Optional field delimiter for a fields-based partitioner derived from a PARTITION BY clause. See <a href="#sink-partitioning">Sink Partitioning</a> for details.</td>
@@ -643,6 +712,7 @@ Connector Options
     <tr>
       <td><h5>sink.producer.*</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">(none)</td>
       <td></td>
       <td>
@@ -654,6 +724,7 @@ Connector Options
     <tr>
       <td><h5>sink.http-client.max-concurrency</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10000</td>
       <td>Integer</td>
       <td>
@@ -663,6 +734,7 @@ Connector Options
     <tr>
       <td><h5>sink.http-client.read-timeout</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">360000</td>
       <td>Integer</td>
       <td>
@@ -672,6 +744,7 @@ Connector Options
     <tr>
       <td><h5>sink.http-client.protocol.version</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">HTTP2</td>
       <td>String</td>
       <td>Http version used by Kinesis Client.</td>
@@ -679,6 +752,7 @@ Connector Options
     <tr>
       <td><h5>sink.batch.max-size</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">500</td>
       <td>Integer</td>
       <td>Maximum batch size of elements to be passed to <code>KinesisAsyncClient</code> to be written downstream.</td>
@@ -686,6 +760,7 @@ Connector Options
     <tr>
       <td><h5>sink.requests.max-inflight</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">16</td>
       <td>Integer</td>
       <td>Request threshold for uncompleted requests by <code>KinesisAsyncClient</code>before blocking new write requests and applying backpressure.</td>
@@ -693,6 +768,7 @@ Connector Options
     <tr>
       <td><h5>sink.requests.max-buffered</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">10000</td>
       <td>String</td>
       <td>Request buffer threshold for buffered requests by <code>KinesisAsyncClient</code> before blocking new write requests and applying backpressure.</td>
@@ -700,6 +776,7 @@ Connector Options
     <tr>
       <td><h5>sink.flush-buffer.size</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">5242880</td>
       <td>Long</td>
       <td>Threshold value in bytes for writer buffer in <code>KinesisAsyncClient</code> before flushing.</td>
@@ -707,6 +784,7 @@ Connector Options
     <tr>
       <td><h5>sink.flush-buffer.timeout</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">5000</td>
       <td>Long</td>
       <td>Threshold time in milliseconds for an element to be in a buffer of<code>KinesisAsyncClient</code> before flushing.</td>
@@ -798,7 +876,7 @@ You can enable and configure EFO with the following properties:
     to invoke [RegisterStreamConsumer](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RegisterStreamConsumer.html).
     Stream consumer ARNs should be provided to the job via the consumer configuration.
 * `scan.stream.efo.consumerarn.<stream-name>`: ARNs identifying externally registered ARN-consumers (substitute `<stream-name>` with the name of your stream in the parameter name).
-  Use this if you choose to use `NONE` as a `scan.stream.efo.registration` strategy.
+   Use this if you choose to use `NONE` as a `scan.stream.efo.registration` strategy.
 
 <span class="label label-info">Note</span> For a given Kinesis data stream, each EFO consumer must have a unique name.
 However, consumer names do not have to be unique across data streams.
@@ -819,12 +897,12 @@ Please refer to the [Formats]({{< ref "docs/connectors/table/formats/overview" >
 
 # Updates in 1.15
 
-Kinesis table API connector sink data stream depends on <code>FlinkKinesisProducer</code> till 1.14, with the introduction of <code>KinesisStreamsSink</code> in 1.15 kinesis table API sink connector has been migrated to the new <code>KinesisStreamsSink</code>. Authentication options have been migrated identically while sink configuration options are now compatible with <code>KinesisStreamsSink</code>.
+Kinesis table API connector sink data stream depends on <code>FlinkKinesisProducer</code> till 1.14, with the introduction of <code>KinesisStreamsSink</code> in 1.15 kinesis table API sink connector has been migrated to the new <code>KinesisStreamsSink</code>. Authentication options have been migrated identically while sink configuration options are now compatible with <code>KinesisStreamsSink</code>. 
 
-Options configuring <code>FlinkKinesisProducer</code> are now deprecated with fallback support for common configuration options with <code>KinesisStreamsSink</code>.
+Options configuring <code>FlinkKinesisProducer</code> are now deprecated with fallback support for common configuration options with <code>KinesisStreamsSink</code>. 
 
-<code>KinesisStreamsSink</code> uses <code>KinesisAsyncClient</code> to send records to kinesis,
-which doesn't support aggregation. In consequence, table options configuring aggregation in the deprecated <code>FlinkKinesisProducer</code>
+<code>KinesisStreamsSink</code> uses <code>KinesisAsyncClient</code> to send records to kinesis, 
+which doesn't support aggregation. In consequence, table options configuring aggregation in the deprecated <code>FlinkKinesisProducer</code> 
 are now deprecated and will be ignored, this includes <code>sink.producer.aggregation-enabled</code> and
 <code>sink.producer.aggregation-count</code>.
 

--- a/docs/content.zh/docs/connectors/table/kinesis.md
+++ b/docs/content.zh/docs/connectors/table/kinesis.md
@@ -132,7 +132,7 @@ Connector Options
         <th class="text-center" style="width: 42%">Description</th>
     </tr>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Common Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Common Options</th>
     </tr>
     </thead>
     <tbody>
@@ -187,7 +187,7 @@ Connector Options
     </tbody>
     <thead>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Authentication Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Authentication Options</th>
     </tr>
     </thead>
     <tbody>
@@ -282,7 +282,7 @@ Connector Options
     </tbody>
     <thead>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Source Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Source Options</th>
     </tr>
     </thead>
     <tbody>
@@ -689,7 +689,7 @@ Connector Options
     </tbody>
     <thead>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Sink Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Sink Options</th>
     </tr>
     </thead>
     <tbody>
@@ -788,6 +788,14 @@ Connector Options
       <td style="word-wrap: break-word;">5000</td>
       <td>Long</td>
       <td>Threshold time in milliseconds for an element to be in a buffer of<code>KinesisAsyncClient</code> before flushing.</td>
+    </tr>
+    <tr>
+      <td><h5>sink.fail-on-error</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Flag used for retrying failed requests. If set any request failure will not be retried and will fail the job.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -133,7 +133,7 @@ Connector Options
         <th class="text-center" style="width: 42%">Description</th>
     </tr>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Common Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Common Options</th>
     </tr>
     </thead>
     <tbody>
@@ -188,7 +188,7 @@ Connector Options
     </tbody>
     <thead>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Authentication Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Authentication Options</th>
     </tr>
     </thead>
     <tbody>
@@ -283,7 +283,7 @@ Connector Options
     </tbody>
     <thead>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Source Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Source Options</th>
     </tr>
     </thead>
     <tbody>
@@ -690,7 +690,7 @@ Connector Options
     </tbody>
     <thead>
     <tr>
-      <th colspan="5" class="text-left" style="width: 100%">Sink Options</th>
+      <th colspan="6" class="text-left" style="width: 100%">Sink Options</th>
     </tr>
     </thead>
     <tbody>
@@ -789,6 +789,14 @@ Connector Options
       <td style="word-wrap: break-word;">5000</td>
       <td>Long</td>
       <td>Threshold time in milliseconds for an element to be in a buffer of<code>KinesisAsyncClient</code> before flushing.</td>
+    </tr>
+    <tr>
+      <td><h5>sink.fail-on-error</h5></td>
+      <td>optional</td>
+      <td>yes</td>
+      <td style="word-wrap: break-word;">false</td>
+      <td>Boolean</td>
+      <td>Flag used for retrying failed requests. If set any request failure will not be retried and will fail the job.</td>
     </tr>
     </tbody>
 </table>

--- a/docs/content/docs/connectors/table/kinesis.md
+++ b/docs/content/docs/connectors/table/kinesis.md
@@ -180,6 +180,7 @@ Connector Options
     <tr>
       <td><h5>aws.trust.all.certificates</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">false</td>
       <td>Boolean</td>
       <td>If true accepts all SSL certificates.</td>
@@ -724,6 +725,7 @@ Connector Options
     <tr>
       <td><h5>sink.http-client.max-concurrency</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">10000</td>
       <td>Integer</td>
       <td>
@@ -733,6 +735,7 @@ Connector Options
     <tr>
       <td><h5>sink.http-client.read-timeout</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">360000</td>
       <td>Integer</td>
       <td>
@@ -742,6 +745,7 @@ Connector Options
     <tr>
       <td><h5>sink.http-client.protocol.version</h5></td>
       <td>optional</td>
+      <td>no</td>
       <td style="word-wrap: break-word;">HTTP2</td>
       <td>String</td>
       <td>Http version used by Kinesis Client.</td>
@@ -749,6 +753,7 @@ Connector Options
     <tr>
       <td><h5>sink.batch.max-size</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">500</td>
       <td>Integer</td>
       <td>Maximum batch size of elements to be passed to <code>KinesisAsyncClient</code> to be written downstream.</td>
@@ -756,6 +761,7 @@ Connector Options
     <tr>
       <td><h5>sink.requests.max-inflight</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">16</td>
       <td>Integer</td>
       <td>Request threshold for uncompleted requests by <code>KinesisAsyncClient</code>before blocking new write requests and applying backpressure.</td>
@@ -763,6 +769,7 @@ Connector Options
     <tr>
       <td><h5>sink.requests.max-buffered</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">10000</td>
       <td>String</td>
       <td>Request buffer threshold for buffered requests by <code>KinesisAsyncClient</code> before blocking new write requests and applying backpressure.</td>
@@ -770,6 +777,7 @@ Connector Options
     <tr>
       <td><h5>sink.flush-buffer.size</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">5242880</td>
       <td>Long</td>
       <td>Threshold value in bytes for writer buffer in <code>KinesisAsyncClient</code> before flushing.</td>
@@ -777,6 +785,7 @@ Connector Options
     <tr>
       <td><h5>sink.flush-buffer.timeout</h5></td>
       <td>optional</td>
+      <td>yes</td>
       <td style="word-wrap: break-word;">5000</td>
       <td>Long</td>
       <td>Threshold time in milliseconds for an element to be in a buffer of<code>KinesisAsyncClient</code> before flushing.</td>


### PR DESCRIPTION
… configurations and synced chinese docs with non-chinese docs

## What is the purpose of the change
Hotfix for Kinesis Data Streams Table API docs

## Brief change log
- Added missing "forwarded" columns for a couple of configs
- Synced non-chinese docs with chinese docs
- Added missing config for `sink.fail-on-error` in Table API docs


## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
