### PR TITLE
[FLINK-30278][streaming] Unset parallelism in the SinkTransformationTranslator if it wasn't set before

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -344,6 +344,11 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
         return this;
     }
 
+    @Internal
+    public void resetParallelism() {
+        configuration.removeConfig(CoreOptions.DEFAULT_PARALLELISM);
+    }
+
     /**
      * Gets the maximum degree of parallelism defined for the program.
      *


### PR DESCRIPTION
PoC of the fix

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
