### PR TITLE
[FLINK-30392] Replace default thread dump depth to 50

### DIFF
--- a/docs/layouts/shortcodes/generated/cluster_configuration.html
+++ b/docs/layouts/shortcodes/generated/cluster_configuration.html
@@ -70,7 +70,7 @@
         </tr>
         <tr>
             <td><h5>cluster.thread-dump.stacktrace-max-depth</h5></td>
-            <td style="word-wrap: break-word;">8</td>
+            <td style="word-wrap: break-word;">50</td>
             <td>Integer</td>
             <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.</td>
         </tr>

--- a/docs/layouts/shortcodes/generated/expert_cluster_section.html
+++ b/docs/layouts/shortcodes/generated/expert_cluster_section.html
@@ -22,7 +22,7 @@
         </tr>
         <tr>
             <td><h5>cluster.thread-dump.stacktrace-max-depth</h5></td>
-            <td style="word-wrap: break-word;">8</td>
+            <td style="word-wrap: break-word;">50</td>
             <td>Integer</td>
             <td>The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.</td>
         </tr>

--- a/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/ClusterOptions.java
@@ -132,7 +132,7 @@ public class ClusterOptions {
     public static final ConfigOption<Integer> THREAD_DUMP_STACKTRACE_MAX_DEPTH =
             key("cluster.thread-dump.stacktrace-max-depth")
                     .intType()
-                    .defaultValue(8)
+                    .defaultValue(50)
                     .withDescription(
                             "The maximum stacktrace depth of TaskManager and JobManager's thread dump web-frontend displayed.");
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the thread dump function still have the default stack-trace depth as 8, which is the same as before. However, the default value is really too small for developers to know the actual thread info.
From our experiences, we can set this value as 50.


## Brief change log

  - Replace default value of `cluster.thread-dump.stacktrace-max-depth` to `50`.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
