### PR TITLE
[FLINK-30308][python] Fix ClassLeakCleaner to work with Java 11.0.16+ and 17.0.4+

### DIFF
--- a/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ClassLeakCleaner.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/utils/ClassLeakCleaner.java
@@ -55,20 +55,22 @@ public class ClassLeakCleaner {
             throws ReflectiveOperationException, SecurityException, ClassCastException {
         Field f = target.getDeclaredField(mapName);
         f.setAccessible(true);
-        Map<?, ?> map = (Map<?, ?>) f.get(null);
-        Iterator<?> keys = map.keySet().iterator();
-        while (keys.hasNext()) {
-            Object key = keys.next();
-            if (key instanceof Reference) {
-                Object clazz = ((Reference<?>) key).get();
-                if (clazz instanceof Class) {
-                    ClassLoader cl = ((Class<?>) clazz).getClassLoader();
-                    while (cl != null) {
-                        if (cl == classLoader) {
-                            keys.remove();
-                            break;
+        Object map = f.get(null);
+        if (map instanceof Map) {
+            Iterator<?> keys = ((Map<?, ?>) map).keySet().iterator();
+            while (keys.hasNext()) {
+                Object key = keys.next();
+                if (key instanceof Reference) {
+                    Object clazz = ((Reference<?>) key).get();
+                    if (clazz instanceof Class) {
+                        ClassLoader cl = ((Class<?>) clazz).getClassLoader();
+                        while (cl != null) {
+                            if (cl == classLoader) {
+                                keys.remove();
+                                break;
+                            }
+                            cl = cl.getParent();
                         }
-                        cl = cl.getParent();
                     }
                 }
             }


### PR DESCRIPTION
## What is the purpose of the change

*This pull request fixes ClassLeakCleaner to work with Java 11.0.16+ and 17.0.4+.*



## Verifying this change

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
