### PR TITLE
[FLINK-30116][rest] Don't Show Env Vars in Web UI

### DIFF
--- a/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
+++ b/docs/layouts/shortcodes/generated/rest_v1_dispatcher.html
@@ -704,21 +704,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
         "type" : "string"
       }
     },
-    "environment" : {
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo:EnvironmentVariableItem",
-        "properties" : {
-          "key" : {
-            "type" : "string"
-          },
-          "value" : {
-            "type" : "string"
-          }
-        }
-      }
-    },
     "jvm" : {
       "type" : "object",
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo:JVMInfo",
@@ -1547,6 +1532,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
           "processed_data" : {
             "type" : "integer"
           },
+          "savepointFormat" : {
+            "type" : "string"
+          },
           "state_size" : {
             "type" : "integer"
           },
@@ -1614,6 +1602,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             },
             "processed_data" : {
               "type" : "integer"
+            },
+            "savepointFormat" : {
+              "type" : "string"
             },
             "state_size" : {
               "type" : "integer"
@@ -1713,6 +1704,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
             },
             "processed_data" : {
               "type" : "integer"
+            },
+            "savepointFormat" : {
+              "type" : "string"
             },
             "state_size" : {
               "type" : "integer"
@@ -2057,6 +2051,9 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
     },
     "processed_data" : {
       "type" : "integer"
+    },
+    "savepointFormat" : {
+      "type" : "string"
     },
     "state_size" : {
       "type" : "integer"
@@ -2721,21 +2718,6 @@ Using 'curl' you can upload a jar via 'curl -X POST -H "Expect:" -F "jarfile=@pa
       "type" : "array",
       "items" : {
         "type" : "string"
-      }
-    },
-    "environment" : {
-      "type" : "array",
-      "items" : {
-        "type" : "object",
-        "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo:EnvironmentVariableItem",
-        "properties" : {
-          "key" : {
-            "type" : "string"
-          },
-          "value" : {
-            "type" : "string"
-          }
-        }
       }
     },
     "jvm" : {

--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -1719,6 +1719,8 @@ components:
         processed_data:
           type: integer
           format: int64
+        savepointFormat:
+          type: string
         state_size:
           type: integer
           format: int64
@@ -1915,19 +1917,8 @@ components:
           type: array
           items:
             type: string
-        environment:
-          type: array
-          items:
-            $ref: '#/components/schemas/EnvironmentVariableItem'
         jvm:
           $ref: '#/components/schemas/JVMInfo'
-    EnvironmentVariableItem:
-      type: object
-      properties:
-        key:
-          type: string
-        value:
-          type: string
     ExceptionInfo:
       type: object
       properties:

--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -532,21 +532,6 @@
       "type" : "object",
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo",
       "properties" : {
-        "environment" : {
-          "type" : "array",
-          "items" : {
-            "type" : "object",
-            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo:EnvironmentVariableItem",
-            "properties" : {
-              "key" : {
-                "type" : "string"
-              },
-              "value" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
         "jvm" : {
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo:JVMInfo",
@@ -2110,21 +2095,6 @@
       "type" : "object",
       "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo",
       "properties" : {
-        "environment" : {
-          "type" : "array",
-          "items" : {
-            "type" : "object",
-            "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo:EnvironmentVariableItem",
-            "properties" : {
-              "key" : {
-                "type" : "string"
-              },
-              "value" : {
-                "type" : "string"
-              }
-            }
-          }
-        },
         "jvm" : {
           "type" : "object",
           "id" : "urn:jsonschema:org:apache:flink:runtime:rest:messages:EnvironmentInfo:JVMInfo",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EnvironmentInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/EnvironmentInfo.java
@@ -23,7 +23,6 @@ import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -31,14 +30,9 @@ import java.util.Objects;
 /** The response of environment info. */
 public class EnvironmentInfo implements ResponseBody {
 
-    private static final String FIELD_NAME_ENVIRONMENT_INFO = "environment";
-
     private static final String FIELD_NAME_JVM_INFO = "jvm";
 
     private static final String FIELD_NAME_CLASSPATH = "classpath";
-
-    @JsonProperty(FIELD_NAME_ENVIRONMENT_INFO)
-    private final List<EnvironmentVariableItem> environmentVariables;
 
     @JsonProperty(FIELD_NAME_JVM_INFO)
     private final JVMInfo jvmInfo;
@@ -48,11 +42,8 @@ public class EnvironmentInfo implements ResponseBody {
 
     @JsonCreator
     public EnvironmentInfo(
-            @JsonProperty(FIELD_NAME_ENVIRONMENT_INFO)
-                    List<EnvironmentVariableItem> environmentVariables,
             @JsonProperty(FIELD_NAME_JVM_INFO) JVMInfo jvmInfo,
             @JsonProperty(FIELD_NAME_CLASSPATH) List<String> classpath) {
-        this.environmentVariables = environmentVariables;
         this.jvmInfo = jvmInfo;
         this.classpath = classpath;
     }
@@ -66,28 +57,17 @@ public class EnvironmentInfo implements ResponseBody {
             return false;
         }
         EnvironmentInfo that = (EnvironmentInfo) o;
-        return environmentVariables.equals(that.environmentVariables)
-                && jvmInfo.equals(that.jvmInfo)
-                && classpath.equals(that.classpath);
+        return jvmInfo.equals(that.jvmInfo) && classpath.equals(that.classpath);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(environmentVariables, jvmInfo, classpath);
+        return Objects.hash(jvmInfo, classpath);
     }
 
     public static EnvironmentInfo create() {
-        List<EnvironmentVariableItem> environmentVariableItems = new ArrayList<>();
-        System.getenv()
-                .forEach(
-                        (key, value) ->
-                                environmentVariableItems.add(
-                                        new EnvironmentVariableItem(key, value)));
-
         return new EnvironmentInfo(
-                environmentVariableItems,
-                JVMInfo.create(),
-                Arrays.asList(System.getProperty("java.class.path").split(":")));
+                JVMInfo.create(), Arrays.asList(System.getProperty("java.class.path").split(":")));
     }
 
     /** A single key-value pair entry in the {@link EnvironmentInfo} response. */


### PR DESCRIPTION
## What is the purpose of the change

Remove REST APIs for the environmental information.

## Brief change log

- remove JobManagerEnvironmentHandler Env Vars


## Verifying this change

remove jobmanager env handlers

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): yes
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (no)
