### PR TITLE
[FLINK-30480][runtime] Add benchmarks for adaptive batch scheduler.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -257,7 +257,8 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
                         || hybridPartitionDataConsumeConstraint.isOnlyConsumeFinishedPartition();
     }
 
-    void initializeVerticesIfPossible() {
+    @VisibleForTesting
+    public void initializeVerticesIfPossible() {
         final List<ExecutionJobVertex> newlyInitializedJobVertices = new ArrayList<>();
         try {
             final long createTimestamp = System.currentTimeMillis();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/JobConfiguration.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/JobConfiguration.java
@@ -19,13 +19,15 @@
 package org.apache.flink.runtime.scheduler.benchmark;
 
 import org.apache.flink.api.common.ExecutionMode;
+import org.apache.flink.configuration.JobManagerOptions.HybridPartitionDataConsumeConstraint;
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobType;
 
 /**
  * {@link JobConfiguration} contains the configuration of a STREAMING/BATCH job. It concludes {@link
- * DistributionPattern}, {@link ResultPartitionType}, {@link JobType}, {@link ExecutionMode}.
+ * DistributionPattern}, {@link ResultPartitionType}, {@link JobType}, {@link ExecutionMode}, {@link
+ * HybridPartitionDataConsumeConstraint}.
  */
 public enum JobConfiguration {
     STREAMING(
@@ -44,6 +46,33 @@ public enum JobConfiguration {
             4000,
             false),
 
+    BATCH_HYBRID_DEFAULT(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.HYBRID_FULL,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            HybridPartitionDataConsumeConstraint.UNFINISHED_PRODUCERS,
+            4000,
+            false),
+
+    BATCH_HYBRID_PARTIAL_FINISHED(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.HYBRID_FULL,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            HybridPartitionDataConsumeConstraint.ONLY_FINISHED_PRODUCERS,
+            4000,
+            false),
+
+    BATCH_HYBRID_ALL_FINISHED(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.HYBRID_FULL,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            HybridPartitionDataConsumeConstraint.ALL_PRODUCERS_FINISHED,
+            4000,
+            false),
+
     STREAMING_TEST(
             DistributionPattern.ALL_TO_ALL,
             ResultPartitionType.PIPELINED,
@@ -57,6 +86,33 @@ public enum JobConfiguration {
             ResultPartitionType.BLOCKING,
             JobType.BATCH,
             ExecutionMode.BATCH,
+            10,
+            false),
+
+    BATCH_HYBRID_DEFAULT_TEST(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.HYBRID_FULL,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            HybridPartitionDataConsumeConstraint.UNFINISHED_PRODUCERS,
+            10,
+            false),
+
+    BATCH_HYBRID_PARTIAL_FINISHED_TEST(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.HYBRID_FULL,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            HybridPartitionDataConsumeConstraint.ONLY_FINISHED_PRODUCERS,
+            10,
+            false),
+
+    BATCH_HYBRID_ALL_FINISHED_TEST(
+            DistributionPattern.ALL_TO_ALL,
+            ResultPartitionType.HYBRID_FULL,
+            JobType.BATCH,
+            ExecutionMode.BATCH,
+            HybridPartitionDataConsumeConstraint.ALL_PRODUCERS_FINISHED,
             10,
             false),
 
@@ -98,6 +154,7 @@ public enum JobConfiguration {
     private final JobType jobType;
     private final ExecutionMode executionMode;
     private final boolean evenlySpreadOutSlots;
+    private final HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint;
 
     JobConfiguration(
             DistributionPattern distributionPattern,
@@ -106,10 +163,29 @@ public enum JobConfiguration {
             ExecutionMode executionMode,
             int parallelism,
             boolean evenlySpreadOutSlots) {
+        this(
+                distributionPattern,
+                resultPartitionType,
+                jobType,
+                executionMode,
+                HybridPartitionDataConsumeConstraint.UNFINISHED_PRODUCERS,
+                parallelism,
+                evenlySpreadOutSlots);
+    }
+
+    JobConfiguration(
+            DistributionPattern distributionPattern,
+            ResultPartitionType resultPartitionType,
+            JobType jobType,
+            ExecutionMode executionMode,
+            HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint,
+            int parallelism,
+            boolean evenlySpreadOutSlots) {
         this.distributionPattern = distributionPattern;
         this.resultPartitionType = resultPartitionType;
         this.jobType = jobType;
         this.executionMode = executionMode;
+        this.hybridPartitionDataConsumeConstraint = hybridPartitionDataConsumeConstraint;
         this.parallelism = parallelism;
         this.evenlySpreadOutSlots = evenlySpreadOutSlots;
     }
@@ -132,6 +208,10 @@ public enum JobConfiguration {
 
     public ExecutionMode getExecutionMode() {
         return executionMode;
+    }
+
+    public HybridPartitionDataConsumeConstraint getHybridPartitionDataConsumeConstraint() {
+        return hybridPartitionDataConsumeConstraint;
     }
 
     public boolean isEvenlySpreadOutSlots() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/SchedulerBenchmarkUtils.java
@@ -31,12 +31,19 @@ import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.DefaultSchedulerBuilder;
+import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
+import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulerOperations;
+import org.apache.flink.runtime.scheduler.strategy.VertexwiseSchedulingStrategy;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
@@ -47,6 +54,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+
+import static org.apache.flink.runtime.scheduler.DefaultSchedulerBuilder.createCustomParallelismDecider;
+import static org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchSchedulerFactory.loadInputConsumableDeciderFactory;
 
 /** Utilities for scheduler benchmarks. */
 public class SchedulerBenchmarkUtils {
@@ -92,7 +102,7 @@ public class SchedulerBenchmarkUtils {
         return jobGraph;
     }
 
-    public static ExecutionGraph createAndInitExecutionGraph(
+    public static DefaultScheduler createAndInitScheduler(
             List<JobVertex> jobVertices,
             JobConfiguration jobConfiguration,
             ScheduledExecutorService scheduledExecutorService)
@@ -103,15 +113,57 @@ public class SchedulerBenchmarkUtils {
         final ComponentMainThreadExecutor mainThreadExecutor =
                 ComponentMainThreadExecutorServiceAdapter.forMainThread();
 
-        final DefaultScheduler scheduler =
+        DefaultSchedulerBuilder schedulerBuilder =
                 new DefaultSchedulerBuilder(jobGraph, mainThreadExecutor, scheduledExecutorService)
                         .setIoExecutor(scheduledExecutorService)
                         .setFutureExecutor(scheduledExecutorService)
                         .setDelayExecutor(
-                                new ScheduledExecutorServiceAdapter(scheduledExecutorService))
-                        .build();
+                                new ScheduledExecutorServiceAdapter(scheduledExecutorService));
+        if (jobConfiguration.getJobType() == JobType.BATCH) {
+            AdaptiveBatchScheduler adaptiveBatchScheduler =
+                    createAdaptiveBatchScheduler(schedulerBuilder, jobConfiguration);
+            adaptiveBatchScheduler.initializeVerticesIfPossible();
+            return adaptiveBatchScheduler;
+        } else {
+            return schedulerBuilder.build();
+        }
+    }
 
+    public static AdaptiveBatchScheduler createAdaptiveBatchScheduler(
+            DefaultSchedulerBuilder schedulerBuilder, JobConfiguration jobConfiguration)
+            throws Exception {
+        return schedulerBuilder
+                .setVertexParallelismAndInputInfosDecider(
+                        createCustomParallelismDecider(jobConfiguration.getParallelism()))
+                .setInputConsumableDeciderFactory(
+                        loadInputConsumableDeciderFactory(
+                                jobConfiguration.getHybridPartitionDataConsumeConstraint()))
+                .buildAdaptiveBatchJobScheduler();
+    }
+
+    public static ExecutionGraph createAndInitExecutionGraph(
+            List<JobVertex> jobVertices,
+            JobConfiguration jobConfiguration,
+            ScheduledExecutorService scheduledExecutorService)
+            throws Exception {
+        DefaultScheduler scheduler =
+                createAndInitScheduler(jobVertices, jobConfiguration, scheduledExecutorService);
         return scheduler.getExecutionGraph();
+    }
+
+    public static SchedulingStrategy createSchedulingStrategy(
+            JobConfiguration jobConfiguration, SchedulingTopology schedulingTopology) {
+        TestingSchedulerOperations schedulerOperations = new TestingSchedulerOperations();
+
+        if (jobConfiguration.getJobType() == JobType.BATCH) {
+            return new VertexwiseSchedulingStrategy(
+                    schedulerOperations,
+                    schedulingTopology,
+                    loadInputConsumableDeciderFactory(
+                            jobConfiguration.getHybridPartitionDataConsumeConstraint()));
+        } else {
+            return new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
+        }
     }
 
     public static void deployTasks(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingDownstreamTasksInBatchJobBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.deploying;
 
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of deploying downstream tasks in a BATCH job. The related method is {@link
  * Execution#deploy}.
  */
-public class DeployingDownstreamTasksInBatchJobBenchmarkTest extends TestLogger {
+class DeployingDownstreamTasksInBatchJobBenchmarkTest {
 
     @Test
-    public void deployDownstreamTasks() throws Exception {
+    void deployDownstreamTasks() throws Exception {
         DeployingDownstreamTasksInBatchJobBenchmark benchmark =
                 new DeployingDownstreamTasksInBatchJobBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/deploying/DeployingTasksInStreamingJobBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.deploying;
 
 import org.apache.flink.runtime.executiongraph.Execution;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of deploying tasks in a STREAMING job. The related method is {@link
  * Execution#deploy}.
  */
-public class DeployingTasksInStreamingJobBenchmarkTest extends TestLogger {
+class DeployingTasksInStreamingJobBenchmarkTest {
 
     @Test
-    public void deployAllTasks() throws Exception {
+    void deployAllTasks() throws Exception {
         DeployingTasksInStreamingJobBenchmark benchmark =
                 new DeployingTasksInStreamingJobBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/CreateSchedulerBenchmarkTest.java
@@ -19,14 +19,13 @@
 package org.apache.flink.runtime.scheduler.benchmark.e2e;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /** The benchmark of creating the scheduler in a STREAMING/BATCH job. */
-public class CreateSchedulerBenchmarkTest extends TestLogger {
+class CreateSchedulerBenchmarkTest {
     @Test
-    public void createSchedulerInStreamingJob() throws Exception {
+    void createSchedulerInStreamingJob() throws Exception {
         CreateSchedulerBenchmark benchmark = new CreateSchedulerBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.createScheduler();
@@ -34,7 +33,7 @@ public class CreateSchedulerBenchmarkTest extends TestLogger {
     }
 
     @Test
-    public void createSchedulerInBatchJob() throws Exception {
+    void createSchedulerInBatchJob() throws Exception {
         CreateSchedulerBenchmark benchmark = new CreateSchedulerBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.createScheduler();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerEndToEndBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulerEndToEndBenchmarkBase.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.benchmark.e2e;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmaster.slotpool.DeclarativeSlotPoolBridgeBuilder;
 import org.apache.flink.runtime.jobmaster.slotpool.LocationPreferenceSlotSelectionStrategy;
@@ -37,6 +38,7 @@ import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAdaptiveBatchScheduler;
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createJobGraph;
 
@@ -48,12 +50,14 @@ public class SchedulerEndToEndBenchmarkBase extends SchedulerBenchmarkBase {
 
     ComponentMainThreadExecutor mainThreadExecutor;
 
+    JobConfiguration jobConfiguration;
     JobGraph jobGraph;
     PhysicalSlotProvider physicalSlotProvider;
     SlotPool slotPool;
 
     public void setup(JobConfiguration jobConfiguration) throws Exception {
         super.setup();
+        this.jobConfiguration = jobConfiguration;
 
         mainThreadExecutor =
                 ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
@@ -76,16 +80,21 @@ public class SchedulerEndToEndBenchmarkBase extends SchedulerBenchmarkBase {
         return new PhysicalSlotProviderImpl(slotSelectionStrategy, slotPool);
     }
 
-    static DefaultScheduler createScheduler(
+    DefaultScheduler createScheduler(
             JobGraph jobGraph,
             PhysicalSlotProvider physicalSlotProvider,
             ComponentMainThreadExecutor mainThreadExecutor,
             ScheduledExecutorService executorService)
             throws Exception {
-        return new DefaultSchedulerBuilder(jobGraph, mainThreadExecutor, executorService)
-                .setExecutionSlotAllocatorFactory(
-                        SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
-                                physicalSlotProvider))
-                .build();
+        DefaultSchedulerBuilder schedulerBuilder =
+                new DefaultSchedulerBuilder(jobGraph, mainThreadExecutor, executorService)
+                        .setExecutionSlotAllocatorFactory(
+                                SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory(
+                                        physicalSlotProvider));
+        if (jobGraph.getJobType() == JobType.BATCH) {
+            return createAdaptiveBatchScheduler(schedulerBuilder, jobConfiguration);
+        } else {
+            return schedulerBuilder.build();
+        }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/e2e/SchedulingAndDeployingBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.e2e;
 
 import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of scheduling tasks in a STREAMING/BATCH job. The related method is {@link
  * DefaultScheduler#startScheduling}.
  */
-public class SchedulingAndDeployingBenchmarkTest extends TestLogger {
+class SchedulingAndDeployingBenchmarkTest {
 
     @Test
-    public void scheduleAndDeployInStreamingJob() throws Exception {
+    void scheduleAndDeployInStreamingJob() throws Exception {
         SchedulingAndDeployingBenchmark benchmark = new SchedulingAndDeployingBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.startScheduling();
@@ -39,7 +38,7 @@ public class SchedulingAndDeployingBenchmarkTest extends TestLogger {
     }
 
     @Test
-    public void scheduleAndDeployInBatchJob() throws Exception {
+    void scheduleAndDeployInBatchJob() throws Exception {
         SchedulingAndDeployingBenchmark benchmark = new SchedulingAndDeployingBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.startScheduling();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInBatchJobBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.failover;
 
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of calculating the regions to restart when failover occurs in a BATCH job. The
  * related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
  */
-public class RegionToRestartInBatchJobBenchmarkTest extends TestLogger {
+class RegionToRestartInBatchJobBenchmarkTest {
 
     @Test
-    public void calculateRegionToRestart() throws Exception {
+    void calculateRegionToRestart() throws Exception {
         RegionToRestartInBatchJobBenchmark benchmark = new RegionToRestartInBatchJobBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.calculateRegionToRestart();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/failover/RegionToRestartInStreamingJobBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.failover;
 
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRegionFailoverStrategy;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of calculating region to restart when failover occurs in a STREAMING job. The
  * related method is {@link RestartPipelinedRegionFailoverStrategy#getTasksNeedingRestart}.
  */
-public class RegionToRestartInStreamingJobBenchmarkTest extends TestLogger {
+class RegionToRestartInStreamingJobBenchmarkTest {
 
     @Test
-    public void calculateRegionToRestart() throws Exception {
+    void calculateRegionToRestart() throws Exception {
         RegionToRestartInStreamingJobBenchmark benchmark =
                 new RegionToRestartInStreamingJobBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/partitionrelease/PartitionReleaseInBatchJobBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.partitionrelease;
 
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.RegionPartitionGroupReleaseStrategy;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of releasing partitions in a BATCH job. The related method is {@link
  * RegionPartitionGroupReleaseStrategy#vertexFinished}.
  */
-public class PartitionReleaseInBatchJobBenchmarkTest extends TestLogger {
+class PartitionReleaseInBatchJobBenchmarkTest {
 
     @Test
-    public void partitionRelease() throws Exception {
+    void partitionRelease() throws Exception {
         PartitionReleaseInBatchJobBenchmark benchmark = new PartitionReleaseInBatchJobBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.partitionRelease();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/InitSchedulingStrategyBenchmarkTest.java
@@ -20,17 +20,16 @@ package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of initializing {@link PipelinedRegionSchedulingStrategy} in a STREAMING/BATCH job.
  */
-public class InitSchedulingStrategyBenchmarkTest extends TestLogger {
+class InitSchedulingStrategyBenchmarkTest {
 
     @Test
-    public void initSchedulingStrategyBenchmarkInStreamingJob() throws Exception {
+    void initSchedulingStrategyBenchmarkInStreamingJob() throws Exception {
         InitSchedulingStrategyBenchmark benchmark = new InitSchedulingStrategyBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.initSchedulingStrategy();
@@ -38,7 +37,7 @@ public class InitSchedulingStrategyBenchmarkTest extends TestLogger {
     }
 
     @Test
-    public void initSchedulingStrategyBenchmarkInBatchJob() throws Exception {
+    void initSchedulingStrategyBenchmarkInBatchJob() throws Exception {
         InitSchedulingStrategyBenchmark benchmark = new InitSchedulingStrategyBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.initSchedulingStrategy();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingBenchmarkBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.scheduler.DefaultScheduler;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkBase;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
@@ -27,7 +28,7 @@ import org.apache.flink.runtime.scheduler.strategy.TestingSchedulerOperations;
 
 import java.util.List;
 
-import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitExecutionGraph;
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createAndInitScheduler;
 import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createDefaultJobVertices;
 
 /** The base class of benchmarks related to scheduling tasks. */
@@ -35,6 +36,7 @@ public class SchedulingBenchmarkBase extends SchedulerBenchmarkBase {
 
     TestingSchedulerOperations schedulerOperations;
     List<JobVertex> jobVertices;
+    DefaultScheduler scheduler;
     ExecutionGraph executionGraph;
     SchedulingTopology schedulingTopology;
 
@@ -43,9 +45,8 @@ public class SchedulingBenchmarkBase extends SchedulerBenchmarkBase {
 
         schedulerOperations = new TestingSchedulerOperations();
         jobVertices = createDefaultJobVertices(jobConfiguration);
-        executionGraph =
-                createAndInitExecutionGraph(
-                        jobVertices, jobConfiguration, scheduledExecutorService);
+        scheduler = createAndInitScheduler(jobVertices, jobConfiguration, scheduledExecutorService);
+        executionGraph = scheduler.getExecutionGraph();
         schedulingTopology = executionGraph.getSchedulingTopology();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmark.java
@@ -21,14 +21,17 @@ package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
+import org.apache.flink.runtime.scheduler.strategy.VertexwiseSchedulingStrategy;
+
+import static org.apache.flink.runtime.scheduler.benchmark.SchedulerBenchmarkUtils.createSchedulingStrategy;
 
 /**
  * The benchmark of scheduling downstream task in a BATCH job. The related method is {@link
- * PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
+ * VertexwiseSchedulingStrategy#onExecutionStateChange}.
  */
 public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenchmarkBase {
-    private PipelinedRegionSchedulingStrategy schedulingStrategy;
+    private SchedulingStrategy schedulingStrategy;
 
     private int parallelism;
 
@@ -36,9 +39,8 @@ public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenc
     public void setup(JobConfiguration jobConfiguration) throws Exception {
         super.setup(jobConfiguration);
 
-        schedulingStrategy =
-                new PipelinedRegionSchedulingStrategy(schedulerOperations, schedulingTopology);
-
+        schedulingStrategy = createSchedulingStrategy(jobConfiguration, schedulingTopology);
+        schedulingStrategy.startScheduling();
         parallelism = jobConfiguration.getParallelism();
     }
 
@@ -54,6 +56,7 @@ public class SchedulingDownstreamTasksInBatchJobBenchmark extends SchedulingBenc
                 executionGraph.getJobVertex(jobVertices.get(0).getID())
                         .getTaskVertices()[parallelism - 1];
         lastVertex.finishPartitionsIfNeeded();
+
         schedulingStrategy.onExecutionStateChange(lastVertex.getID(), ExecutionState.FINISHED);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
@@ -19,21 +19,31 @@
 package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
+import org.apache.flink.runtime.scheduler.strategy.VertexwiseSchedulingStrategy;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * The benchmark of scheduling downstream task in a BATCH job. The related method is {@link
- * PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
+ * VertexwiseSchedulingStrategy#onExecutionStateChange}.
  */
 class SchedulingDownstreamTasksInBatchJobBenchmarkTest {
 
-    @Test
-    void schedulingDownstreamTasksInBatchJobBenchmark() throws Exception {
+    @ParameterizedTest
+    @EnumSource(
+            value = JobConfiguration.class,
+            names = {
+                "BATCH_TEST",
+                "BATCH_HYBRID_DEFAULT_TEST",
+                "BATCH_HYBRID_PARTIAL_FINISHED_TEST",
+                "BATCH_HYBRID_ALL_FINISHED_TEST"
+            })
+    void schedulingDownstreamTasksInBatchJobBenchmark(JobConfiguration jobConfiguration)
+            throws Exception {
         SchedulingDownstreamTasksInBatchJobBenchmark benchmark =
                 new SchedulingDownstreamTasksInBatchJobBenchmark();
-        benchmark.setup(JobConfiguration.BATCH_TEST);
+        benchmark.setup(jobConfiguration);
         benchmark.schedulingDownstreamTasks();
         benchmark.teardown();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/scheduling/SchedulingDownstreamTasksInBatchJobBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.scheduling;
 
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of scheduling downstream task in a BATCH job. The related method is {@link
  * PipelinedRegionSchedulingStrategy#onExecutionStateChange}.
  */
-public class SchedulingDownstreamTasksInBatchJobBenchmarkTest extends TestLogger {
+class SchedulingDownstreamTasksInBatchJobBenchmarkTest {
 
     @Test
-    public void schedulingDownstreamTasksInBatchJobBenchmark() throws Exception {
+    void schedulingDownstreamTasksInBatchJobBenchmark() throws Exception {
         SchedulingDownstreamTasksInBatchJobBenchmark benchmark =
                 new SchedulingDownstreamTasksInBatchJobBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmarkTest.java
@@ -20,18 +20,17 @@ package org.apache.flink.runtime.scheduler.benchmark.topology;
 
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * The benchmark of building the topology of {@link ExecutionGraph} in a STREAMING/BATCH job. The
  * related method is {@link ExecutionGraph#attachJobGraph},
  */
-public class BuildExecutionGraphBenchmarkTest extends TestLogger {
+class BuildExecutionGraphBenchmarkTest {
 
     @Test
-    public void buildTopologyInStreamingJob() throws Exception {
+    void buildTopologyInStreamingJob() throws Exception {
         BuildExecutionGraphBenchmark benchmark = new BuildExecutionGraphBenchmark();
         benchmark.setup(JobConfiguration.STREAMING_TEST);
         benchmark.buildTopology();
@@ -39,7 +38,7 @@ public class BuildExecutionGraphBenchmarkTest extends TestLogger {
     }
 
     @Test
-    public void buildTopologyInBatchJob() throws Exception {
+    void buildTopologyInBatchJob() throws Exception {
         BuildExecutionGraphBenchmark benchmark = new BuildExecutionGraphBenchmark();
         benchmark.setup(JobConfiguration.BATCH_TEST);
         benchmark.buildTopology();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently we only have benchmarks of DefaultScheduler([FLINK-20612](https://issues.apache.org/jira/browse/FLINK-20612)). We should also have benchmarks of AdaptiveBatchScheduler to identify initializing/scheduling/deployment performance problems or regressions.


## Brief change log
  - *Add benchmark of initializing `VertexwiseSchedulingStrategy`*
  - *Add benchmark of scheduling downstream task in a ADAPTIVE_BATCH job*
  - *Add benchmark of starting scheduling in a BATCH/ADAPTIVE_BATCH job*
  - *Add benchmark of restarting tasks in a BATCH/ADAPTIVE_BATCH job*


## Verifying this change

  - *Add ITCase in `RestartTasksInBatchJobBenchmarkTest`, `InitSchedulingStrategyBenchmarkTest`, `SchedulingDownstreamTasksInBatchJobBenchmarkTest` and `StartSchedulingInBatchJobBenchmarkTest`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
