### PR TITLE
[FLINK-30366][python] Fix Python Group Agg failed in cleaning the idle state

### DIFF
--- a/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
+++ b/flink-python/pyflink/fn_execution/coder_impl_fast.pyx
@@ -327,7 +327,7 @@ cdef class FlattenRowCoderImpl(FieldCoderImpl):
         cdef size_t i
         cdef FieldCoderImpl field_coder
 
-        list_value = <list> value
+        list_value = <list?> value
 
         # encode mask value
         self._mask_utils.write_mask(list_value, 0, out_stream)

--- a/flink-python/pyflink/fn_execution/coder_impl_slow.py
+++ b/flink-python/pyflink/fn_execution/coder_impl_slow.py
@@ -209,6 +209,8 @@ class FlattenRowCoderImpl(FieldCoderImpl):
         self._mask_utils = MaskUtils(self._field_count)
 
     def encode_to_stream(self, value, out_stream: OutputStream):
+        if not isinstance(value, List):
+            raise TypeError('Expected list, got {0}'.format(type(value)))
         # encode mask value
         self._mask_utils.write_mask(value, 0, out_stream)
 

--- a/flink-python/pyflink/fn_execution/table/aggregate_fast.pyx
+++ b/flink-python/pyflink/fn_execution/table/aggregate_fast.pyx
@@ -456,7 +456,7 @@ cdef class GroupAggFunctionBase:
 
     cpdef void on_timer(self, InternalRow key):
         if self.state_cleaning_enabled:
-            self.state_backend.set_current_key(key)
+            self.state_backend.set_current_key(list(key.values))
             accumulator_state = self.state_backend.get_value_state(
                 "accumulators", self.state_value_coder)
             accumulator_state.clear()

--- a/flink-python/pyflink/fn_execution/table/aggregate_slow.py
+++ b/flink-python/pyflink/fn_execution/table/aggregate_slow.py
@@ -436,9 +436,9 @@ class GroupAggFunctionBase(object):
         except KeyError:
             self.buffer[tuple(key)] = [input_data]
 
-    def on_timer(self, key):
+    def on_timer(self, key: Row):
         if self.state_cleaning_enabled:
-            self.state_backend.set_current_key(key)
+            self.state_backend.set_current_key(list(key._values))
             accumulator_state = self.state_backend.get_value_state(
                 "accumulators", self.state_value_coder)
             accumulator_state.clear()

--- a/flink-python/pyflink/fn_execution/tests/test_coders.py
+++ b/flink-python/pyflink/fn_execution/tests/test_coders.py
@@ -189,6 +189,12 @@ class CodersTest(PyFlinkTestCase):
         coder = CountWindowCoder()
         self.check_coder(coder, CountWindow(100))
 
+    def test_coder_with_unmatched_type(self):
+        from pyflink.common import Row
+        coder = FlattenRowCoder([BigIntCoder()])
+        with self.assertRaises(TypeError, msg='Expected list, got Row'):
+            self.check_coder(coder, Row(1))
+
 
 if __name__ == '__main__':
     logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix Python Group Agg failed in cleaning the idle state*

## Brief change log

  - *Adds the type cast*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
