### PR TITLE
[FLINK-25509][connector-base] Add RecordEvaluator to dynamically stop source based on de-serialized records

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEvaluator.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/RecordEvaluator.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.reader;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+import java.io.Serializable;
+
+/**
+ * An interface that evaluates whether a de-serialized record should trigger certain control-flow
+ * operations (e.g. end of stream).
+ */
+@PublicEvolving
+@FunctionalInterface
+public interface RecordEvaluator<T> extends Serializable {
+    /**
+     * Determines whether a record should trigger the end of stream for its split. The given record
+     * wouldn't be emitted from the source if the returned result is true.
+     *
+     * @param record a de-serialized record from the split.
+     * @return a boolean indicating whether the split has reached end of stream.
+     */
+    boolean isEndOfStream(T record);
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SingleThreadMultiplexSourceReaderBase.java
@@ -27,6 +27,8 @@ import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcher
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 
+import javax.annotation.Nullable;
+
 import java.util.function.Supplier;
 
 /**
@@ -112,5 +114,27 @@ public abstract class SingleThreadMultiplexSourceReaderBase<
             Configuration config,
             SourceReaderContext context) {
         super(elementsQueue, splitFetcherManager, recordEmitter, config, context);
+    }
+
+    /**
+     * This constructor behaves like {@link #SingleThreadMultiplexSourceReaderBase(Supplier,
+     * RecordEmitter, Configuration, SourceReaderContext)}, but accepts a specific {@link
+     * FutureCompletingBlockingQueue}, {@link SingleThreadFetcherManager} and {@link
+     * RecordEvaluator}.
+     */
+    public SingleThreadMultiplexSourceReaderBase(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+            SingleThreadFetcherManager<E, SplitT> splitFetcherManager,
+            RecordEmitter<E, T, SplitStateT> recordEmitter,
+            @Nullable RecordEvaluator<T> eofRecordEvaluator,
+            Configuration config,
+            SourceReaderContext context) {
+        super(
+                elementsQueue,
+                splitFetcherManager,
+                recordEmitter,
+                eofRecordEvaluator,
+                config,
+                context);
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.base.source.reader;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.eventtime.Watermark;
 import org.apache.flink.api.connector.source.ReaderOutput;
 import org.apache.flink.api.connector.source.SourceEvent;
 import org.apache.flink.api.connector.source.SourceOutput;
@@ -40,11 +41,13 @@ import javax.annotation.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 import static org.apache.flink.util.Preconditions.checkState;
 
@@ -102,10 +105,22 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
     /** Indicating whether the SourceReader will be assigned more splits or not. */
     private boolean noMoreSplitsAssignment;
 
+    @Nullable protected final RecordEvaluator<T> eofRecordEvaluator;
+
     public SourceReaderBase(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
             SplitFetcherManager<E, SplitT> splitFetcherManager,
             RecordEmitter<E, T, SplitStateT> recordEmitter,
+            Configuration config,
+            SourceReaderContext context) {
+        this(elementsQueue, splitFetcherManager, recordEmitter, null, config, context);
+    }
+
+    public SourceReaderBase(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
+            SplitFetcherManager<E, SplitT> splitFetcherManager,
+            RecordEmitter<E, T, SplitStateT> recordEmitter,
+            @Nullable RecordEvaluator<T> eofRecordEvaluator,
             Configuration config,
             SourceReaderContext context) {
         this.elementsQueue = elementsQueue;
@@ -116,6 +131,7 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
         this.config = config;
         this.context = context;
         this.noMoreSplitsAssignment = false;
+        this.eofRecordEvaluator = eofRecordEvaluator;
 
         numRecordsInCounter = context.metricGroup().getIOMetricGroup().getNumRecordsInCounter();
     }
@@ -211,7 +227,21 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
 
         currentSplitContext = splitStates.get(nextSplitId);
         checkState(currentSplitContext != null, "Have records for a split that was not registered");
-        currentSplitOutput = currentSplitContext.getOrCreateSplitOutput(output);
+
+        Function<T, Boolean> eofRecordHandler = null;
+        if (eofRecordEvaluator != null) {
+            eofRecordHandler =
+                    record -> {
+                        if (!eofRecordEvaluator.isEndOfStream(record)) {
+                            return false;
+                        }
+                        SplitT split =
+                                toSplitType(currentSplitContext.splitId, currentSplitContext.state);
+                        splitFetcherManager.removeSplits(Collections.singletonList(split));
+                        return true;
+                    };
+        }
+        currentSplitOutput = currentSplitContext.getOrCreateSplitOutput(output, eofRecordHandler);
         LOG.trace("Emitting records from fetch for split {}", nextSplitId);
         return true;
     }
@@ -328,14 +358,76 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
             this.splitId = splitId;
         }
 
