### PR TITLE
[FLINK-30613] Improve resolving schema compatibility -- Milestone one

### DIFF
--- a/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/custom_serialization.md
+++ b/docs/content.zh/docs/dev/datastream/fault-tolerance/serialization/custom_serialization.md
@@ -99,7 +99,7 @@ public interface TypeSerializerSnapshot<T> {
     int getCurrentVersion();
     void writeSnapshot(DataOuputView out) throws IOException;
     void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException;
-    TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(TypeSerializer<T> newSerializer);
+    TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(TypeSerializerSnapshot<T> oldSerializerSnapshot);
     TypeSerializer<T> restoreSerializer();
 }
 ```
@@ -125,7 +125,7 @@ the read implementation can handle different versions.
 
 At restore time, the logic that detects whether or not the new serializer's schema has changed should be implemented in
 the `resolveSchemaCompatibility` method. When previous registered state is registered again with new serializers in the
-restored execution of an operator, the new serializer is provided to the previous serializer's snapshot via this method.
+restored execution of an operator, the old serializer snapshot is provided to the new serializer's snapshot via this method.
 This method returns a `TypeSerializerSchemaCompatibility` representing the result of the compatibility resolution,
 which can be one of the following:
 
@@ -162,7 +162,7 @@ to the implementation of state serializers and their serializer snapshots.
  3. **Restored execution re-accesses restored state bytes with new state serializer that has schema _B_**
   - The previous state serializer's snapshot is restored.
   - State bytes are not deserialized on restore, only loaded back to the state backends (therefore, still in schema *A*).
-  - Upon receiving the new serializer, it is provided to the restored previous serializer's snapshot via the
+  - Upon receiving the new serializer, the previous serializer's snapshot is provided to the new serializer's snapshot via the
   `TypeSerializer#resolveSchemaCompatibility` to check for schema compatibility.
  4. **Migrate state bytes in backend from schema _A_ to schema _B_**
   - If the compatibility resolution reflects that the schema has changed and migration is possible, schema migration is 
@@ -186,7 +186,7 @@ to the implementation of state serializers and their serializer snapshots.
   `TypeSerializerSnapshot#restoreSerializer()`, and is used to deserialize state bytes to objects.
   - From now on, all of the state is already deserialized.
  4. **Restored execution re-accesses previous state with new state serializer that has schema _B_**
-  - Upon receiving the new serializer, it is provided to the restored previous serializer's snapshot via the
+  - Upon receiving the new serializer, the previous serializer's snapshot is provided to the new serializer's snapshot via the
   `TypeSerializer#resolveSchemaCompatibility` to check for schema compatibility.
   - If the compatibility check signals that migration is required, nothing happens in this case since for
    heap backends, all state is already deserialized into objects.
@@ -302,7 +302,7 @@ the nested element serializer.
 In these cases, an additional three methods need to be implemented on the `CompositeTypeSerializerSnapshot`:
  * `#writeOuterSnapshot(DataOutputView)`: defines how the outer snapshot information is written.
  * `#readOuterSnapshot(int, DataInputView, ClassLoader)`: defines how the outer snapshot information is read.
- * `#resolveOuterSchemaCompatibility(TypeSerializer)`: checks the compatibility based on the outer snapshot information.
+ * `#resolveOuterSchemaCompatibility(TypeSerializerSnapshot)`: checks the compatibility based on the outer snapshot information.
 
 By default, the `CompositeTypeSerializerSnapshot` assumes that there isn't any outer snapshot information to
 read / write, and therefore have empty default implementations for the above methods. If the subclass
@@ -341,12 +341,15 @@ public final class GenericArraySerializerSnapshot<C> extends CompositeTypeSerial
     protected void readOuterSnapshot(int readOuterSnapshotVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
         this.componentClass = InstantiationUtil.resolveClassByName(in, userCodeClassLoader);
     }
-
-    @Override
-    protected boolean resolveOuterSchemaCompatibility(GenericArraySerializer newSerializer) {
-        return (this.componentClass == newSerializer.getComponentClass())
-            ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
-            : OuterSchemaCompatibility.INCOMPATIBLE;
+    
+    @Override 
+    protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
+            TypeSerializerSnapshot<C[]> oldSerializerSnapshot) {
+        GenericArraySerializerSnapshot<C[]> oldGenericArraySerializerSnapshot = 
+                (GenericArraySerializerSnapshot<C[]>) oldSerializerSnapshot;
+        return (this.componentClass == oldGenericArraySerializerSnapshot.componentClass) 
+                ? OuterSchemaCompatibility.COMPATIBLE_AS_IS 
+                : OuterSchemaCompatibility.INCOMPATIBLE;
     }
 
     @Override
@@ -441,5 +444,24 @@ migrate from the old abstractions. The steps to do this is as follows:
  At this point, it is now safe to remove all implementations of the old abstraction (remove the old
  `TypeSerializerConfigSnapshot` implementation as will as the
  `TypeSerializer#ensureCompatibility(TypeSerializerConfigSnapshot)` from the serializer).
+
+## Migrating from deprecated `TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer newSerializer)` before Flink 1.19
+
+This section is a guide for a method migration from the serializer snapshots that existed before Flink 1.19.
+
+Before Flink 1.19, when using a customized serializer to process data, the schema compatibility in the old serializer
+(maybe in Flink library) has to meet the future need.
+Or else TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer<T> newSerializer) of the old serializer has to be modified.
+There are no ways to specify the compatibility with the old serializer in the new serializer, which also makes scheme evolution
+not supported in some scenarios.
+
+So from Flink 1.19, the direction of resolving schema compatibility has been reversed. The old method
+`TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer newSerializer)` has been marked as deprecated
+and will be removed in the future. it is highly recommended to migrate from the old one to
+`TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot oldSerializerSnapshot)`. The steps to do this are as follows:
+
+1. Implement the `TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot oldSerializerSnapshot)` whose logic
+   should be same as the original `TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer newSerializer)`.
+2. Remove the old method `TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer newSerializer)`.
 
 {{< top >}}

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
@@ -28,6 +28,7 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil.IntermediateCompatibilityResult;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -47,10 +48,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>Serializers that do have some outer snapshot needs to make sure to implement the methods
  * {@link #writeOuterSnapshot(DataOutputView)}, {@link #readOuterSnapshot(int, DataInputView,
- * ClassLoader)}, and {@link #resolveOuterSchemaCompatibility(TypeSerializer)} when using this class
- * as the base for its serializer snapshot class. By default, the base implementations of these
- * methods are empty, i.e. this class assumes that subclasses do not have any outer snapshot that
- * needs to be persisted.
+ * ClassLoader)}, and {@link #resolveOuterSchemaCompatibility(TypeSerializerSnapshot)} when using
+ * this class as the base for its serializer snapshot class. By default, the base implementations of
+ * these methods are empty, i.e. this class assumes that subclasses do not have any outer snapshot
+ * that needs to be persisted.
  *
  * <h2>Snapshot Versioning</h2>
  *
@@ -177,32 +178,36 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
     }
 
     @Override
-    public final TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
-            TypeSerializer<T> newSerializer) {
+    public TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
+            TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof CompositeTypeSerializerSnapshot)) {
+            return TypeSerializerSchemaCompatibility.incompatible();
+        }
+
+        TypeSerializerSnapshot<?>[] oldNestedSerializerSnapshots =
+                ((CompositeTypeSerializerSnapshot<?, ?>) oldSerializerSnapshot)
+                        .getNestedSerializerSnapshots();
+
         return internalResolveSchemaCompatibility(
-                newSerializer, nestedSerializersSnapshotDelegate.getNestedSerializerSnapshots());
+                oldSerializerSnapshot, oldNestedSerializerSnapshots);
     }
 
     @Internal
     TypeSerializerSchemaCompatibility<T> internalResolveSchemaCompatibility(
-            TypeSerializer<T> newSerializer, TypeSerializerSnapshot<?>[] snapshots) {
-        if (newSerializer.getClass() != correspondingSerializerClass) {
+            TypeSerializerSnapshot<T> oldSnapshot, TypeSerializerSnapshot<?>[] oldNestedSnapshots) {
+        TypeSerializerSnapshot<?>[] newNestedSerializerSnapshots =
+                nestedSerializersSnapshotDelegate.getNestedSerializerSnapshots();
+
+        // check that nested serializer arity remains identical; if not, short circuit result
+        if (newNestedSerializerSnapshots.length != oldNestedSnapshots.length) {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
-
-        S castedNewSerializer = correspondingSerializerClass.cast(newSerializer);
 
         final OuterSchemaCompatibility outerSchemaCompatibility =
-                resolveOuterSchemaCompatibility(castedNewSerializer);
-
-        final TypeSerializer<?>[] newNestedSerializers = getNestedSerializers(castedNewSerializer);
-        // check that nested serializer arity remains identical; if not, short circuit result
-        if (newNestedSerializers.length != snapshots.length) {
-            return TypeSerializerSchemaCompatibility.incompatible();
-        }
+                resolveOuterSchemaCompatibility(oldSnapshot);
 
         return constructFinalSchemaCompatibilityResult(
-                newNestedSerializers, snapshots, outerSchemaCompatibility);
+                newNestedSerializerSnapshots, oldNestedSnapshots, outerSchemaCompatibility);
     }
 
     @Internal
@@ -264,7 +269,7 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
      * serializer contains some extra information that needs to be persisted as part of the
      * serializer snapshot, this must be overridden. Note that this method and the corresponding
      * methods {@link #readOuterSnapshot(int, DataInputView, ClassLoader)}, {@link
-     * #resolveOuterSchemaCompatibility(TypeSerializer)} needs to be implemented.
+     * #resolveOuterSchemaCompatibility(TypeSerializerSnapshot)} needs to be implemented.
      *
      * @param out the {@link DataOutputView} to write the outer snapshot to.
      */
@@ -279,7 +284,7 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
      * serializer contains some extra information that has been persisted as part of the serializer
      * snapshot, this must be overridden. Note that this method and the corresponding methods {@link
      * #writeOuterSnapshot(DataOutputView)}, {@link
-     * #resolveOuterSchemaCompatibility(TypeSerializer)} needs to be implemented.
+     * #resolveOuterSchemaCompatibility(TypeSerializerSnapshot)} needs to be implemented.
      *
      * @param readOuterSnapshotVersion the read version of the outer snapshot.
      * @param in the {@link DataInputView} to read the outer snapshot from.
@@ -288,6 +293,40 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
     protected void readOuterSnapshot(
             int readOuterSnapshotVersion, DataInputView in, ClassLoader userCodeClassLoader)
             throws IOException {}
+
+    /**
+     * Checks the schema compatibility of the given old serializer snapshot based on the outer
+     * snapshot.
+     *
+     * <p>The base implementation of this method assumes that the outer serializer only has nested
+     * serializers and no extra information, and therefore the result of the check is {@link
+     * OuterSchemaCompatibility#COMPATIBLE_AS_IS}. Otherwise, if the outer serializer contains some
+     * extra information that has been persisted as part of the serializer snapshot, this must be
+     * overridden. Note that this method and the corresponding methods {@link
+     * #writeOuterSnapshot(DataOutputView)}, {@link #readOuterSnapshot(int, DataInputView,
+     * ClassLoader)} needs to be implemented.
+     *
+     * @param oldSerializerSnapshot the old serializer snapshot, which contains the old outer
+     *     information to check against.
+     * @return a {@link OuterSchemaCompatibility} indicating whether the new serializer's outer
+     *     information is compatible, requires migration, or incompatible with the one written in
+     *     this snapshot.
+     */
+    protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
+            TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        // Call deprecated methods as default, which will be removed after removing these deprecated
+        // methods
+        @SuppressWarnings("unchecked")
+        S newSerializer = (S) this.restoreSerializer();
+        if (isOuterSnapshotCompatible(newSerializer)) {
+            if (oldSerializerSnapshot instanceof CompositeTypeSerializerSnapshot) {
+                return ((CompositeTypeSerializerSnapshot<T, S>) oldSerializerSnapshot)
+                        .resolveOuterSchemaCompatibility(newSerializer);
+            }
+            return OuterSchemaCompatibility.COMPATIBLE_AS_IS;
+        }
+        return OuterSchemaCompatibility.INCOMPATIBLE;
+    }
 
     /**
      * Checks whether the outer snapshot is compatible with a given new serializer.
@@ -305,7 +344,7 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
      * @return a flag indicating whether or not the new serializer's outer information is compatible
      *     with the one written in this snapshot.
      * @deprecated this method is deprecated, and will be removed in the future. Please implement
-     *     {@link #resolveOuterSchemaCompatibility(TypeSerializer)} instead.
+     *     {@link #resolveOuterSchemaCompatibility(TypeSerializerSnapshot)} instead.
      */
     @Deprecated
     protected boolean isOuterSnapshotCompatible(S newSerializer) {
@@ -323,16 +362,17 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
      * #writeOuterSnapshot(DataOutputView)}, {@link #readOuterSnapshot(int, DataInputView,
      * ClassLoader)} needs to be implemented.
      *
+     * @deprecated this method is deprecated, and will be removed in the future. Please implement
+     *     {@link #resolveOuterSchemaCompatibility(TypeSerializerSnapshot)} instead.
      * @param newSerializer the new serializer, which contains the new outer information to check
      *     against.
      * @return a {@link OuterSchemaCompatibility} indicating whether or the new serializer's outer
      *     information is compatible, requires migration, or incompatible with the one written in
      *     this snapshot.
      */
+    @Deprecated
     protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(S newSerializer) {
-        return (isOuterSnapshotCompatible(newSerializer))
-                ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
-                : OuterSchemaCompatibility.INCOMPATIBLE;
+        return OuterSchemaCompatibility.COMPATIBLE_AS_IS;
     }
 
     // ------------------------------------------------------------------------------------------
@@ -369,13 +409,13 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
     }
 
     private TypeSerializerSchemaCompatibility<T> constructFinalSchemaCompatibilityResult(
-            TypeSerializer<?>[] newNestedSerializers,
-            TypeSerializerSnapshot<?>[] nestedSerializerSnapshots,
+            TypeSerializerSnapshot<?>[] newNestedSerializerSnapshots,
+            TypeSerializerSnapshot<?>[] oldNestedSerializerSnapshots,
             OuterSchemaCompatibility outerSchemaCompatibility) {
 
         IntermediateCompatibilityResult<T> nestedSerializersCompatibilityResult =
                 CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
-                        newNestedSerializers, nestedSerializerSnapshots);
+                        newNestedSerializerSnapshots, oldNestedSerializerSnapshots);
 
         if (outerSchemaCompatibility == OuterSchemaCompatibility.INCOMPATIBLE
                 || nestedSerializersCompatibilityResult.isIncompatible()) {
@@ -388,7 +428,6 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
         }
 
         if (nestedSerializersCompatibilityResult.isCompatibleWithReconfiguredSerializer()) {
-            @SuppressWarnings("unchecked")
             TypeSerializer<T> reconfiguredCompositeSerializer =
                     createOuterSerializerWithNestedSerializers(
                             nestedSerializersCompatibilityResult.getNestedSerializers());

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
@@ -28,7 +28,6 @@ import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import static org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil.IntermediateCompatibilityResult;
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -123,30 +122,29 @@ public abstract class CompositeTypeSerializerSnapshot<T, S extends TypeSerialize
 
     private NestedSerializersSnapshotDelegate nestedSerializersSnapshotDelegate;
 
-    private final Class<S> correspondingSerializerClass;
-
     /**
      * Constructor to be used for read instantiation.
      *
+     * @deprecated correspondingSerializerClass is not used to resolve and cast after FLIP-263,
+     *     please use {@link CompositeTypeSerializerSnapshot()} instead.
      * @param correspondingSerializerClass the expected class of the new serializer.
      */
-    @SuppressWarnings("unchecked")
+    @Deprecated
     public CompositeTypeSerializerSnapshot(
-            Class<? extends TypeSerializer> correspondingSerializerClass) {
-        this.correspondingSerializerClass = (Class<S>) checkNotNull(correspondingSerializerClass);
-    }
+            Class<? extends TypeSerializer> correspondingSerializerClass) {}
+
+    /** Constructor to be used for read instantiation. */
+    public CompositeTypeSerializerSnapshot() {}
 
     /**
      * Constructor to be used for writing the snapshot.
      *
      * @param serializerInstance an instance of the originating serializer of this snapshot.
      */
