### PR TITLE
[hotfix] Avoiding unsecure HTTP reference to JBoss repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@ under the License.
 	<repositories>
 		<repository>
 			<id>repository.jboss.org</id>
-			<url>http://repository.jboss.org/nexus/content/groups/public/</url>
+			<url>https://repository.jboss.org/nexus/content/groups/public/</url>
 			<snapshots>
 				<enabled>false</enabled>
 			</snapshots>


### PR DESCRIPTION
I'm not totally sure whether this repo actually is required, as I could build the project with current Maven versions (which block non-HTTPS access), but changing it to make use of HTTPS seems a good practice in any case.