### PR TITLE
[FLINK-30459][sql-client] SQL Client supports "SET 'property'"

### DIFF
--- a/docs/content.zh/docs/dev/table/sqlClient.md
+++ b/docs/content.zh/docs/dev/table/sqlClient.md
@@ -315,6 +315,17 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
 
 ### SQL Client Configuration
 
+You can configure the SQL client by setting the options below, or any valid [Flink configuration]({{< ref "docs/dev/table/config" >}}) entry:
+
+```sql
+--- Set configuration 'key' with 'value'
+SET 'key' = 'value';
+-- Show configuration 'key'
+SET 'key';
+-- Show all configurations
+SET;
+```
+
 {{< generated/sql_client_configuration >}}
 
 ### Initialize Session Using SQL Files

--- a/docs/content/docs/dev/table/sqlClient.md
+++ b/docs/content/docs/dev/table/sqlClient.md
@@ -260,7 +260,12 @@ Mode "embedded" (default) submits Flink jobs from the local machine.
 You can configure the SQL client by setting the options below, or any valid [Flink configuration]({{< ref "docs/dev/table/config" >}}) entry:
 
 ```sql
+--- Set configuration 'key' with 'value'
 SET 'key' = 'value';
+-- Show configuration 'key'
+SET 'key';
+-- Show all configurations
+SET;
 ```
 
 {{< generated/sql_client_configuration >}}

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliClient.java
@@ -512,6 +512,23 @@ public class CliClient implements AutoCloseable {
             executor.setSessionProperty(sessionId, key, value);
             printInfo(MESSAGE_SET_KEY);
         }
