### PR TITLE
[FLINK-30188][coordination] Set partition finished state in ConsumedPartitionGroup for dynamic graph correctly.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
@@ -218,7 +218,7 @@ public class EdgeManagerBuildUtil {
             ConsumedPartitionGroup consumedPartitionGroup) {
         for (IntermediateResultPartitionID consumedPartitionId : consumedPartitionIds) {
             // this is for dynamic graph as consumedPartitionGroup has not been created when the
-            // partition is finish.
+            // partition becomes finished.
             if (intermediateResult.getPartitionById(consumedPartitionId).hasDataAllProduced()) {
                 consumedPartitionGroup.partitionFinished();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -190,6 +191,10 @@ public class EdgeManagerBuildUtil {
         ConsumedPartitionGroup consumedPartitionGroup =
                 ConsumedPartitionGroup.fromSinglePartition(
                         numConsumers, consumedPartitionId, intermediateResult.getResultType());
+        finishAllDataProducedPartitions(
+                intermediateResult,
+                Collections.singletonList(consumedPartitionId),
+                consumedPartitionGroup);
         registerConsumedPartitionGroupToEdgeManager(consumedPartitionGroup, intermediateResult);
         return consumedPartitionGroup;
     }
@@ -201,8 +206,23 @@ public class EdgeManagerBuildUtil {
         ConsumedPartitionGroup consumedPartitionGroup =
                 ConsumedPartitionGroup.fromMultiplePartitions(
                         numConsumers, consumedPartitions, intermediateResult.getResultType());
+        finishAllDataProducedPartitions(
+                intermediateResult, consumedPartitions, consumedPartitionGroup);
         registerConsumedPartitionGroupToEdgeManager(consumedPartitionGroup, intermediateResult);
         return consumedPartitionGroup;
+    }
+
+    private static void finishAllDataProducedPartitions(
+            IntermediateResult intermediateResult,
+            List<IntermediateResultPartitionID> consumedPartitionIds,
+            ConsumedPartitionGroup consumedPartitionGroup) {
+        for (IntermediateResultPartitionID consumedPartitionId : consumedPartitionIds) {
+            // this is for dynamic graph as consumedPartitionGroup has not been created when the
+            // partition is finish.
+            if (intermediateResult.getPartitionById(consumedPartitionId).hasDataAllProduced()) {
+                consumedPartitionGroup.partitionFinished();
+            }
+        }
     }
 
     private static void registerConsumedPartitionGroupToEdgeManager(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopology.java
@@ -301,8 +301,9 @@ public class DefaultExecutionTopology implements SchedulingTopology {
                                                 irp.getIntermediateResult().getId(),
                                                 irp.getResultType(),
                                                 () ->
-                                                        irp.isConsumable()
-                                                                ? ResultPartitionState.CONSUMABLE
+                                                        irp.hasDataAllProduced()
+                                                                ? ResultPartitionState
+                                                                        .ALL_DATA_PRODUCED
                                                                 : ResultPartitionState.CREATED,
                                                 () ->
                                                         partitionConsumerVertexGroupsRetriever

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDecider.java
@@ -80,7 +80,7 @@ class DefaultInputConsumableDecider implements InputConsumableDecider {
         } else {
             for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
                 if (resultPartitionRetriever.apply(partitionId).getState()
-                        != ResultPartitionState.CONSUMABLE) {
+                        != ResultPartitionState.ALL_DATA_PRODUCED) {
                     return false;
                 }
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/PipelinedRegionSchedulingStrategy.java
@@ -325,7 +325,7 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
         } else {
             for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
                 if (schedulingTopology.getResultPartition(partitionId).getState()
-                        != ResultPartitionState.CONSUMABLE) {
+                        != ResultPartitionState.ALL_DATA_PRODUCED) {
                     return false;
                 }
             }
@@ -351,7 +351,7 @@ public class PipelinedRegionSchedulingStrategy implements SchedulingStrategy {
             for (IntermediateResultPartitionID partitionId : consumedPartitionGroup) {
                 if (isExternalConsumedPartition(partitionId, pipelinedRegion)
                         && schedulingTopology.getResultPartition(partitionId).getState()
-                                != ResultPartitionState.CONSUMABLE) {
+                                != ResultPartitionState.ALL_DATA_PRODUCED) {
                     return false;
                 }
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ResultPartitionState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ResultPartitionState.java
@@ -24,10 +24,6 @@ public enum ResultPartitionState {
     /** Partition is just created or is just reset. */
     CREATED,
 
-    /**
-     * Partition is ready for consuming. For pipelined partition, this indicates it has data
-     * produced. For blocking partition, this indicates all result partitions in its parent result
-     * have finished.
-     */
-    CONSUMABLE
+    /** Partition has produced all data. */
+    ALL_DATA_PRODUCED
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -373,7 +373,7 @@ class DefaultExecutionGraphConstructionTest {
         assertThat(consumedPartitionGroup1.getNumberOfUnfinishedPartitions()).isZero();
         partition3.markFinished();
         partition4.markFinished();
-        assertThat(consumedPartitionGroup1.getNumberOfUnfinishedPartitions()).isZero();
+        assertThat(consumedPartitionGroup2.getNumberOfUnfinishedPartitions()).isZero();
     }
 
     @Test

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -338,6 +338,159 @@ class DefaultExecutionGraphConstructionTest {
     }
 
     @Test
+    void testPointWiseConsumedPartitionGroupPartitionFinished() throws Exception {
+        JobVertex v1 = new JobVertex("source");
+        JobVertex v2 = new JobVertex("sink");
+
+        v1.setParallelism(4);
+        v2.setParallelism(2);
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
+
+        List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
+        ExecutionGraph eg = createDefaultExecutionGraph(ordered);
+        eg.attachJobGraph(ordered);
+
+        IntermediateResult result =
+                Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
+
+        IntermediateResultPartition partition1 = result.getPartitions()[0];
+        IntermediateResultPartition partition2 = result.getPartitions()[1];
+        IntermediateResultPartition partition3 = result.getPartitions()[2];
+        IntermediateResultPartition partition4 = result.getPartitions()[3];
+
+        ConsumedPartitionGroup consumedPartitionGroup1 =
+                partition1.getConsumedPartitionGroups().get(0);
+
+        ConsumedPartitionGroup consumedPartitionGroup2 =
+                partition4.getConsumedPartitionGroups().get(0);
+
+        assertThat(consumedPartitionGroup1.getNumberOfUnfinishedPartitions()).isEqualTo(2);
+        assertThat(consumedPartitionGroup2.getNumberOfUnfinishedPartitions()).isEqualTo(2);
+        partition1.markFinished();
+        partition2.markFinished();
+        assertThat(consumedPartitionGroup1.getNumberOfUnfinishedPartitions()).isZero();
+        partition3.markFinished();
+        partition4.markFinished();
+        assertThat(consumedPartitionGroup1.getNumberOfUnfinishedPartitions()).isZero();
+    }
+
+    @Test
+    void testAllToAllConsumedPartitionGroupPartitionFinished() throws Exception {
+        JobVertex v1 = new JobVertex("source");
+        JobVertex v2 = new JobVertex("sink");
+
+        v1.setParallelism(2);
+        v2.setParallelism(2);
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
+        ExecutionGraph eg = createDefaultExecutionGraph(ordered);
+        eg.attachJobGraph(ordered);
+
+        IntermediateResult result =
+                Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
+
+        IntermediateResultPartition partition1 = result.getPartitions()[0];
+        IntermediateResultPartition partition2 = result.getPartitions()[1];
+
+        ConsumedPartitionGroup consumedPartitionGroup =
+                partition1.getConsumedPartitionGroups().get(0);
+
+        assertThat(consumedPartitionGroup.getNumberOfUnfinishedPartitions()).isEqualTo(2);
+        partition1.markFinished();
+        assertThat(consumedPartitionGroup.getNumberOfUnfinishedPartitions()).isEqualTo(1);
+        partition2.markFinished();
+        assertThat(consumedPartitionGroup.getNumberOfUnfinishedPartitions()).isZero();
+    }
+
+    @Test
+    void testDynamicGraphAllToAllConsumedPartitionGroupPartitionFinished() throws Exception {
+        JobVertex v1 = new JobVertex("source");
+        JobVertex v2 = new JobVertex("sink");
+
+        v1.setParallelism(2);
+        v2.setParallelism(2);
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.ALL_TO_ALL, ResultPartitionType.BLOCKING);
+
+        List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
+        ExecutionGraph eg = createDynamicExecutionGraph(ordered);
+        eg.attachJobGraph(ordered);
+
+        ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
+        eg.initializeJobVertex(ejv1, 0L);
+
+        IntermediateResult result =
+                Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
+
+        IntermediateResultPartition partition1 = result.getPartitions()[0];
+        IntermediateResultPartition partition2 = result.getPartitions()[1];
+
+        partition1.markFinished();
+        partition2.markFinished();
+
+        assertThat(partition1.getConsumedPartitionGroups()).isEmpty();
+
+        ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
+        eg.initializeJobVertex(ejv2, 0L);
+
+        ConsumedPartitionGroup consumedPartitionGroup =
+                partition1.getConsumedPartitionGroups().get(0);
+
+        assertThat(consumedPartitionGroup.getNumberOfUnfinishedPartitions()).isZero();
+    }
+
+    @Test
+    void testDynamicGraphPointWiseConsumedPartitionGroupPartitionFinished() throws Exception {
+        JobVertex v1 = new JobVertex("source");
+        JobVertex v2 = new JobVertex("sink");
+
+        v1.setParallelism(4);
+        v2.setParallelism(2);
+
+        v2.connectNewDataSetAsInput(
+                v1, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
+
+        List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
+        ExecutionGraph eg = createDynamicExecutionGraph(ordered);
+        eg.attachJobGraph(ordered);
+
+        ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
+        eg.initializeJobVertex(ejv1, 0L);
+
+        IntermediateResult result =
+                Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
+
+        IntermediateResultPartition partition1 = result.getPartitions()[0];
+        IntermediateResultPartition partition2 = result.getPartitions()[1];
+        IntermediateResultPartition partition3 = result.getPartitions()[2];
+        IntermediateResultPartition partition4 = result.getPartitions()[3];
+
+        partition1.markFinished();
+        partition2.markFinished();
+        partition3.markFinished();
+        partition4.markFinished();
+
+        assertThat(partition1.getConsumedPartitionGroups()).isEmpty();
+        assertThat(partition4.getConsumedPartitionGroups()).isEmpty();
+
+        ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
+        eg.initializeJobVertex(ejv2, 0L);
+
+        ConsumedPartitionGroup consumedPartitionGroup1 =
+                partition1.getConsumedPartitionGroups().get(0);
+        assertThat(consumedPartitionGroup1.getNumberOfUnfinishedPartitions()).isZero();
+        ConsumedPartitionGroup consumedPartitionGroup2 =
+                partition4.getConsumedPartitionGroups().get(0);
+        assertThat(consumedPartitionGroup2.getNumberOfUnfinishedPartitions()).isZero();
+    }
+
+    @Test
     void testAttachToDynamicGraph() throws Exception {
         JobVertex v1 = new JobVertex("source");
         JobVertex v2 = new JobVertex("sink");

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/DefaultInputConsumableDeciderTest.java
@@ -71,7 +71,7 @@ class DefaultInputConsumableDeciderTest {
                 topology.addExecutionVertices().withParallelism(2).finish();
 
         topology.connectAllToAll(producers, consumer)
-                .withResultPartitionState(ResultPartitionState.CONSUMABLE)
+                .withResultPartitionState(ResultPartitionState.ALL_DATA_PRODUCED)
                 .withResultPartitionType(ResultPartitionType.BLOCKING)
                 .finish();
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -98,7 +98,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
                         consumedPartition.getResultType());
 
         consumedPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
-        if (consumedPartition.getState() == ResultPartitionState.CONSUMABLE) {
+        if (consumedPartition.getState() == ResultPartitionState.ALL_DATA_PRODUCED) {
             consumedPartitionGroup.partitionFinished();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -120,7 +120,7 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
     void registerConsumedPartitionGroup(ConsumedPartitionGroup consumedPartitionGroup) {
         consumedPartitionGroups.add(consumedPartitionGroup);
 
-        if (getState() == ResultPartitionState.CONSUMABLE) {
+        if (getState() == ResultPartitionState.ALL_DATA_PRODUCED) {
             consumedPartitionGroup.partitionFinished();
         }
     }
@@ -133,7 +133,7 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
         for (ConsumedPartitionGroup consumedPartitionGroup : consumedPartitionGroups) {
             consumedPartitionGroup.partitionFinished();
         }
-        setState(ResultPartitionState.CONSUMABLE);
+        setState(ResultPartitionState.ALL_DATA_PRODUCED);
     }
 
     void setState(ResultPartitionState state) {
@@ -145,7 +145,7 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
         private IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
         private int partitionNum = 0;
         private ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
-        private ResultPartitionState resultPartitionState = ResultPartitionState.CONSUMABLE;
+        private ResultPartitionState resultPartitionState = ResultPartitionState.ALL_DATA_PRODUCED;
 
         Builder withIntermediateDataSetID(IntermediateDataSetID intermediateDataSetId) {
             this.intermediateDataSetId = intermediateDataSetId;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -232,7 +232,8 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 
         protected ResultPartitionType resultPartitionType = ResultPartitionType.BLOCKING;
 
-        protected ResultPartitionState resultPartitionState = ResultPartitionState.CONSUMABLE;
+        protected ResultPartitionState resultPartitionState =
+                ResultPartitionState.ALL_DATA_PRODUCED;
 
         protected ProducerConsumerConnectionBuilder(
                 final List<TestingSchedulingExecutionVertex> producers,
@@ -370,7 +371,7 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 
             for (TestingSchedulingResultPartition resultPartition : resultPartitions) {
                 resultPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
-                if (resultPartition.getState() == ResultPartitionState.CONSUMABLE) {
+                if (resultPartition.getState() == ResultPartitionState.ALL_DATA_PRODUCED) {
                     consumedPartitionGroup.partitionFinished();
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

*For dynamic graph, the downstream task's parallelism is determined only after the upstream task is finished, and then the connection relationship between the downstream and upstream `ExecutionVertex` will be established (including `ConsumedPartitionGroup`). Therefore, the upstream task did not correctly notify `ConsumedPartitionGroup` to update the partition finished status after it is finished.*


## Brief change log

  - *Set partition finished state when create and register `ConsumedPartitionGroup` to `EdgeManager`.*

## Verifying this change

This change added uint tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
