### PR TITLE
[FLINK-30250][web][flame-graph] Fix the bug that show the flame graph of old type

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/components/flame-graph/flame-graph.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/flame-graph/flame-graph.component.ts
@@ -18,7 +18,7 @@
 
 import { Component, ChangeDetectionStrategy, ElementRef, Input, ViewChild } from '@angular/core';
 
-import { JobFlameGraphNode } from '@flink-runtime-web/interfaces';
+import { FlameGraphType, JobFlameGraphNode } from '@flink-runtime-web/interfaces';
 import * as _d3 from 'd3';
 import { flamegraph, offCpuColorMapper } from 'd3-flame-graph';
 import { format } from 'd3-format';
@@ -35,7 +35,7 @@ import _d3Tip from 'd3-tip';
 export class FlameGraphComponent {
   @ViewChild('flameGraphContainer', { static: true }) flameGraphContainer: ElementRef<Element>;
   @Input() data: JobFlameGraphNode;
-  @Input() graphType: string;
+  @Input() graphType: FlameGraphType;
 
   draw(): void {
     if (this.data) {
@@ -55,7 +55,7 @@ export class FlameGraphComponent {
 
       chart.tooltip(tip);
 
-      if (this.graphType == 'off_cpu') {
+      if (this.graphType == FlameGraphType.OFF_CPU) {
         chart.setColorMapper(offCpuColorMapper);
       }
 

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/job-flamegraph.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/job-flamegraph.ts
@@ -27,3 +27,9 @@ export interface JobFlameGraphNode {
   value: number;
   children: JobFlameGraphNode[];
 }
+
+export enum FlameGraphType {
+  ON_CPU = 'on_cpu',
+  OFF_CPU = 'off_cpu',
+  FULL = 'full'
+}

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
@@ -25,7 +25,7 @@ Type:
   <label
     nz-radio-button
     [nzValue]="FlameGraphType.ON_CPU"
-    (click)="selectFrameGraphType()"
+    (click)="selectFrameGraphType(FlameGraphType.ON_CPU)"
     title="Includes Thread.State.[RUNNABLE, NEW]"
   >
     On-CPU
@@ -33,7 +33,7 @@ Type:
   <label
     nz-radio-button
     [nzValue]="FlameGraphType.OFF_CPU"
-    (click)="selectFrameGraphType()"
+    (click)="selectFrameGraphType(FlameGraphType.OFF_CPU)"
     title="Includes Thread.State.[WAITING, TIMED_WAITING, BLOCKED]"
   >
     Off-CPU
@@ -41,7 +41,7 @@ Type:
   <label
     nz-radio-button
     [nzValue]="FlameGraphType.FULL"
-    (click)="selectFrameGraphType()"
+    (click)="selectFrameGraphType(FlameGraphType.FULL)"
     title="Includes stack traces of threads in all states"
   >
     Mixed

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
@@ -24,7 +24,7 @@ Type:
 <nz-radio-group [(ngModel)]="graphType" nzButtonStyle="solid">
   <label
     nz-radio-button
-    nzValue="on_cpu"
+    [nzValue]="FlameGraphType.ON_CPU"
     (click)="selectFrameGraphType()"
     title="Includes Thread.State.[RUNNABLE, NEW]"
   >
@@ -32,7 +32,7 @@ Type:
   </label>
   <label
     nz-radio-button
-    nzValue="off_cpu"
+    [nzValue]="FlameGraphType.OFF_CPU"
     (click)="selectFrameGraphType()"
     title="Includes Thread.State.[WAITING, TIMED_WAITING, BLOCKED]"
   >
@@ -40,7 +40,7 @@ Type:
   </label>
   <label
     nz-radio-button
-    nzValue="full"
+    [nzValue]="FlameGraphType.FULL"
     (click)="selectFrameGraphType()"
     title="Includes stack traces of threads in all states"
   >

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.ts
@@ -67,7 +67,7 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
-    this.requestFlameGraph();
+    this.requestFlameGraph(this.graphType);
   }
 
   public ngOnDestroy(): void {
@@ -75,12 +75,12 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
     this.destroy$.complete();
   }
 
-  private requestFlameGraph(): void {
+  private requestFlameGraph(graphType: FlameGraphType): void {
     this.jobLocalService
       .jobWithVertexChanges()
       .pipe(
         tap(data => (this.selectedVertex = data.vertex)),
-        mergeMap(data => this.jobService.loadOperatorFlameGraph(data.job.jid, data.vertex!.id, this.graphType)),
+        mergeMap(data => this.jobService.loadOperatorFlameGraph(data.job.jid, data.vertex!.id, graphType)),
         takeUntil(this.destroy$)
       )
       .subscribe(
@@ -89,7 +89,7 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
           if (this.flameGraph.endTimestamp !== data['endTimestamp']) {
             this.isLoading = false;
             this.flameGraph = data;
-            this.flameGraph.graphType = this.graphType;
+            this.flameGraph.graphType = graphType;
           }
           this.cdr.markForCheck();
         },
@@ -100,9 +100,9 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
       );
   }
 
-  public selectFrameGraphType(): void {
+  public selectFrameGraphType(graphType: FlameGraphType): void {
     this.destroy$.next();
     this.flameGraph = {} as JobFlameGraph;
-    this.requestFlameGraph();
+    this.requestFlameGraph(graphType);
   }
 }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.ts
@@ -24,7 +24,7 @@ import { mergeMap, takeUntil, tap } from 'rxjs/operators';
 
 import { FlameGraphComponent } from '@flink-runtime-web/components/flame-graph/flame-graph.component';
 import { HumanizeDurationPipe } from '@flink-runtime-web/components/humanize-duration.pipe';
-import { JobFlameGraph, NodesItemCorrect } from '@flink-runtime-web/interfaces';
+import { FlameGraphType, JobFlameGraph, NodesItemCorrect } from '@flink-runtime-web/interfaces';
 import { JobService } from '@flink-runtime-web/services';
 import { NzRadioModule } from 'ng-zorro-antd/radio';
 import { NzSpinModule } from 'ng-zorro-antd/spin';
@@ -50,12 +50,13 @@ import { JobLocalService } from '../../job-local.service';
   standalone: true
 })
 export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
+  readonly FlameGraphType = FlameGraphType;
   public isLoading = true;
   public now = Date.now();
   public selectedVertex: NodesItemCorrect | null;
   public flameGraph = {} as JobFlameGraph;
 
-  public graphType = 'on_cpu';
+  public graphType = FlameGraphType.ON_CPU;
 
   private readonly destroy$ = new Subject<void>();
 


### PR DESCRIPTION
## What is the purpose of the change

When the flame graph type is switched from On-CPU to Mixed. It still show the graph of On-CPU.

Root cause:
When click the other types, the web frontend will call the requestFlameGraph and update the graphType. However, the graphType is the old type during requestFlameGraph. So the graph type show the new type, but the flame graph is the result of old type.

https://github.com/apache/flink/blob/8bbf52688758bbede45df060a4c11e5fa228b6f0/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.ts#L82


## Brief change log

- The first commit: Using the enum to manage the graphType instead of string
- The second commit: Using the new graph type when request the flameGraph.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
