### PR TITLE
[FLINK-30309][runtime] Allow users to supply custom SslContexts

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/SecurityOptions.java
@@ -217,6 +217,14 @@ public class SecurityOptions {
                     .withDescription(
                             "Turns on SSL for external communication via the REST endpoints.");
 
+    @Documentation.Section(Documentation.Sections.EXPERT_SECURITY_SSL)
+    public static final ConfigOption<String> SSL_REST_SSL_CONTEXT_SUPPLIER =
+            key("security.ssl.rest.ssl-context-supplier")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A fully qualified class name that implements the SslContextSupplier interface.");
+
     /** Enable mututal SSL authentication for external REST endpoints. */
     @Documentation.Section(Documentation.Sections.SECURITY_SSL)
     public static final ConfigOption<Boolean> SSL_REST_AUTHENTICATION_ENABLED =
@@ -497,6 +505,14 @@ public class SecurityOptions {
                                     .build());
 
     // ------------------------ ssl parameters --------------------------------
+
+    @Documentation.Section(Documentation.Sections.EXPERT_SECURITY_SSL)
+    public static final ConfigOption<String> SSL_INTERNAL_SSL_CONTEXT_SUPPLIER =
+            key("security.ssl.internal.ssl-context-supplier")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A fully qualified class name that implements the SslContextSupplier interface.");
 
     /** SSL session cache size. */
     @Documentation.Section(Documentation.Sections.EXPERT_SECURITY_SSL)

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/net/SslContextSupplier.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/net/SslContextSupplier.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.net;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslContext;
+import org.apache.flink.shaded.netty4.io.netty.handler.ssl.SslProvider;
+
+/** An interface that can produce {@link SslContext}s. */
+public interface SslContextSupplier {
+    SslContext get(Configuration configuration, boolean clientMode, SslProvider provider);
+}


### PR DESCRIPTION
## What is the purpose of the change

This change allows users/operators to override the default SslContext configuration/creation with a custom implementation.  For more advanced TLS deployments, the built-in flink configuration may not be sufficient.  

Additionally, a useful and intended side-effect of this is that SslContexts can be recreated if needed, rather than being only created once statically at startup.  This allows things like hot-reloading key material if it changes at runtime.


## Brief change log

  - Add `security.ssl.internal.ssl-context-supplier` and `security.ssl.rest.ssl-context-supplier` configuration settings for internal and REST communication respectively. If either are set to a valid class implementing `Supplier<SslContext>`, it will be used to provide SslContext instances when required.
  
## Verifying this change

This change added tests and can be verified as follows:

  - Added tests to SSLUtils that tests internal/rest and client/server variations of the suppliers.
  - Manually verified the change on cluster with multiple JobManagers and TaskManagers.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs
