### PR TITLE
FLINK-30443 Ensuring more sensitive keys are masked in log output

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/GlobalConfiguration.java
@@ -45,7 +45,17 @@ public final class GlobalConfiguration {
 
     // the keys whose values should be hidden
     private static final String[] SENSITIVE_KEYS =
-            new String[] {"password", "secret", "fs.azure.account.key", "apikey"};
+            new String[] {
+                "password",
+                "secret",
+                "fs.azure.account.key",
+                "apikey",
+                "auth-params",
+                "service-key",
+                "token",
+                "basic-auth",
+                "jaas.config"
+            };
 
     // the hidden content to be displayed
     public static final String HIDDEN_CONTENT = "******";

--- a/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
+++ b/flink-core/src/test/java/org/apache/flink/configuration/GlobalConfigurationTest.java
@@ -129,6 +129,18 @@ public class GlobalConfigurationTest extends TestLogger {
         assertTrue(GlobalConfiguration.isSensitive("123pasSword"));
         assertTrue(GlobalConfiguration.isSensitive("PasSword"));
         assertTrue(GlobalConfiguration.isSensitive("Secret"));
+        assertTrue(GlobalConfiguration.isSensitive("polaris.client-secret"));
+        assertTrue(GlobalConfiguration.isSensitive("client-secret"));
+        assertTrue(GlobalConfiguration.isSensitive("service-key-json"));
+        assertTrue(GlobalConfiguration.isSensitive("auth.basic.password"));
+        assertTrue(GlobalConfiguration.isSensitive("auth.basic.token"));
+        assertTrue(GlobalConfiguration.isSensitive("avro-confluent.basic-auth.user-info"));
+        assertTrue(GlobalConfiguration.isSensitive("key.avro-confluent.basic-auth.user-info"));
+        assertTrue(GlobalConfiguration.isSensitive("value.avro-confluent.basic-auth.user-info"));
+        assertTrue(GlobalConfiguration.isSensitive("kafka.jaas.config"));
+        assertTrue(GlobalConfiguration.isSensitive("properties.ssl.truststore.password"));
+        assertTrue(GlobalConfiguration.isSensitive("properties.ssl.keystore.password"));
+
         assertTrue(
                 GlobalConfiguration.isSensitive(
                         "fs.azure.account.key.storageaccount123456.core.windows.net"));


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-30443

## What is the purpose of the change

Making sure certain sensitive configuration keys don't appear in logs.

## Brief change log

Added more sensitive keys to `GlobalConfiguration.SENSITIVE_KEYS`. I acknowledge that those are somewhat specific, OTOH there is precedence with the Azure account key, and things like "token" or "service-key" should generally be not logged. The alternative would be to create an SPI of sorts which would allow to customize the masked keys for specific Flink deployments; I don't think it's worth the effort really, but I'm curious what others here think.

## Verifying this change

Expanded `GlobalConfigurationTest` accordingly.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
