### PR TITLE
FLINK-30455 [core] Excluding java.lang.String and primitive types from closure cleaning

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/ClosureCleaner.java
@@ -168,6 +168,8 @@ public class ClosureCleaner {
 
     private static boolean needsRecursion(Field f, Object fo) {
         return (fo != null
+                && !f.getType().isPrimitive()
+                && !f.getType().equals(String.class)
                 && !Modifier.isStatic(f.getModifiers())
                 && !Modifier.isTransient(f.getModifiers()));
     }

--- a/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/ClosureCleanerTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.api.java;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.InvalidProgramException;
 import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.functions.util.PrintSinkOutputWriter;
 import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.util.function.SerializableSupplier;
 
@@ -237,6 +238,16 @@ public class ClosureCleanerTest {
     @Test(expected = InvalidProgramException.class)
     public void testCleanObject() {
         ClosureCleaner.clean(new Object(), ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
+    }
+
+    /**
+     * Verifies that {@code testPrintSinkOutputWriter} can be passed to {@code clean()}, as it's the
+     * case when adding the print sink (FLINK-30455).
+     */
+    @Test
+    public void testPrintSinkOutputWriter() {
+        ClosureCleaner.clean(
+                new PrintSinkOutputWriter<>(), ExecutionConfig.ClosureCleanerLevel.RECURSIVE, true);
     }
 }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-30455

## What is the purpose of the change

Avoiding reflective access to java.lang.String which fails on Java 17 and beyond.

## Brief change log

Excluding java.lang.String and primitive types from closure cleaning

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? Not applicable
