### PR TITLE
[FLINK-30189] HsSubpartitionFileReader may load data that has been consumed from memory

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImpl.java
@@ -265,19 +265,24 @@ public class HsSubpartitionFileReaderImpl implements HsSubpartitionFileReader {
 
     private Optional<BufferIndexOrError> checkAndGetFirstBufferIndexOrError(int expectedBufferIndex)
             throws Throwable {
-        if (loadedBuffers.isEmpty()) {
-            return Optional.empty();
-        }
-
         BufferIndexOrError peek = loadedBuffers.peek();
-
-        if (peek.getThrowable().isPresent()) {
-            throw peek.getThrowable().get();
-        } else if (peek.getIndex() != expectedBufferIndex) {
-            return Optional.empty();
+        while (peek != null) {
+            if (peek.getThrowable().isPresent()) {
+                throw peek.getThrowable().get();
+            } else if (peek.getIndex() == expectedBufferIndex) {
+                break;
+            } else if (peek.getIndex() > expectedBufferIndex) {
+                return Optional.empty();
+            } else if (peek.getIndex() < expectedBufferIndex) {
+                // Because the update of consumption progress may be delayed, there is a
+                // very small probability to load the buffer that has been consumed from memory.
+                // Skip these buffers directly to avoid repeated consumption.
+                loadedBuffers.poll();
+                peek = loadedBuffers.peek();
+            }
         }
 
-        return Optional.of(peek);
+        return peek == null ? Optional.empty() : Optional.of(peek);
     }
 
     private void moveFileOffsetToBuffer(int bufferIndex) throws IOException {


### PR DESCRIPTION
## What is the purpose of the change

*In order to solve the problem that data cannot be read from the disk correctly after failover, we changed the calculation logical of the buffer's readable state in [FLINK-29238](https://issues.apache.org/jira/browse/FLINK-29238).  Buffers that are greater than consumingOffset and have been released can be pre-load from file. However, the update of consumingOffset is asynchronous, If it lags behind the actual consumption progress, the buffer will have a chance to be load from the disk again.*


## Brief change log

  - *`HsSubpartitionFileReaderImpl` will skip peek buffer that less than expected.*

## Verifying this change

This change is already covered by existing tests


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
