### PR TITLE
Only for triggering test

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/NettyShuffleEnvironmentOptions.java
@@ -226,6 +226,27 @@ public class NettyShuffleEnvironmentOptions {
                                     + " increased in case of higher round trip times between nodes and/or larger number of machines in the cluster.");
 
     /**
+     * Maximum number of network buffers to use for each outgoing/incoming gate (result
+     * partition/input gate), which contains all exclusive network buffers for all subpartitions and
+     * all floating buffers for the gate. The exclusive network buffers for one channel is
+     * configured by {@link #NETWORK_BUFFERS_PER_CHANNEL} and the floating buffers for one gate is
+     * configured by {@link #NETWORK_EXTRA_BUFFERS_PER_GATE}.
+     */
+    @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)
+    public static final ConfigOption<Integer> NETWORK_REQUIRED_MAX_BUFFERS_PER_GATE =
+            key("taskmanager.memory.network.required-buffer-per-gate.max")
+                    .intType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The maximum number of network buffers to use for each outgoing/incoming gate (result partition/input gate). "
+                                    + " This config option is introduced to improve the usability of Flink and reduce the probability"
+                                    + " of insufficient network memory exceptions. When the total number of buffers used by one gate"
+                                    + " exceeds this threshold, all buffers in the gate will use Floating Buffers. If this option is"
+                                    + " not configured, the default threshold for Batch jobs is 1000, and the default threshold for Stream"
+                                    + " jobs is Integer.MAX_VALUE. If this option is configured, all jobs will take effect. If you want to"
+                                    + " disable the feature, set the value to Integer.MAX_VALUE.");
+
+    /**
      * Minimum number of network buffers required per blocking result partition for sort-shuffle.
      */
     @Documentation.Section(Documentation.Sections.ALL_TASK_MANAGER_NETWORK)

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -504,7 +504,7 @@ public class TaskManagerOptions {
     public static final ConfigOption<MemorySize> NETWORK_MEMORY_MAX =
             key("taskmanager.memory.network.max")
                     .memoryType()
-                    .defaultValue(MemorySize.parse("1g"))
+                    .defaultValue(MemorySize.MAX_VALUE)
                     .withDeprecatedKeys(
                             NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_MEMORY_MAX.key())
                     .withDescription(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleMaster.java
@@ -39,6 +39,10 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
 
     private final int buffersPerInputGate;
 
+    private final boolean isGateRequiredMaxBuffersConfigured;
+
+    private final int requiredMaxBuffersPerGate;
+
     private final int sortShuffleMinParallelism;
 
     private final int sortShuffleMinBuffers;
@@ -51,6 +55,14 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
                 conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_BUFFERS_PER_CHANNEL);
         buffersPerInputGate =
                 conf.getInteger(NettyShuffleEnvironmentOptions.NETWORK_EXTRA_BUFFERS_PER_GATE);
+        isGateRequiredMaxBuffersConfigured =
+                conf.contains(NettyShuffleEnvironmentOptions.NETWORK_REQUIRED_MAX_BUFFERS_PER_GATE);
+        requiredMaxBuffersPerGate =
+                isGateRequiredMaxBuffersConfigured
+                        ? conf.getInteger(
+                                NettyShuffleEnvironmentOptions
+                                        .NETWORK_REQUIRED_MAX_BUFFERS_PER_GATE)
+                        : -1;
         sortShuffleMinParallelism =
                 conf.getInteger(
                         NettyShuffleEnvironmentOptions.NETWORK_SORT_SHUFFLE_MIN_PARALLELISM);
@@ -112,11 +124,14 @@ public class NettyShuffleMaster implements ShuffleMaster<NettyShuffleDescriptor>
                 NettyShuffleUtils.computeNetworkBuffersForAnnouncing(
                         buffersPerInputChannel,
                         buffersPerInputGate,
+                        isGateRequiredMaxBuffersConfigured,
+                        requiredMaxBuffersPerGate,
                         sortShuffleMinParallelism,
                         sortShuffleMinBuffers,
-                        numTotalInputChannels,
                         numTotalInputGates,
+                        desc.getInputChannelNums(),
                         desc.getSubpartitionNums(),
+                        desc.getInputPartitionTypes(),
                         desc.getPartitionTypes());
 
         return new MemorySize((long) networkBufferSize * numRequiredNetworkBuffers);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/TaskInputsOutputsDescriptor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/TaskInputsOutputsDescriptor.java
@@ -38,6 +38,9 @@ public class TaskInputsOutputsDescriptor {
     // Number of subpartitions per dataSet.
     private final Map<IntermediateDataSetID, Integer> subpartitionNums;
 
+    // Result partition types of input channels.
+    private final Map<IntermediateDataSetID, ResultPartitionType> inputPartitionTypes;
+
     // ResultPartitionType per dataSet.
     private final Map<IntermediateDataSetID, ResultPartitionType> partitionTypes;
 
@@ -45,15 +48,18 @@ public class TaskInputsOutputsDescriptor {
             int inputGateNums,
             Map<IntermediateDataSetID, Integer> inputChannelNums,
             Map<IntermediateDataSetID, Integer> subpartitionNums,
+            Map<IntermediateDataSetID, ResultPartitionType> inputPartitionTypes,
             Map<IntermediateDataSetID, ResultPartitionType> partitionTypes) {
 
         checkNotNull(inputChannelNums);
         checkNotNull(subpartitionNums);
+        checkNotNull(inputPartitionTypes);
         checkNotNull(partitionTypes);
 
         this.inputGateNums = inputGateNums;
         this.inputChannelNums = inputChannelNums;
         this.subpartitionNums = subpartitionNums;
+        this.inputPartitionTypes = inputPartitionTypes;
         this.partitionTypes = partitionTypes;
     }
 
@@ -69,6 +75,10 @@ public class TaskInputsOutputsDescriptor {
         return Collections.unmodifiableMap(subpartitionNums);
     }
 
+    public Map<IntermediateDataSetID, ResultPartitionType> getInputPartitionTypes() {
+        return Collections.unmodifiableMap(inputPartitionTypes);
+    }
+
     public Map<IntermediateDataSetID, ResultPartitionType> getPartitionTypes() {
         return Collections.unmodifiableMap(partitionTypes);
     }
@@ -77,9 +87,14 @@ public class TaskInputsOutputsDescriptor {
             int inputGateNums,
             Map<IntermediateDataSetID, Integer> inputChannelNums,
             Map<IntermediateDataSetID, Integer> subpartitionNums,
+            Map<IntermediateDataSetID, ResultPartitionType> inputPartitionTypes,
             Map<IntermediateDataSetID, ResultPartitionType> partitionTypes) {
 
         return new TaskInputsOutputsDescriptor(
-                inputGateNums, inputChannelNums, subpartitionNums, partitionTypes);
+                inputGateNums,
+                inputChannelNums,
+                subpartitionNums,
+                inputPartitionTypes,
+                partitionTypes);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/NettyShuffleEnvironmentBuilder.java
@@ -57,6 +57,10 @@ public class NettyShuffleEnvironmentBuilder {
 
     private int floatingNetworkBuffersPerGate = 8;
 
+    private boolean isRequiredMaxBuffersConfigured = false;
+
+    private int requiredMaxBuffersPerGate = Integer.MAX_VALUE;
+
     private int sortShuffleMinBuffers = 100;
 
     private int sortShuffleMinParallelism = Integer.MAX_VALUE;
@@ -124,6 +128,18 @@ public class NettyShuffleEnvironmentBuilder {
     public NettyShuffleEnvironmentBuilder setFloatingNetworkBuffersPerGate(
             int floatingNetworkBuffersPerGate) {
         this.floatingNetworkBuffersPerGate = floatingNetworkBuffersPerGate;
+        return this;
+    }
+
+    public NettyShuffleEnvironmentBuilder setRequiredMaxBuffersPerGate(
+            int requiredMaxBuffersPerGate) {
+        this.requiredMaxBuffersPerGate = requiredMaxBuffersPerGate;
+        return this;
+    }
+
+    public NettyShuffleEnvironmentBuilder setIsRequiredMaxBuffersConfigured(
+            boolean isRequiredMaxBuffersConfigured) {
+        this.isRequiredMaxBuffersConfigured = isRequiredMaxBuffersConfigured;
         return this;
     }
 
@@ -213,6 +229,8 @@ public class NettyShuffleEnvironmentBuilder {
                         partitionRequestMaxBackoff,
                         networkBuffersPerChannel,
                         floatingNetworkBuffersPerGate,
+                        isRequiredMaxBuffersConfigured,
+                        requiredMaxBuffersPerGate,
                         DEFAULT_REQUEST_SEGMENTS_TIMEOUT,
                         false,
                         nettyConfig,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/GateBuffersNumCalculatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/GateBuffersNumCalculatorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.partition.consumer;
+
+import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
+import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.io.network.TaskEventDispatcher;
+import org.apache.flink.runtime.io.network.TestingConnectionManager;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for {@link SingleInputGateFactory.GateBuffersNumCalculator}. */
+class GateBuffersNumCalculatorTest {
+
+    @Test
+    void testCalculationWhenNotUseFloating() {
+        int numInputChannels = 500;
+        SingleInputGateFactory.GateBuffersNumCalculator gateBuffersNumCalculator =
+                createGateBuffersNumCalculator(numInputChannels);
+
+        assertThat(gateBuffersNumCalculator.getMinFloatingBuffers()).isEqualTo(1);
+        assertThat(gateBuffersNumCalculator.getMaxFloatingBuffers()).isEqualTo(8);
+        assertThat(gateBuffersNumCalculator.getExclusiveBuffersPerChannel()).isEqualTo(2);
+    }
+
+    @Test
+    void testCalculationWhenDecreaseExclusiveBuffers() {
+        int numInputChannels = 501;
+        SingleInputGateFactory.GateBuffersNumCalculator gateBuffersNumCalculator =
+                createGateBuffersNumCalculator(numInputChannels);
+
+        assertThat(gateBuffersNumCalculator.getMinFloatingBuffers()).isEqualTo(1);
+        assertThat(gateBuffersNumCalculator.getMaxFloatingBuffers()).isEqualTo(8);
+        assertThat(gateBuffersNumCalculator.getExclusiveBuffersPerChannel()).isEqualTo(1);
+    }
+
+    @Test
+    void testBoundaryCalculationWhenDecreaseExclusive() {
+        int numInputChannels = 1000;
+        SingleInputGateFactory.GateBuffersNumCalculator gateBuffersNumCalculator =
+                createGateBuffersNumCalculator(numInputChannels);
+
+        assertThat(gateBuffersNumCalculator.getMinFloatingBuffers()).isEqualTo(1);
+        assertThat(gateBuffersNumCalculator.getMaxFloatingBuffers()).isEqualTo(8);
+        assertThat(gateBuffersNumCalculator.getExclusiveBuffersPerChannel()).isEqualTo(1);
+    }
+
+    @Test
+    void testCalculationWhenUseAllFloatingBuffers() {
+        int numInputChannels = 1001;
+        SingleInputGateFactory.GateBuffersNumCalculator gateBuffersNumCalculator =
+                createGateBuffersNumCalculator(numInputChannels);
+
+        assertThat(gateBuffersNumCalculator.getMinFloatingBuffers()).isEqualTo(1000);
+        assertThat(gateBuffersNumCalculator.getMaxFloatingBuffers())
+                .isEqualTo(numInputChannels * 2 + 8);
+        assertThat(gateBuffersNumCalculator.getExclusiveBuffersPerChannel()).isEqualTo(0);
+    }
+
+    private SingleInputGateFactory.GateBuffersNumCalculator createGateBuffersNumCalculator(
+            int numInputChannels) {
+        SingleInputGateFactory factory = createSingleInputGateFactory();
+        ResultPartitionType partitionType = ResultPartitionType.BLOCKING;
+        return factory.new GateBuffersNumCalculator(partitionType, numInputChannels);
+    }
+
+    private SingleInputGateFactory createSingleInputGateFactory() {
+        NettyShuffleEnvironment netEnv = new NettyShuffleEnvironmentBuilder().build();
+        return new SingleInputGateFactory(
+                ResourceID.generate(),
+                netEnv.getConfiguration(),
+                new TestingConnectionManager(),
+                netEnv.getResultPartitionManager(),
+                new TaskEventDispatcher(),
+                netEnv.getNetworkBufferPool());
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateBuilder.java
@@ -111,7 +111,9 @@ public class SingleInputGateBuilder {
         NettyShuffleEnvironmentConfiguration config = environment.getConfiguration();
         this.bufferPoolFactory =
                 SingleInputGateFactory.createBufferPoolFactory(
-                        environment.getNetworkBufferPool(), config.floatingNetworkBuffersPerGate());
+                        environment.getNetworkBufferPool(),
+                        1,
+                        config.floatingNetworkBuffersPerGate());
         this.segmentProvider = environment.getNetworkBufferPool();
         return this;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -1219,8 +1219,7 @@ public class SingleInputGateTest extends InputGateTestBase {
                     new IntermediateResultPartitionID()
                 };
 
-        SubpartitionIndexRange subpartitionIndexRange =
-                new SubpartitionIndexRange(0, subpartitionRandSize - 1);
+        IndexRange subpartitionIndexRange = new IndexRange(0, subpartitionRandSize - 1);
         NettyShuffleEnvironment netEnv = new NettyShuffleEnvironmentBuilder().build();
 
         SingleInputGate gate =

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -233,11 +233,14 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         eg.initializeJobVertex(consumer, 0L);
 
         Map<IntermediateDataSetID, Integer> maxInputChannelNums = new HashMap<>();
+        Map<IntermediateDataSetID, ResultPartitionType> inputPartitionTypes = new HashMap<>();
         SsgNetworkMemoryCalculationUtils.getMaxInputChannelInfoForDynamicGraph(
-                consumer, maxInputChannelNums);
+                consumer, maxInputChannelNums, inputPartitionTypes);
 
         assertThat(maxInputChannelNums.size(), is(1));
         assertThat(maxInputChannelNums.get(result.getId()), is(expectedNumChannels));
+        assertThat(inputPartitionTypes.size(), is(1));
+        assertThat(inputPartitionTypes.get(result.getId()), is(result.getResultType()));
     }
 
     private DefaultExecutionGraph createDynamicExecutionGraph(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -48,6 +48,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -231,8 +232,9 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         consumer.setParallelism(decidedConsumerParallelism);
         eg.initializeJobVertex(consumer, 0L);
 
-        Map<IntermediateDataSetID, Integer> maxInputChannelNums =
-                SsgNetworkMemoryCalculationUtils.getMaxInputChannelNumsForDynamicGraph(consumer);
+        Map<IntermediateDataSetID, Integer> maxInputChannelNums = new HashMap<>();
+        SsgNetworkMemoryCalculationUtils.getMaxInputChannelInfoForDynamicGraph(
+                consumer, maxInputChannelNums);
 
         assertThat(maxInputChannelNums.size(), is(1));
         assertThat(maxInputChannelNums.get(result.getId()), is(expectedNumChannels));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/shuffle/NettyShuffleUtilsTest.java
@@ -64,8 +64,12 @@ public class NettyShuffleUtilsTest extends TestLogger {
     public void testComputeRequiredNetworkBuffers() throws Exception {
         int numBuffersPerChannel = 5;
         int numBuffersPerGate = 8;
+        int numMaxBuffersPerGate = Integer.MAX_VALUE;
         int sortShuffleMinParallelism = 8;
         int numSortShuffleMinBuffers = 12;
+
+        IntermediateDataSetID ids1 = new IntermediateDataSetID();
+        IntermediateDataSetID ids2 = new IntermediateDataSetID();
 
         int numChannels1 = 3;
         int numChannels2 = 4;
@@ -81,16 +85,23 @@ public class NettyShuffleUtilsTest extends TestLogger {
                 ImmutableMap.of(ds1, numSubs1, ds2, numSubs2, ds3, numSubs3);
         Map<IntermediateDataSetID, ResultPartitionType> partitionTypes =
                 ImmutableMap.of(ds1, PIPELINED_BOUNDED, ds2, BLOCKING, ds3, BLOCKING);
+        Map<IntermediateDataSetID, Integer> numInputChannels =
+                ImmutableMap.of(ids1, numChannels1, ids2, numChannels2);
+        Map<IntermediateDataSetID, ResultPartitionType> inputPartitionTypes =
+                ImmutableMap.of(ids1, PIPELINED_BOUNDED, ids2, BLOCKING);
 
         int numTotalBuffers =
                 NettyShuffleUtils.computeNetworkBuffersForAnnouncing(
                         numBuffersPerChannel,
                         numBuffersPerGate,
+                        false,
+                        numMaxBuffersPerGate,
                         sortShuffleMinParallelism,
                         numSortShuffleMinBuffers,
-                        numChannels1 + numChannels2,
                         2,
+                        numInputChannels,
                         subpartitionNums,
+                        inputPartitionTypes,
                         partitionTypes);
 
         NettyShuffleEnvironment sEnv =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/benchmark/SingleInputGateBenchmarkFactory.java
@@ -63,6 +63,7 @@ public class SingleInputGateBenchmarkFactory extends SingleInputGateFactory {
     protected InputChannel createKnownInputChannel(
             SingleInputGate inputGate,
             int index,
+            int buffersPerChannel,
             NettyShuffleDescriptor inputChannelDescriptor,
             int consumedSubpartitionIndex,
             SingleInputGateFactory.ChannelStatistics channelStatistics,


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This is only for triggering test.


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
