### PR TITLE
[hotfix] Fixing indentation in testing example

### DIFF
--- a/docs/content/docs/dev/datastream/testing.md
+++ b/docs/content/docs/dev/datastream/testing.md
@@ -315,10 +315,10 @@ Given its importance, in addition to the previous test harnesses that can be use
 ```java
 public static class PassThroughProcessFunction extends ProcessFunction<Integer, Integer> {
 
-	@Override
-	public void processElement(Integer value, Context ctx, Collector<Integer> out) throws Exception {
+    @Override
+    public void processElement(Integer value, Context ctx, Collector<Integer> out) throws Exception {
         out.collect(value);
-	}
+    }
 }
 ```
 {{< /tab >}}


### PR DESCRIPTION
A quick indentation fix for an example listing in the docs