### PR TITLE
[FLINK-30375][hotfix]sql-client leaks flink-table-planner jar in /tmp

### DIFF
--- a/flink-table/flink-table-planner-loader/src/main/java/org/apache/flink/table/planner/loader/PlannerModule.java
+++ b/flink-table/flink-table-planner-loader/src/main/java/org/apache/flink/table/planner/loader/PlannerModule.java
@@ -112,6 +112,7 @@ class PlannerModule {
             }
 
             IOUtils.copyBytes(resourceStream, Files.newOutputStream(tempFile));
+            tempFile.toFile().deleteOnExit();
 
             this.submoduleClassLoader =
                     new ComponentClassLoader(

--- a/flink-table/flink-table-planner-loader/src/test/java/org/apache/flink/table/planner/loader/LoaderITCase.java
+++ b/flink-table/flink-table-planner-loader/src/test/java/org/apache/flink/table/planner/loader/LoaderITCase.java
@@ -18,12 +18,20 @@
 
 package org.apache.flink.table.planner.loader;
 
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ConfigurationUtils;
 import org.apache.flink.table.delegation.ExecutorFactory;
 import org.apache.flink.table.delegation.PlannerFactory;
 import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.TestLogger;
 
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.apache.flink.table.planner.loader.PlannerModule.FLINK_TABLE_PLANNER_FAT_JAR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,5 +82,14 @@ public class LoaderITCase extends TestLogger {
 
         assertThat(plannerFactory).isNotNull().isInstanceOf(DelegatePlannerFactory.class);
         assertThat(plannerFactory.factoryIdentifier()).isEqualTo(PlannerFactory.DEFAULT_IDENTIFIER);
+    }
+
+    @Test
+    public void testPlannerJarLeak() throws IOException {
+        PlannerModule plannerModule = PlannerModule.getInstance();
+        final Path tmpDirectory =
+                Paths.get(ConfigurationUtils.parseTempDirectories(new Configuration())[0]);
+        Files.createDirectories(FileUtils.getTargetPathIfContainsSymbolicPath(tmpDirectory));
+        assertThat(tmpDirectory.startsWith("flink-table-planner_")).isEqualTo(false);
     }
 }


### PR DESCRIPTION


## What is the purpose of the change

sql-client leaks flink-table-planner jar in /tmp. Fix the leak by removing on exists 


## Brief change log



## Verifying this change

without patch 

```
[root@ip-172-1-1-3 lib]# ls -lrt /tmp/flink-table-planner_*
-rw-rw-r-- 1 hadoop hadoop 39138893 Dec 12 10:08 /tmp/flink-table-planner_acada33f-a10b-4a4a-ad16-6bca25a67e10.jar
-rw-rw-r-- 1 hadoop hadoop 39138893 Dec 12 10:17 /tmp/flink-table-planner_fb2f6e31-48a0-4c1e-ab7b-16129e776125.jar
-rw-rw-r-- 1 hadoop hadoop 39138893 Dec 12 10:22 /tmp/flink-table-planner_83499393-1621-43de-953c-2000bc6967ce.jar
-rw-rw-r-- 1 hadoop hadoop 39138893 Dec 12 10:24 /tmp/flink-table-planner_3aa798da-e794-4c6c-ad9f-49b4574da64b.jar
-rw-rw-r-- 1 hadoop hadoop 39138893 Dec 12 10:36 /tmp/flink-table-planner_ea52d9ea-3148-4fc3-8a58-f83063bb14d5.jar
-rw-rw-r-- 1 hadoop hadoop 39138893 Dec 12 10:44 /tmp/flink-table-planner_fdc64e21-6bc7-4e4a-b8b2-2a97629d0727.jar
-rw-rw-r-- 1 hadoop hadoop 39137545 Dec 12 11:05 /tmp/flink-table-planner_84c00b13-c6b5-4e8b-80cb-5631a2fa3150.jar
-rw-rw-r-- 1 hadoop hadoop 39137601 Dec 12 11:10 /tmp/flink-table-planner_d00b8a7b-e615-46f7-bd21-b5efa684c184.jar
-rw-rw-r-- 1 hadoop hadoop 39137601 Dec 12 11:11 /tmp/flink-table-planner_a413520d-ce15-41f9-aa5e-05a30f7eaff5.jar 
```

with patch

```
[root@ip-172-1-1-3 lib]# ls -lrt /tmp/flink-table-planner_*
--
``` 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no
