### PR TITLE
[hotfix][table-planner] Fix inconsistent test data for temporal join

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/stream/sql/TemporalJoinITCase.scala
@@ -92,7 +92,7 @@ class TemporalJoinITCase(state: StateBackendMode) extends StreamingWithStateTest
     changelogRow("+U", "Euro", "no1", 118L, "2020-08-16T00:01:00"),
     changelogRow("-U", "US Dollar", "no1", 102L, "2020-08-16T00:02:00"),
     changelogRow("+U", "US Dollar", "no1", 106L, "2020-08-16T00:02:00"),
-    changelogRow("-D", "RMB", "no1", 708L, "2020-08-16T00:02:00")
+    changelogRow("-D", "RMB", "no1", 702L, "2020-08-16T00:02:00")
   )
 
   val rowTimeCurrencyDataUsingBeforeTime = List(


### PR DESCRIPTION
This is a minor fix for test data of temporal join, the delete('-D') message should have the same value with corresponding insert('+I') message:
```
changelogRow("+I", "RMB", "no1", 702L, "2020-08-15T00:00:04")
- changelogRow("-D", "RMB", "no1", 708L, "2020-08-16T00:02:00")
+ changelogRow("-D", "RMB", "no1", 702L, "2020-08-16T00:02:00")
```