### PR TITLE
[FLINK-30378][docs] Add v2 sql_connector_download_table shortcode 

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -124,3 +124,6 @@ pygmentsUseClasses = true
 [[module.imports.mounts]]
   source = 'layouts'
   target = 'layouts'
+[[module.imports.mounts]]
+  source = 'data'
+  target = 'data'

--- a/docs/layouts/shortcodes/sql_connector_download_table.html
+++ b/docs/layouts/shortcodes/sql_connector_download_table.html
@@ -21,10 +21,11 @@
     IMPORTANT: the whitespace is relevant. Do not change without looking at the 
     rendered documentation. 
   */}}
-  {{ $artifactId := .Get 0 }}
-  {{ $version := .Get 1 }}
-  {{ $connectors := .Site.Data.sql_connectors }}
-  {{ $connector := index $connectors $artifactId }}
+  {{ $name := .Get 0 }}
+  {{ $connector_version := .Get 1 }}
+  {{ $connector := index .Site.Data $name }}
+  {{ $flink_version := .Site.Params.VersionTitle }}
+  {{ $full_version := printf "%s-%s" $connector_version $flink_version }}
   
   {{ $path := .Page.Path }}
   
@@ -37,14 +38,14 @@
       <th style="text-align:left">SQL Client</th>
     </thead>
     <tbody>
-      {{ range $connector.versions }}    
+      {{ range $connector.variants }}
       <tr>
         <td style="text-align: left">
           <div id="{{ $hash }}" onclick="selectTextAndCopy('{{ $hash }}')"class="highlight">
 <pre class="chroma"><code class="language-xml" data-lang="xml"><span class="nt">&ltdependency&gt</span>
   <span class="nt">&ltgroupId&gt</span>org.apache.flink<span class="nt">&lt/groupId&gt</span>
   <span class="nt">&ltartifactId&gt</span>{{- .maven -}}<span class="nt">&lt/artifactId&gt</span>
-  <span class="nt">&ltversion&gt</span>{{- .version -}}-{{- site.Params.VersionTitle -}}<span class="nt">&lt/version&gt</span>
+  <span class="nt">&ltversion&gt</span>{{- $full_version -}}<span class="nt">&lt/version&gt</span>
 <span class="nt">&lt/dependency&gt</span></code></pre></div>
           <div class="book-hint info" style="text-align:center;display:none" copyable="flink-module" copyattribute="{{ $hash }}">
             Copied to clipboard!
@@ -61,5 +62,4 @@
   Only available for stable versions.
   {{ end }}
 
-  
   

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -27,19 +27,12 @@ function integrate_connector_docs {
   local connector ref additional_folders
   connector=$1
   ref=$2
-  additional_folders=( "${@:3}" )
 
   git clone --single-branch --branch ${ref} https://github.com/apache/flink-connector-${connector}
   theme_dir="../themes/connectors"
   mkdir -p "${theme_dir}"
 
-  for rsync_folder_subpath in "docs/content" "docs/content.zh" "${additional_folders[@]}"; do
-    local rsync_source_path="flink-connector-${connector}/${rsync_folder_subpath}"
-
-    if [ -e "${rsync_source_path}" ]; then
-      rsync -a "flink-connector-${connector}/${rsync_folder_subpath}" "${theme_dir}/"
-    fi
-  done
+  rsync -a flink-connector-${connector}/docs/* "${theme_dir}/"
 }
 
 
@@ -53,7 +46,7 @@ cd tmp
 integrate_connector_docs elasticsearch v3.0.0
 integrate_connector_docs aws v4.0
 integrate_connector_docs cassandra v3.0.0
-integrate_connector_docs pulsar main "docs/layouts"
+integrate_connector_docs pulsar main
 integrate_connector_docs jdbc v3.0.0
 integrate_connector_docs rabbitmq v3.0.0
 


### PR DESCRIPTION
Adds a new shortcode for generating the sql download table for externalized connectors.
Further decouples the Flink/connector docs by no longer relying on docs/data/sql_connectors.yml.

Usage:
```
some_document.md:
{{< sql_connector_download_table_v2 "elasticsearch" 3.0.0 >}}

docs/data/elasticsearch.yml:
variants:
  - maven: flink-connector-elasticsearch6
    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch6/$full_version/flink-sql-connector-elasticsearch6-$full_version.jar
  - maven: flink-connector-elasticsearch7
    sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7/$full_version/flink-sql-connector-elasticsearch7-$full_version.jar
```

@dannycranmer You may be interested in this one.

