### PR TITLE
[FLINK-30355][Kubernetes][Tests] Remove `cri-dockerd` if already cloned earlier

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -56,6 +56,9 @@ function setup_kubernetes_for_linux {
     sudo tar zxvf crictl-$VERSION-linux-amd64.tar.gz -C /usr/local/bin
     rm -f crictl-$VERSION-linux-amd64.tar.gz
     # cri-dockerd is required to use Kubernetes 1.24+ and the none driver
+    if [ -e cri-dockerd ];
+     then rm -r cri-dockerd
+    fi
     git clone https://github.com/Mirantis/cri-dockerd.git
     cd cri-dockerd
     # Checkout version 0.2.3


### PR DESCRIPTION
## What is the purpose of the change

```
2022-12-09T08:27:01.3438980Z Dec 09 08:27:01 crictl
2022-12-09T08:27:01.6120044Z fatal: destination path 'cri-dockerd' already exists and is not an empty directory.
2022-12-09T08:27:01.6151912Z fatal: a branch named 'v0.2.3' already exists
2022-12-09T08:27:01.6169151Z mkdir: cannot create directory ‘bin’: File exists
```

This happens when `cri-dockerd` is cloned, but the directory already exists/has been cloned before. This change checks if the directory exists and removes it, before starting the cloning process

## Brief change log

* Little bash script that checks if folder already exists

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
