### PR TITLE
[FLINK-30128] Introduce Azure Data Lake Gen2 APIs in the Hadoop Recoverable path

### DIFF
--- a/flink-filesystems/flink-azure-fs-hadoop/pom.xml
+++ b/flink-filesystems/flink-azure-fs-hadoop/pom.xml
@@ -186,13 +186,6 @@ under the License.
 							</relocations>
 							<filters>
 								<filter>
-									<artifact>org.apache.flink:flink-hadoop-fs</artifact>
-									<excludes>
-										<exclude>org/apache/flink/runtime/util/HadoopUtils</exclude>
-										<exclude>org/apache/flink/runtime/fs/hdfs/HadoopRecoverable*</exclude>
-									</excludes>
-								</filter>
-								<filter>
 									<artifact>*</artifact>
 									<excludes>
 										<exclude>properties.dtd</exclude>

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AbstractAzureFSFactory.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AbstractAzureFSFactory.java
@@ -21,7 +21,6 @@ package org.apache.flink.fs.azurefs;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.FileSystemFactory;
-import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
 import org.apache.flink.runtime.util.HadoopConfigLoader;
 
 import org.slf4j.Logger;
@@ -77,6 +76,6 @@ public abstract class AbstractAzureFSFactory implements FileSystemFactory {
         org.apache.hadoop.conf.Configuration hadoopConfig = configLoader.getOrLoadHadoopConfig();
         org.apache.hadoop.fs.FileSystem fs = createAzureFS();
         fs.initialize(fsUri, hadoopConfig);
-        return new HadoopFileSystem(fs);
+        return new AzureBlobFileSystem(fs);
     }
 }

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFileSystem.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFileSystem.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.runtime.fs.hdfs.HadoopFileSystem;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.IOException;
+
+/** Wraps the hadoop's file system to create AzureBlobFileSystem. */
+@Internal
+class AzureBlobFileSystem extends HadoopFileSystem {
+    /**
+     * Wraps the given Hadoop File System object as a Flink File System object. The given Hadoop
+     * file system object is expected to be initialized already.
+     *
+     * @param hadoopFileSystem The Azure Blob FileSystem that will be used under the hood.
+     */
+    AzureBlobFileSystem(FileSystem hadoopFileSystem) {
+        super(hadoopFileSystem);
+    }
+
+    @Override
+    public RecoverableWriter createRecoverableWriter() throws IOException {
+        return new AzureBlobRecoverableWriter(getHadoopFileSystem());
+    }
+}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
@@ -19,6 +19,7 @@
 package org.apache.flink.fs.azurefs;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter;
 import org.apache.flink.runtime.fs.hdfs.BaseHadoopFsRecoverableFsDataOutputStream;
@@ -50,7 +51,7 @@ public class AzureBlobFsRecoverableDataOutputStream
     private static final String RENAME = ".rename";
 
     // Not final to override in tests
-    public static int minBufferLength = 2097152;
+    @VisibleForTesting static int minBufferLength = 2097152;
 
     AzureBlobFsRecoverableDataOutputStream(FileSystem fs, Path targetFile, Path tempFile)
             throws IOException {
@@ -209,7 +210,7 @@ public class AzureBlobFsRecoverableDataOutputStream
     }
 
     @Override
