### PR TITLE
[FLINK-28513] Fix Flink Table API CSV streaming sink throws SerializedThrowable exception

### DIFF
--- a/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableFsDataOutputStreamTest.java
+++ b/flink-filesystems/flink-s3-fs-base/src/test/java/org/apache/flink/fs/s3/common/writer/S3RecoverableFsDataOutputStreamTest.java
@@ -254,6 +254,16 @@ public class S3RecoverableFsDataOutputStreamTest {
         streamUnderTest.closeForCommit().commit();
     }
 
+    @Test(expected = Exception.class)
+    public void testSync() throws IOException {
+        streamUnderTest.write(bytesOf("hello"));
+        streamUnderTest.write(bytesOf(" world"));
+        streamUnderTest.sync();
+        assertThat(multipartUploadUnderTest, hasContent(bytesOf("hello world")));
+        streamUnderTest.write(randomBuffer(RefCountedBufferingFileStream.BUFFER_SIZE + 1));
+        assertThat(multipartUploadUnderTest, hasContent(bytesOf("hello world")));
+    }
+
     // ------------------------------------------------------------------------------------------------------------
     // Utils
     // ------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change

CSVBulkWriter calls `sync()` function at the closing time. sync() works for all the file system that are syncable in nature like hdfs and others. S3 currently don't support any `sync()` function. 


## Brief change log

This change modifies `sync()` method to flush all data in buffer and close file and commit the write.

## Verifying this change

1. Added unit test to test sync .
2. Verified in sample EMR cluster.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no 
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no 
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no 
