### PR TITLE
[FLINK-30316][statebackend] Migrate tests to JUnit5

### DIFF
--- a/flink-state-backends/flink-statebackend-common/pom.xml
+++ b/flink-state-backends/flink-statebackend-common/pom.xml
@@ -74,4 +74,25 @@ under the License.
 
     </dependencies>
 
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>test-jar</goal>
+						</goals>
+						<configuration>
+							<excludes>
+								<!-- test-jar is still used by JUnit4 modules -->
+								<exclude>META-INF/services/org.junit.jupiter.api.extension.Extension</exclude>
+							</excludes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
+++ b/flink-state-backends/flink-statebackend-common/src/test/java/org/apache/flink/state/common/PeriodicMaterializationManagerTest.java
@@ -21,21 +21,19 @@ import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorSer
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.state.common.PeriodicMaterializationManager.MaterializationTarget;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.flink.shaded.guava30.com.google.common.collect.Iterators.getOnlyElement;
 import static org.apache.flink.util.concurrent.Executors.newDirectExecutorService;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** {@link PeriodicMaterializationManager} test. */
-public class PeriodicMaterializationManagerTest extends TestLogger {
+class PeriodicMaterializationManagerTest {
 
     @Test
-    public void testInitialDelay() {
+    void testInitialDelay() {
         ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
                 new ManuallyTriggeredScheduledExecutorService();
         long periodicMaterializeDelay = 10_000L;
@@ -56,12 +54,16 @@ public class PeriodicMaterializationManagerTest extends TestLogger {
             test.start();
 
             assertThat(
-                    String.format(
-                            "task for initial materialization should be scheduled with a 0..%d delay",
-                            periodicMaterializeDelay),
-                    getOnlyElement(scheduledExecutorService.getAllScheduledTasks().iterator())
-                            .getDelay(MILLISECONDS),
-                    lessThanOrEqualTo(periodicMaterializeDelay));
+                            getOnlyElement(
+                                            scheduledExecutorService
+                                                    .getAllScheduledTasks()
+                                                    .iterator())
+                                    .getDelay(MILLISECONDS))
+                    .as(
+                            String.format(
+                                    "task for initial materialization should be scheduled with a 0..%d delay",
+                                    periodicMaterializeDelay))
+                    .isLessThanOrEqualTo(periodicMaterializeDelay);
         }
     }
 }

--- a/flink-state-backends/flink-statebackend-common/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-state-backends/flink-statebackend-common/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

Move tests to junit5 and assertj

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
