### PR TITLE
[FLINK-30332] HsFileDataIndex supports caching and spilling index entry

### DIFF
--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -34,15 +34,15 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max</h5></td>
-            <td style="word-wrap: break-word;">9223372036854775807</td>
+            <td style="word-wrap: break-word;">1048576</td>
             <td>Long</td>
             <td>Controls the max number of hybrid retained regions in memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.spill-index-segment-size</h5></td>
-            <td style="word-wrap: break-word;">256</td>
+            <td style="word-wrap: break-word;">1024</td>
             <td>Integer</td>
-            <td>Controls the segment size of hybrid spilled file data index.</td>
+            <td>Controls the segment size(in bytes) of hybrid spilled file data index.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>

--- a/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
+++ b/docs/layouts/shortcodes/generated/all_taskmanager_network_section.html
@@ -33,6 +33,18 @@
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max</h5></td>
+            <td style="word-wrap: break-word;">9223372036854775807</td>
+            <td>Long</td>
+            <td>Controls the max number of hybrid retained regions in memory.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.hybrid-shuffle.spill-index-segment-size</h5></td>
+            <td style="word-wrap: break-word;">256</td>
+            <td>Integer</td>
+            <td>Controls the segment size of hybrid spilled file data index.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -51,6 +51,18 @@
             <td>Boolean flag to enable/disable more detailed metrics about inbound/outbound network queue lengths.</td>
         </tr>
         <tr>
+            <td><h5>taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max</h5></td>
+            <td style="word-wrap: break-word;">9223372036854775807</td>
+            <td>Long</td>
+            <td>Controls the max number of hybrid retained regions in memory.</td>
+        </tr>
+        <tr>
+            <td><h5>taskmanager.network.hybrid-shuffle.spill-index-segment-size</h5></td>
+            <td style="word-wrap: break-word;">256</td>
+            <td>Integer</td>
+            <td>Controls the segment size of hybrid spilled file data index.</td>
+        </tr>
+        <tr>
             <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>
             <td style="word-wrap: break-word;">1</td>
             <td>Integer</td>

--- a/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/netty_shuffle_environment_configuration.html
@@ -52,15 +52,15 @@
         </tr>
         <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max</h5></td>
-            <td style="word-wrap: break-word;">9223372036854775807</td>
+            <td style="word-wrap: break-word;">1048576</td>
             <td>Long</td>
             <td>Controls the max number of hybrid retained regions in memory.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.hybrid-shuffle.spill-index-segment-size</h5></td>
-            <td style="word-wrap: break-word;">256</td>
+            <td style="word-wrap: break-word;">1024</td>
             <td>Integer</td>
-            <td>Controls the segment size of hybrid spilled file data index.</td>
+            <td>Controls the segment size(in bytes) of hybrid spilled file data index.</td>
         </tr>
         <tr>
             <td><h5>taskmanager.network.max-num-tcp-connections</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -270,6 +270,24 @@ public class NettyShuffleEnvironmentOptions {
                                     // this raw value must be changed correspondingly
                                     "taskmanager.memory.framework.off-heap.batch-shuffle.size"));
 
+    /** Segment size of hybrid spilled file data index. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Integer> HYBRID_SHUFFLE_SPILLED_INDEX_SEGMENT_SIZE =
+            key("taskmanager.network.hybrid-shuffle.spill-index-segment-size")
+                    .intType()
+                    .defaultValue(256)
+                    .withDescription(
+                            "Controls the segment size of hybrid spilled file data index.");
+
+    /** Max number of hybrid retained regions in memory. */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Long> HYBRID_SHUFFLE_NUM_RETAINED_IN_MEMORY_REGIONS_MAX =
+            key("taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max")
+                    .longType()
+                    .defaultValue(Long.MAX_VALUE)
+                    .withDescription(
+                            "Controls the max number of hybrid retained regions in memory.");
+
     /** Number of max buffers can be used for each output subpartition. */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Integer> NETWORK_MAX_BUFFERS_PER_CHANNEL =

--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -275,16 +275,16 @@ public class NettyShuffleEnvironmentOptions {
     public static final ConfigOption<Integer> HYBRID_SHUFFLE_SPILLED_INDEX_SEGMENT_SIZE =
             key("taskmanager.network.hybrid-shuffle.spill-index-segment-size")
                     .intType()
-                    .defaultValue(256)
+                    .defaultValue(1024)
                     .withDescription(
-                            "Controls the segment size of hybrid spilled file data index.");
+                            "Controls the segment size(in bytes) of hybrid spilled file data index.");
 
     /** Max number of hybrid retained regions in memory. */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
     public static final ConfigOption<Long> HYBRID_SHUFFLE_NUM_RETAINED_IN_MEMORY_REGIONS_MAX =
             key("taskmanager.network.hybrid-shuffle.num-retained-in-memory-regions-max")
                     .longType()
-                    .defaultValue(Long.MAX_VALUE)
+                    .defaultValue(1024 * 1024L)
                     .withDescription(
                             "Controls the max number of hybrid retained regions in memory.");
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/NettyShuffleServiceFactory.java
@@ -210,7 +210,9 @@ public class NettyShuffleServiceFactory
                         config.sortShuffleMinBuffers(),
                         config.sortShuffleMinParallelism(),
                         config.isSSLEnabled(),
