### PR TITLE
[FLINK-30245][table-runtime] Fix the NPE thrown when filtering decimal(18, x) values after calling DecimalDataUtils.subtract method.

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 
+import static org.apache.flink.table.data.DecimalData.MAX_COMPACT_PRECISION;
 import static org.apache.flink.table.data.DecimalData.MAX_INT_DIGITS;
 import static org.apache.flink.table.data.DecimalData.MAX_LONG_DIGITS;
 import static org.apache.flink.table.data.DecimalData.POW10;
@@ -104,7 +105,10 @@ public final class DecimalDataUtils {
     }
 
     public static DecimalData add(DecimalData v1, DecimalData v2, int precision, int scale) {
-        if (v1.isCompact() && v2.isCompact() && v1.scale == v2.scale) {
+        if (v1.isCompact()
+                && v2.isCompact()
+                && v1.scale == v2.scale
+                && precision <= MAX_COMPACT_PRECISION) {
             assert scale == v1.scale; // no need to rescale
             try {
                 long ls = Math.addExact(v1.longVal, v2.longVal); // checks overflow
@@ -118,7 +122,10 @@ public final class DecimalDataUtils {
     }
 
     public static DecimalData subtract(DecimalData v1, DecimalData v2, int precision, int scale) {
-        if (v1.isCompact() && v2.isCompact() && v1.scale == v2.scale) {
+        if (v1.isCompact()
+                && v2.isCompact()
+                && v1.scale == v2.scale
+                && precision <= MAX_COMPACT_PRECISION) {
             assert scale == v1.scale; // no need to rescale
             try {
                 long ls = Math.subtractExact(v1.longVal, v2.longVal); // checks overflow

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/data/DecimalDataUtils.java
@@ -24,7 +24,6 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 
-import static org.apache.flink.table.data.DecimalData.MAX_COMPACT_PRECISION;
 import static org.apache.flink.table.data.DecimalData.MAX_INT_DIGITS;
 import static org.apache.flink.table.data.DecimalData.MAX_LONG_DIGITS;
 import static org.apache.flink.table.data.DecimalData.POW10;
@@ -108,7 +107,7 @@ public final class DecimalDataUtils {
         if (v1.isCompact()
                 && v2.isCompact()
                 && v1.scale == v2.scale
-                && precision <= MAX_COMPACT_PRECISION) {
+                && DecimalData.isCompact(precision)) {
             assert scale == v1.scale; // no need to rescale
             try {
                 long ls = Math.addExact(v1.longVal, v2.longVal); // checks overflow
@@ -125,7 +124,7 @@ public final class DecimalDataUtils {
         if (v1.isCompact()
                 && v2.isCompact()
                 && v1.scale == v2.scale
-                && precision <= MAX_COMPACT_PRECISION) {
+                && DecimalData.isCompact(precision)) {
             assert scale == v1.scale; // no need to rescale
             try {
                 long ls = Math.subtractExact(v1.longVal, v2.longVal); // checks overflow

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/data/DecimalDataTest.java
@@ -167,6 +167,11 @@ public class DecimalDataTest {
         assertThat(DecimalData.fromBigDecimal(new BigDecimal(Long.MAX_VALUE), 5, 0)).isNull();
         assertThat(DecimalData.zero(20, 2).toBigDecimal().intValue()).isEqualTo(0);
         assertThat(DecimalData.zero(20, 2).toBigDecimal().intValue()).isEqualTo(0);
+
+        DecimalData decimal3 = DecimalData.fromBigDecimal(new BigDecimal(10), 18, 0);
+        DecimalData decimal4 = DecimalData.fromBigDecimal(new BigDecimal(15), 18, 0);
+        assertThat(DecimalDataUtils.compare(subtract(decimal3, decimal4, 19, 0), -5)).isEqualTo(0);
+        assertThat(DecimalDataUtils.compare(add(decimal3, decimal4, 19, 0), 25)).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This pull request fixes the NPE thrown when filtering decimal(18, x) values after calling DecimalDataUtils.subtract method.*


## Brief change log

  - *Check the result precision before calculating the compacted decimal values.*


## Verifying this change

This change is already covered by existing tests, such as *org.apache.flink.table.data.DecimalDataTest.testNotCompact()*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (DecimalData subtract/add only)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
