### PR TITLE
[BP-1.15][FLINK-27944] Input channel metric will no longer be registered multiple times

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironment.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.io.disk.BatchShuffleReadBufferPool;
 import org.apache.flink.runtime.io.disk.FileChannelManager;
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.NetworkBufferPool;
+import org.apache.flink.runtime.io.network.metrics.InputChannelMetrics;
 import org.apache.flink.runtime.io.network.metrics.NettyShuffleMetricFactory;
 import org.apache.flink.runtime.io.network.partition.PartitionProducerStateProvider;
 import org.apache.flink.runtime.io.network.partition.ResultPartition;
@@ -249,6 +250,9 @@ public class NettyShuffleEnvironment
 
             MetricGroup networkInputGroup = ownerContext.getInputGroup();
 
+            InputChannelMetrics inputChannelMetrics =
+                    new InputChannelMetrics(networkInputGroup, ownerContext.getParentGroup());
+
             SingleInputGate[] inputGates =
                     new SingleInputGate[inputGateDeploymentDescriptors.size()];
             for (int gateIndex = 0; gateIndex < inputGates.length; gateIndex++) {
@@ -256,7 +260,11 @@ public class NettyShuffleEnvironment
                         inputGateDeploymentDescriptors.get(gateIndex);
                 SingleInputGate inputGate =
                         singleInputGateFactory.create(
-                                ownerContext, gateIndex, igdd, partitionProducerStateProvider);
+                                ownerContext,
+                                gateIndex,
+                                igdd,
+                                partitionProducerStateProvider,
+                                inputChannelMetrics);
                 InputGateID id =
                         new InputGateID(
                                 igdd.getConsumedResultId(), ownerContext.getExecutionAttemptID());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -117,7 +117,8 @@ public class SingleInputGateFactory {
             @Nonnull ShuffleIOOwnerContext owner,
             int gateIndex,
             @Nonnull InputGateDeploymentDescriptor igdd,
-            @Nonnull PartitionProducerStateProvider partitionProducerStateProvider) {
+            @Nonnull PartitionProducerStateProvider partitionProducerStateProvider,
+            @Nonnull InputChannelMetrics metrics) {
         SupplierWithException<BufferPool, IOException> bufferPoolFactory =
                 createBufferPoolFactory(networkBufferPool, floatingNetworkBuffersPerGate);
 
@@ -148,8 +149,6 @@ public class SingleInputGateFactory {
                         maybeCreateBufferDebloater(
                                 gateIndex, networkInputGroup.addGroup(gateIndex)));
 
-        InputChannelMetrics metrics =
-                new InputChannelMetrics(networkInputGroup, owner.getParentGroup());
         createInputChannels(owningTaskName, igdd, inputGate, subpartitionIndexRange, metrics);
         return inputGate;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentTest.java
@@ -54,13 +54,10 @@ import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.runtime.throughput.BufferDebloatConfiguration;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.runtime.util.NettyShuffleDescriptorBuilder;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -71,27 +68,26 @@ import java.util.concurrent.Executors;
 
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createDummyConnectionManager;
 import static org.apache.flink.runtime.io.network.partition.PartitionTestUtils.createPartition;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.powermock.api.mockito.PowerMockito.spy;
 
 /** Various tests for the {@link NettyShuffleEnvironment} class. */
-public class NettyShuffleEnvironmentTest extends TestLogger {
+class NettyShuffleEnvironmentTest {
 
     private static final String tempDir = EnvironmentInformation.getTemporaryFileDirectory();
 
     private static FileChannelManager fileChannelManager;
 
-    @Rule public ExpectedException expectedException = ExpectedException.none();
-
-    @BeforeClass
-    public static void setUp() {
+    @BeforeAll
+    static void setUp() {
         fileChannelManager = new FileChannelManagerImpl(new String[] {tempDir}, "testing");
     }
 
-    @AfterClass
-    public static void shutdown() throws Exception {
+    @AfterAll
+    static void shutdown() throws Exception {
         fileChannelManager.close();
     }
 
@@ -101,7 +97,7 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
      * working with the bare minimum of required buffers.
      */
     @Test
-    public void testRegisterTaskWithLimitedBuffers() throws Exception {
+    void testRegisterTaskWithLimitedBuffers() throws Exception {
         // outgoing: 1 buffer per channel + 1 extra buffer per ResultPartition
         // incoming: 2 exclusive buffers per channel + 1 floating buffer per single gate
         final int bufferCount =
@@ -115,7 +111,7 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
      * fails if the bare minimum of required buffers is not available (we are one buffer short).
      */
     @Test
-    public void testRegisterTaskWithInsufficientBuffers() throws Exception {
+    void testRegisterTaskWithInsufficientBuffers() throws Exception {
         // outgoing: 1 buffer per channel + 1 extra buffer per ResultPartition
         // incoming: 2 exclusive buffers per channel + 1 floating buffer per single gate
         final int bufferCount =
@@ -125,13 +121,13 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
                                         .defaultValue()
                         - 1;
 
-        expectedException.expect(IOException.class);
-        expectedException.expectMessage("Insufficient number of network buffers");
-        testRegisterTaskWithLimitedBuffers(bufferCount);
+        assertThatThrownBy(() -> testRegisterTaskWithLimitedBuffers(bufferCount))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Insufficient number of network buffers");
     }
 
     @Test
-    public void testSlowIODoesNotBlockRelease() throws Exception {
+    void testSlowIODoesNotBlockRelease() throws Exception {
         BlockerSync sync = new BlockerSync();
         ResultPartitionManager blockingResultPartitionManager =
                 new ResultPartitionManager() {
@@ -155,7 +151,7 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void testRegisteringDebloatingMetrics() throws IOException {
+    void testRegisteringDebloatingMetrics() throws IOException {
         Map<String, Metric> metrics = new ConcurrentHashMap<>();
         final TaskMetricGroup taskMetricGroup = createTaskMetricGroup(metrics);
         final Configuration config = new Configuration();
@@ -184,22 +180,20 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
                                     new NettyShuffleDescriptorBuilder().buildRemote()
                                 })));
         for (int i = 0; i < 2; i++) {
-            assertEquals(
-                    TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().getBytes(),
-                    (long)
+            assertThat(
                             ((Gauge<Integer>)
                                             getDebloatingMetric(
                                                     metrics, i, MetricNames.DEBLOATED_BUFFER_SIZE))
-                                    .getValue());
-            assertEquals(
-                    0L,
-                    (long)
+                                    .getValue())
+                    .isEqualTo(TaskManagerOptions.MEMORY_SEGMENT_SIZE.defaultValue().getBytes());
+            assertThat(
                             ((Gauge<Long>)
                                             getDebloatingMetric(
                                                     metrics,
                                                     i,
                                                     MetricNames.ESTIMATED_TIME_TO_CONSUME_BUFFERS))
-                                    .getValue());
+                                    .getValue())
+                    .isZero();
         }
     }
 
@@ -270,29 +264,30 @@ public class NettyShuffleEnvironmentTest extends TestLogger {
         Task.setupPartitionsAndGates(resultPartitions, inputGates);
 
         // verify buffer pools for the result partitions
-        assertEquals(Integer.MAX_VALUE, rp1.getBufferPool().getMaxNumberOfMemorySegments());
-        assertEquals(Integer.MAX_VALUE, rp2.getBufferPool().getMaxNumberOfMemorySegments());
-        assertEquals(expectedBuffers, rp3.getBufferPool().getMaxNumberOfMemorySegments());
-        assertEquals(expectedRp4Buffers, rp4.getBufferPool().getMaxNumberOfMemorySegments());
+        assertThat(rp1.getBufferPool().getMaxNumberOfMemorySegments()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(rp2.getBufferPool().getMaxNumberOfMemorySegments()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(rp3.getBufferPool().getMaxNumberOfMemorySegments()).isEqualTo(expectedBuffers);
+        assertThat(rp4.getBufferPool().getMaxNumberOfMemorySegments())
+                .isEqualTo(expectedRp4Buffers);
 
         for (ResultPartition rp : resultPartitions) {
-            assertEquals(
-                    rp.getNumberOfSubpartitions() + 1,
-                    rp.getBufferPool().getNumberOfRequiredMemorySegments());
-            assertEquals(rp.getNumberOfSubpartitions() + 1, rp.getBufferPool().getNumBuffers());
+            assertThat(rp.getBufferPool().getNumberOfRequiredMemorySegments())
+                    .isEqualTo(rp.getNumberOfSubpartitions() + 1);
+            assertThat(rp.getBufferPool().getNumBuffers())
+                    .isEqualTo(rp.getNumberOfSubpartitions() + 1);
         }
 
         // verify buffer pools for the input gates (NOTE: credit-based uses minimum required buffers
         // for exclusive buffers not managed by the buffer pool)
-        assertEquals(1, ig1.getBufferPool().getNumberOfRequiredMemorySegments());
-        assertEquals(1, ig2.getBufferPool().getNumberOfRequiredMemorySegments());
-        assertEquals(1, ig3.getBufferPool().getNumberOfRequiredMemorySegments());
-        assertEquals(1, ig4.getBufferPool().getNumberOfRequiredMemorySegments());
+        assertThat(ig1.getBufferPool().getNumberOfRequiredMemorySegments()).isOne();
+        assertThat(ig2.getBufferPool().getNumberOfRequiredMemorySegments()).isOne();
+        assertThat(ig3.getBufferPool().getNumberOfRequiredMemorySegments()).isOne();
+        assertThat(ig4.getBufferPool().getNumberOfRequiredMemorySegments()).isOne();
 
-        assertEquals(floatingBuffers, ig1.getBufferPool().getMaxNumberOfMemorySegments());
-        assertEquals(floatingBuffers, ig2.getBufferPool().getMaxNumberOfMemorySegments());
-        assertEquals(floatingBuffers, ig3.getBufferPool().getMaxNumberOfMemorySegments());
-        assertEquals(floatingBuffers, ig4.getBufferPool().getMaxNumberOfMemorySegments());
+        assertThat(ig1.getBufferPool().getMaxNumberOfMemorySegments()).isEqualTo(floatingBuffers);
+        assertThat(ig2.getBufferPool().getMaxNumberOfMemorySegments()).isEqualTo(floatingBuffers);
+        assertThat(ig3.getBufferPool().getMaxNumberOfMemorySegments()).isEqualTo(floatingBuffers);
+        assertThat(ig4.getBufferPool().getMaxNumberOfMemorySegments()).isEqualTo(floatingBuffers);
 
         verify(ig1, times(1)).setupChannels();
         verify(ig2, times(1)).setupChannels();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -91,6 +91,7 @@ import static org.apache.flink.runtime.checkpoint.CheckpointType.CHECKPOINT;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createLocalInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createRemoteInputChannel;
 import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.createResultSubpartitionView;
+import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.newUnregisteredInputChannelMetrics;
 import static org.apache.flink.runtime.io.network.partition.InputGateFairnessTest.setupInputGate;
 import static org.apache.flink.runtime.io.network.util.TestBufferFactory.createBuffer;
 import static org.apache.flink.runtime.state.CheckpointStorageLocationReference.getDefault;
@@ -1211,7 +1212,8 @@ public class SingleInputGateTest extends InputGateTestBase {
                                 "TestTask", taskMetricGroup.executionId(), taskMetricGroup),
                         0,
                         gateDesc,
-                        SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER);
+                        SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
+                        newUnregisteredInputChannelMetrics());
     }
 
     private static Map<InputGateID, SingleInputGate> createInputGateWithLocalChannels(

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/StreamNetworkBenchmarkEnvironment.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
+import static org.apache.flink.runtime.io.network.partition.InputChannelTestUtils.newUnregisteredInputChannelMetrics;
 import static org.apache.flink.util.ExceptionUtils.suppressExceptions;
 
 /**
@@ -274,7 +275,8 @@ public class StreamNetworkBenchmarkEnvironment<T extends IOReadableWritable> {
                                 taskMetricGroup),
                         gateIndex,
                         gateDescriptor,
-                        SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER);
+                        SingleInputGateBuilder.NO_OP_PRODUCER_CHECKER,
+                        newUnregisteredInputChannelMetrics());
 
         return new InputGateWithMetrics(singleGate, new SimpleCounter());
     }


### PR DESCRIPTION
## What is the purpose of the change

*If a task has multiple input gates, It will create as many `InputChannelMetrics` as the number of gates, so the corresponding metrics are registered repeatedly. This pull request aimed to fix this problem.*


## Brief change log

  - *Create `InputChannelMetrics` in `NettyShuffleEnvironment#createInputGates`.*


## Verifying this change

This change added unit test in `NettyShuffleEnvironmentTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
