### PR TITLE
[FLINK-30425][runtime][security] Generalize token receive side

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -380,6 +380,7 @@ function check_logs_for_errors {
       | grep -v "Error sending fetch request" \
       | grep -v "WARN  akka.remote.ReliableDeliverySupervisor" \
       | grep -v "Options.*error_*" \
+      | grep -v "not packaged with this application" \
       | grep -ic "error" || true)
   if [[ ${error_count} -gt 0 ]]; then
     echo "Found error in log files; printing first 500 lines; see full logs for details:"

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenProvider.java
@@ -25,10 +25,16 @@ import java.util.Optional;
 
 /**
  * Delegation token provider API. Instances of {@link DelegationTokenProvider}s are loaded by {@link
- * DelegationTokenManager} through service loader.
+ * DelegationTokenManager} through service loader. Basically the implementation of this interface is
+ * responsible to produce the serialized form of tokens which will be handled by {@link
+ * DelegationTokenReceiver} instances both on JobManager and TaskManager side.
  */
 @Experimental
 public interface DelegationTokenProvider {
+
+    /** Config prefix of providers. */
+    String CONFIG_PREFIX = "security.delegation.token.provider";
+
     /** Container for obtained delegation tokens. */
     class ObtainedDelegationTokens {
         /** Serialized form of delegation tokens. */
@@ -56,6 +62,11 @@ public interface DelegationTokenProvider {
 
     /** Name of the service to provide delegation tokens. This name should be unique. */
     String serviceName();
+
+    /** Config prefix of the service. */
+    default String serviceConfigPrefix() {
+        return String.format("%s.%s", CONFIG_PREFIX, serviceName());
+    }
 
     /**
      * Called by {@link DelegationTokenManager} to initialize provider after construction.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiver.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * Delegation token receiver API. Instances of {@link DelegationTokenReceiver}s are loaded both on
+ * JobManager and TaskManager side through service loader. Basically the implementation of this
+ * interface is responsible to receive the serialized form of tokens produced by {@link
+ * DelegationTokenProvider}.
+ */
+@Experimental
+public interface DelegationTokenReceiver {
+
+    /** Config prefix of receivers. */
+    String CONFIG_PREFIX = "security.delegation.token.receiver";
+
+    /**
+     * Name of the service to receive delegation tokens for. This name should be unique and the same
+     * as the one provided in the corresponding {@link DelegationTokenProvider}.
+     */
+    String serviceName();
+
+    /** Config prefix of the service. */
+    default String serviceConfigPrefix() {
+        return String.format("%s.%s", CONFIG_PREFIX, serviceName());
+    }
+
+    /**
+     * Called to initialize receiver after construction.
+     *
+     * @param configuration Configuration to initialize the receiver.
+     */
+    void init(Configuration configuration) throws Exception;
+
+    /**
+     * Callback function when new delegation tokens obtained.
+     *
+     * @param tokens Serialized form of delegation tokens. Must be deserialized the reverse way
+     *     which is implemented in {@link DelegationTokenProvider}.
+     */
+    void onNewTokensObtained(byte[] tokens) throws Exception;
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepository.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepository.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.util.FlinkRuntimeException;
+import org.apache.flink.util.InstantiationUtil;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import static org.apache.flink.runtime.security.token.DefaultDelegationTokenManager.isProviderEnabled;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/** Repository for delegation token receivers. */
+@Internal
+public class DelegationTokenReceiverRepository {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(DelegationTokenReceiverRepository.class);
+
+    private final Configuration configuration;
+
+    @VisibleForTesting final Map<String, DelegationTokenReceiver> delegationTokenReceivers;
+
+    public DelegationTokenReceiverRepository(Configuration configuration) {
+        this.configuration = checkNotNull(configuration, "Flink configuration must not be null");
+        this.delegationTokenReceivers = loadReceivers();
+    }
+
+    private Map<String, DelegationTokenReceiver> loadReceivers() {
+        LOG.info("Loading delegation token receivers");
+
+        ServiceLoader<DelegationTokenReceiver> serviceLoader =
+                ServiceLoader.load(DelegationTokenReceiver.class);
+
+        Map<String, DelegationTokenReceiver> receivers = new HashMap<>();
+        for (DelegationTokenReceiver receiver : serviceLoader) {
+            try {
+                if (isProviderEnabled(configuration, receiver.serviceName())) {
+                    receiver.init(configuration);
+                    LOG.info(
+                            "Delegation token receiver {} loaded and initialized",
+                            receiver.serviceName());
+                    checkState(
+                            !receivers.containsKey(receiver.serviceName()),
+                            "Delegation token receiver with service name {} has multiple implementations",
+                            receiver.serviceName());
+                    receivers.put(receiver.serviceName(), receiver);
+                } else {
+                    LOG.info(
+                            "Delegation token receiver {} is disabled so not loaded",
+                            receiver.serviceName());
+                }
+            } catch (Exception | NoClassDefFoundError e) {
+                // The intentional general rule is that if a receiver's init method throws exception
+                // then stop the workload
+                LOG.error(
+                        "Failed to initialize delegation token receiver {}",
+                        receiver.serviceName(),
+                        e);
+                throw new FlinkRuntimeException(e);
+            }
+        }
+
+        LOG.info("Delegation token receivers loaded successfully");
+
+        return receivers;
+    }
+
+    @VisibleForTesting
+    boolean isReceiverLoaded(String serviceName) {
+        return delegationTokenReceivers.containsKey(serviceName);
+    }
+
+    /**
+     * Callback function when new delegation tokens obtained.
+     *
+     * @param containerBytes Serialized form of a DelegationTokenContainer. All the available tokens
+     *     will be forwarded to the appropriate {@link DelegationTokenReceiver} based on service
+     *     name.
+     */
+    public void onNewTokensObtained(byte[] containerBytes) throws Exception {
+        if (containerBytes == null || containerBytes.length == 0) {
+            throw new IllegalArgumentException("Illegal container tried to be processed");
+        }
+        DelegationTokenContainer container =
+                InstantiationUtil.deserializeObject(
+                        containerBytes, DelegationTokenContainer.class.getClassLoader());
+        onNewTokensObtained(container);
+    }
+
+    /**
+     * Callback function when new delegation tokens obtained.
+     *
+     * @param container Serialized form of delegation tokens stored in DelegationTokenContainer. All
+     *     the available tokens will be forwarded to the appropriate {@link DelegationTokenReceiver}
+     *     based on service name.
+     */
+    public void onNewTokensObtained(DelegationTokenContainer container) throws Exception {
+        LOG.info("New delegation tokens arrived, sending them to receivers");
+        for (Map.Entry<String, byte[]> entry : container.getTokens().entrySet()) {
+            String serviceName = entry.getKey();
+            byte[] tokens = entry.getValue();
+            if (!delegationTokenReceivers.containsKey(serviceName)) {
+                throw new IllegalStateException(
+                        "Tokens arrived for service but no receiver found for it: " + serviceName);
+            }
+            try {
+                delegationTokenReceivers.get(serviceName).onNewTokensObtained(tokens);
+            } catch (Exception e) {
+                LOG.warn("Failed to send tokens to delegation token receiver {}", serviceName, e);
+            }
+        }
+        LOG.info("Delegation tokens sent to receivers");
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HBaseDelegationTokenReceiver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HBaseDelegationTokenReceiver.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token.hadoop;
+
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Delegation token receiver implementation for HBase. Basically it would be good to move this to
+ * flink-connector-hbase-base but HBase connection can be made without the connector. All in all I
+ * tend to move this but that would be a breaking change.
+ */
+@Internal
+public class HBaseDelegationTokenReceiver extends HadoopDelegationTokenReceiver {
+
+    @Override
+    public String serviceName() {
+        return "hbase";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenReceiver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenReceiver.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token.hadoop;
+
+import org.apache.flink.annotation.Internal;
+
+/** Delegation token receiver for Hadoop filesystems. */
+@Internal
+public class HadoopFSDelegationTokenReceiver extends HadoopDelegationTokenReceiver {
+
+    @Override
+    public String serviceName() {
+        return "hadoopfs";
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunner.java
@@ -61,6 +61,7 @@ import org.apache.flink.runtime.rpc.RpcSystemUtils;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.security.SecurityConfiguration;
 import org.apache.flink.runtime.security.SecurityUtils;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
 import org.apache.flink.runtime.taskmanager.MemoryLogger;
 import org.apache.flink.runtime.util.ConfigurationParserUtils;
@@ -241,6 +242,9 @@ public class TaskManagerRunner implements FatalErrorHandler {
                     ExternalResourceUtils.createStaticExternalResourceInfoProviderFromConfig(
                             configuration, pluginManager);
 
+            final DelegationTokenReceiverRepository delegationTokenReceiverRepository =
+                    new DelegationTokenReceiverRepository(configuration);
+
             taskExecutorService =
                     taskExecutorServiceFactory.createTaskExecutor(
                             this.configuration,
@@ -253,7 +257,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                             false,
                             externalResourceInfoProvider,
                             workingDirectory.unwrap(),
-                            this);
+                            this,
+                            delegationTokenReceiverRepository);
 
             handleUnexpectedTaskExecutorServiceTermination();
 
@@ -552,7 +557,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
             boolean localCommunicationOnly,
             ExternalResourceInfoProvider externalResourceInfoProvider,
             WorkingDirectory workingDirectory,
-            FatalErrorHandler fatalErrorHandler)
+            FatalErrorHandler fatalErrorHandler,
+            DelegationTokenReceiverRepository delegationTokenReceiverRepository)
             throws Exception {
 
         final TaskExecutor taskExecutor =
@@ -567,7 +573,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                         localCommunicationOnly,
                         externalResourceInfoProvider,
                         workingDirectory,
-                        fatalErrorHandler);
+                        fatalErrorHandler,
+                        delegationTokenReceiverRepository);
 
         return TaskExecutorToServiceAdapter.createFor(taskExecutor);
     }
@@ -583,7 +590,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
             boolean localCommunicationOnly,
             ExternalResourceInfoProvider externalResourceInfoProvider,
             WorkingDirectory workingDirectory,
-            FatalErrorHandler fatalErrorHandler)
+            FatalErrorHandler fatalErrorHandler,
+            DelegationTokenReceiverRepository delegationTokenReceiverRepository)
             throws Exception {
 
         checkNotNull(configuration);
@@ -653,7 +661,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                 metricQueryServiceAddress,
                 taskExecutorBlobService,
                 fatalErrorHandler,
-                new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
+                new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()),
+                delegationTokenReceiverRepository);
     }
 
     /**
@@ -776,7 +785,8 @@ public class TaskManagerRunner implements FatalErrorHandler {
                 boolean localCommunicationOnly,
                 ExternalResourceInfoProvider externalResourceInfoProvider,
                 WorkingDirectory workingDirectory,
-                FatalErrorHandler fatalErrorHandler)
+                FatalErrorHandler fatalErrorHandler,
+                DelegationTokenReceiverRepository delegationTokenReceiverRepository)
                 throws Exception;
     }
 

--- a/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenReceiver
+++ b/flink-runtime/src/main/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenReceiver
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.runtime.security.token.hadoop.HadoopFSDelegationTokenReceiver
+org.apache.flink.runtime.security.token.hadoop.HBaseDelegationTokenReceiver

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManagerTest.java
@@ -22,16 +22,20 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.ManuallyTriggeredScheduledExecutorService;
 import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Clock;
 import java.time.ZoneId;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.time.Instant.ofEpochMilli;
 import static org.apache.flink.configuration.SecurityOptions.DELEGATION_TOKENS_RENEWAL_TIME_RATIO;
+import static org.apache.flink.runtime.security.token.DelegationTokenProvider.CONFIG_PREFIX;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,30 +47,28 @@ public class DefaultDelegationTokenManagerTest {
     @BeforeEach
     public void beforeEach() {
         ExceptionThrowingDelegationTokenProvider.reset();
+        ExceptionThrowingDelegationTokenReceiver.reset();
     }
 
-    @AfterAll
-    public static void afterAll() {
+    @AfterEach
+    public void afterEach() {
         ExceptionThrowingDelegationTokenProvider.reset();
+        ExceptionThrowingDelegationTokenReceiver.reset();
     }
 
     @Test
     public void isProviderEnabledMustGiveBackTrueByDefault() {
         Configuration configuration = new Configuration();
-        DefaultDelegationTokenManager delegationTokenManager =
-                new DefaultDelegationTokenManager(configuration, null, null);
 
-        assertTrue(delegationTokenManager.isProviderEnabled("test"));
+        assertTrue(DefaultDelegationTokenManager.isProviderEnabled(configuration, "test"));
     }
 
     @Test
     public void isProviderEnabledMustGiveBackFalseWhenDisabled() {
         Configuration configuration = new Configuration();
-        configuration.setBoolean("security.delegation.token.provider.test.enabled", false);
-        DefaultDelegationTokenManager delegationTokenManager =
-                new DefaultDelegationTokenManager(configuration, null, null);
+        configuration.setBoolean(CONFIG_PREFIX + ".test.enabled", false);
 
-        assertFalse(delegationTokenManager.isProviderEnabled("test"));
+        assertFalse(DefaultDelegationTokenManager.isProviderEnabled(configuration, "test"));
     }
 
     @Test
@@ -75,18 +77,86 @@ public class DefaultDelegationTokenManagerTest {
     }
 
     @Test
+    public void oneProviderThrowsExceptionMustFailFast() {
+        assertThrows(
+                Exception.class,
+                () -> {
+                    ExceptionThrowingDelegationTokenProvider.throwInInit = true;
+                    new DefaultDelegationTokenManager(new Configuration(), null, null);
+                });
+    }
+
+    @Test
     public void testAllProvidersLoaded() {
         Configuration configuration = new Configuration();
-        configuration.setBoolean("security.delegation.token.provider.throw.enabled", false);
+        configuration.setBoolean(CONFIG_PREFIX + ".throw.enabled", false);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(configuration, null, null);
 
         assertEquals(3, delegationTokenManager.delegationTokenProviders.size());
+
         assertTrue(delegationTokenManager.isProviderLoaded("hadoopfs"));
+        assertTrue(delegationTokenManager.isReceiverLoaded("hadoopfs"));
+
         assertTrue(delegationTokenManager.isProviderLoaded("hbase"));
+        assertTrue(delegationTokenManager.isReceiverLoaded("hbase"));
+
         assertTrue(delegationTokenManager.isProviderLoaded("test"));
+        assertTrue(delegationTokenManager.isReceiverLoaded("test"));
+
         assertTrue(ExceptionThrowingDelegationTokenProvider.constructed);
+        assertTrue(ExceptionThrowingDelegationTokenReceiver.constructed);
         assertFalse(delegationTokenManager.isProviderLoaded("throw"));
+        assertFalse(delegationTokenManager.isReceiverLoaded("throw"));
+    }
+
+    @Test
+    public void checkProviderAndReceiverConsistencyShouldNotThrowWhenNothingLoaded() {
+        DefaultDelegationTokenManager.checkProviderAndReceiverConsistency(
+                Collections.emptyMap(), Collections.emptyMap());
+    }
+
+    @Test
+    public void checkProviderAndReceiverConsistencyShouldThrowWhenMissingReceiver() {
+        Map<String, DelegationTokenProvider> providers = new HashMap<>();
+        providers.put("test", new TestDelegationTokenProvider());
+
+        IllegalStateException e =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                DefaultDelegationTokenManager.checkProviderAndReceiverConsistency(
+                                        providers, Collections.emptyMap()));
+        assertTrue(e.getMessage().contains("Missing receivers: test"));
+    }
+
+    @Test
+    public void checkProviderAndReceiverConsistencyShouldThrowWhenMissingProvider() {
+        Map<String, DelegationTokenReceiver> receivers = new HashMap<>();
+        receivers.put("test", new TestDelegationTokenReceiver());
+
+        IllegalStateException e =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                DefaultDelegationTokenManager.checkProviderAndReceiverConsistency(
+                                        Collections.emptyMap(), receivers));
+        assertTrue(e.getMessage().contains("Missing providers: test"));
+    }
+
+    @Test
+    public void checkProviderAndReceiverConsistencyShouldNotThrowWhenBothLoaded() {
+        Map<String, DelegationTokenProvider> providers = new HashMap<>();
+        providers.put("test", new TestDelegationTokenProvider());
+        Map<String, DelegationTokenReceiver> receivers = new HashMap<>();
+        receivers.put("test", new TestDelegationTokenReceiver());
+
+        DefaultDelegationTokenManager.checkProviderAndReceiverConsistency(providers, receivers);
+
+        assertEquals(1, providers.size());
+        assertTrue(providers.containsKey("test"));
+        assertEquals(1, receivers.size());
+        assertTrue(receivers.containsKey("test"));
     }
 
     @Test
@@ -98,7 +168,7 @@ public class DefaultDelegationTokenManagerTest {
 
         ExceptionThrowingDelegationTokenProvider.addToken = true;
         Configuration configuration = new Configuration();
-        configuration.setBoolean("security.delegation.token.provider.throw.enabled", true);
+        configuration.setBoolean(CONFIG_PREFIX + ".throw.enabled", true);
         AtomicInteger startTokensUpdateCallCount = new AtomicInteger(0);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(configuration, scheduledExecutor, scheduler) {
@@ -124,7 +194,7 @@ public class DefaultDelegationTokenManagerTest {
     @Test
     public void calculateRenewalDelayShouldConsiderRenewalRatio() {
         Configuration configuration = new Configuration();
-        configuration.setBoolean("security.delegation.token.provider.throw.enabled", false);
+        configuration.setBoolean(CONFIG_PREFIX + ".throw.enabled", false);
         configuration.set(DELEGATION_TOKENS_RENEWAL_TIME_RATIO, 0.5);
         DefaultDelegationTokenManager delegationTokenManager =
                 new DefaultDelegationTokenManager(configuration, null, null);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepositoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/DelegationTokenReceiverRepositoryTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.runtime.security.token.DelegationTokenProvider.CONFIG_PREFIX;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Test for {@link DelegationTokenReceiverRepository}. */
+class DelegationTokenReceiverRepositoryTest {
+
+    @BeforeEach
+    public void beforeEach() {
+        ExceptionThrowingDelegationTokenReceiver.reset();
+    }
+
+    @AfterEach
+    public void afterEach() {
+        ExceptionThrowingDelegationTokenReceiver.reset();
+    }
+
+    @Test
+    public void configurationIsNullMustFailFast() {
+        assertThrows(Exception.class, () -> new DelegationTokenReceiverRepository(null));
+    }
+
+    @Test
+    public void oneReceiverThrowsExceptionMustFailFast() {
+        assertThrows(
+                Exception.class,
+                () -> {
+                    ExceptionThrowingDelegationTokenReceiver.throwInInit = true;
+                    new DelegationTokenReceiverRepository(new Configuration());
+                });
+    }
+
+    @Test
+    public void testAllReceiversLoaded() {
+        Configuration configuration = new Configuration();
+        configuration.setBoolean(CONFIG_PREFIX + ".throw.enabled", false);
+        DelegationTokenReceiverRepository delegationTokenReceiverRepository =
+                new DelegationTokenReceiverRepository(configuration);
+
+        assertEquals(3, delegationTokenReceiverRepository.delegationTokenReceivers.size());
+        assertTrue(delegationTokenReceiverRepository.isReceiverLoaded("hadoopfs"));
+        assertTrue(delegationTokenReceiverRepository.isReceiverLoaded("hbase"));
+        assertTrue(delegationTokenReceiverRepository.isReceiverLoaded("test"));
+        assertTrue(ExceptionThrowingDelegationTokenReceiver.constructed);
+        assertFalse(delegationTokenReceiverRepository.isReceiverLoaded("throw"));
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenReceiver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/ExceptionThrowingDelegationTokenReceiver.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+
+/**
+ * An example implementation of {@link DelegationTokenReceiver} which throws exception when enabled.
+ */
+public class ExceptionThrowingDelegationTokenReceiver implements DelegationTokenReceiver {
+
+    public static volatile boolean throwInInit = false;
+    public static volatile boolean throwInUsage = false;
+    public static volatile boolean constructed = false;
+
+    public static void reset() {
+        throwInInit = false;
+        throwInUsage = false;
+        constructed = false;
+    }
+
+    public ExceptionThrowingDelegationTokenReceiver() {
+        constructed = true;
+    }
+
+    @Override
+    public String serviceName() {
+        return "throw";
+    }
+
+    @Override
+    public void init(Configuration configuration) {
+        if (throwInInit) {
+            throw new IllegalArgumentException();
+        }
+    }
+
+    @Override
+    public void onNewTokensObtained(byte[] tokens) throws Exception {
+        if (throwInUsage) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/TestDelegationTokenReceiver.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/TestDelegationTokenReceiver.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.security.token;
+
+import org.apache.flink.configuration.Configuration;
+
+/** An example implementation of {@link DelegationTokenReceiver} which does nothing. */
+public class TestDelegationTokenReceiver implements DelegationTokenReceiver {
+
+    @Override
+    public String serviceName() {
+        return "test";
+    }
+
+    @Override
+    public void init(Configuration configuration) throws Exception {}
+
+    @Override
+    public void onNewTokensObtained(byte[] tokens) throws Exception {}
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorBuilder.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.rest.util.NoOpFatalErrorHandler;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.util.concurrent.Executors;
 
 import javax.annotation.Nullable;
@@ -143,6 +144,9 @@ public class TaskExecutorBuilder {
             resolvedTaskManagerServices = taskManagerServices;
         }
 
+        final DelegationTokenReceiverRepository delegationTokenReceiverRepository =
+                new DelegationTokenReceiverRepository(configuration);
+
         return new TaskExecutor(
                 rpcService,
                 resolvedTaskManagerConfiguration,
@@ -154,7 +158,8 @@ public class TaskExecutorBuilder {
                 metricQueryServiceAddress,
                 resolvedTaskExecutorBlobService,
                 fatalErrorHandler,
-                partitionTracker);
+                partitionTracker,
+                delegationTokenReceiverRepository);
     }
 
     public static TaskExecutorBuilder newBuilder(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorExecutionDeploymentReconciliationTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.resourcemanager.ResourceManagerGateway;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.util.TestingFatalErrorHandlerResource;
@@ -251,7 +252,8 @@ public class TaskExecutorExecutionDeploymentReconciliationTest extends TestLogge
                 null,
                 NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandlerResource.getFatalErrorHandler(),
-                new TestingTaskExecutorPartitionTracker());
+                new TestingTaskExecutorPartitionTracker(),
+                new DelegationTokenReceiverRepository(configuration));
     }
 
     private static TaskDeploymentDescriptor createTaskDeploymentDescriptor(JobID jobId)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorPartitionLifecycleTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGateway;
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotTable;
@@ -599,7 +600,8 @@ public class TaskExecutorPartitionLifecycleTest extends TestLogger {
                 null,
                 NoOpTaskExecutorBlobService.INSTANCE,
                 new TestingFatalErrorHandler(),
-                partitionTracker);
+                partitionTracker,
+                new DelegationTokenReceiverRepository(configuration));
     }
 
     private static TaskSlotTable<Task> createTaskSlotTable() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorSlotLifetimeTest.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGate
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.TaskSlotUtils;
 import org.apache.flink.runtime.taskmanager.LocalUnresolvedTaskManagerLocation;
@@ -236,7 +237,8 @@ public class TaskExecutorSlotLifetimeTest extends TestLogger {
                 null,
                 NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandlerResource.getFatalErrorHandler(),
-                new TestingTaskExecutorPartitionTracker());
+                new TestingTaskExecutorPartitionTracker(),
+                new DelegationTokenReceiverRepository(configuration));
     }
 
     private TaskExecutorLocalStateStoresManager createTaskExecutorLocalStateStoresManager()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskExecutorTest.java