+        // show a property
+        else if (setOperation.getKey().isPresent()) {
+            String key = setOperation.getKey().get().trim();
+            final Map<String, String> properties = executor.getSessionConfigMap(sessionId);
+            if (properties.containsKey(key)) {
+                String prettyEntry =
+                        String.format(
+                                "'%s' = '%s'",
+                                EncodingUtils.escapeSingleQuotes(key),
+                                EncodingUtils.escapeSingleQuotes(properties.get(key)));
+                terminal.writer().println(prettyEntry);
+            } else {
+                terminal.writer()
+                        .println(CliStrings.messageInfo(CliStrings.MESSAGE_EMPTY).toAnsi());
+            }
+            terminal.flush();
+        }
         // show all properties
         else {
             final Map<String, String> properties = executor.getSessionConfigMap(sessionId);

--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/CliStrings.java
@@ -98,7 +98,8 @@ public final class CliStrings {
                     .commandDescription("CLEAR", "Clears the current terminal.")
                     .commandDescription(
                             "SET",
-                            "Sets a session configuration property. Syntax: \"SET '<key>'='<value>';\". Use \"SET;\" for listing all properties.")
+                            "Sets a session configuration property. Syntax: \"SET '<key>'='<value>';\". "
+                                    + "Use \"SET '<key>';\" for showing a property. Use \"SET;\" for listing all properties.")
                     .commandDescription(
                             "RESET",
                             "Resets a session configuration property. Syntax: \"RESET '<key>';\". Use \"RESET;\" for reset all session properties.")

--- a/flink-table/flink-sql-client/src/test/resources/sql/set.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/set.q
@@ -15,6 +15,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set 'k0'='v0';
+[INFO] Session property has been set.
+!info
+
+set 'k0';
+'k0' = 'v0'
+!ok
+
+set;
+'execution.attached' = 'true'
+'execution.savepoint-restore-mode' = 'NO_CLAIM'
+'execution.savepoint.ignore-unclaimed-state' = 'false'
+'execution.shutdown-on-attached-exit' = 'false'
+'execution.target' = 'remote'
+'jobmanager.rpc.address' = '$VAR_JOBMANAGER_RPC_ADDRESS'
+'k0' = 'v0'
+'pipeline.classpaths' = ''
+'pipeline.jars' = ''
+'rest.port' = '$VAR_REST_PORT'
+'table.exec.legacy-cast-behaviour' = 'DISABLED'
+!ok
+
+reset 'k0';
+[INFO] Session property has been reset.
+!info
+
 # test set a configuration
 SET 'sql-client.execution.result-mode' = 'tableau';
 [INFO] Session property has been set.

--- a/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
+++ b/flink-table/flink-sql-parser/src/main/codegen/includes/parserImpls.ftl
@@ -2162,7 +2162,7 @@ SqlShowJars SqlShowJars() :
 
 /*
 * Parses a SET statement:
-* SET ['key' = 'value'];
+* SET ['key'[ = 'value']];
 */
 SqlNode SqlSet() :
 {
@@ -2174,8 +2174,10 @@ SqlNode SqlSet() :
     <SET> { s = span(); }
     [
         key = StringLiteral()
-        <EQ>
-        value = StringLiteral()
+        [
+          LOOKAHEAD(1)
+          <EQ> value = StringLiteral()
+        ]
     ]
     {
         if (key == null && value == null) {

--- a/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlSet.java
+++ b/flink-table/flink-sql-parser/src/main/java/org/apache/flink/sql/parser/ddl/SqlSet.java
@@ -37,7 +37,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Objects;
 
-/** SQL call for "SET" and "SET 'key' = 'value'". */
+/** SQL call for "SET", "SET 'key'" and "SET 'key' = 'value'". */
 @Internal
 public class SqlSet extends SqlCall {
 
@@ -49,7 +49,7 @@ public class SqlSet extends SqlCall {
     public SqlSet(SqlParserPos pos, SqlNode key, SqlNode value) {
         super(pos);
         this.key = Objects.requireNonNull(key, "key cannot be null");
-        this.value = Objects.requireNonNull(value, "value cannot be null");
+        this.value = value;
     }
 
     public SqlSet(SqlParserPos pos) {
@@ -98,8 +98,10 @@ public class SqlSet extends SqlCall {
     public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
         writer.keyword("SET");
 
-        if (key != null && value != null) {
+        if (key != null) {
             key.unparse(writer, leftPrec, rightPrec);
+        }
+        if (value != null) {
             writer.keyword("=");
             value.unparse(writer, leftPrec, rightPrec);
         }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/command/SetOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/command/SetOperation.java
@@ -27,8 +27,11 @@ import java.util.Optional;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
- * Operation to represent SET command. If {@link #getKey()} and {@link #getValue()} are empty, it
- * means show all the configurations. Otherwise, set value to the configuration key.
+ * Operation to represent SET command.
+ *
+ * <p>If {@link #getKey()} and {@link #getValue()} are both empty, it shows all the configurations.
+ * If only {@link #getValue()} is empty, it shows the configuration of the given key. Otherwise, it
+ * sets value to the configuration key.
  */
 public class SetOperation implements Operation {
 
@@ -42,7 +45,7 @@ public class SetOperation implements Operation {
 
     public SetOperation(String key, String value) {
         this.key = checkNotNull(key);
-        this.value = checkNotNull(value);
+        this.value = value;
     }
 
     public Optional<String> getKey() {
@@ -57,6 +60,8 @@ public class SetOperation implements Operation {
     public String asSummaryString() {
         if (key == null && value == null) {
             return "SET";
+        } else if (value == null) {
+            return String.format("SET %s", key);
         } else {
             return String.format("SET %s=%s", key, value);
         }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -1720,6 +1720,12 @@ public class SqlToOperationConverterTest {
         SetOperation setOperation2 = (SetOperation) operation2;
         assertThat(setOperation2.getKey()).hasValue("test-key");
         assertThat(setOperation2.getValue()).hasValue("test-value");
+
+        Operation operation3 = parse("SET 'test-key'", SqlDialect.DEFAULT);
+        assertThat(operation3).isInstanceOf(SetOperation.class);
+        SetOperation setOperation3 = (SetOperation) operation3;
+        assertThat(setOperation3.getKey()).hasValue("test-key");
+        assertThat(setOperation3.getValue()).isNotPresent();
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Currently the SET command in SQL client has two syntax:

- `SET;` for listing all config properties
- `SET 'key'='value'` for setting a property with (new) value

As in Spark SQL and Flink SQL with Hive dialect, it would be convenient to show one config property using the syntax `SET 'key';`. Without this, users will need to find the very one config from all config properties.

## Brief change log

- Add syntax to the parser and converters
- Add unit tests and integration tests
- Update user doc

## Verifying this change

This change added tests and can be verified as follows:
  - *Extended existing unit test and integration test*
  - *Manually verified the change by running a local Flink cluster*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / **docs** / JavaDocs / not documented)
