### PR TITLE
[FLINK-29869][ResourceManager] make ResourceAllocator declarative.

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ResourceManagerOptions.java
@@ -150,6 +150,14 @@ public class ResourceManagerOptions {
                     .defaultValue(Duration.ofMillis(50))
                     .withDescription("The delay of the resource requirements check.");
 
+    @Documentation.ExcludeFromDocumentation(
+            "This is an expert option, that we do not want to expose in the documentation")
+    public static final ConfigOption<Duration> DECLARE_NEEDED_RESOURCE_DELAY =
+            ConfigOptions.key("slotmanager.declare-needed-resource.delay")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(50))
+                    .withDescription("The delay of the declare needed resources.");
+
     /**
      * The timeout for a slot request to be discarded, in milliseconds.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1273,7 +1273,7 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
      */
     public void stopWorkerIfSupported(WorkerType worker) {
         if (resourceAllocator.isSupported()) {
-            resourceAllocator.releaseResource(worker.getResourceID());
+            resourceAllocator.cleaningUpDisconnectedResource(worker.getResourceID());
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/ResourceManager.java
@@ -1520,10 +1520,6 @@ public abstract class ResourceManager<WorkerType extends ResourceIDRetrievable>
     //  Resource Management
     // ------------------------------------------------------------------------
 
-    protected Map<WorkerResourceSpec, Integer> getRequiredResources() {
-        return slotManager.getRequiredResources();
-    }
-
     @Override
     public void onNewTokensObtained(byte[] tokens) throws Exception {
         latestTokens.set(tokens);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -527,7 +527,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
         }
 
         @Override
-        public void releaseResource(ResourceID resourceID) {
+        public void cleaningUpDisconnectedResource(ResourceID resourceID) {
             validateRunsInMainThread();
             internalStopWorker(resourceID);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -620,22 +620,9 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
         }
 
         @Override
-        public void releaseResource(InstanceID instanceId, Exception cause) {
-            validateRunsInMainThread();
-
-            ActiveResourceManager.this.releaseResource(instanceId, cause);
-        }
-
-        @Override
         public void cleaningUpDisconnectedResource(ResourceID resourceID) {
             validateRunsInMainThread();
             internalStopWorker(resourceID);
-        }
-
-        @Override
-        public void allocateResource(WorkerResourceSpec workerResourceSpec) {
-            validateRunsInMainThread();
-            requestNewWorker(workerResourceSpec);
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -307,7 +307,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
                     "Worker {} is terminated. Diagnostics: {}",
                     resourceId.getStringWithMetadata(),
                     diagnostics);
-            requestWorkerIfRequired();
+            checkResourceDeclarations();
         }
         closeTaskManagerConnection(resourceId, new Exception(diagnostics));
     }
@@ -435,7 +435,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
                                         count,
                                         exception);
                                 recordWorkerFailureAndPauseWorkerCreationIfNeeded();
-                                requestWorkerIfRequired();
+                                checkResourceDeclarations();
                             } else {
                                 final ResourceID resourceId = worker.getResourceID();
                                 workerNodeMap.put(resourceId, worker);
@@ -461,7 +461,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
                                 resourceId,
                                 workerRegistrationTimeout);
                         internalStopWorker(resourceId);
-                        requestWorkerIfRequired();
+                        checkResourceDeclarations();
                     }
                 },
                 workerRegistrationTimeout);
@@ -507,17 +507,6 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
             }
         }
         return true;
-    }
-
-    private void requestWorkerIfRequired() {
-        for (Map.Entry<WorkerResourceSpec, Integer> entry : getRequiredResources().entrySet()) {
-            final WorkerResourceSpec workerResourceSpec = entry.getKey();
-            final int requiredCount = entry.getValue();
-
-            while (requiredCount > pendingWorkerCounter.getNum(workerResourceSpec)) {
-                requestNewWorker(workerResourceSpec);
-            }
-        }
     }
 
     private void recordWorkerFailureAndPauseWorkerCreationIfNeeded() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManager.java
@@ -87,7 +87,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
     private final Map<ResourceID, WorkerType> workerNodeMap;
 
     /** Number of requested and not registered workers per worker resource spec. */
-    private final PendingWorkerCounter pendingWorkerCounter;
+    private final WorkerCounter pendingWorkerCounter;
 
     /** Identifiers and worker resource spec of requested not registered workers. */
     private final Map<ResourceID, WorkerResourceSpec> currentAttemptUnregisteredWorkers;
@@ -153,7 +153,7 @@ public class ActiveResourceManager<WorkerType extends ResourceIDRetrievable>
         this.flinkConfig = flinkConfig;
         this.resourceManagerDriver = resourceManagerDriver;
         this.workerNodeMap = new HashMap<>();
-        this.pendingWorkerCounter = new PendingWorkerCounter();
+        this.pendingWorkerCounter = new WorkerCounter();
         this.currentAttemptUnregisteredWorkers = new HashMap<>();
         this.previousAttemptUnregisteredWorkers = new HashSet<>();
         this.startWorkerFailureRater = checkNotNull(startWorkerFailureRater);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/WorkerCounter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/WorkerCounter.java
