### PR TITLE
[FLINK-30417] [Connectors/ RabbitMQ] add "RabbitMQ" to rabbit error while creating the channel

### DIFF
--- a/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
+++ b/flink-connectors/flink-connector-rabbitmq/src/main/java/org/apache/flink/streaming/connectors/rabbitmq/RMQSink.java
@@ -181,7 +181,7 @@ public class RMQSink<IN> extends RichSinkFunction<IN> {
                 channel.addReturnListener(returnListener);
             }
         } catch (IOException e) {
-            throw new RuntimeException("Error while creating the channel", e);
+            throw new RuntimeException("Error while creating the RabbitMQ channel", e);
         }
     }
 


### PR DESCRIPTION
Jira: 

https://issues.apache.org/jira/browse/FLINK-30417

## What is the purpose of the change

To better describe the error of RabbitMQ connection failures.


## Brief change log

  -  Better error indication when we fail to connect to RabbitMQ


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