@@ -79,6 +79,7 @@ import org.apache.flink.runtime.resourcemanager.utils.TestingResourceManagerGate
 import org.apache.flink.runtime.rpc.RpcUtils;
 import org.apache.flink.runtime.rpc.TestingRpcService;
 import org.apache.flink.runtime.rpc.exceptions.RecipientUnreachableException;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.shuffle.ShuffleDescriptor;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
@@ -2818,7 +2819,8 @@ public class TaskExecutorTest extends TestLogger {
                 null,
                 NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandler,
-                taskExecutorPartitionTracker);
+                taskExecutorPartitionTracker,
+                new DelegationTokenReceiverRepository(configuration));
     }
 
     private TestingTaskExecutor createTestingTaskExecutor(TaskManagerServices taskManagerServices)
@@ -2853,7 +2855,8 @@ public class TaskExecutorTest extends TestLogger {
                 null,
                 NoOpTaskExecutorBlobService.INSTANCE,
                 testingFatalErrorHandler,
-                new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
+                new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()),
+                new DelegationTokenReceiverRepository(configuration));
     }
 
     private TaskExecutorTestingContext createTaskExecutorTestingContext(int numberOfSlots)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerStartupTest.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.metrics.scope.ScopeFormats;
 import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcServiceResource;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.testutils.WorkingDirectoryResource;
 import org.apache.flink.util.IOUtils;
 import org.apache.flink.util.TestLogger;
