### PR TITLE
[FLINK-30202][tests] Do not assert on checkpointId

### DIFF
--- a/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
+++ b/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.lib.NumberSequenceSource;
 import org.apache.flink.api.connector.source.mocks.MockSplitEnumeratorContext;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.metrics.groups.SourceReaderMetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.util.SimpleUserCodeClassLoader;
@@ -85,10 +86,10 @@ class DataGeneratorSourceTest {
     @Test
     @DisplayName("Uses the underlying NumberSequenceSource correctly for checkpointing.")
     void testReaderCheckpoints() throws Exception {
-        final long from = 177;
-        final long mid = 333;
-        final long to = 561;
-        final long elementsPerCycle = (to - from) / 3;
+        final long from = 0;
+        final long mid = 156;
+        final long to = 383;
+        final long elementsPerCycle = (to - from + 1) / 3;
 
         final TestingReaderOutput<Long> out = new TestingReaderOutput<>();
 
@@ -117,8 +118,11 @@ class DataGeneratorSourceTest {
             }
         }
 
+        reader.isAvailable().get();
+        assertThat(reader.pollNext(out)).isEqualTo(InputStatus.END_OF_INPUT);
+
         final List<Long> result = out.getEmittedRecords();
-        final Iterable<Long> expected = LongStream.range(from, to)::iterator;
+        final Iterable<Long> expected = LongStream.range(from, to + 1)::iterator;
 
         assertThat(result).containsExactlyElementsOf(expected);
     }

--- a/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
+++ b/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
@@ -109,7 +109,7 @@ class DataGeneratorSourceTest {
             for (int elementInCycle = 0; elementInCycle < elementsPerCycle; elementInCycle++) {
                 assertThat(reader.isAvailable())
                         .as(
-                                "There should be always data available because the test doesn't rely on any no rate-limiting strategy and splits are provided.")
+                                "There should be always data available because the test utilizes no rate-limiting strategy and splits are provided.")
                         .isCompleted();
                 // this never returns END_OF_INPUT because IteratorSourceReaderBase#pollNext does
                 // not immediately return END_OF_INPUT when the input is exhausted
@@ -138,7 +138,7 @@ class DataGeneratorSourceTest {
         // not immediately return END_OF_INPUT when the input is exhausted
         assertThat(reader.isAvailable())
                 .as(
-                        "There should be always data available because the test doesn't rely on any no rate-limiting strategy and splits are provided.")
+                        "There should be always data available because the test utilizes no rate-limiting strategy and splits are provided.")
                 .isCompleted();
         assertThat(reader.pollNext(out)).isSameAs(InputStatus.END_OF_INPUT);
 

--- a/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
+++ b/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
@@ -109,6 +109,10 @@ class DataGeneratorSourceTest {
             }
             // checkpoint
             List<NumberSequenceSource.NumberSequenceSplit> splits = reader.snapshotState(1L);
+            // first cycle partially consumes the first split
+            // second cycle consumes the remaining first split and partially consumes the second
+            // third cycle consumes remaining second split
+            assertThat(splits).hasSize(numCycles - cycle - 1);
 
             // re-create and restore
             reader = createReader();

--- a/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
+++ b/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
@@ -111,6 +111,8 @@ class DataGeneratorSourceTest {
                         .as(
                                 "There should be always data available because the test doesn't rely on any no rate-limiting strategy and splits are provided.")
                         .isCompleted();
+                // this never returns END_OF_INPUT because IteratorSourceReaderBase#pollNext does
+                // not immediately return END_OF_INPUT when the input is exhausted
                 assertThat(reader.pollNext(out))
                         .as(
                                 "Each poll should return a NOTHING_AVAILABLE status to explicitly trigger the availability check through in SourceReader.isAvailable")
@@ -132,6 +134,8 @@ class DataGeneratorSourceTest {
             }
         }
 
+        // we need to go again through isAvailable because IteratorSourceReaderBase#pollNext does
+        // not immediately return END_OF_INPUT when the input is exhausted
         assertThat(reader.isAvailable())
                 .as(
                         "There should be always data available because the test doesn't rely on any no rate-limiting strategy and splits are provided.")

--- a/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
+++ b/flink-connectors/flink-connector-datagen/src/test/java/org/apache/flink/connector/datagen/source/DataGeneratorSourceTest.java
@@ -86,10 +86,11 @@ class DataGeneratorSourceTest {
     @Test
     @DisplayName("Uses the underlying NumberSequenceSource correctly for checkpointing.")
     void testReaderCheckpoints() throws Exception {
+        final int numCycles = 3;
         final long from = 0;
         final long mid = 156;
         final long to = 383;
-        final long elementsPerCycle = (to - from + 1) / 3;
+        final long elementsPerCycle = (to - from + 1) / numCycles;
 
         final TestingReaderOutput<Long> out = new TestingReaderOutput<>();
 
@@ -99,7 +100,7 @@ class DataGeneratorSourceTest {
                         new NumberSequenceSource.NumberSequenceSplit("split-1", from, mid),
                         new NumberSequenceSource.NumberSequenceSplit("split-2", mid + 1, to)));
 
-        for (int cycle = 0; cycle < 3; cycle++) {
+        for (int cycle = 0; cycle < numCycles; cycle++) {
             // this call is not required but mimics what happens at runtime
             reader.pollNext(out);
             for (int elementInCycle = 0; elementInCycle < elementsPerCycle; elementInCycle++) {

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimitedSourceReader.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/util/ratelimit/RateLimitedSourceReader.java
@@ -60,6 +60,10 @@ public class RateLimitedSourceReader<E, SplitT extends SourceSplit>
 
     @Override
     public InputStatus pollNext(ReaderOutput<E> output) throws Exception {
+        if (availabilityFuture == null) {
+            // force isAvailable() to be called first to evaluate rate-limiting
+            return InputStatus.NOTHING_AVAILABLE;
+        }
         // reset future because the next record may hit the rate limit
         availabilityFuture = null;
         final InputStatus inputStatus = sourceReader.pollNext(output);


### PR DESCRIPTION
Capturing the checkpointId for a generated record in a subsequent map function is impossible since the notifyCheckpointComplete notification may arrive at any time (or not at all). Instead just assert that each subtask got exactly as many records as expected, which can only happen (reliably) if the rate-limiting works as expected.
