### PR TITLE
[FLINK-30478] [core] Avoiding dependence on JDK-internal code

### DIFF
--- a/flink-core/pom.xml
+++ b/flink-core/pom.xml
@@ -104,6 +104,12 @@ under the License.
 			<artifactId>flink-shaded-guava</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.github.seancfoley</groupId>
+			<artifactId>ipaddress</artifactId>
+			<version>5.4.0</version>
+		</dependency>
+
 		<!-- ================== test dependencies ================== -->
 
 		<dependency>

--- a/flink-dist/src/main/resources/META-INF/NOTICE
+++ b/flink-dist/src/main/resources/META-INF/NOTICE
@@ -6,6 +6,7 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
+- com.github.seancfoley:ipaddress:5.4.0
 - com.google.code.findbugs:jsr305:1.3.9
 - com.twitter:chill-java:0.7.6
 - com.ververica:frocksdbjni:6.20.3-ververica-1.0


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-30478

## What is the purpose of the change

Increasing the usability of Flink with JDK 17: `sun.net.util.IPAddressUtil` is not exported by the JDK, i.e. `--add-opens` configuration is needed for making use of it.

## Brief change log

 I've replaced the problematic usage in the class `NetUtils` via the library _com.github.seancfoley:ipaddress:5.4.0_ (Apache License v2).

## Verifying this change

This change is already covered by existing tests, see `NetUtilsTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature: no
  - If yes, how is the feature documented: not applicable
