### PR TITLE
[bp-1.16][FLINK-27691][table-planner] Remove unnecessary state ttl to avoid unstable results of RankHarnessTest

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/harness/RankHarnessTest.scala
@@ -230,7 +230,6 @@ class RankHarnessTest(mode: StateBackendMode) extends HarnessTestBase(mode) {
     val data = new mutable.MutableList[(String, Int, Int)]
     val t = env.fromCollection(data).toTable(tEnv, 'word, 'cnt, 'type)
     tEnv.createTemporaryView("T", t)
-    tEnv.getConfig.setIdleStateRetention(Duration.ofSeconds(1))
 
     val sql =
       """


### PR DESCRIPTION
this is a back port pr to 1.16 branch for fixing FLINK-27691