### PR TITLE
[FLINK-30179][runtime] Stop stringifying exception for logging

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1074,19 +1074,22 @@ public class Task
                         currentState,
                         newState);
             } else if (ExceptionUtils.findThrowable(cause, CancelTaskException.class).isPresent()) {
-                LOG.info(
-                        "{} ({}) switched from {} to {} due to CancelTaskException.",
-                        taskNameWithSubtask,
-                        executionId,
-                        currentState,
-                        newState);
-                LOG.debug(
-                        "{} ({}) switched from {} to {} due to CancelTaskException:",
-                        taskNameWithSubtask,
-                        executionId,
-                        currentState,
-                        newState,
-                        cause);
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug(
+                            "{} ({}) switched from {} to {} due to CancelTaskException:",
+                            taskNameWithSubtask,
+                            executionId,
+                            currentState,
+                            newState,
+                            cause);
+                } else {
+                    LOG.info(
+                            "{} ({}) switched from {} to {} due to CancelTaskException.",
+                            taskNameWithSubtask,
+                            executionId,
+                            currentState,
+                            newState);
+                }
             } else {
                 // proper failure of the task. record the exception as the root
                 // cause

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/Task.java
@@ -1081,23 +1081,23 @@ public class Task
                         currentState,
                         newState);
                 LOG.debug(
-                        "{} ({}) switched from {} to {} due to CancelTaskException: {}",
+                        "{} ({}) switched from {} to {} due to CancelTaskException:",
                         taskNameWithSubtask,
                         executionId,
                         currentState,
                         newState,
-                        ExceptionUtils.stringifyException(cause));
+                        cause);
             } else {
                 // proper failure of the task. record the exception as the root
                 // cause
                 failureCause = cause;
                 LOG.warn(
-                        "{} ({}) switched from {} to {} with failure cause: {}",
+                        "{} ({}) switched from {} to {} with failure cause:",
                         taskNameWithSubtask,
                         executionId,
                         currentState,
                         newState,
-                        ExceptionUtils.stringifyException(cause));
+                        cause);
             }
 
             return true;


### PR DESCRIPTION
## What is the purpose of the change

Stop stringifying exception for logging

## Brief change log

In org.apache.flink.runtime.taskmanager.Task there are multiple places where we stringify an exception before logging. According to Slf4j logging, we can just leave the last argument as exception (or throwable) without fitting them into log message string with placeholders.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

I wrote following code and the two print the same exception:
```java
Exception e =  new CompletionException("a", new FlinkException("b", new Exception("c")));
Task.LOG.error("luck number {}", 2022, e); // 1
e.printStackTrace(); // 2
```

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not** documented)
