### PR TITLE
[hotfix] Replace deprecated Calcite's APIs

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserCalcitePlanner.java
@@ -62,7 +62,6 @@ import org.apache.calcite.plan.RelOptCluster;
 import org.apache.calcite.plan.RelTraitSet;
 import org.apache.calcite.plan.ViewExpanders;
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollationImpl;
 import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
@@ -1581,8 +1580,7 @@ public class HiveParserCalcitePlanner {
 
             // create rel node
             RelTraitSet traitSet = cluster.traitSet();
-            RelCollation canonizedCollation =
-                    traitSet.canonize(RelCollationImpl.of(fieldCollations));
+            RelCollation canonizedCollation = traitSet.canonize(RelCollations.of(fieldCollations));
             res = LogicalDistribution.create(realInput, canonizedCollation, distKeys);
 
             Map<String, Integer> hiveColNameCalcitePosMap = buildHiveToCalciteColumnMap(outputRR);
@@ -1740,8 +1738,7 @@ public class HiveParserCalcitePlanner {
 
             // 4. Construct SortRel
             RelTraitSet traitSet = cluster.traitSet();
-            RelCollation canonizedCollation =
-                    traitSet.canonize(RelCollationImpl.of(fieldCollations));
+            RelCollation canonizedCollation = traitSet.canonize(RelCollations.of(fieldCollations));
             sortRel = LogicalSort.create(obInputRel, canonizedCollation, null, null);
 
             // 5. Update the maps

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserDMLHelper.java
@@ -52,7 +52,7 @@ import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.Preconditions;
 
 import org.apache.calcite.rel.RelCollation;
-import org.apache.calcite.rel.RelCollationImpl;
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.SingleRel;
@@ -454,10 +454,7 @@ public class HiveParserDMLHelper {
             }
             shiftedCollations.add(fieldCollation);
         }
-        return plannerContext
-                .getCluster()
-                .traitSet()
-                .canonize(RelCollationImpl.of(shiftedCollations));
+        return plannerContext.getCluster().traitSet().canonize(RelCollations.of(shiftedCollations));
     }
 
     static RelNode addTypeConversions(
@@ -779,10 +776,7 @@ public class HiveParserDMLHelper {
             fieldCollation = fieldCollation.withFieldIndex(newIndex);
             updatedCollations.add(fieldCollation);
         }
-        return plannerContext
-                .getCluster()
-                .traitSet()
-                .canonize(RelCollationImpl.of(updatedCollations));
+        return plannerContext.getCluster().traitSet().canonize(RelCollations.of(updatedCollations));
     }
 
     private List<Integer> updateDistKeys(List<Integer> distKeys, List<Object> updatedIndices) {

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/HiveParserUtils.java
@@ -1685,6 +1685,7 @@ public class HiveParserUtils {
                 ignoreNulls,
                 argList,
                 filterArg,
+                null,
                 collation,
                 type,
                 name);

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserBaseSemanticAnalyzer.java
@@ -60,6 +60,7 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.rex.RexWindowBound;
+import org.apache.calcite.rex.RexWindowBounds;
 import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
@@ -972,12 +973,12 @@ public class HiveParserBaseSemanticAnalyzer {
                 case PRECEDING:
                     if (amt == null) {
                         res =
-                                RexWindowBound.create(
+                                RexWindowBounds.create(
                                         SqlWindow.createUnboundedPreceding(dummyPos), null);
                     } else {
                         SqlCall call = (SqlCall) SqlWindow.createPreceding(amt, dummyPos);
                         res =
-                                RexWindowBound.create(
+                                RexWindowBounds.create(
                                         call,
                                         cluster.getRexBuilder()
                                                 .makeCall(call.getOperator(), amtLiteral));
@@ -985,18 +986,18 @@ public class HiveParserBaseSemanticAnalyzer {
                     break;
 
                 case CURRENT:
-                    res = RexWindowBound.create(SqlWindow.createCurrentRow(dummyPos), null);
+                    res = RexWindowBounds.create(SqlWindow.createCurrentRow(dummyPos), null);
                     break;
 
                 case FOLLOWING:
                     if (amt == null) {
                         res =
-                                RexWindowBound.create(
+                                RexWindowBounds.create(
                                         SqlWindow.createUnboundedFollowing(dummyPos), null);
                     } else {
                         SqlCall call = (SqlCall) SqlWindow.createFollowing(amt, dummyPos);
                         res =
-                                RexWindowBound.create(
+                                RexWindowBounds.create(
                                         call,
                                         cluster.getRexBuilder()
                                                 .makeCall(call.getOperator(), amtLiteral));

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlCountAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlCountAggFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.delegation.hive.copy;
 
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.SqlAggFunction;
@@ -85,8 +86,12 @@ public class HiveParserSqlCountAggFunction extends SqlAggFunction
                             operandTypeInference,
                             operandTypeChecker),
                     false,
+                    false,
+                    false,
                     ImmutableIntList.of(),
                     -1,
+                    null,
+                    RelCollations.EMPTY,
                     typeFactory.createTypeWithNullability(
                             typeFactory.createSqlType(SqlTypeName.BIGINT), true),
                     "count");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlSumAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/planner/delegation/hive/copy/HiveParserSqlSumAggFunction.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.delegation.hive.copy;
 
+import org.apache.calcite.rel.RelCollations;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -100,8 +101,12 @@ public class HiveParserSqlSumAggFunction extends SqlAggFunction
                             operandTypeInference,
                             operandTypeChecker),
                     false,
+                    false,
+                    false,
                     ImmutableIntList.of(),
                     -1,
+                    null,
+                    RelCollations.EMPTY,
                     countRetType,
                     "count");
         }
@@ -145,8 +150,12 @@ public class HiveParserSqlSumAggFunction extends SqlAggFunction
                             operandTypeInference,
                             operandTypeChecker),
                     false,
+                    false,
+                    false,
                     Collections.singletonList(ordinal),
                     -1,
+                    null,
+                    RelCollations.EMPTY,
                     aggregateCall.type,
                     aggregateCall.name);
         }

--- a/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
+++ b/flink-table/flink-sql-parser-hive/src/main/java/org/apache/flink/sql/parser/hive/ddl/HiveDDLUtils.java
@@ -450,7 +450,8 @@ public class HiveDDLUtils {
             if (literal instanceof SqlCharStringLiteral) {
                 SqlCharStringLiteral stringLiteral = (SqlCharStringLiteral) literal;
                 String unescaped =
-                        StringEscapeUtils.unescapeJava(stringLiteral.getNlsString().getValue());
+                        StringEscapeUtils.unescapeJava(
+                                stringLiteral.getValueAs(NlsString.class).getValue());
                 return SqlLiteral.createCharString(unescaped, stringLiteral.getParserPosition());
             }
             return literal;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/calcite/RelTimeIndicatorConverter.java
@@ -453,6 +453,7 @@ public final class RelTimeIndicatorConverter extends RelHomogeneousShuttle {
                                         false,
                                         call.getArgList(),
                                         call.filterArg,
+                                        null,
                                         RelCollations.EMPTY,
                                         callType,
                                         call.name);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/OverConvertRule.java
@@ -38,6 +38,7 @@ import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexFieldCollation;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexWindowBound;
+import org.apache.calcite.rex.RexWindowBounds;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlKind;
@@ -189,11 +190,11 @@ public class OverConvertRule implements CallExpressionConvertRule {
                         sqlKind.equals(SqlKind.PRECEDING)
                                 ? SqlWindow.createUnboundedPreceding(SqlParserPos.ZERO)
                                 : SqlWindow.createUnboundedFollowing(SqlParserPos.ZERO);
-                return RexWindowBound.create(unbounded, null);
+                return RexWindowBounds.create(unbounded, null);
             } else if (BuiltInFunctionDefinitions.CURRENT_ROW.equals(func)
                     || BuiltInFunctionDefinitions.CURRENT_RANGE.equals(func)) {
                 SqlNode currentRow = SqlWindow.createCurrentRow(SqlParserPos.ZERO);
-                return RexWindowBound.create(currentRow, null);
+                return RexWindowBounds.create(currentRow, null);
             } else {
                 throw new IllegalArgumentException("Unexpected expression: " + bound);
             }
@@ -228,7 +229,7 @@ public class OverConvertRule implements CallExpressionConvertRule {
                     context.getRelBuilder()
                             .getRexBuilder()
                             .makeCall(returnType, sqlOperator, expressions);
-            return RexWindowBound.create(node, rexNode);
+            return RexWindowBounds.create(node, rexNode);
         } else {
             throw new TableException("Unexpected expression: " + bound);
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -43,6 +43,7 @@ import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.util.NlsString;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -179,7 +180,7 @@ class SqlCreateTableConverter {
         String tableComment =
                 sqlCreateTable
                         .getComment()
-                        .map(comment -> comment.getNlsString().getValue())
+                        .map(comment -> comment.getValueAs(NlsString.class).getValue())
                         .orElse(null);
 
         return new CatalogTableImpl(mergedSchema, partitionKeys, mergedOptions, tableComment);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -203,6 +203,7 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.calcite.sql.SqlUtil;
 import org.apache.calcite.sql.dialect.CalciteSqlDialect;
 import org.apache.calcite.sql.parser.SqlParser;
+import org.apache.calcite.util.NlsString;
 
 import java.math.BigDecimal;
 import java.sql.Date;
@@ -910,7 +911,7 @@ public class SqlToOperationConverter {
         String databaseComment =
                 sqlCreateDatabase
                         .getComment()
-                        .map(comment -> comment.getNlsString().getValue())
+                        .map(comment -> comment.getValueAs(NlsString.class).getValue())
                         .orElse(null);
         // set with properties
         Map<String, String> properties = new HashMap<>();
@@ -1094,7 +1095,10 @@ public class SqlToOperationConverter {
         ObjectIdentifier identifier = catalogManager.qualifyIdentifier(unresolvedIdentifier);
 
         String comment =
-                sqlCreateView.getComment().map(c -> c.getNlsString().getValue()).orElse(null);
+                sqlCreateView
+                        .getComment()
+                        .map(c -> c.getValueAs(NlsString.class).getValue())
+                        .orElse(null);
         CatalogView catalogView =
                 convertViewQuery(
                         query,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/AggregateCallJsonDeserializer.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/serde/AggregateCallJsonDeserializer.java
@@ -85,6 +85,7 @@ final class AggregateCallJsonDeserializer extends StdDeserializer<AggregateCall>
                 ignoreNulls,
                 argList,
                 filterArg,
+                null,
                 RelCollations.EMPTY,
                 relDataType,
                 name);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateExpandDistinctAggregatesRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkAggregateExpandDistinctAggregatesRule.java
@@ -821,6 +821,7 @@ public final class FlinkAggregateExpandDistinctAggregatesRule extends RelOptRule
                             false,
                             newArgs,
                             newFilterArg,
+                            null,
                             RelCollations.EMPTY,
                             aggCall.getType(),
                             aggCall.getName());
@@ -914,6 +915,7 @@ public final class FlinkAggregateExpandDistinctAggregatesRule extends RelOptRule
                             false,
                             newArgs,
                             -1,
+                            null,
                             RelCollations.EMPTY,
                             aggCall.getType(),
                             aggCall.getName());

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/MatchCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/MatchCodeGenerator.scala
@@ -46,6 +46,7 @@ import _root_.scala.collection.JavaConversions._
 import _root_.scala.collection.JavaConverters._
 import _root_.scala.collection.mutable
 import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.SqlAggFunction
@@ -673,8 +674,11 @@ class MatchCodeGenerator(
             a.sqlAggFunction,
             false,
             false,
+            false,
             a.exprIndices,
             -1,
+            null,
+            RelCollations.EMPTY,
             a.resultType,
             a.sqlAggFunction.getName))
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimator.scala
@@ -166,8 +166,9 @@ class AggCallSelectivityEstimator(agg: RelNode, mq: FlinkRelMetadataQuery)
         Some(1.0)
       } else {
         val rexSimplify =
-          new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY, true, RexUtil.EXECUTOR)
-        val simplifiedPredicate = rexSimplify.simplify(predicate)
+          new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY, RexUtil.EXECUTOR)
+        val simplifiedPredicate =
+          rexSimplify.simplifyUnknownAs(predicate, RexUnknownAs.falseIf(true))
         if (simplifiedPredicate.isAlwaysTrue) {
           Some(1.0)
         } else if (simplifiedPredicate.isAlwaysFalse) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/SelectivityEstimator.scala
@@ -83,8 +83,9 @@ class SelectivityEstimator(rel: RelNode, mq: FlinkRelMetadataQuery)
         Some(1.0)
       } else {
         val rexSimplify =
-          new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY, true, RexUtil.EXECUTOR)
-        val simplifiedPredicate = rexSimplify.simplify(predicate)
+          new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY, RexUtil.EXECUTOR)
+        val simplifiedPredicate =
+          rexSimplify.simplifyUnknownAs(predicate, RexUnknownAs.falseIf(true))
         if (simplifiedPredicate.isAlwaysTrue) {
           Some(1.0)
         } else if (simplifiedPredicate.isAlwaysFalse) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/WindowAggregate.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/calcite/WindowAggregate.scala
