### PR TITLE
[FLINK-30436][Connectors/Opensearch][docs] Integrate Opensearch docs …

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/guarantees.md
+++ b/docs/content.zh/docs/connectors/datastream/guarantees.md
@@ -96,6 +96,11 @@ under the License.
         <td></td>
     </tr>
     <tr>
+        <td>Opensearch</td>
+        <td>至少一次</td>
+        <td></td>
+    </tr>
+    <tr>
         <td>Kafka producer</td>
         <td>至少一次 / 精确一次</td>
         <td>当使用事务生产者时，保证精确一次 (v 0.11+)</td>

--- a/docs/content.zh/docs/connectors/datastream/overview.md
+++ b/docs/content.zh/docs/connectors/datastream/overview.md
@@ -43,6 +43,7 @@ under the License.
  * [Amazon Kinesis Data Streams]({{< ref "docs/connectors/datastream/kinesis" >}}) (source/sink)
  * [Amazon Kinesis Data Firehose]({{< ref "docs/connectors/datastream/firehose" >}}) (sink)
  * [Elasticsearch]({{< ref "docs/connectors/datastream/elasticsearch" >}}) (sink)
+ * [Opensearch]({{< ref "docs/connectors/datastream/opensearch" >}}) (sink)
  * [FileSystem]({{< ref "docs/connectors/datastream/filesystem" >}}) (sink)
  * [RabbitMQ]({{< ref "docs/connectors/datastream/rabbitmq" >}}) (source/sink)
  * [Google PubSub]({{< ref "docs/connectors/datastream/pubsub" >}}) (source/sink)

--- a/docs/content.zh/docs/connectors/table/overview.md
+++ b/docs/content.zh/docs/connectors/table/overview.md
@@ -61,6 +61,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{{< ref "docs/connectors/table/opensearch" >}}">Opensearch</a></td>
+      <td>1.x & 2.x</td>
+      <td>Not supported</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
+    <tr>
       <td><a href="{{< ref "docs/connectors/table/kafka" >}}">Apache Kafka</a></td>
       <td>0.10+</td>
       <td>Unbounded Scan</td>

--- a/docs/content/docs/connectors/datastream/guarantees.md
+++ b/docs/content/docs/connectors/datastream/guarantees.md
@@ -101,6 +101,11 @@ state updates) of Flink coupled with bundled sinks:
         <td></td>
     </tr>
     <tr>
+        <td>Opensearch</td>
+        <td>at least once</td>
+        <td></td>
+    </tr>
+    <tr>
         <td>Kafka producer</td>
         <td>at least once / exactly once</td>
         <td>exactly once with transactional producers (v 0.11+)</td>

--- a/docs/content/docs/connectors/datastream/overview.md
+++ b/docs/content/docs/connectors/datastream/overview.md
@@ -44,6 +44,7 @@ Connectors provide code for interfacing with various third-party systems. Curren
  * [Amazon Kinesis Data Streams]({{< ref "docs/connectors/datastream/kinesis" >}}) (source/sink)
  * [Amazon Kinesis Data Firehose]({{< ref "docs/connectors/datastream/firehose" >}}) (sink)
  * [Elasticsearch]({{< ref "docs/connectors/datastream/elasticsearch" >}}) (sink)
+ * [Opensearch]({{< ref "docs/connectors/datastream/opensearch" >}}) (sink)
  * [FileSystem]({{< ref "docs/connectors/datastream/filesystem" >}}) (source/sink)
  * [RabbitMQ]({{< ref "docs/connectors/datastream/rabbitmq" >}}) (source/sink)
  * [Google PubSub]({{< ref "docs/connectors/datastream/pubsub" >}}) (source/sink)

--- a/docs/content/docs/connectors/table/overview.md
+++ b/docs/content/docs/connectors/table/overview.md
@@ -61,6 +61,12 @@ Flink natively support various connectors. The following tables list all availab
       <td>Streaming Sink, Batch Sink</td>
     </tr>
     <tr>
+      <td><a href="{{< ref "docs/connectors/table/opensearch" >}}">Opensearch</a></td>
+      <td>1.x & 2.x</td>
+      <td>Not supported</td>
+      <td>Streaming Sink, Batch Sink</td>
+    </tr>
+    <tr>
       <td><a href="{{< ref "docs/connectors/table/kafka" >}}">Apache Kafka</a></td>
       <td>0.10+</td>
       <td>Unbounded Scan</td>

--- a/docs/data/sql_connectors.yml
+++ b/docs/data/sql_connectors.yml
@@ -201,3 +201,11 @@ rabbitmq:
     category: connector
     maven: flink-connector-rabbitmq
     sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-rabbitmq/$version/flink-sql-connector-rabbitmq-$version.jar
+
+opensearch:
+    name: Opensearch
+    category: connector
+    versions:
+        - version: 1.0.0
+          maven: flink-connector-opensearch
+          sql_url: https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-opensearch/1.0.0-1.16/flink-sql-connector-opensearch-1.0.0-1.16.jar

--- a/docs/setup_docs.sh
+++ b/docs/setup_docs.sh
@@ -55,6 +55,7 @@ cd tmp
 # we only get the documentation from the main branch
 integrate_connector_docs elasticsearch v3.0.0
 integrate_connector_docs aws v4.0
+integrate_connector_docs opensearch v1.0.0
 
 cd ..
 rm -rf tmp


### PR DESCRIPTION
…into Flink docs

## What is the purpose of the change

Integrate Opensearch docs into Flink docs for Flink 1.16

**Note** This cannot be merged until Opensearch v1.0.0 tag exists

## Brief change log

- See comment for pages changed

## Verifying this change

Built locally and verified in browser

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? n/a