-        SourceOutput<T> getOrCreateSplitOutput(ReaderOutput<T> mainOutput) {
+        SourceOutput<T> getOrCreateSplitOutput(
+                ReaderOutput<T> mainOutput, @Nullable Function<T, Boolean> eofRecordHandler) {
             if (sourceOutput == null) {
                 // The split output should have been created when AddSplitsEvent was processed in
                 // SourceOperator. Here we just use this method to get the previously created
                 // output.
                 sourceOutput = mainOutput.createOutputForSplit(splitId);
+                if (eofRecordHandler != null) {
+                    sourceOutput = new SourceOutputWrapper<>(sourceOutput, eofRecordHandler);
+                }
             }
             return sourceOutput;
+        }
+    }
+
+    /** This output will stop sending records after receiving the eof record. */
+    private static final class SourceOutputWrapper<T> implements SourceOutput<T> {
+        final SourceOutput<T> sourceOutput;
+        final Function<T, Boolean> eofRecordHandler;
+
+        private boolean isStreamEnd = false;
+
+        public SourceOutputWrapper(
+                SourceOutput<T> sourceOutput, Function<T, Boolean> eofRecordHandler) {
+            this.sourceOutput = sourceOutput;
+            this.eofRecordHandler = eofRecordHandler;
+        }
+
+        @Override
+        public void emitWatermark(Watermark watermark) {
+            sourceOutput.emitWatermark(watermark);
+        }
+
+        @Override
+        public void markIdle() {
+            sourceOutput.markIdle();
+        }
+
+        @Override
+        public void markActive() {
+            sourceOutput.markActive();
+        }
+
+        @Override
+        public void collect(T record) {
+            if (!isEndOfStreamReached(record)) {
+                sourceOutput.collect(record);
+            }
+        }
+
+        @Override
+        public void collect(T record, long timestamp) {
+            if (!isEndOfStreamReached(record)) {
+                sourceOutput.collect(record, timestamp);
+            }
+        }
+
+        /**
+         * Judge and handle the eof record.
+         *
+         * @return whether the record is the eof record.
+         */
+        private boolean isEndOfStreamReached(T record) {
+            if (isStreamEnd) {
+                return true;
+            }
+            if (eofRecordHandler.apply(record)) {
+                isStreamEnd = true;
+            }
+            return isStreamEnd;
         }
     }
 }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/RemoveSplitsTask.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/RemoveSplitsTask.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.reader.fetcher;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
+import org.apache.flink.connector.base.source.reader.splitreader.SplitsRemoval;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+/** The task to finish reading some splits. */
+@Internal
+public class RemoveSplitsTask<SplitT extends SourceSplit> implements SplitFetcherTask {
+    private static final Logger LOG = LoggerFactory.getLogger(RemoveSplitsTask.class);
+
+    private final SplitReader<?, SplitT> splitReader;
+    private final List<SplitT> removedSplits;
+    private final Map<String, SplitT> assignedSplits;
+    private final Consumer<Collection<String>> splitFinishedCallback;
+
+    RemoveSplitsTask(
+            SplitReader<?, SplitT> splitReader,
+            List<SplitT> removedSplits,
+            Map<String, SplitT> assignedSplits,
+            Consumer<Collection<String>> splitFinishedCallback) {
+        this.splitReader = splitReader;
+        this.removedSplits = removedSplits;
+        this.assignedSplits = assignedSplits;
+        this.splitFinishedCallback = splitFinishedCallback;
+    }
+
+    @Override
+    public boolean run() {
+        for (SplitT s : removedSplits) {
+            assignedSplits.remove(s.splitId());
+        }
+        splitReader.handleSplitsChanges(new SplitsRemoval<>(removedSplits));
+
+        List<String> splitIds =
+                removedSplits.stream().map(SourceSplit::splitId).collect(Collectors.toList());
+        splitFinishedCallback.accept(splitIds);
+        LOG.info("RecordEvaluator triggers splits {} to finish reading.", splitIds);
+        return true;
+    }
+
+    @Override
+    public void wakeUp() {
+        // Do nothing.
+    }
+
+    @Override
+    public String toString() {
+        return String.format("RemoveSplitsTask: [%s]", removedSplits);
+    }
+}

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SingleThreadFetcherManager.java
@@ -113,6 +113,14 @@ public class SingleThreadFetcherManager<E, SplitT extends SourceSplit>
         }
     }
 
+    @Override
+    public void removeSplits(List<SplitT> splitsToRemove) {
+        SplitFetcher<E, SplitT> fetcher = getRunningFetcher();
+        if (fetcher != null) {
+            fetcher.removeSplits(splitsToRemove);
+        }
+    }
+
     protected SplitFetcher<E, SplitT> getRunningFetcher() {
         return fetchers.isEmpty() ? null : fetchers.values().iterator().next();
     }

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcher.java
@@ -80,6 +80,8 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
 
     private final boolean allowUnalignedSourceSplits;
 
