### PR TITLE
[FLINK-29217][Runtime/Checkpointing] Remove OC's guarantee for OperatorEvent on concurrent checkpoints

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -67,7 +67,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *       closed. Events coming after that are held back (buffered), because they belong to the epoch
  *       after the checkpoint.
  *   <li>Once all coordinators in the job have completed the checkpoint, the barriers to the sources
- *       are injected. If a coordinator receives a {@link AcknowledgeCheckpointEvent} from one of
+ *       are injected. If a coordinator receives an {@link AcknowledgeCheckpointEvent} from one of
  *       its subtasks, which denotes that the subtask has received the checkpoint barrier and
  *       completed checkpoint, the coordinator reopens the corresponding subtask gateway and sends
  *       out buffered events.
@@ -75,23 +75,6 @@ import static org.apache.flink.util.Preconditions.checkState;
  *       coordinator's perspective, these events are lost, because they were sent to a failed
  *       subtask after it's latest complete checkpoint.
  * </ul>
- *
- * Thus, events delivered from coordinators behave as follows.
- *
- * <ul>
- *   <li>If the event is generated before the coordinator completes checkpoint, it would be sent out
- *       immediately.
- *   <li>If the event is generated after the coordinator completes checkpoint, it would be
- *       temporarily buffered and not be sent out to the subtask until the coordinator received a
- *       {@link AcknowledgeCheckpointEvent} from that subtask.
- *   <li>If the event is generated after the coordinator received {@link
- *       AcknowledgeCheckpointEvent}, it would be sent out immediately.
- * </ul>
- *
- * <p>This implementation can handle concurrent checkpoints. In the behavior described above, If an
- * event is generated after the coordinator has completed multiple checkpoints, and before it
- * receives {@link AcknowledgeCheckpointEvent} about any of them, the event would be buffered until
- * the coordinator has received {@link AcknowledgeCheckpointEvent} about all of these checkpoints.
  *
  * <p><b>IMPORTANT:</b> A critical assumption is that all events from the scheduler to the Tasks are
  * transported strictly in order. Events being sent from the coordinator after the checkpoint

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/SubtaskGatewayImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/SubtaskGatewayImpl.java
@@ -45,9 +45,7 @@ import java.util.concurrent.CompletableFuture;
  * releasing them later. If the instance is closed for a specific checkpoint, events arrived after
  * that would be blocked temporarily, and released after the checkpoint finishes. If an event is
  * blocked & buffered when there are multiple ongoing checkpoints, the event would be released after
- * all these checkpoints finish. It is used for "alignment" of operator event streams with
- * checkpoint barrier injection, similar to how the input channels are aligned during a common
- * checkpoint.
+ * all these checkpoints finish.
  *
  * <p>The methods on the critical communication path, including closing/reopening the gateway and
  * sending the operator events, are required to be used in a single-threaded context specified by

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -183,26 +183,6 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
     }
 
     @Test
-    public void triggerConcurrentCheckpoints() throws Exception {
-        final EventReceivingTasks tasks = EventReceivingTasks.createForRunningTasks();
-        final OperatorCoordinatorHolder holder =
-                createCoordinatorHolder(tasks, TestingOperatorCoordinator::new);
-
-        triggerAndCompleteCheckpoint(holder, 1111L);
-        getCoordinator(holder).getSubtaskGateway(0).sendEvent(new TestOperatorEvent(1337));
-        triggerAndCompleteCheckpoint(holder, 1112L);
-        getCoordinator(holder).getSubtaskGateway(0).sendEvent(new TestOperatorEvent(1338));
-        assertThat(tasks.getSentEventsForSubtask(0)).isEmpty();
-
-        holder.handleEventFromOperator(0, 0, new AcknowledgeCheckpointEvent(1111L));
-        assertThat(tasks.getSentEventsForSubtask(0)).containsExactly(new TestOperatorEvent(1337));
-
-        holder.handleEventFromOperator(0, 0, new AcknowledgeCheckpointEvent(1112L));
-        assertThat(tasks.getSentEventsForSubtask(0))
-                .containsExactly(new TestOperatorEvent(1337), new TestOperatorEvent(1338));
-    }
-
-    @Test
     public void takeCheckpointAfterSuccessfulCheckpoint() throws Exception {
         final EventReceivingTasks tasks = EventReceivingTasks.createForRunningTasks();
         final OperatorCoordinatorHolder holder =


### PR DESCRIPTION
## What is the purpose of the change

This pull request removes the guarantee of the consistency of OperatorEvents sent from OperatorCoordinator to its subtasks in case of concurrent checkpoints. This pull request provides a quick fix for the mismatch between OperatorCoordinator's description and its actual behavior. The background information can be found at FLINK-29217.

## Brief change log

- Modify the JavaDoc and remove the tests about OperatorCoordinator's behavior in case of concurrent checkpoints.

## Verifying this change

This change is already covered by existing tests. The test cases related to the OperatorCoordinator's behavior in face of concurrent checkpoints have been removed to match with the expected behavior.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
