### PR TITLE
[FLINK-18229][ResourceManager] Support cancel pending workers if no longer needed.

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriver.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
 /** Implementation of {@link ResourceManagerDriver} for Kubernetes deployment. */
@@ -199,11 +200,29 @@ public class KubernetesResourceManagerDriver
                                     future.completeExceptionally(exception);
                                 }
                             } else {
-                                log.info("Pod {} is created.", podName);
+                                if (requestResourceFuture.isCancelled()) {
+                                    stopPod(podName);
+                                    log.info(
+                                            "pod {} is cancelled before create pod finish, stop it.",
+                                            podName);
+                                } else {
+                                    log.info("Pod {} is created.", podName);
+                                }
                             }
                             return null;
                         },
                         getMainThreadExecutor()));
+
+        requestResourceFuture.whenComplete(
+                (ignore, t) -> {
+                    if (t instanceof CancellationException) {
+                        requestResourceFutures.remove(taskManagerPod.getName());
+                        if (createPodFuture.isDone()) {
+                            log.info("pod {} is cancelled before scheduled, stop it.", podName);
+                            stopPod(taskManagerPod.getName());
+                        }
+                    }
+                });
 
         return requestResourceFuture;
     }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/KubernetesResourceManagerDriverTest.java
@@ -61,6 +61,60 @@ class KubernetesResourceManagerDriverTest
                     new KubernetesResourceManagerDriverConfiguration(CLUSTER_ID, "localhost:9000");
 
     @Test
