### PR TITLE
[FLINK-29461][python] Make the test_process_function more stable

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -980,9 +980,8 @@ class ProcessDataStreamTests(DataStreamTests):
 
             def process_element(self, value, ctx):
                 current_timestamp = ctx.timestamp()
-                current_watermark = ctx.timer_service().current_watermark()
-                yield "current timestamp: {}, current watermark: {}, current_value: {}"\
-                    .format(str(current_timestamp), str(current_watermark), str(value))
+                yield "current timestamp: {}, current_value: {}"\
+                    .format(str(current_timestamp), str(value))
 
         watermark_strategy = WatermarkStrategy.for_monotonous_timestamps()\
             .with_timestamp_assigner(SecondColumnTimestampAssigner())
@@ -990,14 +989,14 @@ class ProcessDataStreamTests(DataStreamTests):
             .process(MyProcessFunction(), output_type=Types.STRING()).add_sink(self.test_sink)
         self.env.execute('test process function')
         results = self.test_sink.get_results()
-        expected = ["current timestamp: 1603708211000, current watermark: "
-                    "-9223372036854775808, current_value: Row(f0=1, f1='1603708211000')",
-                    "current timestamp: 1603708224000, current watermark: "
-                    "-9223372036854775808, current_value: Row(f0=2, f1='1603708224000')",
-                    "current timestamp: 1603708226000, current watermark: "
-                    "-9223372036854775808, current_value: Row(f0=3, f1='1603708226000')",
-                    "current timestamp: 1603708289000, current watermark: "
-                    "-9223372036854775808, current_value: Row(f0=4, f1='1603708289000')"]
+        expected = ["current timestamp: 1603708211000, "
+                    "current_value: Row(f0=1, f1='1603708211000')",
+                    "current timestamp: 1603708224000, "
+                    "current_value: Row(f0=2, f1='1603708224000')",
+                    "current timestamp: 1603708226000, "
+                    "current_value: Row(f0=3, f1='1603708226000')",
+                    "current timestamp: 1603708289000, "
+                    "current_value: Row(f0=4, f1='1603708289000')"]
         self.assert_equals_sorted(expected, results)
 
     def test_process_side_output(self):


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will make the test_process_function more stable*


## Brief change log

  - *Remove checking the current_watermark value. The watermark depends on the processing timer, so I remove the comparison of current watermark to make the test more stable*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
