### PR TITLE
[FLINK-28863][state]Add comments about why snapshot result of RocksDB native savepoint doesn't have empty shared-state

### DIFF
--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -294,6 +294,15 @@ public class RocksIncrementalSnapshotStrategy<K>
                 checkpointedSize += getUploadedStateSize(sstFiles.values());
                 checkpointedSize += getUploadedStateSize(miscFiles.values());
 
+                // We make the 'sstFiles' as the 'sharedState' in IncrementalRemoteKeyedStateHandle,
+                // whether they belong to the sharded CheckpointedStateScope or exclusive
+                // CheckpointedStateScope.
+                // In this way, the first checkpoint after job recovery can be an incremental
+                // checkpoint in CLAIM mode, either restoring from checkpoint or restoring from
+                // native savepoint.
+                // And this has no effect on the registration of shareState currently, because the
+                // snapshot result of native savepoint would not be registered into
+                // 'SharedStateRegistry'.
                 final IncrementalRemoteKeyedStateHandle jmIncrementalKeyedStateHandle =
                         new IncrementalRemoteKeyedStateHandle(
                                 backendUID,


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds some comments about why snapshot result fo rocksdb native savepoint doesn't have emtry shared-state.

## Brief change log

  - Add some comments in RocksDBIncrementalSnapshotOperation#get(CloseableRegistry snapshotCloseableRegistry)

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