-    @SuppressWarnings("unchecked")
     public CompositeTypeSerializerSnapshot(S serializerInstance) {
         checkNotNull(serializerInstance);
         this.nestedSerializersSnapshotDelegate =
                 new NestedSerializersSnapshotDelegate(getNestedSerializers(serializerInstance));
-        this.correspondingSerializerClass = (Class<S>) serializerInstance.getClass();
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/GenericTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/GenericTypeSerializerSnapshot.java
@@ -81,13 +81,16 @@ public abstract class GenericTypeSerializerSnapshot<T, S extends TypeSerializer>
 
     @Override
     public final TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
-            TypeSerializer<T> newSerializer) {
-        if (!serializerClass().isInstance(newSerializer)) {
+            TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof GenericTypeSerializerSnapshot)) {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
-        @SuppressWarnings("unchecked")
-        S casted = (S) newSerializer;
-        if (typeClass == getTypeClass(casted)) {
+        GenericTypeSerializerSnapshot<T, S> previousGenericTypeSerializerSnapshot =
+                (GenericTypeSerializerSnapshot<T, S>) oldSerializerSnapshot;
+        if (serializerClass() != previousGenericTypeSerializerSnapshot.serializerClass()) {
+            return TypeSerializerSchemaCompatibility.incompatible();
+        }
+        if (typeClass == previousGenericTypeSerializerSnapshot.typeClass) {
             return TypeSerializerSchemaCompatibility.compatibleAsIs();
         } else {
             return TypeSerializerSchemaCompatibility.incompatible();

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/NestedSerializersSnapshotDelegate.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/NestedSerializersSnapshotDelegate.java
@@ -97,46 +97,6 @@ public class NestedSerializersSnapshotDelegate {
         return nestedSnapshots;
     }
 
-    /**
-     * Resolves the compatibility of the nested serializer snapshots with the nested serializers of
-     * the new outer serializer.
-     *
-     * @deprecated this no method will be removed in the future. Resolving compatibility for nested
-     *     serializers is now handled by {@link CompositeTypeSerializerSnapshot}.
-     */
-    @Deprecated
-    public <T> TypeSerializerSchemaCompatibility<T> resolveCompatibilityWithNested(
-            TypeSerializerSchemaCompatibility<?> outerCompatibility,
-            TypeSerializer<?>... newNestedSerializers) {
-
-        checkArgument(
-                newNestedSerializers.length == nestedSnapshots.length,
-                "Different number of new serializers and existing serializer configuration snapshots");
-
-        // compatibility of the outer serializer's format
-        if (outerCompatibility.isIncompatible()) {
-            return TypeSerializerSchemaCompatibility.incompatible();
-        }
-
-        // check nested serializers for compatibility
-        boolean nestedSerializerRequiresMigration = false;
-        for (int i = 0; i < nestedSnapshots.length; i++) {
-            TypeSerializerSchemaCompatibility<?> compatibility =
-                    resolveCompatibility(newNestedSerializers[i], nestedSnapshots[i]);
-
-            if (compatibility.isIncompatible()) {
-                return TypeSerializerSchemaCompatibility.incompatible();
-            }
-            if (compatibility.isCompatibleAfterMigration()) {
-                nestedSerializerRequiresMigration = true;
-            }
-        }
-
-        return (nestedSerializerRequiresMigration || !outerCompatibility.isCompatibleAsIs())
-                ? TypeSerializerSchemaCompatibility.compatibleAfterMigration()
-                : TypeSerializerSchemaCompatibility.compatibleAsIs();
-    }
-
     // ------------------------------------------------------------------------
     //  Serialization
     // ------------------------------------------------------------------------
@@ -182,17 +142,6 @@ public class NestedSerializersSnapshotDelegate {
     // ------------------------------------------------------------------------
     //  Utilities
     // ------------------------------------------------------------------------
-
-    /** Utility method to conjure up a new scope for the generic parameters. */
-    @SuppressWarnings("unchecked")
-    private static <E> TypeSerializerSchemaCompatibility<E> resolveCompatibility(
-            TypeSerializer<?> serializer, TypeSerializerSnapshot<?> snapshot) {
-
-        TypeSerializer<E> typedSerializer = (TypeSerializer<E>) serializer;
-        TypeSerializerSnapshot<E> typedSnapshot = (TypeSerializerSnapshot<E>) snapshot;
-
-        return typedSnapshot.resolveSchemaCompatibility(typedSerializer);
-    }
 
     private static TypeSerializer<?>[] snapshotsToRestoreSerializers(
             TypeSerializerSnapshot<?>... snapshots) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/SimpleTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/SimpleTypeSerializerSnapshot.java
@@ -74,9 +74,14 @@ public abstract class SimpleTypeSerializerSnapshot<T> implements TypeSerializerS
 
     @Override
     public TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
-            TypeSerializer<T> newSerializer) {
-
-        return newSerializer.getClass() == serializerSupplier.get().getClass()
+            TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof SimpleTypeSerializerSnapshot)) {
+            return TypeSerializerSchemaCompatibility.incompatible();
+        }
+        SimpleTypeSerializerSnapshot<T> oldSimpleTypeSerializerSnapshot =
+                (SimpleTypeSerializerSnapshot<T>) oldSerializerSnapshot;
+        return oldSimpleTypeSerializerSnapshot.restoreSerializer().getClass()
+                        == restoreSerializer().getClass()
                 ? TypeSerializerSchemaCompatibility.compatibleAsIs()
                 : TypeSerializerSchemaCompatibility.incompatible();
     }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/SingleThreadAccessCheckingTypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/SingleThreadAccessCheckingTypeSerializer.java
@@ -151,12 +151,8 @@ public class SingleThreadAccessCheckingTypeSerializer<T> extends TypeSerializer<
             extends CompositeTypeSerializerSnapshot<
                     T, SingleThreadAccessCheckingTypeSerializer<T>> {
 
-        @SuppressWarnings({"unchecked", "unused"})
-        public SingleThreadAccessCheckingTypeSerializerSnapshot() {
-            super(
-                    (Class<SingleThreadAccessCheckingTypeSerializer<T>>)
-                            (Class<?>) SingleThreadAccessCheckingTypeSerializer.class);
-        }
+        @SuppressWarnings("unused")
+        public SingleThreadAccessCheckingTypeSerializerSnapshot() {}
 
         SingleThreadAccessCheckingTypeSerializerSnapshot(
                 SingleThreadAccessCheckingTypeSerializer<T> serializerInstance) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -191,7 +191,7 @@ public abstract class TypeSerializer<T> implements Serializable {
      * evolution and be future-proof. See the class-level comments, section "Upgrading
      * TypeSerializers to the new TypeSerializerSnapshot model" for details.
      *
-     * @see TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)
+     * @see TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot)
      * @return snapshot of the serializer's current configuration (cannot be {@code null}).
      */
     public abstract TypeSerializerSnapshot<T> snapshotConfiguration();

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializer.java
@@ -48,10 +48,9 @@ import java.io.Serializable;
  *       or intended to have a different class name), retain the old serializer snapshot class
  *       (extending {@code TypeSerializerConfigSnapshot}) under the same name and give the updated
  *       serializer snapshot class (the one extending {@code TypeSerializerSnapshot}) a new name.
- *   <li>Override the {@code
- *       TypeSerializerConfigSnapshot#resolveSchemaCompatibility(TypeSerializer)} method to perform
- *       the compatibility check based on configuration written by the old serializer snapshot
- *       class.
+ *   <li>Implement the {@link
+ *       TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot)} method to
+ *       perform the compatibility check.
  * </ul>
  *
  * @param <T> The data type that the serializer serializes.

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSchemaCompatibility.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSchemaCompatibility.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
  *
  * @param <T> the type of data serialized by the serializer that was being checked.
  * @see TypeSerializer
- * @see TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)
+ * @see TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot)
  */
 @PublicEvolving
 public class TypeSerializerSchemaCompatibility<T> {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSchemaCompatibility.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSchemaCompatibility.java
@@ -28,10 +28,10 @@ import javax.annotation.Nullable;
  * TypeSerializer} can be safely used to read data written by a previous type serializer.
  *
  * <p>Typically, the compatibility of the new serializer is resolved by checking the serializer
- * against the {@link TypeSerializerSnapshot} of the previous serializer. Depending on the type of
- * the resolved compatibility result, migration (i.e., reading bytes with the previous serializer
- * and then writing it again with the new serializer) may be required before the new serializer can
- * be used.
+ * snapshot against the {@link TypeSerializerSnapshot} of the previous serializer. Depending on the
+ * type of the resolved compatibility result, migration (i.e., reading bytes with the previous
+ * serializer and then writing it again with the new serializer) may be required before the new
+ * serializer can be used.
  *
  * @param <T> the type of data serialized by the serializer that was being checked.
  * @see TypeSerializer

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshot.java
@@ -36,8 +36,9 @@ import java.io.IOException;
  *       This is explained in more detail below.
  *   <li><strong>Compatibility checks for new serializers:</strong> when new serializers are
  *       available, they need to be checked whether or not they are compatible to read the data
- *       written by the previous serializer. This is performed by providing the new serializer to
- *       the corresponding serializer configuration snapshots in checkpoints.
+ *       written by the previous serializer. This is performed by providing the new serializer
+ *       snapshots to resolve the compatibility with the corresponding previous serializer snapshots
+ *       in checkpoints.
  *   <li><strong>Factory for a read serializer when schema conversion is required:</strong> in the
  *       case that new serializers are not compatible to read previous data, a schema conversion
  *       process executed across all data is required before the new serializer can be continued to
@@ -125,14 +126,35 @@ public interface TypeSerializerSnapshot<T> {
      * operation.
      *
      * @deprecated This method has been replaced by {@link TypeSerializerSnapshot
-     *     #resolveSchemaCompatibility(TypeSerializerSnapshot)}.
+     *     #resolveSchemaCompatibility(TypeSerializerSnapshot)} and will be removed in the future
+     *     release. It's strongly recommended to migrate from old method to the new one, see the doc
+     *     section "Migrating from deprecated
+     *     `TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer newSerializer)`" for
+     *     more details.
      * @param newSerializer the new serializer to check.
      * @return the serializer compatibility result.
      */
     @Deprecated
     default TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
             TypeSerializer<T> newSerializer) {
-        return newSerializer.snapshotConfiguration().resolveSchemaCompatibility(this);
+        // A temporal check to ensure that at least one method is implemented to avoid infinite loop
+        TypeSerializerSnapshot<T> newSerializerSnapshot = newSerializer.snapshotConfiguration();
+        try {
+            Class<?> subClass =
+                    newSerializerSnapshot
+                            .getClass()
+                            .getMethod("resolveSchemaCompatibility", TypeSerializerSnapshot.class)
+                            .getDeclaringClass();
+            if (subClass == TypeSerializerSnapshot.class) {
+                throw new UnsupportedOperationException(
+                        "Must implement at least one method about 'resolveSchemaCompatibility', "
+                                + "Recommend strongly to implement TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot), see FLIP-263 for more details");
+            }
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        // Call the new method to resolve the schema compatibility which must be implemented
+        return newSerializerSnapshot.resolveSchemaCompatibility(this);
     }
 
     /**
@@ -156,6 +178,25 @@ public interface TypeSerializerSnapshot<T> {
      */
     default TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
             TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        // A temporal check to ensure that at least one method is implemented to avoid infinite
+        // loop,
+        // which will be removed after removing the deprecated method
+        // TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer newSerializer).
+        try {
+            Class<?> subClass =
+                    oldSerializerSnapshot
+                            .getClass()
+                            .getMethod("resolveSchemaCompatibility", TypeSerializer.class)
+                            .getDeclaringClass();
+            if (subClass == TypeSerializerSnapshot.class) {
+                throw new UnsupportedOperationException(
+                        "Must implement at least one method about 'resolveSchemaCompatibility', "
+                                + "Recommend strongly to implement TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot), see FLIP-263 for more details");
+            }
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+        // Call the old method to resolve the schema compatibility which must be implemented
         return oldSerializerSnapshot.resolveSchemaCompatibility(restoreSerializer());
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerConfigSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerConfigSnapshot.java
@@ -19,10 +19,7 @@
 package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.NestedSerializersSnapshotDelegate;
-import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -108,19 +105,13 @@ public final class GenericArraySerializerConfigSnapshot<C> implements TypeSerial
                 componentClass, nestedSnapshot.getRestoredNestedSerializer(0));
     }
 
-    @Override
-    public TypeSerializerSchemaCompatibility<C[]> resolveSchemaCompatibility(
-            TypeSerializer<C[]> newSerializer) {
-        checkState(nestedSnapshot != null);
+    @Nullable
+    public TypeSerializerSnapshot<?>[] getNestedSerializerSnapshots() {
+        return nestedSnapshot == null ? null : nestedSnapshot.getNestedSerializerSnapshots();
+    }
 
-        if (!(newSerializer instanceof GenericArraySerializer)) {
-            return TypeSerializerSchemaCompatibility.incompatible();
-        }
-
-        // delegate to the new snapshot class
-        return CompositeTypeSerializerUtil.delegateCompatibilityCheckToNewSnapshot(
-                newSerializer,
-                new GenericArraySerializerSnapshot<>(componentClass),
-                nestedSnapshot.getNestedSerializerSnapshots());
+    @Nullable
+    public Class<C> getComponentClass() {
+        return componentClass;
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
@@ -19,12 +19,16 @@
 package org.apache.flink.api.common.typeutils.base;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.util.InstantiationUtil;
 
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * Point-in-time configuration of a {@link GenericArraySerializer}.
@@ -77,9 +81,34 @@ public final class GenericArraySerializerSnapshot<C>
     }
 
     @Override
+    public TypeSerializerSchemaCompatibility<C[]> resolveSchemaCompatibility(
+            TypeSerializerSnapshot<C[]> oldSerializerSnapshot) {
+        if (oldSerializerSnapshot instanceof GenericArraySerializerConfigSnapshot) {
+            return CompositeTypeSerializerUtil.delegateCompatibilityCheckToNewSnapshot(
+                    oldSerializerSnapshot,
+                    this,
+                    Objects.requireNonNull(
+                            ((GenericArraySerializerConfigSnapshot<C>) oldSerializerSnapshot)
+                                    .getNestedSerializerSnapshots()));
+        }
+        return super.resolveSchemaCompatibility(oldSerializerSnapshot);
+    }
+
+    @Override
     protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
-            GenericArraySerializer<C> newSerializer) {
-        return (this.componentClass == newSerializer.getComponentClass())
+            TypeSerializerSnapshot<C[]> oldSerializerSnapshot) {
+        Class<C> componentClass;
+        if (oldSerializerSnapshot instanceof GenericArraySerializerSnapshot) {
+            componentClass =
+                    ((GenericArraySerializerSnapshot<C>) oldSerializerSnapshot).componentClass;
+        } else if (oldSerializerSnapshot instanceof GenericArraySerializerConfigSnapshot) {
+            componentClass =
+                    ((GenericArraySerializerConfigSnapshot<C>) oldSerializerSnapshot)
+                            .getComponentClass();
+        } else {
+            return OuterSchemaCompatibility.INCOMPATIBLE;
+        }
+        return (this.componentClass == componentClass)
                 ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
                 : OuterSchemaCompatibility.INCOMPATIBLE;
     }

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/GenericArraySerializerSnapshot.java
@@ -43,9 +43,7 @@ public final class GenericArraySerializerSnapshot<C>
     private Class<C> componentClass;
 
     /** Constructor to be used for read instantiation. */
-    public GenericArraySerializerSnapshot() {
-        super(GenericArraySerializer.class);
-    }
+    public GenericArraySerializerSnapshot() {}
 
     /** Constructor to be used for writing the snapshot. */
     public GenericArraySerializerSnapshot(GenericArraySerializer<C> genericArraySerializer) {
@@ -59,7 +57,6 @@ public final class GenericArraySerializerSnapshot<C>
      */
     @SuppressWarnings("deprecation")
     GenericArraySerializerSnapshot(Class<C> componentClass) {
-        super(GenericArraySerializer.class);
         this.componentClass = componentClass;
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/ListSerializerSnapshot.java
@@ -30,9 +30,7 @@ public class ListSerializerSnapshot<T>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public ListSerializerSnapshot() {
-        super(ListSerializer.class);
-    }
+    public ListSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public ListSerializerSnapshot(ListSerializer<T> listSerializer) {

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/base/MapSerializerSnapshot.java
@@ -31,9 +31,7 @@ public class MapSerializerSnapshot<K, V>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public MapSerializerSnapshot() {
-        super(MapSerializer.class);
-    }
+    public MapSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public MapSerializerSnapshot(MapSerializer<K, V> mapSerializer) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/EitherSerializerSnapshot.java
@@ -19,10 +19,8 @@
 package org.apache.flink.api.java.typeutils.runtime;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.NestedSerializersSnapshotDelegate;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
-import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
@@ -104,19 +102,8 @@ public final class EitherSerializerSnapshot<L, R> implements TypeSerializerSnaps
                 nestedSnapshot.getRestoredNestedSerializer(1));
     }
 
-    @Override
-    public TypeSerializerSchemaCompatibility<Either<L, R>> resolveSchemaCompatibility(
-            TypeSerializer<Either<L, R>> newSerializer) {
-        checkState(nestedSnapshot != null);
-
-        if (newSerializer instanceof EitherSerializer) {
-            // delegate compatibility check to the new snapshot class
-            return CompositeTypeSerializerUtil.delegateCompatibilityCheckToNewSnapshot(
-                    newSerializer,
-                    new JavaEitherSerializerSnapshot<>(),
-                    nestedSnapshot.getNestedSerializerSnapshots());
-        } else {
-            return TypeSerializerSchemaCompatibility.incompatible();
-        }
+    @Nullable
+    public TypeSerializerSnapshot<?>[] getNestedSerializerSnapshots() {
+        return nestedSnapshot == null ? null : nestedSnapshot.getNestedSerializerSnapshots();
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/JavaEitherSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/JavaEitherSerializerSnapshot.java
@@ -19,8 +19,13 @@
 package org.apache.flink.api.java.typeutils.runtime;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerUtil;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.types.Either;
+
+import java.util.Objects;
 
 /** Snapshot class for the {@link EitherSerializer}. */
 public class JavaEitherSerializerSnapshot<L, R>
@@ -42,6 +47,20 @@ public class JavaEitherSerializerSnapshot<L, R>
     @Override
     protected int getCurrentOuterSnapshotVersion() {
         return CURRENT_VERSION;
+    }
+
+    @Override
+    public TypeSerializerSchemaCompatibility<Either<L, R>> resolveSchemaCompatibility(
+            TypeSerializerSnapshot<Either<L, R>> oldSerializerSnapshot) {
+        if (oldSerializerSnapshot instanceof EitherSerializerSnapshot) {
+            return CompositeTypeSerializerUtil.delegateCompatibilityCheckToNewSnapshot(
+                    oldSerializerSnapshot,
+                    this,
+                    Objects.requireNonNull(
+                            ((EitherSerializerSnapshot<L, R>) oldSerializerSnapshot)
+                                    .getNestedSerializerSnapshots()));
+        }
+        return super.resolveSchemaCompatibility(oldSerializerSnapshot);
     }
 
     @Override

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/JavaEitherSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/JavaEitherSerializerSnapshot.java
@@ -34,10 +34,7 @@ public class JavaEitherSerializerSnapshot<L, R>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    @SuppressWarnings("unused")
-    public JavaEitherSerializerSnapshot() {
-        super(EitherSerializer.class);
-    }
+    public JavaEitherSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public JavaEitherSerializerSnapshot(EitherSerializer<L, R> eitherSerializer) {

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
@@ -328,8 +328,13 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
 
         @Override
         protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
-                NullableSerializer<T> newSerializer) {
-            return (nullPaddingLength == newSerializer.nullPaddingLength())
+                TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof NullableSerializerSnapshot)) {
+                return OuterSchemaCompatibility.INCOMPATIBLE;
+            }
+            NullableSerializerSnapshot<T> oldNullableSerializerSnapshot =
+                    (NullableSerializerSnapshot<T>) oldSerializerSnapshot;
+            return (nullPaddingLength == oldNullableSerializerSnapshot.nullPaddingLength)
                     ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
                     : OuterSchemaCompatibility.INCOMPATIBLE;
         }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/NullableSerializer.java
@@ -271,9 +271,7 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
         private int nullPaddingLength;
 
         @SuppressWarnings("unused")
-        public NullableSerializerSnapshot() {
-            super(NullableSerializer.class);
-        }
+        public NullableSerializerSnapshot() {}
 
         public NullableSerializerSnapshot(NullableSerializer<T> serializerInstance) {
             super(serializerInstance);
@@ -281,7 +279,6 @@ public class NullableSerializer<T> extends TypeSerializer<T> {
         }
 
         private NullableSerializerSnapshot(int nullPaddingLength) {
-            super(NullableSerializer.class);
             checkArgument(
                     nullPaddingLength >= 0,
                     "Computed NULL padding can not be negative. %s",

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializer.java
@@ -664,7 +664,8 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
                 registeredSerializers,
                 fields,
                 fieldSerializers,
-                subclassSerializerCache);
+                subclassSerializerCache,
+                executionConfig);
     }
 
     // --------------------------------------------------------------------------------------------
@@ -863,7 +864,8 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
             TypeSerializer<?>[] registeredSubclassSerializers,
             Field[] fields,
             TypeSerializer<?>[] fieldSerializers,
-            Map<Class<?>, TypeSerializer<?>> nonRegisteredSubclassSerializerCache) {
+            Map<Class<?>, TypeSerializer<?>> nonRegisteredSubclassSerializerCache,
+            ExecutionConfig executionConfig) {
 
         final LinkedHashMap<Class<?>, TypeSerializer<?>> subclassRegistry =
                 CollectionUtil.newLinkedHashMapWithExpectedSize(registeredSubclassesToTags.size());
@@ -877,6 +879,7 @@ public final class PojoSerializer<T> extends TypeSerializer<T> {
                 fields,
                 fieldSerializers,
                 subclassRegistry,
-                nonRegisteredSubclassSerializerCache);
+                nonRegisteredSubclassSerializerCache,
+                executionConfig);
     }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshot.java
