### PR TITLE
[hotfix][doc] Fix some errors in sql gateway docs

### DIFF
--- a/docs/content.zh/docs/dev/table/hive-compatibility/hiveserver2.md
+++ b/docs/content.zh/docs/dev/table/hive-compatibility/hiveserver2.md
@@ -245,6 +245,7 @@ import java.sql.Statement;
 
 public class JdbcConnection {
     public static void main(String[] args) throws Exception {
+        Class.forName("org.apache.hive.jdbc.HiveDriver");
         try (
                 // Please replace the JDBC URI with your actual host, port and database.
                 Connection connection = DriverManager.getConnection("jdbc:hive2://{host}:{port}/{database};auth=noSasl");

--- a/docs/content.zh/docs/dev/table/sql-gateway/overview.md
+++ b/docs/content.zh/docs/dev/table/sql-gateway/overview.md
@@ -159,7 +159,7 @@ Start the Flink SQL Gateway as a daemon to submit Flink SQL.
 You can configure the SQL Gateway when starting the SQL Gateway below, or any valid [Flink configuration]({{< ref "docs/dev/table/config" >}}) entry:
 
 ```bash
-$ ./sql-gateway -Dkey=value
+$ ./bin/sql-gateway.sh -Dkey=value
 ```
 
 <table class="configuration table table-bordered">

--- a/docs/content/docs/dev/table/hive-compatibility/hiveserver2.md
+++ b/docs/content/docs/dev/table/hive-compatibility/hiveserver2.md
@@ -245,6 +245,7 @@ import java.sql.Statement;
 
 public class JdbcConnection {
     public static void main(String[] args) throws Exception {
+        Class.forName("org.apache.hive.jdbc.HiveDriver");
         try (
                 // Please replace the JDBC URI with your actual host, port and database.
                 Connection connection = DriverManager.getConnection("jdbc:hive2://{host}:{port}/{database};auth=noSasl"); 

--- a/docs/content/docs/dev/table/sql-gateway/overview.md
+++ b/docs/content/docs/dev/table/sql-gateway/overview.md
@@ -159,7 +159,7 @@ Start the Flink SQL Gateway as a daemon to submit Flink SQL.
 You can configure the SQL Gateway when starting the SQL Gateway below, or any valid [Flink configuration]({{< ref "docs/dev/table/config" >}}) entry:
 
 ```bash
-$ ./sql-gateway -Dkey=value
+$ ./bin/sql-gateway.sh -Dkey=value
 ```
 
 <table class="configuration table table-bordered">


### PR DESCRIPTION
## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*

Fix some errros in SQL Gateway related documents.

## Brief change log

- docs/content.zh/docs/dev/table/hive-compatibility/hiveserver2.md
- docs/content.zh/docs/dev/table/sql-gateway/overview.md
- docs/content/docs/dev/table/hive-compatibility/hiveserver2.md
- docs/content/docs/dev/table/sql-gateway/overview.md

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
