### PR TITLE
[FLINK-29899][runtime][test] Removes obsolete printStackTrace()

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
@@ -148,7 +148,6 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
 
                 fail("The execution graph future should have been completed exceptionally.");
             } catch (ExecutionException ee) {
-                ee.printStackTrace();
                 assertTrue(ee.getCause() instanceof FlinkException);
             }
 


### PR DESCRIPTION
## What is the purpose of the change

The stacktrace printout must have been accidentally added with PR #14804. It ends up in the regular CI Maven log output for the tests and confuses developers who analyze the logs.

## Brief change log

Removes printout.

## Verifying this change

This change is a trivial rework.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
