### PR TITLE
[FLINK-30167][build] Upgrade japicmp to 0.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2105,7 +2105,7 @@ under the License.
 				<plugin>
 					<groupId>io.github.zentol.japicmp</groupId>
 					<artifactId>japicmp-maven-plugin</artifactId>
-					<version>0.16.0_m325</version>
+					<version>0.17.1.1_m325</version>
 					<configuration>
 						<oldVersion>
 							<dependency>


### PR DESCRIPTION
Upgrade to a newer version, containing some fixes that should unblock #20757.

Note: The version in the pom is 0.17.1.1 because I messed up the release. It is equivalent to the original 0.17.1.