### PR TITLE
[FLINK-30213] Fix logic for determining downstream subtasks for partitioner replacement

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamMockEnvironment.java
@@ -95,7 +95,7 @@ public class StreamMockEnvironment implements Environment {
 
     private final List<IndexedInputGate> inputs;
 
-    private final List<ResultPartitionWriter> outputs;
+    private List<ResultPartitionWriter> outputs;
 
     private final JobID jobID;
 
@@ -234,6 +234,10 @@ public class StreamMockEnvironment implements Environment {
             t.printStackTrace();
             fail(t.getMessage());
         }
+    }
+
+    public void setOutputs(List<ResultPartitionWriter> outputs) {
+        this.outputs = outputs;
     }
 
     public void setExternalExceptionHandler(Consumer<Throwable> externalExceptionHandler) {


### PR DESCRIPTION
## What is the purpose of the change

Fix a bug in the partitioner replacement logic for determining the downstream subtasks. As the streamconfig is fixed at jobgraph creation we must use the env directly.


## Verifying this change

`StreamTaskTest` modified to verify the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