@@ -56,6 +56,12 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
     /** Contains the actual content for the serializer snapshot. */
     private PojoSerializerSnapshotData<T> snapshotData;
 
+    /**
+     * Configuration of the current execution. WARN: it's just used as point-in-time view to check
+     * or generate something which should never be used in writeSnapshot or readSnapshot.
+     */
+    private ExecutionConfig executionConfig;
+
     /** Constructor for reading the snapshot. */
     public PojoSerializerSnapshot() {}
 
@@ -77,7 +83,8 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
             Field[] fields,
             TypeSerializer<?>[] fieldSerializers,
             LinkedHashMap<Class<?>, TypeSerializer<?>> registeredSubclassSerializers,
-            Map<Class<?>, TypeSerializer<?>> nonRegisteredSubclassSerializers) {
+            Map<Class<?>, TypeSerializer<?>> nonRegisteredSubclassSerializers,
+            ExecutionConfig executionConfig) {
 
         this.snapshotData =
                 PojoSerializerSnapshotData.createFrom(
@@ -86,6 +93,7 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
                         fieldSerializers,
                         registeredSubclassSerializers,
                         nonRegisteredSubclassSerializers);
+        this.executionConfig = executionConfig;
     }
 
     /**
@@ -101,7 +109,8 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
             LinkedHashMap<Class<?>, TypeSerializerSnapshot<?>>
                     existingRegisteredSubclassSerializerSnapshots,
             Map<Class<?>, TypeSerializerSnapshot<?>>
-                    existingNonRegisteredSubclassSerializerSnapshots) {
+                    existingNonRegisteredSubclassSerializerSnapshots,
+            ExecutionConfig executionConfig) {
 
         this.snapshotData =
                 PojoSerializerSnapshotData.createFrom(
@@ -110,6 +119,7 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
                         existingFieldSerializerSnapshots,
                         existingRegisteredSubclassSerializerSnapshots,
                         existingNonRegisteredSubclassSerializerSnapshots);
+        this.executionConfig = executionConfig;
     }
 
     @Override
@@ -173,24 +183,28 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
 
     @Override
     public TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
-            TypeSerializer<T> newSerializer) {
-        if (newSerializer.getClass() != PojoSerializer.class) {
+            TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof PojoSerializerSnapshot)) {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
 
-        final PojoSerializer<T> newPojoSerializer = (PojoSerializer<T>) newSerializer;
+        PojoSerializerSnapshot<T> previousPojoSerializerSnapshot =
+                (PojoSerializerSnapshot<T>) oldSerializerSnapshot;
 
-        final Class<T> previousPojoClass = snapshotData.getPojoClass();
+        final Class<T> previousPojoClass =
+                previousPojoSerializerSnapshot.snapshotData.getPojoClass();
         final LinkedOptionalMap<Field, TypeSerializerSnapshot<?>> fieldSerializerSnapshots =
-                snapshotData.getFieldSerializerSnapshots();
+                previousPojoSerializerSnapshot.snapshotData.getFieldSerializerSnapshots();
         final LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
                 registeredSubclassSerializerSnapshots =
-                        snapshotData.getRegisteredSubclassSerializerSnapshots();
+                        previousPojoSerializerSnapshot.snapshotData
+                                .getRegisteredSubclassSerializerSnapshots();
         final LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
                 nonRegisteredSubclassSerializerSnapshots =
-                        snapshotData.getNonRegisteredSubclassSerializerSnapshots();
+                        previousPojoSerializerSnapshot.snapshotData
+                                .getNonRegisteredSubclassSerializerSnapshots();
 
-        if (previousPojoClass != newPojoSerializer.getPojoClass()) {
+        if (previousPojoClass != snapshotData.getPojoClass()) {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
 
@@ -203,7 +217,7 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
         }
 
         final IntermediateCompatibilityResult<T> preExistingFieldSerializersCompatibility =
-                getCompatibilityOfPreExistingFields(newPojoSerializer, fieldSerializerSnapshots);
+                getCompatibilityOfPreExistingFields(fieldSerializerSnapshots);
 
         if (preExistingFieldSerializersCompatibility.isIncompatible()) {
             return TypeSerializerSchemaCompatibility.incompatible();
@@ -211,14 +225,13 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
 
         final IntermediateCompatibilityResult<T> preExistingRegistrationsCompatibility =
                 getCompatibilityOfPreExistingRegisteredSubclasses(
-                        newPojoSerializer, registeredSubclassSerializerSnapshots);
+                        registeredSubclassSerializerSnapshots);
 
         if (preExistingRegistrationsCompatibility.isIncompatible()) {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
 
         if (newPojoSerializerIsCompatibleAfterMigration(
-                newPojoSerializer,
                 preExistingFieldSerializersCompatibility,
                 preExistingRegistrationsCompatibility,
                 fieldSerializerSnapshots)) {
@@ -227,7 +240,6 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
         }
 
         if (newPojoSerializerIsCompatibleWithReconfiguredSerializer(
-                newPojoSerializer,
                 preExistingFieldSerializersCompatibility,
                 preExistingRegistrationsCompatibility,
                 registeredSubclassSerializerSnapshots,
@@ -235,7 +247,6 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
 
             return TypeSerializerSchemaCompatibility.compatibleWithReconfiguredSerializer(
                     constructReconfiguredPojoSerializer(
-                            newPojoSerializer,
                             preExistingFieldSerializersCompatibility,
                             registeredSubclassSerializerSnapshots,
                             preExistingRegistrationsCompatibility,
@@ -289,128 +300,105 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
     }
 
     /**
-     * Finds which Pojo fields exists both in the new {@link PojoSerializer} as well as in the
-     * previous one (represented by this snapshot), and returns an {@link
-     * IntermediateCompatibilityResult} of the serializers of those preexisting fields.
+     * Finds which Pojo fields exists both in the new {@link PojoSerializerSnapshot} as well as in
+     * the previous one, and returns an {@link IntermediateCompatibilityResult} of the serializers
+     * of those preexisting fields.
      */
-    private static <T> IntermediateCompatibilityResult<T> getCompatibilityOfPreExistingFields(
-            PojoSerializer<T> newPojoSerializer,
-            LinkedOptionalMap<Field, TypeSerializerSnapshot<?>> fieldSerializerSnapshots) {
+    private IntermediateCompatibilityResult<T> getCompatibilityOfPreExistingFields(
+            LinkedOptionalMap<Field, TypeSerializerSnapshot<?>> oldFieldSerializerSnapshots) {
 
         // the present entries dictates the preexisting fields, because removed fields would be
         // represented as absent keys in the optional map.
         final Set<LinkedOptionalMap.KeyValue<Field, TypeSerializerSnapshot<?>>>
-                presentFieldSnapshots = fieldSerializerSnapshots.getPresentEntries();
+                presentFieldSnapshots = oldFieldSerializerSnapshots.getPresentEntries();
 
         final ArrayList<TypeSerializerSnapshot<?>> associatedFieldSerializerSnapshots =
                 new ArrayList<>(presentFieldSnapshots.size());
-        final ArrayList<TypeSerializer<?>> associatedNewFieldSerializers =
+        final ArrayList<TypeSerializerSnapshot<?>> associatedNewFieldSerializerSnapshots =
                 new ArrayList<>(presentFieldSnapshots.size());
 
-        final Map<Field, TypeSerializer<?>> newFieldSerializersIndex =
-                buildNewFieldSerializersIndex(newPojoSerializer);
+        Map<Field, TypeSerializerSnapshot<?>> newFieldSerializerSnapshots =
+                snapshotData.getFieldSerializerSnapshots().unwrapOptionals();
         for (LinkedOptionalMap.KeyValue<Field, TypeSerializerSnapshot<?>> presentFieldEntry :
                 presentFieldSnapshots) {
-            TypeSerializer<?> associatedNewFieldSerializer =
-                    newFieldSerializersIndex.get(presentFieldEntry.getKey());
+            TypeSerializerSnapshot<?> associatedNewFieldSerializer =
+                    newFieldSerializerSnapshots.get(presentFieldEntry.getKey());
             checkState(
                     associatedNewFieldSerializer != null,
                     "a present field should have its associated new field serializer available.");
 
             associatedFieldSerializerSnapshots.add(presentFieldEntry.getValue());
-            associatedNewFieldSerializers.add(associatedNewFieldSerializer);
+            associatedNewFieldSerializerSnapshots.add(associatedNewFieldSerializer);
         }
 
         return CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
-                associatedNewFieldSerializers.toArray(
-                        new TypeSerializer<?>[associatedNewFieldSerializers.size()]),
+                associatedNewFieldSerializerSnapshots.toArray(
+                        new TypeSerializerSnapshot<?>
+                                [associatedNewFieldSerializerSnapshots.size()]),
                 associatedFieldSerializerSnapshots.toArray(
                         new TypeSerializerSnapshot<?>[associatedFieldSerializerSnapshots.size()]));
     }
 
     /**
-     * Builds an index of fields to their corresponding serializers for the new {@link
-     * PojoSerializer} for faster field serializer lookups.
+     * Finds which registered subclasses exists both in the new {@link PojoSerializerSnapshot} as
+     * well as in the previous one, and returns an {@link IntermediateCompatibilityResult} of the
+     * serializers of this preexisting registered subclasses.
      */