@@ -24,36 +24,36 @@ import org.apache.flink.util.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 
-/** Utility class for counting pending workers per {@link WorkerResourceSpec}. */
-class PendingWorkerCounter {
-    private final Map<WorkerResourceSpec, Integer> pendingWorkerNums;
+/** Utility class for counting workers per {@link WorkerResourceSpec}. */
+class WorkerCounter {
+    private final Map<WorkerResourceSpec, Integer> workerNums;
 
-    PendingWorkerCounter() {
-        pendingWorkerNums = new HashMap<>();
+    WorkerCounter() {
+        workerNums = new HashMap<>();
     }
 
     int getTotalNum() {
-        return pendingWorkerNums.values().stream().reduce(0, Integer::sum);
+        return workerNums.values().stream().reduce(0, Integer::sum);
     }
 
     int getNum(final WorkerResourceSpec workerResourceSpec) {
-        return pendingWorkerNums.getOrDefault(Preconditions.checkNotNull(workerResourceSpec), 0);
+        return workerNums.getOrDefault(Preconditions.checkNotNull(workerResourceSpec), 0);
     }
 
     int increaseAndGet(final WorkerResourceSpec workerResourceSpec) {
-        return pendingWorkerNums.compute(
+        return workerNums.compute(
                 Preconditions.checkNotNull(workerResourceSpec),
                 (ignored, num) -> num != null ? num + 1 : 1);
     }
 
     int decreaseAndGet(final WorkerResourceSpec workerResourceSpec) {
         final Integer newValue =
-                pendingWorkerNums.compute(
+                workerNums.compute(
                         Preconditions.checkNotNull(workerResourceSpec),
                         (ignored, num) -> {
                             Preconditions.checkState(
                                     num != null && num > 0,
-                                    "Cannot decrease, no pending worker of spec %s.",
+                                    "Cannot decrease, no worker of spec %s.",
                                     workerResourceSpec);
                             return num == 1 ? null : num - 1;
                         });

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -30,7 +30,6 @@ import org.apache.flink.runtime.messages.Acknowledge;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.SlotManagerMetricGroup;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirement;
@@ -785,11 +784,6 @@ public class DeclarativeSlotManager implements SlotManager {
     @Override
     public int getNumberFreeSlotsOf(InstanceID instanceId) {
         return taskExecutorManager.getNumberFreeSlotsOf(instanceId);
-    }
-
-    @Override
-    public Map<WorkerResourceSpec, Integer> getRequiredResources() {
-        return taskExecutorManager.getRequiredWorkers();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManager.java
@@ -139,6 +139,7 @@ public class DeclarativeSlotManager implements SlotManager {
                                 slotManagerConfiguration.isWaitResultConsumedBeforeRelease(),
                                 slotManagerConfiguration.getRedundantTaskManagerNum(),
                                 slotManagerConfiguration.getTaskManagerTimeout(),
+                                slotManagerConfiguration.getDeclareNeededResourceDelay(),
                                 scheduledExecutor,
                                 executor,
                                 resourceAllocator);
@@ -319,19 +320,8 @@ public class DeclarativeSlotManager implements SlotManager {
         }
     }
 
-    /**
-     * Registers a new task manager at the slot manager. This will make the task managers slots
-     * known and, thus, available for allocation.
-     *
-     * @param taskExecutorConnection for the new task manager
-     * @param initialSlotReport for the new task manager
-     * @param totalResourceProfile for the new task manager
-     * @param defaultSlotResourceProfile for the new task manager
-     * @return True if the task manager has not been registered before and is registered
-     *     successfully; otherwise false
-     */
     @Override
-    public boolean registerTaskManager(
+    public RegistrationResult registerTaskManager(
             final TaskExecutorConnection taskExecutorConnection,
             SlotReport initialSlotReport,
             ResourceProfile totalResourceProfile,
@@ -348,7 +338,7 @@ public class DeclarativeSlotManager implements SlotManager {
                     "Task executor {} was already registered.",
                     taskExecutorConnection.getResourceID());
             reportSlotStatus(taskExecutorConnection.getInstanceID(), initialSlotReport);
-            return false;
+            return RegistrationResult.IGNORED;
         } else {
             if (!taskExecutorManager.registerTaskManager(
                     taskExecutorConnection,
@@ -358,7 +348,7 @@ public class DeclarativeSlotManager implements SlotManager {
                 LOG.debug(
                         "Task executor {} could not be registered.",
                         taskExecutorConnection.getResourceID());
-                return false;
+                return RegistrationResult.REJECTED;
             }
 
             // register the new slots
@@ -371,7 +361,7 @@ public class DeclarativeSlotManager implements SlotManager {
             }
 
             checkResourceRequirementsWithDelay();
-            return true;
+            return RegistrationResult.SUCCESS;
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -719,17 +719,6 @@ public class FineGrainedSlotManager implements SlotManager {
     }
 
     @Override
-    public Map<WorkerResourceSpec, Integer> getRequiredResources() {
-        return taskManagerTracker.getPendingTaskManagers().stream()
-                .map(
-                        pendingTaskManager ->
-                                WorkerResourceSpec.fromTotalResourceProfile(
-                                        pendingTaskManager.getTotalResourceProfile(),
-                                        pendingTaskManager.getNumSlots()))
-                .collect(Collectors.groupingBy(Function.identity(), Collectors.summingInt(e -> 1)));
-    }
-
-    @Override
     public ResourceProfile getRegisteredResource() {
         return taskManagerTracker.getRegisteredResource();
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedTaskManagerTracker.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.Preconditions;
@@ -47,6 +48,9 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
     /** All currently registered task managers. */
     private final Map<InstanceID, FineGrainedTaskManagerRegistration> taskManagerRegistrations;
 
+    /** All unwanted task managers. */
+    private final Map<InstanceID, WorkerResourceSpec> unWantedTaskManagers;
+
     private final Map<PendingTaskManagerId, PendingTaskManager> pendingTaskManagers;
 
     private final Map<PendingTaskManagerId, Map<JobID, ResourceCounter>>
@@ -65,6 +69,7 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
     public FineGrainedTaskManagerTracker() {
         slots = new HashMap<>();
         taskManagerRegistrations = new HashMap<>();
+        unWantedTaskManagers = new HashMap<>();
         pendingTaskManagers = new HashMap<>();
         pendingSlotAllocationRecords = new HashMap<>();
         totalAndDefaultSlotProfilesToPendingTaskManagers = new HashMap<>();
@@ -109,6 +114,7 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
     @Override
     public void removeTaskManager(InstanceID instanceId) {
         Preconditions.checkNotNull(instanceId);
+        unWantedTaskManagers.remove(instanceId);
         final FineGrainedTaskManagerRegistration taskManager =
                 Preconditions.checkNotNull(taskManagerRegistrations.remove(instanceId));
         totalRegisteredResource = totalRegisteredResource.subtract(taskManager.getTotalResource());
@@ -116,6 +122,28 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
         for (AllocationID allocationId : taskManager.getAllocatedSlots().keySet()) {
             slots.remove(allocationId);
         }
+    }
+
+    @Override
+    public void addUnWantedTaskManager(InstanceID instanceId) {
+        final FineGrainedTaskManagerRegistration taskManager =
+                taskManagerRegistrations.get(instanceId);
+        if (taskManager != null) {
+            unWantedTaskManagers.put(
+                    instanceId,
+                    WorkerResourceSpec.fromTotalResourceProfile(
+                            taskManager.getTotalResource(),
+                            SlotManagerUtils.calculateDefaultNumSlots(
+                                    taskManager.getTotalResource(),
+                                    taskManager.getDefaultSlotResourceProfile())));
+        } else {
+            LOG.debug("Unwanted task manager {} does not exists.", instanceId);
+        }
+    }
+
+    @Override
+    public Map<InstanceID, WorkerResourceSpec> getUnWantedTaskManager() {
+        return unWantedTaskManagers;
     }
 
     @Override
@@ -354,5 +382,6 @@ public class FineGrainedTaskManagerTracker implements TaskManagerTracker {
         pendingTaskManagers.clear();
         totalPendingResource = ResourceProfile.ZERO;
         pendingSlotAllocationRecords.clear();
+        unWantedTaskManagers.clear();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import java.util.Collection;
 
@@ -37,16 +35,7 @@ public class NonSupportedResourceAllocatorImpl implements ResourceAllocator {
     }
 
     @Override
-    public void releaseResource(InstanceID instanceId, Exception cause) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void cleaningUpDisconnectedResource(ResourceID resourceID) {
-        throw new UnsupportedOperationException();
-    }
-
-    public void allocateResource(WorkerResourceSpec workerResourceSpec) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
+import java.util.Collection;
+
 /** ResourceAllocator that not support to allocate/release resources. */
 public class NonSupportedResourceAllocatorImpl implements ResourceAllocator {
     public static final NonSupportedResourceAllocatorImpl INSTANCE =
@@ -45,6 +47,11 @@ public class NonSupportedResourceAllocatorImpl implements ResourceAllocator {
     }
 
     public void allocateResource(WorkerResourceSpec workerResourceSpec) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void declareResourceNeeded(Collection<ResourceDeclaration> resourceDeclarations) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/NonSupportedResourceAllocatorImpl.java
@@ -40,7 +40,7 @@ public class NonSupportedResourceAllocatorImpl implements ResourceAllocator {
     }
 
     @Override
-    public void releaseResource(ResourceID resourceID) {
+    public void cleaningUpDisconnectedResource(ResourceID resourceID) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
@@ -37,11 +37,11 @@ public interface ResourceAllocator {
     void releaseResource(InstanceID instanceId, Exception cause);
 
     /**
-     * Releases the resource with the given resource id.
+     * Clean up the disconnected resource with the given resource id.
      *
-     * @param resourceID identifying which resource to release
+     * @param resourceID identifying which resource to clean up
      */
-    void releaseResource(ResourceID resourceID);
+    void cleaningUpDisconnectedResource(ResourceID resourceID);
 
     /**
      * Requests to allocate a resource with the given {@link WorkerResourceSpec}.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
@@ -22,6 +22,8 @@ import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
+import java.util.Collection;
+
 /** Resource related actions which the {@link SlotManager} can perform. */
 public interface ResourceAllocator {
 
@@ -49,4 +51,7 @@ public interface ResourceAllocator {
      * @param workerResourceSpec for the to be allocated worker
      */
     void allocateResource(WorkerResourceSpec workerResourceSpec);
+
+    /** declare resource need by slot manager. */
+    void declareResourceNeeded(Collection<ResourceDeclaration> resourceDeclarations);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceAllocator.java
@@ -19,8 +19,6 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import java.util.Collection;
 
@@ -31,26 +29,11 @@ public interface ResourceAllocator {
     boolean isSupported();
 
     /**
-     * Releases the resource with the given instance id.
-     *
-     * @param instanceId identifying which resource to release
-     * @param cause why the resource is released
-     */
-    void releaseResource(InstanceID instanceId, Exception cause);
-
-    /**
      * Clean up the disconnected resource with the given resource id.
      *
      * @param resourceID identifying which resource to clean up
      */
     void cleaningUpDisconnectedResource(ResourceID resourceID);
-
-    /**
-     * Requests to allocate a resource with the given {@link WorkerResourceSpec}.
-     *
-     * @param workerResourceSpec for the to be allocated worker
-     */
-    void allocateResource(WorkerResourceSpec workerResourceSpec);
 
     /** declare resource need by slot manager. */
     void declareResourceNeeded(Collection<ResourceDeclaration> resourceDeclarations);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceDeclaration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/ResourceDeclaration.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.resourcemanager.slotmanager;
+
+import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Objects;
+
+/** ResourceDeclaration for {@link ResourceAllocator}. */
+public class ResourceDeclaration {
+    private final WorkerResourceSpec spec;
+    private final int numNeeded;
+
+    /**
+     * workers that {@link SlotManager} does not wanted. This is just a hint for {@link
+     * ResourceAllocator} to decide which worker should be release.
+     */
+    private final Collection<InstanceID> unwantedWorkers;
+
+    public ResourceDeclaration(
+            WorkerResourceSpec spec, int numNeeded, Collection<InstanceID> unwantedWorkers) {
+        this.spec = spec;
+        this.numNeeded = numNeeded;
+        this.unwantedWorkers = Collections.unmodifiableCollection(unwantedWorkers);
+    }
+
+    public WorkerResourceSpec getSpec() {
+        return spec;
+    }
+
+    public int getNumNeeded() {
+        return numNeeded;
+    }
+
+    public Collection<InstanceID> getUnwantedWorkers() {
+        return unwantedWorkers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResourceDeclaration that = (ResourceDeclaration) o;
+        return numNeeded == that.numNeeded
+                && Objects.equals(spec, that.spec)
+                && Objects.equals(unwantedWorkers, that.unwantedWorkers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(spec, numNeeded, unwantedWorkers);
+    }
+
+    @Override
+    public String toString() {
+        return "ResourceDeclaration{"
+                + "spec="
+                + spec
+                + ", numNeeded="
+                + numNeeded
+                + ", unwantedWorkers="
+                + unwantedWorkers
+                + '}';
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -25,14 +25,12 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.Collection;
-import java.util.Map;
 import java.util.concurrent.Executor;
 
 /**
@@ -54,15 +52,6 @@ public interface SlotManager extends AutoCloseable {
     int getNumberFreeSlots();
 
     int getNumberFreeSlotsOf(InstanceID instanceId);
-
-    /**
-     * Get number of workers SlotManager requested from {@link ResourceAllocator} that are not yet
-     * fulfilled.
-     *
-     * @return a map whose key set is all the unique resource specs of the pending workers, and the
-     *     corresponding value is number of pending workers of that resource spec.
-     */
-    Map<WorkerResourceSpec, Integer> getRequiredResources();
 
     ResourceProfile getRegisteredResource();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManager.java
@@ -40,7 +40,7 @@ import java.util.concurrent.Executor;
  * their allocation and all pending slot requests. Whenever a new slot is registered or an allocated
  * slot is freed, then it tries to fulfill another pending slot request. Whenever there are not
  * enough slots available the slot manager will notify the resource manager about it via {@link
- * ResourceAllocator#allocateResource(WorkerResourceSpec)}.
+ * ResourceAllocator#declareResourceNeeded}.
  *
  * <p>In order to free resources and avoid resource leaks, idling task managers (task managers whose
  * slots are currently not used) and pending slot requests time out triggering their release and
@@ -116,10 +116,9 @@ public interface SlotManager extends AutoCloseable {
      * @param initialSlotReport for the new task manager
      * @param totalResourceProfile for the new task manager
      * @param defaultSlotResourceProfile for the new task manager
-     * @return True if the task manager has not been registered before and is registered
-     *     successfully; otherwise false
+     * @return The result of task manager registration
      */
-    boolean registerTaskManager(
+    RegistrationResult registerTaskManager(
             TaskExecutorConnection taskExecutorConnection,
             SlotReport initialSlotReport,
             ResourceProfile totalResourceProfile,
@@ -160,4 +159,11 @@ public interface SlotManager extends AutoCloseable {
      * changed.
      */
     void triggerResourceRequirementsCheck();
+
+    /** The result of task manager registration. */
+    enum RegistrationResult {
+        SUCCESS, // task manager has not been registered before and is registered successfully
+        IGNORED, // task manager has been registered before and is ignored
+        REJECTED, // task manager is rejected and should be disconnected
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfiguration.java
@@ -45,6 +45,7 @@ public class SlotManagerConfiguration {
     private final Time slotRequestTimeout;
     private final Time taskManagerTimeout;
     private final Duration requirementCheckDelay;
+    private final Duration declareNeededResourceDelay;
     private final boolean waitResultConsumedBeforeRelease;
     private final SlotMatchingStrategy slotMatchingStrategy;
     private final WorkerResourceSpec defaultWorkerResourceSpec;
@@ -59,6 +60,7 @@ public class SlotManagerConfiguration {
             Time slotRequestTimeout,
             Time taskManagerTimeout,
             Duration requirementCheckDelay,
+            Duration declareNeededResourceDelay,
             boolean waitResultConsumedBeforeRelease,
             SlotMatchingStrategy slotMatchingStrategy,
             WorkerResourceSpec defaultWorkerResourceSpec,
@@ -72,6 +74,7 @@ public class SlotManagerConfiguration {
         this.slotRequestTimeout = Preconditions.checkNotNull(slotRequestTimeout);
         this.taskManagerTimeout = Preconditions.checkNotNull(taskManagerTimeout);
         this.requirementCheckDelay = Preconditions.checkNotNull(requirementCheckDelay);
+        this.declareNeededResourceDelay = Preconditions.checkNotNull(declareNeededResourceDelay);
         this.waitResultConsumedBeforeRelease = waitResultConsumedBeforeRelease;
         this.slotMatchingStrategy = Preconditions.checkNotNull(slotMatchingStrategy);
         this.defaultWorkerResourceSpec = Preconditions.checkNotNull(defaultWorkerResourceSpec);
@@ -99,6 +102,10 @@ public class SlotManagerConfiguration {
 
     public Duration getRequirementCheckDelay() {
         return requirementCheckDelay;
+    }
+
+    public Duration getDeclareNeededResourceDelay() {
+        return declareNeededResourceDelay;
     }
 
     public boolean isWaitResultConsumedBeforeRelease() {
@@ -148,6 +155,9 @@ public class SlotManagerConfiguration {
         final Duration requirementCheckDelay =
                 configuration.get(ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY);
 
+        final Duration declareNeededResourceDelay =
+                configuration.get(ResourceManagerOptions.DECLARE_NEEDED_RESOURCE_DELAY);
+
         boolean waitResultConsumedBeforeRelease =
                 configuration.getBoolean(
                         ResourceManagerOptions.TASK_MANAGER_RELEASE_WHEN_RESULT_CONSUMED);
@@ -171,6 +181,7 @@ public class SlotManagerConfiguration {
                 slotRequestTimeout,
                 taskManagerTimeout,
                 requirementCheckDelay,
+                declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
                 slotMatchingStrategy,
                 defaultWorkerResourceSpec,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManager.java
@@ -299,14 +299,6 @@ class TaskExecutorManager implements AutoCloseable {
                 > maxSlotNum;
     }
 
-    public Map<WorkerResourceSpec, Integer> getRequiredWorkers() {
-        final int pendingWorkerNum =
-                MathUtils.divideRoundUp(getNumberPendingTaskManagerSlots(), numSlotsPerWorker);
-        return pendingWorkerNum > 0
-                ? Collections.singletonMap(defaultWorkerResourceSpec, pendingWorkerNum)
-                : Collections.emptyMap();
-    }
-
     private Collection<ResourceDeclaration> getResourceDeclaration() {
         final int pendingWorkerNum =
                 MathUtils.divideRoundUp(getNumberPendingTaskManagerSlots(), numSlotsPerWorker);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskManagerTracker.java
@@ -21,6 +21,7 @@ import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.instance.InstanceID;
+import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.util.ResourceCounter;
 
@@ -67,6 +68,16 @@ interface TaskManagerTracker
      * @return the allocation records associated to the removed pending task manager
      */
     Map<JobID, ResourceCounter> removePendingTaskManager(PendingTaskManagerId pendingTaskManagerId);
+
+    /**
+     * Add an unwanted task manager.
+     *
+     * @param instanceId identifier of task manager.
+     */
+    void addUnWantedTaskManager(InstanceID instanceId);
+
+    /** Get unwanted task managers. */
+    Map<InstanceID, WorkerResourceSpec> getUnWantedTaskManager();
 
     // ---------------------------------------------------------------------------------------------
     // Slot status updates

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -26,19 +26,24 @@ import org.apache.flink.runtime.clusterframework.TaskExecutorProcessSpec;
 import org.apache.flink.runtime.clusterframework.TaskExecutorProcessUtils;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
+import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.entrypoint.ClusterInformation;
 import org.apache.flink.runtime.instance.HardwareDescription;
+import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.io.network.partition.NoOpResourceManagerPartitionTracker;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.registration.RegistrationResponse;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.TaskExecutorRegistration;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
+import org.apache.flink.runtime.resourcemanager.slotmanager.ResourceDeclaration;
 import org.apache.flink.runtime.resourcemanager.slotmanager.SlotManager;
 import org.apache.flink.runtime.resourcemanager.slotmanager.TestingSlotManagerBuilder;
 import org.apache.flink.runtime.resourcemanager.utils.MockResourceManagerRuntimeServices;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
+import org.apache.flink.runtime.taskexecutor.SlotReport;
+import org.apache.flink.runtime.taskexecutor.SlotStatus;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorGateway;
 import org.apache.flink.runtime.taskexecutor.TaskExecutorMemoryConfiguration;
 import org.apache.flink.runtime.taskexecutor.TestingTaskExecutorGateway;
@@ -54,6 +59,7 @@ import org.junit.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -131,6 +137,259 @@ public class ActiveResourceManagerTest extends TestLogger {
                             assertThat(
                                     registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
                                     instanceOf(RegistrationResponse.Success.class));
+                        });
+            }
+        };
+    }
+
+    /** Tests unwanted worker released. */
+    @Test
+    public void testReleaseUnWantedResources() throws Exception {
+        new Context() {
+            {
+                final ResourceID tmResourceId = ResourceID.generate();
+                final CompletableFuture<ResourceID> releaseResourceFuture =
+                        new CompletableFuture<>();
+
+                driverBuilder
+                        .setRequestResourceFunction(
+                                taskExecutorProcessSpec ->
+                                        CompletableFuture.completedFuture(tmResourceId))
+                        .setReleaseResourceConsumer(releaseResourceFuture::complete);
+
+                runTest(
+                        () -> {
+                            // request new worker
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .requestNewWorker(WORKER_RESOURCE_SPEC));
+
+                            CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =
+                                    registerTaskExecutor(tmResourceId);
+                            assertThat(
+                                    registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    instanceOf(RegistrationResponse.Success.class));
+
+                            InstanceID instanceID =
+                                    getResourceManager()
+                                            .getInstanceIdByResourceId(tmResourceId)
+                                            .get();
+
+                            runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .sendSlotReport(
+                                                                    tmResourceId,
+                                                                    instanceID,
+                                                                    new SlotReport(
+                                                                            new SlotStatus(
+                                                                                    new SlotID(
+                                                                                            tmResourceId,
+                                                                                            0),
+                                                                                    ResourceProfile
+                                                                                            .ANY)),
+                                                                    TIMEOUT_TIME))
+                                    .get(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+                            // release unknown unwanted registered worker.
+                            CompletableFuture<Void> releaseFuture =
+                                    runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    0,
+                                                                                    Collections
+                                                                                            .singleton(
+                                                                                                    new InstanceID())))));
+
+                            // resource not in less wanted will not be released.
+                            releaseFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+                            // release unwanted registered worker.
+                            releaseFuture =
+                                    runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    0,
+                                                                                    Collections
+                                                                                            .singleton(
+                                                                                                    instanceID)))));
+                            // resource in less wanted will be released.
+                            releaseFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+                            // verify worker is released.
+                            assertThat(
+                                    releaseResourceFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    is(tmResourceId));
+                        });
+            }
+        };
+    }
+
+    /** Tests request new workers when resources less than declared. */
+    @Test
+    public void testLessThanDeclareResource() throws Exception {
+        new Context() {
+            {
+                final AtomicInteger requestCount = new AtomicInteger(0);
+                final List<CompletableFuture<ResourceID>> resourceIdFutures = new ArrayList<>();
+                resourceIdFutures.add(CompletableFuture.completedFuture(ResourceID.generate()));
+                resourceIdFutures.add(new CompletableFuture<>());
+                resourceIdFutures.add(new CompletableFuture<>());
+
+                driverBuilder.setRequestResourceFunction(
+                        taskExecutorProcessSpec ->
+                                resourceIdFutures.get(requestCount.getAndIncrement()));
+
+                runTest(
+                        () -> {
+                            // request two new worker
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .requestNewWorker(WORKER_RESOURCE_SPEC));
+
+                            runInMainThread(
+                                    () ->
+                                            getResourceManager()
+                                                    .requestNewWorker(WORKER_RESOURCE_SPEC));
+
+                            // release registered worker.
+                            CompletableFuture<Void> declareResourceFuture =
+                                    runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    3,
+                                                                                    Collections
+                                                                                            .emptySet()))));
+
+                            declareResourceFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+                            // request new worker.
+                            assertThat(requestCount.get(), is(3));
+                        });
+            }
+        };
+    }
+
+    /** Test release workers if more than resources declared. */
+    @Test
+    public void testMoreThanDeclaredResource() throws Exception {
+        new Context() {
+            {
+                final AtomicInteger requestCount = new AtomicInteger(0);
+                final List<CompletableFuture<ResourceID>> resourceIdFutures =
+                        Arrays.asList(
+                                CompletableFuture.completedFuture(ResourceID.generate()),
+                                CompletableFuture.completedFuture(ResourceID.generate()));
+
+                final AtomicInteger releaseCount = new AtomicInteger(0);
+                final List<CompletableFuture<ResourceID>> releaseResourceFutures =
+                        Collections.singletonList(new CompletableFuture<>());
+
+                driverBuilder
+                        .setRequestResourceFunction(
+                                taskExecutorProcessSpec ->
+                                        resourceIdFutures.get(requestCount.getAndIncrement()))
+                        .setReleaseResourceConsumer(
+                                resourceID ->
+                                        releaseResourceFutures
+                                                .get(releaseCount.getAndIncrement())
+                                                .complete(resourceID));
+
+                runTest(
+                        () -> {
+                            // request two new workers.
+                            runInMainThread(
+                                    () -> {
+                                        for (int i = 0; i < 2; i++) {
+                                            getResourceManager()
+                                                    .requestNewWorker(WORKER_RESOURCE_SPEC);
+                                        }
+                                    });
+                            ResourceID resourceID1 = resourceIdFutures.get(0).get();
+                            CompletableFuture<RegistrationResponse> registerTaskExecutorFuture =
+                                    registerTaskExecutor(resourceID1);
+                            assertThat(
+                                    registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    instanceOf(RegistrationResponse.Success.class));
+                            InstanceID instanceID1 =
+                                    getResourceManager()
+                                            .getInstanceIdByResourceId(resourceID1)
+                                            .get();
+                            runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .sendSlotReport(
+                                                                    resourceID1,
+                                                                    instanceID1,
+                                                                    new SlotReport(
+                                                                            new SlotStatus(
+                                                                                    new SlotID(
+                                                                                            resourceID1,
+                                                                                            0),
+                                                                                    ResourceProfile
+                                                                                            .ANY)),
+                                                                    TIMEOUT_TIME))
+                                    .get(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+                            ResourceID resourceID2 = resourceIdFutures.get(1).get();
+                            registerTaskExecutorFuture = registerTaskExecutor(resourceID2);
+                            assertThat(
+                                    registerTaskExecutorFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS),
+                                    instanceOf(RegistrationResponse.Success.class));
+                            InstanceID instanceID2 =
+                                    getResourceManager()
+                                            .getInstanceIdByResourceId(resourceID2)
+                                            .get();
+                            runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .sendSlotReport(
+                                                                    resourceID2,
+                                                                    instanceID2,
+                                                                    new SlotReport(
+                                                                            new SlotStatus(
+                                                                                    new SlotID(
+                                                                                            resourceID2,
+                                                                                            0),
+                                                                                    ResourceProfile
+                                                                                            .ANY)),
+                                                                    TIMEOUT_TIME))
+                                    .get(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+                            // declare resource needed, will release unwanted worker.
+                            CompletableFuture<Void> declareResourceFuture =
+                                    runInMainThread(
+                                            () ->
+                                                    getResourceManager()
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    1,
+                                                                                    Collections
+                                                                                            .singleton(
+                                                                                                    instanceID1)))));
+
+                            declareResourceFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+
+                            // release 1 worker.
+                            assertThat(releaseCount.get(), is(1));
+                            // release less wanted worker.
+                            assertThat(releaseResourceFutures.get(0).get(), is(resourceID1));
                         });
             }
         };
@@ -857,9 +1116,17 @@ public class ActiveResourceManagerTest extends TestLogger {
                                                                     tmResourceId1, tmResourceId2)));
 
                             runInMainThread(
-                                    () -> getResourceManager().onWorkerRegistered(tmResourceId1));
+                                    () ->
+                                            getResourceManager()
+                                                    .onWorkerRegistered(
+                                                            tmResourceId1,
+                                                            WorkerResourceSpec.ZERO));
                             runInMainThread(
-                                    () -> getResourceManager().onWorkerRegistered(tmResourceId2));
+                                    () ->
+                                            getResourceManager()
+                                                    .onWorkerRegistered(
+                                                            tmResourceId2,
+                                                            WorkerResourceSpec.ZERO));
                             runInMainThread(
                                             () ->
                                                     assertTrue(
@@ -895,7 +1162,11 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     });
 
                             runInMainThread(
-                                    () -> getResourceManager().onWorkerRegistered(tmResourceId1));
+                                    () ->
+                                            getResourceManager()
+                                                    .onWorkerRegistered(
+                                                            tmResourceId1,
+                                                            WorkerResourceSpec.ZERO));
                             getResourceManager()
                                     .getReadyToServeFuture()
                                     .get(TIMEOUT_SEC, TimeUnit.SECONDS);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/ActiveResourceManagerTest.java
@@ -423,9 +423,6 @@ public class ActiveResourceManagerTest extends TestLogger {
                             return resourceIdFutures.get(idx);
                         });
 
-                slotManagerBuilder.setGetRequiredResourcesSupplier(
-                        () -> Collections.singletonMap(WORKER_RESOURCE_SPEC, 1));
-
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
@@ -433,8 +430,13 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .requestNewWorker(
-                                                                    WORKER_RESOURCE_SPEC));
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    1,
+                                                                                    Collections
+                                                                                            .emptySet()))));
                             TaskExecutorProcessSpec taskExecutorProcessSpec1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
@@ -501,9 +503,6 @@ public class ActiveResourceManagerTest extends TestLogger {
                             return CompletableFuture.completedFuture(tmResourceIds.get(idx));
                         });
 
-                slotManagerBuilder.setGetRequiredResourcesSupplier(
-                        () -> Collections.singletonMap(WORKER_RESOURCE_SPEC, 1));
-
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
@@ -511,8 +510,13 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .requestNewWorker(
-                                                                    WORKER_RESOURCE_SPEC));
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    1,
+                                                                                    Collections
+                                                                                            .emptySet()))));
                             TaskExecutorProcessSpec taskExecutorProcessSpec1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
