### PR TITLE
[FLINK-29720][hive] Supports native avg function for hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveAverageAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveAverageAggFunction.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+
+import java.math.BigDecimal;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.cast;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.div;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.equalTo;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.hiveAggDecimalPlus;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.literal;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullOf;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.tryCast;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.typeLiteral;
+import static org.apache.flink.table.types.logical.DecimalType.MAX_PRECISION;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
+
+/** built-in hive average aggregate function. */
+public class HiveAverageAggFunction extends HiveDeclarativeAggregateFunction {
+
+    private final UnresolvedReferenceExpression sum = unresolvedRef("sum");
+    private final UnresolvedReferenceExpression count = unresolvedRef("count");
+    private DataType resultType;
+    private DataType sumResultType;
+
+    @Override
+    public int operandCount() {
+        return 1;
+    }
+
+    @Override
+    public UnresolvedReferenceExpression[] aggBufferAttributes() {
+        return new UnresolvedReferenceExpression[] {sum, count};
+    }
+
+    @Override
+    public DataType[] getAggBufferTypes() {
+        return new DataType[] {getSumResultType(), DataTypes.BIGINT()};
+    }
+
+    @Override
+    public DataType getResultType() {
+        return resultType;
+    }
+
+    @Override
+    public Expression[] initialValuesExpressions() {
+        return new Expression[] {/* sum = */ sumInitialValue(), /* count = */ literal(0L)};
+    }
+
+    @Override
+    public Expression[] accumulateExpressions() {
+        // cast the operand to sum needed type
+        Expression tryCastOperand = tryCast(operand(0), typeLiteral(getSumResultType()));
+        return new Expression[] {
+            /* sum = */ ifThenElse(isNull(tryCastOperand), sum, adjustedPlus(sum, tryCastOperand)),
+            /* count = */ ifThenElse(isNull(tryCastOperand), count, plus(count, literal(1L))),
+        };
+    }
+
+    @Override
+    public Expression[] retractExpressions() {
+        throw new TableException("Avg aggregate function does not support retraction.");
+    }
+
+    @Override
+    public Expression[] mergeExpressions() {
+        return new Expression[] {
+            /* sum = */ adjustedPlus(sum, mergeOperand(sum)),
+            /* count = */ plus(count, mergeOperand(count))
+        };
+    }
+
+    @Override
+    public Expression getValueExpression() {
+        // If all input are nulls, count will be 0 and we will get null after the division.
+        Expression ifTrue = nullOf(getResultType());
+        Expression ifFalse = cast(div(sum, count), typeLiteral(getResultType()));
+        return ifThenElse(equalTo(count, literal(0L)), ifTrue, ifFalse);
+    }
+
+    @Override
+    public void setArguments(CallContext callContext) {
+        if (resultType == null) {
+            DataType argsType = callContext.getArgumentDataTypes().get(0);
+            resultType = initResultType(argsType);
+            sumResultType = initSumResultType(argsType);
+        }
+    }
+
+    private DataType initResultType(DataType argsType) {
+        switch (argsType.getLogicalType().getTypeRoot()) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case CHAR:
+            case VARCHAR:
+                return DataTypes.DOUBLE();
+            case DECIMAL:
+                // The avg result type has 4 more integer digits and 4 more decimal digits,
+                // following spark and hive
+                int precision =
+                        Math.min(MAX_PRECISION, getPrecision(argsType.getLogicalType()) + 4);
+                int scale = Math.min(38, getScale(argsType.getLogicalType()) + 4);
+                return DataTypes.DECIMAL(precision, scale);
+            default:
+                throw new TableException(
+                        String.format(
+                                "Avg aggregate function does not support type: '%s'. Please re-check the data type.",
+                                argsType.getLogicalType().getTypeRoot()));
+        }
+    }
+
+    private DataType initSumResultType(DataType argsType) {
+        switch (argsType.getLogicalType().getTypeRoot()) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case CHAR:
+            case VARCHAR:
+                return DataTypes.DOUBLE();
+            case DECIMAL:
+                // The intermediate sum field has 10 more integer digits with the same scale.
+                int precision =
+                        Math.min(MAX_PRECISION, getPrecision(argsType.getLogicalType()) + 10);
+                return DataTypes.DECIMAL(precision, getScale(argsType.getLogicalType()));
+            default:
+                throw new TableException(
+                        String.format(
+                                "Avg aggregate function does not support type: '%s'. Please re-check the data type.",
+                                argsType.getLogicalType().getTypeRoot()));
+        }
+    }
+
+    private DataType getSumResultType() {
+        return sumResultType;
+    }
+
+    private UnresolvedCallExpression adjustedPlus(Expression arg1, Expression arg2) {
+        if (getSumResultType().getLogicalType().is(DECIMAL)) {
+            return hiveAggDecimalPlus(arg1, arg2);
+        } else {
+            return plus(arg1, arg2);
+        }
+    }
+
+    private ValueLiteralExpression sumInitialValue() {
+        if (getSumResultType().getLogicalType().is(DECIMAL)) {
+            return literal(BigDecimal.ZERO, getSumResultType().notNull());
+        } else {
+            return literal(0D, getSumResultType().notNull());
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveDeclarativeAggregateFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveDeclarativeAggregateFunction.java
@@ -50,6 +50,8 @@ import static org.apache.flink.connectors.hive.HiveOptions.TABLE_EXEC_HIVE_NATIV
 @Internal
 public abstract class HiveDeclarativeAggregateFunction extends DeclarativeAggregateFunction {
 
+    protected static final int MAX_SCALE = 38;
+
     /**
      * Set input arguments for the function if need some inputs to infer the aggBuffer type and
      * result type. Otherwise, just implements it do nothing.

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveDeclarativeAggregateFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveDeclarativeAggregateFunction.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.functions.hive;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.DataTypeFactory;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
 import org.apache.flink.table.functions.DeclarativeAggregateFunction;
 import org.apache.flink.table.functions.FunctionKind;
 import org.apache.flink.table.types.DataType;
@@ -34,6 +36,10 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.connectors.hive.HiveOptions.TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED;
+
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.hiveAggDecimalPlus;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
 
 /**
  * API for hive aggregation functions that are expressed in terms of expressions.
@@ -85,6 +91,15 @@ public abstract class HiveDeclarativeAggregateFunction extends DeclarativeAggreg
                             logicalType.getTypeRoot(),
                             TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED.key(),
                             functionName));
+        }
+    }
+
+    protected UnresolvedCallExpression adjustedPlus(
+            DataType dataType, Expression arg1, Expression arg2) {
+        if (dataType.getLogicalType().is(DECIMAL)) {
+            return hiveAggDecimalPlus(arg1, arg2);
+        } else {
+            return plus(arg1, arg2);
         }
     }
 

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveDeclarativeAggregateFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveDeclarativeAggregateFunction.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.apache.flink.connectors.hive.HiveOptions.TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED;
-
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.hiveAggDecimalPlus;
 import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
 import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -89,7 +89,8 @@ public class HiveModule implements Module {
                                     "tumble_start")));
 
     static final Set<String> BUILTIN_NATIVE_AGG_FUNC =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("sum", "count", "avg", "min", "max")));
+            Collections.unmodifiableSet(
+                    new HashSet<>(Arrays.asList("sum", "count", "avg", "min", "max")));
 
     private final HiveFunctionDefinitionFactory factory;
     private final String hiveVersion;
@@ -207,19 +208,19 @@ public class HiveModule implements Module {
     private Optional<FunctionDefinition> getBuiltInNativeAggFunction(String name) {
         switch (name) {
             case "sum":
-                // We override Hive's sum function by native implementation to supports hash-agg
+                // We override Hive's sum function by native implementation to support hash-agg
                 return Optional.of(new HiveSumAggFunction());
             case "count":
-                // We override Hive's sum function by native implementation to supports hash-agg
+                // We override Hive's sum function by native implementation to support hash-agg
                 return Optional.of(new HiveCountAggFunction());
             case "avg":
-                // We override Hive's avg function by native implementation to supports hash-agg
+                // We override Hive's avg function by native implementation to support hash-agg
                 return Optional.of(new HiveAverageAggFunction());
             case "min":
-                // We override Hive's min function by native implementation to supports hash-agg
+                // We override Hive's min function by native implementation to support hash-agg
                 return Optional.of(new HiveMinAggFunction());
             case "max":
-                // We override Hive's max function by native implementation to supports hash-agg
+                // We override Hive's max function by native implementation to support hash-agg
                 return Optional.of(new HiveMaxAggFunction());
             default:
                 throw new UnsupportedOperationException(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -89,7 +89,7 @@ public class HiveModule implements Module {
                                     "tumble_start")));
 
     static final Set<String> BUILTIN_NATIVE_AGG_FUNC =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("sum", "count", "min", "max")));
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("sum", "count", "avg", "min", "max")));
 
     private final HiveFunctionDefinitionFactory factory;
     private final String hiveVersion;
@@ -153,10 +153,6 @@ public class HiveModule implements Module {
             return getBuiltInNativeAggFunction(name.toLowerCase());
         }
 
-        if (name.equalsIgnoreCase("avg")) {
-            return Optional.of(new HiveAverageAggFunction());
-        }
-
         // We override Hive's grouping function. Refer to the implementation for more details.
         if (name.equalsIgnoreCase("grouping")) {
             return Optional.of(
@@ -216,6 +212,9 @@ public class HiveModule implements Module {
             case "count":
                 // We override Hive's sum function by native implementation to supports hash-agg
                 return Optional.of(new HiveCountAggFunction());
+            case "avg":
+                // We override Hive's avg function by native implementation to supports hash-agg
+                return Optional.of(new HiveAverageAggFunction());
             case "min":
                 // We override Hive's min function by native implementation to supports hash-agg
                 return Optional.of(new HiveMinAggFunction());

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.factories.HiveFunctionDefinitionFactory;
 import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.hive.HiveAverageAggFunction;
 import org.apache.flink.table.functions.hive.HiveCountAggFunction;
 import org.apache.flink.table.functions.hive.HiveMaxAggFunction;
 import org.apache.flink.table.functions.hive.HiveMinAggFunction;
@@ -150,6 +151,10 @@ public class HiveModule implements Module {
         // We override some Hive's function by native implementation to supports hash-agg
         if (isNativeAggFunctionEnabled() && BUILTIN_NATIVE_AGG_FUNC.contains(name.toLowerCase())) {
             return getBuiltInNativeAggFunction(name.toLowerCase());
+        }
+
+        if (name.equalsIgnoreCase("avg")) {
+            return Optional.of(new HiveAverageAggFunction());
         }
 
         // We override Hive's grouping function. Refer to the implementation for more details.

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectAggITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectAggITCase.java
@@ -276,7 +276,7 @@ public class HiveDialectAggITCase {
         // test unsupported type
         String expectedMessage =
                 "Native hive avg aggregate function does not support type: TIMESTAMP(9). "
-                        + "Please set option 'table.exec.hive.native-agg-function.enabled' to false.";
+                        + "Please set option 'table.exec.hive.native-agg-function.enabled' to false to fall back to Hive's own avg function.";
         assertSqlException("select avg(ts)from test_avg", TableException.class, expectedMessage);
 
         tableEnv.executeSql("drop table test_avg");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectAggITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectAggITCase.java
@@ -219,6 +219,70 @@ public class HiveDialectAggITCase {
     }
 
     @Test
+    public void testAvgAggFunction() throws Exception {
+        tableEnv.executeSql(
+                "create table test_avg(a int, x string, y string, z int, f bigint, d decimal(20, 5), d2 decimal(37, 20), e double, ts timestamp)");
+        tableEnv.executeSql(
+                        "insert into test_avg values (1, NULL, '2', 1, 2, 2.22, NULL, 2.3, '2021-08-04 16:26:33.4'), "
+                                + "(1, NULL, 'b', 2, NULL, 3.33, NULL, 3.4, '2021-08-07 16:26:33.4'), "
+                                + "(2, NULL, '4', 1, 2, 4.55, NULL, 4.5, '2021-08-08 16:26:33.4'), "
+                                + "(2, NULL, NULL, 4, 3, 5.66, NULL, 5.2, '2021-08-09 16:26:33.4')")
+                .await();
+
+        // test avg all element is null
+        List<Row> result =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select avg(x) from test_avg").collect());
+        assertThat(result.toString()).isEqualTo("[+I[null]]");
+
+        // test avg that some string elements can't convert to double
+        List<Row> result2 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select avg(y) from test_avg").collect());
+        assertThat(result2.toString()).isEqualTo("[+I[3.0]]");
+
+        // test avg bigint with null element
+        List<Row> result3 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select avg(f) from test_avg").collect());
+        assertThat(result3.toString()).isEqualTo("[+I[2.3333333333333335]]");
+
+        // test avg decimal
+        List<Row> result4 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select avg(d) from test_avg").collect());
+        assertThat(result4.toString()).isEqualTo("[+I[3.940000000]]");
+
+        // test avg decimal with null element
+        List<Row> result5 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select avg(d2) from test_avg").collect());
+        assertThat(result5.toString()).isEqualTo("[+I[null]]");
+
+        // test avg distinct
+        List<Row> result6 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select avg(distinct z) from test_avg").collect());
+        assertThat(result6.toString()).isEqualTo("[+I[2.3333333333333335]]");
+
+        // test avg with group key
+        List<Row> result7 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql(
+                                        "select a, avg(y), avg(z), avg(f) from test_avg group by a")
+                                .collect());
+        assertThat(result7.toString()).isEqualTo("[+I[1, 2.0, 1.5, 2.0], +I[2, 4.0, 2.5, 2.5]]");
+
+        // test unsupported type
+        String expectedMessage =
+                "Native hive avg aggregate function does not support type: TIMESTAMP(9). "
+                        + "Please set option 'table.exec.hive.native-agg-function.enabled' to false.";
+        assertSqlException("select avg(ts)from test_avg", TableException.class, expectedMessage);
+
+        tableEnv.executeSql("drop table test_avg");
+    }
+
+    @Test
     public void testMinAggFunction() throws Exception {
         tableEnv.executeSql(
                 "create table test_min(a int, b boolean, x string, y string, z int, d decimal(10,5), e float, f double, ts timestamp, dt date, bar binary)");

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -68,7 +68,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.apache.flink.table.planner.utils.TableTestUtil.readFromResource;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -985,82 +984,6 @@ public class HiveDialectQueryITCase {
             tableEnv.executeSql("drop table t_bigint");
             tableEnv.executeSql("drop table t_array");
         }
-    }
-
-    @Test
-    public void testAvgAggFunctionPlan() {
-        // test explain
-        String actualPlan = explainSql("select x, avg(y) from foo group by x");
-        assertThat(actualPlan).isEqualTo(readFromResource("/explain/testAvgAggFunctionPlan.out"));
-    }
-
-    @Test
-    public void testAvgAggFunction() throws Exception {
-        tableEnv.executeSql(
-                "create table test_avg(a int, x string, y string, z int, f bigint, d decimal(20, 5), d2 decimal(37, 20), e double, ts timestamp)");
-        tableEnv.executeSql(
-                        "insert into test_avg values (1, NULL, '2', 1, 2, 2.22, NULL, 2.3, '2021-08-04 16:26:33.4'), "
-                                + "(1, NULL, 'b', 2, NULL, 3.33, NULL, 3.4, '2021-08-07 16:26:33.4'), "
-                                + "(2, NULL, '4', 1, 2, 4.55, NULL, 4.5, '2021-08-08 16:26:33.4'), "
-                                + "(2, NULL, NULL, 4, 3, 5.66, NULL, 5.2, '2021-08-09 16:26:33.4')")
-                .await();
-
-        // test avg all element is null
-        List<Row> result =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select avg(x) from test_avg").collect());
-        assertThat(result.toString()).isEqualTo("[+I[null]]");
-
-        // test avg that some string elements can't convert to double
-        List<Row> result2 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select avg(y) from test_avg").collect());
-        assertThat(result2.toString()).isEqualTo("[+I[3.0]]");
-
-        // test avg bigint with null element
-        List<Row> result3 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select avg(f) from test_avg").collect());
-        assertThat(result3.toString()).isEqualTo("[+I[2.3333333333333335]]");
-
-        // test avg decimal
-        List<Row> result4 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select avg(d) from test_avg").collect());
-        assertThat(result4.toString()).isEqualTo("[+I[3.940000000]]");
-
-        // test avg decimal with null element
-        List<Row> result5 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select avg(d2) from test_avg").collect());
-        assertThat(result5.toString()).isEqualTo("[+I[null]]");
-
-        // test avg distinct
-        List<Row> result6 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select avg(distinct z) from test_avg").collect());
-        assertThat(result6.toString()).isEqualTo("[+I[2.3333333333333335]]");
-
-        // test avg with group key
-        List<Row> result7 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql(
-                                        "select a, avg(y), avg(z), avg(f) from test_avg group by a")
-                                .collect());
-        assertThat(result7.toString()).isEqualTo("[+I[1, 2.0, 1.5, 2.0], +I[2, 4.0, 2.5, 2.5]]");
-
-        // test unsupported type
-        assertThatThrownBy(
-                        () ->
-                                CollectionUtil.iteratorToList(
-                                        tableEnv.executeSql("select avg(ts)from test_avg")
-                                                .collect()))
-                .rootCause()
-                .satisfiesAnyOf(
-                        anyCauseMatches(
-                                "Only numeric or string type arguments are accepted but TIMESTAMP(9) is passed."));
-
-        tableEnv.executeSql("drop table test_avg");
     }
 
     private void runQFile(File qfile) throws Exception {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryPlanTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryPlanTest.java
@@ -96,6 +96,20 @@ public class HiveDialectQueryPlanTest {
     }
 
     @Test
+    public void testAvgAggFunctionPlan() {
+        // test explain
+        String sql = "select x, avg(y) from foo group by x";
+        String actualPlan = explainSql(sql);
+        assertThat(actualPlan).isEqualTo(readFromResource("/explain/testAvgAggFunctionPlan.out"));
+
+        // test fallback to hive avg udaf
+        tableEnv.getConfig().set(TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED, false);
+        String actualSortAggPlan = explainSql(sql);
+        assertThat(actualSortAggPlan)
+                .isEqualTo(readFromResource("/explain/testAvgAggFunctionFallbackPlan.out"));
+    }
+
+    @Test
     public void testMinAggFunctionPlan() {
         // test explain
         String sql = "select x, min(y) from foo group by x";

--- a/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionFallbackPlan.out
+++ b/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionFallbackPlan.out
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(x=[$0], _o__c1=[$1])
++- LogicalAggregate(group=[{0}], agg#0=[avg($1)])
+   +- LogicalProject($f0=[$0], $f1=[$1])
+      +- LogicalTableScan(table=[[test-catalog, default, foo]])
+
+== Optimized Physical Plan ==
+SortAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg($f1) AS $f1])
++- Sort(orderBy=[x ASC])
+   +- Exchange(distribution=[hash[x]])
+      +- LocalSortAggregate(groupBy=[x], select=[x, Partial_avg(y) AS $f1])
+         +- Sort(orderBy=[x ASC])
+            +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])
+
+== Optimized Execution Plan ==
+SortAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg($f1) AS $f1])
++- Sort(orderBy=[x ASC])
+   +- Exchange(distribution=[hash[x]])
+      +- LocalSortAggregate(groupBy=[x], select=[x, Partial_avg(y) AS $f1])
+         +- Sort(orderBy=[x ASC])
+            +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])

--- a/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionPlan.out
+++ b/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionPlan.out
@@ -1,0 +1,17 @@
+== Abstract Syntax Tree ==
+LogicalProject(x=[$0], _o__c1=[$1])
++- LogicalAggregate(group=[{0}], agg#0=[avg($1)])
+   +- LogicalProject($f0=[$0], $f1=[$1])
+      +- LogicalTableScan(table=[[test-catalog, default, foo]])
+
+== Optimized Physical Plan ==
+HashAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg(sum$0, count$1) AS $f1])
++- Exchange(distribution=[hash[x]])
+   +- LocalHashAggregate(groupBy=[x], select=[x, Partial_avg(y) AS (sum$0, count$1)])
+      +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])
+
+== Optimized Execution Plan ==
+HashAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg(sum$0, count$1) AS $f1])
++- Exchange(distribution=[hash[x]])
+   +- LocalHashAggregate(groupBy=[x], select=[x, Partial_avg(y) AS (sum$0, count$1)])
+      +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])


### PR DESCRIPTION
## What is the purpose of the change

*Implementing a native hive avg function based on the expression aggregate function, can improve the agg performance by using hash-agg strategy.*


## Brief change log

  - *Supports native avg function for hive dialect*


## Verifying this change

This change added tests and can be verified as follows:

  - *Added integration tests in HiveDialectQueryITCase*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
