### PR TITLE
[hotfix][misprint] Remove duplicate word `version`

### DIFF
--- a/docs/content.zh/docs/dev/configuration/overview.md
+++ b/docs/content.zh/docs/dev/configuration/overview.md
@@ -58,7 +58,7 @@ under the License.
 <a name="maven-command"></a>
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content.zh/docs/dev/datastream/overview.md
+++ b/docs/content.zh/docs/dev/datastream/overview.md
@@ -62,7 +62,7 @@ Flink 程序看起来像一个转换 `DataStream` 的常规程序。每个程序
 5. 触发程序执行。
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content.zh/docs/dev/datastream/scala_api_extensions.md
+++ b/docs/content.zh/docs/dev/datastream/scala_api_extensions.md
@@ -26,7 +26,7 @@ under the License.
 -->
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content.zh/docs/dev/table/common.md
+++ b/docs/content.zh/docs/dev/table/common.md
@@ -38,7 +38,7 @@ Table API 和 SQL 程序的结构
 所有用于批处理和流处理的 Table API 和 SQL 程序都遵循相同的模式。下面的代码示例展示了 Table API 和 SQL 程序的通用结构。
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content.zh/docs/learn-flink/datastream_api.md
+++ b/docs/content.zh/docs/learn-flink/datastream_api.md
@@ -81,7 +81,7 @@ Flink 的序列化器[支持的 POJO 类型数据结构升级]({{< ref "docs/dev
 如果你了解 Scala，那一定知道 tuple 和 case class。
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content/docs/dev/configuration/overview.md
+++ b/docs/content/docs/dev/configuration/overview.md
@@ -60,7 +60,7 @@ You can create a project based on an [Archetype](https://maven.apache.org/guides
 with the Maven command below or use the provided quickstart bash script.
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content/docs/dev/datastream/overview.md
+++ b/docs/content/docs/dev/datastream/overview.md
@@ -73,7 +73,7 @@ program consists of the same basic parts:
 5. Trigger the program execution
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content/docs/dev/datastream/scala_api_extensions.md
+++ b/docs/content/docs/dev/datastream/scala_api_extensions.md
@@ -26,7 +26,7 @@ under the License.
 -->
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content/docs/dev/table/common.md
+++ b/docs/content/docs/dev/table/common.md
@@ -36,7 +36,7 @@ Structure of Table API and SQL Programs
 The following code example shows the common structure of Table API and SQL programs.
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/docs/content/docs/learn-flink/datastream_api.md
+++ b/docs/content/docs/learn-flink/datastream_api.md
@@ -86,7 +86,7 @@ Flink's serializer [supports schema evolution for POJO types]({{< ref "docs/dev/
 These work just as you'd expect.
 
 {{< hint warning >}}
-All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
+All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can still build your application in Scala, but you should move to the Java version of either the DataStream and/or Table API.
 
 See <a href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">FLIP-265 Deprecate and remove Scala API support</a>
 {{< /hint >}}

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/ExecutionEnvironment.scala
@@ -58,9 +58,9 @@ import scala.reflect.ClassTag
  * the program is submitted to a cluster a remote execution environment will be created.
  *
  * @deprecated
- *   All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You
- *   can still build your application in Scala, but you should move to the Java version of either
- *   the DataStream and/or Table API.
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can
+ *   still build your application in Scala, but you should move to the Java version of either the
+ *   DataStream and/or Table API.
  * @see
  *   <a
  *   href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">

--- a/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
+++ b/flink-scala/src/main/scala/org/apache/flink/api/scala/package.scala
@@ -41,9 +41,9 @@ import language.experimental.macros
  * depending on the context where your program is executing.
  *
  * @deprecated
- *   All Flink Scala APIs are deprecated and will be removed in a future Flink version version. You
- *   can still build your application in Scala, but you should move to the Java version of either
- *   the DataStream and/or Table API.
+ *   All Flink Scala APIs are deprecated and will be removed in a future Flink version. You can
+ *   still build your application in Scala, but you should move to the Java version of either the
+ *   DataStream and/or Table API.
  * @see
  *   <a
  *   href="https://cwiki.apache.org/confluence/display/FLINK/FLIP-265+Deprecate+and+remove+Scala+API+support">


### PR DESCRIPTION
## What is the purpose of the change

There is a duplicate `version` in a phrase `All Flink Scala APIs are deprecated and will be removed in a future Flink version version.` The PR removes one extra word.

## Verifying this change
This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
