### PR TITLE
[FLINK-30177][Connectors/JDBC] Update pgjdbc to avoid CVE-2022-41946

### DIFF
--- a/flink-connectors/flink-connector-jdbc/pom.xml
+++ b/flink-connectors/flink-connector-jdbc/pom.xml
@@ -35,7 +35,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<postgres.version>42.5.0</postgres.version>
+		<postgres.version>42.5.1</postgres.version>
 		<oracle.version>19.3.0.0</oracle.version>
 	</properties>
 


### PR DESCRIPTION
## What is the purpose of the change

The PR upgrades postgres jdbc version to 42.5.1 to cope with CVE-2022-41946 as it is also mentioned in release notes https://jdbc.postgresql.org/changelogs/2022-11-23-42.5.1-release/

## Brief change log

*flink-connectors/flink-connector-jdbc/pom.xml*

## Verifying this change
 trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