@@ -292,6 +293,7 @@ public class TaskManagerRunnerStartupTest extends TestLogger {
                 false,
                 ExternalResourceInfoProvider.NO_EXTERNAL_RESOURCES,
                 workingDirectory,
-                error -> {});
+                error -> {},
+                new DelegationTokenReceiverRepository(configuration));
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskManagerRunnerTest.java
@@ -35,6 +35,7 @@ import org.apache.flink.runtime.highavailability.HighAvailabilityServices;
 import org.apache.flink.runtime.metrics.MetricRegistry;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.TimeUtils;
@@ -276,7 +277,8 @@ public class TaskManagerRunnerTest extends TestLogger {
                 localCommunicationOnly,
                 externalResourceInfoProvider,
                 workingDirectory,
-                fatalErrorHandler) -> taskExecutorService;
+                fatalErrorHandler,
+                delegationTokenReceiverRepository) -> taskExecutorService;
     }
 
     private static Configuration createConfiguration() {
@@ -317,7 +319,8 @@ public class TaskManagerRunnerTest extends TestLogger {
                 boolean localCommunicationOnly,
                 ExternalResourceInfoProvider externalResourceInfoProvider,
                 WorkingDirectory workingDirectory,
-                FatalErrorHandler fatalErrorHandler) {
+                FatalErrorHandler fatalErrorHandler,
+                DelegationTokenReceiverRepository delegationTokenReceiverRepository) {
             return TestingTaskExecutorService.newBuilder()
                     .setStartRunnable(
                             () ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TaskSubmissionTestEnvironment.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.rpc.MainThreadExecutable;
 import org.apache.flink.runtime.rpc.RpcService;
 import org.apache.flink.runtime.rpc.TestingRpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 import org.apache.flink.runtime.shuffle.ShuffleEnvironment;
 import org.apache.flink.runtime.state.TaskExecutorLocalStateStoresManager;
 import org.apache.flink.runtime.taskexecutor.slot.DefaultTimerService;
@@ -268,7 +269,8 @@ class TaskSubmissionTestEnvironment implements AutoCloseable {
                 metricQueryServiceAddress,
                 taskExecutorBlobService,
                 testingFatalErrorHandler,
-                new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()));
+                new TaskExecutorPartitionTrackerImpl(taskManagerServices.getShuffleEnvironment()),
+                new DelegationTokenReceiverRepository(configuration));
     }
 
     private static ShuffleEnvironment<?, ?> createShuffleEnvironment(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskexecutor/TestingTaskExecutor.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.metrics.groups.TaskManagerMetricGroup;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.rpc.MainThreadExecutable;
 import org.apache.flink.runtime.rpc.RpcService;
+import org.apache.flink.runtime.security.token.DelegationTokenReceiverRepository;
 
 import javax.annotation.Nullable;
 
@@ -47,7 +48,8 @@ class TestingTaskExecutor extends TaskExecutor {
             @Nullable String metricQueryServiceAddress,
             TaskExecutorBlobService taskExecutorBlobService,
             FatalErrorHandler fatalErrorHandler,
-            TaskExecutorPartitionTracker partitionTracker) {
+            TaskExecutorPartitionTracker partitionTracker,
+            DelegationTokenReceiverRepository delegationTokenReceiverRepository) {
         super(
                 rpcService,
                 taskManagerConfiguration,
@@ -59,7 +61,8 @@ class TestingTaskExecutor extends TaskExecutor {
                 metricQueryServiceAddress,
                 taskExecutorBlobService,
                 fatalErrorHandler,
-                partitionTracker);
+                partitionTracker,
+                delegationTokenReceiverRepository);
     }
 
     @Override

--- a/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenReceiver
+++ b/flink-runtime/src/test/resources/META-INF/services/org.apache.flink.runtime.security.token.DelegationTokenReceiver
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.runtime.security.token.TestDelegationTokenReceiver
+org.apache.flink.runtime.security.token.ExceptionThrowingDelegationTokenReceiver

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterDescriptor.java
@@ -1300,9 +1300,12 @@ public class YarnClusterDescriptor implements ClusterDescriptor<ApplicationId> {
         DelegationTokenContainer container = new DelegationTokenContainer();
         delegationTokenManager.obtainDelegationTokens(container);
 
+        // This is here for backward compatibility to make log aggregation work
         Credentials credentials = new Credentials();
-        for (byte[] v : container.getTokens().values()) {
-            credentials.addAll(HadoopDelegationTokenConverter.deserialize(v));
+        for (Map.Entry<String, byte[]> e : container.getTokens().entrySet()) {
+            if (e.getKey().equals("hadoopfs")) {
+                credentials.addAll(HadoopDelegationTokenConverter.deserialize(e.getValue()));
+            }
         }
         ByteBuffer tokens = ByteBuffer.wrap(HadoopDelegationTokenConverter.serialize(credentials));
         containerLaunchContext.setTokens(tokens);


### PR DESCRIPTION
## What is the purpose of the change

Flink delegation token obtain side is generic already but on the receiver side there is still an assumption that only Hadoop tokens can come. In this PR I've introduced `DelegationTokenReceiver` interface which can be implemented by every.

## Brief change log

* Added `DelegationTokenReceiver` interface
* Added `HadoopFSDelegationTokenReceiver` for Hadoop FS
* Added `HBaseDelegationTokenReceiver` for HBase
* Added `DelegationTokenReceiverRepository` which loads all receivers, and propagates new tokens to them
* New/updated automated tests

## Verifying this change

Existing/new unit/integration tests + manually on [minikube](https://gist.github.com/gaborgsomogyi/ac4f71ead8494da2f5c35265bcb1e885).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
