### PR TITLE
[FLINK-30291][Connector/DynamoDB] Update docs to render DynamoDB conn… (1.15)

### DIFF
--- a/.github/workflows/docs.sh
+++ b/.github/workflows/docs.sh
@@ -31,6 +31,13 @@ if ! curl --fail -OL $HUGO_REPO ; then
 fi
 tar -zxvf $HUGO_ARTIFACT
 git submodule update --init --recursive
+# Setup the external documentation modules
+cd docs
+source setup_docs.sh
+cd ..
+# Build the docs
+./hugo --source docs
+
 # generate docs into docs/target
 ./hugo -v --source docs --destination target
 if [ $? -ne 0 ]; then

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -85,6 +85,9 @@ stages:
         pool:
           vmImage: 'ubuntu-20.04'
         steps:
+          - task: GoTool@0
+            inputs:
+              version: '1.18.1'
           - script: ./tools/ci/docs.sh
   # CI / Special stage for release, e.g. building PyFlink wheel packages, etc:
   - stage: ci_release

--- a/docs/build_docs.sh
+++ b/docs/build_docs.sh
@@ -24,5 +24,6 @@ then
 	exit 1
 fi
 git submodule update --init --recursive
-
+./setup_docs.sh
+hugo mod get -u
 hugo -b "" serve 

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -108,3 +108,15 @@ pygmentsUseClasses = true
   languageName = '中文版'
   contentDir = 'content.zh'
   weight = 2
+
+[module]
+[[module.imports]]
+  path = 'connectors'
+[[module.imports.mounts]]
+  source = 'content'
+  target = 'content'
+  lang = 'en'
+[[module.imports.mounts]]
+  source = 'content.zh'
+  target = 'content'
+  lang = 'zh'

--- a/docs/content.zh/docs/connectors/datastream/guarantees.md
+++ b/docs/content.zh/docs/connectors/datastream/guarantees.md
@@ -106,6 +106,11 @@ under the License.
         <td>只有当更新是幂等时，保证精确一次</td>
     </tr>
     <tr>
+        <td>Amazon DynamoDB</td>
+        <td>至少一次</td>
+        <td></td>
+    </tr>
+        <tr>
         <td>Amazon Kinesis Data Streams</td>
         <td>至少一次</td>
         <td></td>

--- a/docs/content.zh/docs/connectors/datastream/overview.md
+++ b/docs/content.zh/docs/connectors/datastream/overview.md
@@ -39,6 +39,7 @@ under the License.
 
  * [Apache Kafka]({{< ref "docs/connectors/datastream/kafka" >}}) (source/sink)
  * [Apache Cassandra]({{< ref "docs/connectors/datastream/cassandra" >}}) (sink)
+ * [Amazon DynamoDB]({{< ref "docs/connectors/datastream/dynamodb" >}}) (sink)
  * [Amazon Kinesis Data Streams]({{< ref "docs/connectors/datastream/kinesis" >}}) (source/sink)
  * [Amazon Kinesis Data Firehose]({{< ref "docs/connectors/datastream/firehose" >}}) (sink)
  * [Elasticsearch]({{< ref "docs/connectors/datastream/elasticsearch" >}}) (sink)

--- a/docs/content.zh/docs/connectors/table/overview.md
+++ b/docs/content.zh/docs/connectors/table/overview.md
@@ -67,6 +67,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{{< ref "docs/connectors/table/dynamodb" >}}">Amazon DynamoDB</a></td>
+      <td></td>
+      <td>Not supported</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
+    <tr>
       <td><a href="{{< ref "docs/connectors/table/kinesis" >}}">Amazon Kinesis Data Streams</a></td>
       <td></td>
       <td>Unbounded Scan</td>

--- a/docs/content/docs/connectors/datastream/guarantees.md
+++ b/docs/content/docs/connectors/datastream/guarantees.md
@@ -111,6 +111,11 @@ state updates) of Flink coupled with bundled sinks:
         <td>exactly once only for idempotent updates</td>
     </tr>
     <tr>
