### PR TITLE
[FLINK-30231][kubernetes] Update to Fabric8 Kubernetes Client to a version that has automatic renewal of service account tokens

### DIFF
--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -17,8 +17,8 @@ under the License.
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.apache.flink</groupId>
@@ -31,7 +31,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<kubernetes.client.version>5.12.3</kubernetes.client.version>
+		<kubernetes.client.version>5.12.4</kubernetes.client.version>
 	</properties>
 
 	<dependencies>
@@ -110,10 +110,15 @@ under the License.
 
 									<!-- Shade all the dependencies of kubernetes client  -->
 									<include>com.fasterxml.jackson.core:jackson-core</include>
-									<include>com.fasterxml.jackson.core:jackson-annotations</include>
+									<include>com.fasterxml.jackson.core:jackson-annotations
+									</include>
 									<include>com.fasterxml.jackson.core:jackson-databind</include>
-									<include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
-									<include>com.fasterxml.jackson.datatype:jackson-datatype-jsr310</include>
+									<include>
+										com.fasterxml.jackson.dataformat:jackson-dataformat-yaml
+									</include>
+									<include>
+										com.fasterxml.jackson.datatype:jackson-datatype-jsr310
+									</include>
 									<include>com.squareup.okhttp3:*</include>
 									<include>com.squareup.okio:okio</include>
 									<include>org.yaml:*</include>
@@ -142,7 +147,9 @@ under the License.
 							<relocations>
 								<relocation>
 									<pattern>com.fasterxml.jackson</pattern>
-									<shadedPattern>org.apache.flink.kubernetes.shaded.com.fasterxml.jackson</shadedPattern>
+									<shadedPattern>
+										org.apache.flink.kubernetes.shaded.com.fasterxml.jackson
+									</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>okhttp3/internal/publicsuffix</pattern>
@@ -153,23 +160,29 @@ under the License.
 								</relocation>
 								<relocation>
 									<pattern>okhttp3</pattern>
-									<shadedPattern>org.apache.flink.kubernetes.shaded.okhttp3</shadedPattern>
+									<shadedPattern>org.apache.flink.kubernetes.shaded.okhttp3
+									</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>okio</pattern>
-									<shadedPattern>org.apache.flink.kubernetes.shaded.okio</shadedPattern>
+									<shadedPattern>org.apache.flink.kubernetes.shaded.okio
+									</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>org.yaml</pattern>
-									<shadedPattern>org.apache.flink.kubernetes.shaded.org.yaml</shadedPattern>
+									<shadedPattern>org.apache.flink.kubernetes.shaded.org.yaml
+									</shadedPattern>
 								</relocation>
 								<relocation>
 									<pattern>dk.brics.automaton</pattern>
-									<shadedPattern>org.apache.flink.kubernetes.shaded.dk.brics.automaton</shadedPattern>
+									<shadedPattern>
+										org.apache.flink.kubernetes.shaded.dk.brics.automaton
+									</shadedPattern>
 								</relocation>
 								<relocation>
-								    <pattern>io.fabric8</pattern>
-								    <shadedPattern>org.apache.flink.kubernetes.shaded.io.fabric8</shadedPattern>
+									<pattern>io.fabric8</pattern>
+									<shadedPattern>org.apache.flink.kubernetes.shaded.io.fabric8
+									</shadedPattern>
 								</relocation>
 							</relocations>
 						</configuration>


### PR DESCRIPTION
## Contribution Checklist

## What is the purpose of the change

Update to Fabric8 Kubernetes Client to a version that has automatic renewal of service account tokens

## Brief change log
Update to Fabric8 Kubernetes Client to a version that has automatic renewal of service account tokens
Fabric version upgrade version 5.12.3->5.12.3


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
