### PR TITLE
[FLINK-30228][test] Use thread-safe list

### DIFF
--- a/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/api/connector/source/lib/util/RateLimitedSourceReaderITCase.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -103,7 +104,8 @@ public class RateLimitedSourceReaderITCase extends TestLogger {
 
     private static class MockRateLimiterStrategy implements RateLimiterStrategy {
 
-        private static final List<MockRateLimiter> rateLimiters = new ArrayList<>();
+        private static final List<MockRateLimiter> rateLimiters =
+                Collections.synchronizedList(new ArrayList<>());
 
         @Override
         public RateLimiter createRateLimiter(int parallelism) {


### PR DESCRIPTION
Haven't reproduced it yet locally because my IDE is throwing up due to Scala, but this is the only possible explanation that I could come up with anyway.