+        <td>Amazon DynamoDB</td>
+        <td>at least once</td>
+        <td></td>
+    </tr>
+    <tr>
         <td>Amazon Kinesis Data Streams</td>
         <td>at least once</td>
         <td></td>

--- a/docs/content/docs/connectors/datastream/overview.md
+++ b/docs/content/docs/connectors/datastream/overview.md
@@ -40,6 +40,7 @@ Connectors provide code for interfacing with various third-party systems. Curren
 
  * [Apache Kafka]({{< ref "docs/connectors/datastream/kafka" >}}) (source/sink)
  * [Apache Cassandra]({{< ref "docs/connectors/datastream/cassandra" >}}) (sink)
+ * [Amazon DynamoDB]({{< ref "docs/connectors/datastream/dynamodb" >}}) (sink)
  * [Amazon Kinesis Data Streams]({{< ref "docs/connectors/datastream/kinesis" >}}) (source/sink)
  * [Amazon Kinesis Data Firehose]({{< ref "docs/connectors/datastream/firehose" >}}) (sink)
  * [Elasticsearch]({{< ref "docs/connectors/datastream/elasticsearch" >}}) (sink)

--- a/docs/content/docs/connectors/table/overview.md
+++ b/docs/content/docs/connectors/table/overview.md
@@ -67,6 +67,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{{< ref "docs/connectors/table/dynamodb" >}}">Amazon DynamoDB</a></td>
+      <td></td>
+      <td>Not supported</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
+    <tr>
       <td><a href="{{< ref "docs/connectors/table/kinesis" >}}">Amazon Kinesis Data Streams</a></td>
       <td></td>
       <td>Unbounded Scan</td>

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -171,3 +171,11 @@ aws-kinesis-firehose:
   category: connector
   maven: flink-connector-kinesis-firehose
   sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-aws-kinesis-firehose/$version/flink-sql-connector-aws-kinesis-firehose-$version.jar
+
+dynamodb:
+    name: Amazon DynamoDB
+    category: connector
+    versions:
+        - version: 3.0.0
+          maven: flink-connector-dynamodb
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-dynamodb/3.0.0-1.15/flink-sql-connector-dynamodb-3.0.0-1.15.jar

--- a/docs/layouts/shortcodes/connector_artifact.html
+++ b/docs/layouts/shortcodes/connector_artifact.html
@@ -1,0 +1,42 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  
+    http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  */}}
+  {{/* 
+    Generates an XML snippet for the maven artifact. 
+    IMPORTANT: the whitespace is relevant. Do not change without looking at the 
+    rendered documentation. 
+  */}}
+  {{ $artifactId := .Get 0 }}
+  {{ $version := .Get 1 }}
+  
+  {{ $path := .Page.Path }}
+  
+  {{ $hash := md5 now }}
+  
+  {{ if $.Site.Params.IsStable }}
+  <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight"><pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+    <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
+    <span class="nt">&ltartifactId&gt</span>{{- $artifactId -}}<span class="nt">&lt/artifactId&gt</span>
+    <span class="nt">&ltversion&gt</span>{{- $version -}}-{{- site.Params.VersionTitle -}}<span class="nt">&lt/version&gt</span>
+<span class="nt">&lt/dependency&gt</span></code></pre></div>
+  <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
+    Copied to clipboard!
+  </div>
+  {{ else }}
+  Only available for stable versions.
+  {{ end }}

