### PR TITLE
[FLINK-30345][state/changelog] Avoid using sync DataOutputViewStreamWrapper to serialize records to changelog

### DIFF
--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractStateChangeLogger.java
@@ -17,7 +17,8 @@
 
 package org.apache.flink.state.changelog;
 
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputSerializer;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
@@ -27,11 +28,8 @@ import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshotReadersWriters;
 import org.apache.flink.util.function.ThrowingConsumer;
 
-import org.apache.flink.shaded.guava30.com.google.common.io.Closer;
-
 import javax.annotation.Nullable;
 
-import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
 
@@ -55,8 +53,7 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
     protected final InternalKeyContext<Key> keyContext;
     protected RegisteredStateMetaInfoBase metaInfo;
     private final StateMetaInfoSnapshot.BackendStateType stateType;
-    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    private final DataOutputViewStreamWrapper wrapper = new DataOutputViewStreamWrapper(out);
+    private final DataOutputSerializer out = new DataOutputSerializer(128);
     private boolean metaDataWritten = false;
     private final short stateShortId;
 
@@ -96,8 +93,7 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
         }
     }
 
-    protected abstract void serializeValue(Value value, DataOutputViewStreamWrapper out)
-            throws IOException;
+    protected abstract void serializeValue(Value value, DataOutputView out) throws IOException;
 
     @Override
     public void valueAdded(Value addedValue, Ns ns) throws IOException {
@@ -111,21 +107,21 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
 
     @Override
     public void valueElementAdded(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, Ns ns)
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, Ns ns)
             throws IOException {
         log(ADD_ELEMENT, dataSerializer, ns);
     }
 
     @Override
     public void valueElementAddedOrUpdated(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, Ns ns)
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, Ns ns)
             throws IOException {
         log(ADD_OR_UPDATE_ELEMENT, dataSerializer, ns);
     }
 
     @Override
     public void valueElementRemoved(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, Ns ns)
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, Ns ns)
             throws IOException {
         log(REMOVE_ELEMENT, dataSerializer, ns);
     }
@@ -148,7 +144,7 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
 
     protected void log(
             StateChangeOperation op,
-            @Nullable ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataWriter,
+            @Nullable ThrowingConsumer<DataOutputView, IOException> dataWriter,
             Ns ns)
             throws IOException {
         logMetaIfNeeded();
@@ -176,12 +172,12 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
         }
     }
 
-    protected void writeDefaultValueAndTtl(DataOutputViewStreamWrapper out) throws IOException {}
+    protected void writeDefaultValueAndTtl(DataOutputView out) throws IOException {}
 
     private byte[] serialize(
             StateChangeOperation op,
             Ns ns,
-            @Nullable ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataWriter)
+            @Nullable ThrowingConsumer<DataOutputView, IOException> dataWriter)
             throws IOException {
         return serializeRaw(
                 wrapper -> {
@@ -194,24 +190,18 @@ abstract class AbstractStateChangeLogger<Key, Value, Ns>
                 });
     }
 
-    protected abstract void serializeScope(Ns ns, DataOutputViewStreamWrapper out)
-            throws IOException;
+    protected abstract void serializeScope(Ns ns, DataOutputView out) throws IOException;
 
-    private byte[] serializeRaw(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataWriter)
+    private byte[] serializeRaw(ThrowingConsumer<DataOutputView, IOException> dataWriter)
             throws IOException {
-        dataWriter.accept(wrapper);
-        wrapper.flush();
-        byte[] bytes = out.toByteArray();
-        out.reset();
+        dataWriter.accept(out);
+        byte[] bytes = out.getCopyOfBuffer();
+        out.clear();
         return bytes;
     }
 
     @Override
     public void close() throws IOException {
-        try (Closer closer = Closer.create()) {
-            closer.register(wrapper);
-            closer.register(out);
-        }
+        // do nothing
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogMapState.java
@@ -21,7 +21,7 @@ package org.apache.flink.state.changelog;
 import org.apache.flink.api.common.state.MapState;
 import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.typeutils.base.MapSerializer;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.changelog.StateChange;
 import org.apache.flink.runtime.state.heap.InternalKeyContext;
 import org.apache.flink.runtime.state.internal.InternalKvState;
@@ -199,15 +199,15 @@ class ChangelogMapState<K, N, UK, UV>
         }
     }
 
