### PR TITLE
[FLINK-30097][docs] Update the example in the docs of DataStream cache

### DIFF
--- a/docs/content/docs/dev/datastream/operators/overview.md
+++ b/docs/content/docs/dev/datastream/operators/overview.md
@@ -586,12 +586,12 @@ lost, it will be recomputed using the original transformations.
 {{< tabs cache >}}
 {{< tab "Java" >}}
 ```java
-DataStream<Integer> dataStream = //...
+SingleOutputStreamOperator<Integer> dataStream = //...
 CachedDataStream<Integer> cachedDataStream = dataStream.cache();
 cachedDataStream.print(); // Do anything with the cachedDataStream
 ...
 env.execute(); // Execute and create cache.
-        
+
 cachedDataStream.print(); // Consume cached result.
 env.execute();
 ```


### PR DESCRIPTION
## What is the purpose of the change

Update the example in the docs of DataStream cache to fix the wrong type usage.


## Brief change log

- Update the example in the docs of DataStream cache


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable