### PR TITLE
[FLINK-30138][runtime][test] Increases timeout to essentially wait forever for an expected Exception to be thrown

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/blob/BlobServerCleanupTest.java
@@ -36,7 +36,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -258,10 +257,13 @@ public class BlobServerCleanupTest extends TestLogger {
         testFailedCleanup(
                 new JobID(),
                 (testInstance, jobId, executor) ->
-                        assertThat(testInstance.globalCleanupAsync(new JobID(), executor))
-                                .failsWithin(Duration.ofMillis(100))
-                                .withThrowableOfType(ExecutionException.class)
-                                .withCauseInstanceOf(IOException.class),
+                        assertThatThrownBy(
+                                        () ->
+                                                testInstance
+                                                        .globalCleanupAsync(new JobID(), executor)
+                                                        .get())
+                                .isInstanceOf(ExecutionException.class)
+                                .hasCauseInstanceOf(IOException.class),
                 blobStore);
     }
 
@@ -279,10 +281,13 @@ public class BlobServerCleanupTest extends TestLogger {
         testFailedCleanup(
                 new JobID(),
                 (testInstance, jobId, executor) ->
-                        assertThat(testInstance.globalCleanupAsync(new JobID(), executor))
-                                .failsWithin(Duration.ofMillis(100))
-                                .withThrowableOfType(ExecutionException.class)
-                                .withCause(actualException),
+                        assertThatThrownBy(
+                                        () ->
+                                                testInstance
+                                                        .globalCleanupAsync(new JobID(), executor)
+                                                        .get())
+                                .isInstanceOf(ExecutionException.class)
+                                .hasCause(actualException),
                 blobStore);
     }
 


### PR DESCRIPTION
## What is the purpose of the change

The tests run the cleanup logic in a separate thread. The assert requires a timeout which was not necessarily long enough for the exception to be caught.

## Brief change log

* Increases the timeout to a day to simulate "waiting forever"

## Verifying this change

This change is a trivial rework.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable