### PR TITLE
[FLINK-30435][table] `SHOW CREATE TABLE` statement shows column comment

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/describe.md
+++ b/docs/content.zh/docs/dev/table/sql/describe.md
@@ -67,11 +67,11 @@ TableEnvironment tableEnv = TableEnvironment.create(...);
 // 注册名为 “Orders” 的表
 tableEnv.executeSql(
         "CREATE TABLE Orders (" +
-        " `user` BIGINT NOT NULl," +
+        " `user` BIGINT NOT NULl comment 'this is primary key'," +
         " product VARCHAR(32)," +
         " amount INT," +
-        " ts TIMESTAMP(3)," +
-        " ptime AS PROCTIME()," +
+        " ts TIMESTAMP(3) comment 'notice: watermark'," +
+        " ptime AS PROCTIME() comment 'this is a computed column'," +
         " PRIMARY KEY(`user`) NOT ENFORCED," +
         " WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS" +
         ") with (...)");
@@ -90,11 +90,11 @@ val tableEnv = TableEnvironment.create(...)
 // 注册名为 “Orders” 的表
  tableEnv.executeSql(
         "CREATE TABLE Orders (" +
-        " `user` BIGINT NOT NULl," +
-        " product VARCHAR(32)," +
-        " amount INT," +
-        " ts TIMESTAMP(3)," +
-        " ptime AS PROCTIME()," +
+          " `user` BIGINT NOT NULl comment 'this is primary key'," +
+          " product VARCHAR(32)," +
+          " amount INT," +
+          " ts TIMESTAMP(3) comment 'notice: watermark'," +
+          " ptime AS PROCTIME() comment 'this is a computed column'," +
         " PRIMARY KEY(`user`) NOT ENFORCED," +
         " WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS" +
         ") with (...)")
@@ -113,11 +113,11 @@ table_env = TableEnvironment.create(...)
 # 注册名为 “Orders” 的表
 table_env.execute_sql( \
         "CREATE TABLE Orders (" 
-        " `user` BIGINT NOT NULl," 
+        " `user` BIGINT NOT NULl comment 'this is primary key'," 
         " product VARCHAR(32),"
         " amount INT,"
-        " ts TIMESTAMP(3),"
-        " ptime AS PROCTIME(),"
+        " ts TIMESTAMP(3) comment 'notice: watermark',"
+        " ptime AS PROCTIME() comment 'this is a computed column',"
         " PRIMARY KEY(`user`) NOT ENFORCED,"
         " WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS"
         ") with (...)");

