### PR TITLE
[FLINK-29420][build] Upgrade Zookeeper to 3.7.1

### DIFF
--- a/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkTestcontainersConfigurator.java
+++ b/flink-test-utils-parent/flink-connector-test-utils/src/main/java/org/apache/flink/connector/testframe/container/FlinkTestcontainersConfigurator.java
@@ -107,7 +107,7 @@ class FlinkTestcontainersConfigurator {
 
     private GenericContainer<?> configureZookeeperContainer() {
         return configureContainer(
-                new GenericContainer<>(DockerImageName.parse("zookeeper").withTag("3.5.9")),
+                new GenericContainer<>(DockerImageName.parse("zookeeper").withTag("3.7.1")),
                 flinkContainersSettings.getZookeeperHostname(),
                 "Zookeeper");
     }

--- a/pom.xml
+++ b/pom.xml
@@ -138,8 +138,8 @@ under the License.
 		<scala.version>2.12.7</scala.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<chill.version>0.7.6</chill.version>
-		<!-- keep FlinkContainersBuilder#buildZookeeperContainer() in sync -->
-		<zookeeper.version>3.5.10</zookeeper.version>
+		<!-- keep FlinkTestcontainersConfigurator.configureZookeeperContainer in sync -->
+		<zookeeper.version>3.7.1</zookeeper.version>
 		<curator.version>5.2.0</curator.version>
 		<avro.version>1.11.1</avro.version>
 		<!-- Version for transitive Jackson dependencies that are not used within Flink itself.-->


### PR DESCRIPTION
Upgrade to the latest stable Zookeeper release. This client is compatible with 3.5 onwards.