-                        config.getMaxOverdraftBuffersPerGate());
+                        config.getMaxOverdraftBuffersPerGate(),
+                        config.getHybridShuffleSpilledIndexSegmentSize(),
+                        config.getHybridShuffleNumRetainedInMemoryRegionsMax());
 
         SingleInputGateFactory singleInputGateFactory =
                 new SingleInputGateFactory(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndex.java
@@ -64,6 +64,9 @@ public interface HsFileDataIndex {
      */
     void markBufferReleased(int subpartitionId, int bufferIndex);
 
+    /** Close this file data index. */
+    void close();
+
     /**
      * Represents a series of physically continuous buffers in the file, which are readable, from
      * the same subpartition, and has sequential buffer index.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexCache.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexCache.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.IOUtils;
+
+import org.apache.flink.shaded.guava30.com.google.common.cache.Cache;
+import org.apache.flink.shaded.guava30.com.google.common.cache.CacheBuilder;
+import org.apache.flink.shaded.guava30.com.google.common.cache.RemovalNotification;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * A cache layer of hybrid data index. This class encapsulates the logic of the index's put and get,
+ * and automatically caches some indexes in memory. When there are too many cached indexes, it is
+ * this class's responsibility to decide and eliminate some indexes to disk.
+ */
+public class HsFileDataIndexCache {
+    /**
+     * This struct stores all in memory {@link InternalRegion}s. Each element is a treeMap contains
+     * all in memory {@link InternalRegion}'s of specific subpartition corresponding to the
+     * subscript. The value of this treeMap is a {@link InternalRegion}, and the key is
+     * firstBufferIndex of this region. Only cached in memory region will be put to here.
+     */
+    private final List<TreeMap<Integer, InternalRegion>>
+            subpartitionFirstBufferIndexInternalRegions;
+
+    /**
+     * This cache is used to help eliminate regions from memory. It is only maintains the key of
+     * each in memory region, the value is just a placeholder. Note that this internal cache must be
+     * consistent with subpartitionFirstBufferIndexInternalRegions, that means both of them must add
+     * or delete elements at the same time.
+     */
+    private final Cache<CachedRegionKey, Object> internalCache;
+
+    private final HsFileDataIndexSpilledRegionManager spilledRegionManager;
+
+    private final Path indexFilePath;
+
+    /**
+     * Placeholder of cache entry's value. Because the cache is only used for managing region's
+     * elimination, does not need the real region as value.
+     */
+    public static final Object PLACEHOLDER = new Object();
+
+    public HsFileDataIndexCache(
+            int numSubpartitions,
+            Path indexFilePath,
+            long numRetainedInMemoryRegionsMax,
+            int spilledIndexSegmentSize,
+            HsFileDataIndexSpilledRegionManager.Factory spilledRegionManagerFactory) {
+        this.subpartitionFirstBufferIndexInternalRegions = new ArrayList<>(numSubpartitions);
+        for (int subpartitionId = 0; subpartitionId < numSubpartitions; ++subpartitionId) {
+            subpartitionFirstBufferIndexInternalRegions.add(new TreeMap<>());
+        }
+        this.internalCache =
+                CacheBuilder.newBuilder()
+                        .maximumSize(numRetainedInMemoryRegionsMax)
+                        .removalListener(this::handleRemove)
+                        .build();
+        this.indexFilePath = checkNotNull(indexFilePath);
+        this.spilledRegionManager =
+                spilledRegionManagerFactory.create(
+                        numSubpartitions,
+                        indexFilePath,
+                        spilledIndexSegmentSize,
+                        (subpartition, region) -> {
+                            internalCache.put(
+                                    new CachedRegionKey(subpartition, region.getFirstBufferIndex()),
+                                    PLACEHOLDER);
+                            subpartitionFirstBufferIndexInternalRegions
+                                    .get(subpartition)
+                                    .put(region.getFirstBufferIndex(), region);
+                        });
+    }
+
+    /**
+     * Get a region contains target bufferIndex and belong to target subpartition.
+     *
+     * @param subpartitionId the subpartition that target buffer belong to.
+     * @param bufferIndex the index of target buffer.
+     * @return If target region can be founded from memory or disk, return optional contains target
+     *     region. Otherwise, return {@code Optional#empty()};
+     */
+    public Optional<InternalRegion> get(int subpartitionId, int bufferIndex) {
+        // first of all, try to get region in memory.
+        Optional<InternalRegion> regionOpt =
+                getCachedRegionContainsTargetBufferIndex(subpartitionId, bufferIndex);
+        if (regionOpt.isPresent()) {
+            InternalRegion region = regionOpt.get();
+            checkNotNull(
+                    // this is needed for cache entry remove algorithm like LRU.
+                    internalCache.getIfPresent(
+                            new CachedRegionKey(subpartitionId, region.getFirstBufferIndex())));
+            return Optional.of(region);
+        } else {
+            // try to find target region and load it into cache if founded.
+            spilledRegionManager.findRegion(subpartitionId, bufferIndex, true);
+            return getCachedRegionContainsTargetBufferIndex(subpartitionId, bufferIndex);
+        }
+    }
+
+    /**
+     * Put regions to cache.
+     *
+     * @param subpartition the subpartition's id of regions.
+     * @param internalRegions regions to be cached.
+     */
+    public void put(int subpartition, List<InternalRegion> internalRegions) {
+        TreeMap<Integer, InternalRegion> treeMap =
+                subpartitionFirstBufferIndexInternalRegions.get(subpartition);
+        for (InternalRegion internalRegion : internalRegions) {
+            internalCache.put(
+                    new CachedRegionKey(subpartition, internalRegion.getFirstBufferIndex()),
+                    PLACEHOLDER);
+            treeMap.put(internalRegion.getFirstBufferIndex(), internalRegion);
+        }
+    }
+
+    /**
+     * Close {@link HsFileDataIndexCache}, this will delete the index file. After that, the index
+     * can no longer be read or written.
+     */
+    public void close() throws IOException {
+        spilledRegionManager.close();
+        IOUtils.deleteFileQuietly(indexFilePath);
+    }
+
+    // This is a callback after internal cache removed an entry from itself.
+    private void handleRemove(RemovalNotification<CachedRegionKey, Object> removedEntry) {
+        CachedRegionKey removedKey = removedEntry.getKey();
+        // remove the corresponding region from memory.
+        InternalRegion removedRegion =
+                subpartitionFirstBufferIndexInternalRegions
+                        .get(removedKey.getSubpartition())
+                        .remove(removedKey.getFirstBufferIndex());
+
+        // write this region to file. After that, no strong reference point to this region, it can
+        // be safely released by gc.
+        writeRegion(removedKey.getSubpartition(), removedRegion);
+    }
+
+    private void writeRegion(int subpartition, InternalRegion region) {
+        try {
+            spilledRegionManager.appendOrOverwriteRegion(subpartition, region);
+        } catch (IOException e) {
+            ExceptionUtils.rethrow(e);
+        }
+    }
+
+    /**
+     * Get the cached in memory region contains target buffer.
+     *
+     * @param subpartitionId the subpartition that target buffer belong to.
+     * @param bufferIndex the index of target buffer.
+     * @return If target region is cached in memory, return optional contains target region.
+     *     Otherwise, return {@code Optional#empty()};
+     */
+    private Optional<InternalRegion> getCachedRegionContainsTargetBufferIndex(
+            int subpartitionId, int bufferIndex) {
+        return Optional.ofNullable(
+                        subpartitionFirstBufferIndexInternalRegions
+                                .get(subpartitionId)
+                                .floorEntry(bufferIndex))
+                .map(Map.Entry::getValue)
+                .filter(internalRegion -> internalRegion.containBuffer(bufferIndex));
+    }
+
+    /**
+     * This class represents the key of cached region, it is uniquely identified by the region's
+     * subpartition id and firstBufferIndex.
+     */
+    private static class CachedRegionKey {
+        /** The subpartition id of cached region. */
+        private final int subpartition;
+
+        /** The first buffer's index of cached region. */
+        private final int firstBufferIndex;
+
+        public CachedRegionKey(int subpartition, int firstBufferIndex) {
+            this.subpartition = subpartition;
+            this.firstBufferIndex = firstBufferIndex;
+        }
+
+        public int getSubpartition() {
+            return subpartition;
+        }
+
+        public int getFirstBufferIndex() {
+            return firstBufferIndex;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CachedRegionKey that = (CachedRegionKey) o;
+            return subpartition == that.subpartition && firstBufferIndex == that.firstBufferIndex;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(subpartition, firstBufferIndex);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -198,7 +198,7 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
             this.released = released;
         }
 
-        private boolean containBuffer(int bufferIndex) {
+        boolean containBuffer(int bufferIndex) {
             return bufferIndex >= firstBufferIndex && bufferIndex < firstBufferIndex + numBuffers;
         }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -18,9 +18,13 @@
 
 package org.apache.flink.runtime.io.network.partition.hybrid;
 
+import org.apache.flink.util.ExceptionUtils;
+
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.TreeMap;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
 
@@ -38,15 +41,35 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 public class HsFileDataIndexImpl implements HsFileDataIndex {
 
     @GuardedBy("lock")
-    private final List<TreeMap<Integer, InternalRegion>>
-            subpartitionFirstBufferIndexInternalRegions;
+    private final HsFileDataIndexCache indexCache;
 
+    /**
+     * {@link HsFileDataIndexCache} is not thread-safe, any access to it needs to hold this lock.
+     */
     private final Object lock = new Object();
 
-    public HsFileDataIndexImpl(int numSubpartitions) {
-        this.subpartitionFirstBufferIndexInternalRegions = new ArrayList<>(numSubpartitions);
-        for (int subpartitionId = 0; subpartitionId < numSubpartitions; ++subpartitionId) {
-            subpartitionFirstBufferIndexInternalRegions.add(new TreeMap<>());
+    public HsFileDataIndexImpl(
+            int numSubpartitions,
+            Path indexFilePath,
+            int spilledIndexSegmentSize,
+            long numRetainedInMemoryRegionsMax) {
+        this.indexCache =
+                new HsFileDataIndexCache(
+                        numSubpartitions,
+                        indexFilePath,
+                        numRetainedInMemoryRegionsMax,
+                        spilledIndexSegmentSize,
+                        HsFileDataIndexSpilledRegionManagerImpl.Factory.INSTANCE);
+    }
+
+    @Override
+    public void close() {
+        synchronized (lock) {
+            try {
+                indexCache.close();
+            } catch (IOException e) {
+                ExceptionUtils.rethrow(e);
+            }
         }
     }
 
@@ -67,14 +90,7 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
         final Map<Integer, List<InternalRegion>> subpartitionInternalRegions =
                 convertToInternalRegions(spilledBuffers);
         synchronized (lock) {
-            subpartitionInternalRegions.forEach(
-                    (subpartition, internalRegions) -> {
-                        TreeMap<Integer, InternalRegion> treeMap =
-                                subpartitionFirstBufferIndexInternalRegions.get(subpartition);
-                        for (InternalRegion internalRegion : internalRegions) {
-                            treeMap.put(internalRegion.firstBufferIndex, internalRegion);
-                        }
-                    });
+            subpartitionInternalRegions.forEach(indexCache::put);
         }
     }
 
@@ -88,12 +104,7 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
 
     @GuardedBy("lock")
     private Optional<InternalRegion> getInternalRegion(int subpartitionId, int bufferIndex) {
-        return Optional.ofNullable(
-                        subpartitionFirstBufferIndexInternalRegions
-                                .get(subpartitionId)
-                                .floorEntry(bufferIndex))
-                .map(Map.Entry::getValue)
-                .filter(internalRegion -> internalRegion.containBuffer(bufferIndex));
+        return indexCache.get(subpartitionId, bufferIndex);
     }
 
     private static Map<Integer, List<InternalRegion>> convertToInternalRegions(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -182,11 +182,11 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
      */
     static class InternalRegion {
         /**
-         * {@link InternalRegion} is consists of immutable and variable parts. (firstBufferIndex,
-         * firstBufferOffset, numBuffer) are immutable part that have fixed size. The array of
-         * released is variable part. This field represents the size of fixed part.
+         * {@link InternalRegion} is consists of header and payload. (firstBufferIndex,
+         * firstBufferOffset, numBuffer) are immutable header part that have fixed size. The array
+         * of released is variable payload. This field represents the size of header.
          */
-        public static final int FIXED_SIZE = Integer.BYTES + Long.BYTES + Integer.BYTES;
+        public static final int HEADER_SIZE = Integer.BYTES + Long.BYTES + Integer.BYTES;
 
         private final int firstBufferIndex;
         private final long firstBufferOffset;
@@ -230,9 +230,9 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
             released[bufferIndex - firstBufferIndex] = true;
         }
 
-        /** Get the total size in bytes of this region, including immutable and variable part. */
+        /** Get the total size in bytes of this region, including header and payload. */
         int getSize() {
-            return FIXED_SIZE + numBuffers;
+            return HEADER_SIZE + numBuffers;
         }
 
         int getFirstBufferIndex() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -58,8 +58,8 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
                         numSubpartitions,
                         indexFilePath,
                         numRetainedInMemoryRegionsMax,
-                        spilledIndexSegmentSize,
-                        HsFileDataIndexSpilledRegionManagerImpl.Factory.INSTANCE);
+                        new HsFileDataIndexSpilledRegionManagerImpl.Factory(
+                                spilledIndexSegmentSize, numRetainedInMemoryRegionsMax));
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImpl.java
@@ -169,7 +169,14 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
      * <p>Note: This index may not always maintain the longest possible regions. E.g., 2-1, 2-2, 2-3
      * are in two separate regions.
      */
-    private static class InternalRegion {
+    static class InternalRegion {
+        /**
+         * {@link InternalRegion} is consists of immutable and variable parts. (firstBufferIndex,
+         * firstBufferOffset, numBuffer) are immutable part that have fixed size. The array of
+         * released is variable part. This field represents the size of fixed part.
+         */
+        public static final int FIXED_SIZE = Integer.BYTES + Long.BYTES + Integer.BYTES;
+
         private final int firstBufferIndex;
         private final long firstBufferOffset;
         private final int numBuffers;
@@ -181,6 +188,14 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
             this.numBuffers = numBuffers;
             this.released = new boolean[numBuffers];
             Arrays.fill(released, false);
+        }
+
+        InternalRegion(
+                int firstBufferIndex, long firstBufferOffset, int numBuffers, boolean[] released) {
+            this.firstBufferIndex = firstBufferIndex;
+            this.firstBufferOffset = firstBufferOffset;
+            this.numBuffers = numBuffers;
+            this.released = released;
         }
 
         private boolean containBuffer(int bufferIndex) {
@@ -202,6 +217,27 @@ public class HsFileDataIndexImpl implements HsFileDataIndex {
 
         private void markBufferReleased(int bufferIndex) {
             released[bufferIndex - firstBufferIndex] = true;
+        }
+
+        /** Get the total size in bytes of this region, including immutable and variable part. */
+        int getSize() {
+            return FIXED_SIZE + numBuffers;
+        }
+
+        int getFirstBufferIndex() {
+            return firstBufferIndex;
+        }
+
+        long getFirstBufferOffset() {
+            return firstBufferOffset;
+        }
+
+        int getNumBuffers() {
+            return numBuffers;
+        }
+
+        boolean[] getReleased() {
+            return released;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManager.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.function.BiConsumer;
+
+/** This class is responsible for spilling region to disk and managing these spilled regions. */
+public interface HsFileDataIndexSpilledRegionManager extends AutoCloseable {
+    /**
+     * Write this region to index file. If target region already spilled, overwrite it.
+     *
+     * @param subpartition the subpartition id of this region.
+     * @param region the region to be spilled to index file.
+     */
+    void appendOrOverwriteRegion(int subpartition, InternalRegion region) throws IOException;
+
+    /**
+     * Find the region contains target bufferIndex and belong to target subpartition.
+     *
+     * @param subpartition the subpartition id that target region belong to.
+     * @param bufferIndex the buffer index that target region contains.
+     * @param loadToCache whether to load the found region into the cache.
+     * @return if target region can be founded, return it's offset in index file. Otherwise, return
+     *     -1.
+     */
+    long findRegion(int subpartition, int bufferIndex, boolean loadToCache);
+
+    /** Close this spilled region manager. */
+    void close() throws IOException;
+
+    /** Factory of {@link HsFileDataIndexSpilledRegionManager}. */
+    interface Factory {
+        HsFileDataIndexSpilledRegionManager create(
+                int numSubpartitions,
+                Path indexFilePath,
+                int segmentSize,
+                BiConsumer<Integer, InternalRegion> cacheRegionConsumer);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManager.java
@@ -53,7 +53,6 @@ public interface HsFileDataIndexSpilledRegionManager extends AutoCloseable {
         HsFileDataIndexSpilledRegionManager create(
                 int numSubpartitions,
                 Path indexFilePath,
-                int segmentSize,
                 BiConsumer<Integer, InternalRegion> cacheRegionConsumer);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManagerImpl.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+import org.apache.flink.util.ExceptionUtils;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.InternalRegionWriteReadUtils.allocateAndConfigureBuffer;
+
+/**
+ * Default implementation of {@link HsFileDataIndexSpilledRegionManager}. This manager will handle
+ * and spill regions in the following way:
+ *
+ * <ul>
+ *   <li>All regions will be written to the same file, namely index file.
+ *   <li>Multiple regions belonging to the same subpartition form a segment.
+ *   <li>The regions in the same segment have no special relationship, but are only related to the
+ *       order in which they are spilled.
+ *   <li>Each segment is independent. Even if the previous segment is not full, the next segment can
+ *       still be allocated.
+ *   <li>If a region has been written to the index file already, spill it again will overwrite the
+ *       previous region.
+ *   <li>The very large region will monopolize a single segment.
+ * </ul>
+ */
+public class HsFileDataIndexSpilledRegionManagerImpl
+        implements HsFileDataIndexSpilledRegionManager {
+
+    /** Reusable buffer used to read and write the immutable part of region. */
+    private final ByteBuffer immutablePartBuffer =
+            allocateAndConfigureBuffer(InternalRegion.FIXED_SIZE);
+
+    /**
+     * List of subpartition's segment meta. Each element is a treeMap contains all {@link
+     * SegmentMeta}'s of specific subpartition corresponding to the subscript. The value of this
+     * treeMap is a {@link SegmentMeta}, and the key is minBufferIndex of this segment. Only
+     * finished(i.e. no longer appended) segment will be put to here.
+     */
+    private final List<TreeMap<Integer, SegmentMeta>> subpartitionFinishedSegmentMetas;
+
+    private FileChannel channel;
+
+    /** The Offset of next segment, new segment will start from this offset. */
+    private long nextSegmentOffset = 0L;
+
+    private final long[] subpartitionCurrentOffset;
+
+    /** Free space of every subpartition's current segment. */
+    private final int[] subpartitionFreeSpace;
+
+    /** Metadata of every subpartition's current segment. */
+    private final SegmentMeta[] currentSegmentMeta;
+
+    /**
+     * Default size of segment. If the size of a region is larger than this value, it will be
+     * allocated and occupy a single segment.
+     */
+    private final int segmentSize;
+
+    /**
+     * This consumer is used to load region to cache. The first parameter is subpartition id, and
+     * second parameter is the region to load.
+     */
+    private final BiConsumer<Integer, InternalRegion> cacheRegionConsumer;
+
+    public HsFileDataIndexSpilledRegionManagerImpl(
+            int numSubpartitions,
+            Path indexFilePath,
+            int segmentSize,
+            BiConsumer<Integer, InternalRegion> cacheRegionConsumer) {
+        try {
+            this.channel =
+                    FileChannel.open(
+                            indexFilePath,
+                            StandardOpenOption.CREATE_NEW,
+                            StandardOpenOption.READ,
+                            StandardOpenOption.WRITE);
+        } catch (IOException e) {
+            ExceptionUtils.rethrow(e);
+        }
+        this.subpartitionFinishedSegmentMetas = new ArrayList<>(numSubpartitions);
+        this.subpartitionCurrentOffset = new long[numSubpartitions];
+        this.subpartitionFreeSpace = new int[numSubpartitions];
+        this.currentSegmentMeta = new SegmentMeta[numSubpartitions];
+        for (int i = 0; i < numSubpartitions; i++) {
+            subpartitionFinishedSegmentMetas.add(new TreeMap<>());
+        }
+        this.cacheRegionConsumer = cacheRegionConsumer;
+        this.segmentSize = segmentSize;
+    }
+
+    @Override
+    public long findRegion(int subpartition, int bufferIndex, boolean loadToCache) {
+        // first of all, find the region from current writing segment.
+        SegmentMeta segmentMeta = currentSegmentMeta[subpartition];
+        if (segmentMeta != null) {
+            long regionOffset =
+                    findRegionInSegment(subpartition, bufferIndex, segmentMeta, loadToCache);
+            if (regionOffset != -1) {
+                return regionOffset;
+            }
+        }
+
+        // next, find the region from finished segments.
+        TreeMap<Integer, SegmentMeta> subpartitionSegmentMetaTreeMap =
+                subpartitionFinishedSegmentMetas.get(subpartition);
+        // all segments with a minBufferIndex less than or equal to this target buffer index may
+        // contain the target region.
+        for (SegmentMeta meta :
+                subpartitionSegmentMetaTreeMap.headMap(bufferIndex, true).values()) {
+            long regionOffset = findRegionInSegment(subpartition, bufferIndex, meta, loadToCache);
+            if (regionOffset != -1) {
+                return regionOffset;
+            }
+        }
+        return -1;
+    }
+
+    private long findRegionInSegment(
+            int subpartition, int bufferIndex, SegmentMeta meta, boolean loadToCache) {
+        if (bufferIndex < meta.getMaxBufferIndex()) {
+            try {
+                // read all regions belong to this segment.
+                List<Tuple2<InternalRegion, Long>> regionAndOffsets =
+                        readSegment(meta.getOffset(), meta.getNumRegions());
+                for (Tuple2<InternalRegion, Long> regionAndOffset : regionAndOffsets) {
+                    InternalRegion region = regionAndOffset.f0;
+                    // whether the region contains this buffer.
+                    if (region.containBuffer(bufferIndex)) {
+                        // target region is founded.
+                        if (loadToCache) {
+                            // load this region to cache if needed.
+                            cacheRegionConsumer.accept(subpartition, region);
+                        }
+                        // return the offset of target region.
+                        return regionAndOffset.f1;
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        // -1 indicates that target region is not founded from this segment.
+        return -1;
+    }
+
+    @Override
+    public void appendOrOverwriteRegion(int subpartition, InternalRegion newRegion)
+            throws IOException {
+        long oldRegionOffset = findRegion(subpartition, newRegion.getFirstBufferIndex(), false);
+        if (oldRegionOffset != -1) {
+            // if region is already exists in file, overwrite it.
+            writeRegionToOffset(oldRegionOffset, newRegion);
+        } else {
+            // otherwise, append region to segment.
+            appendRegion(subpartition, newRegion);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (channel != null) {
+            channel.close();
+        }
+    }
+
+    private void appendRegion(int subpartition, InternalRegion region) throws IOException {
+        int regionSize = region.getSize();
+        // check whether we have enough space to append this region.
+        if (subpartitionFreeSpace[subpartition] < regionSize) {
+            // No enough free space, start a new segment. Note that if region is larger than
+            // segment's size, this will start a new segment only contains the big region.
+            startNewSegment(subpartition, Math.max(regionSize, segmentSize));
+        }
+        // spill this region to current offset of file index.
+        writeRegionToOffset(subpartitionCurrentOffset[subpartition], region);
+        // a new region was appended to segment, update it.
+        updateSegment(subpartition, region);
+    }
+
+    private void writeRegionToOffset(long offset, InternalRegion region) throws IOException {
+        channel.position(offset);
+        InternalRegionWriteReadUtils.writeRegionToFile(channel, immutablePartBuffer, region);
+    }
+
+    private void startNewSegment(int subpartition, int newSegmentSize) {
+        SegmentMeta oldSegmentMeta = currentSegmentMeta[subpartition];
+        currentSegmentMeta[subpartition] = new SegmentMeta(nextSegmentOffset);
+        subpartitionCurrentOffset[subpartition] = nextSegmentOffset;
+        nextSegmentOffset += newSegmentSize;
+        subpartitionFreeSpace[subpartition] = newSegmentSize;
+        if (oldSegmentMeta != null) {
+            // put the finished segment to subpartitionFinishedSegmentMetas.
+            subpartitionFinishedSegmentMetas
+                    .get(subpartition)
+                    .put(oldSegmentMeta.minBufferIndex, oldSegmentMeta);
+        }
+    }
+
+    private void updateSegment(int subpartition, InternalRegion region) {
+        int regionSize = region.getSize();
+        subpartitionFreeSpace[subpartition] -= regionSize;
+        subpartitionCurrentOffset[subpartition] += regionSize;
+        SegmentMeta segmentMeta = currentSegmentMeta[subpartition];
+        // update min/max buffer index of segment.
+        if (region.getFirstBufferIndex() < segmentMeta.getMinBufferIndex()) {
+            segmentMeta.setMinBufferIndex(region.getFirstBufferIndex());
+        }
+        if (region.getFirstBufferIndex() + region.getNumBuffers()
+                > segmentMeta.getMaxBufferIndex()) {
+            segmentMeta.setMaxBufferIndex(region.getFirstBufferIndex() + region.getNumBuffers());
+        }
+        segmentMeta.addRegion();
+    }
+
+    /**
+     * Read segment from index file.
+     *
+     * @param offset offset of this segment.
+     * @param numRegions number of regions of this segment.
+     * @return List of all regions and its offset belong to this segment.
+     */
+    private List<Tuple2<InternalRegion, Long>> readSegment(long offset, int numRegions)
+            throws IOException {
+        List<Tuple2<InternalRegion, Long>> regionAndOffsets = new ArrayList<>();
+        for (int i = 0; i < numRegions; i++) {
+            InternalRegion region =
+                    InternalRegionWriteReadUtils.readRegionFromFile(
+                            channel, immutablePartBuffer, offset);
+            regionAndOffsets.add(Tuple2.of(region, offset));
+            offset += region.getSize();
+        }
+        return regionAndOffsets;
+    }
+
+    /**
+     * Metadata of spilled regions segment. When a segment is finished(i.e. no longer appended), its
+     * corresponding {@link SegmentMeta} becomes immutable.
+     */
+    private static class SegmentMeta {
+        /**
+         * Minimum buffer index of this segment. It is the smallest bufferIndex(inclusive) in all
+         * regions belong to this segment.
+         */
+        private int minBufferIndex;
+
+        /**
+         * Maximum buffer index of this segment. It is the largest bufferIndex(exclusive) in all
+         * regions belong to this segment.
+         */
+        private int maxBufferIndex;
+
+        /** Number of regions belong to this segment. */
+        private int numRegions;
+
+        /** The index file offset of this segment. */
+        private final long offset;
+
+        public SegmentMeta(long offset) {
+            this.offset = offset;
+            this.minBufferIndex = Integer.MAX_VALUE;
+            this.maxBufferIndex = 0;
+            this.numRegions = 0;
+        }
+
+        public int getMinBufferIndex() {
+            return minBufferIndex;
+        }
+
+        public int getMaxBufferIndex() {
+            return maxBufferIndex;
+        }
+
+        public long getOffset() {
+            return offset;
+        }
+
+        public int getNumRegions() {
+            return numRegions;
+        }
+
+        public void setMinBufferIndex(int minBufferIndex) {
+            this.minBufferIndex = minBufferIndex;
+        }
+
+        public void setMaxBufferIndex(int maxBufferIndex) {
+            this.maxBufferIndex = maxBufferIndex;
+        }
+
+        public void addRegion() {
+            this.numRegions++;
+        }
+    }
+
+    /** Factory of {@link HsFileDataIndexSpilledRegionManager}. */
+    public static class Factory implements HsFileDataIndexSpilledRegionManager.Factory {
+        public static final Factory INSTANCE = new Factory();
+
+        @Override
+        public HsFileDataIndexSpilledRegionManager create(
+                int numSubpartitions,
+                Path indexFilePath,
+                int segmentSize,
+                BiConsumer<Integer, InternalRegion> cacheRegionConsumer) {
+            return new HsFileDataIndexSpilledRegionManagerImpl(
+                    numSubpartitions, indexFilePath, segmentSize, cacheRegionConsumer);
+        }
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
@@ -179,7 +179,8 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
         }
     }
 
-    public void deleteShuffleFile() {
+    public void closeDataIndexAndDeleteShuffleFile() {
+        dataIndex.close();
         IOUtils.deleteFileQuietly(dataFilePath);
     }
 
@@ -207,8 +208,8 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
             failSubpartitionReaders(
                     pendingReaders,
                     new IllegalStateException("Result partition has been already released."));
-            // delete the shuffle file only when no reader is reading now.
-            releaseFuture.thenRun(this::deleteShuffleFile);
+            // close data index and delete shuffle file only when no reader is reading now.
+            releaseFuture.thenRun(this::closeDataIndexAndDeleteShuffleFile);
         }
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -60,6 +60,8 @@ import static org.apache.flink.util.Preconditions.checkState;
 public class HsResultPartition extends ResultPartition {
     public static final String DATA_FILE_SUFFIX = ".hybrid.data";
 
+    public static final String INDEX_FILE_SUFFIX = ".hybrid.index";
+
     public static final int BROADCAST_CHANNEL = 0;
 
     private final HsFileDataIndex dataIndex;
@@ -67,6 +69,8 @@ public class HsResultPartition extends ResultPartition {
     private final HsFileDataManager fileDataManager;
 
     private final Path dataFilePath;
+
+    private final Path indexFilePath;
 
     private final int networkBufferSize;
 
@@ -109,8 +113,14 @@ public class HsResultPartition extends ResultPartition {
                 bufferCompressor,
                 bufferPoolFactory);
         this.networkBufferSize = networkBufferSize;
-        this.dataIndex = new HsFileDataIndexImpl(isBroadcastOnly ? 1 : numSubpartitions);
         this.dataFilePath = new File(dataFileBashPath + DATA_FILE_SUFFIX).toPath();
+        this.indexFilePath = new File(dataFileBashPath + INDEX_FILE_SUFFIX).toPath();
+        this.dataIndex =
+                new HsFileDataIndexImpl(
+                        isBroadcastOnly ? 1 : numSubpartitions,
+                        indexFilePath,
+                        hybridShuffleConfiguration.getSpilledIndexSegmentSize(),
+                        hybridShuffleConfiguration.getNumRetainedInMemoryRegionsMax());
         this.hybridShuffleConfiguration = hybridShuffleConfiguration;
         this.isBroadcastOnly = isBroadcastOnly;
         this.fileDataManager =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
@@ -38,6 +38,10 @@ public class HybridShuffleConfiguration {
 
     private static final long DEFAULT_BUFFER_POLL_SIZE_CHECK_INTERVAL_MS = 1000;
 
+    private static final long DEFAULT_NUM_RETAINED_IN_MEMORY_REGIONS_MAX = Long.MAX_VALUE;
+
+    private static final int DEFAULT_SPILLED_INDEX_SEGMENT_SIZE = 256;
+
     private static final SpillingStrategyType DEFAULT_SPILLING_STRATEGY_NAME =
             SpillingStrategyType.FULL;
 
@@ -48,6 +52,12 @@ public class HybridShuffleConfiguration {
     private final int maxRequestedBuffers;
 
     private final SpillingStrategyType spillingStrategyType;
+
+    private final long numRetainedInMemoryRegionsMax;
+
+    private final int spilledIndexSegmentSize;
+
+    private final long bufferPoolSizeCheckIntervalMs;
 
     // ----------------------------------------
     //        Selective Spilling Strategy
@@ -65,8 +75,6 @@ public class HybridShuffleConfiguration {
 
     private final float fullStrategyReleaseBufferRatio;
 
-    private final long bufferPoolSizeCheckIntervalMs;
-
     private HybridShuffleConfiguration(
             int maxBuffersReadAhead,
             Duration bufferRequestTimeout,
@@ -77,7 +85,9 @@ public class HybridShuffleConfiguration {
             float fullStrategyReleaseThreshold,
             float fullStrategyReleaseBufferRatio,
             SpillingStrategyType spillingStrategyType,
-            long bufferPoolSizeCheckIntervalMs) {
+            long bufferPoolSizeCheckIntervalMs,
+            long numRetainedInMemoryRegionsMax,
+            int spilledIndexSegmentSize) {
         this.maxBuffersReadAhead = maxBuffersReadAhead;
         this.bufferRequestTimeout = bufferRequestTimeout;
         this.maxRequestedBuffers = maxRequestedBuffers;
@@ -89,6 +99,8 @@ public class HybridShuffleConfiguration {
         this.fullStrategyReleaseBufferRatio = fullStrategyReleaseBufferRatio;
         this.spillingStrategyType = spillingStrategyType;
         this.bufferPoolSizeCheckIntervalMs = bufferPoolSizeCheckIntervalMs;
+        this.numRetainedInMemoryRegionsMax = numRetainedInMemoryRegionsMax;
+        this.spilledIndexSegmentSize = spilledIndexSegmentSize;
     }
 
     public static Builder builder(int numSubpartitions, int numBuffersPerRequest) {
@@ -159,6 +171,16 @@ public class HybridShuffleConfiguration {
         return bufferPoolSizeCheckIntervalMs;
     }
 
+    /** Segment size of hybrid spilled file data index. */
+    public int getSpilledIndexSegmentSize() {
+        return spilledIndexSegmentSize;
+    }
+
+    /** Max number of hybrid retained regions in memory. */
+    public long getNumRetainedInMemoryRegionsMax() {
+        return numRetainedInMemoryRegionsMax;
+    }
+
     /** Type of {@link HsSpillingStrategy}. */
     public enum SpillingStrategyType {
         FULL,
@@ -186,6 +208,10 @@ public class HybridShuffleConfiguration {
         private long bufferPoolSizeCheckIntervalMs = DEFAULT_BUFFER_POLL_SIZE_CHECK_INTERVAL_MS;
 
         private SpillingStrategyType spillingStrategyType = DEFAULT_SPILLING_STRATEGY_NAME;
+
+        private long numRetainedInMemoryRegionsMax = DEFAULT_NUM_RETAINED_IN_MEMORY_REGIONS_MAX;
+
+        private int spilledIndexSegmentSize = DEFAULT_SPILLED_INDEX_SEGMENT_SIZE;
 
         private final int numSubpartitions;
 
@@ -244,6 +270,16 @@ public class HybridShuffleConfiguration {
             return this;
         }
 
+        public Builder setNumRetainedInMemoryRegionsMax(long numRetainedInMemoryRegionsMax) {
+            this.numRetainedInMemoryRegionsMax = numRetainedInMemoryRegionsMax;
+            return this;
+        }
+
+        public Builder setSpilledIndexSegmentSize(int spilledIndexSegmentSize) {
+            this.spilledIndexSegmentSize = spilledIndexSegmentSize;
+            return this;
+        }
+
         public HybridShuffleConfiguration build() {
             return new HybridShuffleConfiguration(
                     maxBuffersReadAhead,
@@ -255,7 +291,9 @@ public class HybridShuffleConfiguration {
                     fullStrategyReleaseThreshold,
                     fullStrategyReleaseBufferRatio,
                     spillingStrategyType,
-                    bufferPoolSizeCheckIntervalMs);
+                    bufferPoolSizeCheckIntervalMs,
+                    numRetainedInMemoryRegionsMax,
+                    spilledIndexSegmentSize);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/InternalRegionWriteReadUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/InternalRegionWriteReadUtils.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.BufferReaderWriterUtil;
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+
+/** Utils for read and write {@link InternalRegion}. */
+public class InternalRegionWriteReadUtils {
+
+    /**
+     * Allocate a buffer with specific size and configure it to native order.
+     *
+     * @param bufferSize the size of buffer to allocate.
+     * @return a native order buffer with expected size.
+     */
+    public static ByteBuffer allocateAndConfigureBuffer(int bufferSize) {
+        ByteBuffer buffer = ByteBuffer.allocateDirect(bufferSize);
+        buffer.order(ByteOrder.nativeOrder());
+        return buffer;
+    }
+
+    /**
+     * Write {@link InternalRegion} to {@link FileChannel}.
+     *
+     * @param channel the file's channel to write.
+     * @param fixedRegionBuffer the buffer to write {@link InternalRegion}'s fixed part.
+     * @param region the region to be written to channel.
+     */
+    public static void writeRegionToFile(
+            FileChannel channel, ByteBuffer fixedRegionBuffer, InternalRegion region)
+            throws IOException {
+        // write fixed buffer.
+        fixedRegionBuffer.clear();
+        fixedRegionBuffer.putInt(region.getFirstBufferIndex());
+        fixedRegionBuffer.putInt(region.getNumBuffers());
+        fixedRegionBuffer.putLong(region.getFirstBufferOffset());
+        fixedRegionBuffer.flip();
+
+        // write variable buffer.
+        ByteBuffer variableBuffer = allocateAndConfigureBuffer(region.getNumBuffers());
+        boolean[] released = region.getReleased();
+        for (boolean b : released) {
+            variableBuffer.put(b ? (byte) 1 : (byte) 0);
+        }
+        variableBuffer.flip();
+
+        BufferReaderWriterUtil.writeBuffers(
+                channel,
+                fixedRegionBuffer.capacity() + variableBuffer.capacity(),
+                fixedRegionBuffer,
+                variableBuffer);
+    }
+
+    /**
+     * Read {@link InternalRegion} from {@link FileChannel}.
+     *
+     * @param channel the channel to read.
+     * @param fixedRegionBuffer the buffer to read {@link InternalRegion}'s fixed part.
+     * @param position position to start read.
+     * @return the {@link InternalRegion} that read from this channel.
+     */
+    public static InternalRegion readRegionFromFile(
+            FileChannel channel, ByteBuffer fixedRegionBuffer, long position) throws IOException {
+        fixedRegionBuffer.clear();
+        BufferReaderWriterUtil.readByteBufferFully(channel, fixedRegionBuffer, position);
+        fixedRegionBuffer.flip();
+        int firstBufferIndex = fixedRegionBuffer.getInt();
+        int numBuffers = fixedRegionBuffer.getInt();
+        long firstBufferOffset = fixedRegionBuffer.getLong();
+        ByteBuffer variablePart = allocateAndConfigureBuffer(numBuffers);
+        BufferReaderWriterUtil.readByteBufferFully(
+                channel, variablePart, position + InternalRegion.FIXED_SIZE);
+        boolean[] released = new boolean[numBuffers];
+        variablePart.flip();
+        for (int i = 0; i < numBuffers; i++) {
+            released[i] = variablePart.get() != 0;
+        }
+        return new InternalRegion(firstBufferIndex, firstBufferOffset, numBuffers, released);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskmanager/NettyShuffleEnvironmentConfiguration.java
@@ -99,6 +99,10 @@ public class NettyShuffleEnvironmentConfiguration {
 
     private final int maxOverdraftBuffersPerGate;
 
+    private final int hybridShuffleSpilledIndexSegmentSize;
+
+    private final long hybridShuffleNumRetainedInMemoryRegionsMax;
+
     public NettyShuffleEnvironmentConfiguration(
             int numNetworkBuffers,
             int networkBufferSize,
@@ -120,7 +124,9 @@ public class NettyShuffleEnvironmentConfiguration {
             BufferDebloatConfiguration debloatConfiguration,
             int maxNumberOfConnections,
             boolean connectionReuseEnabled,
-            int maxOverdraftBuffersPerGate) {
+            int maxOverdraftBuffersPerGate,
+            int hybridShuffleSpilledIndexSegmentSize,
+            long hybridShuffleNumRetainedInMemoryRegionsMax) {
 
         this.numNetworkBuffers = numNetworkBuffers;
         this.networkBufferSize = networkBufferSize;
@@ -143,6 +149,9 @@ public class NettyShuffleEnvironmentConfiguration {
         this.maxNumberOfConnections = maxNumberOfConnections;
         this.connectionReuseEnabled = connectionReuseEnabled;
         this.maxOverdraftBuffersPerGate = maxOverdraftBuffersPerGate;
+        this.hybridShuffleSpilledIndexSegmentSize = hybridShuffleSpilledIndexSegmentSize;
+        this.hybridShuffleNumRetainedInMemoryRegionsMax =
+                hybridShuffleNumRetainedInMemoryRegionsMax;
     }
 
     // ------------------------------------------------------------------------
@@ -233,6 +242,14 @@ public class NettyShuffleEnvironmentConfiguration {
 
     public int getMaxOverdraftBuffersPerGate() {
         return maxOverdraftBuffersPerGate;
+    }
+
+    public long getHybridShuffleNumRetainedInMemoryRegionsMax() {
+        return hybridShuffleNumRetainedInMemoryRegionsMax;
+    }
+
+    public int getHybridShuffleSpilledIndexSegmentSize() {
+        return hybridShuffleSpilledIndexSegmentSize;
     }
 
     // ------------------------------------------------------------------------
@@ -333,6 +350,15 @@ public class NettyShuffleEnvironmentConfiguration {
                 configuration.get(
                         NettyShuffleEnvironmentOptions.TCP_CONNECTION_REUSE_ACROSS_JOBS_ENABLED);
 
+        int hybridShuffleSpilledIndexSegmentSize =
+                configuration.get(
+                        NettyShuffleEnvironmentOptions.HYBRID_SHUFFLE_SPILLED_INDEX_SEGMENT_SIZE);
+
+        long hybridShuffleNumRetainedInMemoryRegionsMax =
+                configuration.get(
+                        NettyShuffleEnvironmentOptions
+                                .HYBRID_SHUFFLE_NUM_RETAINED_IN_MEMORY_REGIONS_MAX);
+
         return new NettyShuffleEnvironmentConfiguration(
                 numberOfNetworkBuffers,
                 pageSize,
@@ -354,7 +380,9 @@ public class NettyShuffleEnvironmentConfiguration {
                 BufferDebloatConfiguration.fromConfiguration(configuration),
                 maxNumConnections,
                 connectionReuseEnabled,
-                maxOverdraftBuffersPerGate);
+                maxOverdraftBuffersPerGate,
+                hybridShuffleSpilledIndexSegmentSize,
+                hybridShuffleNumRetainedInMemoryRegionsMax);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -88,6 +88,10 @@ public class NettyShuffleEnvironmentBuilder {
 
     private int maxNumberOfConnections = 1;
 
+    private long hybridShuffleNumRetainedInMemoryRegionsMax = Long.MAX_VALUE;
+
+    private int hybridShuffleSpilledIndexSegmentSize = 256;
+
     public NettyShuffleEnvironmentBuilder setTaskManagerLocation(ResourceID taskManagerLocation) {
         this.taskManagerLocation = taskManagerLocation;
         return this;
@@ -204,6 +208,19 @@ public class NettyShuffleEnvironmentBuilder {
         return this;
     }
 
+    public NettyShuffleEnvironmentBuilder setHybridShuffleNumRetainedInMemoryRegionsMax(
+            long hybridShuffleNumRetainedInMemoryRegionsMax) {
+        this.hybridShuffleNumRetainedInMemoryRegionsMax =
+                hybridShuffleNumRetainedInMemoryRegionsMax;
+        return this;
+    }
+
+    public NettyShuffleEnvironmentBuilder setHybridShuffleSpilledIndexSegmentSize(
+            int hybridShuffleSpilledIndexSegmentSize) {
+        this.hybridShuffleSpilledIndexSegmentSize = hybridShuffleSpilledIndexSegmentSize;
+        return this;
+    }
+
     public NettyShuffleEnvironment build() {
         return NettyShuffleServiceFactory.createNettyShuffleEnvironment(
                 new NettyShuffleEnvironmentConfiguration(
@@ -227,7 +244,9 @@ public class NettyShuffleEnvironmentBuilder {
                         debloatConfiguration,
                         maxNumberOfConnections,
                         connectionReuseEnabled,
-                        maxOverdraftBuffersPerGate),
+                        maxOverdraftBuffersPerGate,
+                        hybridShuffleSpilledIndexSegmentSize,
+                        hybridShuffleNumRetainedInMemoryRegionsMax),
                 taskManagerLocation,
                 new TaskEventDispatcher(),
                 resultPartitionManager,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionBuilder.java
@@ -85,6 +85,10 @@ public class ResultPartitionBuilder {
 
     private int maxOverdraftBuffersPerGate = 5;
 
+    private int hybridShuffleSpilledIndexSegmentSize = 256;
+
+    private long hybridShuffleNumRetainedInMemoryRegionsMax = Long.MAX_VALUE;
+
     public ResultPartitionBuilder setResultPartitionIndex(int partitionIndex) {
         this.partitionIndex = partitionIndex;
         return this;
@@ -218,6 +222,19 @@ public class ResultPartitionBuilder {
         return this;
     }
 
+    public ResultPartitionBuilder setHybridShuffleNumRetainedInMemoryRegionsMax(
+            long hybridShuffleNumRetainedInMemoryRegionsMax) {
+        this.hybridShuffleNumRetainedInMemoryRegionsMax =
+                hybridShuffleNumRetainedInMemoryRegionsMax;
+        return this;
+    }
+
+    public ResultPartitionBuilder setHybridShuffleSpilledIndexSegmentSize(
+            int hybridShuffleSpilledIndexSegmentSize) {
+        this.hybridShuffleSpilledIndexSegmentSize = hybridShuffleSpilledIndexSegmentSize;
+        return this;
+    }
+
     public ResultPartition build() {
         ResultPartitionFactory resultPartitionFactory =
                 new ResultPartitionFactory(
@@ -236,7 +253,9 @@ public class ResultPartitionBuilder {
                         sortShuffleMinBuffers,
                         sortShuffleMinParallelism,
                         sslEnabled,
-                        maxOverdraftBuffersPerGate);
+                        maxOverdraftBuffersPerGate,
+                        hybridShuffleSpilledIndexSegmentSize,
+                        hybridShuffleNumRetainedInMemoryRegionsMax);
 
         SupplierWithException<BufferPool, IOException> factory =
                 bufferPoolFactory.orElseGet(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -174,7 +174,9 @@ class ResultPartitionFactoryTest {
                         10,
                         sortShuffleMinParallelism,
                         false,
-                        0);
+                        0,
+                        256,
+                        Long.MAX_VALUE);
 
         final ResultPartitionDeploymentDescriptor descriptor =
                 new ResultPartitionDeploymentDescriptor(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexCacheTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.assertRegionEquals;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createAllUnreleasedRegions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsFileDataIndexCache}. */
+class HsFileDataIndexCacheTest {
+    private HsFileDataIndexCache indexCache;
+
+    private TestingFileDataIndexSpilledRegionManager spilledRegionManager;
+
+    private final int numSubpartitions = 1;
+
+    private static final int SPILLED_INDEX_SEGMENT_SIZE = 256;
+
+    private int numRetainedIndexEntry = 10;
+
+    @BeforeEach
+    void before(@TempDir Path tmpPath) throws Exception {
+        Path indexFilePath = Files.createFile(tmpPath.resolve(UUID.randomUUID().toString()));
+        indexCache =
+                new HsFileDataIndexCache(
+                        numSubpartitions,
+                        indexFilePath,
+                        numRetainedIndexEntry,
+                        SPILLED_INDEX_SEGMENT_SIZE,
+                        TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE);
+        spilledRegionManager =
+                TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE
+                        .getLastSpilledRegionManager();
+    }
+
+    @Test
+    void testPutAndGet() {
+        indexCache.put(0, createAllUnreleasedRegions(0, 0L, 3, 1));
+        Optional<InternalRegion> regionOpt = indexCache.get(0, 0);
+        assertThat(regionOpt)
+                .hasValueSatisfying(
+                        (region) -> {
+                            assertThat(region.getFirstBufferIndex()).isEqualTo(0);
+                            assertThat(region.getFirstBufferOffset()).isEqualTo(0);
+                            assertThat(region.getNumBuffers()).isEqualTo(3);
+                        });
+    }
+
+    @Test
+    void testCachedRegionRemovedWhenExceedsRetainedEntry(@TempDir Path tmpPath) throws Exception {
+        numRetainedIndexEntry = 3;
+        Path indexFilePath = Files.createFile(tmpPath.resolve(UUID.randomUUID().toString()));
+        indexCache =
+                new HsFileDataIndexCache(
+                        numSubpartitions,
+                        indexFilePath,
+                        numRetainedIndexEntry,
+                        SPILLED_INDEX_SEGMENT_SIZE,
+                        TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE);
+        spilledRegionManager =
+                TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE
+                        .getLastSpilledRegionManager();
+
+        // region 0, 1, 2
+        List<InternalRegion> regionList = createAllUnreleasedRegions(0, 0L, 3, 3);
+        indexCache.put(0, regionList);
+        assertThat(spilledRegionManager.getSpilledRegionSize(0)).isZero();
+
+        // number of regions exceeds numRetainedIndexEntry, trigger cache purge.
+        indexCache.put(0, createAllUnreleasedRegions(9, 9L, 3, 1));
+        assertThat(spilledRegionManager.getSpilledRegionSize(0)).isEqualTo(1);
+        InternalRegion region = spilledRegionManager.getRegion(0, 0);
+        assertThat(region).isNotNull();
+        assertRegionEquals(region, regionList.get(0));
+        // number of regions exceeds numRetainedIndexEntry, trigger cache purge.
+        indexCache.put(0, createAllUnreleasedRegions(12, 12L, 3, 1));
+        assertThat(spilledRegionManager.getSpilledRegionSize(0)).isEqualTo(2);
+        InternalRegion region2 = spilledRegionManager.getRegion(0, 3);
+        assertThat(region2).isNotNull();
+        assertRegionEquals(region2, regionList.get(1));
+    }
+
+    @Test
+    void testGetNonExistentRegion() {
+        Optional<InternalRegion> region = indexCache.get(0, 0);
+        // get a non-existent region.
+        assertThat(region).isNotPresent();
+    }
+
+    @Test
+    void testCacheLoadSpilledRegion(@TempDir Path tmpPath) throws Exception {
+        numRetainedIndexEntry = 1;
+        Path indexFilePath = Files.createFile(tmpPath.resolve(UUID.randomUUID().toString()));
+        indexCache =
+                new HsFileDataIndexCache(
+                        numSubpartitions,
+                        indexFilePath,
+                        numRetainedIndexEntry,
+                        SPILLED_INDEX_SEGMENT_SIZE,
+                        TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE);
+        spilledRegionManager =
+                TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE
+                        .getLastSpilledRegionManager();
+
+        indexCache.put(0, createAllUnreleasedRegions(0, 0L, 1, 2));
+        assertThat(spilledRegionManager.getSpilledRegionSize(0)).isEqualTo(1);
+
+        assertThat(spilledRegionManager.getFindRegionInvoked()).isZero();
+        Optional<InternalRegion> regionOpt = indexCache.get(0, 0);
+        assertThat(spilledRegionManager.getSpilledRegionSize(0)).isEqualTo(2);
+        assertThat(regionOpt).isPresent();
+        assertThat(spilledRegionManager.getFindRegionInvoked()).isEqualTo(1);
+        // previously get should already load this region to cache.
+        assertThat(indexCache.get(0, 0)).isPresent();
+        assertThat(spilledRegionManager.getFindRegionInvoked()).isEqualTo(1);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexCacheTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexCacheTest.java
@@ -54,7 +54,6 @@ class HsFileDataIndexCacheTest {
                         numSubpartitions,
                         indexFilePath,
                         numRetainedIndexEntry,
-                        SPILLED_INDEX_SEGMENT_SIZE,
                         TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE);
         spilledRegionManager =
                 TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE
@@ -83,7 +82,6 @@ class HsFileDataIndexCacheTest {
                         numSubpartitions,
                         indexFilePath,
                         numRetainedIndexEntry,
-                        SPILLED_INDEX_SEGMENT_SIZE,
                         TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE);
         spilledRegionManager =
                 TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE
@@ -124,7 +122,6 @@ class HsFileDataIndexCacheTest {
                         numSubpartitions,
                         indexFilePath,
                         numRetainedIndexEntry,
-                        SPILLED_INDEX_SEGMENT_SIZE,
                         TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE);
         spilledRegionManager =
                 TestingFileDataIndexSpilledRegionManager.Factory.INSTANCE

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexImplTest.java
@@ -25,7 +25,9 @@ import org.apache.flink.util.TestLoggerExtension;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,8 +44,10 @@ class HsFileDataIndexImplTest {
     private HsFileDataIndex hsDataIndex;
 
     @BeforeEach
-    void before() {
-        hsDataIndex = new HsFileDataIndexImpl(NUM_SUBPARTITIONS);
+    void before(@TempDir Path tempDir) throws Exception {
+        hsDataIndex =
+                new HsFileDataIndexImpl(
+                        NUM_SUBPARTITIONS, tempDir.resolve(".index"), 256, Long.MAX_VALUE);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManagerImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataIndexSpilledRegionManagerImplTest.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.channels.FileChannel;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.assertRegionEquals;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createAllUnreleasedRegions;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createSingleUnreleasedRegion;
+import static org.apache.flink.runtime.io.network.partition.hybrid.InternalRegionWriteReadUtils.allocateAndConfigureBuffer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link HsFileDataIndexSpilledRegionManagerImpl}. */
+class HsFileDataIndexSpilledRegionManagerImplTest {
+    private Path indexFilePath;
+
+    @BeforeEach
+    void before(@TempDir Path tmpPath) {
+        indexFilePath = tmpPath.resolve(UUID.randomUUID().toString());
+    }
+
+    @Test
+    void testFindNonExistentRegion() throws Exception {
+        CompletableFuture<Void> cachedRegionFuture = new CompletableFuture<>();
+        try (HsFileDataIndexSpilledRegionManager spilledRegionManager =
+                createSpilledRegionManager(
+                        (ignore1, ignore2) -> cachedRegionFuture.complete(null))) {
+            long regionOffset = spilledRegionManager.findRegion(0, 0, true);
+            assertThat(regionOffset).isEqualTo(-1);
+            assertThat(cachedRegionFuture).isNotCompleted();
+        }
+    }
+
+    @Test
+    void testAppendOrOverwriteRegion() throws Exception {
+        CompletableFuture<Void> cachedRegionFuture = new CompletableFuture<>();
+        try (HsFileDataIndexSpilledRegionManager spilledRegionManager =
+                createSpilledRegionManager(
+                        (ignore1, ignore2) -> cachedRegionFuture.complete(null))) {
+            InternalRegion region = createSingleUnreleasedRegion(0, 0L, 1);
+            // append region to index file.
+            spilledRegionManager.appendOrOverwriteRegion(0, region);
+            assertThat(cachedRegionFuture).isNotCompleted();
+            FileChannel indexFileChannel = FileChannel.open(indexFilePath, StandardOpenOption.READ);
+            InternalRegion readRegion =
+                    InternalRegionWriteReadUtils.readRegionFromFile(
+                            indexFileChannel,
+                            allocateAndConfigureBuffer(InternalRegion.FIXED_SIZE),
+                            0L);
+            assertRegionEquals(readRegion, region);
+
+            // new region must have the same size of old region.
+            InternalRegion newRegion = createSingleUnreleasedRegion(0, 10L, 1);
+            // overwrite old region.
+            spilledRegionManager.appendOrOverwriteRegion(0, newRegion);
+            // appendOrOverwriteRegion will not trigger cache load.
+            assertThat(cachedRegionFuture).isNotCompleted();
+            InternalRegion readNewRegion =
+                    InternalRegionWriteReadUtils.readRegionFromFile(
+                            indexFileChannel,
+                            allocateAndConfigureBuffer(InternalRegion.FIXED_SIZE),
+                            0L);
+            assertRegionEquals(readNewRegion, newRegion);
+        }
+    }
+
+    @Test
+    void testWriteMoreThanOneSegment() throws Exception {
+        List<InternalRegion> regions = createAllUnreleasedRegions(0, 0L, 2, 2);
+        int segmentSize = regions.stream().mapToInt(InternalRegion::getSize).sum() + 1;
+        try (HsFileDataIndexSpilledRegionManager spilledRegionManager =
+                createSpilledRegionManager(segmentSize, (ignore1, ignore2) -> {})) {
+            spilledRegionManager.appendOrOverwriteRegion(0, regions.get(0));
+            spilledRegionManager.appendOrOverwriteRegion(0, regions.get(1));
+            // segment has no enough space, will start new segment.
+            InternalRegion regionInNewSegment = createSingleUnreleasedRegion(4, 4L, 2);
+            spilledRegionManager.appendOrOverwriteRegion(0, regionInNewSegment);
+            FileChannel indexFileChannel = FileChannel.open(indexFilePath, StandardOpenOption.READ);
+            InternalRegion readRegion =
+                    InternalRegionWriteReadUtils.readRegionFromFile(
+                            indexFileChannel,
+                            allocateAndConfigureBuffer(InternalRegion.FIXED_SIZE),
+                            // offset is segment size instead of two regions size to prove that new
+                            // segment is started.
+                            segmentSize);
+            assertRegionEquals(readRegion, regionInNewSegment);
+        }
+    }
+
+    @Test
+    void testWriteBigRegion() throws Exception {
+        int segmentSize = 4;
+        try (HsFileDataIndexSpilledRegionManager spilledRegionManager =
+                createSpilledRegionManager(segmentSize, (ignore1, ignore2) -> {})) {
+            List<InternalRegion> regions = createAllUnreleasedRegions(0, 0L, 1, 2);
+            InternalRegion region1 = regions.get(0);
+            InternalRegion region2 = regions.get(1);
+            assertThat(region1.getSize()).isGreaterThan(segmentSize);
+            assertThat(region2.getSize()).isGreaterThan(segmentSize);
+
+            spilledRegionManager.appendOrOverwriteRegion(0, region1);
+            spilledRegionManager.appendOrOverwriteRegion(0, region2);
+            FileChannel indexFileChannel = FileChannel.open(indexFilePath, StandardOpenOption.READ);
+            InternalRegion readRegion1 =
+                    InternalRegionWriteReadUtils.readRegionFromFile(
+                            indexFileChannel,
+                            allocateAndConfigureBuffer(InternalRegion.FIXED_SIZE),
+                            0L);
+            assertRegionEquals(readRegion1, region1);
+
+            InternalRegion readRegion2 =
+                    InternalRegionWriteReadUtils.readRegionFromFile(
+                            indexFileChannel,
+                            allocateAndConfigureBuffer(InternalRegion.FIXED_SIZE),
+                            readRegion1.getSize());
+            assertRegionEquals(readRegion2, region2);
+        }
+    }
+
+    @Test
+    void testFindRegionFirstBufferIndexInMultipleSegments() throws Exception {
+        final int numBuffersPerRegion = 2;
+        final int subpartition = 0;
+        CompletableFuture<InternalRegion> regionFuture = new CompletableFuture<>();
+        try (HsFileDataIndexSpilledRegionManager spilledRegionManager =
+                createSpilledRegionManager(
+                        // every segment can store two regions.
+                        (InternalRegion.FIXED_SIZE + numBuffersPerRegion) * 2,
+                        (ignore, region) -> regionFuture.complete(region))) {
+            // segment1: region1(0-2), region2(9-11), min:0, max: 11
+            spilledRegionManager.appendOrOverwriteRegion(
+                    subpartition, createSingleUnreleasedRegion(0, 0L, numBuffersPerRegion));
+            spilledRegionManager.appendOrOverwriteRegion(
+                    subpartition, createSingleUnreleasedRegion(9, 9L, numBuffersPerRegion));
+
+            // segment2: region1(2-4), region2(11-13) min: 2, max: 13
+            InternalRegion targetRegion = createSingleUnreleasedRegion(2, 2L, 2);
+            spilledRegionManager.appendOrOverwriteRegion(subpartition, targetRegion);
+            spilledRegionManager.appendOrOverwriteRegion(
+                    subpartition, createSingleUnreleasedRegion(11, 11L, 2));
+
+            // segment3: region1(7-9) min: 7, max: 9
+            spilledRegionManager.appendOrOverwriteRegion(
+                    subpartition, createSingleUnreleasedRegion(7, 7L, 2));
+
+            // find target region
+            long regionOffset = spilledRegionManager.findRegion(subpartition, 3, true);
+            assertThat(regionOffset).isNotEqualTo(-1L);
+            assertThat(regionFuture).isCompleted();
+            assertRegionEquals(regionFuture.get(), targetRegion);
+        }
+    }
+
+    private HsFileDataIndexSpilledRegionManager createSpilledRegionManager(
+            BiConsumer<Integer, InternalRegion> cacheRegionConsumer) {
+        return createSpilledRegionManager(256, cacheRegionConsumer);
+    }
+
+    private HsFileDataIndexSpilledRegionManager createSpilledRegionManager(
+            int segmentSize, BiConsumer<Integer, InternalRegion> cacheRegionConsumer) {
+        int numSubpartitions = 2;
+        return HsFileDataIndexSpilledRegionManagerImpl.Factory.INSTANCE.create(
+                numSubpartitions, indexFilePath, segmentSize, cacheRegionConsumer);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManagerTest.java
@@ -96,7 +96,8 @@ class HsFileDataManagerTest {
                 new HsFileDataManager(
                         bufferPool,
                         ioExecutor,
-                        new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
+                        new HsFileDataIndexImpl(
+                                NUM_SUBPARTITIONS, tempDir.resolve(".index"), 256, Long.MAX_VALUE),
                         dataFilePath,
                         factory,
                         HybridShuffleConfiguration.builder(
@@ -218,7 +219,7 @@ class HsFileDataManagerTest {
     }
 
     @Test
-    void testRunRequestBufferTimeout() throws Exception {
+    void testRunRequestBufferTimeout(@TempDir Path tempDir) throws Exception {
         Duration bufferRequestTimeout = Duration.ofSeconds(3);
 
         // request all buffer first.
@@ -229,7 +230,8 @@ class HsFileDataManagerTest {
                 new HsFileDataManager(
                         bufferPool,
                         ioExecutor,
-                        new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
+                        new HsFileDataIndexImpl(
+                                NUM_SUBPARTITIONS, tempDir.resolve(".index"), 256, Long.MAX_VALUE),
                         dataFilePath,
                         factory,
                         HybridShuffleConfiguration.builder(
@@ -351,7 +353,7 @@ class HsFileDataManagerTest {
      * release subpartition reader and subpartition reader fail should not be inside lock.
      */
     @Test
-    void testConsumeWhileReleaseNoDeadlock() throws Exception {
+    void testConsumeWhileReleaseNoDeadlock(@TempDir Path tempDir) throws Exception {
         CompletableFuture<Void> consumerStart = new CompletableFuture<>();
         CompletableFuture<Void> readerFail = new CompletableFuture<>();
         HsSubpartitionConsumer subpartitionView =
@@ -363,7 +365,8 @@ class HsFileDataManagerTest {
                         DEFAULT,
                         dataFileChannel,
                         subpartitionView,
-                        new HsFileDataIndexImpl(NUM_SUBPARTITIONS),
+                        new HsFileDataIndexImpl(
+                                NUM_SUBPARTITIONS, tempDir.resolve(".index"), 256, Long.MAX_VALUE),
                         5,
                         fileDataManager::releaseSubpartitionReader,
                         BufferReaderWriterUtil.allocatedHeaderBuffer()) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsMemoryDataManagerTest.java
@@ -55,9 +55,12 @@ class HsMemoryDataManagerTest {
 
     private Path dataFilePath;
 
+    private Path indexFilePath;
+
     @BeforeEach
     void before(@TempDir Path tempDir) {
         this.dataFilePath = tempDir.resolve(".data");
+        this.indexFilePath = tempDir.resolve(".index");
     }
 
     @Test
@@ -242,7 +245,9 @@ class HsMemoryDataManagerTest {
 
     private HsMemoryDataManager createMemoryDataManager(HsSpillingStrategy spillStrategy)
             throws Exception {
-        return createMemoryDataManager(spillStrategy, new HsFileDataIndexImpl(NUM_SUBPARTITIONS));
+        return createMemoryDataManager(
+                spillStrategy,
+                new HsFileDataIndexImpl(NUM_SUBPARTITIONS, indexFilePath, 256, Long.MAX_VALUE));
     }
 
     private HsMemoryDataManager createMemoryDataManager(
@@ -255,7 +260,9 @@ class HsMemoryDataManagerTest {
     private HsMemoryDataManager createMemoryDataManager(
             HsSpillingStrategy spillingStrategy, BufferPool bufferPool) throws Exception {
         return createMemoryDataManager(
-                bufferPool, spillingStrategy, new HsFileDataIndexImpl(NUM_SUBPARTITIONS));
+                bufferPool,
+                spillingStrategy,
+                new HsFileDataIndexImpl(NUM_SUBPARTITIONS, indexFilePath, 256, Long.MAX_VALUE));
     }
 
     private HsMemoryDataManager createMemoryDataManager(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionFileReaderImplTest.java
@@ -79,14 +79,17 @@ class HsSubpartitionFileReaderImplTest {
 
     private FileChannel dataFileChannel;
 
+    private Path indexFilePath;
+
     private long currentFileOffset;
 
     @BeforeEach
     void before(@TempDir Path tempPath) throws Exception {
         random = new Random();
         Path dataFilePath = Files.createFile(tempPath.resolve(UUID.randomUUID().toString()));
+        indexFilePath = tempPath.resolve(UUID.randomUUID().toString());
         dataFileChannel = openFileChannel(dataFilePath);
-        diskIndex = new HsFileDataIndexImpl(1);
+        diskIndex = createDataIndex(1, indexFilePath);
         subpartitionOperation = new TestingSubpartitionConsumerInternalOperation();
         currentFileOffset = 0L;
     }
@@ -97,8 +100,8 @@ class HsSubpartitionFileReaderImplTest {
     }
 
     @Test
-    void testReadBuffer() throws Exception {
-        diskIndex = new HsFileDataIndexImpl(2);
+    void testReadBuffer(@TempDir Path tmpPath) throws Exception {
+        diskIndex = createDataIndex(2, tmpPath.resolve(".index"));
         TestingSubpartitionConsumerInternalOperation viewNotifier1 =
                 new TestingSubpartitionConsumerInternalOperation();
         TestingSubpartitionConsumerInternalOperation viewNotifier2 =
@@ -135,13 +138,14 @@ class HsSubpartitionFileReaderImplTest {
 
     @ParameterizedTest
     @ValueSource(strings = {"LZ4", "LZO", "ZSTD"})
-    void testReadBufferCompressed(String compressionFactoryName) throws Exception {
+    void testReadBufferCompressed(String compressionFactoryName, @TempDir Path tmpPath)
+            throws Exception {
         BufferCompressor bufferCompressor =
                 new BufferCompressor(bufferSize, compressionFactoryName);
         BufferDecompressor bufferDecompressor =
                 new BufferDecompressor(bufferSize, compressionFactoryName);
 
-        diskIndex = new HsFileDataIndexImpl(1);
+        diskIndex = createDataIndex(1, tmpPath.resolve(".index"));
         TestingSubpartitionConsumerInternalOperation viewNotifier =
                 new TestingSubpartitionConsumerInternalOperation();
         HsSubpartitionFileReaderImpl fileReader1 = createSubpartitionFileReader(0, viewNotifier);
@@ -360,8 +364,8 @@ class HsSubpartitionFileReaderImplTest {
     }
 
     @Test
-    void testCompareTo() throws Exception {
-        diskIndex = new HsFileDataIndexImpl(2);
+    void testCompareTo(@TempDir Path tempPath) throws Exception {
+        diskIndex = createDataIndex(2, tempPath.resolve(".index"));
         TestingSubpartitionConsumerInternalOperation viewNotifier1 =
                 new TestingSubpartitionConsumerInternalOperation();
         TestingSubpartitionConsumerInternalOperation viewNotifier2 =
@@ -600,6 +604,10 @@ class HsSubpartitionFileReaderImplTest {
                 MAX_BUFFERS_READ_AHEAD,
                 (ignore) -> {},
                 BufferReaderWriterUtil.allocatedHeaderBuffer());
+    }
+
+    private HsFileDataIndexImpl createDataIndex(int numSubpartitions, Path indexFilePath) {
+        return new HsFileDataIndexImpl(numSubpartitions, indexFilePath, 256, Long.MAX_VALUE);
     }
 
     private static FileChannel openFileChannel(Path path) throws IOException {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/HsSubpartitionViewTest.java
@@ -113,7 +113,8 @@ class HsSubpartitionViewTest {
                         bufferSize,
                         bufferPool,
                         spillingStrategy,
-                        new HsFileDataIndexImpl(1),
+                        new HsFileDataIndexImpl(
+                                1, dataFilePath.resolve(".index"), 256, Long.MAX_VALUE),
                         dataFilePath.resolve(".data"),
                         null,
                         0);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/InternalRegionWriteReadUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/InternalRegionWriteReadUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.UUID;
+
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion.FIXED_SIZE;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.assertRegionEquals;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createSingleUnreleasedRegion;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link InternalRegionWriteReadUtils}. */
+class InternalRegionWriteReadUtilsTest {
+    @Test
+    void testAllocateAndConfigureBuffer() {
+        final int bufferSize = 16;
+        ByteBuffer buffer = InternalRegionWriteReadUtils.allocateAndConfigureBuffer(bufferSize);
+        assertThat(buffer.capacity()).isEqualTo(16);
+        assertThat(buffer.limit()).isEqualTo(16);
+        assertThat(buffer.position()).isZero();
+        assertThat(buffer.isDirect()).isTrue();
+        assertThat(buffer.order()).isEqualTo(ByteOrder.nativeOrder());
+    }
+
+    @Test
+    void testReadPrematureEndOfFile(@TempDir Path tmpPath) throws Exception {
+        FileChannel channel = tmpFileChannel(tmpPath);
+        ByteBuffer buffer = InternalRegionWriteReadUtils.allocateAndConfigureBuffer(FIXED_SIZE);
+        InternalRegionWriteReadUtils.writeRegionToFile(
+                channel, buffer, createSingleUnreleasedRegion(0, 0L, 1));
+        channel.truncate(channel.position() - 1);
+        buffer.flip();
+        assertThatThrownBy(
+                        () -> InternalRegionWriteReadUtils.readRegionFromFile(channel, buffer, 0L))
+                .isInstanceOf(IOException.class);
+    }
+
+    @Test
+    void testWriteAndReadRegion(@TempDir Path tmpPath) throws Exception {
+        FileChannel channel = tmpFileChannel(tmpPath);
+        ByteBuffer buffer = InternalRegionWriteReadUtils.allocateAndConfigureBuffer(FIXED_SIZE);
+        InternalRegion region = createSingleUnreleasedRegion(10, 100L, 1);
+        InternalRegionWriteReadUtils.writeRegionToFile(channel, buffer, region);
+        buffer.flip();
+        InternalRegion readRegion =
+                InternalRegionWriteReadUtils.readRegionFromFile(channel, buffer, 0L);
+        assertRegionEquals(readRegion, region);
+    }
+
+    private static FileChannel tmpFileChannel(Path tempPath) throws IOException {
+        return FileChannel.open(
+                Files.createFile(tempPath.resolve(UUID.randomUUID().toString())),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.READ,
+                StandardOpenOption.WRITE);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/InternalRegionWriteReadUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/InternalRegionWriteReadUtilsTest.java
@@ -32,7 +32,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.UUID;
 
-import static org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion.FIXED_SIZE;
+import static org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion.HEADER_SIZE;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.assertRegionEquals;
 import static org.apache.flink.runtime.io.network.partition.hybrid.HybridShuffleTestUtils.createSingleUnreleasedRegion;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,7 +54,7 @@ class InternalRegionWriteReadUtilsTest {
     @Test
     void testReadPrematureEndOfFile(@TempDir Path tmpPath) throws Exception {
         FileChannel channel = tmpFileChannel(tmpPath);
-        ByteBuffer buffer = InternalRegionWriteReadUtils.allocateAndConfigureBuffer(FIXED_SIZE);
+        ByteBuffer buffer = InternalRegionWriteReadUtils.allocateAndConfigureBuffer(HEADER_SIZE);
         InternalRegionWriteReadUtils.writeRegionToFile(
                 channel, buffer, createSingleUnreleasedRegion(0, 0L, 1));
         channel.truncate(channel.position() - 1);
@@ -67,7 +67,7 @@ class InternalRegionWriteReadUtilsTest {
     @Test
     void testWriteAndReadRegion(@TempDir Path tmpPath) throws Exception {
         FileChannel channel = tmpFileChannel(tmpPath);
-        ByteBuffer buffer = InternalRegionWriteReadUtils.allocateAndConfigureBuffer(FIXED_SIZE);
+        ByteBuffer buffer = InternalRegionWriteReadUtils.allocateAndConfigureBuffer(HEADER_SIZE);
         InternalRegion region = createSingleUnreleasedRegion(10, 100L, 1);
         InternalRegionWriteReadUtils.writeRegionToFile(channel, buffer, region);
         buffer.flip();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingFileDataIndex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingFileDataIndex.java
@@ -60,6 +60,11 @@ public class TestingFileDataIndex implements HsFileDataIndex {
         markBufferReadableConsumer.accept(subpartitionId, bufferIndex);
     }
 
+    @Override
+    public void close() {
+        // do nothing.
+    }
+
     public static Builder builder() {
         return new Builder();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingFileDataIndexSpilledRegionManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingFileDataIndexSpilledRegionManager.java
@@ -100,7 +100,6 @@ public class TestingFileDataIndexSpilledRegionManager
         public HsFileDataIndexSpilledRegionManager create(
                 int numSubpartitions,
                 Path indexFilePath,
-                int segmentSize,
                 BiConsumer<Integer, InternalRegion> cacheRegionConsumer) {
             TestingFileDataIndexSpilledRegionManager testingFileDataIndexSpilledRegionManager =
                     new TestingFileDataIndexSpilledRegionManager(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingFileDataIndexSpilledRegionManager.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/hybrid/TestingFileDataIndexSpilledRegionManager.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.hybrid;
+
+import org.apache.flink.runtime.io.network.partition.hybrid.HsFileDataIndexImpl.InternalRegion;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.function.BiConsumer;
+
+/** Mock {@link HsFileDataIndexSpilledRegionManager} for testing. */
+public class TestingFileDataIndexSpilledRegionManager
+        implements HsFileDataIndexSpilledRegionManager {
+    private final List<TreeMap<Integer, InternalRegion>> regions;
+
+    private final BiConsumer<Integer, InternalRegion> cacheRegionConsumer;
+
+    private int findRegionInvoked = 0;
+
+    public TestingFileDataIndexSpilledRegionManager(
+            int numSubpartitions, BiConsumer<Integer, InternalRegion> cacheRegionConsumer) {
+        this.regions = new ArrayList<>();
+        this.cacheRegionConsumer = cacheRegionConsumer;
+        for (int i = 0; i < numSubpartitions; i++) {
+            regions.add(new TreeMap<>());
+        }
+    }
+
+    @Nullable
+    public InternalRegion getRegion(int subpartition, int bufferIndex) {
+        return regions.get(subpartition).get(bufferIndex);
+    }
+
+    public int getSpilledRegionSize(int subpartition) {
+        return regions.get(subpartition).size();
+    }
+
+    public int getFindRegionInvoked() {
+        return findRegionInvoked;
+    }
+
+    @Override
+    public void appendOrOverwriteRegion(int subpartition, InternalRegion region)
+            throws IOException {
+        regions.get(subpartition).put(region.getFirstBufferIndex(), region);
+    }
+
+    @Override
+    public long findRegion(int subpartition, int bufferIndex, boolean loadToCache) {
+        findRegionInvoked++;
+        InternalRegion region = regions.get(subpartition).get(bufferIndex);
+        if (region == null) {
+            return -1;
+        } else {
+            // return non -1 value indicates this region is exists.
+            if (loadToCache) {
+                cacheRegionConsumer.accept(subpartition, region);
+            }
+            return 1;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        // do nothing.
+    }
+
+    /** Factory of {@link TestingFileDataIndexSpilledRegionManager}. */
+    public static class Factory implements HsFileDataIndexSpilledRegionManager.Factory {
+        public static final Factory INSTANCE = new Factory();
+
+        public TestingFileDataIndexSpilledRegionManager lastSpilledRegionManager;
+
+        public TestingFileDataIndexSpilledRegionManager getLastSpilledRegionManager() {
+            return lastSpilledRegionManager;
+        }
+
+        @Override
+        public HsFileDataIndexSpilledRegionManager create(
+                int numSubpartitions,
+                Path indexFilePath,
+                int segmentSize,
+                BiConsumer<Integer, InternalRegion> cacheRegionConsumer) {
+            TestingFileDataIndexSpilledRegionManager testingFileDataIndexSpilledRegionManager =
+                    new TestingFileDataIndexSpilledRegionManager(
+                            numSubpartitions, cacheRegionConsumer);
+            lastSpilledRegionManager = testingFileDataIndexSpilledRegionManager;
+            return testingFileDataIndexSpilledRegionManager;
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

*`HsFileDataIndex` is maintains in a list of treeMap(i.e. in memory), there is no problem in our 10T TPC-DS test. However, with the increase of job's data volume, the index will continue to grow, and there is a risk of OOM. We should support index data spilling and loading to avoid this problem.*


## Brief change log

  - *HsFileDataIndex supports caching and spilling index entry*

## Verifying this change

This change added unit tests .

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
