### PR TITLE
[FLINK-30224][Connectors/Kinesis] An IT test for slow FlinKinesisConsumer's run() which caused an NPE in close

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisITCase.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisITCase.java
@@ -18,6 +18,7 @@
 package org.apache.flink.streaming.connectors.kinesis;
 
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.serialization.SimpleStringSchema;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.connectors.kinesis.testutils.KinesaliteContainer;
@@ -29,7 +30,10 @@ import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.InitialPosition;
+import org.apache.flink.streaming.connectors.kinesis.internals.KinesisDataFetcher;
 import org.apache.flink.streaming.connectors.kinesis.testutils.KinesisPubsubClient;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
 import org.apache.flink.testutils.junit.SharedObjects;
@@ -52,9 +56,12 @@ import java.io.ObjectInputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
@@ -63,6 +70,8 @@ import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfi
 import static org.apache.flink.streaming.connectors.kinesis.config.ConsumerConfigConstants.STREAM_INITIAL_POSITION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertTrue;
 
 /** IT cases for using Kinesis consumer/producer based on Kinesalite. */
 public class FlinkKinesisITCase extends TestLogger {
@@ -175,6 +184,40 @@ public class FlinkKinesisITCase extends TestLogger {
         }
     }
 
+    /**
+     * Tests stop with savepoint while {@link
+     * FlinkKinesisConsumer#run(SourceFunction.SourceContext)}} with a slow run method is still
+     * hasn't finished run method and hasn't set a {@link KinesisDataFetcher} yet.
+     */
+    @Test
+    public void testStopWithSavepointWithSlowConsumer() throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+        env.enableCheckpointing(100L);
+
+        SharedReference<CyclicBarrier> savepointTrigger = sharedObjects.add(new CyclicBarrier(2));
+        env.addSource(createSlowKinesisConsumer(savepointTrigger)).addSink(new DiscardingSink<>());
+
+        ForkJoinTask<String> stopTask =
+                ForkJoinPool.commonPool()
+                        .submit(
+                                () -> {
+                                    // Wait until run method is reached in the consumer
+                                    savepointTrigger.get().await();
+                                    String result = stopWithSavepoint(savepointTrigger);
+                                    log.info("StopWithSavepoint result: {}", result);
+                                    return result;
+                                });
+
+        env.execute();
+        String result = stopTask.get(1, TimeUnit.MINUTES);
+
+        assertThat("Savepoint result shouldn't be null", result, notNullValue());
+        assertTrue(
+                "Unexpected savepoint file's name format",
+                result.matches("^file:.*/savepoint-.*$"));
+    }
+
     private FlinkKinesisConsumer<String> createKinesisConsumer(boolean efo) {
         Properties config = getContainerProperties();
         config.setProperty(STREAM_INITIAL_POSITION, InitialPosition.TRIM_HORIZON.name());
@@ -185,21 +228,42 @@ public class FlinkKinesisITCase extends TestLogger {
         return new FlinkKinesisConsumer<>(stream, STRING_SCHEMA, config);
     }
 
+    private FlinkKinesisConsumer<String> createSlowKinesisConsumer(
+            SharedReference<CyclicBarrier> savepointTrigger) {
+        Properties config = getContainerProperties();
+        config.setProperty(STREAM_INITIAL_POSITION, InitialPosition.TRIM_HORIZON.name());
+        return new SlowFlinkKinesisConsumer<>(stream, STRING_SCHEMA, config, savepointTrigger);
+    }
+
     private Properties getContainerProperties() {
         return kinesalite.getContainerProperties();
     }
 
     private String stopWithSavepoint(boolean drain) throws Exception {
+        return callStopWithSavepoint(drain).get();
+    }
+
+    private String stopWithSavepoint(SharedReference<CyclicBarrier> savepointTrigger)
+            throws Exception {
+        CompletableFuture<String> resultFuture = callStopWithSavepoint(false);
+        // Release barrier in consumer after stop was called
+        savepointTrigger.get().await();
+
+        return resultFuture.get();
+    }
+
+    private CompletableFuture<String> callStopWithSavepoint(boolean drain) throws Exception {
         JobStatusMessage job =
                 miniCluster.getClusterClient().listJobs().get().stream().findFirst().get();
+
+        log.info("Calling stopWithSavepoint: {}", job.getJobId());
         return miniCluster
                 .getClusterClient()
                 .stopWithSavepoint(
                         job.getJobId(),
                         drain,
                         temp.getRoot().getAbsolutePath(),
-                        SavepointFormatType.CANONICAL)
-                .get();
+                        SavepointFormatType.CANONICAL);
     }
 
     private static class WaitingMapper
@@ -249,5 +313,35 @@ public class FlinkKinesisITCase extends TestLogger {
 
         @Override
         public void initializeState(FunctionInitializationContext context) {}
+    }
+
+    /**
+     * A simple implementation of {@link FlinkKinesisConsumer} with a slow run() method's execution
+     * which is controlled by incoming {@link CyclicBarrier} from the test.
+     */
+    private static class SlowFlinkKinesisConsumer<T> extends FlinkKinesisConsumer<T> {
+        private final SharedReference<CyclicBarrier> savepointTrigger;
+
+        public SlowFlinkKinesisConsumer(
+                String stream,
+                DeserializationSchema<T> deserializer,
+                Properties configProps,
+                SharedReference<CyclicBarrier> savepointTrigger) {
+            super(stream, deserializer, configProps);
+            this.savepointTrigger = savepointTrigger;
+        }
+
+        @Override
+        public void run(SourceContext<T> sourceContext) throws Exception {
+            // Wait until it's allowed to do a stop-with-savepoint operation
+            // (a job and a task are both in RUNNING state)
+            savepointTrigger.get().await();
+
+            // Start a new waiting cycle and imitate a slow run operation until stop is called
+            savepointTrigger.get().reset();
+            savepointTrigger.get().await();
+
+            super.run(sourceContext);
+        }
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisITCase.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/FlinkKinesisITCase.java
@@ -185,9 +185,9 @@ public class FlinkKinesisITCase extends TestLogger {
     }
 
     /**
-     * Tests stop with savepoint while {@link
-     * FlinkKinesisConsumer#run(SourceFunction.SourceContext)}} with a slow run method is still
-     * hasn't finished run method and hasn't set a {@link KinesisDataFetcher} yet.
+     * This test ensures that a slow initialization of {@link KinesisDataFetcher}
+     * in {@link FlinkKinesisConsumer#run } method doesn't cause an exception during
+     * a job's cancellation event (stop-with-savepoint) close after the job was switched to RUNNING.
      */
     @Test
     public void testStopWithSavepointWithSlowConsumer() throws Exception {


### PR DESCRIPTION
## What is the purpose of the change
[FLINK-30224](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-30224)
- An IT test was added which ensures that the issue with a slow KDS consumer initialization doesn't cause an NPE during cancelation;
- Previously the issue itself was fixed in [FLINK-29324](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-29324).

## Brief change log
Improvement. An IT test was added which checks this fix: [FLINK-29324](https://issues.apache.org/jira/projects/FLINK/issues/FLINK-29324)

## Verifying this change
This change only adds a new test. Azure build succeeded.

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): **No**
- The public API, i.e., is any changed class annotated with @Public(Evolving): **No**
- The serializers: **No**
- The runtime per-record code paths (performance sensitive): **No**
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **No**
- The S3 file system connector: **No**

## Documentation
- Does this pull request introduce a new feature? **No**
- If yes, how is the feature documented? not applicable