+    private final Consumer<Collection<String>> splitFinishedHook;
+
     SplitFetcher(
             int id,
             FutureCompletingBlockingQueue<RecordsWithSplitIds<E>> elementsQueue,
@@ -94,6 +96,7 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
         this.errorHandler = checkNotNull(errorHandler);
         this.shutdownHook = checkNotNull(shutdownHook);
         this.allowUnalignedSourceSplits = allowUnalignedSourceSplits;
+        this.splitFinishedHook = splitFinishedHook;
 
         this.fetchTask =
                 new FetchTask<>(
@@ -233,6 +236,23 @@ public class SplitFetcher<E, SplitT extends SourceSplit> implements Runnable {
         lock.lock();
         try {
             enqueueTaskUnsafe(new AddSplitsTask<>(splitReader, splitsToAdd, assignedSplits));
+            wakeUpUnsafe(true);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * Notice the split fetcher that some splits finished. This operation is asynchronous.
+     *
+     * @param splitsToRemove the splits need to be removed.
+     */
+    public void removeSplits(List<SplitT> splitsToRemove) {
+        lock.lock();
+        try {
+            enqueueTaskUnsafe(
+                    new RemoveSplitsTask<>(
+                            splitReader, splitsToRemove, assignedSplits, splitFinishedHook));
             wakeUpUnsafe(true);
         } finally {
             lock.unlock();

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/fetcher/SplitFetcherManager.java
@@ -153,6 +153,8 @@ public abstract class SplitFetcherManager<E, SplitT extends SourceSplit> {
 
     public abstract void addSplits(List<SplitT> splitsToAdd);
 
+    public abstract void removeSplits(List<SplitT> splitsToRemove);
+
     public void pauseOrResumeSplits(
             Collection<String> splitIdsToPause, Collection<String> splitIdsToResume) {
         for (SplitFetcher<E, SplitT> fetcher : fetchers.values()) {

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -59,6 +59,10 @@ public interface SplitReader<E, SplitT extends SourceSplit> extends AutoCloseabl
      * RecordsWithSplitIds} as finished splits so that SourceReaderBase could be able to clean up
      * resources created for it.
      *
+     * <p>For the consistency of internal state in SourceReaderBase, if a split is removed, it
+     * should be put back into {@link RecordsWithSplitIds} as finished splits so that
+     * SourceReaderBase could be able to clean up resources created for it.
+     *
      * @param splitsChanges the split changes that the SplitReader needs to handle.
      */
     void handleSplitsChanges(SplitsChange<SplitT> splitsChanges);

--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitsRemoval.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitsRemoval.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.base.source.reader.splitreader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
+
+import java.util.List;
+
+/**
+ * A change to remove splits.
+ *
+ * <p>This type of {@link SplitsChange} is only used when the {@link RecordEvaluator} reports the
+ * end of the stream.
+ *
+ * <p>The SplitsRemoval change between the enumerator and the reader may cause a data loss. See more
+ * details at <a href="https://lists.apache.org/thread/7r4h7v5k281w9cnbfw9lb8tp56r30lwt">the
+ * discussion e-mail</a>.
+ *
+ * @param <SplitT> the split type.
+ */
+@Internal
+public class SplitsRemoval<SplitT> extends SplitsChange<SplitT> {
+    public SplitsRemoval(List<SplitT> splits) {
+        super(splits);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("SplitsRemoval:[%s]", splits());
+    }
+}

--- a/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
+++ b/flink-connectors/flink-connector-base/src/test/java/org/apache/flink/connector/base/source/reader/mocks/MockSourceReader.java
@@ -21,6 +21,7 @@ package org.apache.flink.connector.base.source.reader.mocks;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.mocks.MockSourceSplit;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordEvaluator;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SingleThreadMultiplexSourceReaderBase;
 import org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager;
@@ -57,6 +58,21 @@ public class MockSourceReader
                 elementsQueue,
                 splitSplitFetcherManager,
                 new MockRecordEmitter(context.metricGroup()),
+                config,
+                context);
+    }
+
+    public MockSourceReader(
+            FutureCompletingBlockingQueue<RecordsWithSplitIds<int[]>> elementsQueue,
+            SingleThreadFetcherManager<int[], MockSourceSplit> splitSplitFetcherManager,
+            Configuration config,
+            SourceReaderContext context,
+            RecordEvaluator<Integer> recordEvaluator) {
+        super(
+                elementsQueue,
+                splitSplitFetcherManager,
+                new MockRecordEmitter(context.metricGroup()),
+                recordEvaluator,
                 config,
                 context);
     }


### PR DESCRIPTION
## What is the purpose of the change

This pull request add RecordEvaluator to dynamically stop source based on de-serialized records.

## Brief change log

The changes could be found in FLIP-208(https://cwiki.apache.org/confluence/display/FLINK/FLIP-208%3A+Add+RecordEvaluator+to+dynamically+stop+source+based+on+de-serialized+records).

## Verifying this change

This change added unit tests about the new interface.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
