### PR TITLE
[FLINK-29721][hive] Supports native hive min function for hive dialect

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveMinAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveMinAggFunction.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.lessThan;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullOf;
+
+/** built-in hive min aggregate function. */
+public class HiveMinAggFunction extends HiveDeclarativeAggregateFunction {
+
+    private final UnresolvedReferenceExpression min = unresolvedRef("min");
+    private DataType resultType;
+
+    @Override
+    public int operandCount() {
+        return 1;
+    }
+
+    @Override
+    public UnresolvedReferenceExpression[] aggBufferAttributes() {
+        return new UnresolvedReferenceExpression[] {min};
+    }
+
+    @Override
+    public DataType[] getAggBufferTypes() {
+        return new DataType[] {getResultType()};
+    }
+
+    @Override
+    public DataType getResultType() {
+        return resultType;
+    }
+
+    @Override
+    public Expression[] initialValuesExpressions() {
+        return new Expression[] {
+            /* min */
+            nullOf(getResultType())
+        };
+    }
+
+    @Override
+    public Expression[] accumulateExpressions() {
+        return new Expression[] {
+            /* min = */ ifThenElse(
+                    isNull(operand(0)),
+                    min,
+                    ifThenElse(
+                            isNull(min),
+                            operand(0),
+                            ifThenElse(lessThan(operand(0), min), operand(0), min)))
+        };
+    }
+
+    @Override
+    public Expression[] retractExpressions() {
+        throw new TableException("Min aggregate function does not support retraction.");
+    }
+
+    @Override
+    public Expression[] mergeExpressions() {
+        return new Expression[] {
+            /* max = */ ifThenElse(
+                    isNull(mergeOperand(min)),
+                    min,
+                    ifThenElse(
+                            isNull(min),
+                            mergeOperand(min),
+                            ifThenElse(lessThan(mergeOperand(min), min), mergeOperand(min), min)))
+        };
+    }
+
+    @Override
+    public Expression getValueExpression() {
+        return min;
+    }
+
+    @Override
+    public void setArguments(CallContext callContext) {
+        if (resultType == null) {
+            // check argument type firstly
+            checkArgumentType(callContext.getArgumentDataTypes().get(0).getLogicalType());
+            resultType = callContext.getArgumentDataTypes().get(0);
+        }
+    }
+
+    private void checkArgumentType(LogicalType logicalType) {
+        // Flink doesn't support to compare nested type now, so here can't support it, see
+        // ScalarOperatorGens#generateComparison for more detail
+        if (logicalType.is(LogicalTypeRoot.ARRAY)
+                || logicalType.is(LogicalTypeRoot.MAP)
+                || logicalType.is(LogicalTypeRoot.ROW)) {
+            throw new TableException(
+                    String.format(
+                            "Hive native min aggregate function does not support type: '%s' now. Please re-check the data type.",
+                            logicalType.getTypeRoot()));
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveMinAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveMinAggFunction.java
@@ -87,7 +87,7 @@ public class HiveMinAggFunction extends HiveDeclarativeAggregateFunction {
     @Override
     public Expression[] mergeExpressions() {
         return new Expression[] {
-            /* max = */ ifThenElse(
+            /* min = */ ifThenElse(
                     isNull(mergeOperand(min)),
                     min,
                     ifThenElse(

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -85,7 +85,7 @@ public class HiveModule implements Module {
                                     "tumble_rowtime",
                                     "tumble_start")));
 
-    static final Set<String> FLINK_BUILT_IN_FUNC_FOR_HIVE =
+    static final Set<String> BUILTIN_NATIVE_AGG_FUNC =
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList("sum", "min")));
 
     private final HiveFunctionDefinitionFactory factory;
@@ -146,9 +146,8 @@ public class HiveModule implements Module {
         FunctionDefinitionFactory.Context context = () -> classLoader;
 
         // We override some Hive's function by native implementation to supports hash-agg
-        if (isNativeAggFunctionEnabled()
-                && FLINK_BUILT_IN_FUNC_FOR_HIVE.contains(name.toLowerCase())) {
-            return getFlinkBuiltInFunction(name.toLowerCase(), context);
+        if (isNativeAggFunctionEnabled() && BUILTIN_NATIVE_AGG_FUNC.contains(name.toLowerCase())) {
+            return getBuiltInNativeAggFunction(name.toLowerCase());
         }
 
         // We override Hive's grouping function. Refer to the implementation for more details.
@@ -202,8 +201,7 @@ public class HiveModule implements Module {
         return config.get(TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED);
     }
 
-    private Optional<FunctionDefinition> getFlinkBuiltInFunction(
-            String name, FunctionDefinitionFactory.Context context) {
+    private Optional<FunctionDefinition> getBuiltInNativeAggFunction(String name) {
         switch (name) {
             case "sum":
                 // We override Hive's sum function by native implementation to supports hash-agg
@@ -213,7 +211,8 @@ public class HiveModule implements Module {
                 return Optional.of(new HiveMinAggFunction());
             default:
                 throw new UnsupportedOperationException(
-                        "flink built-in hive function not support " + name + " yet!");
+                        String.format(
+                                "Built-in hive aggregate function doesn't support %s yet!", name));
         }
     }
 }

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -21,7 +21,6 @@ package org.apache.flink.connectors.hive;
 import org.apache.flink.table.HiveVersionTestUtil;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
-import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.GenericInMemoryCatalog;
 import org.apache.flink.table.catalog.hive.HiveCatalog;
@@ -39,7 +38,6 @@ import org.apache.flink.util.FileUtils;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
-import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -986,187 +984,6 @@ public class HiveDialectQueryITCase {
             tableEnv.executeSql("drop table t_bigint");
             tableEnv.executeSql("drop table t_array");
         }
-    }
-
-    @Test
-    public void testSimpleSumAggFunction() throws Exception {
-        tableEnv.executeSql(
-                "create table test_sum(x string, y string, z int, d decimal(10,5), e float, f double)");
-        tableEnv.executeSql(
-                        "insert into test_sum values (NULL, '2', 1, 1.11, 1.2, 1.3), "
-                                + "(NULL, 'b', 2, 2.22, 2.3, 2.4), "
-                                + "(NULL, '4', 3, 3.33, 3.5, 3.6), "
-                                + "(NULL, NULL, 4, 4.45, 4.7, 4.8)")
-                .await();
-
-        // test sum with all elements are null
-        List<Row> result =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select sum(x) from test_sum").collect());
-        assertThat(result.toString()).isEqualTo("[+I[null]]");
-
-        // test sum string type with partial element can't convert to double, result type is double
-        List<Row> result2 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select sum(y) from test_sum").collect());
-        assertThat(result2.toString()).isEqualTo("[+I[6.0]]");
-
-        // test decimal type
-        List<Row> result3 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select sum(d) from test_sum").collect());
-        assertThat(result3.toString()).isEqualTo("[+I[11.11000]]");
-
-        // test sum int, result type is bigint
-        List<Row> result4 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select sum(z) from test_sum").collect());
-        assertThat(result4.toString()).isEqualTo("[+I[10]]");
-
-        // test float type
-        List<Row> result5 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select sum(e) from test_sum").collect());
-        float actualFloatValue = ((Double) result5.get(0).getField(0)).floatValue();
-        assertThat(actualFloatValue).isEqualTo(11.7f);
-
-        // test double type
-        List<Row> result6 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select sum(f) from test_sum").collect());
-        actualFloatValue = ((Double) result6.get(0).getField(0)).floatValue();
-        assertThat(actualFloatValue).isEqualTo(12.1f);
-
-        // test sum string&int type simultaneously
-        List<Row> result7 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select sum(y), sum(z) from test_sum").collect());
-        assertThat(result7.toString()).isEqualTo("[+I[6.0, 10]]");
-
-        tableEnv.executeSql("drop table test_sum");
-    }
-
-    @Test
-    public void testSumAggWithGroupKey() throws Exception {
-        tableEnv.executeSql(
-                "create table test_sum_group(name string, num bigint, price decimal(10,5))");
-        tableEnv.executeSql(
-                        "insert into test_sum_group values ('tom', 2, 7.2), ('tony', 2, 23.7), ('tom', 10, 3.33), ('tony', 4, 4.45), ('nadal', 4, 10.455)")
-                .await();
-
-        List<Row> result =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql(
-                                        "select name, sum(num), sum(price),  sum(num * price) from test_sum_group group by name")
-                                .collect());
-        assertThat(result.toString())
-                .isEqualTo(
-                        "[+I[tom, 12, 10.53000, 47.70000], +I[tony, 6, 28.15000, 65.20000], +I[nadal, 4, 10.45500, 41.82000]]");
-
-        tableEnv.executeSql("drop table test_sum_group");
-    }
-
-    @Test
-    public void testMinAggFunction() throws Exception {
-        tableEnv.executeSql(
-                "create table test_min(a int, b boolean, x string, y string, z int, d decimal(10,5), e float, f double, ts timestamp, dt date, bar binary)");
-        tableEnv.executeSql(
-                        "insert into test_min values (1, true, NULL, '2', 1, 1.11, 1.2, 1.3, '2021-08-04 16:26:33.4','2021-08-04', 'data1'), "
-                                + "(1, false, NULL, 'b', 2, 2.22, 2.3, 2.4, '2021-08-06 16:26:33.4','2021-08-07', 'data2'), "
-                                + "(2, false, NULL, '4', 1, 3.33, 3.5, 3.6, '2021-08-08 16:26:33.4','2021-08-08', 'data3'), "
-                                + "(2, true, NULL, NULL, 4, 4.45, 4.7, 4.8, '2021-08-10 16:26:33.4','2021-08-01', 'data4')")
-                .await();
-
-        // test min with all elements are null
-        List<Row> result =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(x) from test_min").collect());
-        assertThat(result.toString()).isEqualTo("[+I[null]]");
-
-        // test min with some elements are null
-        List<Row> result2 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(y) from test_min").collect());
-        assertThat(result2.toString()).isEqualTo("[+I[2]]");
-
-        // test min with some elements repeated
-        List<Row> result3 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(z) from test_min").collect());
-        assertThat(result3.toString()).isEqualTo("[+I[1]]");
-
-        // test min with decimal type
-        List<Row> result4 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(d) from test_min").collect());
-        assertThat(result4.toString()).isEqualTo("[+I[1.11000]]");
-
-        // test min with float type
-        List<Row> result5 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(e) from test_min").collect());
-        assertThat(result5.toString()).isEqualTo("[+I[1.2]]");
-
-        // test min with double type
-        List<Row> result6 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(f) from test_min").collect());
-        assertThat(result6.toString()).isEqualTo("[+I[1.3]]");
-
-        // test min with boolean type
-        List<Row> result7 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(b) from test_min").collect());
-        assertThat(result7.toString()).isEqualTo("[+I[false]]");
-
-        // test min with timestamp type
-        List<Row> result8 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(ts) from test_min").collect());
-        assertThat(result8.toString()).isEqualTo("[+I[2021-08-04T16:26:33.400]]");
-
-        // test min with date type
-        List<Row> result9 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(dt) from test_min").collect());
-        assertThat(result9.toString()).isEqualTo("[+I[2021-08-01]]");
-
-        // test min with binary type
-        List<Row> result10 =
-                CollectionUtil.iteratorToList(
-                        tableEnv.executeSql("select min(bar) from test_min").collect());
-        assertThat(result10.toString()).isEqualTo("[+I[[100, 97, 116, 97, 49]]]");
-
-        tableEnv.executeSql("drop table test_min");
-
-        // test min with unsupported data type
-        tableEnv.executeSql(
-                "create table test_min_not_support_type(a array<int>,m map<int, string>,s struct<f1:int,f2:string>)");
-        // test min with row type
-        String expectedRowMessage =
-                "Hive native min aggregate function does not support type: 'ROW' now. Please re-check the data type.";
-        assertSqlException(
-                "select min(s) from test_min_not_support_type",
-                TableException.class,
-                expectedRowMessage);
-
-        // test min with array type
-        String expectedArrayMessage =
-                "Hive native min aggregate function does not support type: 'ARRAY' now. Please re-check the data type.";
-        assertSqlException(
-                "select min(a) from test_min_not_support_type",
-                TableException.class,
-                expectedArrayMessage);
-
-        // test min with map type, hive also does not support map type comparisons.
-        String expectedMapMessage =
-                "Cannot support comparison of map<> type or complex type containing map<>.";
-        assertSqlException(
-                "select min(m) from test_min_not_support_type",
-                UDFArgumentTypeException.class,
-                expectedMapMessage);
-
-        tableEnv.executeSql("drop table test_min_not_support_type");
     }
 
     private void runQFile(File qfile) throws Exception {

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -986,6 +986,172 @@ public class HiveDialectQueryITCase {
         }
     }
 
+    @Test
+    public void testSumAggFunctionPlan() {
+        // test explain
+        String actualPlan = explainSql("select x, sum(y) from foo group by x");
+        assertThat(actualPlan).isEqualTo(readFromResource("/explain/testSumAggFunctionPlan.out"));
+    }
+
+    @Test
+    public void testSimpleSumAggFunction() throws Exception {
+        tableEnv.executeSql(
+                "create table test_sum(x string, y string, z int, d decimal(10,5), e float, f double)");
+        tableEnv.executeSql(
+                        "insert into test_sum values (NULL, '2', 1, 1.11, 1.2, 1.3), "
+                                + "(NULL, 'b', 2, 2.22, 2.3, 2.4), "
+                                + "(NULL, '4', 3, 3.33, 3.5, 3.6), "
+                                + "(NULL, NULL, 4, 4.45, 4.7, 4.8)")
+                .await();
+
+        // test sum with all elements are null
+        List<Row> result =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select sum(x) from test_sum").collect());
+        assertThat(result.toString()).isEqualTo("[+I[null]]");
+
+        // test sum string type with partial element can't convert to double, result type is double
+        List<Row> result2 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select sum(y) from test_sum").collect());
+        assertThat(result2.toString()).isEqualTo("[+I[6.0]]");
+
+        // test decimal type
+        List<Row> result3 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select sum(d) from test_sum").collect());
+        assertThat(result3.toString()).isEqualTo("[+I[11.11000]]");
+
+        // test sum int, result type is bigint
+        List<Row> result4 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select sum(z) from test_sum").collect());
+        assertThat(result4.toString()).isEqualTo("[+I[10]]");
+
+        // test float type
+        List<Row> result5 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select sum(e) from test_sum").collect());
+        float actualFloatValue = ((Double) result5.get(0).getField(0)).floatValue();
+        assertThat(actualFloatValue).isEqualTo(11.7f);
+
+        // test double type
+        List<Row> result6 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select sum(f) from test_sum").collect());
+        actualFloatValue = ((Double) result6.get(0).getField(0)).floatValue();
+        assertThat(actualFloatValue).isEqualTo(12.1f);
+
+        // test sum string&int type simultaneously
+        List<Row> result7 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select sum(y), sum(z) from test_sum").collect());
+        assertThat(result7.toString()).isEqualTo("[+I[6.0, 10]]");
+
+        tableEnv.executeSql("drop table test_sum");
+    }
+
+    @Test
+    public void testSumAggWithGroupKey() throws Exception {
+        tableEnv.executeSql(
+                "create table test_sum_group(name string, num bigint, price decimal(10,5))");
+        tableEnv.executeSql(
+                        "insert into test_sum_group values ('tom', 2, 7.2), ('tony', 2, 23.7), ('tom', 10, 3.33), ('tony', 4, 4.45), ('nadal', 4, 10.455)")
+                .await();
+
+        List<Row> result =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql(
+                                        "select name, sum(num), sum(price),  sum(num * price) from test_sum_group group by name")
+                                .collect());
+        assertThat(result.toString())
+                .isEqualTo(
+                        "[+I[tom, 12, 10.53000, 47.70000], +I[tony, 6, 28.15000, 65.20000], +I[nadal, 4, 10.45500, 41.82000]]");
+
+        tableEnv.executeSql("drop table test_sum_group");
+    }
+
+    @Test
+    public void testMinAggFunctionPlan() {
+        // test explain
+        String actualPlan = explainSql("select x, min(y) from foo group by x");
+        assertThat(actualPlan).isEqualTo(readFromResource("/explain/testMinAggFunctionPlan.out"));
+    }
+
+    @Test
+    public void testMinAggFunction() throws Exception {
+        tableEnv.executeSql(
+                "create table test_min(a int, b boolean, x string, y string, z int, d decimal(10,5), e float, f double, ts timestamp, dt date, bar binary)");
+        tableEnv.executeSql(
+                        "insert into test_min values (1, true, NULL, '2', 1, 1.11, 1.2, 1.3, '2021-08-04 16:26:33.4','2021-08-04', 'data1'), "
+                                + "(1, false, NULL, 'b', 2, 2.22, 2.3, 2.4, '2021-08-06 16:26:33.4','2021-08-07', 'data2'), "
+                                + "(2, false, NULL, '4', 1, 3.33, 3.5, 3.6, '2021-08-08 16:26:33.4','2021-08-08', 'data3'), "
+                                + "(2, true, NULL, NULL, 4, 4.45, 4.7, 4.8, '2021-08-10 16:26:33.4','2021-08-01', 'data4')")
+                .await();
+
+        // test max with all elements are null
+        List<Row> result =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(x) from test_min").collect());
+        assertThat(result.toString()).isEqualTo("[+I[null]]");
+
+        // test max with some elements are null
+        List<Row> result2 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(y) from test_min").collect());
+        assertThat(result2.toString()).isEqualTo("[+I[2]]");
+
+        // test max with some elements repeated
+        List<Row> result3 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(z) from test_min").collect());
+        assertThat(result3.toString()).isEqualTo("[+I[1]]");
+
+        // test max with decimal type
+        List<Row> result4 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(d) from test_min").collect());
+        assertThat(result4.toString()).isEqualTo("[+I[1.11000]]");
+
+        // test max with float type
+        List<Row> result5 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(e) from test_min").collect());
+        assertThat(result5.toString()).isEqualTo("[+I[1.2]]");
+
+        // test max with double type
+        List<Row> result6 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(f) from test_min").collect());
+        assertThat(result6.toString()).isEqualTo("[+I[1.3]]");
+
+        // test max with boolean type
+        List<Row> result7 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(b) from test_min").collect());
+        assertThat(result7.toString()).isEqualTo("[+I[false]]");
+
+        // test max with timestamp type
+        List<Row> result8 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(ts) from test_min").collect());
+        assertThat(result8.toString()).isEqualTo("[+I[2021-08-04T16:26:33.400]]");
+
+        // test max with date type
+        List<Row> result9 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(dt) from test_min").collect());
+        assertThat(result9.toString()).isEqualTo("[+I[2021-08-01]]");
+
+        // test max with binary type
+        List<Row> result10 =
+                CollectionUtil.iteratorToList(
+                        tableEnv.executeSql("select min(bar) from test_min").collect());
+        assertThat(result10.toString()).isEqualTo("[+I[[100, 97, 116, 97, 49]]]");
+
+        tableEnv.executeSql("drop table test_min");
+    }
+
     private void runQFile(File qfile) throws Exception {
         QTest qTest = extractQTest(qfile);
         for (int i = 0; i < qTest.statements.size(); i++) {

--- a/flink-connectors/flink-connector-hive/src/test/resources/explain/testMinAggFunctionFallbackPlan.out
+++ b/flink-connectors/flink-connector-hive/src/test/resources/explain/testMinAggFunctionFallbackPlan.out
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(x=[$0], _o__c1=[$1])
++- LogicalAggregate(group=[{0}], agg#0=[min($1)])
+   +- LogicalProject($f0=[$0], $f1=[$1])
+      +- LogicalTableScan(table=[[test-catalog, default, foo]])
+
+== Optimized Physical Plan ==
+SortAggregate(isMerge=[true], groupBy=[x], select=[x, Final_min($f1) AS $f1])
++- Sort(orderBy=[x ASC])
+   +- Exchange(distribution=[hash[x]])
+      +- LocalSortAggregate(groupBy=[x], select=[x, Partial_min(y) AS $f1])
+         +- Sort(orderBy=[x ASC])
+            +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])
+
+== Optimized Execution Plan ==
+SortAggregate(isMerge=[true], groupBy=[x], select=[x, Final_min($f1) AS $f1])
++- Sort(orderBy=[x ASC])
+   +- Exchange(distribution=[hash[x]])
+      +- LocalSortAggregate(groupBy=[x], select=[x, Partial_min(y) AS $f1])
+         +- Sort(orderBy=[x ASC])
+            +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])

--- a/flink-connectors/flink-connector-hive/src/test/resources/explain/testMinAggFunctionPlan.out
+++ b/flink-connectors/flink-connector-hive/src/test/resources/explain/testMinAggFunctionPlan.out
@@ -1,0 +1,17 @@
+== Abstract Syntax Tree ==
+LogicalProject(x=[$0], _o__c1=[$1])
++- LogicalAggregate(group=[{0}], agg#0=[min($1)])
+   +- LogicalProject($f0=[$0], $f1=[$1])
+      +- LogicalTableScan(table=[[test-catalog, default, foo]])
+
+== Optimized Physical Plan ==
+HashAggregate(isMerge=[true], groupBy=[x], select=[x, Final_min(min$0) AS $f1])
++- Exchange(distribution=[hash[x]])
+   +- LocalHashAggregate(groupBy=[x], select=[x, Partial_min(y) AS min$0])
+      +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])
+
+== Optimized Execution Plan ==
+HashAggregate(isMerge=[true], groupBy=[x], select=[x, Final_min(min$0) AS $f1])
++- Exchange(distribution=[hash[x]])
+   +- LocalHashAggregate(groupBy=[x], select=[x, Partial_min(y) AS min$0])
+      +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])


### PR DESCRIPTION
## What is the purpose of the change

Supports native hive min function for hive dialect. Due to flink doesn't support compare array and row type, so this implementation also doesn't min array and row type, but hive udaf supports it.


## Brief change log

* Supports native hive min function for hive dialect


## Verifying this change

This change added tests and can be verified as follows:

* Added integration tests in HiveDialectQueryITCase

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
