### PR TITLE
[FLINK-30358][rest] Exception location contains TM resource id and link to TM pages.

### DIFF
--- a/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
+++ b/flink-runtime-web/src/test/resources/rest_api_v1.snapshot
@@ -1953,6 +1953,9 @@
               },
               "timestamp" : {
                 "type" : "integer"
+              },
+              "taskManagerId" : {
+                "type" : "string"
               }
             }
           }
@@ -1985,6 +1988,9 @@
                   "location" : {
                     "type" : "string"
                   },
+                  "taskManagerId" : {
+                    "type" : "string"
+                  },
                   "concurrentExceptions" : {
                     "type" : "array",
                     "items" : {
@@ -2004,6 +2010,9 @@
                           "type" : "string"
                         },
                         "location" : {
+                          "type" : "string"
+                        },
+                        "taskManagerId" : {
                           "type" : "string"
                         }
                       }

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.html
@@ -78,7 +78,15 @@
                   </nz-option>
                 </nz-select>
               </td>
-              <td>{{ item.selected.location || '(unassigned)' }}</td>
+              <td class="clickable" (click)="navigateTo(item.selected.taskManagerId)">
+                <a>
+                  {{
+                    item.selected.location
+                      ? item.selected.taskManagerId + '(' + item.selected.location + ')'
+                      : '(unassigned)'
+                  }}
+                </a>
+              </td>
             </tr>
             <tr [nzExpand]="item.expand">
               <td colspan="5" class="expand-td">

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/exceptions/job-exceptions.component.ts
@@ -19,6 +19,7 @@
 import { DatePipe, formatDate, NgForOf, NgIf } from '@angular/common';
 import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 import { distinctUntilChanged, mergeMap, takeUntil, tap } from 'rxjs/operators';
 
@@ -103,7 +104,8 @@ export class JobExceptionsComponent implements OnInit, OnDestroy {
   constructor(
     private readonly jobService: JobService,
     private readonly jobLocalService: JobLocalService,
-    private readonly cdr: ChangeDetectorRef
+    private readonly cdr: ChangeDetectorRef,
+    private readonly router: Router
   ) {}
 
   public ngOnInit(): void {
@@ -150,5 +152,11 @@ export class JobExceptionsComponent implements OnInit, OnDestroy {
           };
         });
       });
+  }
+
+  public navigateTo(taskManagerId: string | null): void {
+    if (taskManagerId !== null) {
+      this.router.navigate(['task-manager', taskManagerId, 'metrics']).then();
+    }
   }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/handler/job/JobExceptionsHandler.java
@@ -144,7 +144,8 @@ public class JobExceptionsHandler
                                     failure.get().getExceptionAsString(),
                                     task.getTaskNameWithSubtaskIndex(),
                                     locationString,
-                                    timestamp == 0 ? -1 : timestamp));
+                                    timestamp == 0 ? -1 : timestamp,
+                                    toTaskManagerId(location)));
                 }
             }
         }
@@ -200,6 +201,7 @@ public class JobExceptionsHandler
                 historyEntry.getTimestamp(),
                 historyEntry.getFailingTaskName(),
                 toString(historyEntry.getTaskManagerLocation()),
+                toTaskManagerId(historyEntry.getTaskManagerLocation()),
                 concurrentExceptions);
     }
 
@@ -212,7 +214,8 @@ public class JobExceptionsHandler
                 exceptionHistoryEntry.getExceptionAsString(),
                 exceptionHistoryEntry.getTimestamp(),
                 exceptionHistoryEntry.getFailingTaskName(),
-                toString(exceptionHistoryEntry.getTaskManagerLocation()));
+                toString(exceptionHistoryEntry.getTaskManagerLocation()),
+                toTaskManagerId(exceptionHistoryEntry.getTaskManagerLocation()));
     }
 
     private static void assertLocalExceptionInfo(ExceptionHistoryEntry exceptionHistoryEntry) {
@@ -231,11 +234,24 @@ public class JobExceptionsHandler
     }
 
     @VisibleForTesting
+    static String toTaskManagerId(@Nullable TaskManagerLocation location) {
+        // '(unassigned)' being the default value is added to support backward-compatibility for the
+        // deprecated fields
+        return location != null ? String.format("%s", location.getResourceID()) : "(unassigned)";
+    }
+
+    @VisibleForTesting
     @Nullable
     static String toString(@Nullable ExceptionHistoryEntry.ArchivedTaskManagerLocation location) {
         return location != null
                 ? taskManagerLocationToString(location.getFQDNHostname(), location.getPort())
                 : null;
+    }
+
+    @VisibleForTesting
+    static String toTaskManagerId(
+            @Nullable ExceptionHistoryEntry.ArchivedTaskManagerLocation location) {
+        return location != null ? String.format("%s", location.getResourceID()) : null;
     }
 
     private static String taskManagerLocationToString(String fqdnHostname, int port) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfo.java
