### PR TITLE
[FLINK-30386] Fix the issue that column constraint lacks primary key not enforced check

### DIFF
--- a/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-1.4/src/test/java/org/apache/flink/connector/hbase1/HBaseConnectorITCase.java
@@ -152,7 +152,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 
         tEnv.executeSql(
                 "CREATE TABLE hTable ("
-                        + " rowkey INT PRIMARY KEY,"
+                        + " rowkey INT PRIMARY KEY NOT ENFORCED,"
                         + " family2 ROW<col1 STRING, col2 BIGINT>,"
                         + " family3 ROW<col1 DOUBLE, col2 BOOLEAN, col3 STRING>,"
                         + " family1 ROW<col1 INT>"

--- a/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
+++ b/flink-connectors/flink-connector-hbase-2.2/src/test/java/org/apache/flink/connector/hbase2/HBaseConnectorITCase.java
@@ -168,7 +168,7 @@ public class HBaseConnectorITCase extends HBaseTestBase {
 
         tEnv.executeSql(
                 "CREATE TABLE hTable ("
-                        + " rowkey INT PRIMARY KEY,"
+                        + " rowkey INT PRIMARY KEY NOT ENFORCED,"
                         + " family2 ROW<col1 STRING, col2 BIGINT>,"
                         + " family3 ROW<col1 DOUBLE, col2 BOOLEAN, col3 STRING>,"
                         + " family1 ROW<col1 INT>"

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointITCase.java
@@ -750,7 +750,7 @@ public class HiveServer2EndpointITCase extends TestLogger {
 
             statement.execute(
                     "CREATE TABLE db_test1.tbl_1(\n"
-                            + "`user` BIGINT CONSTRAINT `pk` PRIMARY KEY COMMENT 'user id.',\n"
+                            + "`user` BIGINT CONSTRAINT `pk` PRIMARY KEY NOT ENFORCED COMMENT 'user id.',\n"
                             + "`product` STRING NOT NULL,\n"
                             + "`amount`  INT) COMMENT 'temporary table tbl_1'");
             statement.execute(

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlConstraintValidator.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/SqlConstraintValidator.java
@@ -71,6 +71,10 @@ public class SqlConstraintValidator {
             Set<String> primaryKeyColumns =
                     Arrays.stream(constraint.getColumnNames()).collect(Collectors.toSet());
 
+            // rewrite primary key's nullability to false
+            // e.g. CREATE TABLE tbl (`a` STRING PRIMARY KEY NOT ENFORCED, ...) or
+            // CREATE TABLE tbl (`a` STRING, PRIMARY KEY(`a`) NOT ENFORCED) will change `a`
+            // to STRING NOT NULL
             for (SqlNode column : columnList) {
                 SqlTableColumn tableColumn = (SqlTableColumn) column;
                 if (tableColumn instanceof SqlTableColumn.SqlRegularColumn
@@ -84,7 +88,7 @@ public class SqlConstraintValidator {
         }
     }
 
-    /** Check table/column constraint. */
+    /** Check table constraint. */
     private static void validate(SqlTableConstraint constraint) throws SqlValidateException {
         if (constraint.isUnique()) {
             throw new SqlValidateException(
@@ -93,10 +97,9 @@ public class SqlConstraintValidator {
         if (constraint.isEnforced()) {
             throw new SqlValidateException(
                     constraint.getParserPosition(),
-                    "Flink doesn't support ENFORCED mode for "
-                            + "PRIMARY KEY constraint. ENFORCED/NOT ENFORCED controls if the constraint checks are performed on the incoming/outgoing data. "
-                            + "Flink does not own the data therefore the only supported mode "
-                            + "is the NOT ENFORCED mode");
+                    "Flink doesn't support ENFORCED mode for PRIMARY KEY constraint. ENFORCED/NOT ENFORCED "
+                            + "controls if the constraint checks are performed on the incoming/outgoing data. "
+                            + "Flink does not own the data therefore the only supported mode is the NOT ENFORCED mode");
         }
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/AlterSchemaConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/AlterSchemaConverter.java
@@ -73,7 +73,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -91,17 +90,14 @@ public class AlterSchemaConverter {
 
     private final SqlValidator sqlValidator;
     private final Function<SqlNode, String> escapeExpression;
-    private final Consumer<SqlTableConstraint> constraintValidator;
     private final CatalogManager catalogManager;
 
     AlterSchemaConverter(
             SqlValidator sqlValidator,
-            Consumer<SqlTableConstraint> constraintValidator,
             Function<SqlNode, String> escapeExpression,
             CatalogManager catalogManager) {
         this.sqlValidator = sqlValidator;
         this.escapeExpression = escapeExpression;
-        this.constraintValidator = constraintValidator;
         this.catalogManager = catalogManager;
     }
 
@@ -305,7 +301,6 @@ public class AlterSchemaConverter {
         Function<SqlNode, String> escapeExpressions;
         FlinkTypeFactory typeFactory;
         SqlValidator sqlValidator;
-        Consumer<SqlTableConstraint> constraintValidator;
         SchemaResolver schemaResolver;
 
         List<TableChange> changesCollector;
@@ -315,12 +310,10 @@ public class AlterSchemaConverter {
                 Schema oldSchema,
                 FlinkTypeFactory typeFactory,
                 SqlValidator sqlValidator,
-                Consumer<SqlTableConstraint> constraintValidator,
                 Function<SqlNode, String> escapeExpressions,
                 SchemaResolver schemaResolver) {
             this.typeFactory = typeFactory;
             this.sqlValidator = sqlValidator;
-            this.constraintValidator = constraintValidator;
             this.escapeExpressions = escapeExpressions;
             this.schemaResolver = schemaResolver;
             this.changesCollector = new ArrayList<>();
@@ -380,7 +373,6 @@ public class AlterSchemaConverter {
 
         private void updatePrimaryKey(SqlTableConstraint alterPrimaryKey) {
             checkAndCollectPrimaryKeyChange();
-            constraintValidator.accept(alterPrimaryKey);
             List<String> primaryKeyColumns = Arrays.asList(alterPrimaryKey.getColumnNames());
             primaryKey =
                     new Schema.UnresolvedPrimaryKey(
@@ -550,16 +542,9 @@ public class AlterSchemaConverter {
                 Schema oldSchema,
                 FlinkTypeFactory typeFactory,
                 SqlValidator sqlValidator,
-                Consumer<SqlTableConstraint> constraintValidator,
                 Function<SqlNode, String> escapeExpressions,
                 SchemaResolver schemaResolver) {
-            super(
-                    oldSchema,
-                    typeFactory,
-                    sqlValidator,
-                    constraintValidator,
-                    escapeExpressions,
-                    schemaResolver);
+            super(oldSchema, typeFactory, sqlValidator, escapeExpressions, schemaResolver);
         }
 
         @Override
@@ -642,14 +627,12 @@ public class AlterSchemaConverter {
                 ResolvedCatalogTable oldTable,
                 FlinkTypeFactory typeFactory,
                 SqlValidator sqlValidator,
-                Consumer<SqlTableConstraint> constraintValidator,
                 Function<SqlNode, String> escapeExpressions,
                 SchemaResolver schemaResolver) {
             super(
                     oldTable.getUnresolvedSchema(),
                     typeFactory,
                     sqlValidator,
-                    constraintValidator,
                     escapeExpressions,
                     schemaResolver);
             this.oldTable = oldTable;
@@ -962,7 +945,6 @@ public class AlterSchemaConverter {
                     oldTable.getUnresolvedSchema(),
                     (FlinkTypeFactory) sqlValidator.getTypeFactory(),
                     sqlValidator,
-                    constraintValidator,
                     escapeExpression,
                     catalogManager.getSchemaResolver());
         } else if (alterTableSchema instanceof SqlAlterTableModify) {
@@ -970,7 +952,6 @@ public class AlterSchemaConverter {
                     oldTable,
                     (FlinkTypeFactory) sqlValidator.getTypeFactory(),
                     sqlValidator,
-                    constraintValidator,
                     escapeExpression,
                     catalogManager.getSchemaResolver());
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlCreateTableConverter.java
@@ -52,7 +52,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -61,21 +60,17 @@ class SqlCreateTableConverter {
 
     private final MergeTableLikeUtil mergeTableLikeUtil;
     private final CatalogManager catalogManager;
-    private final Consumer<SqlTableConstraint> validateTableConstraint;
 
     SqlCreateTableConverter(
             FlinkCalciteSqlValidator sqlValidator,
             CatalogManager catalogManager,
-            Function<SqlNode, String> escapeExpression,
-            Consumer<SqlTableConstraint> validateTableConstraint) {
+            Function<SqlNode, String> escapeExpression) {
         this.mergeTableLikeUtil = new MergeTableLikeUtil(sqlValidator, escapeExpression);
         this.catalogManager = catalogManager;
-        this.validateTableConstraint = validateTableConstraint;
     }
 
     /** Convert the {@link SqlCreateTable} node. */
     Operation convertCreateTable(SqlCreateTable sqlCreateTable) {
-        sqlCreateTable.getTableConstraints().forEach(validateTableConstraint);
         CatalogTable catalogTable = createCatalogTable(sqlCreateTable);
 
         UnresolvedIdentifier unresolvedIdentifier =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -61,7 +61,6 @@ import org.apache.flink.sql.parser.ddl.SqlTableOption;
 import org.apache.flink.sql.parser.ddl.SqlUseCatalog;
 import org.apache.flink.sql.parser.ddl.SqlUseDatabase;
 import org.apache.flink.sql.parser.ddl.SqlUseModules;
-import org.apache.flink.sql.parser.ddl.constraint.SqlTableConstraint;
 import org.apache.flink.sql.parser.ddl.resource.SqlResource;
 import org.apache.flink.sql.parser.ddl.resource.SqlResourceType;
 import org.apache.flink.sql.parser.dml.RichSqlInsert;
@@ -259,12 +258,10 @@ public class SqlToOperationConverter {
                 new SqlCreateTableConverter(
                         flinkPlanner.getOrCreateSqlValidator(),
                         catalogManager,
-                        this::getQuotedSqlString,
-                        this::validateTableConstraint);
+                        this::getQuotedSqlString);
         this.alterSchemaConverter =
                 new AlterSchemaConverter(
                         flinkPlanner.getOrCreateSqlValidator(),
-                        this::validateTableConstraint,
                         this::getQuotedSqlString,
                         catalogManager);
     }
@@ -1564,20 +1561,6 @@ public class SqlToOperationConverter {
         PlannerQueryOperation queryOperation = new PlannerQueryOperation(tableModify);
         return new SinkModifyOperation(
                 contextResolvedTable, queryOperation, SinkModifyOperation.ModifyType.UPDATE);
-    }
-
-    private void validateTableConstraint(SqlTableConstraint constraint) {
-        if (constraint.isUnique()) {
-            throw new UnsupportedOperationException("UNIQUE constraint is not supported yet");
-        }
-        if (constraint.isEnforced()) {
-            throw new ValidationException(
-                    "Flink doesn't support ENFORCED mode for "
-                            + "PRIMARY KEY constraint. ENFORCED/NOT ENFORCED controls if the constraint "
-                            + "checks are performed on the incoming/outgoing data. "
-                            + "Flink does not own the data therefore the only supported mode "
-                            + "is the NOT ENFORCED mode");
-        }
     }
 
     private String getQuotedSqlString(SqlNode sqlNode) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.operations;
 
 import org.apache.flink.sql.parser.ddl.SqlCreateTable;
+import org.apache.flink.sql.parser.error.SqlValidateException;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.SqlDialect;
@@ -1477,12 +1478,12 @@ public class SqlDdlToOperationConverterTest extends SqlToOperationConverterTestB
 
         // add unique constraint
         assertThatThrownBy(() -> parse("alter table tb3 add unique(b)"))
-                .isInstanceOf(UnsupportedOperationException.class)
+                .isInstanceOf(SqlValidateException.class)
                 .hasMessageContaining("UNIQUE constraint is not supported yet");
 
         // lack NOT ENFORCED
         assertThatThrownBy(() -> parse("alter table tb3 add primary key(b)"))
-                .isInstanceOf(ValidationException.class)
+                .isInstanceOf(SqlValidateException.class)
                 .hasMessageContaining(
                         "Flink doesn't support ENFORCED mode for PRIMARY KEY constraint");
 

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -106,6 +106,38 @@ class TableEnvironmentTest {
   }
 
   @Test
+  def testCreateTableWithEnforcedMode(): Unit = {
+    // check column constraint
+    assertThatThrownBy(() => tableEnv.executeSql("""
+                                                   |CREATE TABLE MyTable (
+                                                   |  a bigint primary key,
+                                                   |  b int,
+                                                   |  c varchar
+                                                   |) with (
+                                                   |  'connector' = 'COLLECTION',
+                                                   |  'is-bounded' = 'false'
+                                                   |)
+    """.stripMargin))
+      .hasMessageContaining("Flink doesn't support ENFORCED mode for PRIMARY KEY constraint.")
+      .isInstanceOf[ValidationException]
+
+    // check table constraint
+    assertThatThrownBy(() => tableEnv.executeSql("""
+                                                   |CREATE TABLE MyTable (
+                                                   |  a bigint,
+                                                   |  b int,
+                                                   |  c varchar,
+                                                   |  primary key(a)
+                                                   |) with (
+                                                   |  'connector' = 'COLLECTION',
+                                                   |  'is-bounded' = 'false'
+                                                   |)
+    """.stripMargin))
+      .hasMessageContaining("Flink doesn't support ENFORCED mode for PRIMARY KEY constraint.")
+      .isInstanceOf[ValidationException]
+  }
+
+  @Test
   def testStreamTableEnvironmentExplain(): Unit = {
     val execEnv = StreamExecutionEnvironment.getExecutionEnvironment
     val settings = EnvironmentSettings.newInstance().inStreamingMode().build()


### PR DESCRIPTION
## What is the purpose of the change

This pull request aims to fix the issue that the column constraint lacks the not enforced check.
```sql
CREATE TABLE foo (
  a INT PRIMARY KEY, -- currently this passes the validation, but it should be `a INT PRIMARY KEY NOT ENFORCED`
  b STRING
) WITH (...)
```


## Brief change log

Currently, the constraint check(on the duplicate primary key, unique key, and enforced mode) spreads over the parse and conversion phase(see `SqlCreateTable#validate` and `SqlToOperatoinConverter#validateTableConstraint`).

To improve this, introduce a `SqlConstraintValidator` to perform the unified check for both column and table constraints. 
The logic of`SqlToOperatoinConverter#validateTableConstraint` is moved to `SqlConstraintValidator`.

## Verifying this change

This change added tests and can be verified as follows:
- FlinkSqlParserImplTest
- SqlToOperationConverterTest
- HBaseConnectorITCase
- HiveServer2EndpointITCase


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduces a new feature? no
  - If yes, how is the feature documented? not applicable
