### PR TITLE
[FLINK-30402][security][runtime] Separate token framework generic and hadoop specific parts

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/entrypoint/ClusterEntrypoint.java
@@ -66,7 +66,7 @@ import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
 import org.apache.flink.runtime.security.contexts.SecurityContext;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
-import org.apache.flink.runtime.security.token.KerberosDelegationTokenManagerFactory;
+import org.apache.flink.runtime.security.token.hadoop.KerberosDelegationTokenManagerFactory;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.runtime.webmonitor.retriever.impl.RpcMetricQueryServiceRetriever;
 import org.apache.flink.util.AutoCloseableAsync;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/minicluster/MiniCluster.java
@@ -90,7 +90,7 @@ import org.apache.flink.runtime.rpc.RpcSystem;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.scheduler.ExecutionGraphInfo;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
-import org.apache.flink.runtime.security.token.KerberosDelegationTokenManagerFactory;
+import org.apache.flink.runtime.security.token.hadoop.KerberosDelegationTokenManagerFactory;
 import org.apache.flink.runtime.taskexecutor.TaskExecutor;
 import org.apache.flink.runtime.taskexecutor.TaskManagerRunner;
 import org.apache.flink.runtime.webmonitor.retriever.LeaderRetriever;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -21,7 +21,7 @@ package org.apache.flink.runtime.security.modules;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.hadoop.HadoopUserUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
-import org.apache.flink.runtime.security.token.KerberosLoginProvider;
+import org.apache.flink.runtime.security.token.hadoop.KerberosLoginProvider;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.security.Credentials;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HBaseDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HBaseDelegationTokenProvider.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.Configuration;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenConverter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenConverter.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.annotation.Internal;
 
@@ -29,7 +29,7 @@ import java.io.IOException;
 
 /** Delegation token serializer and deserializer functionality. */
 @Internal