+    void testCancelRequestedResource() throws Exception {
+        new Context() {
+            {
+                final CompletableFuture<KubernetesPod> createPodFuture = new CompletableFuture<>();
+                final CompletableFuture<Void> createTaskManagerPodFuture =
+                        new CompletableFuture<>();
+                final CompletableFuture<String> stopPodFuture = new CompletableFuture<>();
+
+                flinkKubeClientBuilder
+                        .setCreateTaskManagerPodFunction(
+                                (pod) -> {
+                                    createPodFuture.complete(pod);
+                                    return createTaskManagerPodFuture;
+                                })
+                        .setStopPodFunction(
+                                (podName) -> {
+                                    stopPodFuture.complete(podName);
+                                    return FutureUtils.completedVoidFuture();
+                                });
+
+                runTest(
+                        () -> {
+                            // request new pod and then cancel it.
+                            runInMainThread(
+                                    () -> {
+                                        CompletableFuture<KubernetesWorkerNode> requestFuture =
+                                                getDriver()
+                                                        .requestResource(
+                                                                TASK_EXECUTOR_PROCESS_SPEC);
+                                        requestFuture.cancel(true);
+                                    });
+
+                            final KubernetesPod pod =
+                                    new TestingKubernetesPod(
+                                            createPodFuture
+                                                    .get(TIMEOUT_SEC, TimeUnit.SECONDS)
+                                                    .getName(),
+                                            false,
+                                            true);
+
+                            assertThat(stopPodFuture.isDone()).isFalse();
+                            runInMainThread(() -> createTaskManagerPodFuture.complete(null));
+                            // pod should be stopped when create pod rpc finished.
+                            final CompletableFuture<Void> validationFuture =
+                                    stopPodFuture.thenAccept(
+                                            (podName) ->
+                                                    assertThat(podName).isEqualTo(pod.getName()));
+                            validationFuture.get(TIMEOUT_SEC, TimeUnit.SECONDS);
+                        });
+            }
+        };
+    }
+
+    @Test
     void testOnPodAdded() throws Exception {
         new Context() {
             {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/active/ResourceManagerDriver.java
@@ -75,6 +75,10 @@ public interface ResourceManagerDriver<WorkerType extends ResourceIDRetrievable>
      * taskExecutorProcessSpec. The returned future will be completed with a worker node in the
      * deployment specific type, or exceptionally if the allocation has failed.
      *
+     * <p>Note: The returned future could be cancelled by ResourceManager. This means
+     * ResourceManager don't need this resource anymore, Driver should try to cancel this request
+     * from the external resource manager.
+     *
      * <p>Note: Completion of the returned future does not necessarily mean the success of resource
      * allocation and task manager launching. Allocation and launching failures can still happen
      * after the future completion. In such cases, {@link ResourceEventHandler#onWorkerTerminated}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -303,6 +303,9 @@ public class FineGrainedSlotManager implements SlotManager {
         if (resourceRequirements.getResourceRequirements().isEmpty()) {
             LOG.info("Clearing resource requirements of job {}", resourceRequirements.getJobId());
             jobMasterTargetAddresses.remove(resourceRequirements.getJobId());
+            if (resourceAllocator.isSupported()) {
+                taskManagerTracker.clearPendingAllocationsOfJob(resourceRequirements.getJobId());
+            }
         } else {
             LOG.info(
                     "Received resource requirements from job {}: {}",

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManager.java
@@ -666,7 +666,9 @@ public class FineGrainedSlotManager implements SlotManager {
             }
         }
 
-        declareNeededResourcesWithDelay();
+        if (resourceAllocator.isSupported()) {
+            declareNeededResourcesWithDelay();
+        }
     }
 
     private void allocateSlotsAccordingTo(Map<JobID, Map<InstanceID, ResourceCounter>> result) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/DeclarativeSlotManagerTest.java
@@ -1092,16 +1092,13 @@ class DeclarativeSlotManagerTest {
             // the first 2 requirements should be fulfillable with the pending slots of the first
             // allocation (2 slots per worker)
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 1));
-            assertThat(resourceRequestNumber.size()).isEqualTo(1);
-            assertThat(resourceRequestNumber.get(0)).isEqualTo(1);
+            assertThat(resourceRequestNumber.get(resourceRequestNumber.size() - 1)).isEqualTo(1);
 
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 2));
-            assertThat(resourceRequestNumber.size()).isEqualTo(1);
-            assertThat(resourceRequestNumber.get(0)).isEqualTo(1);
+            assertThat(resourceRequestNumber.get(resourceRequestNumber.size() - 1)).isEqualTo(1);
 
             slotManager.processResourceRequirements(createResourceRequirements(jobId, 3));
-            assertThat(resourceRequestNumber.size()).isEqualTo(2);
-            assertThat(resourceRequestNumber.get(1)).isEqualTo(2);
+            assertThat(resourceRequestNumber.get(resourceRequestNumber.size() - 1)).isEqualTo(2);
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTest.java
@@ -379,6 +379,9 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
         allocateResourceFutures.add(new CompletableFuture<>());
         new Context() {
             {
+                PendingTaskManager pendingTaskManager =
+                        new PendingTaskManager(
+                                DEFAULT_TOTAL_RESOURCE_PROFILE, DEFAULT_NUM_SLOTS_PER_WORKER);
                 resourceAllocatorBuilder.setDeclareResourceNeededConsumer(
                         (resourceDeclarations) -> {
                             assertThat(requestCount.get()).isLessThan(2);
@@ -391,10 +394,11 @@ class FineGrainedSlotManagerTest extends FineGrainedSlotManagerTestBase {
                 resourceAllocationStrategyBuilder.setTryFulfillRequirementsFunction(
                         ((jobIDCollectionMap, taskManagerResourceInfoProvider) ->
                                 ResourceAllocationResult.builder()
-                                        .addPendingTaskManagerAllocate(
-                                                new PendingTaskManager(
-                                                        DEFAULT_TOTAL_RESOURCE_PROFILE,
-                                                        DEFAULT_NUM_SLOTS_PER_WORKER))
+                                        .addPendingTaskManagerAllocate(pendingTaskManager)
+                                        .addAllocationOnPendingResource(
+                                                jobId,
+                                                pendingTaskManager.getPendingTaskManagerId(),
+                                                DEFAULT_SLOT_RESOURCE_PROFILE)
                                         .build()));
                 runTest(
                         () -> {


### PR DESCRIPTION

## What is the purpose of the change

Currently, if Kubernetes/Yarn does not have enough resources to fulfill Flink's resource requirement, there will be pending pod/container requests on Kubernetes/Yarn. These pending resource requirements are never cleared until either fulfilled or the Flink cluster is shutdown.
However, sometimes Flink no longer needs the pending resources. E.g., the slot request is then fulfilled by another slots that become available, or the job failed due to slot request timeout (in a session cluster). In such cases, Flink does not remove the resource request until the resource is allocated, then it discovers that it no longer needs the allocated resource and release them. This would affect the underlying Kubernetes/Yarn cluster, especially when the cluster is under heavy workload.
It would be good for Flink to cancel pod/container requests as earlier as possible if it can discover that some of the pending workers are no longer needed.

## Brief change log
  - *SlotManager will remove unused PendingTaskManagerSlot/PendingTaskManager and then declare the resources needed to ResourceAllocator*
  - *ActiveResourceManager will cancel pending workers by complete requestWorkerFuture by RequestCancelledException*
  - *(YARN/Kubernetes)ResourceManagerDriver will stop/release the pending workers when get the RequestCancelledException*


## Verifying this change
This change added tests and can be verified as follows:

*(example:)*
  - *Added unit test for (YARN/Kubernetes)ResourceManagerDriver releasing pending worker*
  - *Added unit test for ActiveResouceManager dealing with declareResourceNeeded*
  - *Manually verified the change by running 2 registered TaskManagers, 3 pending TaskManagers, a streaming program with set slot.request.timeout to 10000, and the job will failed after slot request timeout, and the pending TaskManagers will be cancelled. Verified both in YARN/Kubernetes.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: SlotManager,Kubernetes/Yarn
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? 
    - https://docs.google.com/document/d/1lcmf3MKmcmf9tsPc1whaZHMYKurGoGtqOXEep9ngP2k/edit