@@ -26,6 +26,7 @@ import org.apache.calcite.plan.{RelOptCluster, RelTraitSet}
 import org.apache.calcite.rel.`type`.RelDataType
 import org.apache.calcite.rel.{RelNode, RelShuttle, RelWriter}
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
+import org.apache.calcite.rel.hint.RelHint
 import org.apache.calcite.util.ImmutableBitSet
 
 import java.util
@@ -45,7 +46,14 @@ abstract class WindowAggregate(
     aggCalls: util.List[AggregateCall],
     window: LogicalWindow,
     namedProperties: util.List[NamedWindowProperty])
-  extends Aggregate(cluster, traitSet, child, groupSet, ImmutableList.of(groupSet), aggCalls) {
+  extends Aggregate(
+    cluster,
+    traitSet,
+    new util.ArrayList[RelHint],
+    child,
+    groupSet,
+    ImmutableList.of(groupSet),
+    aggCalls) {
 
   def getWindow: LogicalWindow = window
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/AggregateReduceGroupingRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/AggregateReduceGroupingRule.scala
@@ -23,6 +23,7 @@ import org.apache.flink.table.planner.plan.metadata.FlinkRelMetadataQuery
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall, RelFactories}
 import org.apache.calcite.rel.core.Aggregate.Group
 import org.apache.calcite.tools.RelBuilderFactory
@@ -92,8 +93,11 @@ class AggregateReduceGroupingRule(relBuilderFactory: RelBuilderFactory)
           FlinkSqlOperatorTable.AUXILIARY_GROUP,
           false,
           false,
+          false,
           ImmutableList.of(column),
           -1,
+          null,
+          RelCollations.EMPTY,
           fieldType,
           fieldName)
     }.toList

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/SplitAggregateRule.scala
@@ -32,6 +32,7 @@ import org.apache.flink.table.planner.utils.ShortcutUtils.unwrapTableConfig
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall}
 import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.rex.{RexInputRef, RexNode}
 import org.apache.calcite.sql.{SqlAggFunction, SqlKind}
