### PR TITLE
[FLINK-30501] Update Flink build instruction to deprecate Java 8 instead of requiring Java 11

### DIFF
--- a/docs/content.zh/docs/dev/configuration/gradle.md
+++ b/docs/content.zh/docs/dev/configuration/gradle.md
@@ -29,7 +29,7 @@ under the License.
 ## 要求
 
 - Gradle 7.x 
-- Java 11
+- Java 8 (deprecated) 或 Java 11
 
 ## 将项目导入 IDE
 

--- a/docs/content.zh/docs/dev/configuration/maven.md
+++ b/docs/content.zh/docs/dev/configuration/maven.md
@@ -29,7 +29,7 @@ under the License.
 ## 要求
 
 - Maven 3.0.4 (or higher)
-- Java 11
+- Java 8 (deprecated) or Java 11
 
 ## 将项目导入 IDE
 

--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -35,7 +35,7 @@ under the License.
 
 首先需要准备源码。可以[从发布版本下载源码]({{< downloads >}}) 或者[从 Git 库克隆 Flink 源码]({{< github_repo >}})。
 
-还需要准备 **Maven 3** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 11** 或更新的版本来进行构建。
+还需要准备 **Maven 3** 和 **JDK** (Java开发套件)。Flink 依赖 **Java 8 (deprecated) 或 Java 11** 来进行构建。
 
 *注意：Maven 3.3.x 可以构建 Flink，但是不能正确地屏蔽掉指定的依赖。Maven 3.2.5 可以正确地构建库文件。
 

--- a/docs/content/docs/dev/configuration/gradle.md
+++ b/docs/content/docs/dev/configuration/gradle.md
@@ -31,7 +31,7 @@ to automate tasks in the development process.
 ## Requirements
 
 - Gradle 7.x 
-- Java 11
+- Java 8 (deprecated) or Java 11
 
 ## Importing the project into your IDE
 

--- a/docs/content/docs/dev/configuration/maven.md
+++ b/docs/content/docs/dev/configuration/maven.md
@@ -31,7 +31,7 @@ publish, and deploy projects. You can use it to manage the entire lifecycle of y
 ## Requirements
 
 - Maven 3.0.4 (or higher)
-- Java 11
+- Java 8 (deprecated) or Java 11
 
 ## Importing the project into your IDE
 

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -33,7 +33,7 @@ This page covers how to build Flink {{< version >}} from sources.
 
 In order to build Flink you need the source code. Either [download the source of a release]({{< downloads >}}) or [clone the git repository]({{< github_repo >}}).
 
-In addition you need **Maven 3** and a **JDK** (Java Development Kit). Flink requires **at least Java 11** to build.
+In addition you need **Maven 3** and a **JDK** (Java Development Kit). Flink requires **Java 8 (deprecated) or Java 11** to build.
 
 *NOTE: Maven 3.3.x can build Flink, but will not properly shade away certain dependencies. Maven 3.2.5 creates the libraries properly.*
 


### PR DESCRIPTION
## What is the purpose of the change

Flink 1.15 and later versions require at least Java 11 to build from sources [1], whereas the pom.xml specifies the source/target is 1.8. This inconsistency confuses users.

As mentioned in the [FLINK-25247](https://issues.apache.org/jira/browse/FLINK-25247) title, the goal of that ticket is to "Inform users about deprecation". It will be better to inform users that "Java 8 is deprecated" instead of saying "Fink requires at least Java 11 to build", so that users have the right information to make the right choice for themselves.

Also note that Flink community is regularly running flink-ml benchmark for both Java 8 and Java 11 [2], which suggests that we are practically ensuring Java 8 is supported.

If we decide to official drop Java 8 support, Flink community probably should give explicit notice regarding the deprecation period so that users can be prepared for this breaking change. We can follow the Kafka website doc [3] for example, which says "Java 8, Java 11, and Java 17 are supported. Note that Java 8 support has been deprecated since Apache Kafka 3.0 and will be removed in Apache Kafka 4.0".


[1] https://nightlies.apache.org/flink/flink-docs-release-1.15/docs/flinkdev/building/
[2] http://codespeed.dak8s.net:8000/timeline/?ben=mapSink.F27_UNBOUNDED&env=2
[3] https://kafka.apache.org/documentation/

## Brief change log

Update Flink doc to mention that "Java 8 is deprecated" instead of saying "Flink requires at least Java 11 to build".

## Verifying this change

N/A.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? N/A