@@ -579,9 +583,6 @@ public class ActiveResourceManagerTest extends TestLogger {
                             return CompletableFuture.completedFuture(tmResourceIds.get(idx));
                         });
 
-                slotManagerBuilder.setGetRequiredResourcesSupplier(
-                        () -> Collections.singletonMap(WORKER_RESOURCE_SPEC, 1));
-
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
@@ -589,8 +590,13 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .requestNewWorker(
-                                                                    WORKER_RESOURCE_SPEC));
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    1,
+                                                                                    Collections
+                                                                                            .emptySet()))));
                             TaskExecutorProcessSpec taskExecutorProcessSpec1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
@@ -787,9 +793,6 @@ public class ActiveResourceManagerTest extends TestLogger {
                             return CompletableFuture.completedFuture(tmResourceIds.get(idx));
                         });
 
-                slotManagerBuilder.setGetRequiredResourcesSupplier(
-                        () -> Collections.singletonMap(WORKER_RESOURCE_SPEC, 1));
-
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
@@ -797,8 +800,13 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .requestNewWorker(
-                                                                    WORKER_RESOURCE_SPEC));
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    1,
+                                                                                    Collections
+                                                                                            .emptySet()))));
                             long t1 =
                                     requestWorkerFromDriverFutures
                                             .get(0)