@@ -222,12 +223,16 @@ class SplitAggregateRule
               aggFunc,
               aggCall.isDistinct,
               aggCall.isApproximate,
+              false,
               aggCall.getArgList,
               aggCall.filterArg,
+              null,
+              RelCollations.EMPTY,
               fullGroupSet.cardinality,
               relBuilder.peek(),
               null,
-              null)
+              null
+            )
         }
         partialAggCalls.addAll(newAggCalls)
         newAggCalls.foreach {
@@ -323,8 +328,11 @@ class SplitAggregateRule
               aggFunction,
               false,
               aggCall.isApproximate,
+              false,
               newArgList,
               -1,
+              null,
+              RelCollations.EMPTY,
               originalAggregate.getGroupCount,
               relBuilder.peek(),
               null,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/AggregateUtil.scala
@@ -56,6 +56,7 @@ import org.apache.flink.table.types.logical.utils.LogicalTypeChecks
 import org.apache.flink.table.types.utils.DataTypeUtils
 
 import org.apache.calcite.rel.`type`._
+import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall}
 import org.apache.calcite.rel.core.Aggregate.AggCallBinding
 import org.apache.calcite.sql.`type`.{SqlTypeName, SqlTypeUtil}
@@ -761,10 +762,14 @@ object AggregateUtil extends Enumeration {
         SqlStdOperatorTable.COUNT,
         false,
         false,
+        false,
         new util.ArrayList[Integer](),
         -1,
+        null,
+        RelCollations.EMPTY,
         typeFactory.createSqlType(SqlTypeName.BIGINT),
-        "_$count1$_")
+        "_$count1$_"
+      )
 
       indexOfCountStar = Some(aggregateCalls.length)
       countStarInserted = true
