### PR TITLE
[FLINK-30536][runtime] Remove CountingOutput from per-record code path for most operators

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CountingOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/CountingOutput.java
@@ -19,20 +19,23 @@
 package org.apache.flink.streaming.api.operators;
 
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.WatermarkGaugeExposingOutput;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.OutputTag;
 
 /** Wrapping {@link Output} that updates metrics on the number of emitted elements. */
-public class CountingOutput<OUT> implements Output<StreamRecord<OUT>> {
-    private final Output<StreamRecord<OUT>> output;
+public class CountingOutput<OUT> implements WatermarkGaugeExposingOutput<StreamRecord<OUT>> {
+    private final WatermarkGaugeExposingOutput<StreamRecord<OUT>> output;
     private final Counter numRecordsOut;
 
-    public CountingOutput(Output<StreamRecord<OUT>> output, Counter counter) {
+    public CountingOutput(
+            WatermarkGaugeExposingOutput<StreamRecord<OUT>> output, Counter numRecordsOut) {
         this.output = output;
-        this.numRecordsOut = counter;
+        this.numRecordsOut = numRecordsOut;
     }
 
     @Override
@@ -65,5 +68,10 @@ public class CountingOutput<OUT> implements Output<StreamRecord<OUT>> {
     @Override
     public void close() {
         output.close();
+    }
+
+    @Override
+    public Gauge<Long> getWatermarkGauge() {
+        return output.getWatermarkGauge();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/operators/sink/SinkWriterOperator.java
@@ -30,7 +30,6 @@ import org.apache.flink.api.connector.sink2.StatefulSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink;
 import org.apache.flink.api.connector.sink2.TwoPhaseCommittingSink.PrecommittingSinkWriter;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
-import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
 import org.apache.flink.runtime.state.StateInitializationContext;
@@ -42,7 +41,6 @@ import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
 import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
-import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.StreamingRuntimeContext;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -216,22 +214,6 @@ class SinkWriterOperator<InputT, CommT> extends AbstractStreamOperator<Committab
     @Override
     public void close() throws Exception {
         closeAll(sinkWriter, super::close);
-    }
-
-    /**
-     * Skip registering numRecordsOut counter on output.
-     *
-     * <p>Metric "numRecordsOut" is defined as the total number of records written to the external
-     * system in FLIP-33, but this metric is occupied in AbstractStreamOperator as the number of
-     * records sent to downstream operators, which is number of Committable batches sent to
-     * SinkCommitter. So we skip registering this metric on output and leave this metric to sink
-     * writer implementations to report.
-     */
-    @Override
-    protected Output<StreamRecord<CommittableMessage<CommT>>> registerCounterOnOutput(
-            Output<StreamRecord<CommittableMessage<CommT>>> output,
-            OperatorMetricGroup operatorMetricGroup) {
-        return output;
     }
 
     private void emit(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CopyingChainingOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/CopyingChainingOutput.java
@@ -18,9 +18,9 @@
 package org.apache.flink.streaming.runtime.tasks;
 
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.streaming.api.operators.Input;
-import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.OutputTag;
 
@@ -31,19 +31,12 @@ final class CopyingChainingOutput<T> extends ChainingOutput<T> {
     private final TypeSerializer<T> serializer;
 
     public CopyingChainingOutput(
-            OneInputStreamOperator<T, ?> operator,
-            TypeSerializer<T> serializer,
-            @Nullable OutputTag<T> outputTag) {
-        super(operator, outputTag);
-        this.serializer = serializer;
-    }
-
-    public CopyingChainingOutput(
             Input<T> input,
             TypeSerializer<T> serializer,
-            OperatorMetricGroup operatorMetricGroup,
+            @Nullable Counter prevRecordsOutCounter,
+            OperatorMetricGroup curOperatorMetricGroup,
             @Nullable OutputTag<T> outputTag) {
-        super(input, operatorMetricGroup, outputTag);
+        super(input, prevRecordsOutCounter, curOperatorMetricGroup, outputTag);
         this.serializer = serializer;
     }
 
@@ -76,6 +69,7 @@ final class CopyingChainingOutput<T> extends ChainingOutput<T> {
             @SuppressWarnings("unchecked")
             StreamRecord<T> castRecord = (StreamRecord<T>) record;
 
+            numRecordsOut.inc();
             numRecordsIn.inc();
             StreamRecord<T> copy = castRecord.copy(serializer.copy(castRecord.getValue()));
             input.setKeyContextElement(copy);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OperatorChain.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.CheckpointException;
 import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
@@ -36,6 +37,7 @@ import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.InternalOperatorMetricGroup;
 import org.apache.flink.runtime.operators.coordination.AcknowledgeCheckpointEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.operators.coordination.OperatorEventDispatcher;
@@ -46,6 +48,7 @@ import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.operators.BoundedMultiInput;
+import org.apache.flink.streaming.api.operators.CountingOutput;
 import org.apache.flink.streaming.api.operators.Input;
 import org.apache.flink.streaming.api.operators.MultipleInputStreamOperator;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
@@ -58,6 +61,7 @@ import org.apache.flink.streaming.api.operators.StreamOperatorFactoryUtil;
 import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
 import org.apache.flink.streaming.runtime.io.RecordWriterOutput;
 import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
+import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorFactory;
 import org.apache.flink.util.FlinkException;
@@ -199,7 +203,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                             userCodeClassloader,
                             recordWriterOutputs,
                             allOpWrappers,
-                            containingTask.getMailboxExecutorFactory());
+                            containingTask.getMailboxExecutorFactory(),
+                            operatorFactory != null);
 
             if (operatorFactory != null) {
                 Tuple2<OP, Optional<ProcessingTimeService>> mainOperatorAndTimeService =
@@ -622,6 +627,44 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
         return chainedSourceInputs;
     }
 
+    /**
+     * Get the numRecordsOut counter for the operator represented by the given config. And re-use
+     * the operator-level counter for the task-level numRecordsOut counter if this operator is at
+     * the end of the operator chain.
+     *
+     * <p>Return null if we should not use the numRecordsOut counter to track the records emitted by
+     * this operator.
+     */
+    @Nullable
+    private Counter getOperatorRecordsOutCounter(
+            StreamTask<?, ?> containingTask, StreamConfig operatorConfig) {
+        ClassLoader userCodeClassloader = containingTask.getUserCodeClassLoader();
+        StreamOperatorFactory<?> operatorFactory =
+                operatorConfig.getStreamOperatorFactory(userCodeClassloader);
+        // Do not use the numRecordsOut counter on output if this operator is SinkWriterOperator.
+        //
+        // Metric "numRecordsOut" is defined as the total number of records written to the
+        // external system in FLIP-33, but this metric is occupied in AbstractStreamOperator as the
+        // number of records sent to downstream operators, which is number of Committable batches
+        // sent to SinkCommitter. So we skip registering this metric on output and leave this metric
+        // to sink writer implementations to report.
+        if (operatorFactory instanceof SinkWriterOperatorFactory) {
+            return null;
+        }
+
+        InternalOperatorMetricGroup operatorMetricGroup =
+                containingTask
+                        .getEnvironment()
+                        .getMetricGroup()
+                        .getOrAddOperator(
+                                operatorConfig.getOperatorID(), operatorConfig.getOperatorName());
+        if (operatorConfig.isChainEnd()) {
+            operatorMetricGroup.getIOMetricGroup().reuseOutputMetricsForTask();
+        }
+
+        return operatorMetricGroup.getIOMetricGroup().getNumRecordsOutCounter();
+    }
+
     @SuppressWarnings({"rawtypes", "unchecked"})
     private WatermarkGaugeExposingOutput<StreamRecord> createChainedSourceOutput(
             StreamTask<?, OP> containingTask,
@@ -631,14 +674,18 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             OperatorMetricGroup metricGroup,
             OutputTag outputTag) {
 
+        Counter recordsOutCounter = getOperatorRecordsOutCounter(containingTask, sourceInputConfig);
+
         WatermarkGaugeExposingOutput<StreamRecord> chainedSourceOutput;
         if (containingTask.getExecutionConfig().isObjectReuseEnabled()) {
-            chainedSourceOutput = new ChainingOutput(input, metricGroup, outputTag);
+            chainedSourceOutput =
+                    new ChainingOutput(input, recordsOutCounter, metricGroup, outputTag);
         } else {
             TypeSerializer<?> inSerializer =
                     sourceInputConfig.getTypeSerializerOut(userCodeClassloader);
             chainedSourceOutput =
-                    new CopyingChainingOutput(input, inSerializer, metricGroup, outputTag);
+                    new CopyingChainingOutput(
+                            input, inSerializer, recordsOutCounter, metricGroup, outputTag);
         }
         /**
          * Chained sources are closed when {@link
@@ -654,7 +701,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             ClassLoader userCodeClassloader,
             Map<IntermediateDataSetID, RecordWriterOutput<?>> recordWriterOutputs,
             List<StreamOperatorWrapper<?, ?>> allOperatorWrappers,
-            MailboxExecutorFactory mailboxExecutorFactory) {
+            MailboxExecutorFactory mailboxExecutorFactory,
+            boolean shouldAddMetric) {
         List<WatermarkGaugeExposingOutput<StreamRecord<T>>> allOutputs = new ArrayList<>(4);
 
         // create collectors for the network outputs
@@ -675,18 +723,26 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             WatermarkGaugeExposingOutput<StreamRecord<T>> output =
                     createOperatorChain(
                             containingTask,
+                            operatorConfig,
                             chainedOpConfig,
                             chainedConfigs,
                             userCodeClassloader,
                             recordWriterOutputs,
                             allOperatorWrappers,
                             outputEdge.getOutputTag(),
-                            mailboxExecutorFactory);
+                            mailboxExecutorFactory,
+                            shouldAddMetric);
             allOutputs.add(output);
+            // If the operator has multiple downstream chained operators, only one of them should
+            // increment the recordsOutCounter for this operator. Set shouldAddMetric to false
+            // so that we would skip adding the counter to other downstream operators.
+            shouldAddMetric = false;
         }
 
+        WatermarkGaugeExposingOutput<StreamRecord<T>> result;
+
         if (allOutputs.size() == 1) {
-            return allOutputs.get(0);
+            result = allOutputs.get(0);
         } else {
             // send to N outputs. Note that this includes the special case
             // of sending to zero outputs
@@ -700,11 +756,22 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
             // If the chaining output does not copy we need to copy in the broadcast output,
             // otherwise multi-chaining would not work correctly.
             if (containingTask.getExecutionConfig().isObjectReuseEnabled()) {
-                return closer.register(new CopyingBroadcastingOutputCollector<>(asArray));
+                result = closer.register(new CopyingBroadcastingOutputCollector<>(asArray));
             } else {
-                return closer.register(new BroadcastingOutputCollector<>(asArray));
+                result = closer.register(new BroadcastingOutputCollector<>(asArray));
             }
         }
+
+        if (shouldAddMetric) {
+            // Create a CountingOutput to increment the recordsOutCounter for this operator
+            // if we have not added the counter to any downstream chained operator.
+            Counter recordsOutCounter =
+                    getOperatorRecordsOutCounter(containingTask, operatorConfig);
+            if (recordsOutCounter != null) {
+                result = new CountingOutput<>(result, recordsOutCounter);
+            }
+        }
+        return result;
     }
 
     /**
@@ -713,13 +780,15 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
      */
     private <IN, OUT> WatermarkGaugeExposingOutput<StreamRecord<IN>> createOperatorChain(
             StreamTask<OUT, ?> containingTask,
+            StreamConfig prevOperatorConfig,
             StreamConfig operatorConfig,
             Map<Integer, StreamConfig> chainedConfigs,
             ClassLoader userCodeClassloader,
             Map<IntermediateDataSetID, RecordWriterOutput<?>> recordWriterOutputs,
             List<StreamOperatorWrapper<?, ?>> allOperatorWrappers,
             OutputTag<IN> outputTag,
-            MailboxExecutorFactory mailboxExecutorFactory) {
+            MailboxExecutorFactory mailboxExecutorFactory,
+            boolean shouldAddMetricForPrevOperator) {
         // create the output that the operator writes to first. this may recursively create more
         // operators
         WatermarkGaugeExposingOutput<StreamRecord<OUT>> chainedOperatorOutput =
@@ -730,7 +799,8 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                         userCodeClassloader,
                         recordWriterOutputs,
                         allOperatorWrappers,
-                        mailboxExecutorFactory);
+                        mailboxExecutorFactory,
+                        true);
 
         OneInputStreamOperator<IN, OUT> chainedOperator =
                 createOperator(
@@ -742,7 +812,13 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
                         false);
 
         return wrapOperatorIntoOutput(
-                chainedOperator, containingTask, operatorConfig, userCodeClassloader, outputTag);
+                chainedOperator,
+                containingTask,
+                prevOperatorConfig,
+                operatorConfig,
+                userCodeClassloader,
+                outputTag,
+                shouldAddMetricForPrevOperator);
     }
 
     /**
@@ -786,17 +862,33 @@ public abstract class OperatorChain<OUT, OP extends StreamOperator<OUT>>
     private <IN, OUT> WatermarkGaugeExposingOutput<StreamRecord<IN>> wrapOperatorIntoOutput(
             OneInputStreamOperator<IN, OUT> operator,
             StreamTask<OUT, ?> containingTask,
+            StreamConfig prevOperatorConfig,
             StreamConfig operatorConfig,
             ClassLoader userCodeClassloader,
-            OutputTag<IN> outputTag) {
+            OutputTag<IN> outputTag,
+            boolean shouldAddMetricForPrevOperator) {
+
+        Counter recordsOutCounter = null;
+
+        if (shouldAddMetricForPrevOperator) {
+            recordsOutCounter = getOperatorRecordsOutCounter(containingTask, prevOperatorConfig);
+        }
 
         WatermarkGaugeExposingOutput<StreamRecord<IN>> currentOperatorOutput;
         if (containingTask.getExecutionConfig().isObjectReuseEnabled()) {
-            currentOperatorOutput = new ChainingOutput<>(operator, outputTag);
+            currentOperatorOutput =
+                    new ChainingOutput<>(
+                            operator, recordsOutCounter, operator.getMetricGroup(), outputTag);
         } else {
             TypeSerializer<IN> inSerializer =
                     operatorConfig.getTypeSerializerIn1(userCodeClassloader);
-            currentOperatorOutput = new CopyingChainingOutput<>(operator, inSerializer, outputTag);
+            currentOperatorOutput =
+                    new CopyingChainingOutput<>(
+                            operator,
+                            inSerializer,
+                            recordsOutCounter,
+                            operator.getMetricGroup(),
+                            outputTag);
         }
 
         // wrap watermark gauges since registered metrics must be unique

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OperatorChainTest.java
@@ -98,7 +98,7 @@ public class OperatorChainTest {
                 if (op instanceof SetupableStreamOperator) {
                     ((SetupableStreamOperator) op).setup(containingTask, cfg, lastWriter);
                 }
-                lastWriter = new ChainingOutput<>(op, null);
+                lastWriter = new ChainingOutput<>(op, null, op.getMetricGroup(), null);
 
                 ProcessingTimeService processingTimeService = null;
                 if (op instanceof AbstractStreamOperator) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskTest.java
@@ -67,6 +67,7 @@ import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.jobgraph.tasks.TaskInvokable;
 import org.apache.flink.runtime.metrics.TimerGauge;
 import org.apache.flink.runtime.metrics.groups.TaskIOMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
@@ -1907,6 +1908,8 @@ public class StreamTaskTest extends TestLogger {
                         any(CheckpointOptions.class),
                         any(CheckpointStreamFactory.class)))
                 .thenReturn(operatorSnapshotResult);
+        when(operator.getMetricGroup())
+                .thenReturn(UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup());
 
         return operator;
     }
@@ -1923,6 +1926,8 @@ public class StreamTaskTest extends TestLogger {
                         any(CheckpointOptions.class),
                         any(CheckpointStreamFactory.class)))
                 .thenThrow(exception);
+        when(operator.getMetricGroup())
+                .thenReturn(UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup());
 
         return operator;
     }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/SubtaskCheckpointCoordinatorTest.java
@@ -41,6 +41,7 @@ import org.apache.flink.runtime.io.network.api.writer.RecordOrEventCollectingRes
 import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriter;
 import org.apache.flink.runtime.io.network.buffer.BufferBuilderTestUtils;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.operators.testutils.MockEnvironment;
 import org.apache.flink.runtime.state.CheckpointStorageLocationReference;
@@ -810,7 +811,7 @@ public class SubtaskCheckpointCoordinatorTest {
 
         @Override
         public OperatorMetricGroup getMetricGroup() {
-            return null;
+            return UnregisteredMetricGroups.createUnregisteredOperatorMetricGroup();
         }
 
         @Override


### PR DESCRIPTION
## What is the purpose of the change

This PR reduces the Flink runtime overhead by reducing the call stack depth needed to produce a record. This is achieved by adding a Counter in the ChainingOutput instead of adding a CountingOutput that wraps around ChainingOutput.

## Brief change log

- Updated `AbstractStreamOperator` so that it no longer adds a `CountingOutput` that wraps around the given output.
- Updated `AbstractStreamOperatorV2` so that it no longer adds a `CountingOutput` that wraps around the given output.
- Updated `OperatorChain` and `ChainingOutput` so that ChainingOutput would create a Counter that maintains the number of records emitted from the operator on the operator chain.


## Verifying this change

```
DataStream<Long> stream = env.fromSequence(1, 500000000L);
for (int i = 0; i < 10; i++) {
    stream = stream.map(x -> x);
}
stream.addSink(new DiscardingSink<>());
```

Here are the benchmark results obtained by running the above program with parallelism=1 and object re-use enabled. The results are averaged across 5 runs for each setup.
- Prior to the proposed change, the average execution time is 56.54 sec with std=4.9 sec.
- After the proposed change, the average execution time is 63.43 sec with std=6.3 sec.
- The proposed change increases throughput by 12.2%.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): yes
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable