### PR TITLE
[FLINK-29940][runtime] ExecutionGraph logs job state change at WARN level when job fails 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1149,13 +1149,23 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         // now do the actual state transition
         if (state == current) {
             state = newState;
-            LOG.info(
-                    "Job {} ({}) switched from state {} to {}.",
-                    getJobName(),
-                    getJobID(),
-                    current,
-                    newState,
-                    error);
+            if (newState == JobStatus.FAILED) {
+                LOG.error(
+                        "Job {} ({}) switched from state {} to {}.",
+                        getJobName(),
+                        getJobID(),
+                        current,
+                        newState,
+                        error);
+            } else {
+                LOG.info(
+                        "Job {} ({}) switched from state {} to {}.",
+                        getJobName(),
+                        getJobID(),
+                        current,
+                        newState,
+                        error);
+            }
 
             stateTimestamps[newState.ordinal()] = System.currentTimeMillis();
             notifyJobStatusChange(newState);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraph.java
@@ -1150,7 +1150,7 @@ public class DefaultExecutionGraph implements ExecutionGraph, InternalExecutionG
         if (state == current) {
             state = newState;
             if (newState == JobStatus.FAILED) {
-                LOG.error(
+                LOG.warn(
                         "Job {} ({}) switched from state {} to {}.",
                         getJobName(),
                         getJobID(),


### PR DESCRIPTION
## What is the purpose of the change

When job switched to FAILED state, the log is very useful to understand why it failed along with the root cause exception stack. However, the current log level is INFO - a bit inconvenient for users to search from logging with so many surrounding log lines.

## Brief change log

We can log at WARN level when the job switched to FAILED state. I firstly proposed ERROR level which is only for the cases when system can not proceed normally.

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
