### PR TITLE
[FLINK-30175][Build] Bump snakeyaml from 1.31 to 1.33

### DIFF
--- a/flink-kubernetes/src/main/resources/META-INF/NOTICE
+++ b/flink-kubernetes/src/main/resources/META-INF/NOTICE
@@ -36,7 +36,7 @@ This project bundles the following dependencies under the Apache Software Licens
 - io.fabric8:kubernetes-model-scheduling:5.12.3
 - io.fabric8:kubernetes-model-storageclass:5.12.3
 - io.fabric8:zjsonpatch:0.3.0
-- org.yaml:snakeyaml:1.31
+- org.yaml:snakeyaml:1.33
 
 This project bundles the following dependencies under the BSD License.
 See bundled license files for details.

--- a/pom.xml
+++ b/pom.xml
@@ -879,7 +879,7 @@ under the License.
 				<!-- Bumped for security purposes and making it work with Jackson dependencies (2.10.1) -->
 				<groupId>org.yaml</groupId>
 				<artifactId>snakeyaml</artifactId>
-				<version>1.31</version>
+				<version>1.33</version>
 			</dependency>
 			<dependency>
 				<groupId>io.netty</groupId>
@@ -1707,12 +1707,12 @@ under the License.
 							<rules>
 								<bannedDependencies>
 									<excludes>
-										<exclude>org.yaml:snakeyaml:(,1.30]</exclude>
+										<exclude>org.yaml:snakeyaml:(,1.31]</exclude>
 									</excludes>
 									<includes>
 										<!-- Snakeyaml is pulled in by many modules without using it in production,
 											so there's no benefit in us investing time into bumping these. -->
-										<include>org.yaml:snakeyaml:(,1.30]:*:test</include>
+										<include>org.yaml:snakeyaml:(,1.31]:*:test</include>
 									</includes>
 									<message>Older snakeyaml versions are not allowed due to security vulnerabilities.</message>
 								</bannedDependencies>


### PR DESCRIPTION
## What is the purpose of the change

* Bump snakeyaml

## Brief change log

* Updated POM

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
