### PR TITLE
fix(sec): upgrade org.apache.calcite:calcite-core to 1.32.0

### DIFF
--- a/flink-table/pom.xml
+++ b/flink-table/pom.xml
@@ -76,7 +76,7 @@ under the License.
 	</dependencyManagement>
 
 	<properties>
-		<calcite.version>1.28.0</calcite.version>
+		<calcite.version>1.32.0</calcite.version>
 		<!-- Calcite 1.28.0 depends on 3.1.6
 		 at the same time here it is a list of issues required to be fixed
 		 before movement to 3.1.x


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.calcite:calcite-core 1.28.0
- [CVE-2022-39135](https://www.oscs1024.com/hd/CVE-2022-39135)


### What did I do？
Upgrade org.apache.calcite:calcite-core from 1.28.0 to 1.32.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS