### PR TITLE
[FLINK-30462][runtime] The leader session ID is now saved properly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -248,7 +248,13 @@ public class DefaultMultipleComponentLeaderElectionService
             LeaderElectionEventHandler leaderElectionEventHandler,
             LeaderInformation leaderInformation) {
         leadershipOperationExecutor.execute(
-                () -> leaderElectionEventHandler.onLeaderInformationChange(leaderInformation));
+                () -> {
+                    synchronized (lock) {
+                        if (running && multipleComponentLeaderElectionDriver.hasLeadership()) {
+                            leaderElectionEventHandler.onLeaderInformationChange(leaderInformation);
+                        }
+                    }
+                });
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -192,7 +192,10 @@ public class DefaultMultipleComponentLeaderElectionService
                 return;
             }
 
-            currentLeaderSessionId = UUID.randomUUID();
+            Preconditions.checkState(
+                    currentLeaderSessionId == null,
+                    "notLeader() wasn't called by the LeaderElection backend before assigning leadership to this LeaderElectionService.");
+            currentLeaderSessionId = newLeaderSessionId;
 
             forEachLeaderElectionEventHandler(
                     leaderElectionEventHandler ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
@@ -33,7 +33,9 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,6 +118,108 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
             for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
                 assertThat(eventListener.hasLeadership()).isFalse();
             }
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    @Test
+    public void testLeaderInformationChangeOnlyCalledOnLeaderForSingleComponent() throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            final SimpleTestingLeaderElectionEventListener leaderElectionEventHandler =
+                    new SimpleTestingLeaderElectionEventListener();
+            final String componentId = "test-component";
+            leaderElectionService.registerLeaderElectionEventHandler(
+                    componentId, leaderElectionEventHandler);
+
+            final LeaderInformation leaderInformation =
+                    LeaderInformation.known(UUID.randomUUID(), "leader-address");
+            leaderElectionService.notifyLeaderInformationChange(componentId, leaderInformation);
+
+            assertThat(leaderElectionEventHandler.getLeaderInformation())
+                    .as(
+                            "The leader information should not be updated because the leadership was not acquired, yet.")
+                    .isNull();
+
+            leaderElectionDriver.grantLeadership();
+
+            assertThat(leaderElectionEventHandler.getLeaderInformation())
+                    .as(
+                            "The leader information should not be updated because no change event was triggered after the leadership was granted.")
+                    .isNull();
+
+            leaderElectionService.notifyLeaderInformationChange(componentId, leaderInformation);
+
+            assertThat(leaderElectionEventHandler.getLeaderInformation())
+                    .isEqualTo(leaderInformation);
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    @Test
+    public void testLeaderInformationChangeOnlyCalledOnLeaderForAllKnownComponents()
+            throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            final String componentWithChangeId = "component-with-change";
+            final SimpleTestingLeaderElectionEventListener componentWithChangeListener =
+                    new SimpleTestingLeaderElectionEventListener();
+            final String componentWithoutChangeId = "component-without-change";
+            final SimpleTestingLeaderElectionEventListener componentWithoutChangeListener =
+                    new SimpleTestingLeaderElectionEventListener();
+
+            final Map<String, SimpleTestingLeaderElectionEventListener> listeners = new HashMap<>();
+            listeners.put(componentWithChangeId, componentWithChangeListener);
+            listeners.put(componentWithoutChangeId, componentWithoutChangeListener);
+
+            listeners.forEach(leaderElectionService::registerLeaderElectionEventHandler);
+
+            final LeaderInformation leaderInformation =
+                    LeaderInformation.known(UUID.randomUUID(), "leader-address");
+            final Collection<LeaderInformationWithComponentId> componentsWithChange =
+                    Collections.singleton(
+                            LeaderInformationWithComponentId.create(
+                                    componentWithChangeId, leaderInformation));
+            leaderElectionService.notifyAllKnownLeaderInformation(componentsWithChange);
+
+            assertThat(listeners)
+                    .allSatisfy(
+                            (componentId, listener) ->
+                                    assertThat(listener.getLeaderInformation())
+                                            .as(
+                                                    "The leader information should not be updated for %s because the leadership was not acquired, yet.",
+                                                    componentId)
+                                            .isNull());
+
+            leaderElectionDriver.grantLeadership();
+
+            assertThat(listeners)
+                    .allSatisfy(
+                            (componentId, listener) ->
+                                    assertThat(listener.getLeaderInformation())
+                                            .as(
+                                                    "The leader information should not be updated for %s because no change event was triggered after the leadership was granted.",
+                                                    componentId)
+                                            .isNull());
+
+            leaderElectionService.notifyAllKnownLeaderInformation(componentsWithChange);
+
+            assertThat(componentWithChangeListener.getLeaderInformation())
+                    .isEqualTo(leaderInformation);
+            assertThat(componentWithoutChangeListener.getLeaderInformation())
+                    .isEqualTo(LeaderInformation.empty());
         } finally {
             leaderElectionService.close();
         }


### PR DESCRIPTION
## What is the purpose of the change

Previous to this fix, different components could have used different session IDs even though they belonged to the same session. It still puzzles me that this never appeared in any bug report. Wrong session IDs should have caused messages being rejected.

## Brief change log

* Fixed the bug in `DefaultMultipleComponentLeaderElectionService`

## Verifying this change

* Added test case to cover this issue

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
