### PR TITLE
[hotfix][table-common] Remove unused private methods

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFactoryService.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/TableFactoryService.java
@@ -453,12 +453,4 @@ public class TableFactoryService {
                 .map(s -> s.substring(0, s.length() - 1))
                 .collect(Collectors.toList());
     }
-
-    /**
-     * Performs filtering for special cases (i.e. table format factories with schema derivation).
-     */
-    private static List<String> filterSupportedPropertiesFactorySpecific(
-            TableFactory factory, List<String> keys) {
-        return keys;
-    }
 }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/logical/utils/LogicalTypeCasts.java
@@ -473,21 +473,6 @@ public final class LogicalTypeCasts {
             return this;
         }
 
-        /**
-         * Should be called after {@link #explicitFromFamily(LogicalTypeFamily...)} to remove
-         * previously added types.
-         */
-        CastingRuleBuilder explicitNotFromFamily(LogicalTypeFamily... sourceFamilies) {
-            for (LogicalTypeFamily family : sourceFamilies) {
-                for (LogicalTypeRoot root : LogicalTypeRoot.values()) {
-                    if (root.getFamilies().contains(family)) {
-                        this.explicitSourceTypes.remove(root);
-                    }
-                }
-            }
-            return this;
-        }
-
         void build() {
             implicitCastingRules.put(targetType, implicitSourceTypes);
             explicitCastingRules.put(targetType, explicitSourceTypes);


### PR DESCRIPTION
The PR removes 2 private unused methods from `flink-table-common`

## What is the purpose of the change
`org.apache.flink.table.factories.TableFactoryService#filterSupportedPropertiesFactorySpecific` The usage was removed at https://github.com/apache/flink/commit/8212230414f0c49a9f5b636bfc5101417e921a66#diff-b95578386c94cdc85a50a5514cbf34e3a5964eac6b9c71c2e22a810bf142bc9aL392-L393

`explicitNotFromFamily` from `org.apache.flink.table.types.logical.utils.LogicalTypeCasts` The usage was removed at 
https://github.com/apache/flink/commit/7dc419342779d08f6c1ae6adf42e58bdc6056971


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
