### PR TITLE
[FLINK-30185] Provide the flame graph to the subtask level

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -2736,6 +2736,9 @@
       "queryParameters" : [ {
         "key" : "type",
         "mandatory" : false
+      }, {
+        "key" : "subtaskindex",
+        "mandatory" : false
       } ]
     },
     "request" : {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.html
@@ -48,6 +48,24 @@ Type:
   </label>
 </nz-radio-group>
 
+Subtask:
+<nz-select
+  nzSize="small"
+  [ngModel]="subtaskIndex"
+  nzShowSearch
+  (ngModelChange)="selectSubtask($event)"
+>
+  <nz-option
+    *ngFor="let name of listOfRunningSubtasks"
+    [nzLabel]="name"
+    [nzValue]="name"
+    nzCustomContent
+  >
+    <span [title]="name">{{ name }}</span>
+  </nz-option>
+</nz-select>
+
+&nbsp; &nbsp;
 <ng-container [ngSwitch]="flameGraph.endTimestamp">
   <span *ngSwitchCase="-1">The task has already been terminated</span>
   <span *ngSwitchCase="-2">

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.less
@@ -19,7 +19,7 @@
 @import "theme";
 
 nz-select {
-  width: 300px;
+  width: 100px;
 }
 
 .metric-selector {

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/flamegraph/job-overview-drawer-flamegraph.component.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { NgIf, NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
+import { NgForOf, NgIf, NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Subject } from 'rxjs';
@@ -26,7 +26,9 @@ import { FlameGraphComponent } from '@flink-runtime-web/components/flame-graph/f
 import { HumanizeDurationPipe } from '@flink-runtime-web/components/humanize-duration.pipe';
 import { FlameGraphType, JobFlameGraph, NodesItemCorrect } from '@flink-runtime-web/interfaces';
 import { JobService } from '@flink-runtime-web/services';
+import { isNil } from '@flink-runtime-web/utils';
 import { NzRadioModule } from 'ng-zorro-antd/radio';
+import { NzSelectModule } from 'ng-zorro-antd/select';
 import { NzSpinModule } from 'ng-zorro-antd/spin';
 
 import { JobLocalService } from '../../job-local.service';
@@ -38,6 +40,8 @@ import { JobLocalService } from '../../job-local.service';
   styleUrls: ['./job-overview-drawer-flamegraph.component.less'],
   imports: [
     NgIf,
+    NgForOf,
+    NzSelectModule,
     NzRadioModule,
     FormsModule,
     NgSwitch,
@@ -55,8 +59,11 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
   public now = Date.now();
   public selectedVertex: NodesItemCorrect | null;
   public flameGraph = {} as JobFlameGraph;
+  public allSubtasks = 'all';
+  public listOfRunningSubtasks: string[] = [this.allSubtasks];
 
   public graphType = FlameGraphType.ON_CPU;
+  public subtaskIndex = this.allSubtasks;
 
   private readonly destroy$ = new Subject<void>();
 
@@ -67,6 +74,7 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
   ) {}
 
   public ngOnInit(): void {
+    this.requestRunningSubtasks();
     this.requestFlameGraph(this.graphType);
   }
 
@@ -76,11 +84,22 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
   }
 
   private requestFlameGraph(graphType: FlameGraphType): void {
+    this.flameGraph = {} as JobFlameGraph;
     this.jobLocalService
       .jobWithVertexChanges()
       .pipe(
         tap(data => (this.selectedVertex = data.vertex)),
-        mergeMap(data => this.jobService.loadOperatorFlameGraph(data.job.jid, data.vertex!.id, graphType)),
+        mergeMap(data => {
+          if (this.subtaskIndex === this.allSubtasks) {
+            return this.jobService.loadOperatorFlameGraph(data.job.jid, data.vertex!.id, graphType);
+          }
+          return this.jobService.loadOperatorFlameGraphForSingleSubtask(
+            data.job.jid,
+            data.vertex!.id,
+            graphType,
+            this.subtaskIndex
+          );
+        }),
         takeUntil(this.destroy$)
       )
       .subscribe(
@@ -100,9 +119,43 @@ export class JobOverviewDrawerFlameGraphComponent implements OnInit, OnDestroy {
       );
   }
 
+  private requestRunningSubtasks(): void {
+    this.jobLocalService
+      .jobWithVertexChanges()
+      .pipe(
+        tap(data => (this.selectedVertex = data.vertex)),
+        mergeMap(data => {
+          return this.jobService.loadSubTasks(data.job.jid, data.vertex!.id);
+        }),
+        takeUntil(this.destroy$)
+      )
+      .subscribe(
+        data => {
+          const runningSubtasks = data?.subtasks
+            .filter(subtaskInfo => subtaskInfo.status === 'RUNNING')
+            .map(subtaskInfo => subtaskInfo.subtask.toString());
+          if (isNil(runningSubtasks)) {
+            return;
+          }
+          this.listOfRunningSubtasks = [this.allSubtasks, ...runningSubtasks];
+          this.cdr.markForCheck();
+        },
+        () => {
+          this.listOfRunningSubtasks = [this.allSubtasks];
+          this.cdr.markForCheck();
+        }
+      );
+  }
+
+  public selectSubtask(subtaskIndex: string): void {
+    this.destroy$.next();
+    this.subtaskIndex = subtaskIndex;
+    this.cdr.markForCheck();
+    this.requestFlameGraph(this.graphType);
+  }
+
   public selectFrameGraphType(graphType: FlameGraphType): void {
     this.destroy$.next();
-    this.flameGraph = {} as JobFlameGraph;
     this.requestFlameGraph(graphType);
   }
 }

--- a/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
+++ b/flink-runtime-web/web-dashboard/src/app/services/job.service.ts
@@ -122,6 +122,17 @@ export class JobService {
     );
   }
 
+  public loadOperatorFlameGraphForSingleSubtask(
+    jobId: string,
+    vertexId: string,
+    type: string,
+    subtaskIndex: string
+  ): Observable<JobFlameGraph> {
+    return this.httpClient.get<JobFlameGraph>(
+      `${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}/flamegraph?type=${type}&subtaskindex=${subtaskIndex}`
+    );
+  }
+
   public loadSubTasks(jobId: string, vertexId: string): Observable<JobVertexSubTaskDetail> {
     return this.httpClient.get<JobVertexSubTaskDetail>(
       `${this.configService.BASE_URL}/jobs/${jobId}/vertices/${vertexId}`

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/TaskThreadInfoResponse.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/TaskThreadInfoResponse.java
@@ -18,24 +18,26 @@
 
 package org.apache.flink.runtime.messages;
 
+import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.util.Preconditions;
 
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Map;
 
 /** Response to the request to collect thread details samples. */
 public class TaskThreadInfoResponse implements Serializable {
 
     private static final long serialVersionUID = -4786454630050578031L;
 
-    private final Collection<ThreadInfoSample> samples;
+    private final Map<ExecutionAttemptID, Collection<ThreadInfoSample>> samples;
 
     /**
      * Creates a response to the request to collect thread details samples.
      *
      * @param samples Thread info samples.
      */
-    public TaskThreadInfoResponse(Collection<ThreadInfoSample> samples) {
+    public TaskThreadInfoResponse(Map<ExecutionAttemptID, Collection<ThreadInfoSample>> samples) {
         this.samples = Preconditions.checkNotNull(samples);
     }
 
@@ -44,7 +46,7 @@ public class TaskThreadInfoResponse implements Serializable {
      *
      * @return A collection of thread info samples for a particular execution attempt (Task)
      */
-    public Collection<ThreadInfoSample> getSamples() {
+    public Map<ExecutionAttemptID, Collection<ThreadInfoSample>> getSamples() {
         return samples;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/messages/ThreadInfoSample.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/messages/ThreadInfoSample.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import java.io.Serializable;
 import java.lang.management.ThreadInfo;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -63,13 +64,15 @@ public class ThreadInfoSample implements Serializable {
      * @param threadInfos the collection of {@link ThreadInfo}.
      * @return the collection of the corresponding {@link ThreadInfoSample}s.
      */
-    public static Collection<ThreadInfoSample> from(Collection<ThreadInfo> threadInfos) {
+    public static Map<Long, ThreadInfoSample> from(Collection<ThreadInfo> threadInfos) {
         return threadInfos.stream()
-                .map(
-                        threadInfo ->
-                                new ThreadInfoSample(
-                                        threadInfo.getThreadState(), threadInfo.getStackTrace()))
-                .collect(Collectors.toList());
+                .collect(
+                        Collectors.toMap(
+                                ThreadInfo::getThreadId,
+                                threadInfo ->
+                                        new ThreadInfoSample(
+                                                threadInfo.getThreadState(),
+                                                threadInfo.getStackTrace())));
     }
 
     public Thread.State getThreadState() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/FlameGraphTypeQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/FlameGraphTypeQueryParameter.java
@@ -24,10 +24,10 @@ import java.util.Arrays;
 public class FlameGraphTypeQueryParameter
         extends MessageQueryParameter<FlameGraphTypeQueryParameter.Type> {
 
-    private static final String key = "type";
+    public static final String KEY = "type";
 
     public FlameGraphTypeQueryParameter() {
-        super(key, MessageParameterRequisiteness.OPTIONAL);
+        super(KEY, MessageParameterRequisiteness.OPTIONAL);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexFlameGraphHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobVertexFlameGraphHeaders.java
@@ -20,14 +20,14 @@ package org.apache.flink.runtime.rest.messages;
 
 import org.apache.flink.runtime.rest.HttpMethodWrapper;
 import org.apache.flink.runtime.rest.handler.job.JobVertexFlameGraphHandler;
-import org.apache.flink.runtime.webmonitor.threadinfo.JobVertexFlameGraph;
+import org.apache.flink.runtime.webmonitor.threadinfo.VertexFlameGraph;
 
 import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
 
 /** Message headers for the {@link JobVertexFlameGraphHandler}. */
 public class JobVertexFlameGraphHeaders
         implements RuntimeMessageHeaders<
-                EmptyRequestBody, JobVertexFlameGraph, JobVertexFlameGraphParameters> {
+                EmptyRequestBody, VertexFlameGraph, JobVertexFlameGraphParameters> {
 
     private static final JobVertexFlameGraphHeaders INSTANCE = new JobVertexFlameGraphHeaders();
 
@@ -44,8 +44,8 @@ public class JobVertexFlameGraphHeaders
     }
 
     @Override
-    public Class<JobVertexFlameGraph> getResponseClass() {
-        return JobVertexFlameGraph.class;
+    public Class<VertexFlameGraph> getResponseClass() {
+        return VertexFlameGraph.class;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtaskIndexQueryParameter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/SubtaskIndexQueryParameter.java
@@ -18,20 +18,32 @@
 
 package org.apache.flink.runtime.rest.messages;
 
-import java.util.Arrays;
-import java.util.Collection;
+/** Query parameter specifying the index of a subtask. */
+public class SubtaskIndexQueryParameter extends MessageQueryParameter<Integer> {
 
-/** Message parameters for job vertex Flame Graph REST handler. */
-public class JobVertexFlameGraphParameters extends JobVertexMessageParameters {
+    public static final String KEY = "subtaskindex";
 
-    public final FlameGraphTypeQueryParameter flameGraphTypeQueryParameter =
-            new FlameGraphTypeQueryParameter();
-
-    public final SubtaskIndexQueryParameter subtaskIndexQueryParameter =
-            new SubtaskIndexQueryParameter();
+    public SubtaskIndexQueryParameter() {
+        super(KEY, MessageParameterRequisiteness.OPTIONAL);
+    }
 
     @Override
-    public Collection<MessageQueryParameter<?>> getQueryParameters() {
-        return Arrays.asList(flameGraphTypeQueryParameter, subtaskIndexQueryParameter);
+    public Integer convertStringToValue(String value) throws ConversionException {
+        final int subtaskIndex = Integer.parseInt(value);
+        if (subtaskIndex >= 0) {
+            return subtaskIndex;
+        } else {
+            throw new ConversionException("subtaskindex must be positive, was: " + subtaskIndex);
+        }
+    }
+
+    @Override
+    public String convertValueToString(Integer value) {
+        return value.toString();
+    }
+
+    @Override
+    public String getDescription() {
+        return "Positive integer value that identifies a subtask.";
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -571,11 +571,17 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             }
         }
 
-        Collection<SampleableTask> sampleableTasks =
-                tasks.stream().map(SampleableTaskAdapter::fromTask).collect(Collectors.toList());
+        Map<Long, ExecutionAttemptID> sampleableTasks =
+                tasks.stream()
+                        .collect(
+                                Collectors.toMap(
+                                        task -> task.getExecutingThread().getId(),
+                                        Task::getExecutionId));
 
-        final CompletableFuture<Collection<ThreadInfoSample>> stackTracesFuture =
-                threadInfoSampleService.requestThreadInfoSamples(sampleableTasks, requestParams);
+        final CompletableFuture<Map<ExecutionAttemptID, Collection<ThreadInfoSample>>>
+                stackTracesFuture =
+                        threadInfoSampleService.requestThreadInfoSamples(
+                                sampleableTasks, requestParams);
 
         return stackTracesFuture.thenApply(TaskThreadInfoResponse::new);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/util/JvmUtils.java
@@ -29,6 +29,7 @@ import java.lang.management.ThreadMXBean;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -70,9 +71,10 @@ public final class JvmUtils {
      *
      * @param threadIds The IDs of the threads to create the thread dump for.
      * @param maxStackTraceDepth The maximum number of entries in the stack trace to be collected.
-     * @return The thread information for the requested thread IDs.
+     * @return The map key is the thread id, the map value is the thread information for the
+     *     requested thread IDs.
      */
-    public static Collection<ThreadInfoSample> createThreadInfoSample(
+    public static Map<Long, ThreadInfoSample> createThreadInfoSample(
             Collection<Long> threadIds, int maxStackTraceDepth) {
         ThreadMXBean threadMxBean = ManagementFactory.getThreadMXBean();
         long[] threadIdsArray = threadIds.stream().mapToLong(l -> l).toArray();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/WebMonitorEndpoint.java
@@ -148,10 +148,10 @@ import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.webmonitor.history.ArchivedJson;
 import org.apache.flink.runtime.webmonitor.history.JsonArchivist;
 import org.apache.flink.runtime.webmonitor.retriever.GatewayRetriever;
-import org.apache.flink.runtime.webmonitor.threadinfo.JobVertexThreadInfoStats;
 import org.apache.flink.runtime.webmonitor.threadinfo.JobVertexThreadInfoTracker;
 import org.apache.flink.runtime.webmonitor.threadinfo.JobVertexThreadInfoTrackerBuilder;
 import org.apache.flink.runtime.webmonitor.threadinfo.ThreadInfoRequestCoordinator;
+import org.apache.flink.runtime.webmonitor.threadinfo.VertexThreadInfoStats;
 import org.apache.flink.util.ConfigurationException;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.ExecutorUtils;
@@ -241,7 +241,7 @@ public class WebMonitorEndpoint<T extends RestfulGateway> extends RestServerEndp
         this.fatalErrorHandler = Preconditions.checkNotNull(fatalErrorHandler);
     }
 
-    private JobVertexThreadInfoTracker<JobVertexThreadInfoStats> initializeThreadInfoTracker(
+    private JobVertexThreadInfoTracker<VertexThreadInfoStats> initializeThreadInfoTracker(
             ScheduledExecutorService executor) {
         final Duration akkaTimeout = clusterConfiguration.get(AkkaOptions.ASK_TIMEOUT_DURATION);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoStats.java
@@ -22,8 +22,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.messages.ThreadInfoSample;
 import org.apache.flink.runtime.webmonitor.stats.Statistics;
 
-import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
-
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -46,8 +44,7 @@ public class JobVertexThreadInfoStats implements Statistics {
     private final long endTime;
 
     /** Map of thread info samples by execution ID. */
-    private final Map<ImmutableSet<ExecutionAttemptID>, Collection<ThreadInfoSample>>
-            samplesBySubtask;
+    private final Map<ExecutionAttemptID, Collection<ThreadInfoSample>> samplesBySubtask;
 
     /**
      * Creates a thread details sample.
@@ -61,7 +58,7 @@ public class JobVertexThreadInfoStats implements Statistics {
             int requestId,
             long startTime,
             long endTime,
-            Map<ImmutableSet<ExecutionAttemptID>, Collection<ThreadInfoSample>> samplesBySubtask) {
+            Map<ExecutionAttemptID, Collection<ThreadInfoSample>> samplesBySubtask) {
 
         checkArgument(requestId >= 0, "Negative request ID");
         checkArgument(startTime >= 0, "Negative start time");
@@ -106,8 +103,7 @@ public class JobVertexThreadInfoStats implements Statistics {
      *
      * @return Map of thread info samples by task (execution ID)
      */
-    public Map<ImmutableSet<ExecutionAttemptID>, Collection<ThreadInfoSample>>
-            getSamplesBySubtask() {
+    public Map<ExecutionAttemptID, Collection<ThreadInfoSample>> getSamplesBySubtask() {
         return samplesBySubtask;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTracker.java
@@ -77,7 +77,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
     @GuardedBy("lock")
     private final ThreadInfoRequestCoordinator coordinator;
 
-    private final Function<JobVertexThreadInfoStats, T> createStatsFn;
+    private final Function<VertexThreadInfoStats, T> createStatsFn;
 
     private final ExecutorService executor;
 
@@ -108,7 +108,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
     JobVertexThreadInfoTracker(
             ThreadInfoRequestCoordinator coordinator,
             GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
-            Function<JobVertexThreadInfoStats, T> createStatsFn,
+            Function<VertexThreadInfoStats, T> createStatsFn,
             ScheduledExecutorService executor,
             Duration cleanUpInterval,
             int numSamples,
@@ -193,7 +193,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
             final CompletableFuture<ResourceManagerGateway> gatewayFuture =
                     resourceManagerGatewayRetriever.getFuture();
 
-            CompletableFuture<JobVertexThreadInfoStats> sample =
+            CompletableFuture<VertexThreadInfoStats> sample =
                     gatewayFuture.thenCompose(
                             (ResourceManagerGateway resourceManagerGateway) ->
                                     coordinator.triggerThreadInfoRequest(
@@ -334,7 +334,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
 
     /** Callback on completed thread info sample. */
     private class ThreadInfoSampleCompletionCallback
-            implements BiConsumer<JobVertexThreadInfoStats, Throwable> {
+            implements BiConsumer<VertexThreadInfoStats, Throwable> {
 
         private final Key key;
         private final AccessExecutionJobVertex vertex;
@@ -345,7 +345,7 @@ public class JobVertexThreadInfoTracker<T extends Statistics> implements JobVert
         }
 
         @Override
-        public void accept(JobVertexThreadInfoStats threadInfoStats, Throwable throwable) {
+        public void accept(VertexThreadInfoStats threadInfoStats, Throwable throwable) {
             synchronized (lock) {
                 try {
                     if (shutDown) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/JobVertexThreadInfoTrackerBuilder.java
@@ -42,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class JobVertexThreadInfoTrackerBuilder<T extends Statistics> {
 
     private final GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever;
-    private final Function<JobVertexThreadInfoStats, T> createStatsFn;
+    private final Function<VertexThreadInfoStats, T> createStatsFn;
     private final ScheduledExecutorService executor;
     private final Time restTimeout;
 
@@ -56,7 +56,7 @@ public class JobVertexThreadInfoTrackerBuilder<T extends Statistics> {
 
     JobVertexThreadInfoTrackerBuilder(
             GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
-            Function<JobVertexThreadInfoStats, T> createStatsFn,
+            Function<VertexThreadInfoStats, T> createStatsFn,
             ScheduledExecutorService executor,
             Time restTimeout) {
         this.resourceManagerGatewayRetriever = resourceManagerGatewayRetriever;
@@ -188,7 +188,7 @@ public class JobVertexThreadInfoTrackerBuilder<T extends Statistics> {
      */
     public static <T extends Statistics> JobVertexThreadInfoTrackerBuilder<T> newBuilder(
             GatewayRetriever<ResourceManagerGateway> resourceManagerGatewayRetriever,
-            Function<JobVertexThreadInfoStats, T> createStatsFn,
+            Function<VertexThreadInfoStats, T> createStatsFn,
             ScheduledExecutorService executor,
             Time restTimeout) {
         return new JobVertexThreadInfoTrackerBuilder<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinator.java
@@ -42,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** A coordinator for triggering and collecting thread info stats of running job vertex subtasks. */
 public class ThreadInfoRequestCoordinator
         extends TaskStatsRequestCoordinator<
-                Map<ExecutionAttemptID, Collection<ThreadInfoSample>>, JobVertexThreadInfoStats> {
+                Map<ExecutionAttemptID, Collection<ThreadInfoSample>>, VertexThreadInfoStats> {
 
     /**
      * Creates a new coordinator for the job.
@@ -68,7 +68,7 @@ public class ThreadInfoRequestCoordinator
      *     samples.
      * @return A future of the completed thread info stats.
      */
-    public CompletableFuture<JobVertexThreadInfoStats> triggerThreadInfoRequest(
+    public CompletableFuture<VertexThreadInfoStats> triggerThreadInfoRequest(
             Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                     executionsWithGateways,
             int numSamples,
@@ -161,8 +161,7 @@ public class ThreadInfoRequestCoordinator
 
     private static class PendingThreadInfoRequest
             extends PendingStatsRequest<
-                    Map<ExecutionAttemptID, Collection<ThreadInfoSample>>,
-                    JobVertexThreadInfoStats> {
+                    Map<ExecutionAttemptID, Collection<ThreadInfoSample>>, VertexThreadInfoStats> {
 
         PendingThreadInfoRequest(
                 int requestId, Collection<? extends Set<ExecutionAttemptID>> tasksToCollect) {
@@ -170,13 +169,13 @@ public class ThreadInfoRequestCoordinator
         }
 
         @Override
-        protected JobVertexThreadInfoStats assembleCompleteStats(long endTime) {
+        protected VertexThreadInfoStats assembleCompleteStats(long endTime) {
             HashMap<ExecutionAttemptID, Collection<ThreadInfoSample>> samples = new HashMap<>();
             for (Map<ExecutionAttemptID, Collection<ThreadInfoSample>> map :
                     statsResultByTaskGroup.values()) {
                 samples.putAll(map);
             }
-            return new JobVertexThreadInfoStats(requestId, startTime, endTime, samples);
+            return new VertexThreadInfoStats(requestId, startTime, endTime, samples);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinator.java
@@ -30,6 +30,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.ImmutableSet;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -41,7 +42,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 /** A coordinator for triggering and collecting thread info stats of running job vertex subtasks. */
 public class ThreadInfoRequestCoordinator
         extends TaskStatsRequestCoordinator<
-                Collection<ThreadInfoSample>, JobVertexThreadInfoStats> {
+                Map<ExecutionAttemptID, Collection<ThreadInfoSample>>, JobVertexThreadInfoStats> {
 
     /**
      * Creates a new coordinator for the job.
@@ -159,7 +160,9 @@ public class ThreadInfoRequestCoordinator
     // ------------------------------------------------------------------------
 
     private static class PendingThreadInfoRequest
-            extends PendingStatsRequest<Collection<ThreadInfoSample>, JobVertexThreadInfoStats> {
+            extends PendingStatsRequest<
+                    Map<ExecutionAttemptID, Collection<ThreadInfoSample>>,
+                    JobVertexThreadInfoStats> {
 
         PendingThreadInfoRequest(
                 int requestId, Collection<? extends Set<ExecutionAttemptID>> tasksToCollect) {
@@ -168,8 +171,12 @@ public class ThreadInfoRequestCoordinator
 
         @Override
         protected JobVertexThreadInfoStats assembleCompleteStats(long endTime) {
-            return new JobVertexThreadInfoStats(
-                    requestId, startTime, endTime, statsResultByTaskGroup);
+            HashMap<ExecutionAttemptID, Collection<ThreadInfoSample>> samples = new HashMap<>();
+            for (Map<ExecutionAttemptID, Collection<ThreadInfoSample>> map :
+                    statsResultByTaskGroup.values()) {
+                samples.putAll(map);
+            }
+            return new JobVertexThreadInfoStats(requestId, startTime, endTime, samples);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraph.java
@@ -28,12 +28,12 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonPro
 import java.util.List;
 
 /**
- * Flame Graph representation for a job vertex.
+ * Flame Graph representation for a job vertex or an execution vertex.
  *
  * <p>Statistics are gathered by sampling stack traces of running tasks.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class JobVertexFlameGraph implements ResponseBody {
+public class VertexFlameGraph implements ResponseBody {
 
     private static final String FIELD_NAME_END_TIMESTAMP = "endTimestamp";
     private static final String FIELD_NAME_DATA = "data";
@@ -46,7 +46,7 @@ public class JobVertexFlameGraph implements ResponseBody {
     private final Node root;
 
     @JsonCreator
-    public JobVertexFlameGraph(
+    public VertexFlameGraph(
             @JsonProperty(FIELD_NAME_END_TIMESTAMP) long endTimestamp,
             @JsonProperty(FIELD_NAME_DATA) Node root) {
         this.endTimestamp = endTimestamp;
@@ -69,18 +69,18 @@ public class JobVertexFlameGraph implements ResponseBody {
     }
 
     // Indicates that the task execution has been terminated
-    public static JobVertexFlameGraph terminated() {
-        return new JobVertexFlameGraph(-1, null);
+    public static VertexFlameGraph terminated() {
+        return new VertexFlameGraph(-1, null);
     }
 
     // Indicates that the flame graph feature has been disabled
-    public static JobVertexFlameGraph disabled() {
-        return new JobVertexFlameGraph(-2, null);
+    public static VertexFlameGraph disabled() {
+        return new VertexFlameGraph(-2, null);
     }
 
     // Indicates that it is waiting for the first samples to creating the flame graph
-    public static JobVertexFlameGraph waiting() {
-        return new JobVertexFlameGraph(-3, null);
+    public static VertexFlameGraph waiting() {
+        return new VertexFlameGraph(-3, null);
     }
 
     /** Graph node. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexFlameGraphFactory.java
@@ -30,21 +30,21 @@ import java.util.Map;
 import java.util.Set;
 
 /** Factory class for creating Flame Graph representations. */
-public class JobVertexFlameGraphFactory {
+public class VertexFlameGraphFactory {
 
     /**
-     * Converts {@link JobVertexThreadInfoStats} into a FlameGraph.
+     * Converts {@link VertexThreadInfoStats} into a FlameGraph.
      *
      * @param sample Thread details sample containing stack traces.
      * @return FlameGraph data structure
      */
-    public static JobVertexFlameGraph createFullFlameGraphFrom(JobVertexThreadInfoStats sample) {
+    public static VertexFlameGraph createFullFlameGraphFrom(VertexThreadInfoStats sample) {
         EnumSet<Thread.State> included = EnumSet.allOf(Thread.State.class);
         return createFlameGraphFromSample(sample, included);
     }
 
     /**
-     * Converts {@link JobVertexThreadInfoStats} into a FlameGraph representing blocked (Off-CPU)
+     * Converts {@link VertexThreadInfoStats} into a FlameGraph representing blocked (Off-CPU)
      * threads.
      *
      * <p>Includes threads in states Thread.State.[TIMED_WAITING, BLOCKED, WAITING].
@@ -52,14 +52,14 @@ public class JobVertexFlameGraphFactory {
      * @param sample Thread details sample containing stack traces.
      * @return FlameGraph data structure.
      */
-    public static JobVertexFlameGraph createOffCpuFlameGraph(JobVertexThreadInfoStats sample) {
+    public static VertexFlameGraph createOffCpuFlameGraph(VertexThreadInfoStats sample) {
         EnumSet<Thread.State> included =
                 EnumSet.of(Thread.State.TIMED_WAITING, Thread.State.BLOCKED, Thread.State.WAITING);
         return createFlameGraphFromSample(sample, included);
     }
 
     /**
-     * Converts {@link JobVertexThreadInfoStats} into a FlameGraph representing actively running
+     * Converts {@link VertexThreadInfoStats} into a FlameGraph representing actively running
      * (On-CPU) threads.
      *
      * <p>Includes threads in states Thread.State.[RUNNABLE, NEW].
@@ -67,13 +67,13 @@ public class JobVertexFlameGraphFactory {
      * @param sample Thread details sample containing stack traces.
      * @return FlameGraph data structure
      */
-    public static JobVertexFlameGraph createOnCpuFlameGraph(JobVertexThreadInfoStats sample) {
+    public static VertexFlameGraph createOnCpuFlameGraph(VertexThreadInfoStats sample) {
         EnumSet<Thread.State> included = EnumSet.of(Thread.State.RUNNABLE, Thread.State.NEW);
         return createFlameGraphFromSample(sample, included);
     }
 
-    private static JobVertexFlameGraph createFlameGraphFromSample(
-            JobVertexThreadInfoStats sample, Set<Thread.State> threadStates) {
+    private static VertexFlameGraph createFlameGraphFromSample(
+            VertexThreadInfoStats sample, Set<Thread.State> threadStates) {
         final NodeBuilder root = new NodeBuilder("root");
         for (Collection<ThreadInfoSample> threadInfoSubSamples :
                 sample.getSamplesBySubtask().values()) {
@@ -94,7 +94,7 @@ public class JobVertexFlameGraphFactory {
                 }
             }
         }
-        return new JobVertexFlameGraph(sample.getEndTime(), root.toNode());
+        return new VertexFlameGraph(sample.getEndTime(), root.toNode());
     }
 
     private static class NodeBuilder {
@@ -119,12 +119,12 @@ public class JobVertexFlameGraphFactory {
             hitCount++;
         }
 
-        private JobVertexFlameGraph.Node toNode() {
-            final List<JobVertexFlameGraph.Node> childrenNodes = new ArrayList<>(children.size());
+        private VertexFlameGraph.Node toNode() {
+            final List<VertexFlameGraph.Node> childrenNodes = new ArrayList<>(children.size());
             for (NodeBuilder builderChild : children.values()) {
                 childrenNodes.add(builderChild.toNode());
             }
-            return new JobVertexFlameGraph.Node(
+            return new VertexFlameGraph.Node(
                     stackTraceLocation, hitCount, Collections.unmodifiableList(childrenNodes));
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexThreadInfoStats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/webmonitor/threadinfo/VertexThreadInfoStats.java
@@ -28,11 +28,8 @@ import java.util.Map;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
-/**
- * Thread info statistics of multiple tasks. Each subtask can deliver multiple samples for
- * statistical purposes.
- */
-public class JobVertexThreadInfoStats implements Statistics {
+/** Thread info statistics of single JobVertex or ExecutionVertex. */
+public class VertexThreadInfoStats implements Statistics {
 
     /** ID of the corresponding request. */
     private final int requestId;
@@ -54,7 +51,7 @@ public class JobVertexThreadInfoStats implements Statistics {
      * @param endTime Timestamp, when all thread info samples were collected.
      * @param samplesBySubtask Map of thread info samples by subtask (execution ID).
      */
-    public JobVertexThreadInfoStats(
+    public VertexThreadInfoStats(
             int requestId,
             long startTime,
             long endTime,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/job/JobVertexFlameGraphHandlerTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.rest.handler.job;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.api.common.time.Time;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.accumulators.StringifiedAccumulatorResult;
+import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.execution.ExecutionState;
+import org.apache.flink.runtime.executiongraph.AccessExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecution;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.ArchivedExecutionVertex;
+import org.apache.flink.runtime.executiongraph.ExecutionHistory;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.rest.handler.HandlerRequest;
+import org.apache.flink.runtime.rest.handler.HandlerRequestException;
+import org.apache.flink.runtime.rest.handler.RestHandlerConfiguration;
+import org.apache.flink.runtime.rest.handler.legacy.DefaultExecutionGraphCache;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
+import org.apache.flink.runtime.rest.messages.FlameGraphTypeQueryParameter;
+import org.apache.flink.runtime.rest.messages.JobIDPathParameter;
+import org.apache.flink.runtime.rest.messages.JobVertexFlameGraphParameters;
+import org.apache.flink.runtime.rest.messages.JobVertexIdPathParameter;
+import org.apache.flink.runtime.rest.messages.SubtaskIndexQueryParameter;
+import org.apache.flink.runtime.webmonitor.stats.JobVertexStatsTracker;
+import org.apache.flink.runtime.webmonitor.threadinfo.VertexFlameGraph;
+import org.apache.flink.runtime.webmonitor.threadinfo.VertexThreadInfoStats;
+import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.concurrent.Executors;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createExecutionAttemptId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests of {@link JobVertexFlameGraphHandler}. */
+public class JobVertexFlameGraphHandlerTest extends TestLogger {
+
+    private static final JobID JOB_ID = new JobID();
+    private static final JobVertexID JOB_VERTEX_ID = new JobVertexID();
+
+    private static VertexThreadInfoStats taskThreadInfoStatsDefaultSample;
+    private static JobVertexFlameGraphHandler handler;
+
+    @BeforeAll
+    public static void setUp() {
+        taskThreadInfoStatsDefaultSample =
+                new VertexThreadInfoStats(
+                        8,
+                        System.currentTimeMillis(),
+                        System.currentTimeMillis() + 100,
+                        Collections.emptyMap());
+
+        final RestHandlerConfiguration restHandlerConfiguration =
+                RestHandlerConfiguration.fromConfiguration(new Configuration());
+        handler =
+                new JobVertexFlameGraphHandler(
+                        () -> null,
+                        Time.milliseconds(100L),
+                        Collections.emptyMap(),
+                        new DefaultExecutionGraphCache(
+                                restHandlerConfiguration.getTimeout(),
+                                Time.milliseconds(restHandlerConfiguration.getRefreshInterval())),
+                        Executors.directExecutor(),
+                        new TestThreadInfoTracker(taskThreadInfoStatsDefaultSample));
+    }
+
+    /** Some subtasks are finished, some subtasks are running. */
+    @Test
+    void testHandleMixedSubtasks() throws Exception {
+        final ArchivedExecutionJobVertex archivedExecutionJobVertex =
+                new ArchivedExecutionJobVertex(
+                        new ArchivedExecutionVertex[] {
+                            generateExecutionVertex(0, ExecutionState.FINISHED),
+                            generateExecutionVertex(1, ExecutionState.RUNNING)
+                        },
+                        JOB_VERTEX_ID,
+                        "test",
+                        2,
+                        2,
+                        ResourceProfile.UNKNOWN,
+                        new StringifiedAccumulatorResult[0]);
+
+        // Check the finished subtask
+        HandlerRequest<EmptyRequestBody> request = generateJobVertexFlameGraphParameters(0);
+        VertexFlameGraph jobVertexFlameGraph =
+                handler.handleRequest(request, archivedExecutionJobVertex);
+        assertThat(jobVertexFlameGraph.getEndTime())
+                .isEqualTo(VertexFlameGraph.terminated().getEndTime());
+
+        // Check the running subtask
+        request = generateJobVertexFlameGraphParameters(1);
+        jobVertexFlameGraph = handler.handleRequest(request, archivedExecutionJobVertex);
+        assertThat(jobVertexFlameGraph.getEndTime())
+                .isEqualTo(taskThreadInfoStatsDefaultSample.getEndTime());
+
+        // Check the job vertex
+        request = generateJobVertexFlameGraphParameters(null);
+        jobVertexFlameGraph = handler.handleRequest(request, archivedExecutionJobVertex);
+        assertThat(jobVertexFlameGraph.getEndTime())
+                .isEqualTo(taskThreadInfoStatsDefaultSample.getEndTime());
+    }
+
+    /** All subtasks are finished. */
+    @Test
+    void testHandleFinishedJobVertex() throws Exception {
+        final ArchivedExecutionJobVertex archivedExecutionJobVertex =
+                new ArchivedExecutionJobVertex(
+                        new ArchivedExecutionVertex[] {
+                            generateExecutionVertex(0, ExecutionState.FINISHED),
+                            generateExecutionVertex(1, ExecutionState.FINISHED)
+                        },
+                        JOB_VERTEX_ID,
+                        "test",
+                        2,
+                        2,
+                        ResourceProfile.UNKNOWN,
+                        new StringifiedAccumulatorResult[0]);
+
+        HandlerRequest<EmptyRequestBody> request = generateJobVertexFlameGraphParameters(null);
+        VertexFlameGraph jobVertexFlameGraph =
+                handler.handleRequest(request, archivedExecutionJobVertex);
+        assertThat(jobVertexFlameGraph.getEndTime())
+                .isEqualTo(VertexFlameGraph.terminated().getEndTime());
+    }
+
+    private HandlerRequest<EmptyRequestBody> generateJobVertexFlameGraphParameters(
+            Integer subtaskIndex) throws HandlerRequestException {
+        final HashMap<String, String> receivedPathParameters = new HashMap<>(2);
+        receivedPathParameters.put(JobIDPathParameter.KEY, JOB_ID.toString());
+        receivedPathParameters.put(JobVertexIdPathParameter.KEY, JOB_VERTEX_ID.toString());
+
+        Map<String, List<String>> queryParams = new HashMap<>(2);
+        queryParams.put(
+                FlameGraphTypeQueryParameter.KEY,
+                Collections.singletonList(FlameGraphTypeQueryParameter.Type.FULL.name()));
+        if (subtaskIndex != null) {
+            queryParams.put(
+                    SubtaskIndexQueryParameter.KEY,
+                    Collections.singletonList(subtaskIndex.toString()));
+        }
+
+        return HandlerRequest.resolveParametersAndCreate(
+                EmptyRequestBody.getInstance(),
+                new JobVertexFlameGraphParameters(),
+                receivedPathParameters,
+                queryParams,
+                Collections.emptyList());
+    }
+
+    private ArchivedExecutionVertex generateExecutionVertex(
+            int subtaskIndex, ExecutionState executionState) {
+        return new ArchivedExecutionVertex(
+                subtaskIndex,
+                "test task",
+                new ArchivedExecution(
+                        new StringifiedAccumulatorResult[0],
+                        null,
+                        createExecutionAttemptId(JOB_VERTEX_ID, subtaskIndex, 0),
+                        executionState,
+                        null,
+                        null,
+                        null,
+                        new long[ExecutionState.values().length],
+                        new long[ExecutionState.values().length]),
+                new ExecutionHistory(0));
+    }
+
+    /**
+     * A {@link JobVertexStatsTracker} which returns the pre-generated thread info stats directly.
+     */
+    private static class TestThreadInfoTracker
+            implements JobVertexStatsTracker<VertexThreadInfoStats> {
+
+        private final VertexThreadInfoStats stats;
+
+        public TestThreadInfoTracker(VertexThreadInfoStats stats) {
+            this.stats = stats;
+        }
+
+        @Override
+        public Optional<VertexThreadInfoStats> getVertexStats(
+                JobID jobId, AccessExecutionJobVertex vertex) {
+            return Optional.of(stats);
+        }
+
+        @Override
+        public void shutDown() throws FlinkException {}
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
@@ -104,14 +104,14 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.SUCCESSFULLY);
 
-        CompletableFuture<JobVertexThreadInfoStats> requestFuture =
+        CompletableFuture<VertexThreadInfoStats> requestFuture =
                 coordinator.triggerThreadInfoRequest(
                         executionWithGateways,
                         DEFAULT_NUMBER_OF_SAMPLES,
                         DEFAULT_DELAY_BETWEEN_SAMPLES,
                         DEFAULT_MAX_STACK_TRACE_DEPTH);
 
-        JobVertexThreadInfoStats threadInfoStats = requestFuture.get();
+        VertexThreadInfoStats threadInfoStats = requestFuture.get();
 
         // verify the request result
         assertThat(threadInfoStats.getRequestId()).isEqualTo(0);
@@ -133,7 +133,7 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.EXCEPTIONALLY);
 
-        CompletableFuture<JobVertexThreadInfoStats> requestFuture =
+        CompletableFuture<VertexThreadInfoStats> requestFuture =
                 coordinator.triggerThreadInfoRequest(
                         executionWithGateways,
                         DEFAULT_NUMBER_OF_SAMPLES,
@@ -156,7 +156,7 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.TIMEOUT);
 
-        CompletableFuture<JobVertexThreadInfoStats> requestFuture =
+        CompletableFuture<VertexThreadInfoStats> requestFuture =
                 coordinator.triggerThreadInfoRequest(
                         executionWithGateways,
                         DEFAULT_NUMBER_OF_SAMPLES,
@@ -184,16 +184,16 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
                         createMockSubtaskWithGateways(
                                 CompletionType.SUCCESSFULLY, CompletionType.TIMEOUT);
 
-        List<CompletableFuture<JobVertexThreadInfoStats>> requestFutures = new ArrayList<>();
+        List<CompletableFuture<VertexThreadInfoStats>> requestFutures = new ArrayList<>();
 
-        CompletableFuture<JobVertexThreadInfoStats> requestFuture1 =
+        CompletableFuture<VertexThreadInfoStats> requestFuture1 =
                 coordinator.triggerThreadInfoRequest(
                         executionWithGateways,
                         DEFAULT_NUMBER_OF_SAMPLES,
                         DEFAULT_DELAY_BETWEEN_SAMPLES,
                         DEFAULT_MAX_STACK_TRACE_DEPTH);
 
-        CompletableFuture<JobVertexThreadInfoStats> requestFuture2 =
+        CompletableFuture<VertexThreadInfoStats> requestFuture2 =
                 coordinator.triggerThreadInfoRequest(
                         executionWithGateways,
                         DEFAULT_NUMBER_OF_SAMPLES,
@@ -204,7 +204,7 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
         requestFutures.add(requestFuture1);
         requestFutures.add(requestFuture2);
 
-        for (CompletableFuture<JobVertexThreadInfoStats> future : requestFutures) {
+        for (CompletableFuture<VertexThreadInfoStats> future : requestFutures) {
             assertThat(future).isNotDone();
         }
 
@@ -212,12 +212,12 @@ public class ThreadInfoRequestCoordinatorTest extends TestLogger {
         coordinator.shutDown();
 
         // verify all completed
-        for (CompletableFuture<JobVertexThreadInfoStats> future : requestFutures) {
+        for (CompletableFuture<VertexThreadInfoStats> future : requestFutures) {
             assertThat(future).isCompletedExceptionally();
         }
 
         // verify new trigger returns failed future
-        CompletableFuture<JobVertexThreadInfoStats> future =
+        CompletableFuture<VertexThreadInfoStats> future =
                 coordinator.triggerThreadInfoRequest(
                         executionWithGateways,
                         DEFAULT_NUMBER_OF_SAMPLES,


### PR DESCRIPTION
## What is the purpose of the change

Provide the flame graph to the subtask level

## Brief change log

- [FLINK-30185][rest][refactor] Add the owner id for ThreadInfoSample
- [FLINK-30185][rest] Add the subtask index parameter for flame graph handler
- [FLINK-30185][ui] Allow choose the subtask index in the flame graph page

## Verifying this change

This change added tests and can be verified as follows:

- Added the new test: `JobVertexFlameGraphHandlerTest`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs