### PR TITLE
[FLINK-26372][runtime][state] Allow to configure Changelog Storage per program

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/ExecutionConfig.java
@@ -293,18 +293,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
                 periodicMaterializeInterval);
     }
 
-    @Internal
-    public int getMaterializationMaxAllowedFailures() {
-        return configuration.get(StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED);
-    }
-
-    @Internal
-    public void setMaterializationMaxAllowedFailures(int materializationMaxAllowedFailures) {
-        configuration.set(
-                StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED,
-                materializationMaxAllowedFailures);
-    }
-
     /**
      * Gets the parallelism with which operation are executed by default. Operations can
      * individually override this value to use a specific parallelism.
@@ -1123,9 +1111,6 @@ public class ExecutionConfig implements Serializable, Archiveable<ArchivedExecut
         configuration
                 .getOptional(StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL)
                 .ifPresent(this::setPeriodicMaterializeIntervalMillis);
-        configuration
-                .getOptional(StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED)
-                .ifPresent(this::setMaterializationMaxAllowedFailures);
 
         configuration
                 .getOptional(PipelineOptions.MAX_PARALLELISM)

--- a/flink-core/src/main/java/org/apache/flink/configuration/StateChangelogOptionsInternal.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/StateChangelogOptionsInternal.java
@@ -22,22 +22,10 @@ import org.apache.flink.util.InstantiationUtil;
 
 import java.io.IOException;
 
-import static org.apache.flink.configuration.StateChangelogOptions.ENABLE_STATE_CHANGE_LOG;
-
 /** StateChangelog options that are used to pass job-level configuration from JM to TM. */
 @Internal
 public class StateChangelogOptionsInternal {
     private StateChangelogOptionsInternal() {}
-
-    public static final ConfigOption<Boolean> ENABLE_CHANGE_LOG_FOR_APPLICATION =
-            ConfigOptions.key("state.backend.changelog.enabled_for_application")
-                    .booleanType()
-                    .noDefaultValue()
-                    .withDescription(
-                            String.format(
-                                    "Whether to enable job-level changelog."
-                                            + "If this config is not set explicitly, it would use %s's value",
-                                    ENABLE_STATE_CHANGE_LOG.key()));
 
     public static final String CHANGE_LOG_CONFIGURATION = "state.backend.changelog.configuration";
 

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -77,20 +77,26 @@ public class FsStateChangelogStorageFactory implements StateChangelogStorageFact
     @Override
     public Configuration extractConfiguration(ReadableConfig src) {
         Configuration dst = StateChangelogStorageFactory.super.extractConfiguration(src);
-        dst.set(BASE_PATH, src.get(BASE_PATH));
-        dst.set(COMPRESSION_ENABLED, src.get(COMPRESSION_ENABLED));
-        dst.set(PREEMPTIVE_PERSIST_THRESHOLD, src.get(PREEMPTIVE_PERSIST_THRESHOLD));
-        dst.set(PERSIST_DELAY, src.get(PERSIST_DELAY));
-        dst.set(PERSIST_SIZE_THRESHOLD, src.get(PERSIST_SIZE_THRESHOLD));
-        dst.set(UPLOAD_BUFFER_SIZE, src.get(UPLOAD_BUFFER_SIZE));
-        dst.set(NUM_UPLOAD_THREADS, src.get(NUM_UPLOAD_THREADS));
-        dst.set(NUM_DISCARD_THREADS, src.get(NUM_DISCARD_THREADS));
-        dst.set(IN_FLIGHT_DATA_LIMIT, src.get(IN_FLIGHT_DATA_LIMIT));
-        dst.set(RETRY_POLICY, src.get(RETRY_POLICY));
-        dst.set(UPLOAD_TIMEOUT, src.get(UPLOAD_TIMEOUT));
-        dst.set(RETRY_MAX_ATTEMPTS, src.get(RETRY_MAX_ATTEMPTS));
-        dst.set(RETRY_DELAY_AFTER_FAILURE, src.get(RETRY_DELAY_AFTER_FAILURE));
-        dst.set(CACHE_IDLE_TIMEOUT, src.get(CACHE_IDLE_TIMEOUT));
+        src.getOptional(BASE_PATH).ifPresent(value -> dst.set(BASE_PATH, value));
+        src.getOptional(COMPRESSION_ENABLED)
+                .ifPresent(value -> dst.set(COMPRESSION_ENABLED, value));
+        src.getOptional(PREEMPTIVE_PERSIST_THRESHOLD)
+                .ifPresent(value -> dst.set(PREEMPTIVE_PERSIST_THRESHOLD, value));
+        src.getOptional(PERSIST_DELAY).ifPresent(value -> dst.set(PERSIST_DELAY, value));
+        src.getOptional(PERSIST_SIZE_THRESHOLD)
+                .ifPresent(value -> dst.set(PERSIST_SIZE_THRESHOLD, value));
+        src.getOptional(UPLOAD_BUFFER_SIZE).ifPresent(value -> dst.set(UPLOAD_BUFFER_SIZE, value));
+        src.getOptional(NUM_UPLOAD_THREADS).ifPresent(value -> dst.set(NUM_UPLOAD_THREADS, value));
+        src.getOptional(NUM_DISCARD_THREADS)
+                .ifPresent(value -> dst.set(NUM_DISCARD_THREADS, value));
+        src.getOptional(IN_FLIGHT_DATA_LIMIT)
+                .ifPresent(value -> dst.set(IN_FLIGHT_DATA_LIMIT, value));
+        src.getOptional(RETRY_POLICY).ifPresent(value -> dst.set(RETRY_POLICY, value));
+        src.getOptional(UPLOAD_TIMEOUT).ifPresent(value -> dst.set(UPLOAD_TIMEOUT, value));
+        src.getOptional(RETRY_MAX_ATTEMPTS).ifPresent(value -> dst.set(RETRY_MAX_ATTEMPTS, value));
+        src.getOptional(RETRY_DELAY_AFTER_FAILURE)
+                .ifPresent(value -> dst.set(RETRY_DELAY_AFTER_FAILURE, value));
+        src.getOptional(CACHE_IDLE_TIMEOUT).ifPresent(value -> dst.set(CACHE_IDLE_TIMEOUT, value));
         return dst;
     }
 

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorageFactory.java
@@ -20,6 +20,7 @@ package org.apache.flink.changelog.fs;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
@@ -31,7 +32,18 @@ import java.io.IOException;
 import java.time.Duration;
 
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.BASE_PATH;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.CACHE_IDLE_TIMEOUT;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.COMPRESSION_ENABLED;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.IN_FLIGHT_DATA_LIMIT;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.NUM_DISCARD_THREADS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.NUM_UPLOAD_THREADS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_DELAY;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PERSIST_SIZE_THRESHOLD;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.PREEMPTIVE_PERSIST_THRESHOLD;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.RETRY_DELAY_AFTER_FAILURE;
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.RETRY_MAX_ATTEMPTS;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.RETRY_POLICY;
+import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_BUFFER_SIZE;
 import static org.apache.flink.changelog.fs.FsStateChangelogOptions.UPLOAD_TIMEOUT;
 import static org.apache.flink.configuration.StateChangelogOptions.STATE_CHANGE_LOG_STORAGE;
 
@@ -60,6 +72,26 @@ public class FsStateChangelogStorageFactory implements StateChangelogStorageFact
     public StateChangelogStorageView<?> createStorageView(Configuration configuration) {
         return new FsStateChangelogStorageForRecovery(
                 new ChangelogStreamHandleReaderWithCache(configuration));
+    }
+
+    @Override
+    public Configuration extractConfiguration(ReadableConfig src) {
+        Configuration dst = StateChangelogStorageFactory.super.extractConfiguration(src);
+        dst.set(BASE_PATH, src.get(BASE_PATH));
+        dst.set(COMPRESSION_ENABLED, src.get(COMPRESSION_ENABLED));
+        dst.set(PREEMPTIVE_PERSIST_THRESHOLD, src.get(PREEMPTIVE_PERSIST_THRESHOLD));
+        dst.set(PERSIST_DELAY, src.get(PERSIST_DELAY));
+        dst.set(PERSIST_SIZE_THRESHOLD, src.get(PERSIST_SIZE_THRESHOLD));
+        dst.set(UPLOAD_BUFFER_SIZE, src.get(UPLOAD_BUFFER_SIZE));
+        dst.set(NUM_UPLOAD_THREADS, src.get(NUM_UPLOAD_THREADS));
+        dst.set(NUM_DISCARD_THREADS, src.get(NUM_DISCARD_THREADS));
+        dst.set(IN_FLIGHT_DATA_LIMIT, src.get(IN_FLIGHT_DATA_LIMIT));
+        dst.set(RETRY_POLICY, src.get(RETRY_POLICY));
+        dst.set(UPLOAD_TIMEOUT, src.get(UPLOAD_TIMEOUT));
+        dst.set(RETRY_MAX_ATTEMPTS, src.get(RETRY_MAX_ATTEMPTS));
+        dst.set(RETRY_DELAY_AFTER_FAILURE, src.get(RETRY_DELAY_AFTER_FAILURE));
+        dst.set(CACHE_IDLE_TIMEOUT, src.get(CACHE_IDLE_TIMEOUT));
+        return dst;
     }
 
     public static void configure(

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/SavepointEnvironment.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ConfigurationUtils;
+import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.accumulators.AccumulatorRegistry;
@@ -174,8 +175,9 @@ public class SavepointEnvironment implements Environment {
     public Configuration getJobConfiguration() {
         Configuration jobConfiguration = new Configuration();
         // This means leaving this stateBackend unwrapped.
-        jobConfiguration.setBoolean(
-                StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION, false);
+        Configuration changelogConfiguration = new Configuration();
+        changelogConfiguration.setBoolean(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false);
+        StateChangelogOptionsInternal.putConfiguration(jobConfiguration, changelogConfiguration);
         return jobConfiguration;
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -640,9 +640,6 @@ public class JobGraph implements Serializable {
                 || TernaryBoolean.UNDEFINED.equals(changelogStateBackendEnabled)) {
             return;
         }
-        this.jobConfiguration.setBoolean(
-                StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION,
-                changelogStateBackendEnabled.getAsBoolean());
         if (changelogStateBackendEnabled.getOrDefault(false)) {
             StateChangelogOptionsInternal.putConfiguration(
                     jobConfiguration, changelogConfiguration);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobGraph.java
@@ -634,7 +634,8 @@ public class JobGraph implements Serializable {
         }
     }
 
-    public void setChangelogStateBackendEnabled(TernaryBoolean changelogStateBackendEnabled) {
+    public void setChangelogStateBackendEnabled(
+            TernaryBoolean changelogStateBackendEnabled, Configuration changelogConfiguration) {
         if (changelogStateBackendEnabled == null
                 || TernaryBoolean.UNDEFINED.equals(changelogStateBackendEnabled)) {
             return;
@@ -642,6 +643,10 @@ public class JobGraph implements Serializable {
         this.jobConfiguration.setBoolean(
                 StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION,
                 changelogStateBackendEnabled.getAsBoolean());
+        if (changelogStateBackendEnabled.getOrDefault(false)) {
+            StateChangelogOptionsInternal.putConfiguration(
+                    jobConfiguration, changelogConfiguration);
+        }
     }
 
     public void setJobStatusHooks(List<JobStatusHook> hooks) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManager.java
@@ -22,7 +22,6 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.StateChangelogOptions;
-import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.runtime.clusterframework.types.AllocationID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.FileUtils;
@@ -126,8 +125,7 @@ public class TaskExecutorLocalStateStoresManager {
             @Nonnull AllocationID allocationID,
             @Nonnull JobVertexID jobVertexID,
             @Nonnegative int subtaskIndex,
-            Configuration clusterConfiguration,
-            Configuration jobConfiguration) {
+            Configuration cfg) {
 
         synchronized (lock) {
             if (closed) {
@@ -169,16 +167,8 @@ public class TaskExecutorLocalStateStoresManager {
                 LocalRecoveryConfig localRecoveryConfig =
                         new LocalRecoveryConfig(directoryProvider);
 
-                boolean changelogEnabled =
-                        jobConfiguration
-                                .getOptional(
-                                        StateChangelogOptionsInternal
-                                                .ENABLE_CHANGE_LOG_FOR_APPLICATION)
-                                .orElse(
-                                        clusterConfiguration.getBoolean(
-                                                StateChangelogOptions.ENABLE_STATE_CHANGE_LOG));
-
-                if (localRecoveryConfig.isLocalRecoveryEnabled() && changelogEnabled) {
+                if (localRecoveryConfig.isLocalRecoveryEnabled()
+                        && cfg.getBoolean(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)) {
                     taskLocalStateStore =
                             new ChangelogTaskLocalStateStore(
                                     jobId,

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
@@ -55,12 +55,14 @@ public interface StateChangelogStorageFactory {
     /** Extract the relevant to this factory portion of the configuration. */
     default Configuration extractConfiguration(ReadableConfig src) {
         Configuration dst = new Configuration();
-        dst.set(PERIODIC_MATERIALIZATION_INTERVAL, src.get(PERIODIC_MATERIALIZATION_INTERVAL));
-        dst.set(
-                MATERIALIZATION_MAX_FAILURES_ALLOWED,
-                src.get(MATERIALIZATION_MAX_FAILURES_ALLOWED));
-        dst.set(ENABLE_STATE_CHANGE_LOG, src.get(ENABLE_STATE_CHANGE_LOG));
-        dst.set(STATE_CHANGE_LOG_STORAGE, src.get(STATE_CHANGE_LOG_STORAGE));
+        src.getOptional(PERIODIC_MATERIALIZATION_INTERVAL)
+                .ifPresent(value -> dst.set(PERIODIC_MATERIALIZATION_INTERVAL, value));
+        src.getOptional(MATERIALIZATION_MAX_FAILURES_ALLOWED)
+                .ifPresent(value -> dst.set(MATERIALIZATION_MAX_FAILURES_ALLOWED, value));
+        src.getOptional(ENABLE_STATE_CHANGE_LOG)
+                .ifPresent(value -> dst.set(ENABLE_STATE_CHANGE_LOG, value));
+        src.getOptional(STATE_CHANGE_LOG_STORAGE)
+                .ifPresent(value -> dst.set(STATE_CHANGE_LOG_STORAGE, value));
         return dst;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogStorageFactory.java
@@ -21,10 +21,16 @@ package org.apache.flink.runtime.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.runtime.metrics.groups.TaskManagerJobMetricGroup;
 import org.apache.flink.runtime.state.LocalRecoveryConfig;
 
 import java.io.IOException;
+
+import static org.apache.flink.configuration.StateChangelogOptions.ENABLE_STATE_CHANGE_LOG;
+import static org.apache.flink.configuration.StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED;
+import static org.apache.flink.configuration.StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL;
+import static org.apache.flink.configuration.StateChangelogOptions.STATE_CHANGE_LOG_STORAGE;
 
 /**
  * A factory for {@link StateChangelogStorage}. Please use {@link StateChangelogStorageLoader} to
@@ -45,4 +51,16 @@ public interface StateChangelogStorageFactory {
 
     /** Create the storage for recovery. */
     StateChangelogStorageView<?> createStorageView(Configuration configuration) throws IOException;
+
+    /** Extract the relevant to this factory portion of the configuration. */
+    default Configuration extractConfiguration(ReadableConfig src) {
+        Configuration dst = new Configuration();
+        dst.set(PERIODIC_MATERIALIZATION_INTERVAL, src.get(PERIODIC_MATERIALIZATION_INTERVAL));
+        dst.set(
+                MATERIALIZATION_MAX_FAILURES_ALLOWED,
+                src.get(MATERIALIZATION_MAX_FAILURES_ALLOWED));
+        dst.set(ENABLE_STATE_CHANGE_LOG, src.get(ENABLE_STATE_CHANGE_LOG));
+        dst.set(STATE_CHANGE_LOG_STORAGE, src.get(STATE_CHANGE_LOG_STORAGE));
+        return dst;
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/taskexecutor/TaskExecutor.java
@@ -22,6 +22,9 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.ClusterOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.IllegalConfigurationException;
+import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.management.jmx.JMXService;
 import org.apache.flink.runtime.accumulators.AccumulatorSnapshot;
 import org.apache.flink.runtime.blob.JobPermanentBlobService;
@@ -699,22 +702,25 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
             PartitionProducerStateChecker partitionStateChecker =
                     jobManagerConnection.getPartitionStateChecker();
 
+            final Configuration mergedConfig =
+                    createMergedConfiguration(
+                            jobInformation.getJobConfiguration(),
+                            taskManagerConfiguration.getConfiguration());
+
             final TaskLocalStateStore localStateStore =
                     localStateStoresManager.localStateStoreForSubtask(
                             jobId,
                             tdd.getAllocationId(),
                             taskInformation.getJobVertexId(),
                             tdd.getSubtaskIndex(),
-                            taskManagerConfiguration.getConfiguration(),
-                            jobInformation.getJobConfiguration());
+                            mergedConfig);
 
-            // TODO: Pass config value from user program and do overriding here.
             final StateChangelogStorage<?> changelogStorage;
             try {
                 changelogStorage =
                         changelogStoragesManager.stateChangelogStorageForJob(
                                 jobId,
-                                taskManagerConfiguration.getConfiguration(),
+                                mergedConfig,
                                 jobGroup,
                                 localStateStore.getLocalRecoveryConfig());
             } catch (IOException e) {
@@ -801,6 +807,22 @@ public class TaskExecutor extends RpcEndpoint implements TaskExecutorGateway {
         } catch (TaskSubmissionException e) {
             return FutureUtils.completedExceptionally(e);
         }
+    }
+
+    /** Adds the relevant job configuration to this TM configuration */
+    private Configuration createMergedConfiguration(
+            Configuration jobConfiguration, Configuration configuration)
+            throws TaskSubmissionException {
+        Configuration mergedConfig = new Configuration(configuration);
+        try {
+            mergedConfig.addAll(
+                    StateChangelogOptionsInternal.getConfiguration(
+                            jobConfiguration, getClass().getClassLoader()));
+        } catch (IllegalConfigurationException e) {
+            throw new TaskSubmissionException(
+                    "Could not deserialize the changelog configuration.", e);
+        }
+        return mergedConfig;
     }
 
     private void setupResultPartitionBookkeeping(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TaskExecutorLocalStateStoresManagerTest.java
@@ -166,12 +166,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         TaskLocalStateStore taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID,
-                        allocationID,
-                        jobVertexID,
-                        subtaskIdx,
-                        new Configuration(),
-                        new Configuration());
+                        jobID, allocationID, jobVertexID, subtaskIdx, new Configuration());
 
         Assert.assertFalse(taskLocalStateStore.getLocalRecoveryConfig().isLocalRecoveryEnabled());
         Assert.assertNull(
@@ -207,12 +202,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         TaskLocalStateStore taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID,
-                        allocationID,
-                        jobVertexID,
-                        subtaskIdx,
-                        new Configuration(),
-                        new Configuration());
+                        jobID, allocationID, jobVertexID, subtaskIdx, new Configuration());
 
         LocalRecoveryDirectoryProvider directoryProvider =
                 taskLocalStateStore
@@ -268,12 +258,7 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         taskLocalStateStore =
                 storesManager.localStateStoreForSubtask(
-                        jobID,
-                        otherAllocationID,
-                        jobVertexID,
-                        subtaskIdx,
-                        new Configuration(),
-                        new Configuration());
+                        jobID, otherAllocationID, jobVertexID, subtaskIdx, new Configuration());
 
         directoryProvider =
                 taskLocalStateStore
@@ -353,14 +338,9 @@ public class TaskExecutorLocalStateStoresManagerTest extends TestLogger {
 
         // register local state stores
         taskExecutorLocalStateStoresManager.localStateStoreForSubtask(
-                jobId,
-                retainedAllocationId,
-                jobVertexId,
-                0,
-                new Configuration(),
-                new Configuration());
+                jobId, retainedAllocationId, jobVertexId, 0, new Configuration());
         taskExecutorLocalStateStoresManager.localStateStoreForSubtask(
-                jobId, otherAllocationId, jobVertexId, 1, new Configuration(), new Configuration());
+                jobId, otherAllocationId, jobVertexId, 1, new Configuration());
 
         final Collection<Path> allocationDirectories =
                 TaskExecutorLocalStateStoresManager.listAllocationDirectoriesIn(localStateStore);

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/AbstractChangelogStateBackend.java
@@ -21,6 +21,8 @@ package org.apache.flink.state.changelog;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.core.fs.CloseableRegistry;
 import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.runtime.execution.Environment;
@@ -44,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -197,5 +200,15 @@ public abstract class AbstractChangelogStateBackend
                 .filter(Objects::nonNull)
                 .map(ChangelogStateBackendHandleImpl::getChangelogStateBackendHandle)
                 .collect(Collectors.toList());
+    }
+
+    protected Configuration createMergedConfiguration(Environment env)
+            throws IOException, ClassNotFoundException {
+        Configuration configuration =
+                new Configuration(env.getTaskManagerInfo().getConfiguration());
+        configuration.addAll(
+                StateChangelogOptionsInternal.getConfiguration(
+                        env.getJobConfiguration(), getClass().getClassLoader()));
+        return configuration;
     }
 }

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogStateBackend.java
@@ -20,6 +20,7 @@ package org.apache.flink.state.changelog;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.IllegalConfigurationException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.metrics.MetricGroup;
@@ -40,6 +41,8 @@ import org.apache.flink.util.Preconditions;
 
 import java.util.Collection;
 
+import static org.apache.flink.configuration.StateChangelogOptions.MATERIALIZATION_MAX_FAILURES_ALLOWED;
+import static org.apache.flink.configuration.StateChangelogOptions.PERIODIC_MATERIALIZATION_INTERVAL;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -88,11 +91,12 @@ public class ChangelogStateBackend extends AbstractChangelogStateBackend
 
         String subtaskName = env.getTaskInfo().getTaskNameWithSubtasks();
         ExecutionConfig executionConfig = env.getExecutionConfig();
+        Configuration mergedConfiguration = createMergedConfiguration(env);
 
         ChangelogStateFactory changelogStateFactory = new ChangelogStateFactory();
         CheckpointableKeyedStateBackend<K> keyedStateBackend =
                 ChangelogBackendRestoreOperation.restore(
-                        env.getTaskManagerInfo().getConfiguration(),
+                        mergedConfiguration,
                         env.getUserCodeClassLoader().asClassLoader(),
                         env.getTaskStateManager(),
                         stateBackendHandles,
@@ -124,8 +128,8 @@ public class ChangelogStateBackend extends AbstractChangelogStateBackend
                                 env.failExternally(new AsynchronousException(message, exception)),
                         changelogKeyedStateBackend,
                         new ChangelogMaterializationMetricGroup(metricGroup),
-                        executionConfig.getPeriodicMaterializeIntervalMillis(),
-                        executionConfig.getMaterializationMaxAllowedFailures(),
+                        mergedConfiguration.get(PERIODIC_MATERIALIZATION_INTERVAL).toMillis(),
+                        mergedConfiguration.get(MATERIALIZATION_MAX_FAILURES_ALLOWED),
                         operatorIdentifier);
 
         // keyedStateBackend is responsible to close periodicMaterializationManager

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/DeactivatedChangelogStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/DeactivatedChangelogStateBackend.java
@@ -68,7 +68,7 @@ public class DeactivatedChangelogStateBackend extends AbstractChangelogStateBack
         ChangelogStateFactory changelogStateFactory = new ChangelogStateFactory();
 
         return ChangelogBackendRestoreOperation.restore(
-                env.getTaskManagerInfo().getConfiguration(),
+                createMergedConfiguration(env),
                 env.getUserCodeClassLoader().asClassLoader(),
                 env.getTaskStateManager(),
                 stateBackendHandles,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -993,6 +993,16 @@ public class StreamExecutionEnvironment implements AutoCloseable {
                                                 .extractConfiguration(configuration));
                             }
                         });
+        this.configuration
+                .getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)
+                .ifPresent(
+                        enabled -> {
+                            if (enabled) {
+                                this.configuration.addAll(
+                                        StateChangelogStorageLoader.loadFactory(configuration)
+                                                .extractConfiguration(configuration));
+                            }
+                        });
         Optional.ofNullable(loadStateBackend(configuration, classLoader))
                 .ifPresent(this::setStateBackend);
         configuration

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -75,6 +75,7 @@ import org.apache.flink.runtime.scheduler.ClusterDatasetCorruptedException;
 import org.apache.flink.runtime.state.KeyGroupRangeAssignment;
 import org.apache.flink.runtime.state.StateBackend;
 import org.apache.flink.runtime.state.StateBackendLoader;
+import org.apache.flink.runtime.state.changelog.StateChangelogStorageLoader;
 import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.TimeCharacteristic;
 import org.apache.flink.streaming.api.datastream.DataStream;
@@ -197,9 +198,6 @@ public class StreamExecutionEnvironment implements AutoCloseable {
 
     /** The state backend used for storing k/v state and state snapshots. */
     private StateBackend defaultStateBackend;
-
-    /** Whether to enable ChangelogStateBackend, default value is unset. */
-    private TernaryBoolean changelogStateBackendEnabled = TernaryBoolean.UNDEFINED;
 
     /** The default savepoint directory used by the job. */
     private Path defaultSavepointDirectory;
@@ -705,7 +703,7 @@ public class StreamExecutionEnvironment implements AutoCloseable {
      */
     @PublicEvolving
     public StreamExecutionEnvironment enableChangelogStateBackend(boolean enabled) {
-        this.changelogStateBackendEnabled = TernaryBoolean.fromBoolean(enabled);
+        this.configuration.set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, enabled);
         return this;
     }
 
@@ -719,7 +717,10 @@ public class StreamExecutionEnvironment implements AutoCloseable {
      */
     @PublicEvolving
     public TernaryBoolean isChangelogStateBackendEnabled() {
-        return changelogStateBackendEnabled;
+        return this.configuration
+                .getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)
+                .map(TernaryBoolean::fromBoolean)
+                .orElse(TernaryBoolean.UNDEFINED);
     }
 
     /**
@@ -983,7 +984,15 @@ public class StreamExecutionEnvironment implements AutoCloseable {
                 .ifPresent(this::setStreamTimeCharacteristic);
         configuration
                 .getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)
-                .ifPresent(this::enableChangelogStateBackend);
+                .ifPresent(
+                        enabled -> {
+                            enableChangelogStateBackend(enabled);
+                            if (enabled) {
+                                this.configuration.addAll(
+                                        StateChangelogStorageLoader.loadFactory(configuration)
+                                                .extractConfiguration(configuration));
+                            }
+                        });
         Optional.ofNullable(loadStateBackend(configuration, classLoader))
                 .ifPresent(this::setStateBackend);
         configuration
@@ -2278,7 +2287,6 @@ public class StreamExecutionEnvironment implements AutoCloseable {
         return new StreamGraphGenerator(
                         new ArrayList<>(transformations), config, checkpointCfg, configuration)
                 .setStateBackend(defaultStateBackend)
-                .setChangelogStateBackendEnabled(changelogStateBackendEnabled)
                 .setSavepointDir(defaultSavepointDirectory)
                 .setChaining(isChainingEnabled)
                 .setUserArtifacts(cacheFile)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -32,6 +32,7 @@ import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
@@ -126,7 +127,8 @@ public class StreamGraph implements Pipeline {
     protected Map<Integer, String> vertexIDtoBrokerID;
     protected Map<Integer, Long> vertexIDtoLoopTimeout;
     private StateBackend stateBackend;
-    private TernaryBoolean changelogStateBackendEnabled;
+    private TernaryBoolean changelogStateBackendEnabled = TernaryBoolean.UNDEFINED; // todo: remove?
+    private Configuration changelogConfiguration = new Configuration();
     private CheckpointStorage checkpointStorage;
     private Path savepointDir;
     private Set<Tuple2<StreamNode, StreamNode>> iterationSourceSinkPairs;
@@ -201,8 +203,10 @@ public class StreamGraph implements Pipeline {
         return this.stateBackend;
     }
 
-    public void setChangelogStateBackendEnabled(TernaryBoolean changelogStateBackendEnabled) {
+    public void setChangelogStateBackendEnabled(
+            TernaryBoolean changelogStateBackendEnabled, Configuration changelogConfiguration) {
         this.changelogStateBackendEnabled = changelogStateBackendEnabled;
+        this.changelogConfiguration = changelogConfiguration;
     }
 
     public TernaryBoolean isChangelogStateBackendEnabled() {
@@ -1065,5 +1069,9 @@ public class StreamGraph implements Pipeline {
 
     public List<JobStatusHook> getJobStatusHooks() {
         return this.jobStatusHooks;
+    }
+
+    public Configuration getChangelogConfiguration() {
+        return this.changelogConfiguration;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -34,6 +34,7 @@ import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.PipelineOptions;
+import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.core.memory.ManagedMemoryUseCase;
 import org.apache.flink.runtime.clusterframework.types.ResourceProfile;
@@ -127,7 +128,6 @@ public class StreamGraph implements Pipeline {
     protected Map<Integer, String> vertexIDtoBrokerID;
     protected Map<Integer, Long> vertexIDtoLoopTimeout;
     private StateBackend stateBackend;
-    private TernaryBoolean changelogStateBackendEnabled = TernaryBoolean.UNDEFINED; // todo: remove?
     private Configuration changelogConfiguration = new Configuration();
     private CheckpointStorage checkpointStorage;
     private Path savepointDir;
@@ -203,14 +203,15 @@ public class StreamGraph implements Pipeline {
         return this.stateBackend;
     }
 
-    public void setChangelogStateBackendEnabled(
-            TernaryBoolean changelogStateBackendEnabled, Configuration changelogConfiguration) {
-        this.changelogStateBackendEnabled = changelogStateBackendEnabled;
+    public void setChangelogStateBackendEnabled(Configuration changelogConfiguration) {
         this.changelogConfiguration = changelogConfiguration;
     }
 
     public TernaryBoolean isChangelogStateBackendEnabled() {
-        return changelogStateBackendEnabled;
+        return this.changelogConfiguration
+                .getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)
+                .map(TernaryBoolean::fromBoolean)
+                .orElse(TernaryBoolean.UNDEFINED);
     }
 
     public void setCheckpointStorage(CheckpointStorage checkpointStorage) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -86,7 +86,6 @@ import org.apache.flink.streaming.runtime.translators.SourceTransformationTransl
 import org.apache.flink.streaming.runtime.translators.TimestampsAndWatermarksTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.TwoInputTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.UnionTransformationTranslator;
-import org.apache.flink.util.TernaryBoolean;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -431,7 +430,7 @@ public class StreamGraphGenerator {
         if (useStateBackend) {
             LOG.debug("Using BATCH execution state backend and timer service.");
             graph.setStateBackend(new BatchExecutionStateBackend());
-            graph.setChangelogStateBackendEnabled(TernaryBoolean.FALSE, new Configuration());
+            graph.setChangelogStateBackendEnabled(new Configuration());
             graph.setCheckpointStorage(new BatchExecutionCheckpointStorage());
             graph.setTimerServiceProvider(BatchExecutionInternalTimeServiceManager::create);
         } else {
@@ -444,12 +443,12 @@ public class StreamGraphGenerator {
         Optional<Boolean> enabled =
                 configuration.getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG);
         if (!enabled.isPresent()) {
-            graph.setChangelogStateBackendEnabled(TernaryBoolean.UNDEFINED, new Configuration());
+            graph.setChangelogStateBackendEnabled(new Configuration());
         } else if (!enabled.get()) {
-            graph.setChangelogStateBackendEnabled(TernaryBoolean.FALSE, new Configuration());
+            graph.setChangelogStateBackendEnabled(
+                    new Configuration().set(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG, false));
         } else {
             graph.setChangelogStateBackendEnabled(
-                    TernaryBoolean.TRUE,
                     // assumption: if any factory option is passed here then the correct factory
                     // must also be chosen
                     StateChangelogStorageLoader.loadFactory(configuration)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGenerator.java
@@ -274,7 +274,9 @@ public class StreamingJobGraphGenerator {
                             + "This indicates that non-serializable types (like custom serializers) were registered");
         }
 
-        jobGraph.setChangelogStateBackendEnabled(streamGraph.isChangelogStateBackendEnabled());
+        jobGraph.setChangelogStateBackendEnabled(
+                streamGraph.isChangelogStateBackendEnabled(),
+                streamGraph.getChangelogConfiguration());
 
         addVertexIndexPrefixInVertexName();
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.operators.MailboxExecutor;
 import org.apache.flink.api.common.operators.ProcessingTimeService.ProcessingTimeCallback;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.StateChangelogOptions;
 import org.apache.flink.configuration.StateChangelogOptionsInternal;
 import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.core.fs.AutoCloseableRegistry;
@@ -1475,17 +1476,13 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         final StateBackend fromApplication =
                 configuration.getStateBackend(getUserCodeClassLoader());
 
-        // todo: move this parsing to SBL?
-        Configuration mergedConfig =
-                new Configuration(environment.getTaskManagerInfo().getConfiguration());
-        mergedConfig.addAll(
+        Configuration changelogConfigFromJob =
                 StateChangelogOptionsInternal.getConfiguration(
-                        environment.getJobConfiguration(), getClass().getClassLoader()));
+                        environment.getJobConfiguration(), getClass().getClassLoader());
 
         final TernaryBoolean isChangelogEnabled =
-                mergedConfig
-                        .getOptional(
-                                StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION)
+                changelogConfigFromJob
+                        .getOptional(StateChangelogOptions.ENABLE_STATE_CHANGE_LOG)
                         .map(TernaryBoolean::fromBoolean)
                         .orElse(TernaryBoolean.UNDEFINED);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -1474,19 +1474,24 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     private StateBackend createStateBackend() throws Exception {
         final StateBackend fromApplication =
                 configuration.getStateBackend(getUserCodeClassLoader());
-        final Optional<Boolean> isChangelogEnabledOptional =
-                environment
-                        .getJobConfiguration()
+
+        // todo: move this parsing to SBL?
+        Configuration mergedConfig =
+                new Configuration(environment.getTaskManagerInfo().getConfiguration());
+        mergedConfig.addAll(
+                StateChangelogOptionsInternal.getConfiguration(
+                        environment.getJobConfiguration(), getClass().getClassLoader()));
+
+        final TernaryBoolean isChangelogEnabled =
+                mergedConfig
                         .getOptional(
-                                StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION);
-        final TernaryBoolean isChangelogStateBackendEnableFromApplication =
-                isChangelogEnabledOptional.isPresent()
-                        ? TernaryBoolean.fromBoolean(isChangelogEnabledOptional.get())
-                        : TernaryBoolean.UNDEFINED;
+                                StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION)
+                        .map(TernaryBoolean::fromBoolean)
+                        .orElse(TernaryBoolean.UNDEFINED);
 
         return StateBackendLoader.fromApplicationOrConfigOrDefault(
                 fromApplication,
-                isChangelogStateBackendEnableFromApplication,
+                isChangelogEnabled,
                 getEnvironment().getTaskManagerInfo().getConfiguration(),
                 getUserCodeClassLoader(),
                 LOG);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR wants to support configuring Changelog Storage via `StreamExecutionEnvironment`, allow to configure Changelog Storage per program.
```Java
Configuration changlogStorageConf = new Configuration();
changlogStorageConf.setBoolean(FsStateChangelogOptions.STATE_CHANGE_LOG_STORAGE,"filesystem");
changlogStorageConf.setString(FsStateChangelogOptions.BASE_PATH, "file:///dstl");
changlogStorageConf.setBoolean(FsStateChangelogOptions.COMPRESSION_ENABLED, true);
StreamExecutionEnvironment env = 
    StreamExecutionEnvironment.getExecutionEnvironment();

env.enableChangelogStateBackend(true);
env.configure(changlogStorageConf);
```


## Brief change log
- Add `changelogConfiguration` into `StreamGraph`. 
- Add `StateChangelogOptionsInternal.CHANGE_LOG_CONFIGURATION` and remove `StateChangelogOptionsInternal.ENABLE_CHANGE_LOG_FOR_APPLICATION`.
- Add serialize/deserialize method for `CHANGE_LOG_CONFIGURATION`, to pass the `StreamGraph.changelogConfiguration` to TM as a (serialized) string map. The path in common cases is as follows:
env -> streamGraphGenerator -> streamGraph -> jobGraph -> TM



## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