@@ -146,6 +146,7 @@ public class JobExceptionsInfo {
         public static final String FIELD_NAME_TASK = "task";
         public static final String FIELD_NAME_LOCATION = "location";
         public static final String FIELD_NAME_TIMESTAMP = "timestamp";
+        public static final String FIELD_NAME_TASK_MANAGER_ID = "taskManagerId";
 
         @JsonProperty(FIELD_NAME_EXCEPTION)
         private final String exception;
@@ -159,16 +160,21 @@ public class JobExceptionsInfo {
         @JsonProperty(FIELD_NAME_TIMESTAMP)
         private final long timestamp;
 
+        @JsonProperty(FIELD_NAME_TASK_MANAGER_ID)
+        private final String taskManagerId;
+
         @JsonCreator
         public ExecutionExceptionInfo(
                 @JsonProperty(FIELD_NAME_EXCEPTION) String exception,
                 @JsonProperty(FIELD_NAME_TASK) String task,
                 @JsonProperty(FIELD_NAME_LOCATION) String location,
-                @JsonProperty(FIELD_NAME_TIMESTAMP) long timestamp) {
+                @JsonProperty(FIELD_NAME_TIMESTAMP) long timestamp,
+                @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) String taskManagerId) {
             this.exception = Preconditions.checkNotNull(exception);
             this.task = Preconditions.checkNotNull(task);
             this.location = Preconditions.checkNotNull(location);
             this.timestamp = timestamp;
+            this.taskManagerId = taskManagerId;
         }
 
         @Override
@@ -184,12 +190,13 @@ public class JobExceptionsInfo {
             return timestamp == that.timestamp
                     && Objects.equals(exception, that.exception)
                     && Objects.equals(task, that.task)
-                    && Objects.equals(location, that.location);
+                    && Objects.equals(location, that.location)
+                    && Objects.equals(taskManagerId, that.taskManagerId);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(timestamp, exception, task, location);
+            return Objects.hash(timestamp, exception, task, location, taskManagerId);
         }
 
         @Override
@@ -199,6 +206,7 @@ public class JobExceptionsInfo {
                     .add("task='" + task + "'")
                     .add("location='" + location + "'")
                     .add("timestamp=" + timestamp)
+                    .add("taskManagerId=" + taskManagerId)
                     .toString();
         }
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistory.java
@@ -176,6 +176,7 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         public static final String FIELD_NAME_EXCEPTION_TIMESTAMP = "timestamp";
         public static final String FIELD_NAME_TASK_NAME = "taskName";
         public static final String FIELD_NAME_LOCATION = "location";
+        public static final String FIELD_NAME_TASK_MANAGER_ID = "taskManagerId";
 
         @JsonProperty(FIELD_NAME_EXCEPTION_NAME)
         private final String exceptionName;
@@ -196,8 +197,13 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         @Nullable
         private final String location;
 
+        @JsonInclude(NON_NULL)
+        @JsonProperty(FIELD_NAME_TASK_MANAGER_ID)
+        @Nullable
+        private final String taskManagerId;
+
         public ExceptionInfo(String exceptionName, String stacktrace, long timestamp) {
-            this(exceptionName, stacktrace, timestamp, null, null);
+            this(exceptionName, stacktrace, timestamp, null, null, null);
         }
 
         @JsonCreator
@@ -206,12 +212,14 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 @JsonProperty(FIELD_NAME_EXCEPTION_STACKTRACE) String stacktrace,
                 @JsonProperty(FIELD_NAME_EXCEPTION_TIMESTAMP) long timestamp,
                 @JsonProperty(FIELD_NAME_TASK_NAME) @Nullable String taskName,
-                @JsonProperty(FIELD_NAME_LOCATION) @Nullable String location) {
+                @JsonProperty(FIELD_NAME_LOCATION) @Nullable String location,
+                @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) @Nullable String taskManagerId) {
             this.exceptionName = checkNotNull(exceptionName);
             this.stacktrace = checkNotNull(stacktrace);
             this.timestamp = timestamp;
             this.taskName = taskName;
             this.location = location;
+            this.taskManagerId = taskManagerId;
         }
 
         @JsonIgnore
