### PR TITLE
[FLINK-30239][rest] Fix the problem that FlameGraph cannot be generated due to using ImmutableSet incorrectly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
@@ -269,7 +269,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
 
                 ExecutionAttemptID attemptId = execution.getAttemptId();
                 groupedAttemptIds.add(attemptId);
-                executionAttemptsByLocation.put(tmLocation, ImmutableSet.copyOf(groupedAttemptIds));
+                executionAttemptsByLocation.put(tmLocation, groupedAttemptIds);
             }
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
@@ -274,7 +274,9 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
         }
 
         return executionAttemptsByLocation.entrySet().stream()
-                .collect(Collectors.toMap(e -> e.getKey(), e -> ImmutableSet.copyOf(e.getValue())));
+                .collect(
+                        Collectors.toMap(
+                                Map.Entry::getKey, e -> ImmutableSet.copyOf(e.getValue())));
     }
 
     @VisibleForTesting
@@ -353,7 +355,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
                         vertexStatsCache.put(key, createStatsFn.apply(threadInfoStats));
                         resultAvailableFuture.complete(null);
                     } else {
-                        LOG.debug(
+                        LOG.error(
                                 "Failed to gather a thread info sample for {}",
                                 vertex.getName(),
                                 throwable);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerTest.java
@@ -135,7 +135,7 @@ public class JobVertexThreadInfoTrackerTest extends TestLogger {
         Optional<JobVertexThreadInfoStats> result =
                 tracker.getVertexStats(JOB_ID, EXECUTION_JOB_VERTEX);
         // cached result is returned instead of unusedThreadInfoStats
-        assertThat(threadInfoStatsDefaultSample).isEqualTo(result.get());
+        assertThat(result).isPresent().hasValue(threadInfoStatsDefaultSample);
     }
 
     /** Tests that cached result is NOT reused after refresh interval. */


### PR DESCRIPTION
## What is the purpose of the change

Fix the problem that FlameGraph cannot be generated due to using ImmutableSet incorrectly


## Brief change log

- The first commit : Change the log level to error when flame graph generation fails and refactor some codes (It's useful to trouble-shooting int the future)
- The second commit: Remove the ImmutableSet to fix the bug and improve the unit test


## Verifying this change

This change added tests and can be verified as follows:

  - *JobVertexThreadInfoTrackerTest#testGroupExecutionsByLocation*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
