### PR TITLE
[FLINK-30491][hive] Hive table partition supports deserializing later during runtime

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSource.java
@@ -64,7 +64,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
 
     private final String hiveVersion;
     private final List<String> dynamicFilterPartitionKeys;
-    private final List<HiveTablePartition> partitions;
+    private final List<byte[]> partitionBytes;
     private final ContinuousPartitionFetcher<Partition, ?> fetcher;
     private final HiveTableSource.HiveContinuousPartitionFetcherContext<?> fetcherContext;
     private final ObjectPath tablePath;
@@ -80,7 +80,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
             List<String> partitionKeys,
             String hiveVersion,
             @Nullable List<String> dynamicFilterPartitionKeys,
-            List<HiveTablePartition> partitions,
+            List<byte[]> partitionBytes,
             @Nullable ContinuousPartitionFetcher<Partition, ?> fetcher,
             @Nullable HiveTableSource.HiveContinuousPartitionFetcherContext<?> fetcherContext) {
         super(
@@ -94,7 +94,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
         this.partitionKeys = partitionKeys;
         this.hiveVersion = hiveVersion;
         this.dynamicFilterPartitionKeys = dynamicFilterPartitionKeys;
-        this.partitions = partitions;
+        this.partitionBytes = partitionBytes;
         this.fetcher = fetcher;
         this.fetcherContext = fetcherContext;
     }
@@ -181,7 +181,7 @@ public class HiveSource<T> extends AbstractFileSource<T, HiveSourceSplit> {
                 new HiveSourceDynamicFileEnumerator.Provider(
                         tablePath.getFullName(),
                         dynamicFilterPartitionKeys,
-                        partitions,
+                        partitionBytes,
                         hiveVersion,
                         jobConfWrapper),
                 getAssignerFactory());

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
@@ -236,6 +236,9 @@ public class HiveSourceBuilder {
                         : SimpleSplitAssigner::new;
         List<byte[]> hiveTablePartitionBytes = Collections.emptyList();
         if (partitions != null) {
+            // Serializing the HiveTablePartition list manually at compile time to avoid
+            // deserializing it in TaskManager during runtime. The HiveTablePartition list is no
+            // need for TM.
             hiveTablePartitionBytes = HivePartitionUtils.serializeHiveTablePartition(partitions);
         }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceBuilder.java
@@ -234,11 +234,15 @@ public class HiveSourceBuilder {
                 continuousSourceSettings == null || partitionKeys.isEmpty()
                         ? DEFAULT_SPLIT_ASSIGNER
                         : SimpleSplitAssigner::new;
+        List<byte[]> hiveTablePartitionBytes = Collections.emptyList();
+        if (partitions != null) {
+            hiveTablePartitionBytes = HivePartitionUtils.serializeHiveTablePartition(partitions);
+        }
+
         return new HiveSource<>(
                 new Path[1],
                 new HiveSourceFileEnumerator.Provider(
-                        partitions != null ? partitions : Collections.emptyList(),
-                        new JobConfWrapper(jobConf)),
+                        hiveTablePartitionBytes, new JobConfWrapper(jobConf)),
                 splitAssigner,
                 bulkFormat,
                 continuousSourceSettings,
@@ -247,7 +251,7 @@ public class HiveSourceBuilder {
                 partitionKeys,
                 hiveVersion,
                 dynamicFilterPartitionKeys,
-                partitions,
+                hiveTablePartitionBytes,
                 fetcher,
                 fetcherContext);
     }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceDynamicFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceDynamicFileEnumerator.java
@@ -185,9 +185,9 @@ public class HiveSourceDynamicFileEnumerator implements DynamicFileEnumerator {
     /** A factory to create {@link HiveSourceDynamicFileEnumerator}. */
     public static class Provider implements DynamicFileEnumerator.Provider {
 
-        private final Logger LOG = LoggerFactory.getLogger(Provider.class);
-
         private static final long serialVersionUID = 1L;
+
+        private static final Logger LOG = LoggerFactory.getLogger(Provider.class);
 
         private final String table;
         private final List<String> dynamicFilterPartitionKeys;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceDynamicFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceDynamicFileEnumerator.java
@@ -187,10 +187,10 @@ public class HiveSourceDynamicFileEnumerator implements DynamicFileEnumerator {
 
         private static final long serialVersionUID = 1L;
 
-        private static final Logger LOG = LoggerFactory.getLogger(Provider.class);
-
         private final String table;
         private final List<String> dynamicFilterPartitionKeys;
+        // The binary HiveTablePartition list, serialize it manually at compile time to avoid
+        // deserializing it in TaskManager during runtime.
         private final List<byte[]> partitionBytes;
         private final String hiveVersion;
         private final JobConfWrapper jobConfWrapper;
@@ -210,9 +210,6 @@ public class HiveSourceDynamicFileEnumerator implements DynamicFileEnumerator {
 
         @Override
         public DynamicFileEnumerator create() {
-            LOG.info(
-                    "Deserialize {} hive table partition in HiveSourceDynamicFileEnumerator.",
-                    table);
             return new HiveSourceDynamicFileEnumerator(
                     table,
                     dynamicFilterPartitionKeys,

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceDynamicFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceDynamicFileEnumerator.java
@@ -185,33 +185,38 @@ public class HiveSourceDynamicFileEnumerator implements DynamicFileEnumerator {
     /** A factory to create {@link HiveSourceDynamicFileEnumerator}. */
     public static class Provider implements DynamicFileEnumerator.Provider {
 
+        private final Logger LOG = LoggerFactory.getLogger(Provider.class);
+
         private static final long serialVersionUID = 1L;
 
         private final String table;
         private final List<String> dynamicFilterPartitionKeys;
-        private final List<HiveTablePartition> partitions;
+        private final List<byte[]> partitionBytes;
         private final String hiveVersion;
         private final JobConfWrapper jobConfWrapper;
 
         public Provider(
                 String table,
                 List<String> dynamicFilterPartitionKeys,
-                List<HiveTablePartition> partitions,
+                List<byte[]> partitionBytes,
                 String hiveVersion,
                 JobConfWrapper jobConfWrapper) {
             this.table = checkNotNull(table);
             this.dynamicFilterPartitionKeys = checkNotNull(dynamicFilterPartitionKeys);
-            this.partitions = checkNotNull(partitions);
+            this.partitionBytes = checkNotNull(partitionBytes);
             this.hiveVersion = checkNotNull(hiveVersion);
             this.jobConfWrapper = checkNotNull(jobConfWrapper);
         }
 
         @Override
         public DynamicFileEnumerator create() {
+            LOG.info(
+                    "Deserialize {} hive table partition in HiveSourceDynamicFileEnumerator.",
+                    table);
             return new HiveSourceDynamicFileEnumerator(
                     table,
                     dynamicFilterPartitionKeys,
-                    partitions,
+                    HivePartitionUtils.deserializeHiveTablePartition(partitionBytes),
                     hiveVersion,
                     jobConfWrapper.conf());
         }

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveSourceFileEnumerator.java
@@ -33,8 +33,6 @@ import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.InputSplit;
 import org.apache.hadoop.mapred.JobConf;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -225,10 +223,10 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
     /** A factory to create {@link HiveSourceFileEnumerator}. */
     public static class Provider implements FileEnumerator.Provider {
 
-        private static final Logger LOG = LoggerFactory.getLogger(Provider.class);
-
         private static final long serialVersionUID = 1L;
 
+        // The binary HiveTablePartition list, serialize it manually at compile time to avoid
+        // deserializing it in TaskManager during runtime.
         private final List<byte[]> partitionBytes;
         private final JobConfWrapper jobConfWrapper;
 
@@ -239,7 +237,6 @@ public class HiveSourceFileEnumerator implements FileEnumerator {
 
         @Override
         public FileEnumerator create() {
-            LOG.info("Deserialize hive table partition in HiveSourceFileEnumerator.");
             return new HiveSourceFileEnumerator(
                     HivePartitionUtils.deserializeHiveTablePartition(partitionBytes),
                     jobConfWrapper.conf());

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartitionSerializer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartitionSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.apache.flink.util.Preconditions.checkArgument;
+
+/** SerDe for {@link HiveTablePartition}. */
+public class HiveTablePartitionSerializer implements SimpleVersionedSerializer<HiveTablePartition> {
+
+    private static final int VERSION = 1;
+
+    public static final HiveTablePartitionSerializer INSTANCE = new HiveTablePartitionSerializer();
+
+    @Override
+    public int getVersion() {
+        return VERSION;
+    }
+
+    @Override
+    public byte[] serialize(HiveTablePartition hiveTablePartition) throws IOException {
+        checkArgument(
+                hiveTablePartition.getClass() == HiveTablePartition.class,
+                "Cannot serialize subclasses of HiveTablePartition");
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        try (ObjectOutputStream outputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            outputStream.writeObject(hiveTablePartition);
+        }
+        return byteArrayOutputStream.toByteArray();
+    }
+
+    @Override
+    public HiveTablePartition deserialize(int version, byte[] serialized) throws IOException {
+        if (version == 1) {
+            try (ObjectInputStream inputStream =
+                    new ObjectInputStream(new ByteArrayInputStream(serialized))) {
+                return (HiveTablePartition) inputStream.readObject();
+            } catch (ClassNotFoundException e) {
+                throw new IOException("Failed to deserialize HiveTablePartition", e);
+            }
+        } else {
+            throw new IOException("Unknown version: " + version);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartitionSerializer.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTablePartitionSerializer.java
@@ -31,13 +31,13 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /** SerDe for {@link HiveTablePartition}. */
 public class HiveTablePartitionSerializer implements SimpleVersionedSerializer<HiveTablePartition> {
 
-    private static final int VERSION = 1;
+    private static final int CURRENT_VERSION = 1;
 
     public static final HiveTablePartitionSerializer INSTANCE = new HiveTablePartitionSerializer();
 
     @Override
     public int getVersion() {
-        return VERSION;
+        return CURRENT_VERSION;
     }
 
     @Override
@@ -54,7 +54,7 @@ public class HiveTablePartitionSerializer implements SimpleVersionedSerializer<H
 
     @Override
     public HiveTablePartition deserialize(int version, byte[] serialized) throws IOException {
-        if (version == 1) {
+        if (version == CURRENT_VERSION) {
             try (ObjectInputStream inputStream =
                     new ObjectInputStream(new ByteArrayInputStream(serialized))) {
                 return (HiveTablePartition) inputStream.readObject();

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/HivePartitionUtils.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/util/HivePartitionUtils.java
@@ -20,6 +20,7 @@ package org.apache.flink.connectors.hive.util;
 
 import org.apache.flink.connectors.hive.FlinkHiveException;
 import org.apache.flink.connectors.hive.HiveTablePartition;
+import org.apache.flink.connectors.hive.HiveTablePartitionSerializer;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.hive.client.HiveMetastoreClientFactory;
@@ -289,5 +290,34 @@ public class HivePartitionUtils {
                 listStatusRecursively(fs, stat, level + 1, expectLevel, results);
             }
         }
+    }
+
+    public static List<byte[]> serializeHiveTablePartition(
+            List<HiveTablePartition> hiveTablePartitions) {
+        List<byte[]> partitionBytes = new ArrayList<>(hiveTablePartitions.size());
+        try {
+            for (HiveTablePartition hiveTablePartition : hiveTablePartitions) {
+                partitionBytes.add(
+                        HiveTablePartitionSerializer.INSTANCE.serialize(hiveTablePartition));
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        return partitionBytes;
+    }
+
+    public static List<HiveTablePartition> deserializeHiveTablePartition(
+            List<byte[]> partitionBytes) {
+        List<HiveTablePartition> hiveTablePartitions = new ArrayList<>(partitionBytes.size());
+        try {
+            for (byte[] bytes : partitionBytes) {
+                hiveTablePartitions.add(
+                        HiveTablePartitionSerializer.INSTANCE.deserialize(
+                                HiveTablePartitionSerializer.INSTANCE.getVersion(), bytes));
+            }
+        } catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+        return hiveTablePartitions;
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/util/HivePartitionUtilsTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/util/HivePartitionUtilsTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.connectors.hive.util;
 
 import org.apache.flink.connectors.hive.HiveTablePartition;

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/util/HivePartitionUtilsTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/util/HivePartitionUtilsTest.java
@@ -1,0 +1,52 @@
+package org.apache.flink.connectors.hive.util;
+
+import org.apache.flink.connectors.hive.HiveTablePartition;
+
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link HivePartitionUtils}. */
+public class HivePartitionUtilsTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void testHiveTablePartitionSerDe() throws Exception {
+        String baseFilePath =
+                Objects.requireNonNull(this.getClass().getResource("/orc/test.orc")).getPath();
+        File wareHouse = temporaryFolder.newFolder("testHiveTablePartitionSerDe");
+        int partitionNum = 10;
+        List<HiveTablePartition> expectedHiveTablePartitions = new ArrayList<>();
+        for (int i = 0; i < partitionNum; i++) {
+            // create partition directory
+            Path partitionPath = Paths.get(wareHouse.getPath(), "p_" + i);
+            Files.createDirectory(partitionPath);
+            // copy file to the partition directory
+            Files.copy(Paths.get(baseFilePath), Paths.get(partitionPath.toString(), "t.orc"));
+            StorageDescriptor sd = new StorageDescriptor();
+            sd.setLocation(partitionPath.toString());
+            expectedHiveTablePartitions.add(new HiveTablePartition(sd, new Properties()));
+        }
+
+        List<byte[]> hiveTablePartitionBytes =
+                HivePartitionUtils.serializeHiveTablePartition(expectedHiveTablePartitions);
+
+        List<HiveTablePartition> actualHiveTablePartitions =
+                HivePartitionUtils.deserializeHiveTablePartition(hiveTablePartitionBytes);
+
+        assertThat(actualHiveTablePartitions).isEqualTo(expectedHiveTablePartitions);
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change
Hive table partition supports deserializing later during runtime, the JobManager needs to deserialize it for the enumerator, but the partition info isn't required for TaskManager, so we don't need to deserialize it, so we can reduce the cost of the task initializing phase.

## Brief change log
  - *Hive table partition supports deserializing later during runtime*


## Verifying this change


This change is already covered by existing hive tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
