### PR TITLE
[FLINK-30286][build] Run rat-plugin in validate phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1387,7 +1387,7 @@ under the License.
 				<inherited>false</inherited>
 				<executions>
 					<execution>
-						<phase>verify</phase>
+						<phase>validate</phase>
 						<goals>
 							<goal>check</goal>
 						</goals>

--- a/tools/ci/compile.sh
+++ b/tools/ci/compile.sh
@@ -71,7 +71,7 @@ echo "============ Checking Javadocs ============"
 
 # use the same invocation as .github/workflows/docs.sh
 run_mvn javadoc:aggregate -DadditionalJOption='-Xdoclint:none' \
-      -Dmaven.javadoc.failOnError=false -Dcheckstyle.skip=true -Denforcer.skip=true -Dspotless.skip=true \
+      -Dmaven.javadoc.failOnError=false -Dcheckstyle.skip=true -Denforcer.skip=true -Dspotless.skip=true -Drat.skip=true \
       -Dheader=someTestHeader > javadoc.out
 EXIT_CODE=$?
 if [ $EXIT_CODE != 0 ] ; then


### PR DESCRIPTION
Run the plugin before the shade-plugin to not be affected by the shade-plugin changing the basedir, breaking relative paths in exclusions.

Additionally skips the rat plugin when building the javadocs on CI. This previously happened implicitly (since we never reached the verify stage), but it would fail now because of the javadoc plugin output.