### PR TITLE
[FLINK-30334][runtime] Fix noMoreSplits event handling for HybridSource

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsIntermediateNoMoreSplits.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsIntermediateNoMoreSplits.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A decorative interface of {@link SplitEnumeratorContext} which allows to handle intermediate
+ * NoMoreSplits.
+ *
+ * <p>The split enumerator must implement this interface if it needs to deal with NoMoreSplits event
+ * in cases of a subtask can have multiple child sources. e.g. hybrid source.
+ */
+@Internal
+public interface SupportsIntermediateNoMoreSplits {
+    /**
+     * Signals a subtask that it will not receive split for current source, but it will receive
+     * split for next sources. A common scenario is HybridSource. This indicates that task not truly
+     * read finished.
+     *
+     * @param subtask The index of the operator's parallel subtask that shall be signaled it will
+     *     receive splits later.
+     */
+    void signalIntermediateNoMoreSplits(int subtask);
+}

--- a/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
+++ b/flink-core/src/test/java/org/apache/flink/api/connector/source/mocks/MockSplitEnumeratorContext.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceSplit;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.apache.flink.api.connector.source.SupportsIntermediateNoMoreSplits;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
 import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
 import org.apache.flink.util.ThrowableCatchingRunnable;
@@ -49,7 +50,7 @@ import java.util.function.BiConsumer;
 
 /** A mock class for {@link SplitEnumeratorContext}. */
 public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
-        implements SplitEnumeratorContext<SplitT>, AutoCloseable {
+        implements SplitEnumeratorContext<SplitT>, SupportsIntermediateNoMoreSplits, AutoCloseable {
     private final Map<Integer, List<SourceEvent>> sentSourceEvent;
     private final ConcurrentMap<Integer, ReaderInfo> registeredReaders;
     private final List<SplitsAssignment<SplitT>> splitsAssignmentSequence;
@@ -61,6 +62,7 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
     private final BlockingQueue<Callable<Future<?>>> oneTimeCallables;
     private final List<Callable<Future<?>>> periodicCallables;
     private final AtomicBoolean stoppedAcceptAsyncCalls;
+    private final boolean[] subtaskHasNoMoreSplits;
 
     private final int parallelism;
 
@@ -78,6 +80,7 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
                 getExecutor(getThreadFactory("SplitEnumerator-worker", errorInWorkerThread));
         this.mainExecutor = getExecutor(mainThreadFactory);
         this.stoppedAcceptAsyncCalls = new AtomicBoolean(false);
+        this.subtaskHasNoMoreSplits = new boolean[parallelism];
     }
 
     @Override
@@ -120,7 +123,16 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
     }
 
     @Override
-    public void signalNoMoreSplits(int subtask) {}
+    public void signalNoMoreSplits(int subtask) {
+        subtaskHasNoMoreSplits[subtask] = true;
+    }
+
+    @Override
+    public void signalIntermediateNoMoreSplits(int subtask) {}
+
+    public void resetNoMoreSplits(int subtask) {
+        subtaskHasNoMoreSplits[subtask] = false;
+    }
 
     @Override
     public <T> void callAsync(Callable<T> callable, BiConsumer<T, Throwable> handler) {
@@ -227,6 +239,10 @@ public class MockSplitEnumeratorContext<SplitT extends SourceSplit>
 
     public List<SplitsAssignment<SplitT>> getSplitsAssignmentSequence() {
         return splitsAssignmentSequence;
+    }
+
+    public boolean hasNoMoreSplits(int subtaskIndex) {
+        return subtaskHasNoMoreSplits[subtaskIndex];
     }
 
     // ------------- private helpers -------------

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContextTest.java
@@ -223,6 +223,26 @@ class SourceCoordinatorContextTest extends SourceCoordinatorTestBase {
         assertThat(operatorCoordinatorContext.isJobFailed()).isFalse();
     }
 
+    @Test
+    void testSupportsIntermediateNoMoreSplits() throws Exception {
+        sourceReady();
+        registerReaders();
+
+        SplitsAssignment<MockSourceSplit> splitsAssignment = getSplitsAssignment(2, 0);
+        context.assignSplits(splitsAssignment);
+        context.signalIntermediateNoMoreSplits(0);
+        context.signalIntermediateNoMoreSplits(1);
+        assertThat(context.hasNoMoreSplits(0)).isFalse();
+        assertThat(context.hasNoMoreSplits(1)).isFalse();
+        assertThat(context.hasNoMoreSplits(2)).isFalse();
+
+        context.signalNoMoreSplits(0);
+        context.signalNoMoreSplits(1);
+        assertThat(context.hasNoMoreSplits(0)).isTrue();
+        assertThat(context.hasNoMoreSplits(1)).isTrue();
+        assertThat(context.hasNoMoreSplits(2)).isFalse();
+    }
+
     // ------------------------
 
     private List<ReaderInfo> registerReaders() {


### PR DESCRIPTION
## What is the purpose of the change

SourceCoordinator#handleRequestSplitEvent hasNoMoreSplits check not consider the HybridSource situation. It will cause HybridSource do not read next child sources data and finally lead to data loss and unexpected runtime behavior.

## Brief change log

Add an intercept strategy for hasNoMoreSplits checking correctly of HybridSourceSplitEnumerator.

## Verifying this change
Add 2 new cases to cover the code path about the issue.

HybridSourceSplitEnumeratorTest#testInterceptNoMoreSplitEvent
SourceCoordinatorContextTest#testSignalNoMoreSplits

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable