### PR TITLE
[FLINK-30479][doc] Document flink-connector-files for local execution

### DIFF
--- a/docs/content/docs/connectors/table/filesystem.md
+++ b/docs/content/docs/connectors/table/filesystem.md
@@ -33,6 +33,18 @@ The file system connector itself is included in Flink and does not require an ad
 The corresponding jar can be found in the Flink distribution inside the `/lib` directory.
 A corresponding format needs to be specified for reading and writing rows from and to a file system.
 
+NOTE: If you use the filesystem connector for [local execution]({{< ref "docs/dev/dataset/local_execution" >}}),
+for e.g. running Flink job in your IDE, you will need to add dependency.
+
+```xml
+<dependency>
+  <groupId>org.apache.flink</groupId>
+  <artifactId>flink-connector-files</artifactId>
+  <version>{{< version >}}</version>
+  <scope>provided</scope>
+</dependency>
+```
+
 The file system connector allows for reading and writing from a local or distributed filesystem. A filesystem table can be defined as:
 
 ```sql


### PR DESCRIPTION
## What is the purpose of the change

The file system SQL connector itself is included in Flink and does not require an additional dependency. However, if a user uses the filesystem connector for [local execution](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/dataset/local_execution/#local-execution), for e.g. running Flink job in the IDE, she will need to add dependency. Otherwise, the user will get validation exception: `Cannot discover a connector using option: 'connector'='filesystem'`. This is confusing and can be documented.

## Brief change log

The scope of the files connector dependency should be `provided`, because they should not be packaged into the job JAR file. So we do not use the `sql_download_table` shortcodes like `{{< sql_download_table "files" >}}`. Also that shortcodes has texts saying the dependencies are required for SQL Client with SQL JAR bundles. That is not applicable to files connector as it's already shipped int he `/lib` directlory.


## Verifying this change

This is a doc change, and I have tested it rendered locally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
