### PR TITLE
[BP-1.16][FLINK-29899][runtime][test] Removes obsolete printStackTrace()

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/DefaultExecutionGraphCacheTest.java
@@ -148,7 +148,6 @@ public class DefaultExecutionGraphCacheTest extends TestLogger {
 
                 fail("The execution graph future should have been completed exceptionally.");
             } catch (ExecutionException ee) {
-                ee.printStackTrace();
                 assertTrue(ee.getCause() instanceof FlinkException);
             }
 


### PR DESCRIPTION
1.16 backport PR for parent PR #21395