### PR TITLE
[FLINK-30383][datadog] Add "flink." prefix to logical identifier

### DIFF
--- a/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
+++ b/flink-metrics/flink-metrics-datadog/src/main/java/org/apache/flink/metrics/datadog/DatadogHttpReporter.java
@@ -88,7 +88,8 @@ public class DatadogHttpReporter implements MetricReporter, Scheduled {
     public void notifyOfAddedMetric(Metric metric, String metricName, MetricGroup group) {
         final String name =
                 this.useLogicalIdentifier
-                        ? ((LogicalScopeProvider) group)
+                        ? "flink."
+                                + ((LogicalScopeProvider) group)
                                         .getLogicalScope(CharacterFilter.NO_OP_FILTER)
                                 + "."
                                 + metricName


### PR DESCRIPTION
DataDog only considers metrics as coming from Flink if the metric name has "flink" prefix. Otherwise they are considered as custom metrics, governed by different billing rules.

This was so far achieved by the users configuring scope formats as [instructed by DataDog](https://docs.datadoghq.com/integrations/flink/#metric-collection).
Scope formats however don't work for logical identifiers, breaking this behavior.

I manually verified that this prefix results in all metrics being considered as coming from Flink.