-    private void serializeValue(UV value, DataOutputViewStreamWrapper out) throws IOException {
+    private void serializeValue(UV value, DataOutputView out) throws IOException {
         getMapSerializer().getValueSerializer().serialize(value, out);
     }
 
-    private void serializeKey(UK key, DataOutputViewStreamWrapper out) throws IOException {
+    private void serializeKey(UK key, DataOutputView out) throws IOException {
         getMapSerializer().getKeySerializer().serialize(key, out);
     }
 
-    private ThrowingConsumer<DataOutputViewStreamWrapper, IOException> getWriter(UK key, UV value) {
+    private ThrowingConsumer<DataOutputView, IOException> getWriter(UK key, UV value) {
         return out -> {
             serializeKey(key, out);
             serializeValue(value, out);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/KvStateChangeLoggerImpl.java
@@ -19,7 +19,8 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.state.StateTtlConfig;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.ByteArrayOutputStreamWithPos;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.RegisteredKeyValueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
@@ -78,21 +79,25 @@ class KvStateChangeLoggerImpl<Key, Value, Ns> extends AbstractStateChangeLogger<
     }
 
     @Override
-    protected void serializeValue(Value value, DataOutputViewStreamWrapper out) throws IOException {
+    protected void serializeValue(Value value, DataOutputView out) throws IOException {
         valueSerializer.serialize(value, out);
     }
 
     @Override
-    protected void serializeScope(Ns ns, DataOutputViewStreamWrapper out) throws IOException {
+    protected void serializeScope(Ns ns, DataOutputView out) throws IOException {
         keySerializer.serialize(keyContext.getCurrentKey(), out);
         namespaceSerializer.serialize(ns, out);
     }
 
-    protected void writeDefaultValueAndTtl(DataOutputViewStreamWrapper out) throws IOException {
+    protected void writeDefaultValueAndTtl(DataOutputView out) throws IOException {
         out.writeBoolean(ttlConfig.isEnabled());
         if (ttlConfig.isEnabled()) {
-            try (ObjectOutputStream o = new ObjectOutputStream(out)) {
-                o.writeObject(ttlConfig);
+            try (ByteArrayOutputStreamWithPos outputStreamWithPos =
+                            new ByteArrayOutputStreamWithPos();
+                    ObjectOutputStream objectOutputStream =
+                            new ObjectOutputStream(outputStreamWithPos)) {
+                objectOutputStream.writeObject(ttlConfig);
+                out.write(outputStreamWithPos.toByteArray());
             }
         }
         out.writeBoolean(defaultValue != null);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/PriorityQueueStateChangeLoggerImpl.java
@@ -18,7 +18,7 @@
 package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.RegisteredPriorityQueueStateBackendMetaInfo;
 import org.apache.flink.runtime.state.RegisteredStateMetaInfoBase;
 import org.apache.flink.runtime.state.changelog.StateChangelogWriter;
@@ -42,13 +42,12 @@ class PriorityQueueStateChangeLoggerImpl<K, T> extends AbstractStateChangeLogger
     }
 
     @Override
-    protected void serializeValue(T t, DataOutputViewStreamWrapper out) throws IOException {
+    protected void serializeValue(T t, DataOutputView out) throws IOException {
         serializer.serialize(t, out);
     }
 
     @Override
-    protected void serializeScope(Void unused, DataOutputViewStreamWrapper out)
-            throws IOException {}
+    protected void serializeScope(Void unused, DataOutputView out) throws IOException {}
 
     @Override
     protected PriorityQueueStateChangeLoggerImpl<K, T> setMetaInfo(

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLogger.java
@@ -19,7 +19,7 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.ListState;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import java.io.Closeable;
@@ -60,17 +60,17 @@ public interface StateChangeLogger<Value, Namespace> extends Closeable {
 
     /** State element added, such as append of a single element to a list. */
     void valueElementAdded(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, Namespace ns)
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, Namespace ns)
             throws IOException;
 
     /** State element added or updated, such as put into a map. */
     void valueElementAddedOrUpdated(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, Namespace ns)
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, Namespace ns)
             throws IOException;
 
     /** State element removed, such mapping removal from a map. */
     void valueElementRemoved(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, Namespace ns)
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, Namespace ns)
             throws IOException;
 
     /** Enable logging meta data before next writes. */

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLoggingIterator.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/StateChangeLoggingIterator.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.state.changelog;
 
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.function.BiConsumerWithException;
@@ -32,16 +32,14 @@ class StateChangeLoggingIterator<State, StateElement, Namespace>
 
     private final CloseableIterator<StateElement> iterator;
     private final StateChangeLogger<State, Namespace> changeLogger;
-    private final BiConsumerWithException<StateElement, DataOutputViewStreamWrapper, IOException>
-            removalWriter;
+    private final BiConsumerWithException<StateElement, DataOutputView, IOException> removalWriter;
     private final Namespace ns;
     @Nullable private StateElement lastReturned;
 
     private StateChangeLoggingIterator(
             CloseableIterator<StateElement> iterator,
             StateChangeLogger<State, Namespace> changeLogger,
-            BiConsumerWithException<StateElement, DataOutputViewStreamWrapper, IOException>
-                    removalWriter,
+            BiConsumerWithException<StateElement, DataOutputView, IOException> removalWriter,
             Namespace ns) {
         this.iterator = iterator;
         this.changeLogger = changeLogger;
@@ -73,8 +71,7 @@ class StateChangeLoggingIterator<State, StateElement, Namespace>
     public static <Namespace, State, StateElement> CloseableIterator<StateElement> create(
             CloseableIterator<StateElement> iterator,
             StateChangeLogger<State, Namespace> changeLogger,
-            BiConsumerWithException<StateElement, DataOutputViewStreamWrapper, IOException>
-                    removalWriter,
+            BiConsumerWithException<StateElement, DataOutputView, IOException> removalWriter,
             Namespace ns) {
         return new StateChangeLoggingIterator<>(iterator, changeLogger, removalWriter, ns);
     }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/restore/ChangelogMigrationRestoreTarget.java
@@ -21,7 +21,7 @@ import org.apache.flink.api.common.state.State;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.CheckpointStreamFactory;
@@ -170,20 +170,17 @@ public class ChangelogMigrationRestoreTarget<K> implements ChangelogRestoreTarge
 
         @Override
         public void valueElementAdded(
-                ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
-                Namespace ns)
+                ThrowingConsumer<DataOutputView, IOException> dataSerializer, Namespace ns)
                 throws IOException {}
 
         @Override
         public void valueElementAddedOrUpdated(
-                ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
-                Namespace ns)
+                ThrowingConsumer<DataOutputView, IOException> dataSerializer, Namespace ns)
                 throws IOException {}
 
         @Override
         public void valueElementRemoved(
-                ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
-                Namespace ns)
+                ThrowingConsumer<DataOutputView, IOException> dataSerializer, Namespace ns)
                 throws IOException {}
 
         @Override

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogPqStateTest.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/ChangelogPqStateTest.java
@@ -18,7 +18,7 @@
 package org.apache.flink.state.changelog;
 
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.function.FunctionWithException;
@@ -157,22 +157,19 @@ public class ChangelogPqStateTest {
 
         @Override
         public void valueElementAdded(
-                ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
-                Void ns) {
+                ThrowingConsumer<DataOutputView, IOException> dataSerializer, Void ns) {
             stateElementAdded = true;
         }
 
         @Override
         public void valueElementAddedOrUpdated(
-                ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
-                Void ns) {
+                ThrowingConsumer<DataOutputView, IOException> dataSerializer, Void ns) {
             stateElementChanged = true;
         }
 
         @Override
         public void valueElementRemoved(
-                ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer,
-                Void ns) {
+                ThrowingConsumer<DataOutputView, IOException> dataSerializer, Void ns) {
             stateElementRemoved = true;
         }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/TestChangeLoggerKv.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/TestChangeLoggerKv.java
@@ -17,7 +17,7 @@
 
 package org.apache.flink.state.changelog;
 
-import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
+import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.function.ThrowingConsumer;
 
 import java.io.IOException;
@@ -101,19 +101,19 @@ class TestChangeLoggerKv<State> implements KvStateChangeLogger<State, String> {
 
     @Override
     public void valueElementAdded(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, String ns) {
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, String ns) {
         stateElementAdded = true;
     }
 
     @Override
     public void valueElementAddedOrUpdated(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, String ns) {
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, String ns) {
         stateElementChanged = true;
     }
 
     @Override
     public void valueElementRemoved(
-            ThrowingConsumer<DataOutputViewStreamWrapper, IOException> dataSerializer, String ns) {
+            ThrowingConsumer<DataOutputView, IOException> dataSerializer, String ns) {
         stateElementRemoved = true;
     }
 


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, AbstractStateChangeLogger use sync 

DataOutputViewStreamWrapper to serialize state change which is unnecessary because it will always be executed in single thread.

So replace it with a unsync one could improve the performance of serialization.

In my simple stateful WordCount case, it could improve TPS by 10% at least.

Furthermore, because the serialization and deserialization of key and value have been executed in some delegaed state backend, maybe we could avoid double serialization. It may improve the performance if the serialization logic is complex and even is the bottleneck.

This pr focuses on the sync serializer problem.
The second problem about double serialization could also be disscussed, and I will create a new pr if necessary.

## Brief change log

 - Replace DataOutputViewStreamWrapper with DataOutputViewStream

## Verifying this change


This change is already covered by existing tests, such as *StateChangeLoggerTestBase*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
