### PR TITLE
[BP-1.16][FLINK-28352][tests] Disable PulsarSourceUnorderedE2ECase, PulsarUnorderedPartitionSplitReaderTest and PulsarUnorderedSourceITCase

### DIFF
--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarUnorderedSourceITCase.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/PulsarUnorderedSourceITCase.java
@@ -32,12 +32,14 @@ import org.apache.flink.connector.testframe.junit.annotations.TestSemantics;
 import org.apache.flink.streaming.api.CheckpointingMode;
 
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 /**
  * Unit test class for {@link PulsarSource}. Used for {@link SubscriptionType#Shared} subscription.
  */
 @Tag("org.apache.flink.testutils.junit.FailsOnJava11")
+@Disabled("FLINK-30351")
 public class PulsarUnorderedSourceITCase extends UnorderedSourceTestSuiteBase<String> {
 
     // Defines test environment on Flink MiniCluster

--- a/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-pulsar/src/test/java/org/apache/flink/connector/pulsar/source/reader/split/PulsarUnorderedPartitionSplitReaderTest.java
@@ -21,8 +21,10 @@ package org.apache.flink.connector.pulsar.source.reader.split;
 import org.apache.flink.connector.pulsar.testutils.extension.SubType;
 
 import org.apache.pulsar.client.api.SubscriptionType;
+import org.junit.jupiter.api.Disabled;
 
 /** Unit tests for {@link PulsarUnorderedPartitionSplitReaderTest}. */
+@Disabled("FLINK-30351")
 class PulsarUnorderedPartitionSplitReaderTest extends PulsarPartitionSplitReaderTestBase {
     @SubType SubscriptionType subscriptionType = SubscriptionType.Shared;
 }

--- a/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/PulsarSourceUnorderedE2ECase.java
+++ b/flink-end-to-end-tests/flink-end-to-end-tests-pulsar/src/test/java/org/apache/flink/tests/util/pulsar/PulsarSourceUnorderedE2ECase.java
@@ -30,6 +30,7 @@ import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.tests.util.pulsar.common.FlinkContainerWithPulsarEnvironment;
 import org.apache.flink.tests.util.pulsar.common.PulsarContainerTestEnvironment;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 
 /**
@@ -38,6 +39,7 @@ import org.junit.jupiter.api.Tag;
  */
 @SuppressWarnings("unused")
 @Tag("org.apache.flink.testutils.junit.FailsOnJava11")
+@Disabled("FLINK-30351")
 public class PulsarSourceUnorderedE2ECase extends UnorderedSourceTestSuiteBase<String> {
 
     // Defines the Semantic.


### PR DESCRIPTION
1.16 backport PR for parent PR #21478