-    private static <T> Map<Field, TypeSerializer<?>> buildNewFieldSerializersIndex(
-            PojoSerializer<T> newPojoSerializer) {
-        final Field[] newFields = newPojoSerializer.getFields();
-        final TypeSerializer<?>[] newFieldSerializers = newPojoSerializer.getFieldSerializers();
-
-        checkState(newFields.length == newFieldSerializers.length);
-
-        int numFields = newFields.length;
-        final Map<Field, TypeSerializer<?>> index =
-                CollectionUtil.newHashMapWithExpectedSize(numFields);
-        for (int i = 0; i < numFields; i++) {
-            index.put(newFields[i], newFieldSerializers[i]);
-        }
-
-        return index;
-    }
-
-    /**
-     * Finds which registered subclasses exists both in the new {@link PojoSerializer} as well as in
-     * the previous one (represented by this snapshot), and returns an {@link
-     * IntermediateCompatibilityResult} of the serializers of this preexisting registered
-     * subclasses.
-     */
-    private static <T>
-            IntermediateCompatibilityResult<T> getCompatibilityOfPreExistingRegisteredSubclasses(
-                    PojoSerializer<T> newPojoSerializer,
-                    LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
-                            registeredSubclassSerializerSnapshots) {
+    private IntermediateCompatibilityResult<T> getCompatibilityOfPreExistingRegisteredSubclasses(
+            LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
+                    registeredSubclassSerializerSnapshots) {
 
         final LinkedHashMap<Class<?>, TypeSerializerSnapshot<?>> unwrappedSerializerSnapshots =
                 registeredSubclassSerializerSnapshots.unwrapOptionals();
 
         final ArrayList<TypeSerializerSnapshot<?>> associatedSubclassSerializerSnapshots =
                 new ArrayList<>();
-        final ArrayList<TypeSerializer<?>> associatedNewSubclassSerializers = new ArrayList<>();
+        final ArrayList<TypeSerializerSnapshot<?>> associatedNewSubclassSerializerSnapshots =
+                new ArrayList<>();
 
-        final LinkedHashMap<Class<?>, TypeSerializer<?>> newSubclassSerializerRegistry =
-                newPojoSerializer.getBundledSubclassSerializerRegistry();
+        final LinkedHashMap<Class<?>, TypeSerializerSnapshot<?>> newSubclassSerializerRegistry =
+                snapshotData.getRegisteredSubclassSerializerSnapshots().unwrapOptionals();
 
         for (Map.Entry<Class<?>, TypeSerializerSnapshot<?>> entry :
                 unwrappedSerializerSnapshots.entrySet()) {
-            TypeSerializer<?> newRegisteredSerializer =
+            TypeSerializerSnapshot<?> newRegisteredSerializerSnapshot =
                     newSubclassSerializerRegistry.get(entry.getKey());
-            if (newRegisteredSerializer != null) {
+            if (newRegisteredSerializerSnapshot != null) {
                 associatedSubclassSerializerSnapshots.add(entry.getValue());
-                associatedNewSubclassSerializers.add(newRegisteredSerializer);
+                associatedNewSubclassSerializerSnapshots.add(newRegisteredSerializerSnapshot);
             }
         }
 
         return CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
-                associatedNewSubclassSerializers.toArray(
-                        new TypeSerializer<?>[associatedNewSubclassSerializers.size()]),
+                associatedNewSubclassSerializerSnapshots.toArray(
+                        new TypeSerializerSnapshot<?>
+                                [associatedNewSubclassSerializerSnapshots.size()]),
                 associatedSubclassSerializerSnapshots.toArray(
                         new TypeSerializerSnapshot<?>
                                 [associatedSubclassSerializerSnapshots.size()]));
     }
 
-    /** Checks if the new {@link PojoSerializer} is compatible after migration. */
-    private static <T> boolean newPojoSerializerIsCompatibleAfterMigration(
-            PojoSerializer<T> newPojoSerializer,
+    /** Checks if the new {@link PojoSerializerSnapshot} is compatible after migration. */
+    private boolean newPojoSerializerIsCompatibleAfterMigration(
             IntermediateCompatibilityResult<T> fieldSerializerCompatibility,
             IntermediateCompatibilityResult<T> preExistingRegistrationsCompatibility,
             LinkedOptionalMap<Field, TypeSerializerSnapshot<?>> fieldSerializerSnapshots) {
-        return newPojoHasNewOrRemovedFields(fieldSerializerSnapshots, newPojoSerializer)
+        return newPojoHasNewOrRemovedFields(fieldSerializerSnapshots)
                 || fieldSerializerCompatibility.isCompatibleAfterMigration()
                 || preExistingRegistrationsCompatibility.isCompatibleAfterMigration();
     }
 
-    /** Checks if the new {@link PojoSerializer} is compatible with a reconfigured instance. */
-    private static <T> boolean newPojoSerializerIsCompatibleWithReconfiguredSerializer(
-            PojoSerializer<T> newPojoSerializer,
+    /**
+     * Checks if the new {@link PojoSerializerSnapshot} is compatible with a reconfigured instance.
+     */
+    private boolean newPojoSerializerIsCompatibleWithReconfiguredSerializer(
             IntermediateCompatibilityResult<T> fieldSerializerCompatibility,
             IntermediateCompatibilityResult<T> preExistingRegistrationsCompatibility,
             LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
                     registeredSubclassSerializerSnapshots,
             LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
                     nonRegisteredSubclassSerializerSnapshots) {
-        return newPojoHasDifferentSubclassRegistrationOrder(
-                        registeredSubclassSerializerSnapshots, newPojoSerializer)
+        return newPojoHasDifferentSubclassRegistrationOrder(registeredSubclassSerializerSnapshots)
                 || previousSerializerHasNonRegisteredSubclasses(
                         nonRegisteredSubclassSerializerSnapshots)
                 || fieldSerializerCompatibility.isCompatibleWithReconfiguredSerializer()
@@ -418,31 +406,31 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
     }
 
     /**
-     * Checks whether the new {@link PojoSerializer} has new or removed fields compared to the
-     * previous one.
+     * Checks whether the new {@link PojoSerializerSnapshot} has new or removed fields compared to
+     * the previous one.
      */
-    private static boolean newPojoHasNewOrRemovedFields(
-            LinkedOptionalMap<Field, TypeSerializerSnapshot<?>> fieldSerializerSnapshots,
-            PojoSerializer<?> newPojoSerializer) {
+    private boolean newPojoHasNewOrRemovedFields(
+            LinkedOptionalMap<Field, TypeSerializerSnapshot<?>> fieldSerializerSnapshots) {
         int numRemovedFields = fieldSerializerSnapshots.absentKeysOrValues().size();
         int numPreexistingFields = fieldSerializerSnapshots.size() - numRemovedFields;
 
         boolean hasRemovedFields = numRemovedFields > 0;
-        boolean hasNewFields = newPojoSerializer.getFields().length - numPreexistingFields > 0;
+        boolean hasNewFields =
+                snapshotData.getFieldSerializerSnapshots().size() - numPreexistingFields > 0;
         return hasRemovedFields || hasNewFields;
     }
 
     /**
-     * Checks whether the new {@link PojoSerializer} has a different subclass registration order
-     * compared to the previous one.
+     * Checks whether the new {@link PojoSerializerSnapshot} has a different subclass registration
+     * order compared to the previous one.
      */
-    private static boolean newPojoHasDifferentSubclassRegistrationOrder(
+    private boolean newPojoHasDifferentSubclassRegistrationOrder(
             LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
-                    registeredSubclassSerializerSnapshots,
-            PojoSerializer<?> newPojoSerializer) {
+                    registeredSubclassSerializerSnapshots) {
         Set<Class<?>> previousRegistrationOrder =
                 registeredSubclassSerializerSnapshots.unwrapOptionals().keySet();
-        Set<Class<?>> newRegistrationOrder = newPojoSerializer.getRegisteredClasses().keySet();
+        Set<Class<?>> newRegistrationOrder =
+                snapshotData.getRegisteredSubclassSerializerSnapshots().unwrapOptionals().keySet();
         return !isPreviousRegistrationPrefixOfNewRegistration(
                 previousRegistrationOrder, newRegistrationOrder);
     }
@@ -474,10 +462,8 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
     }
 
     /**
-     * Creates a reconfigured version of the {@link PojoSerializer}.
+     * Creates a reconfigured version of the {@link PojoSerializerSnapshot}.
      *
-     * @param originalNewPojoSerializer the original new {@link PojoSerializer} to create a
-     *     reconfigured version of.
      * @param fieldSerializerCompatibility compatibility of preexisting fields' serializers.
      * @param registeredSerializerSnapshots snapshot of previous registered subclasses' serializers.
      * @param preExistingRegistrationsCompatibility compatibility of preexisting subclasses'
@@ -486,8 +472,7 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
      *     subclasses' serializers.
      * @return a reconfigured version of the original new {@link PojoSerializer}.
      */
-    private static <T> PojoSerializer<T> constructReconfiguredPojoSerializer(
-            PojoSerializer<T> originalNewPojoSerializer,
+    private PojoSerializer<T> constructReconfiguredPojoSerializer(
             IntermediateCompatibilityResult<T> fieldSerializerCompatibility,
             LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>> registeredSerializerSnapshots,
             IntermediateCompatibilityResult<T> preExistingRegistrationsCompatibility,
@@ -500,19 +485,25 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
 
         Tuple2<LinkedHashMap<Class<?>, Integer>, TypeSerializer<Object>[]>
                 reconfiguredSubclassRegistry =
-                        constructReconfiguredSubclassRegistry(
-                                originalNewPojoSerializer.getBundledSubclassSerializerRegistry(),
+                        constructReconfiguredSubclassRegistrations(
+                                snapshotData
+                                        .getRegisteredSubclassSerializerSnapshots()
+                                        .unwrapOptionals(),
                                 registeredSerializerSnapshots,
                                 preExistingRegistrationsCompatibility);
 
         return new PojoSerializer<>(
-                originalNewPojoSerializer.getPojoClass(),
-                originalNewPojoSerializer.getFields(),
+                snapshotData.getPojoClass(),
+                snapshotData
+                        .getFieldSerializerSnapshots()
+                        .unwrapOptionals()
+                        .keySet()
+                        .toArray(new Field[0]),
                 reconfiguredFieldSerializers,
                 reconfiguredSubclassRegistry.f0,
                 reconfiguredSubclassRegistry.f1,
                 restoreSerializers(nonRegisteredSubclassSerializerSnapshots.unwrapOptionals()),
-                originalNewPojoSerializer.getExecutionConfig());
+                executionConfig);
     }
 
     private static TypeSerializer[] constructReconfiguredFieldSerializers(
@@ -524,10 +515,10 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
     }
 
     private static Tuple2<LinkedHashMap<Class<?>, Integer>, TypeSerializer<Object>[]>
-            constructReconfiguredSubclassRegistry(
-                    LinkedHashMap<Class<?>, TypeSerializer<?>> newSubclassRegistrations,
+            constructReconfiguredSubclassRegistrations(
+                    LinkedHashMap<Class<?>, TypeSerializerSnapshot<?>> newSubclassRegistrations,
                     LinkedOptionalMap<Class<?>, TypeSerializerSnapshot<?>>
-                            registeredSerializerSnapshots,
+                            oldRegisteredSerializerSnapshots,
                     IntermediateCompatibilityResult<?> preExistingRegistrationsCompatibility) {
 
         checkArgument(
@@ -535,7 +526,7 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
                         && !preExistingRegistrationsCompatibility.isCompatibleAfterMigration());
 
         LinkedHashMap<Class<?>, TypeSerializer<?>> reconfiguredSubclassSerializerRegistry =
-                restoreSerializers(registeredSerializerSnapshots.unwrapOptionals());
+                restoreSerializers(oldRegisteredSerializerSnapshots.unwrapOptionals());
 
         Iterator<TypeSerializer<?>> serializersForPreexistingRegistrations =
                 Arrays.asList(preExistingRegistrationsCompatibility.getNestedSerializers())
@@ -553,13 +544,13 @@ public class PojoSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
         // then, for all new registration that did not exist before, append it to the registry
         // simply with their
         // new serializers
-        for (Map.Entry<Class<?>, TypeSerializer<?>> newRegistration :
+        for (Map.Entry<Class<?>, TypeSerializerSnapshot<?>> newRegistration :
                 newSubclassRegistrations.entrySet()) {
             TypeSerializer<?> oldRegistration =
                     reconfiguredSubclassSerializerRegistry.get(newRegistration.getKey());
             if (oldRegistration == null) {
                 reconfiguredSubclassSerializerRegistry.put(
-                        newRegistration.getKey(), newRegistration.getValue());
+                        newRegistration.getKey(), newRegistration.getValue().restoreSerializer());
             }
         }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
@@ -519,8 +519,13 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
         @Override
         protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
-                RowSerializer newSerializer) {
-            if (supportsRowKind != newSerializer.supportsRowKind) {
+                TypeSerializerSnapshot<Row> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof RowSerializerSnapshot)) {
+                return OuterSchemaCompatibility.INCOMPATIBLE;
+            }
+            RowSerializerSnapshot oldRowSerializerSnapshot =
+                    (RowSerializerSnapshot) oldSerializerSnapshot;
+            if (supportsRowKind != oldRowSerializerSnapshot.supportsRowKind) {
                 return OuterSchemaCompatibility.COMPATIBLE_AFTER_MIGRATION;
             }
             return OuterSchemaCompatibility.COMPATIBLE_AS_IS;

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/RowSerializer.java
@@ -485,9 +485,7 @@ public final class RowSerializer extends TypeSerializer<Row> {
 
         private boolean supportsRowKind = true;
 
-        public RowSerializerSnapshot() {
-            super(RowSerializer.class);
-        }
+        public RowSerializerSnapshot() {}
 
         RowSerializerSnapshot(RowSerializer serializerInstance) {
             super(serializerInstance);

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/TupleSerializerSnapshot.java
@@ -41,9 +41,7 @@ public final class TupleSerializerSnapshot<T extends Tuple>
     private Class<T> tupleClass;
 
     @SuppressWarnings("unused")
-    public TupleSerializerSnapshot() {
-        super(TupleSerializer.class);
-    }
+    public TupleSerializerSnapshot() {}
 
     TupleSerializerSnapshot(TupleSerializer<T> serializerInstance) {
         super(serializerInstance);
@@ -56,7 +54,6 @@ public final class TupleSerializerSnapshot<T extends Tuple>
      * TupleSerializer#resolveSchemaCompatibilityViaRedirectingToNewSnapshotClass}.
      */
     TupleSerializerSnapshot(Class<T> tupleClass) {
-        super(TupleSerializer.class);
         this.tupleClass = checkNotNull(tupleClass, "tuple class can not be NULL");
     }
 

--- a/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
+++ b/flink-core/src/main/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializer.java
@@ -250,22 +250,6 @@ public class KryoSerializer<T> extends TypeSerializer<T> {
                 checkNotNull(kryoRegistrations, "Kryo registrations cannot be null.");
     }
 
-    Class<T> getType() {
-        return type;
-    }
-
-    LinkedHashMap<Class<?>, SerializableSerializer<?>> getDefaultKryoSerializers() {
-        return defaultSerializers;
-    }
-
-    LinkedHashMap<Class<?>, Class<? extends Serializer<?>>> getDefaultKryoSerializerClasses() {
-        return defaultSerializerClasses;
-    }
-
-    LinkedHashMap<String, KryoRegistration> getKryoRegistrations() {
-        return kryoRegistrations;
-    }
-
     // ------------------------------------------------------------------------
 
     @Override

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeSerializerTest.java
@@ -214,7 +214,6 @@ class CompositeSerializerTest {
 
         /** Constructor for read instantiation. */
         public TestListCompositeSerializerSnapshot() {
-            super(TestListCompositeSerializer.class);
             this.isImmutableTargetType = false;
         }
 

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshotTest.java
@@ -367,9 +367,7 @@ public class CompositeTypeSerializerSnapshotTest {
 
         private OuterSchemaCompatibility mockOuterSchemaCompatibility;
 
-        public TestCompositeTypeSerializerSnapshot() {
-            super(TestCompositeTypeSerializer.class);
-        }
+        public TestCompositeTypeSerializerSnapshot() {}
 
         TestCompositeTypeSerializerSnapshot(TestCompositeTypeSerializer serializer) {
             super(serializer);

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUpgradeTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerUpgradeTest.java
@@ -20,16 +20,19 @@ package org.apache.flink.api.common.typeutils;
 
 import org.apache.flink.FlinkVersion;
 import org.apache.flink.api.common.typeutils.base.GenericArraySerializer;
+import org.apache.flink.api.common.typeutils.base.GenericArraySerializerConfigSnapshot;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.typeutils.runtime.EitherSerializer;
 import org.apache.flink.types.Either;
 
 import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.hamcrest.Matchers.is;
 
 /** A {@link TypeSerializerUpgradeTestBase} for {@link GenericArraySerializer}. */
@@ -142,5 +145,18 @@ class CompositeTypeSerializerUpgradeTest extends TypeSerializerUpgradeTestBase<O
                 FlinkVersion version) {
             return TypeSerializerMatchers.isCompatibleAsIs();
         }
+    }
+
+    @Test
+    public void testUpgradeFromDeprecatedSnapshot() {
+        GenericArraySerializer<String> genericArraySerializer =
+                new GenericArraySerializer<>(String.class, StringSerializer.INSTANCE);
+        GenericArraySerializerConfigSnapshot<String> oldSnapshot =
+                new GenericArraySerializerConfigSnapshot<>(genericArraySerializer);
+        TypeSerializerSchemaCompatibility<String[]> schemaCompatibility =
+                genericArraySerializer
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(oldSnapshot);
+        assertThat(schemaCompatibility.isCompatibleAsIs()).isTrue();
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/SerializerTestBase.java
@@ -154,7 +154,7 @@ public abstract class SerializerTestBase<T> {
         }
 
         TypeSerializerSchemaCompatibility<T> strategy =
-                restoredConfig.resolveSchemaCompatibility(getSerializer());
+                getSerializer().snapshotConfiguration().resolveSchemaCompatibility(restoredConfig);
         final TypeSerializer<T> restoreSerializer;
         if (strategy.isCompatibleAsIs()) {
             restoreSerializer = restoredConfig.restoreSerializer();

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerSnapshotTest.java
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common.typeutils;
+
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link TypeSerializerSnapshot} */
+public class TypeSerializerSnapshotTest {
+
+    @Test
+    public void testIllegalSchemaCompatibility() {
+        TypeSerializerSnapshot<Integer> illegalSnapshot =
+                new NotCompletedTypeSerializerSnapshot() {};
+
+        // Should throw UnsupportedOperationException if both two methods are not implemented
+        assertThatThrownBy(
+                        () ->
+                                illegalSnapshot.resolveSchemaCompatibility(
+                                        new NotCompletedTypeSerializer()))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(
+                        () ->
+                                illegalSnapshot.resolveSchemaCompatibility(
+                                        new NotCompletedTypeSerializer().snapshotConfiguration()))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    public void testNewSchemaCompatibility() {
+        TypeSerializerSnapshot<Integer> legalSnapshot =
+                new NotCompletedTypeSerializerSnapshot() {
+                    @Override
+                    public TypeSerializerSchemaCompatibility<Integer> resolveSchemaCompatibility(
+                            TypeSerializerSnapshot<Integer> oldSerializerSnapshot) {
+                        return TypeSerializerSchemaCompatibility.compatibleAsIs();
+                    }
+                };
+
+        // The result of resolving schema compatibility should always be determined by legalSnapshot
+        assertThat(
+                        new NotCompletedTypeSerializerSnapshot()
+                                .resolveSchemaCompatibility(
+                                        new NotCompletedTypeSerializer() {
+                                            @Override
+                                            public TypeSerializerSnapshot<Integer>
+                                                    snapshotConfiguration() {
+                                                return legalSnapshot;
+                                            }
+                                        })
+                                .isCompatibleAsIs())
+                .isTrue();
+        assertThat(
+                        legalSnapshot
+                                .resolveSchemaCompatibility(
+                                        new NotCompletedTypeSerializerSnapshot() {})
+                                .isCompatibleAsIs())
+                .isTrue();
+    }
+
+    @Test
+    public void testOldSchemaCompatibility() {
+        TypeSerializerSnapshot<Integer> legalSnapshot =
+                new NotCompletedTypeSerializerSnapshot() {
+
+                    @Override
+                    public TypeSerializerSchemaCompatibility<Integer> resolveSchemaCompatibility(
+                            TypeSerializer<Integer> newSerializer) {
+                        return TypeSerializerSchemaCompatibility.compatibleAsIs();
+                    }
+                };
+
+        // The result of resolving schema compatibility should always be determined by legalSnapshot
+        assertThat(
+                        legalSnapshot
+                                .resolveSchemaCompatibility(new NotCompletedTypeSerializer())
+                                .isCompatibleAsIs())
+                .isTrue();
+        assertThat(
+                        new NotCompletedTypeSerializerSnapshot()
+                                .resolveSchemaCompatibility(legalSnapshot)
+                                .isCompatibleAsIs())
+                .isTrue();
+    }
+
+    @Test
+    public void testNestedSchemaCompatibility() {
+        TypeSerializerSnapshot<Integer> innerSnapshot =
+                new NotCompletedTypeSerializerSnapshot() {
+                    @Override
+                    public TypeSerializerSchemaCompatibility<Integer> resolveSchemaCompatibility(
+                            TypeSerializerSnapshot<Integer> oldSerializerSnapshot) {
+                        return TypeSerializerSchemaCompatibility.compatibleAsIs();
+                    }
+                };
+
+        TypeSerializerSnapshot<Integer> outerSnapshot =
+                new NotCompletedTypeSerializerSnapshot() {
+                    @Override
+                    public TypeSerializerSchemaCompatibility<Integer> resolveSchemaCompatibility(
+                            TypeSerializer<Integer> newSerializer) {
+                        return innerSnapshot.resolveSchemaCompatibility(
+                                innerSnapshot.restoreSerializer());
+                    }
+                };
+
+        // The result of resolving schema compatibility should be determined by the new method of
+        // innerSnapshot
+        assertThat(outerSnapshot.resolveSchemaCompatibility(outerSnapshot).isCompatibleAsIs())
+                .isTrue();
+    }
+
+    private static class NotCompletedTypeSerializer extends TypeSerializer<Integer> {
+
+        @Override
+        public boolean isImmutableType() {
+            return true;
+        }
+
+        @Override
+        public TypeSerializer<Integer> duplicate() {
+            return this;
+        }
+
+        @Override
+        public Integer createInstance() {
+            return 0;
+        }
+
+        @Override
+        public Integer copy(Integer from) {
+            return from;
+        }
+
+        @Override
+        public Integer copy(Integer from, Integer reuse) {
+            return from;
+        }
+
+        @Override
+        public int getLength() {
+            return 1;
+        }
+
+        @Override
+        public void serialize(Integer record, DataOutputView target) {
+            // do nothing
+        }
+
+        @Override
+        public Integer deserialize(DataInputView source) {
+            return 0;
+        }
+
+        @Override
+        public Integer deserialize(Integer reuse, DataInputView source) {
+            return reuse;
+        }
+
+        @Override
+        public void copy(DataInputView source, DataOutputView target) {
+            // do nothing
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return 0;
+        }
+
+        @Override
+        public TypeSerializerSnapshot<Integer> snapshotConfiguration() {
+            return new NotCompletedTypeSerializerSnapshot() {
+                @Override
+                public TypeSerializer<Integer> restoreSerializer() {
+                    return NotCompletedTypeSerializer.this;
+                }
+            };
+        }
+    }
+
+    private static class NotCompletedTypeSerializerSnapshot
+            implements TypeSerializerSnapshot<Integer> {
+
+        @Override
+        public int getCurrentVersion() {
+            return 0;
+        }
+
+        @Override
+        public void writeSnapshot(DataOutputView out) {
+            // do nothing
+        }
+
+        @Override
+        public void readSnapshot(
+                int readVersion, DataInputView in, ClassLoader userCodeClassLoader) {
+            // do nothing
+        }
+
+        @Override
+        public TypeSerializer<Integer> restoreSerializer() {
+            return new NotCompletedTypeSerializer() {
+                @Override
+                public TypeSerializerSnapshot<Integer> snapshotConfiguration() {
+                    return NotCompletedTypeSerializerSnapshot.this;
+                }
+            };
+        }
+    }
+}

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/TypeSerializerUpgradeTestBase.java
@@ -326,7 +326,9 @@ public abstract class TypeSerializerUpgradeTestBase<PreviousElementT, UpgradedEl
                     testSpecification.verifier.createUpgradedSerializer();
 
             TypeSerializerSchemaCompatibility<UpgradedElementT> upgradeCompatibility =
-                    restoredSerializerSnapshot.resolveSchemaCompatibility(upgradedSerializer);
+                    upgradedSerializer
+                            .snapshotConfiguration()
+                            .resolveSchemaCompatibility(restoredSerializerSnapshot);
 
             assertThat(upgradeCompatibility)
                     .is(
@@ -350,7 +352,9 @@ public abstract class TypeSerializerUpgradeTestBase<PreviousElementT, UpgradedEl
                     testSpecification.verifier.createUpgradedSerializer();
 
             TypeSerializerSchemaCompatibility<UpgradedElementT> upgradeCompatibility =
-                    restoredSerializerSnapshot.resolveSchemaCompatibility(upgradedSerializer);
+                    upgradedSerializer
+                            .snapshotConfiguration()
+                            .resolveSchemaCompatibility(restoredSerializerSnapshot);
             assumeThat(upgradeCompatibility)
                     .as(
                             "This test only applies for test specifications that verify an upgraded serializer that requires migration to be compatible.")
@@ -387,7 +391,9 @@ public abstract class TypeSerializerUpgradeTestBase<PreviousElementT, UpgradedEl
                     testSpecification.verifier.createUpgradedSerializer();
 
             TypeSerializerSchemaCompatibility<UpgradedElementT> upgradeCompatibility =
-                    restoredSerializerSnapshot.resolveSchemaCompatibility(upgradedSerializer);
+                    upgradedSerializer
+                            .snapshotConfiguration()
+                            .resolveSchemaCompatibility(restoredSerializerSnapshot);
             assumeThat(upgradeCompatibility)
                     .as(
                             "This test only applies for test specifications that verify an upgraded serializer that requires reconfiguration to be compatible.")
@@ -418,7 +424,9 @@ public abstract class TypeSerializerUpgradeTestBase<PreviousElementT, UpgradedEl
                     testSpecification.verifier.createUpgradedSerializer();
 
             TypeSerializerSchemaCompatibility<UpgradedElementT> upgradeCompatibility =
-                    restoredSerializerSnapshot.resolveSchemaCompatibility(upgradedSerializer);
+                    upgradedSerializer
+                            .snapshotConfiguration()
+                            .resolveSchemaCompatibility(restoredSerializerSnapshot);
             assumeThat(upgradeCompatibility)
                     .as(
                             "This test only applies for test specifications that verify an upgraded serializer that is compatible as is.")

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerCompatibilityTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerCompatibilityTest.java
@@ -108,6 +108,6 @@ public class EnumSerializerCompatibilityTest extends TestLogger {
         }
 
         EnumSerializer enumSerializer2 = new EnumSerializer(classLoader2.loadClass(ENUM_NAME));
-        return restoredSnapshot.resolveSchemaCompatibility(enumSerializer2);
+        return enumSerializer2.snapshotConfiguration().resolveSchemaCompatibility(restoredSnapshot);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/common/typeutils/base/EnumSerializerTest.java
@@ -93,7 +93,7 @@ public class EnumSerializerTest extends TestLogger {
         EnumSerializer.EnumSerializerSnapshot serializerSnapshot =
                 new EnumSerializer.EnumSerializerSnapshot(PublicEnum.class, mockPreviousOrder);
         TypeSerializerSchemaCompatibility compatibility =
-                serializerSnapshot.resolveSchemaCompatibility(serializer);
+                serializer.snapshotConfiguration().resolveSchemaCompatibility(serializerSnapshot);
         assertTrue(compatibility.isCompatibleWithReconfiguredSerializer());
 
         // after reconfiguration, the order should be first the original BAR, PAULA, NATHANIEL,
@@ -138,7 +138,7 @@ public class EnumSerializerTest extends TestLogger {
         }
 
         TypeSerializerSchemaCompatibility<PublicEnum> compatResult =
-                restoredConfig.resolveSchemaCompatibility(serializer);
+                serializer.snapshotConfiguration().resolveSchemaCompatibility(restoredConfig);
         assertTrue(compatResult.isCompatibleAsIs());
 
         assertEquals(
@@ -248,7 +248,7 @@ public class EnumSerializerTest extends TestLogger {
         EnumSerializer.EnumSerializerSnapshot serializerSnapshot =
                 new EnumSerializer.EnumSerializerSnapshot(PublicEnum.class, mockPreviousOrder);
         TypeSerializerSchemaCompatibility compatibility =
-                serializerSnapshot.resolveSchemaCompatibility(serializer);
+                serializer.snapshotConfiguration().resolveSchemaCompatibility(serializerSnapshot);
         assertTrue(compatibility.isCompatibleWithReconfiguredSerializer());
 
         // verify that after the serializer was read, the reconfigured constant ordering is

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerSnapshotTest.java
@@ -187,93 +187,105 @@ public class PojoSerializerSnapshotTest {
 
     @Test
     public void testResolveSchemaCompatibilityWithSameFields() {
-        final PojoSerializerSnapshot<TestPojo> testSnapshot =
+        final PojoSerializerSnapshot<TestPojo> oldSnapshot =
                 buildTestSnapshot(Arrays.asList(ID_FIELD, NAME_FIELD, HEIGHT_FIELD));
 
-        final PojoSerializer<TestPojo> newPojoSerializer =
-                buildTestNewPojoSerializer(Arrays.asList(ID_FIELD, NAME_FIELD, HEIGHT_FIELD));
+        final PojoSerializerSnapshot<TestPojo> newSnapshot =
+                buildTestSnapshot(Arrays.asList(ID_FIELD, NAME_FIELD, HEIGHT_FIELD));
 
         final TypeSerializerSchemaCompatibility<TestPojo> resultCompatibility =
-                testSnapshot.resolveSchemaCompatibility(newPojoSerializer);
+                newSnapshot.resolveSchemaCompatibility(oldSnapshot);
 
         assertTrue(resultCompatibility.isCompatibleAsIs());
     }
 
     @Test
     public void testResolveSchemaCompatibilityWithRemovedFields() {
-        final PojoSerializerSnapshot<TestPojo> testSnapshot =
+        final PojoSerializerSnapshot<TestPojo> oldSnapshot =
                 buildTestSnapshot(
                         Arrays.asList(
                                 mockRemovedField(ID_FIELD),
                                 NAME_FIELD,
                                 mockRemovedField(HEIGHT_FIELD)));
 
-        final PojoSerializer<TestPojo> newPojoSerializer =
-                buildTestNewPojoSerializer(Collections.singletonList(NAME_FIELD));
+        final PojoSerializerSnapshot<TestPojo> newSnapshot =
+                buildTestSnapshot(Collections.singletonList(NAME_FIELD));
 
         final TypeSerializerSchemaCompatibility<TestPojo> resultCompatibility =
-                testSnapshot.resolveSchemaCompatibility(newPojoSerializer);
+                newSnapshot.resolveSchemaCompatibility(oldSnapshot);
 
         assertTrue(resultCompatibility.isCompatibleAfterMigration());
     }
 
     @Test
     public void testResolveSchemaCompatibilityWithNewFields() {
-        final PojoSerializerSnapshot<TestPojo> testSnapshot =
+        final PojoSerializerSnapshot<TestPojo> oldSnapshot =
                 buildTestSnapshot(Collections.singletonList(HEIGHT_FIELD));
 
-        final PojoSerializer<TestPojo> newPojoSerializer =
-                buildTestNewPojoSerializer(Arrays.asList(ID_FIELD, NAME_FIELD, HEIGHT_FIELD));
+        final PojoSerializerSnapshot<TestPojo> newSnapshot =
+                buildTestSnapshot(Arrays.asList(ID_FIELD, NAME_FIELD, HEIGHT_FIELD));
 
         final TypeSerializerSchemaCompatibility<TestPojo> resultCompatibility =
-                testSnapshot.resolveSchemaCompatibility(newPojoSerializer);
+                newSnapshot.resolveSchemaCompatibility(oldSnapshot);
 
         assertTrue(resultCompatibility.isCompatibleAfterMigration());
     }
 
     @Test
     public void testResolveSchemaCompatibilityWithNewAndRemovedFields() {
-        final PojoSerializerSnapshot<TestPojo> testSnapshot =
+        final PojoSerializerSnapshot<TestPojo> oldSnapshot =
                 buildTestSnapshot(Collections.singletonList(mockRemovedField(ID_FIELD)));
 
-        final PojoSerializer<TestPojo> newPojoSerializer =
-                buildTestNewPojoSerializer(Arrays.asList(NAME_FIELD, HEIGHT_FIELD));
+        final PojoSerializerSnapshot<TestPojo> newSnapshot =
+                buildTestSnapshot(Arrays.asList(NAME_FIELD, HEIGHT_FIELD));
 
         final TypeSerializerSchemaCompatibility<TestPojo> resultCompatibility =
-                testSnapshot.resolveSchemaCompatibility(newPojoSerializer);
+                newSnapshot.resolveSchemaCompatibility(oldSnapshot);
 
         assertTrue(resultCompatibility.isCompatibleAfterMigration());
     }
 
     @Test
     public void testResolveSchemaCompatibilityWithIncompatibleFieldSerializers() {
-        final PojoSerializerSnapshot<TestPojo> testSnapshot =
+        final PojoSerializerSnapshot<TestPojo> oldSnapshot =
+                buildTestSnapshot(
+                        Arrays.asList(
+                                ID_FIELD,
+                                mockFieldSerializerSnapshot(
+                                        NAME_FIELD,
+                                        new SchemaCompatibilityTestingSerializer()
+                                                .snapshotConfiguration()),
+                                HEIGHT_FIELD));
+
+        final PojoSerializerSnapshot<TestPojo> newSnapshot =
                 buildTestSnapshot(
                         Arrays.asList(
                                 ID_FIELD,
                                 mockFieldSerializerSnapshot(
                                         NAME_FIELD,
                                         SchemaCompatibilityTestingSnapshot
-                                                .thatIsIncompatibleWithTheNextSerializer()),
-                                HEIGHT_FIELD));
-
-        final PojoSerializer<TestPojo> newPojoSerializer =
-                buildTestNewPojoSerializer(
-                        Arrays.asList(
-                                ID_FIELD,
-                                mockFieldSerializer(
-                                        NAME_FIELD, new SchemaCompatibilityTestingSerializer()),
+                                                .thatIsIncompatibleWithTheLastSerializer()),
                                 HEIGHT_FIELD));
 
         final TypeSerializerSchemaCompatibility<TestPojo> resultCompatibility =
-                testSnapshot.resolveSchemaCompatibility(newPojoSerializer);
+                newSnapshot.resolveSchemaCompatibility(oldSnapshot);
 
         assertTrue(resultCompatibility.isIncompatible());
     }
 
     @Test
     public void testResolveSchemaCompatibilityWithCompatibleAfterMigrationFieldSerializers() {
-        final PojoSerializerSnapshot<TestPojo> testSnapshot =
+        final PojoSerializerSnapshot<TestPojo> oldSnapshot =
+                buildTestSnapshot(
+                        Arrays.asList(
+                                ID_FIELD,
+                                NAME_FIELD,
+                                mockFieldSerializerSnapshot(
+                                        HEIGHT_FIELD,
+                                        new SchemaCompatibilityTestingSerializer()
+                                                .snapshotConfiguration())));
+
+        final PojoSerializerSnapshot<TestPojo> newSnapshot =
                 buildTestSnapshot(
                         Arrays.asList(
                                 ID_FIELD,
@@ -281,44 +293,38 @@ public class PojoSerializerSnapshotTest {
                                 mockFieldSerializerSnapshot(
                                         HEIGHT_FIELD,
                                         SchemaCompatibilityTestingSnapshot
-                                                .thatIsCompatibleWithNextSerializerAfterMigration())));
-
-        final PojoSerializer<TestPojo> newPojoSerializer =
-                buildTestNewPojoSerializer(
-                        Arrays.asList(
-                                ID_FIELD,
-                                NAME_FIELD,
-                                mockFieldSerializer(
-                                        HEIGHT_FIELD, new SchemaCompatibilityTestingSerializer())));
+                                                .thatIsCompatibleWithLastSerializerAfterMigration())));
 
         final TypeSerializerSchemaCompatibility<TestPojo> resultCompatibility =
-                testSnapshot.resolveSchemaCompatibility(newPojoSerializer);
+                newSnapshot.resolveSchemaCompatibility(oldSnapshot);
 
         assertTrue(resultCompatibility.isCompatibleAfterMigration());
     }
 
     @Test
     public void testResolveSchemaCompatibilityWithCompatibleWithReconfigurationFieldSerializers() {
-        final PojoSerializerSnapshot<TestPojo> testSnapshot =
+        final PojoSerializerSnapshot<TestPojo> oldSnapshot =
+                buildTestSnapshot(
+                        Arrays.asList(
+                                mockFieldSerializerSnapshot(
+                                        ID_FIELD,
+                                        new SchemaCompatibilityTestingSerializer()
+                                                .snapshotConfiguration()),
+                                NAME_FIELD,
+                                HEIGHT_FIELD));
+
+        final PojoSerializerSnapshot<TestPojo> newSnapshot =
                 buildTestSnapshot(
                         Arrays.asList(
                                 mockFieldSerializerSnapshot(
                                         ID_FIELD,
                                         SchemaCompatibilityTestingSnapshot
-                                                .thatIsCompatibleWithNextSerializerAfterReconfiguration()),
-                                NAME_FIELD,
-                                HEIGHT_FIELD));
-
-        final PojoSerializer<TestPojo> newPojoSerializer =
-                buildTestNewPojoSerializer(
-                        Arrays.asList(
-                                mockFieldSerializer(
-                                        ID_FIELD, new SchemaCompatibilityTestingSerializer()),
+                                                .thatIsCompatibleWithLastSerializerAfterReconfiguration()),
                                 NAME_FIELD,
                                 HEIGHT_FIELD));
 
         final TypeSerializerSchemaCompatibility<TestPojo> resultCompatibility =
-                testSnapshot.resolveSchemaCompatibility(newPojoSerializer);
+                newSnapshot.resolveSchemaCompatibility(oldSnapshot);
 
         assertTrue(resultCompatibility.isCompatibleWithReconfiguredSerializer());
 
@@ -360,38 +366,13 @@ public class PojoSerializerSnapshotTest {
                 fields.toArray(new Field[numFields]),
                 fieldSerializerSnapshots.toArray(new TypeSerializerSnapshot[numFields]),
                 new LinkedHashMap<>(),
-                new LinkedHashMap<>());
-    }
-
-    private static PojoSerializer<TestPojo> buildTestNewPojoSerializer(
-            List<TestPojoField> fieldsForNewPojo) {
-        int numFields = fieldsForNewPojo.size();
-
-        final ArrayList<Field> fields = new ArrayList<>(numFields);
-        final ArrayList<TypeSerializer<?>> fieldSerializers = new ArrayList<>(numFields);
-        fieldsForNewPojo.forEach(
-                fieldForNewPojo -> {
-                    fields.add(fieldForNewPojo.field);
-                    fieldSerializers.add(fieldForNewPojo.serializer);
-                });
-
-        return new PojoSerializer<>(
-                TestPojo.class,
-                fieldSerializers.toArray(new TypeSerializer[numFields]),
-                fields.toArray(new Field[numFields]),
+                new LinkedHashMap<>(),
                 new ExecutionConfig());
     }
 
     private static TestPojoField mockRemovedField(TestPojoField original) {
         TestPojoField copy = original.shallowCopy();
         copy.field = null;
-        return copy;
-    }
-
-    private static TestPojoField mockFieldSerializer(
-            TestPojoField original, TypeSerializer<?> mockSerializer) {
-        TestPojoField copy = original.shallowCopy();
-        copy.serializer = mockSerializer;
         return copy;
     }
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/PojoSerializerTest.java
@@ -358,7 +358,9 @@ class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.TestUserC
 
         @SuppressWarnings("unchecked")
         TypeSerializerSchemaCompatibility<SubTestUserClassA> compatResult =
-                pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer2);
+                pojoSerializer2
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(pojoSerializerConfigSnapshot);
         assertThat(compatResult.isIncompatible()).isTrue();
     }
 
@@ -406,7 +408,9 @@ class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.TestUserC
 
         @SuppressWarnings("unchecked")
         TypeSerializerSchemaCompatibility<TestUserClass> compatResult =
-                pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
+                pojoSerializer
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(pojoSerializerConfigSnapshot);
         assertThat(compatResult.isCompatibleWithReconfiguredSerializer()).isTrue();
         assertThat(compatResult.getReconfiguredSerializer()).isInstanceOf(PojoSerializer.class);
 
@@ -470,7 +474,9 @@ class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.TestUserC
         // repopulated
         @SuppressWarnings("unchecked")
         TypeSerializerSchemaCompatibility<TestUserClass> compatResult =
-                pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
+                pojoSerializer
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(pojoSerializerConfigSnapshot);
         assertThat(compatResult.isCompatibleWithReconfiguredSerializer()).isTrue();
         assertThat(compatResult.getReconfiguredSerializer()).isInstanceOf(PojoSerializer.class);
 
@@ -542,7 +548,9 @@ class PojoSerializerTest extends SerializerTestBase<PojoSerializerTest.TestUserC
         // 2) registrations also contain the now registered subclasses
         @SuppressWarnings("unchecked")
         TypeSerializerSchemaCompatibility<TestUserClass> compatResult =
-                pojoSerializerConfigSnapshot.resolveSchemaCompatibility(pojoSerializer);
+                pojoSerializer
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(pojoSerializerConfigSnapshot);
         assertThat(compatResult.isCompatibleWithReconfiguredSerializer()).isTrue();
         assertThat(compatResult.getReconfiguredSerializer()).isInstanceOf(PojoSerializer.class);
 

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerCompatibilityTest.java
@@ -77,7 +77,9 @@ public class KryoSerializerCompatibilityTest {
 
         @SuppressWarnings("unchecked")
         TypeSerializerSchemaCompatibility<TestClassB> compatResult =
-                kryoSerializerConfigSnapshot.resolveSchemaCompatibility(kryoSerializerForB);
+                kryoSerializerForB
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(kryoSerializerConfigSnapshot);
         assertTrue(compatResult.isIncompatible());
     }
 
@@ -246,7 +248,9 @@ public class KryoSerializerCompatibilityTest {
         // reconfigure - check reconfiguration result and that registration id remains the same
         @SuppressWarnings("unchecked")
         TypeSerializerSchemaCompatibility<TestClass> compatResult =
-                kryoSerializerConfigSnapshot.resolveSchemaCompatibility(kryoSerializer);
+                kryoSerializer
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(kryoSerializerConfigSnapshot);
         assertTrue(compatResult.isCompatibleWithReconfiguredSerializer());
 
         kryoSerializer = (KryoSerializer<TestClass>) compatResult.getReconfiguredSerializer();

--- a/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotTest.java
+++ b/flink-core/src/test/java/org/apache/flink/api/java/typeutils/runtime/kryo/KryoSerializerSnapshotTest.java
@@ -106,7 +106,10 @@ public class KryoSerializerSnapshotTest {
                 new KryoSerializer<>(Animal.class, new ExecutionConfig());
 
         assertThat(
-                restoredSnapshot.resolveSchemaCompatibility(currentSerializer), isIncompatible());
+                currentSerializer
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(restoredSnapshot),
+                isIncompatible());
     }
 
     // -------------------------------------------------------------------------------------------------------
@@ -156,6 +159,8 @@ public class KryoSerializerSnapshotTest {
                 previousSerializer.snapshotConfiguration();
 
         TypeSerializer<Animal> currentSerializer = new KryoSerializer<>(Animal.class, current);
-        return previousSnapshot.resolveSchemaCompatibility(currentSerializer);
+        return currentSerializer
+                .snapshotConfiguration()
+                .resolveSchemaCompatibility(previousSnapshot);
     }
 }

--- a/flink-core/src/test/java/org/apache/flink/testutils/migration/SchemaCompatibilityTestingSerializer.java
+++ b/flink-core/src/test/java/org/apache/flink/testutils/migration/SchemaCompatibilityTestingSerializer.java
@@ -40,8 +40,8 @@ import java.util.function.Function;
  *
  * <p>To start from a snapshot, the class {@link SchemaCompatibilityTestingSnapshot} can be
  * configured to return a predefined {@link TypeSerializerSchemaCompatibility} result when {@link
- * TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializer)} would be called, the following
- * static factory methods return a pre-configured snapshot class:
+ * TypeSerializerSnapshot#resolveSchemaCompatibility(TypeSerializerSnapshot)} would be called, the
+ * following static factory methods return a pre-configured snapshot class:
  *
  * <ul>
  *   <li>{@code thatIsCompatibleWithNextSerializer}.
@@ -79,7 +79,8 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
 
     private static final long serialVersionUID = 2588814752302505240L;
 
-    private final Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>>
+    private final Function<
+                    TypeSerializerSnapshot<Integer>, TypeSerializerSchemaCompatibility<Integer>>
             resolver;
 
     @Nullable private final String tokenForEqualityChecks;
@@ -94,7 +95,7 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
 
     public SchemaCompatibilityTestingSerializer(
             @Nullable String tokenForEqualityChecks,
-            Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>>
+            Function<TypeSerializerSnapshot<Integer>, TypeSerializerSchemaCompatibility<Integer>>
                     resolver) {
         this.resolver = resolver;
         this.tokenForEqualityChecks = tokenForEqualityChecks;
@@ -186,7 +187,7 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
     // -----------------------------------------------------------------------------------------------------------
 
     private static final Function<
-                    TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>>
+                    TypeSerializerSnapshot<Integer>, TypeSerializerSchemaCompatibility<Integer>>
             ALWAYS_COMPATIBLE = unused -> TypeSerializerSchemaCompatibility.compatibleAsIs();
 
     // -----------------------------------------------------------------------------------------------------------
@@ -198,11 +199,11 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
     public static final class SchemaCompatibilityTestingSnapshot
             implements TypeSerializerSnapshot<Integer> {
 
-        public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializer() {
-            return thatIsCompatibleWithNextSerializer(null);
+        public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithLastSerializer() {
+            return thatIsCompatibleWithLastSerializer(null);
         }
 
-        public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithNextSerializer(
+        public static SchemaCompatibilityTestingSnapshot thatIsCompatibleWithLastSerializer(
                 String tokenForEqualityChecks) {
             return new SchemaCompatibilityTestingSnapshot(
                     tokenForEqualityChecks,
@@ -210,12 +211,12 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
         }
 
         public static SchemaCompatibilityTestingSnapshot
-                thatIsCompatibleWithNextSerializerAfterReconfiguration() {
-            return thatIsCompatibleWithNextSerializerAfterReconfiguration(null);
+                thatIsCompatibleWithLastSerializerAfterReconfiguration() {
+            return thatIsCompatibleWithLastSerializerAfterReconfiguration(null);
         }
 
         public static SchemaCompatibilityTestingSnapshot
-                thatIsCompatibleWithNextSerializerAfterReconfiguration(
+                thatIsCompatibleWithLastSerializerAfterReconfiguration(
                         String tokenForEqualityChecks) {
             SchemaCompatibilityTestingSerializer reconfiguredSerializer =
                     new SchemaCompatibilityTestingSerializer(
@@ -228,22 +229,22 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
         }
 
         public static SchemaCompatibilityTestingSnapshot
-                thatIsCompatibleWithNextSerializerAfterMigration() {
-            return thatIsCompatibleWithNextSerializerAfterMigration(null);
+                thatIsCompatibleWithLastSerializerAfterMigration() {
+            return thatIsCompatibleWithLastSerializerAfterMigration(null);
         }
 
         public static SchemaCompatibilityTestingSnapshot
-                thatIsCompatibleWithNextSerializerAfterMigration(String tokenForEqualityChecks) {
+                thatIsCompatibleWithLastSerializerAfterMigration(String tokenForEqualityChecks) {
             return new SchemaCompatibilityTestingSnapshot(
                     tokenForEqualityChecks,
                     unused -> TypeSerializerSchemaCompatibility.compatibleAfterMigration());
         }
 
-        public static SchemaCompatibilityTestingSnapshot thatIsIncompatibleWithTheNextSerializer() {
-            return thatIsIncompatibleWithTheNextSerializer(null);
+        public static SchemaCompatibilityTestingSnapshot thatIsIncompatibleWithTheLastSerializer() {
+            return thatIsIncompatibleWithTheLastSerializer(null);
         }
 
-        public static SchemaCompatibilityTestingSnapshot thatIsIncompatibleWithTheNextSerializer(
+        public static SchemaCompatibilityTestingSnapshot thatIsIncompatibleWithTheLastSerializer(
                 String tokenForEqualityChecks) {
             return new SchemaCompatibilityTestingSnapshot(
                     tokenForEqualityChecks,
@@ -251,12 +252,15 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
         }
 
         @Nullable private final String tokenForEqualityChecks;
-        private final Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>>
+        private final Function<
+                        TypeSerializerSnapshot<Integer>, TypeSerializerSchemaCompatibility<Integer>>
                 resolver;
 
         SchemaCompatibilityTestingSnapshot(
                 @Nullable String tokenForEqualityChecks,
-                Function<TypeSerializer<Integer>, TypeSerializerSchemaCompatibility<Integer>>
+                Function<
+                                TypeSerializerSnapshot<Integer>,
+                                TypeSerializerSchemaCompatibility<Integer>>
                         resolver) {
             this.tokenForEqualityChecks = tokenForEqualityChecks;
             this.resolver = resolver;
@@ -264,18 +268,18 @@ public final class SchemaCompatibilityTestingSerializer extends TypeSerializer<I
 
         @Override
         public TypeSerializerSchemaCompatibility<Integer> resolveSchemaCompatibility(
-                TypeSerializer<Integer> newSerializer) {
-            if (!(newSerializer instanceof SchemaCompatibilityTestingSerializer)) {
+                TypeSerializerSnapshot<Integer> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof SchemaCompatibilityTestingSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
-            SchemaCompatibilityTestingSerializer schemaCompatibilityTestingSerializer =
-                    (SchemaCompatibilityTestingSerializer) newSerializer;
+            SchemaCompatibilityTestingSnapshot schemaCompatibilityTestingSnapshot =
+                    (SchemaCompatibilityTestingSnapshot) oldSerializerSnapshot;
             if (!(Objects.equals(
-                    schemaCompatibilityTestingSerializer.tokenForEqualityChecks,
+                    schemaCompatibilityTestingSnapshot.tokenForEqualityChecks,
                     tokenForEqualityChecks))) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
-            return resolver.apply(newSerializer);
+            return resolver.apply(oldSerializerSnapshot);
         }
 
         @Override

--- a/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/verify/ValueWithTs.java
+++ b/flink-end-to-end-tests/flink-stream-state-ttl-test/src/main/java/org/apache/flink/streaming/tests/verify/ValueWithTs.java
@@ -122,9 +122,7 @@ public class ValueWithTs<V> implements Serializable {
         private static final int VERSION = 2;
 
         @SuppressWarnings("unused")
-        public ValueWithTsSerializerSnapshot() {
-            super(Serializer.class);
-        }
+        public ValueWithTsSerializerSnapshot() {}
 
         ValueWithTsSerializerSnapshot(Serializer serializerInstance) {
             super(serializerInstance);

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshot.java
@@ -130,12 +130,13 @@ public class AvroSerializerSnapshot<T> implements TypeSerializerSnapshot<T> {
 
     @Override
     public TypeSerializerSchemaCompatibility<T> resolveSchemaCompatibility(
-            TypeSerializer<T> newSerializer) {
-        if (!(newSerializer instanceof AvroSerializer)) {
+            TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof AvroSerializerSnapshot)) {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
-        AvroSerializer<?> newAvroSerializer = (AvroSerializer<?>) newSerializer;
-        return resolveSchemaCompatibility(schema, newAvroSerializer.getAvroSchema());
+        AvroSerializerSnapshot<?> oldAvroSerializerSnapshot =
+                (AvroSerializerSnapshot<?>) oldSerializerSnapshot;
+        return resolveSchemaCompatibility(oldAvroSerializerSnapshot.schema, schema);
     }
 
     @Override

--- a/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
+++ b/flink-formats/flink-avro/src/test/java/org/apache/flink/formats/avro/typeutils/AvroSerializerSnapshotTest.java
@@ -112,7 +112,7 @@ class AvroSerializerSnapshotTest {
 
         TypeSerializerSnapshot<GenericRecord> snapshot = serializer.snapshotConfiguration();
 
-        assertThat(snapshot.resolveSchemaCompatibility(serializer))
+        assertThat(serializer.snapshotConfiguration().resolveSchemaCompatibility(snapshot))
                 .is(matching(isCompatibleAsIs()));
     }
 
@@ -124,7 +124,7 @@ class AvroSerializerSnapshotTest {
         AvroSerializerSnapshot<GenericRecord> restored =
                 roundTrip(serializer.snapshotConfiguration());
 
-        assertThat(restored.resolveSchemaCompatibility(serializer))
+        assertThat(serializer.snapshotConfiguration().resolveSchemaCompatibility(restored))
                 .is(matching(isCompatibleAsIs()));
     }
 
@@ -135,7 +135,7 @@ class AvroSerializerSnapshotTest {
 
         AvroSerializerSnapshot<User> restored = roundTrip(serializer.snapshotConfiguration());
 
-        assertThat(restored.resolveSchemaCompatibility(serializer))
+        assertThat(serializer.snapshotConfiguration().resolveSchemaCompatibility(restored))
                 .is(matching(isCompatibleAsIs()));
     }
 
@@ -145,7 +145,7 @@ class AvroSerializerSnapshotTest {
 
         AvroSerializerSnapshot<Pojo> restored = roundTrip(serializer.snapshotConfiguration());
 
-        assertThat(restored.resolveSchemaCompatibility(serializer))
+        assertThat(serializer.snapshotConfiguration().resolveSchemaCompatibility(restored))
                 .is(matching(isCompatibleAsIs()));
     }
 
@@ -169,7 +169,7 @@ class AvroSerializerSnapshotTest {
         AvroSerializerSnapshot<GenericRecord> restored =
                 roundTrip(serializer.snapshotConfiguration());
 
-        assertThat(restored.resolveSchemaCompatibility(serializer))
+        assertThat(serializer.snapshotConfiguration().resolveSchemaCompatibility(restored))
                 .is(matching(isCompatibleAsIs()));
     }
 
@@ -205,7 +205,10 @@ class AvroSerializerSnapshotTest {
         TypeSerializerSnapshot<GenericRecord> originalSnapshot =
                 originalSerializer.snapshotConfiguration();
 
-        assertThat(originalSnapshot.resolveSchemaCompatibility(newSerializer))
+        assertThat(
+                        newSerializer
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(originalSnapshot))
                 .is(matching(isCompatibleAfterMigration()));
     }
 
@@ -219,7 +222,10 @@ class AvroSerializerSnapshotTest {
         TypeSerializerSnapshot<GenericRecord> originalSnapshot =
                 originalSerializer.snapshotConfiguration();
 
-        assertThat(originalSnapshot.resolveSchemaCompatibility(newSerializer))
+        assertThat(
+                        newSerializer
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(originalSnapshot))
                 .is(matching(isIncompatible()));
     }
 
@@ -235,7 +241,10 @@ class AvroSerializerSnapshotTest {
         AvroSerializer<Object> specificSerializer = new AvroSerializer(User.class);
         specificSerializer.snapshotConfiguration();
 
-        assertThat(genericSnapshot.resolveSchemaCompatibility(specificSerializer))
+        assertThat(
+                        specificSerializer
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(genericSnapshot))
                 .is(matching(isCompatibleAsIs()));
     }
 
@@ -253,7 +262,10 @@ class AvroSerializerSnapshotTest {
                     TypeSerializerSnapshotSerializationUtil.readSerializerSnapshot(
                             in, AvroSerializer.class.getClassLoader());
 
-            assertThat(restored.resolveSchemaCompatibility(currentSerializer))
+            assertThat(
+                            currentSerializer
+                                    .snapshotConfiguration()
+                                    .resolveSchemaCompatibility(restored))
                     .is(matching(isCompatibleAsIs()));
         }
     }

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -984,9 +984,7 @@ public class NFA<T> {
 
         private static final int VERSION = 2;
 
-        public MigratedNFASerializerSnapshot() {
-            super(NFASerializer.class);
-        }
+        public MigratedNFASerializerSnapshot() {}
 
         MigratedNFASerializerSnapshot(NFASerializer<T> legacyNfaSerializer) {
             super(legacyNfaSerializer);

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializerSnapshot.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializerSnapshot.java
@@ -39,9 +39,7 @@ public class NFAStateSerializerSnapshot
     private boolean supportsPreviousTimestamp = true;
 
     /** Constructor for read instantiation. */
-    public NFAStateSerializerSnapshot() {
-        super(NFAStateSerializer.class);
-    }
+    public NFAStateSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public NFAStateSerializerSnapshot(NFAStateSerializer serializerInstance) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializerSnapshot.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFAStateSerializerSnapshot.java
@@ -20,6 +20,7 @@ package org.apache.flink.cep.nfa;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.cep.nfa.sharedbuffer.EventId;
 import org.apache.flink.cep.nfa.sharedbuffer.NodeId;
 import org.apache.flink.core.memory.DataInputView;
@@ -71,8 +72,12 @@ public class NFAStateSerializerSnapshot
 
     @Override
     protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
-            NFAStateSerializer newSerializer) {
-        if (supportsPreviousTimestamp != newSerializer.isSupportsPreviousTimestamp()) {
+            TypeSerializerSnapshot<NFAState> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof NFAStateSerializerSnapshot)) {
+            return OuterSchemaCompatibility.INCOMPATIBLE;
+        }
+        if (supportsPreviousTimestamp
+                != ((NFAStateSerializerSnapshot) oldSerializerSnapshot).supportsPreviousTimestamp) {
             return OuterSchemaCompatibility.COMPATIBLE_AFTER_MIGRATION;
         }
 

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/SharedBuffer.java
@@ -159,9 +159,7 @@ public class SharedBuffer<V> {
 
         private static final int VERSION = 2;
 
-        public SharedBufferSerializerSnapshot() {
-            super(SharedBufferSerializer.class);
-        }
+        public SharedBufferSerializerSnapshot() {}
 
         public SharedBufferSerializerSnapshot(SharedBufferSerializer<K, V> sharedBufferSerializer) {
             super(sharedBufferSerializer);

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerSnapshot.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/LockableTypeSerializerSnapshot.java
@@ -31,9 +31,7 @@ public class LockableTypeSerializerSnapshot<E>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public LockableTypeSerializerSnapshot() {
-        super(Lockable.LockableTypeSerializer.class);
-    }
+    public LockableTypeSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public LockableTypeSerializerSnapshot(

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/NodeId.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/NodeId.java
@@ -167,9 +167,7 @@ public class NodeId {
 
             private static final int VERSION = 1;
 
-            public NodeIdSerializerSnapshot() {
-                super(NodeIdSerializer.class);
-            }
+            public NodeIdSerializerSnapshot() {}
 
             public NodeIdSerializerSnapshot(NodeIdSerializer nodeIdSerializer) {
                 super(nodeIdSerializer);

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferEdge.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferEdge.java
@@ -170,9 +170,7 @@ public class SharedBufferEdge {
 
             private static final int VERSION = 1;
 
-            public SharedBufferEdgeSerializerSnapshot() {
-                super(SharedBufferEdgeSerializer.class);
-            }
+            public SharedBufferEdgeSerializerSnapshot() {}
 
             public SharedBufferEdgeSerializerSnapshot(
                     SharedBufferEdgeSerializer sharedBufferEdgeSerializer) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferNode.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferNode.java
@@ -171,9 +171,7 @@ public class SharedBufferNode {
 
             private static final int VERSION = 1;
 
-            public SharedBufferNodeSerializerSnapshot() {
-                super(SharedBufferNodeSerializer.class);
-            }
+            public SharedBufferNodeSerializerSnapshot() {}
 
             public SharedBufferNodeSerializerSnapshot(
                     SharedBufferNodeSerializer sharedBufferNodeSerializer) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferNodeSerializerSnapshotV2.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/sharedbuffer/SharedBufferNodeSerializerSnapshotV2.java
@@ -27,9 +27,7 @@ public final class SharedBufferNodeSerializerSnapshotV2
 
     private static final int VERSION = 1;
 
-    public SharedBufferNodeSerializerSnapshotV2() {
-        super(SharedBufferNodeSerializer.class);
-    }
+    public SharedBufferNodeSerializerSnapshotV2() {}
 
     public SharedBufferNodeSerializerSnapshotV2(
             SharedBufferNodeSerializer sharedBufferNodeSerializer) {

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DecimalDataSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/DecimalDataSerializer.java
@@ -135,8 +135,8 @@ public class DecimalDataSerializer extends TypeSerializer<DecimalData> {
 
         private static final int CURRENT_VERSION = 1;
 
-        private int previousPrecision;
-        private int previousScale;
+        private int precision;
+        private int scale;
 
         @SuppressWarnings("unused")
         public DecimalSerializerSnapshot() {
@@ -144,8 +144,8 @@ public class DecimalDataSerializer extends TypeSerializer<DecimalData> {
         }
 
         DecimalSerializerSnapshot(int precision, int scale) {
-            this.previousPrecision = precision;
-            this.previousScale = scale;
+            this.precision = precision;
+            this.scale = scale;
         }
 
         @Override
@@ -155,32 +155,33 @@ public class DecimalDataSerializer extends TypeSerializer<DecimalData> {
 
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
-            out.writeInt(previousPrecision);
-            out.writeInt(previousScale);
+            out.writeInt(precision);
+            out.writeInt(scale);
         }
 
         @Override
         public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
                 throws IOException {
-            this.previousPrecision = in.readInt();
-            this.previousScale = in.readInt();
+            this.precision = in.readInt();
+            this.scale = in.readInt();
         }
 
         @Override
         public TypeSerializer<DecimalData> restoreSerializer() {
-            return new DecimalDataSerializer(previousPrecision, previousScale);
+            return new DecimalDataSerializer(precision, scale);
         }
 
         @Override
         public TypeSerializerSchemaCompatibility<DecimalData> resolveSchemaCompatibility(
-                TypeSerializer<DecimalData> newSerializer) {
-            if (!(newSerializer instanceof DecimalDataSerializer)) {
+                TypeSerializerSnapshot<DecimalData> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof DecimalSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            DecimalDataSerializer newDecimalDataSerializer = (DecimalDataSerializer) newSerializer;
-            if (previousPrecision != newDecimalDataSerializer.precision
-                    || previousScale != newDecimalDataSerializer.scale) {
+            DecimalSerializerSnapshot oldDecimalSerializerSnapshot =
+                    (DecimalSerializerSnapshot) oldSerializerSnapshot;
+            if (precision != oldDecimalSerializerSnapshot.precision
+                    || scale != oldDecimalSerializerSnapshot.scale) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             } else {
                 return TypeSerializerSchemaCompatibility.compatibleAsIs();

--- a/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializer.java
+++ b/flink-python/src/main/java/org/apache/flink/table/runtime/typeutils/serializers/python/TimestampSerializer.java
@@ -153,14 +153,14 @@ public class TimestampSerializer extends TypeSerializerSingleton<Timestamp> {
 
         private static final int CURRENT_VERSION = 1;
 
-        private int previousPrecision;
+        private int precision;
 
         public TimestampSerializerSnapshot() {
             // this constructor is used when restoring from a checkpoint/savepoint.
         }
 
         TimestampSerializerSnapshot(int precision) {
-            this.previousPrecision = precision;
+            this.precision = precision;
         }
 
         @Override
@@ -170,29 +170,30 @@ public class TimestampSerializer extends TypeSerializerSingleton<Timestamp> {
 
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
-            out.writeInt(previousPrecision);
+            out.writeInt(precision);
         }
 
         @Override
         public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
                 throws IOException {
-            this.previousPrecision = in.readInt();
+            this.precision = in.readInt();
         }
 
         @Override
         public TypeSerializer<Timestamp> restoreSerializer() {
-            return new TimestampSerializer(previousPrecision);
+            return new TimestampSerializer(precision);
         }
 
         @Override
         public TypeSerializerSchemaCompatibility<Timestamp> resolveSchemaCompatibility(
-                TypeSerializer<Timestamp> newSerializer) {
-            if (!(newSerializer instanceof TimestampSerializer)) {
+                TypeSerializerSnapshot<Timestamp> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof TimestampSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            TimestampSerializer timestampSerializer = (TimestampSerializer) newSerializer;
-            if (previousPrecision != timestampSerializer.precision) {
+            TimestampSerializerSnapshot timestampSerializerSnapshot =
+                    (TimestampSerializerSnapshot) oldSerializerSnapshot;
+            if (precision != timestampSerializerSnapshot.precision) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             } else {
                 return TypeSerializerSchemaCompatibility.compatibleAsIs();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializerSnapshot.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ArrayListSerializerSnapshot.java
@@ -30,9 +30,7 @@ public class ArrayListSerializerSnapshot<T>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public ArrayListSerializerSnapshot() {
-        super(ArrayListSerializer.class);
-    }
+    public ArrayListSerializerSnapshot() {}
 
     /** Constructor for creating the snapshot for writing. */
     public ArrayListSerializerSnapshot(ArrayListSerializer<T> arrayListSerializer) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSerializerProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSerializerProvider.java
@@ -304,7 +304,9 @@ public abstract class StateSerializerProvider<T> {
             }
 
             TypeSerializerSchemaCompatibility<T> result =
-                    previousSerializerSnapshot.resolveSchemaCompatibility(newSerializer);
+                    newSerializer
+                            .snapshotConfiguration()
+                            .resolveSchemaCompatibility(previousSerializerSnapshot);
             if (result.isIncompatible()) {
                 invalidateCurrentSchemaSerializerAccess();
             }
@@ -358,7 +360,9 @@ public abstract class StateSerializerProvider<T> {
             this.previousSerializerSnapshot = previousSerializerSnapshot;
 
             TypeSerializerSchemaCompatibility<T> result =
-                    previousSerializerSnapshot.resolveSchemaCompatibility(registeredSerializer);
+                    Preconditions.checkNotNull(registeredSerializer)
+                            .snapshotConfiguration()
+                            .resolveSchemaCompatibility(previousSerializerSnapshot);
             if (result.isIncompatible()) {
                 invalidateCurrentSchemaSerializerAccess();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/ttl/TtlStateFactory.java
@@ -349,9 +349,7 @@ public class TtlStateFactory<K, N, SV, TTLSV, S extends State, IS extends S> {
         private static final int VERSION = 2;
 
         @SuppressWarnings({"WeakerAccess", "unused"})
-        public TtlSerializerSnapshot() {
-            super(TtlSerializer.class);
-        }
+        public TtlSerializerSnapshot() {}
 
         TtlSerializerSnapshot(TtlSerializer<T> serializerInstance) {
             super(serializerInstance);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/InternalPriorityQueueTestBase.java
@@ -529,13 +529,13 @@ public abstract class InternalPriorityQueueTestBase {
 
             @Override
             public TypeSerializerSchemaCompatibility<TestElement> resolveSchemaCompatibility(
-                    TypeSerializer<TestElement> newSerializer) {
-                if (!(newSerializer instanceof TestElementSerializer)) {
+                    TypeSerializerSnapshot<TestElement> oldSerializerSnapshot) {
+                if (!(oldSerializerSnapshot instanceof Snapshot)) {
                     return TypeSerializerSchemaCompatibility.incompatible();
                 }
 
-                TestElementSerializer testElementSerializer = (TestElementSerializer) newSerializer;
-                return (revision <= testElementSerializer.getRevision())
+                Snapshot snapshot = (Snapshot) oldSerializerSnapshot;
+                return (snapshot.getRevision() <= revision)
                         ? TypeSerializerSchemaCompatibility.compatibleAsIs()
                         : TypeSerializerSchemaCompatibility.incompatible();
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateBackendMigrationTestBase.java
@@ -1223,8 +1223,8 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
                                 testKeyedValueStateUpgrade(
                                         initialAccessDescriptor, newAccessDescriptorAfterRestore))
                 .satisfiesAnyOf(
-                        e -> assertThat(e).isInstanceOf(StateMigrationException.class),
-                        e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
+                        e -> assertThat(e).isInstanceOf(IllegalStateException.class),
+                        e -> assertThat(e).hasCauseInstanceOf(IllegalStateException.class));
     }
 
     @TestTemplate
@@ -1244,8 +1244,8 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
                                 testKeyedValueStateUpgrade(
                                         initialAccessDescriptor, newAccessDescriptorAfterRestore))
                 .satisfiesAnyOf(
-                        e -> assertThat(e).isInstanceOf(IllegalStateException.class),
-                        e -> assertThat(e).hasCauseInstanceOf(IllegalStateException.class));
+                        e -> assertThat(e).isInstanceOf(StateMigrationException.class),
+                        e -> assertThat(e).hasCauseInstanceOf(StateMigrationException.class));
     }
 
     // -------------------------------------------------------------------------------
@@ -1343,7 +1343,7 @@ public abstract class StateBackendMigrationTestBase<B extends StateBackend> {
 
         @Override
         public TypeSerializerSchemaCompatibility<VoidNamespace> resolveSchemaCompatibility(
-                TypeSerializer<VoidNamespace> newSerializer) {
+                TypeSerializerSnapshot<VoidNamespace> oldSerializerSnapshot) {
             return TypeSerializerSchemaCompatibility.compatibleAsIs();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSerializerProviderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/StateSerializerProviderTest.java
@@ -336,7 +336,7 @@ class StateSerializerProviderTest {
 
         @Override
         public TypeSerializerSchemaCompatibility<String> resolveSchemaCompatibility(
-                TypeSerializer<String> newSerializer) {
+                TypeSerializerSnapshot<String> oldSerializerSnapshot) {
             throw new UnsupportedOperationException();
         }
 

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
@@ -43,9 +43,7 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
 
     /** Used via reflection. */
     @SuppressWarnings("unused")
-    public ScalaCaseClassSerializerSnapshot() {
-        super(ScalaCaseClassSerializer.class);
-    }
+    public ScalaCaseClassSerializerSnapshot() {}
 
     /** Used for the snapshot path. */
     public ScalaCaseClassSerializerSnapshot(ScalaCaseClassSerializer<T> serializerInstance) {

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaCaseClassSerializerSnapshot.java
@@ -86,8 +86,14 @@ public final class ScalaCaseClassSerializerSnapshot<T extends scala.Product>
 
     @Override
     protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility
-            resolveOuterSchemaCompatibility(ScalaCaseClassSerializer<T> newSerializer) {
-        return (Objects.equals(type, newSerializer.getTupleClass()))
+            resolveOuterSchemaCompatibility(TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof ScalaCaseClassSerializerSnapshot)) {
+            return OuterSchemaCompatibility.INCOMPATIBLE;
+        }
+
+        ScalaCaseClassSerializerSnapshot<T> oldSnapshot =
+                (ScalaCaseClassSerializerSnapshot<T>) oldSerializerSnapshot;
+        return (Objects.equals(type, oldSnapshot.type))
                 ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
                 : OuterSchemaCompatibility.INCOMPATIBLE;
     }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaEitherSerializerSnapshot.java
@@ -33,9 +33,7 @@ public class ScalaEitherSerializerSnapshot<L, R>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public ScalaEitherSerializerSnapshot() {
-        super(EitherSerializer.class);
-    }
+    public ScalaEitherSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public ScalaEitherSerializerSnapshot(EitherSerializer<L, R> eitherSerializer) {

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaOptionSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaOptionSerializerSnapshot.java
@@ -31,9 +31,7 @@ public final class ScalaOptionSerializerSnapshot<E>
     private static final int VERSION = 2;
 
     @SuppressWarnings("WeakerAccess")
-    public ScalaOptionSerializerSnapshot() {
-        super(OptionSerializer.class);
-    }
+    public ScalaOptionSerializerSnapshot() {}
 
     public ScalaOptionSerializerSnapshot(OptionSerializer<E> serializerInstance) {
         super(serializerInstance);

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/ScalaTrySerializerSnapshot.java
@@ -38,9 +38,7 @@ public class ScalaTrySerializerSnapshot<E>
 
     /** This empty nullary constructor is required for deserializing the configuration. */
     @SuppressWarnings("unused")
-    public ScalaTrySerializerSnapshot() {
-        super(TrySerializer.class);
-    }
+    public ScalaTrySerializerSnapshot() {}
 
     public ScalaTrySerializerSnapshot(TrySerializer<E> trySerializer) {
         super(trySerializer);

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
@@ -20,6 +20,7 @@ package org.apache.flink.api.scala.typeutils;
 
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 
@@ -97,8 +98,14 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
 
     @Override
     protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility
-            resolveOuterSchemaCompatibility(TraversableSerializer<T, E> newSerializer) {
-        return (cbfCode.equals(newSerializer.cbfCode()))
+            resolveOuterSchemaCompatibility(TypeSerializerSnapshot<T> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof TraversableSerializerSnapshot)) {
+            return OuterSchemaCompatibility.INCOMPATIBLE;
+        }
+
+        TraversableSerializerSnapshot<T, E> oldTraversableSerializerSnapshot =
+                (TraversableSerializerSnapshot<T, E>) oldSerializerSnapshot;
+        return (cbfCode.equals(oldTraversableSerializerSnapshot.cbfCode))
                 ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
                 : OuterSchemaCompatibility.INCOMPATIBLE;
     }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/TraversableSerializerSnapshot.java
@@ -47,9 +47,7 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
     private String cbfCode;
 
     @SuppressWarnings("unused")
-    public TraversableSerializerSnapshot() {
-        super(TraversableSerializer.class);
-    }
+    public TraversableSerializerSnapshot() {}
 
     public TraversableSerializerSnapshot(TraversableSerializer<T, E> serializerInstance) {
         super(serializerInstance);
@@ -57,7 +55,6 @@ public class TraversableSerializerSnapshot<T extends TraversableOnce<E>, E>
     }
 
     TraversableSerializerSnapshot(String cbfCode) {
-        super(TraversableSerializer.class);
         checkArgument(cbfCode != null, "cbfCode cannot be null");
 
         this.cbfCode = cbfCode;

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
@@ -91,8 +91,14 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
     @Override
     protected CompositeTypeSerializerSnapshot.OuterSchemaCompatibility
             resolveOuterSchemaCompatibility(
-                    ScalaCaseClassSerializer<Tuple2<T1, T2>> newSerializer) {
-        return (Objects.equals(type, newSerializer.getTupleClass()))
+                    TypeSerializerSnapshot<Tuple2<T1, T2>> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof Tuple2CaseClassSerializerSnapshot)) {
+            return OuterSchemaCompatibility.INCOMPATIBLE;
+        }
+
+        Tuple2CaseClassSerializerSnapshot<T1, T2> oldSnapshot =
+                (Tuple2CaseClassSerializerSnapshot<T1, T2>) oldSerializerSnapshot;
+        return (Objects.equals(type, oldSnapshot.type))
                 ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
                 : OuterSchemaCompatibility.INCOMPATIBLE;
     }

--- a/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
+++ b/flink-scala/src/main/java/org/apache/flink/api/scala/typeutils/Tuple2CaseClassSerializerSnapshot.java
@@ -46,9 +46,7 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
     private Class<Tuple2<T1, T2>> type;
 
     @SuppressWarnings("unused")
-    public Tuple2CaseClassSerializerSnapshot() {
-        super(correspondingSerializerClass());
-    }
+    public Tuple2CaseClassSerializerSnapshot() {}
 
     public Tuple2CaseClassSerializerSnapshot(
             ScalaCaseClassSerializer<Tuple2<T1, T2>> serializerInstance) {
@@ -101,10 +99,5 @@ public final class Tuple2CaseClassSerializerSnapshot<T1, T2>
         return (Objects.equals(type, oldSnapshot.type))
                 ? OuterSchemaCompatibility.COMPATIBLE_AS_IS
                 : OuterSchemaCompatibility.INCOMPATIBLE;
-    }
-
-    private static <T1, T2>
-            Class<ScalaCaseClassSerializer<scala.Tuple2<T1, T2>>> correspondingSerializerClass() {
-        return package$.MODULE$.tuple2ClassForJava();
     }
 }

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerCompatibilityTest.scala
@@ -141,7 +141,7 @@ class EnumValueSerializerCompatibilityTest {
     val enum2 = instantiateEnum[Enumeration](classLoader2, enumName)
 
     val enumValueSerializer2 = new EnumValueSerializer(enum2)
-    snapshot2.resolveSchemaCompatibility(enumValueSerializer2)
+    enumValueSerializer2.snapshotConfiguration().resolveSchemaCompatibility(snapshot2)
   }
 }
 

--- a/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerTest.scala
+++ b/flink-scala/src/test/scala/org/apache/flink/api/scala/typeutils/EnumValueSerializerTest.scala
@@ -32,7 +32,11 @@ class EnumValueSerializerTest {
 
     val snapshot = enumSerializer.snapshotConfiguration()
 
-    assertThat(snapshot.resolveSchemaCompatibility(enumSerializer).isCompatibleAsIs).isTrue
+    assertThat(
+      enumSerializer
+        .snapshotConfiguration()
+        .resolveSchemaCompatibility(snapshot)
+        .isCompatibleAsIs).isTrue
   }
 }
 

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/RocksDBKeyedStateBackend.java
@@ -856,7 +856,9 @@ public class RocksDBKeyedStateBackend<K> extends AbstractKeyedStateBackend<K> {
                 (TypeSerializer<UK>) newMapStateSerializer.getKeySerializer();
 
         TypeSerializerSchemaCompatibility<UK> keyCompatibility =
-                previousKeySerializerSnapshot.resolveSchemaCompatibility(newUserKeySerializer);
+                newUserKeySerializer
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(previousKeySerializerSnapshot);
         return keyCompatibility.isCompatibleAsIs();
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -701,9 +701,7 @@ public class CoGroupedStreams<T1, T2> {
         private static final int VERSION = 2;
 
         @SuppressWarnings("WeakerAccess")
-        public UnionSerializerSnapshot() {
-            super(UnionSerializer.class);
-        }
+        public UnionSerializerSnapshot() {}
 
         UnionSerializerSnapshot(UnionSerializer<T1, T2> serializerInstance) {
             super(serializerInstance);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -27,6 +27,7 @@ import org.apache.flink.api.common.typeinfo.TypeHint;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.core.memory.DataInputView;
 import org.apache.flink.core.memory.DataOutputView;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
@@ -923,8 +924,14 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT> extends RichS
 
         @Override
         protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
-                StateSerializer<TXN, CONTEXT> newSerializer) {
-            if (supportsNullTransaction != newSerializer.supportNullPendingTransaction) {
+                TypeSerializerSnapshot<State<TXN, CONTEXT>> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof StateSerializerSnapshot)) {
+                return OuterSchemaCompatibility.INCOMPATIBLE;
+            }
+
+            StateSerializerSnapshot<TXN, CONTEXT> oldStateSerializerSnapshot =
+                    (StateSerializerSnapshot<TXN, CONTEXT>) oldSerializerSnapshot;
+            if (supportsNullTransaction != oldStateSerializerSnapshot.supportsNullTransaction) {
                 return OuterSchemaCompatibility.COMPATIBLE_AFTER_MIGRATION;
             }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/sink/TwoPhaseCommitSinkFunction.java
@@ -890,9 +890,7 @@ public abstract class TwoPhaseCommitSinkFunction<IN, TXN, CONTEXT> extends RichS
         private boolean supportsNullTransaction = true;
 
         @SuppressWarnings("WeakerAccess")
-        public StateSerializerSnapshot() {
-            super(StateSerializer.class);
-        }
+        public StateSerializerSnapshot() {}
 
         StateSerializerSnapshot(StateSerializer<TXN, CONTEXT> serializerInstance) {
             super(serializerInstance);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImpl.java
@@ -149,9 +149,10 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
             // the following is the case where we restore
             if (restoredTimersSnapshot != null) {
                 TypeSerializerSchemaCompatibility<K> keySerializerCompatibility =
-                        restoredTimersSnapshot
-                                .getKeySerializerSnapshot()
-                                .resolveSchemaCompatibility(keySerializer);
+                        keySerializer
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(
+                                        restoredTimersSnapshot.getKeySerializerSnapshot());
 
                 if (keySerializerCompatibility.isIncompatible()
                         || keySerializerCompatibility.isCompatibleAfterMigration()) {
@@ -160,9 +161,10 @@ public class InternalTimerServiceImpl<K, N> implements InternalTimerService<N> {
                 }
 
                 TypeSerializerSchemaCompatibility<N> namespaceSerializerCompatibility =
-                        restoredTimersSnapshot
-                                .getNamespaceSerializerSnapshot()
-                                .resolveSchemaCompatibility(namespaceSerializer);
+                        namespaceSerializer
+                                .snapshotConfiguration()
+                                .resolveSchemaCompatibility(
+                                        restoredTimersSnapshot.getNamespaceSerializerSnapshot());
 
                 restoredTimersSnapshot = null;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializerSnapshot.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/TimerSerializerSnapshot.java
@@ -30,9 +30,7 @@ public class TimerSerializerSnapshot<K, N>
 
     private static final int VERSION = 2;
 
-    public TimerSerializerSnapshot() {
-        super(TimerSerializer.class);
-    }
+    public TimerSerializerSnapshot() {}
 
     public TimerSerializerSnapshot(TimerSerializer<K, N> timerSerializer) {
         super(timerSerializer);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/co/IntervalJoinOperator.java
@@ -513,9 +513,7 @@ public class IntervalJoinOperator<K, T1, T2, OUT>
         private static final int VERSION = 2;
 
         @SuppressWarnings({"unused", "WeakerAccess"})
-        public BufferEntrySerializerSnapshot() {
-            super(BufferEntrySerializer.class);
-        }
+        public BufferEntrySerializerSnapshot() {}
 
         BufferEntrySerializerSnapshot(BufferEntrySerializer<T> serializerInstance) {
             super(serializerInstance);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/streamrecord/StreamElementSerializer.java
@@ -278,9 +278,7 @@ public final class StreamElementSerializer<T> extends TypeSerializer<StreamEleme
         private static final int VERSION = 2;
 
         @SuppressWarnings("WeakerAccess")
-        public StreamElementSerializerSnapshot() {
-            super(StreamElementSerializer.class);
-        }
+        public StreamElementSerializerSnapshot() {}
 
         StreamElementSerializerSnapshot(StreamElementSerializer<T> serializerInstance) {
             super(serializerInstance);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/ListViewSerializerSnapshot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/ListViewSerializerSnapshot.java
@@ -39,9 +39,7 @@ public final class ListViewSerializerSnapshot<T>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public ListViewSerializerSnapshot() {
-        super(ListViewSerializer.class);
-    }
+    public ListViewSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public ListViewSerializerSnapshot(ListViewSerializer<T> listViewSerializer) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/MapViewSerializerSnapshot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/MapViewSerializerSnapshot.java
@@ -40,9 +40,7 @@ public class MapViewSerializerSnapshot<K, V>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public MapViewSerializerSnapshot() {
-        super(MapViewSerializer.class);
-    }
+    public MapViewSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public MapViewSerializerSnapshot(MapViewSerializer<K, V> mapViewSerializer) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/NullAwareMapSerializerSnapshot.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/dataview/NullAwareMapSerializerSnapshot.java
@@ -38,9 +38,7 @@ public class NullAwareMapSerializerSnapshot<K, V>
     private static final int CURRENT_VERSION = 1;
 
     /** Constructor for read instantiation. */
-    public NullAwareMapSerializerSnapshot() {
-        super(NullAwareMapSerializer.class);
-    }
+    public NullAwareMapSerializerSnapshot() {}
 
     /** Constructor to create the snapshot for writing. */
     public NullAwareMapSerializerSnapshot(NullAwareMapSerializer<K, V> mapViewSerializer) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ArrayDataSerializer.java
@@ -280,8 +280,8 @@ public class ArrayDataSerializer extends TypeSerializer<ArrayData> {
             implements TypeSerializerSnapshot<ArrayData> {
         private static final int CURRENT_VERSION = 3;
 
-        private LogicalType previousType;
-        private TypeSerializer previousEleSer;
+        private LogicalType eleType;
+        private TypeSerializer eleSer;
 
         @SuppressWarnings("unused")
         public ArrayDataSerializerSnapshot() {
@@ -289,8 +289,8 @@ public class ArrayDataSerializer extends TypeSerializer<ArrayData> {
         }
 
         ArrayDataSerializerSnapshot(LogicalType eleType, TypeSerializer eleSer) {
-            this.previousType = eleType;
-            this.previousEleSer = eleSer;
+            this.eleType = eleType;
+            this.eleSer = eleSer;
         }
 
         @Override
@@ -301,8 +301,8 @@ public class ArrayDataSerializer extends TypeSerializer<ArrayData> {
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
             DataOutputViewStream outStream = new DataOutputViewStream(out);
-            InstantiationUtil.serializeObject(outStream, previousType);
-            InstantiationUtil.serializeObject(outStream, previousEleSer);
+            InstantiationUtil.serializeObject(outStream, eleType);
+            InstantiationUtil.serializeObject(outStream, eleSer);
         }
 
         @Override
@@ -310,10 +310,8 @@ public class ArrayDataSerializer extends TypeSerializer<ArrayData> {
                 throws IOException {
             try {
                 DataInputViewStream inStream = new DataInputViewStream(in);
-                this.previousType =
-                        InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
-                this.previousEleSer =
-                        InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
+                this.eleType = InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
+                this.eleSer = InstantiationUtil.deserializeObject(inStream, userCodeClassLoader);
             } catch (ClassNotFoundException e) {
                 throw new IOException(e);
             }
@@ -321,19 +319,20 @@ public class ArrayDataSerializer extends TypeSerializer<ArrayData> {
 
         @Override
         public TypeSerializer<ArrayData> restoreSerializer() {
-            return new ArrayDataSerializer(previousType, previousEleSer);
+            return new ArrayDataSerializer(eleType, eleSer);
         }
 
         @Override
         public TypeSerializerSchemaCompatibility<ArrayData> resolveSchemaCompatibility(
-                TypeSerializer<ArrayData> newSerializer) {
-            if (!(newSerializer instanceof ArrayDataSerializer)) {
+                TypeSerializerSnapshot<ArrayData> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof ArrayDataSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            ArrayDataSerializer newArrayDataSerializer = (ArrayDataSerializer) newSerializer;
-            if (!previousType.equals(newArrayDataSerializer.eleType)
-                    || !previousEleSer.equals(newArrayDataSerializer.eleSer)) {
+            ArrayDataSerializerSnapshot oldArrayDataSerializerSnapshot =
+                    (ArrayDataSerializerSnapshot) oldSerializerSnapshot;
+            if (!eleType.equals(oldArrayDataSerializerSnapshot.eleType)
+                    || !eleSer.equals(oldArrayDataSerializerSnapshot.eleSer)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             } else {
                 return TypeSerializerSchemaCompatibility.compatibleAsIs();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/BinaryRowDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/BinaryRowDataSerializer.java
@@ -339,7 +339,7 @@ public class BinaryRowDataSerializer extends AbstractRowDataSerializer<BinaryRow
             implements TypeSerializerSnapshot<BinaryRowData> {
         private static final int CURRENT_VERSION = 3;
 
-        private int previousNumFields;
+        private int numFields;
 
         @SuppressWarnings("unused")
         public BinaryRowDataSerializerSnapshot() {
@@ -347,7 +347,7 @@ public class BinaryRowDataSerializer extends AbstractRowDataSerializer<BinaryRow
         }
 
         BinaryRowDataSerializerSnapshot(int numFields) {
-            this.previousNumFields = numFields;
+            this.numFields = numFields;
         }
 
         @Override
@@ -357,30 +357,30 @@ public class BinaryRowDataSerializer extends AbstractRowDataSerializer<BinaryRow
 
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
-            out.writeInt(previousNumFields);
+            out.writeInt(numFields);
         }
 
         @Override
         public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
                 throws IOException {
-            this.previousNumFields = in.readInt();
+            this.numFields = in.readInt();
         }
 
         @Override
         public TypeSerializer<BinaryRowData> restoreSerializer() {
-            return new BinaryRowDataSerializer(previousNumFields);
+            return new BinaryRowDataSerializer(numFields);
         }
 
         @Override
         public TypeSerializerSchemaCompatibility<BinaryRowData> resolveSchemaCompatibility(
-                TypeSerializer<BinaryRowData> newSerializer) {
-            if (!(newSerializer instanceof BinaryRowDataSerializer)) {
+                TypeSerializerSnapshot<BinaryRowData> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof BinaryRowDataSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            BinaryRowDataSerializer newBinaryRowSerializer =
-                    (BinaryRowDataSerializer) newSerializer;
-            if (previousNumFields != newBinaryRowSerializer.numFields) {
+            BinaryRowDataSerializerSnapshot oldBinaryRowSerializerSnapshot =
+                    (BinaryRowDataSerializerSnapshot) oldSerializerSnapshot;
+            if (numFields != oldBinaryRowSerializerSnapshot.numFields) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             } else {
                 return TypeSerializerSchemaCompatibility.compatibleAsIs();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/DecimalDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/DecimalDataSerializer.java
@@ -145,8 +145,8 @@ public final class DecimalDataSerializer extends TypeSerializer<DecimalData> {
 
         private static final int CURRENT_VERSION = 3;
 
-        private int previousPrecision;
-        private int previousScale;
+        private int precision;
+        private int scale;
 
         @SuppressWarnings("unused")
         public DecimalSerializerSnapshot() {
@@ -154,8 +154,8 @@ public final class DecimalDataSerializer extends TypeSerializer<DecimalData> {
         }
 
         DecimalSerializerSnapshot(int precision, int scale) {
-            this.previousPrecision = precision;
-            this.previousScale = scale;
+            this.precision = precision;
+            this.scale = scale;
         }
 
         @Override
@@ -165,32 +165,33 @@ public final class DecimalDataSerializer extends TypeSerializer<DecimalData> {
 
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
-            out.writeInt(previousPrecision);
-            out.writeInt(previousScale);
+            out.writeInt(precision);
+            out.writeInt(scale);
         }
 
         @Override
         public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
                 throws IOException {
-            this.previousPrecision = in.readInt();
-            this.previousScale = in.readInt();
+            this.precision = in.readInt();
+            this.scale = in.readInt();
         }
 
         @Override
         public TypeSerializer<DecimalData> restoreSerializer() {
-            return new DecimalDataSerializer(previousPrecision, previousScale);
+            return new DecimalDataSerializer(precision, scale);
         }
 
         @Override
         public TypeSerializerSchemaCompatibility<DecimalData> resolveSchemaCompatibility(
-                TypeSerializer<DecimalData> newSerializer) {
-            if (!(newSerializer instanceof DecimalDataSerializer)) {
+                TypeSerializerSnapshot<DecimalData> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof DecimalSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            DecimalDataSerializer newDecimalDataSerializer = (DecimalDataSerializer) newSerializer;
-            if (previousPrecision != newDecimalDataSerializer.precision
-                    || previousScale != newDecimalDataSerializer.scale) {
+            DecimalSerializerSnapshot oldDecimalSerializerSnapshot =
+                    (DecimalSerializerSnapshot) oldSerializerSnapshot;
+            if (precision != oldDecimalSerializerSnapshot.precision
+                    || scale != oldDecimalSerializerSnapshot.scale) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             } else {
                 return TypeSerializerSchemaCompatibility.compatibleAsIs();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ExternalSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/ExternalSerializer.java
@@ -248,9 +248,7 @@ public final class ExternalSerializer<I, E> extends TypeSerializer<E> {
 
         private boolean isInternalInput;
 
-        public ExternalSerializerSnapshot() {
-            super(ExternalSerializer.class);
-        }
+        public ExternalSerializerSnapshot() {}
 
         public ExternalSerializerSnapshot(ExternalSerializer<I, E> externalSerializer) {
             super(externalSerializer);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializer.java
@@ -223,9 +223,7 @@ public final class LinkedListSerializer<T> extends TypeSerializer<LinkedList<T>>
         private boolean hasNullMask = true;
 
         /** Constructor for read instantiation. */
-        public LinkedListSerializerSnapshot() {
-            super(LinkedListSerializer.class);
-        }
+        public LinkedListSerializerSnapshot() {}
 
         /** Constructor to create the snapshot for writing. */
         public LinkedListSerializerSnapshot(LinkedListSerializer<T> listSerializer) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/LinkedListSerializer.java
@@ -258,8 +258,14 @@ public final class LinkedListSerializer<T> extends TypeSerializer<LinkedList<T>>
 
         @Override
         protected OuterSchemaCompatibility resolveOuterSchemaCompatibility(
-                LinkedListSerializer<T> newSerializer) {
-            if (hasNullMask != newSerializer.hasNullMask) {
+                TypeSerializerSnapshot<LinkedList<T>> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof LinkedListSerializerSnapshot)) {
+                return OuterSchemaCompatibility.INCOMPATIBLE;
+            }
+
+            LinkedListSerializerSnapshot<T> oldLinkedListSerializerSnapshot =
+                    (LinkedListSerializerSnapshot<T>) oldSerializerSnapshot;
+            if (hasNullMask != oldLinkedListSerializerSnapshot.hasNullMask) {
                 return OuterSchemaCompatibility.COMPATIBLE_AFTER_MIGRATION;
             }
             return OuterSchemaCompatibility.COMPATIBLE_AS_IS;

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/RawValueDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/RawValueDataSerializer.java
@@ -149,9 +149,7 @@ public final class RawValueDataSerializer<T> extends TypeSerializer<RawValueData
             extends CompositeTypeSerializerSnapshot<RawValueData<T>, RawValueDataSerializer<T>> {
 
         @SuppressWarnings("unused")
-        public RawValueDataSerializerSnapshot() {
-            super(RawValueDataSerializer.class);
-        }
+        public RawValueDataSerializerSnapshot() {}
 
         public RawValueDataSerializerSnapshot(RawValueDataSerializer<T> serializerInstance) {
             super(serializerInstance);

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/RowDataSerializer.java
@@ -277,7 +277,7 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
     public static final class RowDataSerializerSnapshot implements TypeSerializerSnapshot<RowData> {
         private static final int CURRENT_VERSION = 3;
 
-        private LogicalType[] previousTypes;
+        private LogicalType[] types;
         private NestedSerializersSnapshotDelegate nestedSerializersSnapshotDelegate;
 
         @SuppressWarnings("unused")
@@ -286,7 +286,7 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
         }
 
         RowDataSerializerSnapshot(LogicalType[] types, TypeSerializer[] serializers) {
-            this.previousTypes = types;
+            this.types = types;
             this.nestedSerializersSnapshotDelegate =
                     new NestedSerializersSnapshotDelegate(serializers);
         }
@@ -298,9 +298,9 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
 
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
-            out.writeInt(previousTypes.length);
+            out.writeInt(types.length);
             DataOutputViewStream stream = new DataOutputViewStream(out);
-            for (LogicalType previousType : previousTypes) {
+            for (LogicalType previousType : types) {
                 InstantiationUtil.serializeObject(stream, previousType);
             }
             nestedSerializersSnapshotDelegate.writeNestedSerializerSnapshots(out);
@@ -311,11 +311,10 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
                 throws IOException {
             int length = in.readInt();
             DataInputViewStream stream = new DataInputViewStream(in);
-            previousTypes = new LogicalType[length];
+            types = new LogicalType[length];
             for (int i = 0; i < length; i++) {
                 try {
-                    previousTypes[i] =
-                            InstantiationUtil.deserializeObject(stream, userCodeClassLoader);
+                    types[i] = InstantiationUtil.deserializeObject(stream, userCodeClassLoader);
                 } catch (ClassNotFoundException e) {
                     throw new IOException(e);
                 }
@@ -328,27 +327,28 @@ public class RowDataSerializer extends AbstractRowDataSerializer<RowData> {
         @Override
         public RowDataSerializer restoreSerializer() {
             return new RowDataSerializer(
-                    previousTypes,
-                    nestedSerializersSnapshotDelegate.getRestoredNestedSerializers());
+                    types, nestedSerializersSnapshotDelegate.getRestoredNestedSerializers());
         }
 
         @Override
         public TypeSerializerSchemaCompatibility<RowData> resolveSchemaCompatibility(
-                TypeSerializer<RowData> newSerializer) {
-            if (!(newSerializer instanceof RowDataSerializer)) {
+                TypeSerializerSnapshot<RowData> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof RowDataSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            RowDataSerializer newRowSerializer = (RowDataSerializer) newSerializer;
-            if (!Arrays.equals(previousTypes, newRowSerializer.types)) {
+            RowDataSerializerSnapshot oldRowDataSerializerSnapshot =
+                    (RowDataSerializerSnapshot) oldSerializerSnapshot;
+            if (!Arrays.equals(types, oldRowDataSerializerSnapshot.types)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
             CompositeTypeSerializerUtil.IntermediateCompatibilityResult<RowData>
                     intermediateResult =
                             CompositeTypeSerializerUtil.constructIntermediateCompatibilityResult(
-                                    newRowSerializer.fieldSerializers,
                                     nestedSerializersSnapshotDelegate
+                                            .getNestedSerializerSnapshots(),
+                                    oldRowDataSerializerSnapshot.nestedSerializersSnapshotDelegate
                                             .getNestedSerializerSnapshots());
 
             if (intermediateResult.isCompatibleWithReconfiguredSerializer()) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/SortedMapSerializerSnapshot.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/SortedMapSerializerSnapshot.java
@@ -100,12 +100,13 @@ public class SortedMapSerializerSnapshot<K, V> implements TypeSerializerSnapshot
 
     @Override
     public TypeSerializerSchemaCompatibility<SortedMap<K, V>> resolveSchemaCompatibility(
-            TypeSerializer<SortedMap<K, V>> newSerializer) {
-        if (!(newSerializer instanceof SortedMapSerializer)) {
+            TypeSerializerSnapshot<SortedMap<K, V>> oldSerializerSnapshot) {
+        if (!(oldSerializerSnapshot instanceof SortedMapSerializerSnapshot)) {
             return TypeSerializerSchemaCompatibility.incompatible();
         }
-        SortedMapSerializer newSortedMapSerializer = (SortedMapSerializer) newSerializer;
-        if (!comparator.equals(newSortedMapSerializer.getComparator())) {
+        SortedMapSerializerSnapshot<K, V> oldSortedMapSerializerSnapshot =
+                (SortedMapSerializerSnapshot<K, V>) oldSerializerSnapshot;
+        if (!comparator.equals(oldSortedMapSerializerSnapshot.comparator)) {
             return TypeSerializerSchemaCompatibility.incompatible();
         } else {
             return TypeSerializerSchemaCompatibility.compatibleAsIs();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TimestampDataSerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/TimestampDataSerializer.java
@@ -143,14 +143,14 @@ public class TimestampDataSerializer extends TypeSerializer<TimestampData> {
 
         private static final int CURRENT_VERSION = 1;
 
-        private int previousPrecision;
+        private int precision;
 
         public TimestampDataSerializerSnapshot() {
             // this constructor is used when restoring from a checkpoint/savepoint.
         }
 
         TimestampDataSerializerSnapshot(int precision) {
-            this.previousPrecision = precision;
+            this.precision = precision;
         }
 
         @Override
@@ -160,30 +160,30 @@ public class TimestampDataSerializer extends TypeSerializer<TimestampData> {
 
         @Override
         public void writeSnapshot(DataOutputView out) throws IOException {
-            out.writeInt(previousPrecision);
+            out.writeInt(precision);
         }
 
         @Override
         public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
                 throws IOException {
-            this.previousPrecision = in.readInt();
+            this.precision = in.readInt();
         }
 
         @Override
         public TypeSerializer<TimestampData> restoreSerializer() {
-            return new TimestampDataSerializer(previousPrecision);
+            return new TimestampDataSerializer(precision);
         }
 
         @Override
         public TypeSerializerSchemaCompatibility<TimestampData> resolveSchemaCompatibility(
-                TypeSerializer<TimestampData> newSerializer) {
-            if (!(newSerializer instanceof TimestampDataSerializer)) {
+                TypeSerializerSnapshot<TimestampData> oldSerializerSnapshot) {
+            if (!(oldSerializerSnapshot instanceof TimestampDataSerializerSnapshot)) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             }
 
-            TimestampDataSerializer timestampDataSerializer =
-                    (TimestampDataSerializer) newSerializer;
-            if (previousPrecision != timestampDataSerializer.precision) {
+            TimestampDataSerializerSnapshot timestampDataSerializerSnapshot =
+                    (TimestampDataSerializerSnapshot) oldSerializerSnapshot;
+            if (precision != timestampDataSerializerSnapshot.precision) {
                 return TypeSerializerSchemaCompatibility.incompatible();
             } else {
                 return TypeSerializerSchemaCompatibility.compatibleAsIs();

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/WindowKeySerializer.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/typeutils/WindowKeySerializer.java
@@ -177,9 +177,7 @@ public class WindowKeySerializer extends PagedTypeSerializer<WindowKey> {
         private static final int CURRENT_VERSION = 1;
 
         /** This empty nullary constructor is required for deserializing the configuration. */
-        public WindowKeySerializerSnapshot() {
-            super(WindowKeySerializer.class);
-        }
+        public WindowKeySerializerSnapshot() {}
 
         public WindowKeySerializerSnapshot(WindowKeySerializer serializerInstance) {
             super(serializerInstance);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/SerializerTestUtil.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/typeutils/SerializerTestUtil.java
@@ -61,7 +61,10 @@ public class SerializerTestUtil {
         }
 
         TypeSerializerSchemaCompatibility<T> strategy =
-                restoredConfig.resolveSchemaCompatibility(serializerGetter.getSerializer());
+                serializerGetter
+                        .getSerializer()
+                        .snapshotConfiguration()
+                        .resolveSchemaCompatibility(restoredConfig);
         final TypeSerializer<T> restoredSerializer;
         if (strategy.isCompatibleAsIs()) {
             restoredSerializer = restoredConfig.restoreSerializer();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
This pr reverses the direction of resolving schema compatibility could improve the usability of schema evolution.
See FLIP-263 for more details.

## Brief change log

In the milestone one, we should:

1. Add an extra method (TypeserializeSnapshotr#resolveSchemaCompatibility(TypeSerializerSnapshot<T> oldSerializerSnapshot)) in TypeSerializerSnapshot.java as above.
2. Mark the original method as deprecated and it will use new method to resolve as default.
3. Implement the new method for all built-in TypeserializerSnapshots.


## Verifying this change


This change is already covered by existing tests, such as *TypeSerializerUpgradeTestBase*, *PojoSerializerSnapshotTest*.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