--- a/docs/content.zh/docs/dev/table/sql/show.md
+++ b/docs/content.zh/docs/dev/table/sql/show.md
@@ -540,7 +540,7 @@ SHOW TABLES [ ( FROM | IN ) [catalog_name.]database_name ] [ [NOT] LIKE <sql_lik
 * dim
 
 在会话的当前库下有如下表：
-* fights
+* items
 * orders
 
 - 显示指定库的所有表。
@@ -609,6 +609,46 @@ SHOW CREATE TABLE [catalog_name.][db_name.]table_name
 ```
 
 展示创建指定表的 create 语句。
+
+该语句的输出内容包括表名、列名、数据类型、约束、注释和配置。
+
+当您需要了解现有表的结构、配置和约束，或在另一个数据库中重新创建表时，这个语句非常有用。
+
+假设表 `orders` 是按如下方式创建的：
+```sql
+CREATE TABLE orders (
+  order_id BIGINT NOT NULL comment 'this is the primary key, named ''order_id''.',
+  product VARCHAR(32),
+  amount INT,
+  ts TIMESTAMP(3) comment 'notice: watermark, named ''ts''.',
+  ptime AS PROCTIME() comment 'notice: computed column, named ''ptime''.',
+  WATERMARK FOR ts AS ts - INTERVAL '1' SECOND,
+  CONSTRAINT `PK_3599338` PRIMARY KEY (order_id) NOT ENFORCED
+) WITH (
+  'connector' = 'datagen'
+);
+```
+展示表创建语句。
+```sql
+show create table orders;
++---------------------------------------------------------------------------------------------+
+|                                                                                      result |
++---------------------------------------------------------------------------------------------+
+| CREATE TABLE `default_catalog`.`default_database`.`orders` (
+  `order_id` BIGINT NOT NULL COMMENT 'this is the primary key, named ''order_id''.',
+  `product` VARCHAR(32),
+  `amount` INT,
+  `ts` TIMESTAMP(3) COMMENT 'notice: watermark, named ''ts''.',
+  `ptime` AS PROCTIME() COMMENT 'notice: computed column, named ''ptime''.',
+  WATERMARK FOR `ts` AS `ts` - INTERVAL '1' SECOND,
+  CONSTRAINT `PK_3599338` PRIMARY KEY (`order_id`) NOT ENFORCED
+) WITH (
+  'connector' = 'datagen'
+)
+ |
++---------------------------------------------------------------------------------------------+
+1 row in set
+```
 
 <span class="label label-danger">Attention</span> 目前 `SHOW CREATE TABLE` 只支持通过 Flink SQL DDL 创建的表。
 

--- a/docs/content/docs/dev/table/sql/describe.md
+++ b/docs/content/docs/dev/table/sql/describe.md
@@ -66,11 +66,11 @@ TableEnvironment tableEnv = TableEnvironment.create(...);
 // register a table named "Orders"
 tableEnv.executeSql(
         "CREATE TABLE Orders (" +
-        " `user` BIGINT NOT NULl," +
+        " `user` BIGINT NOT NULl comment 'this is primary key'," +
         " product VARCHAR(32)," +
         " amount INT," +
-        " ts TIMESTAMP(3)," +
-        " ptime AS PROCTIME()," +
+        " ts TIMESTAMP(3) comment 'notice: watermark'," +
+        " ptime AS PROCTIME() comment 'this is a computed column'," +
         " PRIMARY KEY(`user`) NOT ENFORCED," +
         " WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS" +
         ") with (...)");
@@ -89,11 +89,11 @@ val tableEnv = TableEnvironment.create(...)
 // register a table named "Orders"
  tableEnv.executeSql(
         "CREATE TABLE Orders (" +
-        " `user` BIGINT NOT NULl," +
+        " `user` BIGINT NOT NULl comment 'this is primary key'," +
         " product VARCHAR(32)," +
         " amount INT," +
-        " ts TIMESTAMP(3)," +
-        " ptime AS PROCTIME()," +
+        " ts TIMESTAMP(3) comment 'notice: watermark'," +
+        " ptime AS PROCTIME() comment 'this is a computed column'," +
         " PRIMARY KEY(`user`) NOT ENFORCED," +
         " WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS" +
         ") with (...)")
@@ -112,11 +112,11 @@ table_env = TableEnvironment.create(...)
 # register a table named "Orders"
 table_env.execute_sql( \
         "CREATE TABLE Orders (" 
-        " `user` BIGINT NOT NULl," 
+        " `user` BIGINT NOT NULl comment 'this is primary key'," 
         " product VARCHAR(32),"
         " amount INT,"
-        " ts TIMESTAMP(3),"
-        " ptime AS PROCTIME(),"
+        " ts TIMESTAMP(3) comment 'notice: watermark',"
+        " ptime AS PROCTIME() comment 'this is a computed column',"
         " PRIMARY KEY(`user`) NOT ENFORCED,"
         " WATERMARK FOR ts AS ts - INTERVAL '1' SECONDS"
         ") with (...)");

--- a/docs/content/docs/dev/table/sql/show.md
+++ b/docs/content/docs/dev/table/sql/show.md
@@ -540,7 +540,7 @@ Assumes that the `db1` database located in `catalog1` catalog has the following 
 * dim
 
 the current database in session has the following tables:
-* fights
+* items
 * orders
 
 - Shows all tables of the given database.
@@ -610,6 +610,46 @@ SHOW CREATE TABLE
 ```
 
 Show create table statement for specified table.
+
+The output includes the table name, column names, data types, constraints, comments, and configurations.
+
+It is a very useful statement when you need to understand the structure, configuration and constraints of an existing table or to recreate the table in another database.
+
+Assumes that the table `orders` is created as follows:
+```sql
+CREATE TABLE orders (
+  order_id BIGINT NOT NULL comment 'this is the primary key, named ''order_id''.',
+  product VARCHAR(32),
+  amount INT,
+  ts TIMESTAMP(3) comment 'notice: watermark, named ''ts''.',
+  ptime AS PROCTIME() comment 'notice: computed column, named ''ptime''.',
+  WATERMARK FOR ts AS ts - INTERVAL '1' SECOND,
+  CONSTRAINT `PK_3599338` PRIMARY KEY (order_id) NOT ENFORCED
+) WITH (
+  'connector' = 'datagen'
+);
+```
+Shows the creation statement.
+```sql
+show create table orders;
++---------------------------------------------------------------------------------------------+
+|                                                                                      result |
++---------------------------------------------------------------------------------------------+
+| CREATE TABLE `default_catalog`.`default_database`.`orders` (
+  `order_id` BIGINT NOT NULL COMMENT 'this is the primary key, named ''order_id''.',
+  `product` VARCHAR(32),
+  `amount` INT,
+  `ts` TIMESTAMP(3) COMMENT 'notice: watermark, named ''ts''.',
+  `ptime` AS PROCTIME() COMMENT 'notice: computed column, named ''ptime''.',
+  WATERMARK FOR `ts` AS `ts` - INTERVAL '1' SECOND,
+  CONSTRAINT `PK_3599338` PRIMARY KEY (`order_id`) NOT ENFORCED
+) WITH (
+  'connector' = 'datagen'
+)
+ |
++---------------------------------------------------------------------------------------------+
+1 row in set
+```
 
 <span class="label label-danger">Attention</span> Currently `SHOW CREATE TABLE` only supports table that is created by Flink SQL DDL.
 

--- a/flink-table/flink-sql-client/src/test/resources/sql/table.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/table.q
@@ -881,15 +881,15 @@ Empty set
 !ok
 
 # ==========================================================================
-# test describe table with comment
+# test describe/showColumns/showCreateTable with comment
 # ==========================================================================
 
 CREATE TABLE `default_catalog`.`default_database`.`orders3` (
-  `user` BIGINT NOT NULL comment 'this is the first column',
+  `user` BIGINT NOT NULL comment 'this is the primary key, named ''user''.',
   `product` VARCHAR(32),
   `amount` INT,
-  `ts` TIMESTAMP(3) comment 'notice: watermark',
-  `ptime` AS PROCTIME() comment 'notice: computed column',
+  `ts` TIMESTAMP(3) comment 'notice: watermark, named ''ts''.',
+  `ptime` AS PROCTIME() comment 'notice: computed column, named ''ptime''.',
   WATERMARK FOR `ts` AS `ts` - INTERVAL '1' SECOND,
   CONSTRAINT `PK_3599338` PRIMARY KEY (`user`) NOT ENFORCED
 ) WITH (
@@ -899,31 +899,78 @@ CREATE TABLE `default_catalog`.`default_database`.`orders3` (
 [INFO] Execute statement succeed.
 !info
 
+# test describe
 describe orders3;
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                  comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            | this is the first column |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                          |
-|  amount |                         INT |  TRUE |           |               |                            |                          |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |        notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            |  notice: computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                                 comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |  this is the primary key, named 'user'. |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                                         |
+|  amount |                         INT |  TRUE |           |               |                            |                                         |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |          notice: watermark, named 'ts'. |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | notice: computed column, named 'ptime'. |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
 5 rows in set
 !ok
 
-# test desc table
+# test desc
 desc orders3;
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
-|    name |                        type |  null |       key |        extras |                  watermark |                  comment |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
-|    user |                      BIGINT | FALSE | PRI(user) |               |                            | this is the first column |
-| product |                 VARCHAR(32) |  TRUE |           |               |                            |                          |
-|  amount |                         INT |  TRUE |           |               |                            |                          |
-|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |        notice: watermark |
-|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            |  notice: computed column |
-+---------+-----------------------------+-------+-----------+---------------+----------------------------+--------------------------+
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                                 comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |  this is the primary key, named 'user'. |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                                         |
+|  amount |                         INT |  TRUE |           |               |                            |                                         |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |          notice: watermark, named 'ts'. |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | notice: computed column, named 'ptime'. |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
 5 rows in set
+!ok
+
+# test show columns
+show columns from orders3;
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
+|    name |                        type |  null |       key |        extras |                  watermark |                                 comment |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
+|    user |                      BIGINT | FALSE | PRI(user) |               |                            |  this is the primary key, named 'user'. |
+| product |                 VARCHAR(32) |  TRUE |           |               |                            |                                         |
+|  amount |                         INT |  TRUE |           |               |                            |                                         |
+|      ts |      TIMESTAMP(3) *ROWTIME* |  TRUE |           |               | `ts` - INTERVAL '1' SECOND |          notice: watermark, named 'ts'. |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |           | AS PROCTIME() |                            | notice: computed column, named 'ptime'. |
++---------+-----------------------------+-------+-----------+---------------+----------------------------+-----------------------------------------+
+5 rows in set
+!ok
+
+show columns in orders3 like 'p%';
++---------+-----------------------------+-------+-----+---------------+-----------+-----------------------------------------+
+|    name |                        type |  null | key |        extras | watermark |                                 comment |
++---------+-----------------------------+-------+-----+---------------+-----------+-----------------------------------------+
+| product |                 VARCHAR(32) |  TRUE |     |               |           |                                         |
+|   ptime | TIMESTAMP_LTZ(3) *PROCTIME* | FALSE |     | AS PROCTIME() |           | notice: computed column, named 'ptime'. |
++---------+-----------------------------+-------+-----+---------------+-----------+-----------------------------------------+
+2 rows in set
+!ok
+
+# test show create table
+show create table orders3;
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          result |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| CREATE TABLE `default_catalog`.`default_database`.`orders3` (
+  `user` BIGINT NOT NULL COMMENT 'this is the primary key, named ''user''.',
+  `product` VARCHAR(32),
+  `amount` INT,
+  `ts` TIMESTAMP(3) COMMENT 'notice: watermark, named ''ts''.',
+  `ptime` AS PROCTIME() COMMENT 'notice: computed column, named ''ptime''.',
+  WATERMARK FOR `ts` AS `ts` - INTERVAL '1' SECOND,
+  CONSTRAINT `PK_3599338` PRIMARY KEY (`user`) NOT ENFORCED
+) WITH (
+  'connector' = 'kafka',
+  'scan.startup.mode' = 'earliest-offset'
+)
+ |
++---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+1 row in set
 !ok
 
 # ==========================================================================

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ShowCreateUtil.java
@@ -149,7 +149,17 @@ public class ShowCreateUtil {
                                 sb.append(e);
                             });
         }
-        // TODO: Print the column comment until FLINK-18958 is fixed
+        column.getComment()
+                .ifPresent(
+                        comment -> {
+                            if (StringUtils.isNotEmpty(comment)) {
+                                sb.append(" ");
+                                sb.append(
+                                        String.format(
+                                                "COMMENT '%s'",
+                                                EncodingUtils.escapeSingleQuotes(comment)));
+                            }
+                        });
         return sb.toString();
     }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlDdlToOperationConverterTest.java
