### PR TITLE
[FLINK-30551] Add open/close interface to PartitionCommitPolicy

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicy.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/PartitionCommitPolicy.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.file.table;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.table.api.ValidationException;
 
@@ -43,6 +44,16 @@ public interface PartitionCommitPolicy {
     String METASTORE = "metastore";
     String SUCCESS_FILE = "success-file";
     String CUSTOM = "custom";
+
+    /**
+     * open the partition commit policy.
+     *
+     * @param options the options of the table.
+     */
+    default void open(Configuration options) {}
+
+    /** Close the commit policy. */
+    default void close() throws Exception {}
 
     /** Commit a partition. */
     void commit(Context context) throws Exception;

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/FileSystemCommitterTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connector.file.table;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.fs.local.LocalFileSystem;
@@ -35,6 +36,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_POLICY_KIND;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link FileSystemCommitter}. */
@@ -53,8 +56,12 @@ public class FileSystemCommitterTest {
     @BeforeEach
     public void before() throws IOException {
         metaStoreFactory = new TestMetaStoreFactory(new Path(outputPath.toString()));
+        Configuration options = new Configuration();
+        options.set(SINK_PARTITION_COMMIT_POLICY_KIND, "metastore,success-file");
+        options.set(SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME, SUCCESS_FILE_NAME);
+
         policies =
-                new PartitionCommitPolicyFactory("metastore,success-file", null, SUCCESS_FILE_NAME)
+                new PartitionCommitPolicyFactory(options)
                         .createPolicyChain(
                                 Thread.currentThread().getContextClassLoader(),
                                 LocalFileSystem::getSharedInstance);

--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/batch/compact/BatchPartitionCommitterSinkTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/table/batch/compact/BatchPartitionCommitterSinkTest.java
@@ -77,7 +77,7 @@ public class BatchPartitionCommitterSinkTest {
                         new String[] {"p1", "p2"},
                         new LinkedHashMap<>(),
                         identifier,
-                        new PartitionCommitPolicyFactory(null, null, null));
+                        new PartitionCommitPolicyFactory(new Configuration()));
         committerSink.open(new Configuration());
 
         List<Path> pathList1 = createFiles(path, "task-1/p1=0/p2=0/", "f1", "f2");

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -443,10 +443,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 new org.apache.flink.core.fs.Path(toStagingDir(stagingParentDir, jobConf));
 
         PartitionCommitPolicyFactory partitionCommitPolicyFactory =
-                new PartitionCommitPolicyFactory(
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME));
+                new PartitionCommitPolicyFactory(conf);
 
         org.apache.flink.core.fs.Path path = new org.apache.flink.core.fs.Path(sd.getLocation());
         BucketsBuilder<RowData, String, ? extends BucketsBuilder<RowData, ?, ?>> builder =
@@ -596,11 +593,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                 new org.apache.flink.core.fs.Path(toStagingDir(stagingParentDir, jobConf)));
         builder.setOutputFileConfig(fileNaming);
         builder.setIdentifier(identifier);
-        builder.setPartitionCommitPolicyFactory(
-                new PartitionCommitPolicyFactory(
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_KIND),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_POLICY_CLASS),
-                        conf.get(HiveOptions.SINK_PARTITION_COMMIT_SUCCESS_FILE_NAME)));
+        builder.setPartitionCommitPolicyFactory(new PartitionCommitPolicyFactory(conf));
         return BatchSink.createBatchNoCompactSink(
                 dataStream, converter, builder.build(), sinkParallelism, sinkParallelismConfigured);
     }


### PR DESCRIPTION
## What is the purpose of the change

This pr is meant to add `open/close` interface to `PartitionCommitPolicy`. This will be useful when the custom policy have to do some initialize work based on the configuration.

