### PR TITLE
[FLINK-30468][web] Change the SortOrder of BusyRatio to descend by default

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
@@ -57,7 +57,7 @@
     </tr>
     <tr>
       <th>SubTask</th>
-      <th [nzSortFn]="sortByBusyRatio">Backpressured / Idle / Busy</th>
+      <th [nzSortFn]="sortByBusyRatio" [nzSortOrder]="'descend'">Backpressured / Idle / Busy</th>
       <th>Backpressure Status</th>
       <th>Thread Dump</th>
     </tr>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.ts
@@ -103,7 +103,6 @@ export class JobOverviewDrawerBackpressureComponent implements OnInit, OnDestroy
         this.now = Date.now();
         this.backpressure = data;
         this.listOfSubTaskBackpressure = data?.subtasks || [];
-        this.listOfSubTaskBackpressure.sort(this.sortByBusyRatio);
         this.cdr.markForCheck();
       });
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the sort order is ascend by default, it should be descend.

The most busy subtask should be displayed on top.

## Brief change log

- Change the SortOrder of BusyRatio to descend by default.
- Don't change the order of `listOfSubTaskBackpressure`, it will sort by subtask when the user chooses not to sort.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no
  - If yes, how is the feature documented? not documented