@@ -239,6 +247,12 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
         @Nullable
         public String getLocation() {
             return location;
+        }
+
+        @JsonIgnore
+        @Nullable
+        public String getTaskManagerId() {
+            return taskManagerId;
         }
 
         // hashCode and equals are necessary for the test classes deriving from
@@ -292,7 +306,7 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 String stacktrace,
                 long timestamp,
                 Collection<ExceptionInfo> concurrentExceptions) {
-            this(exceptionName, stacktrace, timestamp, null, null, concurrentExceptions);
+            this(exceptionName, stacktrace, timestamp, null, null, null, concurrentExceptions);
         }
 
         @JsonCreator
@@ -302,9 +316,10 @@ public class JobExceptionsInfoWithHistory extends JobExceptionsInfo implements R
                 @JsonProperty(FIELD_NAME_EXCEPTION_TIMESTAMP) long timestamp,
                 @JsonProperty(FIELD_NAME_TASK_NAME) @Nullable String taskName,
                 @JsonProperty(FIELD_NAME_LOCATION) @Nullable String location,
+                @JsonProperty(FIELD_NAME_TASK_MANAGER_ID) @Nullable String taskManagerId,
                 @JsonProperty(FIELD_NAME_CONCURRENT_EXCEPTIONS)
                         Collection<ExceptionInfo> concurrentExceptions) {
-            super(exceptionName, stacktrace, timestamp, taskName, location);
+            super(exceptionName, stacktrace, timestamp, taskName, location, taskManagerId);
             this.concurrentExceptions = concurrentExceptions;
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryNoRootTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryNoRootTest.java
@@ -40,10 +40,18 @@ public class JobExceptionsInfoWithHistoryNoRootTest
                 new ArrayList<>();
         executionTaskExceptionInfoList.add(
                 new JobExceptionsInfo.ExecutionExceptionInfo(
-                        "exception1", "task1", "location1", System.currentTimeMillis()));
+                        "exception1",
+                        "task1",
+                        "location1",
+                        System.currentTimeMillis(),
+                        "taskManagerId1"));
         executionTaskExceptionInfoList.add(
                 new JobExceptionsInfo.ExecutionExceptionInfo(
-                        "exception2", "task2", "location2", System.currentTimeMillis()));
+                        "exception2",
+                        "task2",
+                        "location2",
+                        System.currentTimeMillis(),
+                        "taskManagerId2"));
         return new JobExceptionsInfoWithHistory(
                 null,
                 null,
@@ -61,13 +69,15 @@ public class JobExceptionsInfoWithHistoryNoRootTest
                                                         "stacktrace #2",
                                                         2L,
                                                         "task name #2",
-                                                        "location #2"))),
+                                                        "location #2",
+                                                        "taskManagerId #2"))),
                                 new JobExceptionsInfoWithHistory.RootExceptionInfo(
                                         "local task failure #1",
                                         "stacktrace #1",
                                         1L,
                                         "task name",
                                         "location",
+                                        "taskManagerId",
                                         Collections.emptyList())),
                         false));
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/messages/JobExceptionsInfoWithHistoryTest.java
@@ -47,10 +47,18 @@ public class JobExceptionsInfoWithHistoryTest
                 new ArrayList<>();
         executionTaskExceptionInfoList.add(
                 new JobExceptionsInfo.ExecutionExceptionInfo(
-                        "exception1", "task1", "location1", System.currentTimeMillis()));
+                        "exception1",
+                        "task1",
+                        "location1",
+                        System.currentTimeMillis(),
+                        "taskManagerId1"));
         executionTaskExceptionInfoList.add(
                 new JobExceptionsInfo.ExecutionExceptionInfo(
-                        "exception2", "task2", "location2", System.currentTimeMillis()));
+                        "exception2",
+                        "task2",
+                        "location2",
+                        System.currentTimeMillis(),
+                        "taskManagerId2"));
         return new JobExceptionsInfoWithHistory(
                 "root exception",
                 System.currentTimeMillis(),


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

At present, the web UI exception history page only displays the TM host and port. However, we generally need to search for problems according to the pod name or container ID.

Therefore, it is more convenient to add resource id (pod name on k8s, container id on yarn) to the location column and a link to the task manager id to jump to the task manager page.


## Brief change log

  - Exception location contains tm resource id.
  - Exception location links to taskManagers UI pages.


## Verifying this change

This change is already covered by existing tests, such as JobExceptionsHandlerTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