-    public void flush() throws IOException {
+    public void sync() throws IOException {
         out.hsync();
     }
 

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobFsRecoverableDataOutputStream.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+import org.apache.flink.runtime.fs.hdfs.BaseHadoopFsRecoverableFsDataOutputStream;
+import org.apache.flink.runtime.fs.hdfs.HadoopFsRecoverable;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * An implementation of the {@link RecoverableFsDataOutputStream} for AzureBlob's file system
+ * abstraction.
+ */
+@Internal
+public class AzureBlobFsRecoverableDataOutputStream
+        extends BaseHadoopFsRecoverableFsDataOutputStream {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(AzureBlobFsRecoverableDataOutputStream.class);
+    private static final String RENAME = ".rename";
+
+    // Not final to override in tests
+    public static int minBufferLength = 2097152;
+
+    AzureBlobFsRecoverableDataOutputStream(FileSystem fs, Path targetFile, Path tempFile)
+            throws IOException {
+        this.fs = checkNotNull(fs);
+        this.targetFile = checkNotNull(targetFile);
+        LOG.debug("The targetFile is {}", targetFile.getName());
+        this.tempFile = checkNotNull(tempFile);
+        LOG.debug("The tempFile is {}", tempFile.getName());
+        this.out = fs.create(tempFile);
+    }
+
+    AzureBlobFsRecoverableDataOutputStream(FileSystem fs, HadoopFsRecoverable recoverable)
+            throws IOException {
+        this.fs = checkNotNull(fs);
+        this.targetFile = checkNotNull(recoverable.targetFile());
+        this.tempFile = checkNotNull(recoverable.tempFile());
+        if (!fs.exists(tempFile)) {
+            LOG.error("The temp file is not found {}", tempFile);
+            // trying the temp rename file.
+            Path renameTempPath = new Path(tempFile.toString() + RENAME);
+            if (fs.exists(renameTempPath)) {
+                LOG.info(
+                        "Found the rename file. Probably a case where the rename did not happen {}",
+                        renameTempPath);
+                if (fs.getFileStatus(renameTempPath).getLen() == recoverable.offset()) {
+                    rename(fs, renameTempPath);
+                } else {
+                    LOG.error(
+                            "Unrecoverable error. As the required {} file is not found", tempFile);
+                    throw new IOException(
+                            "Unable to recover the job as the expected "
+                                    + tempFile
+                                    + " file is not found");
+                }
+            } else {
+                LOG.error("Unrecoverable error. As the required {} file is not found", tempFile);
+                throw new IOException(
+                        "Unable to recover the job as the expected "
+                                + tempFile
+                                + " file is not found");
+            }
+        } else {
+            long len = fs.getFileStatus(tempFile).getLen();
+            LOG.info(
+                    "The recoverable offset is {} and the file len is {}",
+                    recoverable.offset(),
+                    len);
+            // Happens when we recover from a previously committed offset. Otherwise this is not
+            // really needed
+            if (len > recoverable.offset()) {
+                truncate(fs, recoverable);
+            } else if (len < recoverable.offset()) {
+                LOG.error(
+                        "Temp file length {} is less than the expected recoverable offset {}",
+                        len,
+                        recoverable.offset());
+                throw new IOException(
+                        "Unable to create recoverable outputstream as length of file "
+                                + len
+                                + " is less than "
+                                + "recoverable offset "
+                                + recoverable.offset());
+            }
+        }
+        out = fs.append(tempFile);
+        if (out.getPos() == 0) {
+            // In ABFS when we try to append we don't account for the initial file size like we do
+            // in DFS.
+            // So we explicitly store this and when we do a persist call we make use of it.
+            // This we have raised a bug in ABFS hadoop driver side. Once fixed this will not be
+            // needed. So it should be ok to put this in side the 'if' check.
+            initialFileSize = fs.getFileStatus(tempFile).getLen();
+        }
+        LOG.debug("Created a new OS for appending {}", tempFile);
+    }
+
+    private void truncate(FileSystem fs, HadoopFsRecoverable recoverable) throws IOException {
+        Path renameTempPath = new Path(tempFile.toString() + RENAME);
+        try {
+            LOG.info(
+                    "Creating the temp rename file {} for truncating the tempFile {}",
+                    renameTempPath,
+                    tempFile);
+            FSDataOutputStream fsDataOutputStream = fs.create(renameTempPath);
+            LOG.info("Opening the tempFile {} for truncate", tempFile);
+            FSDataInputStream fsDis = fs.open(tempFile);
+            // 2 MB buffers. TODO : Make this configurable
+            long remaining = recoverable.offset();
+            byte[] buf = null;
+            long dataWritten = 0;
+            int readBytes = -1;
+            while (remaining != 0) {
+                if (minBufferLength < remaining) {
+                    buf = new byte[minBufferLength];
+                } else {
+                    buf = new byte[(int) remaining];
+                }
+                readBytes = fsDis.read(buf, 0, buf.length);
+                if (readBytes != -1) {
+                    remaining -= readBytes;
+                    LOG.info("Bytes remaining to read {}", remaining);
+                    fsDataOutputStream.write(buf, 0, readBytes);
+                    dataWritten += readBytes;
+                    LOG.info("Successfully wrote {} bytes of data", dataWritten);
+                } else {
+                    LOG.debug("Reached the end of the file");
+                    remaining = 0;
+                }
+            }
+            // TODO : Support intermediate flush?
+            LOG.info("Closing the temp rename file {}", renameTempPath);
+            fsDataOutputStream.close();
+            if (fsDis != null) {
+                LOG.debug("Closing the input stream");
+                fsDis.close();
+            }
+        } catch (IOException e) {
+            LOG.error(
+                    "Unable to recover. Exception while trying to truncate the temp file {}",
+                    tempFile);
+            // We cannot recover. This we can control if user does not want this??
+            throw e;
+        }
+        try {
+            LOG.info("Deleting the actual temp file {}", tempFile);
+            fs.delete(tempFile, false);
+        } catch (IOException e) {
+            LOG.error("Unable to recover. Error while deleting the temp file {}", tempFile);
+            // unable to recover.
+            throw e;
+        }
+        rename(fs, renameTempPath);
+    }
+
+    private void rename(FileSystem fs, Path renameTempPath) throws IOException {
+        LOG.info("Renaming the temp rename file {} back to tempFile {}", renameTempPath, tempFile);
+        try {
+            // Rename by default will overwrite if dest is already found.
+            boolean result = fs.rename(renameTempPath, tempFile);
+            if (!result) {
+                LOG.error(
+                        "Unable to recover. Rename operation failed {} to {}",
+                        renameTempPath,
+                        tempFile);
+                throw new IOException("Unable to recover. Rename operation failed");
+            } else {
+                LOG.info("Rename was successful");
+            }
+        } catch (IOException e) {
+            LOG.error(
+                    "Unable to recover. Renaming of tempFile did not happen after truncating {} to {}",
+                    renameTempPath,
+                    tempFile);
+            throw e;
+        }
+    }
+
+    @Override
+    public void flush() throws IOException {
+        out.hsync();
+    }
+
+    @Override
+    public Committer closeForCommit() throws IOException {
+        final long pos = getPos();
+        close();
+        return new AzureBlobFsRecoverableDataOutputStream.ABFSCommitter(
+                fs, createHadoopFsRecoverable(pos));
+    }
+
+    // ------------------------------------------------------------------------
+    //  Committer
+    // ------------------------------------------------------------------------
+
+    /**
+     * Implementation of a committer for the Hadoop File System abstraction. This implementation
+     * commits by renaming the temp file to the final file path. The temp file is truncated before
+     * renaming in case there is trailing garbage data.
+     */
+    static class ABFSCommitter implements Committer {
+
+        private final FileSystem fs;
+        private final HadoopFsRecoverable recoverable;
+
+        ABFSCommitter(FileSystem fs, HadoopFsRecoverable recoverable) {
+            this.fs = checkNotNull(fs);
+            this.recoverable = checkNotNull(recoverable);
+        }
+
+        @Override
+        public void commit() throws IOException {
+            final Path src = recoverable.tempFile();
+            final Path dest = recoverable.targetFile();
+            final long expectedLength = recoverable.offset();
+            FileStatus srcStatus = null;
+            try {
+                srcStatus = fs.getFileStatus(src);
+            } catch (FileNotFoundException fnfe) {
+                // srcStatus will be null
+            } catch (IOException e) {
+                throw new IOException("Cannot clean commit: Staging file does not exist.");
+            }
+            if (srcStatus != null) {
+                LOG.debug(
+                        "The srcStatus is {} and exp length is {}",
+                        srcStatus.getLen(),
+                        expectedLength);
+                if (srcStatus.getLen() != expectedLength) {
+                    LOG.error(
+                            "The src file {} with length {} does not match the expected length {}",
+                            src,
+                            srcStatus.getLen(),
+                            expectedLength);
+                    throw new IOException(
+                            "The src file "
+                                    + src
+                                    + " with length "
+                                    + srcStatus.getLen()
+                                    + " "
+                                    + "does not match the expected length "
+                                    + expectedLength);
+                }
+                try {
+                    fs.rename(src, dest);
+                } catch (IOException e) {
+                    throw new IOException(
+                            "Committing file by rename failed: " + src + " to " + dest, e);
+                }
+            } else if (!fs.exists(dest)) {
+                // neither exists - that can be a sign of
+                //   - (1) a serious problem (file system loss of data)
+                //   - (2) a recovery of a savepoint that is some time old and the users
+                //         removed the files in the meantime.
+                throw new IOException(
+                        "Unrecoverable exception while trying to recover "
+                                + recoverable.tempFile());
+            }
+        }
+
+        @Override
+        public void commitAfterRecovery() throws IOException {
+            commit();
+        }
+
+        @Override
+        public RecoverableWriter.CommitRecoverable getRecoverable() {
+            return recoverable;
+        }
+    }
+}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriter.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/main/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriter.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.runtime.fs.hdfs.HadoopFsRecoverable;
+import org.apache.flink.runtime.fs.hdfs.HadoopRecoverableWriter;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import java.io.IOException;
+
+/** Recoverable writer for AzureBlob file system. */
+public class AzureBlobRecoverableWriter extends HadoopRecoverableWriter {
+    /**
+     * Creates a new Recoverable writer.
+     *
+     * @param fs The AzureBlob file system on which the writer operates.
+     */
+    public AzureBlobRecoverableWriter(FileSystem fs) {
+        super(fs);
+    }
+
+    protected void checkSupportedFSSchemes(org.apache.hadoop.fs.FileSystem fs) {
+        // This writer is only supported on a subset of file systems
+        if (!("abfs".equalsIgnoreCase(fs.getScheme())
+                || "abfss".equalsIgnoreCase(fs.getScheme()))) {
+            throw new UnsupportedOperationException(
+                    "Recoverable writers on AzureBlob are only supported for ABFS");
+        }
+    }
+
+    @Override
+    protected RecoverableFsDataOutputStream getRecoverableFsDataOutputStream(
+            org.apache.hadoop.fs.Path targetFile, org.apache.hadoop.fs.Path tempFile)
+            throws IOException {
+        return new AzureBlobFsRecoverableDataOutputStream(fs, targetFile, tempFile);
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream recover(ResumeRecoverable recoverable) throws IOException {
+        return new AzureBlobFsRecoverableDataOutputStream(fs, (HadoopFsRecoverable) recoverable);
+    }
+
+    @Override
+    public RecoverableFsDataOutputStream.Committer recoverForCommit(CommitRecoverable recoverable)
+            throws IOException {
+        return new AzureBlobFsRecoverableDataOutputStream.ABFSCommitter(
+                fs, (HadoopFsRecoverable) recoverable);
+    }
+}

--- a/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriterTest.java
+++ b/flink-filesystems/flink-azure-fs-hadoop/src/test/java/org/apache/flink/fs/azurefs/AzureBlobRecoverableWriterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.fs.azurefs;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.fs.AbstractRecoverableWriterTest;
+import org.apache.flink.core.fs.FileSystem;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.StringUtils;
+
+import org.junit.AfterClass;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/** Tests for the {@link AzureBlobRecoverableWriter}. */
+public class AzureBlobRecoverableWriterTest extends AbstractRecoverableWriterTest {
+
+    @ClassRule public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
+
+    /** The cached file system instance. */
+    private static FileSystem fileSystem;
+
+    private static final String CONTAINER = System.getenv("ARTIFACTS_AZURE_CONTAINER");
+    private static final String ACCOUNT = System.getenv("ARTIFACTS_AZURE_STORAGE_ACCOUNT");
+    private static final String ACCESS_KEY = System.getenv("ARTIFACTS_AZURE_ACCESS_KEY");
+    private static final String TEST_DATA_DIR = "tests-" + UUID.randomUUID();
+
+    @BeforeClass
+    public static void checkCredentialsAndSetup() throws IOException {
+        // check whether credentials and container details exist
+        Assume.assumeTrue(
+                "Azure container not configured, skipping test...",
+                !StringUtils.isNullOrWhitespaceOnly(CONTAINER));
+        Assume.assumeTrue(
+                "Azure access key not configured, skipping test...",
+                !StringUtils.isNullOrWhitespaceOnly(ACCESS_KEY));
+        // adjusting the minbuffer length for tests
+        AzureBlobFsRecoverableDataOutputStream.minBufferLength = 4;
+        // initialize configuration with valid credentials
+        final Configuration conf = new Configuration();
+        String uriString = "abfs://" + CONTAINER + "@" + ACCOUNT + ".dfs.core.windows.net";
+        conf.setString("fs.defaultFS", uriString);
+        conf.setString("fs.azure.account.auth.type", "SharedKey");
+        conf.setString("fs.azure.account.key." + ACCOUNT + ".dfs.core.windows.net", ACCESS_KEY);
+        // In 3.3.2 and above we try to create blocks locally. This fails if the runtime is not
+        // able to find the scheme for 'file://'
+        conf.setString("fs.azure.data.blocks.buffer", "bytebuffer");
+        AbstractAzureFSFactory factory = new AzureDataLakeStoreGen2FSFactory();
+        // abfs(s)://yourcontainer@youraccount.blob.core.windows.net/testDataDir
+        Path path = new Path(uriString + "/" + TEST_DATA_DIR);
+        factory.configure(conf);
+        fileSystem = factory.create(path.toUri());
+
+        FileSystem.initialize(conf);
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        AzureBlobFsRecoverableDataOutputStream.minBufferLength = 2097152;
+    }
+
+    @Override
+    public Path getBasePath() throws Exception {
+        String uriString =
+                "abfs"
+                        + "://"
+                        + CONTAINER
+                        + '@'
+                        + ACCOUNT
+                        + ".blob.core.windows.net/"
+                        + TEST_DATA_DIR;
+        return new Path(uriString);
+    }
+
+    @Override
+    public FileSystem initializeFileSystem() {
+        return fileSystem;
+    }
+}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.fs.hdfs;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
+import org.apache.flink.core.fs.RecoverableWriter;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+
+/** Base class for ABFS and Hadoop recoverable stream. */
+@Internal
+public abstract class BaseHadoopFsRecoverableFsDataOutputStream
+        extends RecoverableFsDataOutputStream {
+
+    protected FileSystem fs;
+
+    protected Path targetFile;
+
+    protected Path tempFile;
+
+    protected FSDataOutputStream out;
+
+    // In ABFS outputstream we need to add this to the current pos
+    protected long initialFileSize = 0;
+
+    public long getPos() throws IOException {
+        return out.getPos();
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        out.write(b, off, len);
+    }
+
+    @Override
+    public abstract void flush() throws IOException;
+
+    @Override
+    public void sync() throws IOException {
+        out.hflush();
+        out.hsync();
+    }
+
+    @Override
+    public RecoverableWriter.ResumeRecoverable persist() throws IOException {
+        sync();
+        return createHadoopFsRecoverable(getPos());
+    }
+
+    public HadoopFsRecoverable createHadoopFsRecoverable(long pos) throws IOException {
+        return new HadoopFsRecoverable(targetFile, tempFile, pos + initialFileSize);
+    }
+
+    @Override
+    public abstract Committer closeForCommit() throws IOException;
+
+    @Override
+    public void close() throws IOException {
+        out.close();
+    }
+}

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/BaseHadoopFsRecoverableFsDataOutputStream.java
@@ -59,7 +59,9 @@ public abstract class BaseHadoopFsRecoverableFsDataOutputStream
     }
 
     @Override
-    public abstract void flush() throws IOException;
+    public void flush() throws IOException {
+        out.hsync();
+    }
 
     @Override
     public void sync() throws IOException {

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsRecoverable.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopFsRecoverable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.fs.hdfs;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.core.fs.RecoverableWriter.CommitRecoverable;
 import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
 
@@ -27,10 +28,11 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * An implementation of the resume and commit descriptor objects for Hadoop's file system
+ * An implementation of the resume and commit descriptor objects for Hadoop's/AzureBlob file system
  * abstraction.
  */
-class HadoopFsRecoverable implements CommitRecoverable, ResumeRecoverable {
+@Internal
+public class HadoopFsRecoverable implements CommitRecoverable, ResumeRecoverable {
 
     /** The file path for the final result file. */
     private final Path targetFile;
@@ -47,7 +49,7 @@ class HadoopFsRecoverable implements CommitRecoverable, ResumeRecoverable {
      * @param targetFile The file to resume.
      * @param offset The position to resume from.
      */
-    HadoopFsRecoverable(Path targetFile, Path tempFile, long offset) {
+    public HadoopFsRecoverable(Path targetFile, Path tempFile, long offset) {
         checkArgument(offset >= 0, "offset must be >= 0");
         this.targetFile = checkNotNull(targetFile, "targetFile");
         this.tempFile = checkNotNull(tempFile, "tempFile");

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -95,11 +95,6 @@ class HadoopRecoverableFsDataOutputStream extends BaseHadoopFsRecoverableFsDataO
     }
 
     @Override
-    public void flush() throws IOException {
-        out.hflush();
-    }
-
-    @Override
     public Committer closeForCommit() throws IOException {
         final long pos = getPos();
         close();

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableFsDataOutputStream.java
@@ -22,14 +22,12 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.core.fs.RecoverableFsDataOutputStream;
 import org.apache.flink.core.fs.RecoverableWriter.CommitRecoverable;
-import org.apache.flink.core.fs.RecoverableWriter.ResumeRecoverable;
 import org.apache.flink.runtime.util.HadoopUtils;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.Preconditions;
 
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -51,19 +49,11 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * abstraction.
  */
 @Internal
-class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream {
+class HadoopRecoverableFsDataOutputStream extends BaseHadoopFsRecoverableFsDataOutputStream {
 
     private static final long LEASE_TIMEOUT = 100_000L;
 
     private static Method truncateHandle;
-
-    private final FileSystem fs;
-
-    private final Path targetFile;
-
-    private final Path tempFile;
-
-    private final FSDataOutputStream out;
 
     HadoopRecoverableFsDataOutputStream(FileSystem fs, Path targetFile, Path tempFile)
             throws IOException {
@@ -105,47 +95,15 @@ class HadoopRecoverableFsDataOutputStream extends RecoverableFsDataOutputStream 
     }
 
     @Override
-    public void write(int b) throws IOException {
-        out.write(b);
-    }
-
-    @Override
-    public void write(byte[] b, int off, int len) throws IOException {
-        out.write(b, off, len);
-    }
-
-    @Override
     public void flush() throws IOException {
         out.hflush();
-    }
-
-    @Override
-    public void sync() throws IOException {
-        out.hflush();
-        out.hsync();
-    }
-
-    @Override
-    public long getPos() throws IOException {
-        return out.getPos();
-    }
-
-    @Override
-    public ResumeRecoverable persist() throws IOException {
-        sync();
-        return new HadoopFsRecoverable(targetFile, tempFile, getPos());
     }
 
     @Override
     public Committer closeForCommit() throws IOException {
         final long pos = getPos();
         close();
-        return new HadoopFsCommitter(fs, new HadoopFsRecoverable(targetFile, tempFile, pos));
-    }
-
-    @Override
-    public void close() throws IOException {
-        out.close();
+        return new HadoopFsCommitter(fs, createHadoopFsRecoverable(pos));
     }
 
     // ------------------------------------------------------------------------

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableSerializer.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableSerializer.java
@@ -33,7 +33,7 @@ import java.nio.charset.StandardCharsets;
 @Internal
 class HadoopRecoverableSerializer implements SimpleVersionedSerializer<HadoopFsRecoverable> {
 
-    static final HadoopRecoverableSerializer INSTANCE = new HadoopRecoverableSerializer();
+    public static final HadoopRecoverableSerializer INSTANCE = new HadoopRecoverableSerializer();
 
     private static final Charset CHARSET = StandardCharsets.UTF_8;
 

--- a/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableSerializer.java
+++ b/flink-filesystems/flink-hadoop-fs/src/main/java/org/apache/flink/runtime/fs/hdfs/HadoopRecoverableSerializer.java
@@ -33,7 +33,7 @@ import java.nio.charset.StandardCharsets;
 @Internal
 class HadoopRecoverableSerializer implements SimpleVersionedSerializer<HadoopFsRecoverable> {
 
-    public static final HadoopRecoverableSerializer INSTANCE = new HadoopRecoverableSerializer();
+    static final HadoopRecoverableSerializer INSTANCE = new HadoopRecoverableSerializer();
 
     private static final Charset CHARSET = StandardCharsets.UTF_8;
 


### PR DESCRIPTION

## What is the purpose of the change

Supports ABFS as Streaming file sink


## Brief change log

- Allows sink to write to ABFS
- Allows to recover from ABFS
- There is no truncate API in ABFS hadoop driver. But for cases where we want to recover a job from an older persisted offset, we need to truncate. For which we rewrite the file.


## Verifying this change


This change added tests and can be verified as follows:
  - Verified the basics in a Kubernetes based session cluster with 1 JM and 4 TMs. 
  - Was able to write to ABFS and also recover from it. 
  - **Pls note this is an initial PR, we are still doing some extensive testing. This is for initial feedback**
  -  Used the existing test cases in **HadoopRecoverableWriterTest** and extended the same to verify the functionality but with ABFS.
  - New test case name AzureBlobRecoverableWriterTest
  - Existing Hadoop serializers are used. Nothing changed in this format.
  - `[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.flink.fs.azurefs.AzureBlobRecoverableWriterTest
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 72.345 s - in org.apache.flink.fs.azurefs.AzureBlobRecoverableWriterTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 11, Failures: 0, Errors: 0, Skipped: 0`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (No)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes) - Recovery is also handled here.
  - The S3 file system connector: (No)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)
-->