### PR TITLE
[FLINK-30483] [Formats] [Avro] Add avro format support for TIMESTAMP_LTZ

### DIFF
--- a/docs/content/docs/connectors/table/formats/avro.md
+++ b/docs/content/docs/connectors/table/formats/avro.md
@@ -172,6 +172,11 @@ So the following table lists the type mapping from Flink type to Avro type.
       <td><code>timestamp-millis</code></td>
     </tr>
     <tr>
+      <td><code>TIMESTAMP_LTZ(3)</code></td>
+      <td><code>long</code></td>
+      <td><code>local_timestamp_millis</code></td>
+    </tr>
+    <tr>
       <td><code>ARRAY</code></td>
       <td><code>array</code></td>
       <td></td>

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowSerializationSchema.java
@@ -51,6 +51,8 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -250,7 +252,7 @@ public class AvroRowSerializationSchema implements SerializationSchema<Row> {
                 if (object instanceof Timestamp) {
                     return convertFromTimestamp(schema, (Timestamp) object);
                 } else if (object instanceof LocalDateTime) {
-                    return convertFromTimestamp(schema, Timestamp.valueOf((LocalDateTime) object));
+                    return convertFromLocalDateTime(schema, (LocalDateTime) object);
                 } else if (object instanceof Time) {
                     return convertFromTimeMicros(schema, (Time) object);
                 }
@@ -324,6 +326,17 @@ public class AvroRowSerializationSchema implements SerializationSchema<Row> {
             return micros + offset;
         } else {
             throw new RuntimeException("Unsupported timestamp type.");
+        }
+    }
+
+    private long convertFromLocalDateTime(Schema schema, LocalDateTime localDateTime) {
+        final LogicalType logicalType = schema.getLogicalType();
+        if (logicalType == LogicalTypes.localTimestampMillis()) {
+            ZoneId zoneId = ZoneId.systemDefault();
+            ZonedDateTime zonedDateTime = localDateTime.atZone(zoneId);
+            return zonedDateTime.toInstant().toEpochMilli();
+        } else {
+            throw new RuntimeException("Unsupported localDateTime type.");
         }
     }
 

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatITCase.java
@@ -38,6 +38,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -177,6 +178,7 @@ public class AvroOutputFormatITCase extends JavaProgramTestBase {
             // 20.00
             user.setTypeDecimalFixed(
                     new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"));
             return user;
         }
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroOutputFormatTest.java
@@ -43,6 +43,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -189,6 +190,7 @@ class AvroOutputFormatTest {
             // 20.00
             user.setTypeDecimalFixed(
                     new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"));
 
             outputFormat.writeRecord(user);
         }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRecordInputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRecordInputFormatTest.java
@@ -60,6 +60,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -145,6 +146,7 @@ public class AvroRecordInputFormatTest {
         // 20.00
         user1.setTypeDecimalFixed(
                 new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+        user1.setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"));
 
         // Construct via builder
         User user2 =
@@ -187,6 +189,7 @@ public class AvroRecordInputFormatTest {
                         .setTypeDecimalFixed(
                                 new Fixed2(
                                         BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"))
                         .build();
         DatumWriter<User> userDatumWriter = new SpecificDatumWriter<>(User.class);
         DataFileWriter<User> dataFileWriter = new DataFileWriter<>(userDatumWriter);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroRowDataDeSerializationSchemaTest.java
@@ -43,6 +43,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -181,6 +182,7 @@ class AvroRowDataDeSerializationSchemaTest {
         record.setTypeTimestampMillis(timestamp);
         record.setTypeDate(LocalDate.parse("2014-03-01"));
         record.setTypeTimeMillis(LocalTime.parse("12:12:12"));
+        record.setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"));
         SpecificDatumWriter<LogicalTimeRecord> datumWriter =
                 new SpecificDatumWriter<>(LogicalTimeRecord.class);
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
@@ -193,7 +195,8 @@ class AvroRowDataDeSerializationSchemaTest {
                 ROW(
                                 FIELD("type_timestamp_millis", TIMESTAMP(3).notNull()),
                                 FIELD("type_date", DATE().notNull()),
-                                FIELD("type_time_millis", TIME(3).notNull()))
+                                FIELD("type_time_millis", TIME(3).notNull()),
+                                FIELD("type_local_timestamp_millis", TIMESTAMP(3).notNull()))
                         .notNull();
         AvroRowDataSerializationSchema serializationSchema = createSerializationSchema(dataType);
         AvroRowDataDeserializationSchema deserializationSchema =

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSplittableInputFormatTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/AvroSplittableInputFormatTest.java
@@ -41,6 +41,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -126,6 +127,8 @@ class AvroSplittableInputFormatTest {
         user1.setTypeDecimalFixed(
                 new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
 
+        user1.setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"));
+
         // Construct via builder
         User user2 =
                 User.newBuilder()
@@ -167,6 +170,7 @@ class AvroSplittableInputFormatTest {
                         .setTypeDecimalFixed(
                                 new Fixed2(
                                         BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"))
                         .build();
         DatumWriter<User> userDatumWriter = new SpecificDatumWriter<>(User.class);
         DataFileWriter<User> dataFileWriter = new DataFileWriter<>(userDatumWriter);
@@ -204,6 +208,7 @@ class AvroSplittableInputFormatTest {
             // 20.00
             user.setTypeDecimalFixed(
                     new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+            user.setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"));
 
             dataFileWriter.append(user);
         }
@@ -234,7 +239,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1544, 1158, 1158, 1140);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }
@@ -280,7 +285,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1544, 1158, 1158, 1140);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }
@@ -326,7 +331,7 @@ class AvroSplittableInputFormatTest {
             format.close();
         }
 
-        assertThat(elementsPerSplit).containsExactly(1604, 1203, 1203, 990);
+        assertThat(elementsPerSplit).containsExactly(1544, 1158, 1158, 1140);
         assertThat(elements).isEqualTo(NUM_RECORDS);
         format.close();
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/EncoderDecoderTest.java
@@ -39,6 +39,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -302,9 +303,8 @@ class EncoderDecoderTest {
                         ByteBuffer.wrap(
                                 BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()), // 20.00
                         new Fixed2(
-                                BigDecimal.valueOf(2000, 2)
-                                        .unscaledValue()
-                                        .toByteArray())); // 20.00
+                                BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()), // 20.00
+                        LocalDateTime.parse("2022-12-24T20:40:56.978"));
 
         testObjectSerialization(user);
     }

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSchemaConverterTest.java
@@ -269,7 +269,8 @@ class AvroSchemaConverterTest {
                         DataTypes.FIELD(
                                 "f_map",
                                 DataTypes.MAP(DataTypes.STRING().notNull(), DataTypes.INT())),
-                        DataTypes.FIELD("f_array", DataTypes.ARRAY(DataTypes.INT())));
+                        DataTypes.FIELD("f_array", DataTypes.ARRAY(DataTypes.INT())),
+                        DataTypes.FIELD("f_timestamp_ltz", DataTypes.TIMESTAMP_LTZ(3)));
         Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
         DataType converted = AvroSchemaConverter.convertToDataType(schema.toString());
         assertThat(converted).isEqualTo(dataType);
@@ -313,7 +314,8 @@ class AvroSchemaConverterTest {
                                                 .notNull()),
                                 DataTypes.FIELD(
                                         "f_array",
-                                        DataTypes.ARRAY(DataTypes.INT().notNull()).notNull()))
+                                        DataTypes.ARRAY(DataTypes.INT().notNull()).notNull()),
+                                DataTypes.FIELD("f_timestamp_ltz", DataTypes.TIMESTAMP_LTZ(3)))
                         .notNull();
         Schema schema = AvroSchemaConverter.convertToSchema(dataType.getLogicalType());
         DataType converted = AvroSchemaConverter.convertToDataType(schema.toString());
@@ -423,6 +425,13 @@ class AvroSchemaConverterTest {
                         + "      \"items\" : [ \"null\", \"int\" ]\n"
                         + "    } ],\n"
                         + "    \"default\" : null\n"
+                        + "  }, {\n"
+                        + "    \"name\" : \"f_timestamp_ltz\",\n"
+                        + "    \"type\" : [ \"null\", {\n"
+                        + "      \"type\" : \"long\",\n"
+                        + "      \"logicalType\" : \"local-timestamp-millis\"\n"
+                        + "    } ],\n"
+                        + "    \"default\" : null\n"
                         + "  } ]\n"
                         + "}";
         DataType dataType = AvroSchemaConverter.convertToDataType(schemaStr);
@@ -513,6 +522,13 @@ class AvroSchemaConverterTest {
                         + "      \"type\" : \"array\",\n"
                         + "      \"items\" : \"int\"\n"
                         + "    }\n"
+                        + "  } , {\n"
+                        + "    \"name\" : \"f_timestamp_ltz\",\n"
+                        + "    \"type\" : [ \"null\", {\n"
+                        + "      \"type\" : \"long\",\n"
+                        + "      \"logicalType\" : \"local-timestamp-millis\"\n"
+                        + "    } ],\n"
+                        + "    \"default\" : null\n"
                         + "  } ]\n"
                         + "}";
         DataType dataType = AvroSchemaConverter.convertToDataType(schemaStr);
@@ -555,7 +571,8 @@ class AvroSchemaConverterTest {
                             "type_timestamp_millis",
                             "type_timestamp_micros",
                             "type_decimal_bytes",
-                            "type_decimal_fixed"
+                            "type_decimal_fixed",
+                            "type_local_timestamp_millis",
                         },
                         Types.STRING,
                         Types.INT,
@@ -579,7 +596,8 @@ class AvroSchemaConverterTest {
                         Types.SQL_TIMESTAMP,
                         Types.SQL_TIMESTAMP,
                         Types.BIG_DEC,
-                        Types.BIG_DEC);
+                        Types.BIG_DEC,
+                        Types.LOCAL_DATE_TIME);
 
         assertThat(actual).isEqualTo(user);
 
@@ -640,7 +658,10 @@ class AvroSchemaConverterTest {
                                 DataTypes.FIELD(
                                         "type_decimal_bytes", DataTypes.DECIMAL(4, 2).notNull()),
                                 DataTypes.FIELD(
-                                        "type_decimal_fixed", DataTypes.DECIMAL(4, 2).notNull()))
+                                        "type_decimal_fixed", DataTypes.DECIMAL(4, 2).notNull()),
+                                DataTypes.FIELD(
+                                        "type_local_timestamp_millis",
+                                        DataTypes.TIMESTAMP_LTZ(3).notNull()))
                         .notNull();
 
         assertThat(actual).isEqualTo(user);

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroTypeExtractionTest.java
@@ -112,7 +112,8 @@ class AvroTypeExtractionTest {
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n"
+                        + "\"type_decimal_fixed\": [7, -48], "
+                        + "\"type_local_timestamp_millis\": \"2022-12-24T20:40:56.978\"}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
                         + "\"type_null_test\": null, \"type_bool_test\": false, \"type_array_string\": [], "
@@ -124,7 +125,8 @@ class AvroTypeExtractionTest {
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n";
+                        + "\"type_decimal_fixed\": [7, -48], "
+                        + "\"type_local_timestamp_millis\": \"2022-12-24T20:40:56.978\"}\n";
     }
 
     @ParameterizedTest
@@ -163,7 +165,8 @@ class AvroTypeExtractionTest {
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n"
+                        + "\"type_decimal_fixed\": [7, -48], "
+                        + "\"type_local_timestamp_millis\": \"2022-12-24T20:40:56.978\"}\n"
                         + "{\"name\": \"Charlie\", \"favorite_number\": null, "
                         + "\"favorite_color\": \"blue\", \"type_long_test\": 1337, \"type_double_test\": 1.337, "
                         + "\"type_null_test\": null, \"type_bool_test\": false, \"type_array_string\": [], "
@@ -175,7 +178,8 @@ class AvroTypeExtractionTest {
                         + "\"type_date\": \"2014-03-01\", \"type_time_millis\": \"12:12:12\", \"type_time_micros\": \"00:00:00.123456\", "
                         + "\"type_timestamp_millis\": \"2014-03-01T12:12:12.321Z\", "
                         + "\"type_timestamp_micros\": \"1970-01-01T00:00:00.123456Z\", \"type_decimal_bytes\": \"\\u0007Ð\", "
-                        + "\"type_decimal_fixed\": [7, -48]}\n";
+                        + "\"type_decimal_fixed\": [7, -48], "
+                        + "\"type_local_timestamp_millis\": \"2022-12-24T20:40:56.978\"}\n";
     }
 
     @ParameterizedTest

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/AvroTestUtils.java
@@ -46,6 +46,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -113,9 +114,10 @@ public final class AvroTestUtils {
                         .setTypeDecimalFixed(
                                 new Fixed2(
                                         BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                        .setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"))
                         .build();
 
-        final Row rowUser = new Row(23);
+        final Row rowUser = new Row(24);
         rowUser.setField(0, "Charlie");
         rowUser.setField(1, null);
         rowUser.setField(2, "blue");
@@ -141,6 +143,7 @@ public final class AvroTestUtils {
                 20, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
         rowUser.setField(21, BigDecimal.valueOf(2000, 2));
         rowUser.setField(22, BigDecimal.valueOf(2000, 2));
+        rowUser.setField(23, LocalDateTime.parse("2022-12-24T20:40:56.978"));
 
         final Tuple3<Class<? extends SpecificRecord>, SpecificRecord, Row> t = new Tuple3<>();
         t.f0 = User.class;
@@ -173,7 +176,8 @@ public final class AvroTestUtils {
                         + "\"logicalType\":\"timestamp-millis\"}},{\"name\":\"type_timestamp_micros\",\"type\":{\"type\":\"long\","
                         + "\"logicalType\":\"timestamp-micros\"}},{\"name\":\"type_decimal_bytes\",\"type\":{\"type\":\"bytes\","
                         + "\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}},{\"name\":\"type_decimal_fixed\",\"type\":{\"type\":\"fixed\","
-                        + "\"name\":\"Fixed2\",\"size\":2,\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}}]}";
+                        + "\"name\":\"Fixed2\",\"size\":2,\"logicalType\":\"decimal\",\"precision\":4,\"scale\":2}},{\"name\":\"type_local_timestamp_millis\",\"type\":{\"type\":\"long\","
+                        + "\"logicalType\":\"local-timestamp-millis\"}}]}";
         final Schema schema = new Schema.Parser().parse(schemaString);
         GenericRecord addr =
                 new GenericData.Record(schema.getField("type_nested").schema().getTypes().get(1));
@@ -225,8 +229,9 @@ public final class AvroTestUtils {
                 new GenericData.Fixed(
                         schema.getField("type_decimal_fixed").schema(),
                         BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+        user.put("type_local_timestamp_millis", LocalDateTime.parse("2022-12-24T20:40:56.978"));
 
-        final Row rowUser = new Row(23);
+        final Row rowUser = new Row(24);
         rowUser.setField(0, "Charlie");
         rowUser.setField(1, null);
         rowUser.setField(2, "blue");
@@ -252,6 +257,7 @@ public final class AvroTestUtils {
                 20, Timestamp.from(Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS)));
         rowUser.setField(21, BigDecimal.valueOf(2000, 2));
         rowUser.setField(22, BigDecimal.valueOf(2000, 2));
+        rowUser.setField(23, LocalDateTime.parse("2022-12-24T20:40:56.978"));
 
         final Tuple3<GenericRecord, Row, Schema> t = new Tuple3<>();
         t.f0 = user;

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/utils/TestDataGenerator.java
@@ -29,6 +29,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -63,7 +64,8 @@ public class TestDataGenerator {
                 Instant.parse("2014-03-01T12:12:12.321Z"),
                 Instant.ofEpochSecond(0).plus(123456L, ChronoUnit.MICROS),
                 ByteBuffer.wrap(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()),
-                new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()));
+                new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()),
+                LocalDateTime.parse("2022-12-24T20:40:56.978"));
     }
 
     public static SimpleUser generateRandomSimpleUser(Random rnd) {

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/table/runtime/batch/AvroTypesITCase.java
@@ -43,6 +43,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -94,6 +95,7 @@ public class AvroTypesITCase extends AbstractTestBase {
                                     BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
                     .setTypeDecimalFixed(
                             new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                    .setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"))
                     .build();
 
     private static final User USER_2 =
@@ -124,6 +126,7 @@ public class AvroTypesITCase extends AbstractTestBase {
                                     BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
                     .setTypeDecimalFixed(
                             new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                    .setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"))
                     .build();
 
     private static final User USER_3 =
@@ -154,6 +157,7 @@ public class AvroTypesITCase extends AbstractTestBase {
                                     BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
                     .setTypeDecimalFixed(
                             new Fixed2(BigDecimal.valueOf(2000, 2).unscaledValue().toByteArray()))
+                    .setTypeLocalTimestampMillis(LocalDateTime.parse("2022-12-24T20:40:56.978"))
                     .build();
 
     @Test
@@ -173,16 +177,16 @@ public class AvroTypesITCase extends AbstractTestBase {
         String expected =
                 "+I[black, null, Whatever, [true], [hello], true, java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], "
                         + "2014-03-01, java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48], 0.0, GREEN, "
-                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 42, {}, null, null, null, 00:00:00.123456, "
+                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 2022-12-24T20:40:56.978, 42, {}, null, null, null, 00:00:00.123456, "
                         + "12:12:12, 1970-01-01T00:00:00.123456Z, 2014-03-01T12:12:12.321Z, null]\n"
                         + "+I[blue, null, Charlie, [], [], false, java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], 2014-03-01, "
-                        + "java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48], 1.337, RED, null, 1337, {}, "
+                        + "java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48], 1.337, RED, null, 2022-12-24T20:40:56.978, 1337, {}, "
                         + "+I[Berlin, 42, Berlin, Bakerstreet, 12049], null, null, 00:00:00.123456, 12:12:12, 1970-01-01T00:00:00.123456Z, "
                         + "2014-03-01T12:12:12.321Z, null]\n"
                         + "+I[yellow, null, Terminator, [false], [world], false, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=10 cap=10], 2014-03-01, "
                         + "java.nio.HeapByteBuffer[pos=0 lim=2 cap=2], [7, -48], 0.0, GREEN, "
-                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 1, {}, null, null, null, 00:00:00.123456, "
+                        + "[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 2022-12-24T20:40:56.978, 1, {}, null, null, null, 00:00:00.123456, "
                         + "12:12:12, 1970-01-01T00:00:00.123456Z, 2014-03-01T12:12:12.321Z, null]";
         TestBaseUtils.compareResultAsText(results, expected);
     }

--- a/flink-formats/flink-avro/src/test/resources/avro/user.avsc
+++ b/flink-formats/flink-avro/src/test/resources/avro/user.avsc
@@ -45,7 +45,8 @@
      {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
      {"name": "type_timestamp_micros", "type": {"type": "long", "logicalType": "timestamp-micros"}},
      {"name": "type_decimal_bytes", "type": {"type": "bytes", "logicalType": "decimal", "precision": 4, "scale": 2}},
-     {"name": "type_decimal_fixed", "type": {"name": "Fixed2", "size": 2, "type": "fixed", "logicalType": "decimal", "precision": 4, "scale": 2}}
+     {"name": "type_decimal_fixed", "type": {"name": "Fixed2", "size": 2, "type": "fixed", "logicalType": "decimal", "precision": 4, "scale": 2}},
+     {"name": "type_local_timestamp_millis", "type": {"type": "long", "logicalType": "local-timestamp-millis"}}
  ]
 },
  {"namespace": "org.apache.flink.formats.avro.generated",
@@ -113,6 +114,7 @@
    "fields": [
        {"name": "type_timestamp_millis", "type": {"type": "long", "logicalType": "timestamp-millis"}},
        {"name": "type_date", "type": {"type": "int", "logicalType": "date"}},
-       {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}}
+       {"name": "type_time_millis", "type": {"type": "int", "logicalType": "time-millis"}},
+       {"name": "type_local_timestamp_millis", "type": {"type": "long", "logicalType": "local-timestamp-millis"}}
    ]
  }]


### PR DESCRIPTION

https://issues.apache.org/jira/browse/FLINK-30483

## What is the purpose of the change

This PR adds Avro format support for TIMESTAMP_LTZ milliseconds.


## Brief change log

- Adding Avro format to support TIMESTAMP_LTZ (short for TIMESTAMP_WITH_LOCAL_TIME_ZONE) type for milliseconds in this PR.


## Verifying this change

- Modified existing Avro format test cases to verify this change

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: don't know
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? docs