### PR TITLE
[FLINK-30424][DataStream API] Add source operator addSplits log when restore from state

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -333,6 +333,7 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         // restore the state if necessary.
         final List<SplitT> splits = CollectionUtil.iterableToList(readerState.get());
         if (!splits.isEmpty()) {
+            LOG.info("Restoring state for {} split(s) to reader.", splits.size());
             sourceReader.addSplits(splits);
         }
 


### PR DESCRIPTION
## What is the purpose of the change

If source recover from state, we can not distinguish the newPartitions is from timed discover thread or from reader task state.  So add recover log to help to debug and confirm this scenario.  it's very useful for troubleshooting

## Brief change log

Add restore split log for SourceOperator.

## Verifying this change

Not add new cases. Just add log.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable