### PR TITLE
[FLINK-30525][web] Do not show environment info in web ui.

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/components/configuration-cards/configuration-cards.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/components/configuration-cards/configuration-cards.component.html
@@ -23,13 +23,6 @@
   ></flink-table-display>
 </nz-card>
 
-<nz-card nzType="inner" nzTitle="Environment" [nzLoading]="loading">
-  <flink-table-display
-    *ngIf="environmentInfo && environmentInfo.environment.length; else noDataTemplate"
-    [listOfData]="environmentInfo.environment"
-  ></flink-table-display>
-</nz-card>
-
 <nz-card nzType="inner" nzTitle="JVM" [nzLoading]="loading">
   <flink-table-display
     *ngIf="environmentInfo; else noDataTemplate"

--- a/flink-runtime-web/web-dashboard/src/app/interfaces/configuration.ts
+++ b/flink-runtime-web/web-dashboard/src/app/interfaces/configuration.ts
@@ -23,7 +23,6 @@ export interface JvmInfo {
 }
 
 export interface EnvironmentInfo {
-  environment: Array<{ key: string; value: string }>;
   jvm: JvmInfo;
   classpath: string[];
 }


### PR DESCRIPTION
## What is the purpose of the change
fix that ui of jobmanager.configuration could not open.


## Brief change log
  - *delete environment related logic*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
