### PR TITLE
[FLINK-30299][core] Adds thread dump creation to FatalExitExceptionHandler

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/util/FatalExitExceptionHandler.java
+++ b/flink-core/src/main/java/org/apache/flink/util/FatalExitExceptionHandler.java
@@ -19,6 +19,7 @@
 package org.apache.flink.util;
 
 import org.apache.flink.core.security.FlinkSecurityManager;
+import org.apache.flink.util.concurrent.ThreadUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ public final class FatalExitExceptionHandler implements Thread.UncaughtException
                     "FATAL: Thread '{}' produced an uncaught exception. Stopping the process...",
                     t.getName(),
                     e);
+            ThreadUtils.errorLogThreadDump(LOG);
         } finally {
             FlinkSecurityManager.forceProcessExit(EXIT_CODE);
         }

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/ThreadUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/ThreadUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.util.concurrent;
+
+import org.slf4j.Logger;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/** {@code ThreadUtils} collects helper methods in the context of threading. */
+public class ThreadUtils {
+
+    public static void errorLogThreadDump(Logger logger) {
+        final ThreadInfo[] perThreadInfo =
+                ManagementFactory.getThreadMXBean().dumpAllThreads(true, true);
+        logger.error(
+                "Thread dump: \n{}",
+                Arrays.stream(perThreadInfo).map(Object::toString).collect(Collectors.joining()));
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

It's hard to investigate FLINK-30299. Adding the thread dump might help us identlifying the cause or at least having a pointer what to focus on.

## Brief change log

* Introduced new utility class `ThreadUtils` providing a method for generating the thread dump based on Java's MXBean framework 

## Verifying this change

* Executed (in a unit test) the `FataExitExceptionHandler` and verified the output

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