--- a/docs/layouts/shortcodes/sql_connector_download_table.html
+++ b/docs/layouts/shortcodes/sql_connector_download_table.html
@@ -1,0 +1,65 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+  
+    http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  */}}
+  {{/* 
+    Generates an XML snippet for the SQL connector download table. 
+    IMPORTANT: the whitespace is relevant. Do not change without looking at the 
+    rendered documentation. 
+  */}}
+  {{ $artifactId := .Get 0 }}
+  {{ $version := .Get 1 }}
+  {{ $connectors := .Site.Data.sql_connectors }}
+  {{ $connector := index $connectors $artifactId }}
+  
+  {{ $path := .Page.Path }}
+  
+  {{ $hash := md5 now }}
+  
+  {{ if $.Site.Params.IsStable }}
+  <table style="display:table;margin-left:auto;margin-right:auto" id="download-table">
+    <thead>
+      <th style="text-align:left">Maven dependency</th>
+      <th style="text-align:left">SQL Client</th>
+    </thead>
+    <tbody>
+      {{ range $connector.versions }}    
+      <tr>
+        <td style="text-align: left">
+          <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight">
+<pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
+  <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
+  <span class="nt">&ltartifactId&gt</span>{{- .maven -}}<span class="nt">&lt/artifactId&gt</span>
+  <span class="nt">&ltversion&gt</span>{{- .version -}}-{{- site.Params.VersionTitle -}}<span class="nt">&lt/version&gt</span>
+<span class="nt">&lt/dependency&gt</span></code></pre></div>
+          <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
+            Copied to clipboard!
+          </div> 
+        </td>
+        <td style="text-align: left">
+          <a href="{{- partial "docs/interpolate" .sql_url -}}">Download</a>
+        </td>
+      </tr>
+      {{ end }}
+    </tbody>
+  </table>
+  {{ else }}
+  Only available for stable versions.
+  {{ end }}
+
+  
+  

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -17,25 +17,27 @@
 # limitations under the License.
 ################################################################################
 
-HUGO_REPO=https://github.com/gohugoio/hugo/releases/download/v0.80.0/hugo_extended_0.80.0_Linux-64bit.tar.gz
-HUGO_ARTIFACT=hugo_extended_0.80.0_Linux-64bit.tar.gz
-
-if ! curl --fail -OL $HUGO_REPO ; then 
-	echo "Failed to download Hugo binary"
-	exit 1
+HERE=` basename "$PWD"`
+if [[ "$HERE" != "docs" ]]; then
+    echo "Please only execute in the docs/ directory";
+    exit 1;
 fi
 
-tar -zxvf $HUGO_ARTIFACT
+# Create a default go.mod file
+cat <<EOF >go.mod
+module github.com/apache/flink
 
-git submodule update --init --recursive
-# Setup the external documentation modules
-cd docs
-source setup_docs.sh
-cd ..
-# Build the docs
-./hugo --source docs
+go 1.18
+EOF
 
-if [ $? -ne 0 ]; then
-	echo "Error building the docs"
-	exit 1
+echo "Created temporary file" $goModFileLocation/go.mod
+
+# Make Hugo retrieve modules which are used for externally hosted documentation
+currentBranch=$(git branch --show-current)
+
+if [[ ! "$currentBranch" =~ ^release- ]] || [[ -z "$currentBranch" ]]; then
+  # If the current branch is master or not provided, get the documentation from the main branch
+  $(command -v hugo) mod get -u github.com/apache/flink-connector-elasticsearch/docs@main
+  # Since there's no documentation yet available for a release branch,
+  # we only get the documentation from the main branch
 fi

--- a/tools/azure-pipelines/build-apache-repo.yml
+++ b/tools/azure-pipelines/build-apache-repo.yml
@@ -79,6 +79,9 @@ stages:
           vmImage: 'ubuntu-20.04'
         steps:
           # Skip docs check if this is a pull request that doesn't contain a documentation change
+          - task: GoTool@0
+            inputs:
+              version: '1.18.1'
           - bash: |
               source ./tools/azure-pipelines/build_properties.sh
               pr_contains_docs_changes
@@ -151,6 +154,9 @@ stages:
         pool:
           vmImage: 'ubuntu-20.04'
         steps:
+          - task: GoTool@0
+            inputs:
+              version: '1.18.1'
           - script: ./tools/ci/docs.sh
       - template: build-python-wheels.yml
         parameters:


### PR DESCRIPTION
## What is the purpose of the change

Integrate flink-connector-aws into Flink docs

Related https://github.com/apache/flink/pull/21450
https://github.com/apache/flink/pull/21449

## Brief change log

- Add a new short_code (`sql_connector_download_table`) to render SQL connector info for externalized connectors
- Integrate AWS connectors, flink-connector-dynamodb
- Sync changes from 1.16 to build mounted connector docs

## Verifying this change

Rendered web pages locally

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable 