### PR TITLE
[FLINK-30461][checkpoint] Fix the bug that the shared files will remain forever after the rocksdb incremental checkpoint exception

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -63,6 +63,17 @@ public class StateUtil {
                 handlesToDiscard, StateObject::discardState);
     }
 
+    public static void discardStateObjectQuietly(StateObject stateObject) {
+        if (stateObject == null) {
+            return;
+        }
+        try {
+            stateObject.discardState();
+        } catch (Exception exception) {
+            LOG.warn("Discard {} exception.", stateObject, exception);
+        }
+    }
+
     /**
      * Discards the given state future by first trying to cancel it. If this is not possible, then
      * the state object contained in the future is calculated and afterwards discarded.

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksIncrementalSnapshotStrategy.java
@@ -35,7 +35,6 @@ import org.apache.flink.runtime.state.PlaceholderStreamStateHandle;
 import org.apache.flink.runtime.state.SnapshotDirectory;
 import org.apache.flink.runtime.state.SnapshotResult;
 import org.apache.flink.runtime.state.StateHandleID;
-import org.apache.flink.runtime.state.StateObject;
 import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.metainfo.StateMetaInfoSnapshot;
 import org.apache.flink.util.Preconditions;
@@ -50,7 +49,6 @@ import javax.annotation.Nonnull;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -279,6 +277,7 @@ public class RocksIncrementalSnapshotStrategy<K>
                 metaStateHandle =
                         materializeMetaData(
                                 snapshotCloseableRegistry,
+                                tmpResourcesRegistry,
                                 stateMetaInfoSnapshots,
                                 checkpointId,
                                 checkpointStreamFactory);
@@ -289,7 +288,8 @@ public class RocksIncrementalSnapshotStrategy<K>
                         metaStateHandle.getJobManagerOwnedSnapshot(),
                         "Metadata for job manager was not properly created.");
 
-                uploadSstFiles(sstFiles, miscFiles, snapshotCloseableRegistry);
+                uploadSstFiles(
+                        sstFiles, miscFiles, snapshotCloseableRegistry, tmpResourcesRegistry);
                 long checkpointedSize = metaStateHandle.getStateSize();
                 checkpointedSize += getUploadedStateSize(sstFiles.values());
                 checkpointedSize += getUploadedStateSize(miscFiles.values());
@@ -320,12 +320,7 @@ public class RocksIncrementalSnapshotStrategy<K>
                 return snapshotResult;
             } finally {
                 if (!completed) {
-                    final List<StateObject> statesToDiscard =
-                            new ArrayList<>(1 + miscFiles.size() + sstFiles.size());
-                    statesToDiscard.add(metaStateHandle);
-                    statesToDiscard.addAll(miscFiles.values());
-                    statesToDiscard.addAll(sstFiles.values());
-                    cleanupIncompleteSnapshot(statesToDiscard, localBackupDirectory);
+                    cleanupIncompleteSnapshot(tmpResourcesRegistry, localBackupDirectory);
                 }
             }
         }
@@ -333,7 +328,8 @@ public class RocksIncrementalSnapshotStrategy<K>
         private void uploadSstFiles(
                 @Nonnull Map<StateHandleID, StreamStateHandle> sstFiles,
                 @Nonnull Map<StateHandleID, StreamStateHandle> miscFiles,
-                @Nonnull CloseableRegistry snapshotCloseableRegistry)
+                @Nonnull CloseableRegistry snapshotCloseableRegistry,
+                @Nonnull CloseableRegistry tmpResourcesRegistry)
                 throws Exception {
 
             // write state data
@@ -355,13 +351,15 @@ public class RocksIncrementalSnapshotStrategy<K>
                                 sstFilePaths,
                                 checkpointStreamFactory,
                                 stateScope,
-                                snapshotCloseableRegistry));
+                                snapshotCloseableRegistry,
+                                tmpResourcesRegistry));
                 miscFiles.putAll(
                         stateUploader.uploadFilesToCheckpointFs(
                                 miscFilePaths,
                                 checkpointStreamFactory,
                                 stateScope,
-                                snapshotCloseableRegistry));
+                                snapshotCloseableRegistry,
+                                tmpResourcesRegistry));
 
                 synchronized (uploadedStateIDs) {
                     switch (sharingFilesStrategy) {


### PR DESCRIPTION
## What is the purpose of the change

In rocksdb incremental checkpoint mode, during file upload, if some files have been uploaded and some files have not been uploaded, the checkpoint is canceled due to checkpoint timeout at this time, and the uploaded files will remain.

I did a detailed analysis in FLINK-30461, you can get more information from FLINK-30461.

## Brief change log

Using the CloseableRegistry as the tmpResourcesRegistry. If the async phase is failed, the tmpResourcesRegistry will cleanup all temporary resources.


## Verifying this change

This change added tests and can be verified as follows:

  - *Added test: RocksDBStateUploaderTest#testUploadedSstCanBeCleanedUp*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
