### PR TITLE
[FLINK-30586][table-runtime] Fix calcCodeGen failed if calc with 'like' condition contains double quotation mark

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/GenerateUtils.scala
@@ -304,9 +304,10 @@ object GenerateUtils {
       // as they're not cheap to construct. For the other types, the return term is directly
       // the literal value
       case CHAR | VARCHAR =>
-        val str = literalValue.asInstanceOf[BinaryStringData]
-        val field = ctx.addReusableEscapedStringConstant(EncodingUtils.escapeJava(str.toString))
-        generateNonNullLiteral(literalType, field, str)
+        val escapedValue =
+          EncodingUtils.escapeJava(literalValue.asInstanceOf[BinaryStringData].toString)
+        val field = ctx.addReusableEscapedStringConstant(escapedValue)
+        generateNonNullLiteral(literalType, field, StringData.fromString(escapedValue))
 
       case BINARY | VARBINARY =>
         val bytesVal = literalValue.asInstanceOf[Array[Byte]]


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

If I write a sql like `SELECT * FROM MyTable WHERE b LIKE '%"%'` in Flink-1.16 as `like` condition contains double quotation mark, it will cause code gen failed because wrong code generated by codeGen. 

![code-gen-1](https://user-images.githubusercontent.com/27358654/210964746-29ad061b-ab5c-45c5-8270-cf896ebf8d9b.png)


![code-gen-2](https://user-images.githubusercontent.com/27358654/210964644-5923aa37-8ebf-44f8-9a6f-a62397a2f064.png)

This pr is aims to fix this error.

## Brief change log

- Modify `GenerateUtils` 
- Adding ITCase in `CalcITCase`


## Verifying this change

- Adding ITCase in `CalcITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