-public class DelegationTokenConverter {
+public class HadoopDelegationTokenConverter {
     /** Serializes delegation tokens. */
     public static byte[] serialize(Credentials credentials) throws IOException {
         try (DataOutputBuffer dob = new DataOutputBuffer()) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenProvider.java
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenUpdater.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenUpdater.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.annotation.Internal;
 
@@ -29,18 +29,18 @@ import java.io.IOException;
 
 /** Delegation token updater functionality. */
 @Internal
-public final class DelegationTokenUpdater {
+public final class HadoopDelegationTokenUpdater {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DelegationTokenUpdater.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HadoopDelegationTokenUpdater.class);
 
-    private DelegationTokenUpdater() {}
+    private HadoopDelegationTokenUpdater() {}
 
     /** Updates delegation tokens for the current user. */
     public static void addCurrentUserCredentials(byte[] credentialsBytes) throws IOException {
         if (credentialsBytes == null || credentialsBytes.length == 0) {
             throw new IllegalArgumentException("Illegal credentials tried to be set");
         }
-        Credentials credentials = DelegationTokenConverter.deserialize(credentialsBytes);
+        Credentials credentials = HadoopDelegationTokenConverter.deserialize(credentialsBytes);
         LOG.info("Updating delegation tokens for current user");
         dumpAllTokens(credentials);
         UserGroupInformation.getCurrentUser().addCredentials(credentials);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProvider.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.annotation.VisibleForTesting;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosDelegationTokenManagerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosDelegationTokenManagerFactory.java
@@ -16,12 +16,14 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.runtime.hadoop.HadoopDependency;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
+import org.apache.flink.runtime.security.token.NoOpDelegationTokenManager;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 
 import org.slf4j.Logger;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -94,7 +94,7 @@ import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcEndpoint;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.RpcServiceUtils;
-import org.apache.flink.runtime.security.token.DelegationTokenUpdater;
+import org.apache.flink.runtime.security.token.hadoop.HadoopDelegationTokenUpdater;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
@@ -1340,7 +1340,7 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         }
 
         try {
-            DelegationTokenUpdater.addCurrentUserCredentials(tokens);
+            HadoopDelegationTokenUpdater.addCurrentUserCredentials(tokens);
             return CompletableFuture.completedFuture(Acknowledge.get());
         } catch (Throwable t) {
             log.error("Could not update delegation tokens.", t);
@@ -2379,7 +2379,8 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             if (success.getInitialTokens() != null) {
                 try {
                     log.info("Receive initial delegation tokens from resource manager");
-                    DelegationTokenUpdater.addCurrentUserCredentials(success.getInitialTokens());
+                    HadoopDelegationTokenUpdater.addCurrentUserCredentials(
+                            success.getInitialTokens());
                 } catch (Throwable t) {
                     log.error("Could not update delegation tokens.", t);
                     ExceptionUtils.rethrowIfFatalError(t);

--- a/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.token.hadoop.HadoopDelegationTokenProvider
+++ b/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.token.hadoop.HadoopDelegationTokenProvider
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.runtime.security.token.TestHadoopDelegationTokenProvider
-org.apache.flink.runtime.security.token.ExceptionThrowingHadoopDelegationTokenProvider
+org.apache.flink.runtime.security.token.hadoop.HadoopFSDelegationTokenProvider
+org.apache.flink.runtime.security.token.hadoop.HBaseDelegationTokenProvider

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/ExceptionThrowingHadoopDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/ExceptionThrowingHadoopDelegationTokenProvider.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.configuration.Configuration;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenConverterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenConverterTest.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.Credentials;
@@ -28,8 +28,8 @@ import java.io.IOException;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-/** Test for {@link DelegationTokenConverter}. */
-public class DelegationTokenConverterTest {
+/** Test for {@link HadoopDelegationTokenConverter}. */
+public class HadoopDelegationTokenConverterTest {
 
     @Test
     public void testRoundTrip() throws IOException {
@@ -39,9 +39,9 @@ public class DelegationTokenConverterTest {
         credentials.addToken(
                 tokenService, new Token<>(new byte[4], new byte[4], tokenKind, tokenService));
 
-        byte[] credentialsBytes = DelegationTokenConverter.serialize(credentials);
+        byte[] credentialsBytes = HadoopDelegationTokenConverter.serialize(credentials);
         Credentials deserializedCredentials =
-                DelegationTokenConverter.deserialize(credentialsBytes);
+                HadoopDelegationTokenConverter.deserialize(credentialsBytes);
 
         assertEquals(1, credentials.getAllTokens().size());
         assertEquals(1, deserializedCredentials.getAllTokens().size());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenUpdaterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/HadoopDelegationTokenUpdaterITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.io.Text;
@@ -36,8 +36,8 @@ import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-/** Test for {@link DelegationTokenConverter}. */
-public class DelegationTokenUpdaterITCase {
+/** Test for {@link HadoopDelegationTokenConverter}. */
+public class HadoopDelegationTokenUpdaterITCase {
 
     @Test
     public void addCurrentUserCredentialsShouldThrowExceptionWhenNullCredentials() {
@@ -58,7 +58,7 @@ public class DelegationTokenUpdaterITCase {
                     assertThrows(
                             IllegalArgumentException.class,
                             () ->
-                                    DelegationTokenUpdater.addCurrentUserCredentials(
+                                    HadoopDelegationTokenUpdater.addCurrentUserCredentials(
                                             credentialsBytes));
             assertTrue(e.getMessage().contains("Illegal credentials"));
         }
@@ -72,13 +72,13 @@ public class DelegationTokenUpdaterITCase {
         credentials.addToken(
                 tokenService, new Token<>(new byte[4], new byte[4], tokenKind, tokenService));
 
-        byte[] credentialsBytes = DelegationTokenConverter.serialize(credentials);
+        byte[] credentialsBytes = HadoopDelegationTokenConverter.serialize(credentials);
 
         try (MockedStatic<UserGroupInformation> ugi = mockStatic(UserGroupInformation.class)) {
             UserGroupInformation userGroupInformation = mock(UserGroupInformation.class);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            DelegationTokenUpdater.addCurrentUserCredentials(credentialsBytes);
+            HadoopDelegationTokenUpdater.addCurrentUserCredentials(credentialsBytes);
             ArgumentCaptor<Credentials> argumentCaptor = ArgumentCaptor.forClass(Credentials.class);
             verify(userGroupInformation, times(1)).addCredentials(argumentCaptor.capture());
             assertTrue(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProviderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProviderITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -47,17 +47,20 @@ class HadoopFSDelegationTokenProviderITCase {
     final Text tokenService1 = new Text("TEST_TOKEN_SERVICE1");
     final Text tokenService2 = new Text("TEST_TOKEN_SERVICE2");
 
-    private class TestDelegationToken extends Token<TestDelegationTokenIdentifier> {
+    private class TestDelegationToken extends Token<TestHadoopDelegationTokenIdentifier> {
 
         private long newExpiration;
 
         public TestDelegationToken(
-                Text tokenService, TestDelegationTokenIdentifier identifier, long newExpiration) {
+                Text tokenService,
+                TestHadoopDelegationTokenIdentifier identifier,
+                long newExpiration) {
             super(identifier.getBytes(), new byte[4], identifier.getKind(), tokenService);
             this.newExpiration = newExpiration;
         }
 
-        public TestDelegationToken(Text tokenService, TestDelegationTokenIdentifier identifier) {
+        public TestDelegationToken(
+                Text tokenService, TestHadoopDelegationTokenIdentifier identifier) {
             this(tokenService, identifier, 0L);
         }
 
@@ -112,14 +115,14 @@ class HadoopFSDelegationTokenProviderITCase {
                             String renewer,
                             Set<FileSystem> fileSystemsToAccess,
                             Credentials credentials) {
-                        TestDelegationTokenIdentifier tokenIdentifier1 =
-                                new TestDelegationTokenIdentifier(NOW);
+                        TestHadoopDelegationTokenIdentifier tokenIdentifier1 =
+                                new TestHadoopDelegationTokenIdentifier(NOW);
                         credentials.addToken(
                                 tokenService1,
                                 new TestDelegationToken(tokenService1, tokenIdentifier1, NOW + 1));
 
-                        TestDelegationTokenIdentifier tokenIdentifier2 =
-                                new TestDelegationTokenIdentifier(NOW);
+                        TestHadoopDelegationTokenIdentifier tokenIdentifier2 =
+                                new TestHadoopDelegationTokenIdentifier(NOW);
                         credentials.addToken(
                                 tokenService2,
                                 new TestDelegationToken(tokenService2, tokenIdentifier2, NOW + 2));
@@ -155,10 +158,12 @@ class HadoopFSDelegationTokenProviderITCase {
         HadoopFSDelegationTokenProvider provider = new HadoopFSDelegationTokenProvider();
         Clock constantClock = Clock.fixed(ofEpochMilli(NOW), ZoneId.systemDefault());
         Credentials credentials = new Credentials();
-        TestDelegationTokenIdentifier tokenIdentifier1 = new TestDelegationTokenIdentifier(NOW);
+        TestHadoopDelegationTokenIdentifier tokenIdentifier1 =
+                new TestHadoopDelegationTokenIdentifier(NOW);
         credentials.addToken(
                 tokenService1, new TestDelegationToken(tokenService1, tokenIdentifier1));
-        TestDelegationTokenIdentifier tokenIdentifier2 = new TestDelegationTokenIdentifier(NOW + 1);
+        TestHadoopDelegationTokenIdentifier tokenIdentifier2 =
+                new TestHadoopDelegationTokenIdentifier(NOW + 1);
         credentials.addToken(
                 tokenService2, new TestDelegationToken(tokenService2, tokenIdentifier2));
 
@@ -173,7 +178,7 @@ class HadoopFSDelegationTokenProviderITCase {
         Clock constantClock = Clock.fixed(ofEpochMilli(NOW), ZoneId.systemDefault());
         long issueDate = NOW + 1;
         AbstractDelegationTokenIdentifier tokenIdentifier =
-                new TestDelegationTokenIdentifier(issueDate);
+                new TestHadoopDelegationTokenIdentifier(issueDate);
 
         assertEquals(
                 issueDate,
@@ -188,7 +193,7 @@ class HadoopFSDelegationTokenProviderITCase {
         Clock constantClock = Clock.fixed(ofEpochMilli(NOW), ZoneId.systemDefault());
         long issueDate = NOW - 1;
         AbstractDelegationTokenIdentifier tokenIdentifier =
-                new TestDelegationTokenIdentifier(issueDate);
+                new TestHadoopDelegationTokenIdentifier(issueDate);
 
         assertEquals(
                 issueDate,
@@ -203,7 +208,7 @@ class HadoopFSDelegationTokenProviderITCase {
         Clock constantClock = Clock.fixed(ofEpochMilli(NOW), ZoneId.systemDefault());
         long issueDate = -1;
         AbstractDelegationTokenIdentifier tokenIdentifier =
-                new TestDelegationTokenIdentifier(issueDate);
+                new TestHadoopDelegationTokenIdentifier(issueDate);
 
         assertEquals(
                 NOW,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosDelegationTokenManagerITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosDelegationTokenManagerITCase.java
@@ -16,10 +16,11 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.runtime.security.token.DelegationTokenManager;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
 import org.apache.hadoop.security.UserGroupInformation;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.configuration.Configuration;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/TestHadoopDelegationTokenIdentifier.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/TestHadoopDelegationTokenIdentifier.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier;
@@ -29,16 +29,16 @@ import java.io.IOException;
  * Example test implementation of {@link AbstractDelegationTokenIdentifier} which is used in
  * integration tests.
  */
-public class TestDelegationTokenIdentifier extends AbstractDelegationTokenIdentifier {
+public class TestHadoopDelegationTokenIdentifier extends AbstractDelegationTokenIdentifier {
 
     private static final Text tokenKind = new Text("TEST_TOKEN_KIND");
 
     private long issueDate;
 
     // This is needed for service loader
-    public TestDelegationTokenIdentifier() {}
+    public TestHadoopDelegationTokenIdentifier() {}
 
-    public TestDelegationTokenIdentifier(long issueDate) {
+    public TestHadoopDelegationTokenIdentifier(long issueDate) {
         this.issueDate = issueDate;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/TestHadoopDelegationTokenProvider.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/TestHadoopDelegationTokenProvider.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.flink.runtime.security.token;
+package org.apache.flink.runtime.security.token.hadoop;
 
 import org.apache.flink.configuration.Configuration;
 
@@ -24,7 +24,10 @@ import org.apache.hadoop.security.Credentials;
 
 import java.util.Optional;
 
-/** An example implementation of {@link HadoopDelegationTokenProvider} which does nothing. */
+/**
+ * An example implementation of {@link
+ * org.apache.flink.runtime.security.token.hadoop.HadoopDelegationTokenProvider} which does nothing.
+ */
 public class TestHadoopDelegationTokenProvider implements HadoopDelegationTokenProvider {
 
     @Override

--- a/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.token.hadoop.HadoopDelegationTokenProvider
+++ b/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.token.hadoop.HadoopDelegationTokenProvider
@@ -13,5 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.runtime.security.token.HadoopFSDelegationTokenProvider
-org.apache.flink.runtime.security.token.HBaseDelegationTokenProvider
+org.apache.flink.runtime.security.token.hadoop.TestHadoopDelegationTokenProvider
+org.apache.flink.runtime.security.token.hadoop.ExceptionThrowingHadoopDelegationTokenProvider

--- a/flink-runtime/src/test/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
+++ b/flink-runtime/src/test/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.flink.runtime.security.token.TestDelegationTokenIdentifier
+org.apache.flink.runtime.security.token.hadoop.TestHadoopDelegationTokenIdentifier

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -52,10 +52,10 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobmanager.HighAvailabilityMode;
 import org.apache.flink.runtime.jobmanager.JobManagerProcessSpec;
 import org.apache.flink.runtime.jobmanager.JobManagerProcessUtils;
-import org.apache.flink.runtime.security.token.DelegationTokenConverter;
 import org.apache.flink.runtime.security.token.DelegationTokenManager;
-import org.apache.flink.runtime.security.token.KerberosDelegationTokenManager;
-import org.apache.flink.runtime.security.token.KerberosLoginProvider;
+import org.apache.flink.runtime.security.token.hadoop.HadoopDelegationTokenConverter;
+import org.apache.flink.runtime.security.token.hadoop.KerberosDelegationTokenManager;
+import org.apache.flink.runtime.security.token.hadoop.KerberosLoginProvider;
 import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.CollectionUtil;
 import org.apache.flink.util.FlinkException;
@@ -1300,7 +1300,7 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
                 new KerberosDelegationTokenManager(flinkConfiguration, null, null);
         delegationTokenManager.obtainDelegationTokens(credentials);
 
-        ByteBuffer tokens = ByteBuffer.wrap(DelegationTokenConverter.serialize(credentials));
+        ByteBuffer tokens = ByteBuffer.wrap(HadoopDelegationTokenConverter.serialize(credentials));
         containerLaunchContext.setTokens(tokens);
 
         LOG.info("Delegation tokens added to the AM container.");


### PR DESCRIPTION
## What is the purpose of the change

At the moment generic and Hadoop parts of the delegation token framework is not separated. In this PR I've separated them both in naming and in package.

## Brief change log

Separate token framework generic and hadoop specific parts.

## Verifying this change

Existing unit/integration tests + manually on [minikube](https://gist.github.com/gaborgsomogyi/ac4f71ead8494da2f5c35265bcb1e885).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
