### PR TITLE
[FLINK-27691][table-planner] Remove unnecessary state ttl to avoid unstable results of RankHarnessTest

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -230,7 +230,6 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
     val data = new mutable.MutableList[(String, Int, Int)]
     val t = env.fromCollection(data).toTable(tEnv, 'word, 'cnt, 'type)
     tEnv.createTemporaryView("T", t)
-    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
 
     val sql =
       """


### PR DESCRIPTION
## What is the purpose of the change
Try to fix the long stand unstable test case RankHarnessTest. testUpdateRankWithRowNumberSortKeyDropsToNotLast.
Most probably caused by the unnecessary state ttl of RankHarnessTest which will lead unstable result when execution gets slow (and I checked recent failures, all of their execution duration is greater than 2 second while state ttl in the test is 1 second).

## Brief change log
remove unnecessary state ttl of RankHarnessTest

## Verifying this change
existing tests

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)

