### PR TITLE
[FLINK-29997] Link to the taskmanager page in the expired sub-task of…

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/checkpoints/subtask/job-checkpoints-subtask.component.html
@@ -156,6 +156,11 @@
         <th [nzSortFn]="sortAlignmentDurationFn"><strong>Alignment Duration</strong></th>
         <th [nzSortFn]="sortStartDelayFn"><strong>Start Delay</strong></th>
         <th [nzSortFn]="sortUnalignedCpFn"><strong>Unaligned Checkpoint</strong></th>
+        <ng-container
+          *ngIf="table.data && table.data[0] && table.data[0]['status'] === 'pending_or_failed'"
+        >
+          <th><strong>TaskManager</strong></th>
+        </ng-container>
       </tr>
     </thead>
     <tbody>
@@ -181,7 +186,19 @@
           <td>{{ subTask['unaligned_checkpoint'] }}</td>
         </ng-container>
         <ng-container *ngIf="subTask['status'] === 'pending_or_failed'">
-          <td colspan="8">n/a</td>
+          <td colspan="10">n/a</td>
+          <td>
+            <a
+              *ngIf="mapOfSubtask.get(subTask['index'])"
+              [routerLink]="[
+                '/task-manager',
+                mapOfSubtask.get(subTask['index'])['taskmanager-id'],
+                'logs'
+              ]"
+            >
+              View Logs
+            </a>
+          </td>
         </ng-container>
       </tr>
     </tbody>


### PR DESCRIPTION
… checkpoint tab


## What is the purpose of the change

In the Web UI, we link the pending or failed subtask to the corresponding TM for the job's checkpoint page, which helps to analyze the reason for the long checkpoint time or failure.


## Brief change log

  - We add a link to jump to the corresponding TM for each subtask in the job checkpoint page.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework/code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduces a new feature? no
  - If yes, how is the feature documented? not applicable

<img width="1147" alt="image" src="https://user-images.githubusercontent.com/19743175/208351973-be4c7ffd-6c14-483c-b255-113e8e045877.png">
