### PR TITLE
[FLINK-30183][metrics] Adds more descriptive error in case no default constructor is present.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/ReporterSetup.java
@@ -379,6 +379,7 @@ public final class ReporterSetup {
         if (reporterClassName != null) {
             LOG.warn(
                     "The reporter configuration of '{}' configures the reporter class, which is a deprecated approach to configure reporters."
+                            + " The used reporter might not support this configuration, which would cause errors while loading the reporter."
                             + " Please configure a factory class instead: '{}{}.{}: <factoryClass>' to ensure that the configuration"
                             + " continues to work with future versions.",
                     reporterName,


### PR DESCRIPTION
## What is the purpose of the change

There's already a log message stating that reflection-based reporter instantiation is deprecated. Instead, the user should use switch to the factory-based instantiation method. Some reporters might still work. In other cases (where the default constructor is not implemented), the reflection-based approach would fail with a `NoSuchMethodException` which might be confusing for the user. This PR add a more descriptive error in that case.

## Brief change log

* Wraps `NoSuchMethodException` in a `IllegalConfigurationException`.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
