### PR TITLE
FLINK-30454 [runtime] Fixing visibility issue for SizeGauge.SizeSupplier

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/FileSystemJobResultStore.java
@@ -207,7 +207,7 @@ public class FileSystemJobResultStore extends AbstractThreadsafeJobResultStore {
     @VisibleForTesting
     static class JsonJobResultEntry extends JobResultEntry {
         private static final String FIELD_NAME_RESULT = "result";
-        private static final String FIELD_NAME_VERSION = "version";
+        static final String FIELD_NAME_VERSION = "version";
 
         private JsonJobResultEntry(JobResultEntry entry) {
             this(entry.getJobResult());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/TaskIOMetricGroup.java
@@ -243,7 +243,7 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
         this.numBytesProducedOfPartitions.put(resultPartitionId, numBytesProducedCounter);
     }
 
-    public void registerMailboxSizeSupplier(SizeGauge.SizeSupplier<Integer> supplier) {
+    public void registerMailboxSizeSupplier(SizeSupplier<Integer> supplier) {
         this.mailboxSize.registerSupplier(supplier);
     }
 
@@ -273,11 +273,6 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
     private static class SizeGauge implements Gauge<Integer> {
         private SizeSupplier<Integer> supplier;
 
-        @FunctionalInterface
-        public interface SizeSupplier<R> {
-            R get();
-        }
-
         public void registerSupplier(SizeSupplier<Integer> supplier) {
             this.supplier = supplier;
         }
@@ -290,5 +285,11 @@ public class TaskIOMetricGroup extends ProxyMetricGroup<TaskMetricGroup> {
                 return 0; // return "assumed" empty queue size
             }
         }
+    }
+
+    /** Supplier for sizes. */
+    @FunctionalInterface
+    public interface SizeSupplier<R> {
+        R get();
     }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-30454

## What is the purpose of the change

Making sure the runtime module can be compiled with ecj. I encountered two locations which seem inconsistent with the JLS but were still accepted by javac.

## Brief change log

Reworked two code places to make it compile with ecj. Note the change around `SizeGauge.SizeSupplier` is source-compatible but not binary-compatible, based on the assumption that this code is not invoked in external client code. If that actually is the case, I'd rework the change to simply change the visibility of `SizeGauge` to public.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature: no
  - If yes, how is the feature documented: not applicable