### PR TITLE
[FLINK-30476][Connector/FileSystem] TrackingFsDataInputStream batch tracking issue

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapter.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapter.java
@@ -254,8 +254,8 @@ public final class StreamFormatAdapter<T> implements BulkFormat<T, FileSourceSpl
      * dependent on the consumed data volume, which is more robust than making it dependent on a
      * record count.
      */
-     @VisibleForTesting
-     static final class TrackingFsDataInputStream extends FSDataInputStream {
+    @VisibleForTesting
+    static final class TrackingFsDataInputStream extends FSDataInputStream {
 
         private final FSDataInputStream stream;
         private final long fileLength;

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StreamFormatAdapterTest.java
@@ -95,7 +95,8 @@ class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Integer>> {
         ByteBuffer buffer = ByteBuffer.allocate(batchSize);
         int consumedBytes = dataStream.read(buffer.array(), 0, batchSize);
         assertThat(consumedBytes).isLessThan(batchSize);
-        assertThat(dataStream.hasRemainingInBatch()).isTrue()
+        assertThat(dataStream.hasRemainingInBatch())
+                .isTrue()
                 .describedAs("read() may return less than requested");
     }
 
@@ -108,7 +109,7 @@ class StreamFormatAdapterTest extends AdapterTestBase<StreamFormat<Integer>> {
 
             @Override
             public void seek(long ignored) {
-                //ignored
+                // ignored
             }
 
             @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request fixes a bug inside `org.apache.flink.connector.file.src.impl.StreamFormatAdapter.TrackingFsDataInputStream#read()`. Counter `remainingInBatch` should track bytes that were read from the underlying stream.

## Brief change log

- `org.apache.flink.connector.file.src.impl.StreamFormatAdapter.TrackingFsDataInputStream` counter should account only bytes that were read from the underlying stream.

## Verifying this change

This change added tests and can be verified as follows:
  - Added test `org.apache.flink.connector.file.src.impl.StreamFormatAdapterTest#testTrackingStreamBatchSizeAccounting` that validates that TrackingFsDataInputStream tracks only bytes that were consumed

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: yes

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
