### PR TITLE
[hotfix][docs] Update Zookeper version infromation

### DIFF
--- a/docs/content/docs/deployment/ha/zookeeper_ha.md
+++ b/docs/content/docs/deployment/ha/zookeeper_ha.md
@@ -120,10 +120,9 @@ For more information take a look at [Curator's error handling](https://curator.a
 
 ## ZooKeeper Versions
 
-Flink ships with separate ZooKeeper clients for 3.4 and 3.5, with 3.4 being in the `lib` directory of the distribution
-and thus used by default, whereas 3.5 is placed in the `opt` directory.
+Flink ships with separate ZooKeeper clients for 3.5 and 3.6, with 3.5 being in the `lib` directory of the distribution
+and thus used by default, whereas 3.6 is placed in the `opt` directory.
 
-The 3.5 client allows you to secure the ZooKeeper connection via SSL, but _may_ not work with 3.4- ZooKeeper installations.
 
 You can control which version is used by Flink by placing either jar in the `lib` directory.
 


### PR DESCRIPTION
Updating the doc as Flink 1.15.2 ships with Zookeeper 3.5.9 in `lib` and 3.6.3 in `opt` folder in reality.
And removing a sentence making notes about Zookeeper 3.4 not being compatible with 3.5 because 3.4 is not included in Flink 1.15.2.