### PR TITLE
[FLINK-30291][Connector/DynamoDB] Update docs to render DynamoDB conn… (1.17)

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/guarantees.md
+++ b/docs/content.zh/docs/connectors/datastream/guarantees.md
@@ -106,6 +106,11 @@ under the License.
         <td>只有当更新是幂等时，保证精确一次</td>
     </tr>
     <tr>
+        <td>Amazon DynamoDB</td>
+        <td>至少一次</td>
+        <td></td>
+    </tr>
+        <tr>
         <td>Amazon Kinesis Data Streams</td>
         <td>至少一次</td>
         <td></td>

--- a/docs/content.zh/docs/connectors/datastream/overview.md
+++ b/docs/content.zh/docs/connectors/datastream/overview.md
@@ -39,6 +39,7 @@ under the License.
 
  * [Apache Kafka]({{< ref "docs/connectors/datastream/kafka" >}}) (source/sink)
  * [Apache Cassandra]({{< ref "docs/connectors/datastream/cassandra" >}}) (sink)
+ * [Amazon DynamoDB]({{< ref "docs/connectors/datastream/dynamodb" >}}) (sink)
  * [Amazon Kinesis Data Streams]({{< ref "docs/connectors/datastream/kinesis" >}}) (source/sink)
  * [Amazon Kinesis Data Firehose]({{< ref "docs/connectors/datastream/firehose" >}}) (sink)
  * [DataGen]({{< ref "docs/connectors/datastream/datagen" >}}) (source)

--- a/docs/content.zh/docs/connectors/table/overview.md
+++ b/docs/content.zh/docs/connectors/table/overview.md
@@ -67,6 +67,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{{< ref "docs/connectors/table/dynamodb" >}}">Amazon DynamoDB</a></td>
+      <td></td>
+      <td>Not supported</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
+    <tr>
       <td><a href="{{< ref "docs/connectors/table/kinesis" >}}">Amazon Kinesis Data Streams</a></td>
       <td></td>
       <td>Unbounded Scan</td>

--- a/docs/content/docs/connectors/datastream/guarantees.md
+++ b/docs/content/docs/connectors/datastream/guarantees.md
@@ -111,6 +111,11 @@ state updates) of Flink coupled with bundled sinks:
         <td>exactly once only for idempotent updates</td>
     </tr>
     <tr>
+        <td>Amazon DynamoDB</td>
+        <td>at least once</td>
+        <td></td>
+    </tr>
+    <tr>
         <td>Amazon Kinesis Data Streams</td>
         <td>at least once</td>
         <td></td>

--- a/docs/content/docs/connectors/datastream/overview.md
+++ b/docs/content/docs/connectors/datastream/overview.md
@@ -40,6 +40,7 @@ Connectors provide code for interfacing with various third-party systems. Curren
 
  * [Apache Kafka]({{< ref "docs/connectors/datastream/kafka" >}}) (source/sink)
  * [Apache Cassandra]({{< ref "docs/connectors/datastream/cassandra" >}}) (sink)
+ * [Amazon DynamoDB]({{< ref "docs/connectors/datastream/dynamodb" >}}) (sink)
  * [Amazon Kinesis Data Streams]({{< ref "docs/connectors/datastream/kinesis" >}}) (source/sink)
  * [Amazon Kinesis Data Firehose]({{< ref "docs/connectors/datastream/firehose" >}}) (sink)
  * [DataGen]({{< ref "docs/connectors/datastream/datagen" >}}) (source)

--- a/docs/content/docs/connectors/table/overview.md
+++ b/docs/content/docs/connectors/table/overview.md
@@ -67,6 +67,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{{< ref "docs/connectors/table/dynamodb" >}}">Amazon DynamoDB</a></td>
+      <td></td>
+      <td>Not supported</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
+    <tr>
       <td><a href="{{< ref "docs/connectors/table/kinesis" >}}">Amazon Kinesis Data Streams</a></td>
       <td></td>
       <td>Unbounded Scan</td>

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -178,6 +178,14 @@ aws-kinesis-firehose:
   maven: flink-connector-kinesis-firehose
   sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/$version/flink-sql-connector-aws-kinesis-firehose-$version.jar
 
+dynamodb:
+    name: Amazon DynamoDB
+    category: connector
+    versions:
+        - version: 3.0.0
+          maven: flink-connector-dynamodb
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/3.0.0-1.17/flink-sql-connector-dynamodb-3.0.0-1.17.jar
+
 pulsar:
     name: Pulsar
     category: connector

--- a/docs/layouts/shortcodes/sql_connector_download_table.html
+++ b/docs/layouts/shortcodes/sql_connector_download_table.html
@@ -1,0 +1,65 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  
+    http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  */}}
+  {{/* 
+    Generates an XML snippet for the SQL connector download table. 
+    IMPORTANT: the whitespace is relevant. Do not change without looking at the 
+    rendered documentation. 
+  */}}
+  {{ $artifactId := .Get 0 }}
+  {{ $version := .Get 1 }}
+  {{ $connectors := .Site.Data.sql_connectors }}
+  {{ $connector := index $connectors $artifactId }}
+  
+  {{ $path := .Page.Path }}
+  
+  {{ $hash := md5 now }}
+  
+  {{ if $.Site.Params.IsStable }}
+  <table style="display:table;margin-left:auto;margin-right:auto" id="download-table">
+    <thead>
+      <th style="text-align:left">Maven dependency</th>
+      <th style="text-align:left">SQL Client</th>
+    </thead>
+    <tbody>
+      {{ range $connector.versions }}    
+      <tr>
+        <td style="text-align: left">
+          <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight">
+<pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+  <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
+  <span class="nt">&ltartifactId&gt</span>{{- .maven -}}<span class="nt">&lt/artifactId&gt</span>
+  <span class="nt">&ltversion&gt</span>{{- .version -}}-{{- site.Params.VersionTitle -}}<span class="nt">&lt/version&gt</span>
+<span class="nt">&lt/dependency&gt</span></code></pre></div>
+          <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
+            Copied to clipboard!
+          </div> 
+        </td>
+        <td style="text-align: left">
+          <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+        </td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+  {{ else }}
+  Only available for stable versions.
+  {{ end }}
+
+  
+  

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -54,6 +54,7 @@ cd tmp
 # Since there's no documentation yet available for a release branch,
 # we only get the documentation from the main branch
 integrate_connector_docs elasticsearch v3.0.0
+integrate_connector_docs aws v3.0.0
 
 cd ..
 rm -rf tmp


### PR DESCRIPTION
## What is the purpose of the change

Integrate flink-connector-aws into Flink docs

Related https://github.com/apache/flink/pull/21449

## Brief change log

- Add a new short_code (`sql_connector_download_table`) to render SQL connector info for externalized connectors
- Integrate AWS connectors, flink-connector-dynamodb


## Verifying this change

Rendered web pages locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 