### PR TITLE
[FLINK-24386] Guard JobMaster against exceptions from starting the Op…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -195,7 +195,13 @@ public class OperatorCoordinatorHolder
     public void start() throws Exception {
         mainThreadExecutor.assertRunningInMainThread();
         checkState(context.isInitialized(), "Coordinator Context is not yet initialized");
-        coordinator.start();
+        try {
+            coordinator.start();
+        } catch (Throwable t) {
+            ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
+            LOG.error("Failed to start Operator Coordinator", t);
+            context.failJob(t);
+        }
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinator.java
@@ -211,11 +211,6 @@ public class SourceCoordinator<SplitT extends SourceSplit, EnumChkT>
             try (TemporaryClassLoaderContext ignored =
                     TemporaryClassLoaderContext.of(userCodeClassLoader)) {
                 enumerator = source.createEnumerator(context);
-            } catch (Throwable t) {
-                ExceptionUtils.rethrowIfFatalErrorOrOOM(t);
-                LOG.error("Failed to create Source Enumerator for source {}", operatorName, t);
-                context.failJob(t);
-                return;
             }
         }
 


### PR DESCRIPTION
…eratorCoordinator

## What is the purpose of the change
* Improve the stability of the JobMaster when OperatorCoordinator throws an Exception upon start(). Instead of restarting the entire JobMaster, we will directly restart the job instead.

## Brief change log
* Catch non-fatal Throwables when starting OperatorCoordinator, and fail the job instead of rethrowing the JobMaster main thread.

## Verifying this change
This change added tests and can be verified as follows:
- Added unit test to verify that an OperatorCoordinator exception triggers a job failure without terminating the running thread.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
