### PR TITLE
[FLINK-30368][table-planner] Fix calcite method RelMdUtil$numDistinctVals() wrongly return zero if the method input domainSize much larger than numSelected

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCount.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdDistinctRowCount.scala
@@ -539,7 +539,7 @@ class FlinkRelMdDistinctRowCount private extends MetadataHandler[BuiltInMetadata
         }
         mq.getDistinctRowCount(rel.getLeft, groupKey, newPred)
       case _ =>
-        RelMdUtil.getJoinDistinctRowCount(mq, rel, rel.getJoinType, groupKey, predicate, false)
+        FlinkRelMdUtil.getJoinDistinctRowCount(mq, rel, rel.getJoinType, groupKey, predicate, false)
     }
   }
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtil.scala
@@ -37,6 +37,7 @@ import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeName.{TIME, TIMESTAMP}
 import org.apache.calcite.sql.SqlKind
 import org.apache.calcite.util.{ImmutableBitSet, NumberUtil}
+import org.apache.calcite.util.NumberUtil.multiply
 
 import java.math.BigDecimal
 import java.util
@@ -245,6 +246,77 @@ object FlinkRelMdUtil {
       pushable.add(fun)
     }
     RexUtil.composeConjunction(rexBuilder, pushable, true)
+  }
+
+  /**
+   * This method is copied from calcite RelMdUtil. This method should be removed once CALCITE-4351
+   * is fixed. See CALCITE-4351 and FLINK-19780.
+   *
+   * Computes the number of distinct rows for a set of keys returned from a join. Also known as NDV
+   * (number of distinct values).
+   *
+   * @param joinRel
+   *   RelNode representing the join
+   * @param joinType
+   *   type of join
+   * @param groupKey
+   *   keys that the distinct row count will be computed for
+   * @param predicate
+   *   join predicate
+   * @param useMaxNdv
+   *   If true use formula <code>max(left NDV, right NDV)</code>, otherwise use <code>left NDV *
+   *   right NDV</code>.
+   * @return
+   *   number of distinct rows
+   */
+  def getJoinDistinctRowCount(
+      mq: RelMetadataQuery,
+      joinRel: RelNode,
+      joinType: JoinRelType,
+      groupKey: ImmutableBitSet,
+      predicate: RexNode,
+      useMaxNdv: Boolean): Double = {
+    if ((predicate == null || predicate.isAlwaysTrue) && groupKey.isEmpty) return 1d
+    val join = joinRel.asInstanceOf[Join]
+    if (join.isSemiJoin) return RelMdUtil.getSemiJoinDistinctRowCount(join, mq, groupKey, predicate)
+    val leftMask = ImmutableBitSet.builder
+    val rightMask = ImmutableBitSet.builder
+    val left = joinRel.getInputs.get(0)
+    val right = joinRel.getInputs.get(1)
+    RelMdUtil.setLeftRightBitmaps(groupKey, leftMask, rightMask, left.getRowType.getFieldCount)
+    // determine which filters apply to the left vs right
+    val (leftPred, rightPred) = if (predicate != null) {
+      val leftFilters = new util.ArrayList[RexNode]
+      val rightFilters = new util.ArrayList[RexNode]
+      val joinFilters = new util.ArrayList[RexNode]
+      val predList = RelOptUtil.conjunctions(predicate)
+      RelOptUtil.classifyFilters(
+        joinRel,
+        predList,
+        joinType.canPushIntoFromAbove,
+        joinType.canPushLeftFromAbove,
+        joinType.canPushRightFromAbove,
+        joinFilters,
+        leftFilters,
+        rightFilters)
+      val rexBuilder = joinRel.getCluster.getRexBuilder
+      val leftResult = RexUtil.composeConjunction(rexBuilder, leftFilters, true)
+      val rightResult = RexUtil.composeConjunction(rexBuilder, rightFilters, true)
+      (leftResult, rightResult)
+    } else {
+      (null, null)
+    }
+
+    val distRowCount =
+      if (useMaxNdv)
+        NumberUtil.max(
+          mq.getDistinctRowCount(left, leftMask.build, leftPred),
+          mq.getDistinctRowCount(right, rightMask.build, rightPred))
+      else
+        multiply(
+          mq.getDistinctRowCount(left, leftMask.build, leftPred),
+          mq.getDistinctRowCount(right, rightMask.build, rightPred))
+    RelMdUtil.numDistinctVals(distRowCount, mq.getRowCount(joinRel))
   }
 
   /**

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtilTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/utils/FlinkRelMdUtilTest.scala
@@ -39,6 +39,7 @@ class FlinkRelMdUtilTest {
   @Test
   def testNumDistinctValsWithLargeInputs(): Unit = {
     Assert.assertNotEquals(0.0, FlinkRelMdUtil.numDistinctVals(1e18, 1e10))
+    Assert.assertEquals(9.99999993922529e9, FlinkRelMdUtil.numDistinctVals(1e18, 1e10), 1d)
     // this test will fail once CALCITE-4351 is fixed
     // in that case FlinkRelMdUtil#numDistinctVals should be removed
     // see FLINK-19780


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pr is aims to fix calcite method `RelMdUtil$numDistinctVals()` wrongly return zero if the method input `domainSize` is a very large value.  If `domainSize` is a very large value (like 2 x 10^16), Math.log(1.0 - 1.0 / dSize) will return 0, and `domainSize` will be set to 0, which is unreasonable in this scenario. (This bug will let join type choose `NestedLoopJoin` instead of `HashJoin` in physical program).

## Brief change log
- Class `RelMdUtil` is copied from calcite `org.apache.calcite.rel.metadata.RelMdUtil`, and modified method `numDistinctVals()`.


## Verifying this change

No tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented?  no