@@ -32,11 +32,13 @@ import org.apache.flink.table.catalog.CatalogDatabaseImpl;
 import org.apache.flink.table.catalog.CatalogFunction;
 import org.apache.flink.table.catalog.CatalogFunctionImpl;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.catalog.FunctionLanguage;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.TableChange;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
@@ -76,6 +78,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -185,7 +188,7 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
     public void testCreateTable() {
         final String sql =
                 "CREATE TABLE tbl1 (\n"
-                        + "  a bigint,\n"
+                        + "  a bigint comment 'column a',\n"
                         + "  b varchar, \n"
                         + "  c int, \n"
                         + "  d varchar"
@@ -211,6 +214,15 @@ public class SqlDdlToOperationConverterTest extends SqlNodeToOperationConversion
                             DataTypes.VARCHAR(Integer.MAX_VALUE),
                             DataTypes.INT(),
                             DataTypes.VARCHAR(Integer.MAX_VALUE)
+                        });
+        assertThat(catalogTable).isInstanceOf(ResolvedCatalogTable.class);
+        ResolvedCatalogTable resolvedCatalogTable = (ResolvedCatalogTable) catalogTable;
+        resolvedCatalogTable
+                .getResolvedSchema()
+                .getColumn(0)
+                .ifPresent(
+                        (Column column) -> {
+                            assertThat(column.getComment()).isEqualTo(Optional.of("column a"));
                         });
     }
 


### PR DESCRIPTION
## What is the purpose of the change

After a table with column comments created, we would find that the results generated by `show create table` statement lose column comments, and we could make outputs consistent with ddl and more user-friendly.

## Brief change log

* get column comment in ShowCreateUtil#getColumnString.

## Verifying this change

flink-table/flink-sql-client/src/test/resources/sql/table.q

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no