@@ -867,9 +875,6 @@ public class ActiveResourceManagerTest extends TestLogger {
                             return resourceIdFutures.get(idx);
                         });
 
-                slotManagerBuilder.setGetRequiredResourcesSupplier(
-                        () -> Collections.singletonMap(WORKER_RESOURCE_SPEC, 1));
-
                 runTest(
                         () -> {
                             // received worker request, verify requesting from driver
@@ -877,8 +882,13 @@ public class ActiveResourceManagerTest extends TestLogger {
                                     runInMainThread(
                                             () ->
                                                     getResourceManager()
-                                                            .requestNewWorker(
-                                                                    WORKER_RESOURCE_SPEC));
+                                                            .declareResourceNeeded(
+                                                                    Collections.singleton(
+                                                                            new ResourceDeclaration(
+                                                                                    WORKER_RESOURCE_SPEC,
+                                                                                    1,
+                                                                                    Collections
+                                                                                            .emptySet()))));
 
                             startNewWorkerFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/WorkerCounterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/active/WorkerCounterTest.java
@@ -26,15 +26,15 @@ import org.junit.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-/** Tests for {@link PendingWorkerCounter}. */
-public class PendingWorkerCounterTest extends TestLogger {
+/** Tests for {@link WorkerCounter}. */
+public class WorkerCounterTest extends TestLogger {
 
     @Test
-    public void testPendingWorkerCounterIncreaseAndDecrease() {
+    public void testWorkerCounterIncreaseAndDecrease() {
         final WorkerResourceSpec spec1 = new WorkerResourceSpec.Builder().setCpuCores(1.0).build();
         final WorkerResourceSpec spec2 = new WorkerResourceSpec.Builder().setCpuCores(2.0).build();
 
-        final PendingWorkerCounter counter = new PendingWorkerCounter();
+        final WorkerCounter counter = new WorkerCounter();
         assertThat(counter.getTotalNum(), is(0));
         assertThat(counter.getNum(spec1), is(0));
         assertThat(counter.getNum(spec2), is(0));
@@ -66,9 +66,9 @@ public class PendingWorkerCounterTest extends TestLogger {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testPendingWorkerCounterDecreaseOnZero() {
+    public void testWorkerCounterDecreaseOnZero() {
         final WorkerResourceSpec spec = new WorkerResourceSpec.Builder().build();
-        final PendingWorkerCounter counter = new PendingWorkerCounter();
+        final WorkerCounter counter = new WorkerCounter();
         counter.decreaseAndGet(spec);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerBuilder.java
@@ -50,6 +50,7 @@ public class DeclarativeSlotManagerBuilder {
     private ResourceTracker resourceTracker;
     private SlotTracker slotTracker;
     private Duration requirementCheckDelay;
+    private Duration declareNeededResourceDelay;
 
     private DeclarativeSlotManagerBuilder(ScheduledExecutor scheduledExecutor) {
         this.slotMatchingStrategy = AnyMatchingSlotMatchingStrategy.INSTANCE;
@@ -68,6 +69,7 @@ public class DeclarativeSlotManagerBuilder {
         this.resourceTracker = new DefaultResourceTracker();
         this.slotTracker = new DefaultSlotTracker();
         this.requirementCheckDelay = Duration.ZERO;
+        this.declareNeededResourceDelay = Duration.ZERO;
     }
 
     public static DeclarativeSlotManagerBuilder newBuilder(ScheduledExecutor scheduledExecutor) {
@@ -144,6 +146,12 @@ public class DeclarativeSlotManagerBuilder {
         return this;
     }
 
+    public DeclarativeSlotManagerBuilder setDeclareNeededResourceDelay(
+            Duration declareNeededResourceDelay) {
+        this.declareNeededResourceDelay = declareNeededResourceDelay;
+        return this;
+    }
+
     public DeclarativeSlotManager build() {
         final SlotManagerConfiguration slotManagerConfiguration =
                 new SlotManagerConfiguration(
@@ -151,6 +159,7 @@ public class DeclarativeSlotManagerBuilder {
                         slotRequestTimeout,
                         taskManagerTimeout,
                         requirementCheckDelay,
+                        declareNeededResourceDelay,
                         waitResultConsumedBeforeRelease,
                         slotMatchingStrategy,
                         defaultWorkerResourceSpec,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase.java
@@ -48,12 +48,12 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
      */
     @Test
     void testWorkerOnlyAllocatedIfRequestedSlotCouldBeFulfilled() throws Exception {
-        final AtomicInteger resourceRequests = new AtomicInteger(0);
+        final AtomicInteger declareResourceCount = new AtomicInteger(0);
 
         new Context() {
             {
-                resourceAllocatorBuilder.setAllocateResourceConsumer(
-                        ignored -> resourceRequests.incrementAndGet());
+                resourceAllocatorBuilder.setDeclareResourceNeededConsumer(
+                        (ignored) -> declareResourceCount.incrementAndGet());
                 runTest(
                         () -> {
                             runInMainThread(
@@ -64,7 +64,7 @@ class FineGrainedSlotManagerDefaultResourceAllocationStrategyITCase
                                                                     new JobID(),
                                                                     1,
                                                                     OTHER_SLOT_RESOURCE_PROFILE)));
-                            assertThat(resourceRequests.get()).isEqualTo(0);
+                            assertThat(declareResourceCount.get()).isEqualTo(0);
                         });
             }
         };

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/SlotManagerConfigurationBuilder.java
@@ -33,6 +33,7 @@ public class SlotManagerConfigurationBuilder {
     private Time slotRequestTimeout;
     private Time taskManagerTimeout;
     private Duration requirementCheckDelay;
+    private Duration declareNeededResourceDelay;
     private boolean waitResultConsumedBeforeRelease;
     private WorkerResourceSpec defaultWorkerResourceSpec;
     private int numSlotsPerWorker;
@@ -46,6 +47,8 @@ public class SlotManagerConfigurationBuilder {
         this.slotRequestTimeout = TestingUtils.infiniteTime();
         this.taskManagerTimeout = TestingUtils.infiniteTime();
         this.requirementCheckDelay = ResourceManagerOptions.REQUIREMENTS_CHECK_DELAY.defaultValue();
+        this.declareNeededResourceDelay =
+                ResourceManagerOptions.DECLARE_NEEDED_RESOURCE_DELAY.defaultValue();
         this.waitResultConsumedBeforeRelease = true;
         this.defaultWorkerResourceSpec = WorkerResourceSpec.ZERO;
         this.numSlotsPerWorker = 1;
@@ -79,6 +82,12 @@ public class SlotManagerConfigurationBuilder {
     public SlotManagerConfigurationBuilder setRequirementCheckDelay(
             Duration requirementCheckDelay) {
         this.requirementCheckDelay = requirementCheckDelay;
+        return this;
+    }
+
+    public SlotManagerConfigurationBuilder setDeclareNeededResourceDelay(
+            Duration declareNeededResourceDelay) {
+        this.declareNeededResourceDelay = declareNeededResourceDelay;
         return this;
     }
 
@@ -125,6 +134,7 @@ public class SlotManagerConfigurationBuilder {
                 slotRequestTimeout,
                 taskManagerTimeout,
                 requirementCheckDelay,
+                declareNeededResourceDelay,
                 waitResultConsumedBeforeRelease,
                 AnyMatchingSlotMatchingStrategy.INSTANCE,
                 defaultWorkerResourceSpec,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TaskExecutorManagerBuilder.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
+import java.time.Duration;
 import java.util.concurrent.Executor;
 
 /** Builder for {@link TaskExecutorManager}. */
@@ -33,6 +34,7 @@ public class TaskExecutorManagerBuilder {
     private boolean waitResultConsumedBeforeRelease = true;
     private int redundantTaskManagerNum = 0;
     private Time taskManagerTimeout = Time.seconds(5);
+    private Duration declareNeededResourceDelay = Duration.ofMillis(0);
     private final ScheduledExecutor scheduledExecutor;
     private Executor mainThreadExecutor = Executors.directExecutor();
     private ResourceAllocator newResourceAllocator = new TestingResourceAllocatorBuilder().build();
@@ -83,6 +85,12 @@ public class TaskExecutorManagerBuilder {
         return this;
     }
 
+    public TaskExecutorManagerBuilder setDeclareNeededResourceDelay(
+            Duration declareNeededResourceDelay) {
+        this.declareNeededResourceDelay = declareNeededResourceDelay;
+        return this;
+    }
+
     public TaskExecutorManager createTaskExecutorManager() {
         return new TaskExecutorManager(
                 defaultWorkerResourceSpec,
@@ -91,6 +99,7 @@ public class TaskExecutorManagerBuilder {
                 waitResultConsumedBeforeRelease,
                 redundantTaskManagerNum,
                 taskManagerTimeout,
+                declareNeededResourceDelay,
                 scheduledExecutor,
                 mainThreadExecutor,
                 newResourceAllocator);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
@@ -52,7 +52,7 @@ public class TestingResourceAllocator implements ResourceAllocator {
     }
 
     @Override
-    public void releaseResource(ResourceID resourceID) {
+    public void cleaningUpDisconnectedResource(ResourceID resourceID) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
@@ -19,30 +19,19 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
-import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import javax.annotation.Nonnull;
 
 import java.util.Collection;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Testing implementation of the {@link ResourceAllocator}. */
 public class TestingResourceAllocator implements ResourceAllocator {
 
-    @Nonnull private final BiConsumer<InstanceID, Exception> releaseResourceConsumer;
-
-    @Nonnull private final Consumer<WorkerResourceSpec> allocateResourceConsumer;
-
     @Nonnull private final Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer;
 
     public TestingResourceAllocator(
-            @Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
-            @Nonnull Consumer<WorkerResourceSpec> allocateResourceConsumer,
             @Nonnull Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer) {
-        this.releaseResourceConsumer = releaseResourceConsumer;
-        this.allocateResourceConsumer = allocateResourceConsumer;
         this.declareResourceNeededConsumer = declareResourceNeededConsumer;
     }
 
@@ -52,18 +41,8 @@ public class TestingResourceAllocator implements ResourceAllocator {
     }
 
     @Override
-    public void releaseResource(InstanceID instanceId, Exception cause) {
-        releaseResourceConsumer.accept(instanceId, cause);
-    }
-
-    @Override
     public void cleaningUpDisconnectedResource(ResourceID resourceID) {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void allocateResource(WorkerResourceSpec workerResourceSpec) {
-        allocateResourceConsumer.accept(workerResourceSpec);
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocator.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
 import javax.annotation.Nonnull;
 
+import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -34,11 +35,15 @@ public class TestingResourceAllocator implements ResourceAllocator {
 
     @Nonnull private final Consumer<WorkerResourceSpec> allocateResourceConsumer;
 
+    @Nonnull private final Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer;
+
     public TestingResourceAllocator(
             @Nonnull BiConsumer<InstanceID, Exception> releaseResourceConsumer,
-            @Nonnull Consumer<WorkerResourceSpec> allocateResourceConsumer) {
+            @Nonnull Consumer<WorkerResourceSpec> allocateResourceConsumer,
+            @Nonnull Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer) {
         this.releaseResourceConsumer = releaseResourceConsumer;
         this.allocateResourceConsumer = allocateResourceConsumer;
+        this.declareResourceNeededConsumer = declareResourceNeededConsumer;
     }
 
     @Override
@@ -59,5 +64,10 @@ public class TestingResourceAllocator implements ResourceAllocator {
     @Override
     public void allocateResource(WorkerResourceSpec workerResourceSpec) {
         allocateResourceConsumer.accept(workerResourceSpec);
+    }
+
+    @Override
+    public void declareResourceNeeded(Collection<ResourceDeclaration> resourceDeclarations) {
+        declareResourceNeededConsumer.accept(resourceDeclarations);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
@@ -18,31 +18,13 @@
 
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
-import org.apache.flink.runtime.instance.InstanceID;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
-
 import java.util.Collection;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /** Builder for the {@link TestingResourceAllocator}. */
 public class TestingResourceAllocatorBuilder {
-    private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
-    private Consumer<WorkerResourceSpec> allocateResourceConsumer = (ignored) -> {};
     private Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer =
             (ignored) -> {};
-
-    public TestingResourceAllocatorBuilder setReleaseResourceConsumer(
-            BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
-        this.releaseResourceConsumer = releaseResourceConsumer;
-        return this;
-    }
-
-    public TestingResourceAllocatorBuilder setAllocateResourceConsumer(
-            Consumer<WorkerResourceSpec> allocateResourceConsumer) {
-        this.allocateResourceConsumer = allocateResourceConsumer;
-        return this;
-    }
 
     public TestingResourceAllocatorBuilder setDeclareResourceNeededConsumer(
             Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer) {
@@ -51,7 +33,6 @@ public class TestingResourceAllocatorBuilder {
     }
 
     public TestingResourceAllocator build() {
-        return new TestingResourceAllocator(
-                releaseResourceConsumer, allocateResourceConsumer, declareResourceNeededConsumer);
+        return new TestingResourceAllocator(declareResourceNeededConsumer);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingResourceAllocatorBuilder.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.resourcemanager.slotmanager;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 
+import java.util.Collection;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -28,6 +29,8 @@ import java.util.function.Consumer;
 public class TestingResourceAllocatorBuilder {
     private BiConsumer<InstanceID, Exception> releaseResourceConsumer = (ignoredA, ignoredB) -> {};
     private Consumer<WorkerResourceSpec> allocateResourceConsumer = (ignored) -> {};
+    private Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer =
+            (ignored) -> {};
 
     public TestingResourceAllocatorBuilder setReleaseResourceConsumer(
             BiConsumer<InstanceID, Exception> releaseResourceConsumer) {
@@ -41,7 +44,14 @@ public class TestingResourceAllocatorBuilder {
         return this;
     }
 
+    public TestingResourceAllocatorBuilder setDeclareResourceNeededConsumer(
+            Consumer<Collection<ResourceDeclaration>> declareResourceNeededConsumer) {
+        this.declareResourceNeededConsumer = declareResourceNeededConsumer;
+        return this;
+    }
+
     public TestingResourceAllocator build() {
-        return new TestingResourceAllocator(releaseResourceConsumer, allocateResourceConsumer);
+        return new TestingResourceAllocator(
+                releaseResourceConsumer, allocateResourceConsumer, declareResourceNeededConsumer);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -132,12 +132,12 @@ public class TestingSlotManager implements SlotManager {
     }
 
     @Override
-    public boolean registerTaskManager(
+    public RegistrationResult registerTaskManager(
             TaskExecutorConnection taskExecutorConnection,
             SlotReport initialSlotReport,
             ResourceProfile totalResourceProfile,
             ResourceProfile defaultSlotResourceProfile) {
-        return true;
+        return RegistrationResult.SUCCESS;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManager.java
@@ -25,7 +25,6 @@ import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
 import org.apache.flink.runtime.clusterframework.types.SlotID;
 import org.apache.flink.runtime.instance.InstanceID;
 import org.apache.flink.runtime.resourcemanager.ResourceManagerId;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.resourcemanager.registration.TaskExecutorConnection;
 import org.apache.flink.runtime.rest.messages.taskmanager.SlotInfo;
 import org.apache.flink.runtime.slots.ResourceRequirements;
@@ -33,28 +32,23 @@ import org.apache.flink.runtime.taskexecutor.SlotReport;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /** Implementation of {@link SlotManager} for testing purpose. */
 public class TestingSlotManager implements SlotManager {
 
     private final Consumer<Boolean> setFailUnfulfillableRequestConsumer;
-    private final Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier;
     private final Consumer<ResourceRequirements> processRequirementsConsumer;
     private final Consumer<JobID> clearRequirementsConsumer;
     private final Consumer<Void> triggerRequirementsCheckConsumer;
 
     TestingSlotManager(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer,
-            Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier,
             Consumer<ResourceRequirements> processRequirementsConsumer,
             Consumer<JobID> clearRequirementsConsumer,
             Consumer<Void> triggerRequirementsCheckConsumer) {
         this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
-        this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
         this.processRequirementsConsumer = processRequirementsConsumer;
         this.clearRequirementsConsumer = clearRequirementsConsumer;
         this.triggerRequirementsCheckConsumer = triggerRequirementsCheckConsumer;
@@ -78,11 +72,6 @@ public class TestingSlotManager implements SlotManager {
     @Override
     public int getNumberFreeSlotsOf(InstanceID instanceId) {
         return 0;
-    }
-
-    @Override
-    public Map<WorkerResourceSpec, Integer> getRequiredResources() {
-        return getRequiredResourcesSupplier.get();
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/TestingSlotManagerBuilder.java
@@ -19,20 +19,14 @@
 package org.apache.flink.runtime.resourcemanager.slotmanager;
 
 import org.apache.flink.api.common.JobID;
-import org.apache.flink.runtime.resourcemanager.WorkerResourceSpec;
 import org.apache.flink.runtime.slots.ResourceRequirements;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /** Factory for {@link TestingSlotManager}. */
 public class TestingSlotManagerBuilder {
 
     private Consumer<Boolean> setFailUnfulfillableRequestConsumer = ignored -> {};
-    private Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier =
-            () -> Collections.emptyMap();
     private Consumer<ResourceRequirements> processRequirementsConsumer = ignored -> {};
     private Consumer<JobID> clearRequirementsConsumer = ignored -> {};
     private Consumer<Void> triggerRequirementsCheckConsumer = ignored -> {};
@@ -40,12 +34,6 @@ public class TestingSlotManagerBuilder {
     public TestingSlotManagerBuilder setSetFailUnfulfillableRequestConsumer(
             Consumer<Boolean> setFailUnfulfillableRequestConsumer) {
         this.setFailUnfulfillableRequestConsumer = setFailUnfulfillableRequestConsumer;
-        return this;
-    }
-
-    public TestingSlotManagerBuilder setGetRequiredResourcesSupplier(
-            Supplier<Map<WorkerResourceSpec, Integer>> getRequiredResourcesSupplier) {
-        this.getRequiredResourcesSupplier = getRequiredResourcesSupplier;
         return this;
     }
 
@@ -70,7 +58,6 @@ public class TestingSlotManagerBuilder {
     public TestingSlotManager createSlotManager() {
         return new TestingSlotManager(
                 setFailUnfulfillableRequestConsumer,
-                getRequiredResourcesSupplier,
                 processRequirementsConsumer,
                 clearRequirementsConsumer,
                 triggerRequirementsCheckConsumer);


### PR DESCRIPTION

## What is the purpose of the change

This pull request makes ResourceAllocator declarative in order to reduce the coupling between the SlotManager and the ResourceManager


## Brief change log

  - Introduce declareResourceNeeded into ResourceAllocator. ActiveResourceManager will allocate/release workers to meet the declared resources.
  - SlotManager use declareResourceNeeded instead of allocate/releaseResource to reduce the coupling between the SlotManager and the ResourceManager


## Verifying this change
This change added tests and can be verified as follows:
  - *Added tests that validates that ResourceManager will allocate/release workers to meet the declared resources.*
  - *Update the tests for SlotManager to use the declarative api.*


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes, ResourceManager/SlotManager)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
    -  https://docs.google.com/document/d/1lcmf3MKmcmf9tsPc1whaZHMYKurGoGtqOXEep9ngP2k/edit  