@@ -835,8 +840,11 @@ object AggregateUtil extends Enumeration {
             call.getAggregation,
             false,
             false,
+            false,
             call.getArgList,
             -1, // remove filterArg
+            null,
+            RelCollations.EMPTY,
             call.getType,
             call.getName)
         } else {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -213,8 +213,8 @@ object FlinkRexUtil {
     val binaryComparisonExprReduced =
       sameExprMerged.accept(new BinaryComparisonExprReducer(rexBuilder))
 
-    val rexSimplify = new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY, true, executor)
-    rexSimplify.simplify(binaryComparisonExprReduced)
+    val rexSimplify = new RexSimplify(rexBuilder, RelOptPredicateList.EMPTY, executor)
+    rexSimplify.simplifyUnknownAs(binaryComparisonExprReduced, RexUnknownAs.falseIf(true))
   }
 
   val BINARY_COMPARISON: util.Set[SqlKind] = util.EnumSet.of(

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/AggCallSelectivityEstimatorTest.scala
@@ -28,6 +28,7 @@ import org.apache.flink.util.Preconditions
 import com.google.common.collect.ImmutableList
 import org.apache.calcite.jdbc.CalciteSchema
 import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.{Aggregate, AggregateCall, TableScan}
 import org.apache.calcite.rel.logical.LogicalAggregate
 import org.apache.calcite.rel.metadata.{JaninoRelMetadataProvider, RelMetadataQueryBase}
@@ -103,8 +104,11 @@ class AggCallSelectivityEstimatorTest {
           sqlAggFun,
           false,
           false,
+          false,
           ImmutableList.of(Integer.valueOf(arg)),
           -1,
+          null,
+          RelCollations.EMPTY,
           groupSet.length,
           scan,
           aggCallType,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -973,7 +973,7 @@ class FlinkRelMdHandlerTestBase {
       false,
       Seq(Integer.valueOf(3)).toList,
       -1,
-      RelCollationImpl.of(),
+      RelCollations.of(),
       relDataType,
       ""
     )
@@ -1685,8 +1685,11 @@ class FlinkRelMdHandlerTestBase {
         new SqlCountAggFunction("COUNT"),
         false,
         false,
+        false,
         List[Integer](3),
         -1,
+        null,
+        RelCollations.EMPTY,
         2,
         project,
         null,
@@ -1852,8 +1855,11 @@ class FlinkRelMdHandlerTestBase {
         new SqlCountAggFunction("COUNT"),
         false,
         false,
+        false,
         List[Integer](0),
         -1,
+        null,
+        RelCollations.EMPTY,
         1,
         project,
         null,
@@ -2018,8 +2024,11 @@ class FlinkRelMdHandlerTestBase {
         FlinkSqlOperatorTable.AUXILIARY_GROUP,
         false,
         false,
+        false,
         List[Integer](1),
         -1,
+        null,
+        RelCollations.EMPTY,
         1,
         project,
         null,
@@ -2028,8 +2037,11 @@ class FlinkRelMdHandlerTestBase {
         new SqlCountAggFunction("COUNT"),
         false,
         false,
+        false,
         List[Integer](3),
         -1,
+        null,
+        RelCollations.EMPTY,
         2,
         project,
         null,
@@ -2371,9 +2383,9 @@ class FlinkRelMdHandlerTestBase {
     new Window.Group(
       ImmutableBitSet.of(0),
       true,
-      RexWindowBound.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(0, 0)), null),
-      RexWindowBound.create(SqlWindow.createCurrentRow(new SqlParserPos(0, 0)), null),
-      RelCollationImpl.of(
+      RexWindowBounds.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(0, 0)), null),
+      RexWindowBounds.create(SqlWindow.createCurrentRow(new SqlParserPos(0, 0)), null),
+      RelCollations.of(
         new RelFieldCollation(
           1,
           RelFieldCollation.Direction.ASCENDING,
@@ -2384,6 +2396,7 @@ class FlinkRelMdHandlerTestBase {
           longType,
           ImmutableList.of[RexNode](),
           0,
+          false,
           false
         )
       )
@@ -2503,9 +2516,9 @@ class FlinkRelMdHandlerTestBase {
       new Window.Group(
         ImmutableBitSet.of(5),
         true,
-        RexWindowBound.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(0, 0)), null),
-        RexWindowBound.create(SqlWindow.createCurrentRow(new SqlParserPos(0, 0)), null),
-        RelCollationImpl.of(
+        RexWindowBounds.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(0, 0)), null),
+        RexWindowBounds.create(SqlWindow.createCurrentRow(new SqlParserPos(0, 0)), null),
+        RelCollations.of(
           new RelFieldCollation(
             1,
             RelFieldCollation.Direction.ASCENDING,
@@ -2516,6 +2529,7 @@ class FlinkRelMdHandlerTestBase {
             longType,
             ImmutableList.of[RexNode](),
             0,
+            false,
             false
           )
         )
@@ -2523,9 +2537,9 @@ class FlinkRelMdHandlerTestBase {
       new Window.Group(
         ImmutableBitSet.of(5),
         false,
-        RexWindowBound.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(4, 15)), null),
-        RexWindowBound.create(SqlWindow.createCurrentRow(new SqlParserPos(0, 0)), null),
-        RelCollationImpl.of(
+        RexWindowBounds.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(4, 15)), null),
+        RexWindowBounds.create(SqlWindow.createCurrentRow(new SqlParserPos(0, 0)), null),
+        RelCollations.of(
           new RelFieldCollation(
             2,
             RelFieldCollation.Direction.ASCENDING,
@@ -2536,6 +2550,7 @@ class FlinkRelMdHandlerTestBase {
             longType,
             ImmutableList.of[RexNode](),
             1,
+            false,
             false
           ),
           new Window.RexWinAggCall(
@@ -2543,6 +2558,7 @@ class FlinkRelMdHandlerTestBase {
             longType,
             ImmutableList.of[RexNode](),
             2,
+            false,
             false
           ),
           new Window.RexWinAggCall(
@@ -2550,6 +2566,7 @@ class FlinkRelMdHandlerTestBase {
             longType,
             util.Arrays.asList(new RexInputRef(2, longType)),
             3,
+            false,
             false
           ),
           new Window.RexWinAggCall(
@@ -2557,6 +2574,7 @@ class FlinkRelMdHandlerTestBase {
             doubleType,
             util.Arrays.asList(new RexInputRef(2, doubleType)),
             4,
+            false,
             false
           )
         )
@@ -2564,8 +2582,8 @@ class FlinkRelMdHandlerTestBase {
       new Window.Group(
         ImmutableBitSet.of(),
         false,
-        RexWindowBound.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(7, 19)), null),
-        RexWindowBound.create(SqlWindow.createUnboundedFollowing(new SqlParserPos(0, 0)), null),
+        RexWindowBounds.create(SqlWindow.createUnboundedPreceding(new SqlParserPos(7, 19)), null),
+        RexWindowBounds.create(SqlWindow.createUnboundedFollowing(new SqlParserPos(0, 0)), null),
         RelCollations.EMPTY,
         ImmutableList.of(
           new Window.RexWinAggCall(
@@ -2573,6 +2591,7 @@ class FlinkRelMdHandlerTestBase {
             doubleType,
             util.Arrays.asList(new RexInputRef(2, doubleType)),
             5,
+            false,
             false
           ),
           new Window.RexWinAggCall(
@@ -2580,6 +2599,7 @@ class FlinkRelMdHandlerTestBase {
             longType,
             util.Arrays.asList(new RexInputRef(0, longType)),
             6,
+            false,
             false
           )
         )

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdHandlerTestBase.scala
@@ -973,6 +973,7 @@ class FlinkRelMdHandlerTestBase {
       false,
       Seq(Integer.valueOf(3)).toList,
       -1,
+      null,
       RelCollations.of(),
       relDataType,
       ""

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCountTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdRowCountTest.scala
@@ -21,6 +21,7 @@ import org.apache.flink.table.planner.plan.nodes.calcite.LogicalWindowAggregate
 import org.apache.flink.table.planner.plan.utils.FlinkRelMdUtil
 
 import com.google.common.collect.Lists
+import org.apache.calcite.rel.RelCollations
 import org.apache.calcite.rel.core.AggregateCall
 import org.apache.calcite.sql.fun.SqlCountAggFunction
 import org.apache.calcite.util.ImmutableBitSet
@@ -172,8 +173,11 @@ class FlinkRelMdRowCountTest extends FlinkRelMdHandlerTestBase {
         new SqlCountAggFunction("COUNT"),
         false,
         false,
+        false,
         List[Integer](3),
         -1,
+        null,
+        RelCollations.EMPTY,
         2,
         ts,
         null,

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdSelectivityTest.scala
@@ -24,10 +24,10 @@ import org.apache.flink.table.planner.plan.nodes.physical.batch.{BatchPhysicalCa
 import org.apache.flink.table.planner.plan.utils.ExpandUtil
 
 import com.google.common.collect.{ImmutableList, Lists}
-import org.apache.calcite.rel.{RelCollationImpl, RelCollations, RelFieldCollation}
+import org.apache.calcite.rel.{RelCollations, RelFieldCollation}
 import org.apache.calcite.rel.core.{AggregateCall, CorrelationId, JoinRelType, Window}
 import org.apache.calcite.rel.logical.LogicalJoin
-import org.apache.calcite.rex.{RexInputRef, RexNode, RexProgram, RexUtil, RexWindowBound, RexWindowBounds}
+import org.apache.calcite.rex.{RexInputRef, RexNode, RexProgram, RexUtil, RexWindowBounds}
 import org.apache.calcite.sql.`type`.SqlTypeName.{BIGINT, DOUBLE}
 import org.apache.calcite.sql.SqlWindow
 import org.apache.calcite.sql.fun.{SqlCountAggFunction, SqlStdOperatorTable}


### PR DESCRIPTION
## What is the purpose of the change

1. `org.apache.calcite.sql.SqlCharStringLiteral#getNlsString` was made deprecated at
https://github.com/apache/calcite/commit/a1bdba6d79ac05ef227cdb15b7c044c6e0e54dfa#diff-de2027de5bcb4bbe94314c3414b63166ecd9537b437e08d39f6424c0f903c8fbR48
and as suggested in the same place
    ```
    * @deprecated Use {@link #getValueAs getValueAs(NlsString.class)}
    ```
2. `org.apache.calcite.rex.RexSimplify#RexSimplify(RexBuilder, RelOptPredicateList, boolean, RexExecutor)` was made deprecated at https://issues.apache.org/jira/browse/CALCITE-2604
and it is recommended
   ```
   * @deprecated Use methods with a {@link RexUnknownAs} argument, such as
   * {@link #simplify(RexNode, RexUnknownAs)}. */
   ```
3. `org.apache.calcite.rel.core.AggregateCall#create(SqlAggFunction, boolean, boolean, boolean, List<Integer>, int, RelCollation, RelDataType, String)` was made deprecated at https://issues.apache.org/jira/browse/CALCITE-4483
now distinct keys should be specified

4. `org.apache.calcite.rel.core.Aggregate#Aggregate(RelOptCluster, RelTraitSet, RelNode, ImmutableBitSet, List<ImmutableBitSet>, List<AggregateCall>)` was deprecated at https://issues.apache.org/jira/browse/CALCITE-3723
now hints should be specified

UPDATE:

5. `org.apache.calcite.rex.RexWindowBound#create` was deprecated at https://issues.apache.org/jira/browse/CALCITE-3877. In javadoc it is recommended to use `org.apache.calcite.rex.RexWindowBounds#create` 

6. `org.apache.calcite.rel.RelCollationImpl#of(org.apache.calcite.rel.RelFieldCollation...)` is deprecated at https://issues.apache.org/jira/browse/CALCITE-572. `org.apache.calcite.rel.RelCollations#of(org.apache.calcite.rel.RelFieldCollation...)` should be used instead

7. `org.apache.calcite.rel.core.Window.RexWinAggCall#RexWinAggCall(SqlAggFunction, RelDataType, List<RexNode>, int, boolean)` is deprecated at  https://issues.apache.org/jira/browse/CALCITE-883. `org.apache.calcite.rel.core.Window.RexWinAggCall#RexWinAggCall(SqlAggFunction, RelDataType, List<RexNode>, int, boolean, boolean)` should be used instead

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
