### PR TITLE
[FLINK-30006][table-planner] Make all pure dynamic functions non-deterministic in streaming mode to avoid wrong plans

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1455,6 +1455,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("currentDatabase")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(STRING().notNull()))
+                    .notDeterministic()
                     .build();
 
     // --------------------------------------------------------------------------------------------
@@ -1483,9 +1484,23 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(explicit(TIME().notNull()))
                     .build();
 
+    public static final BuiltInFunctionDefinition LOCAL_TIME =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("localTime")
+                    .kind(SCALAR)
+                    .outputTypeStrategy(explicit(TIME().notNull()))
+                    .build();
+
     public static final BuiltInFunctionDefinition CURRENT_TIMESTAMP =
             BuiltInFunctionDefinition.newBuilder()
                     .name("currentTimestamp")
+                    .kind(SCALAR)
+                    .outputTypeStrategy(explicit(TIMESTAMP_LTZ(3).notNull()))
+                    .build();
+
+    public static final BuiltInFunctionDefinition NOW =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("now")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIMESTAMP_LTZ(3).notNull()))
                     .build();
@@ -1495,13 +1510,7 @@ public final class BuiltInFunctionDefinitions {
                     .name("currentRowTimestamp")
                     .kind(SCALAR)
                     .outputTypeStrategy(explicit(TIMESTAMP_LTZ(3).notNull()))
-                    .build();
-
-    public static final BuiltInFunctionDefinition LOCAL_TIME =
-            BuiltInFunctionDefinition.newBuilder()
-                    .name("localTime")
-                    .kind(SCALAR)
-                    .outputTypeStrategy(explicit(TIME().notNull()))
+                    .notDeterministic()
                     .build();
 
     public static final BuiltInFunctionDefinition LOCAL_TIMESTAMP =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/delegation/PlannerContext.java
@@ -319,6 +319,6 @@ public class PlannerContext {
                         context.getCatalogManager().getDataTypeFactory(),
                         typeFactory,
                         context.getRexFactory()),
-                FlinkSqlOperatorTable.instance());
+                FlinkSqlOperatorTable.instance(context.isBatchMode()));
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkCurrentDateDynamicFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkCurrentDateDynamicFunction.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.calcite.sql.fun.SqlCurrentDateFunction;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+/**
+ * The Flink CURRENT_DATE function differs from the parent {@link SqlCurrentDateFunction} which is
+ * aware of whether it is used in batch mode, if true it will act totally same as the parent {@link
+ * SqlCurrentDateFunction}, but will be a non-deterministic function if not in batch mode.
+ */
+@Internal
+public class FlinkCurrentDateDynamicFunction extends SqlCurrentDateFunction {
+
+    private final boolean isBatchMode;
+
+    public FlinkCurrentDateDynamicFunction(boolean isBatchMode) {
+        this.isBatchMode = isBatchMode;
+    }
+
+    @Override
+    public boolean isDynamicFunction() {
+        return isBatchMode && super.isDynamicFunction();
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        // be a non-deterministic function in streaming mode
+        return isBatchMode;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (!(obj instanceof FlinkCurrentDateDynamicFunction)) {
+            return false;
+        }
+        if (!obj.getClass().equals(this.getClass())) {
+            return false;
+        }
+        FlinkCurrentDateDynamicFunction other = (FlinkCurrentDateDynamicFunction) obj;
+        return this.getName().equals(other.getName())
+                && kind == other.kind
+                && this.isBatchMode == other.isBatchMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, this.getName(), isBatchMode);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkCurrentRowTimestampFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkCurrentRowTimestampFunction.java
@@ -24,19 +24,21 @@ import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.fun.SqlAbstractTimeFunction;
 import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
 
 /**
- * Function that used to define SQL time function like LOCALTIMESTAMP, CURRENT_TIMESTAMP,
- * CURRENT_ROW_TIMESTAMP(), NOW() in Flink, the function support configuring the return type and the
+ * The function CURRENT_ROW_TIMESTAMP() in Flink which supports configuring the return type and the
  * precision of return type.
  */
 @Internal
-public class FlinkSqlTimestampFunction extends SqlAbstractTimeFunction {
+public class FlinkCurrentRowTimestampFunction extends SqlAbstractTimeFunction {
 
     private final SqlTypeName returnTypeName;
     private final int precision;
 
-    public FlinkSqlTimestampFunction(
+    public FlinkCurrentRowTimestampFunction(
             String functionName, SqlTypeName returnTypeName, int precision) {
         // access protected constructor
         super(functionName, returnTypeName);
@@ -50,7 +52,32 @@ public class FlinkSqlTimestampFunction extends SqlAbstractTimeFunction {
     }
 
     @Override
+    public boolean isDynamicFunction() {
+        return false;
+    }
+
+    @Override
     public boolean isDeterministic() {
         return false;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (!(obj instanceof FlinkCurrentRowTimestampFunction)) {
+            return false;
+        }
+        if (!obj.getClass().equals(this.getClass())) {
+            return false;
+        }
+        FlinkCurrentRowTimestampFunction other = (FlinkCurrentRowTimestampFunction) obj;
+        return this.getName().equals(other.getName())
+                && kind == other.kind
+                && this.precision == other.precision
+                && this.returnTypeName.equals(other.returnTypeName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, this.getName(), precision, returnTypeName);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.functions.sql;
 
+import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.functions.sql.internal.SqlAuxiliaryGroupAggFunction;
 import org.apache.flink.table.planner.plan.type.FlinkReturnTypes;
@@ -49,7 +50,9 @@ import org.apache.calcite.sql.validate.SqlNameMatcher;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.apache.flink.table.planner.plan.type.FlinkReturnTypes.ARG0_VARCHAR_FORCE_NULLABLE;
 import static org.apache.flink.table.planner.plan.type.FlinkReturnTypes.STR_MAP_NULLABLE;
@@ -60,18 +63,70 @@ import static org.apache.flink.table.planner.plan.type.FlinkReturnTypes.VARCHAR_
 public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
 
     /** The table of contains Flink-specific operators. */
-    private static FlinkSqlOperatorTable instance;
+    private static final Map<Boolean, FlinkSqlOperatorTable> cachedInstances = new HashMap<>();
 
     /** Returns the Flink operator table, creating it if necessary. */
-    public static synchronized FlinkSqlOperatorTable instance() {
+    public static synchronized FlinkSqlOperatorTable instance(boolean isBatchMode) {
+        FlinkSqlOperatorTable instance = cachedInstances.get(isBatchMode);
         if (instance == null) {
             // Creates and initializes the standard operator table.
             // Uses two-phase construction, because we can't initialize the
             // table until the constructor of the sub-class has completed.
             instance = new FlinkSqlOperatorTable();
             instance.init();
+
+            // ensure no dynamic function declares directly
+            validateNoDynamicFunction(instance);
+
+            // register functions based on batch or streaming mode
+            final FlinkSqlOperatorTable finalInstance = instance;
+            dynamicFunctions(isBatchMode).forEach(f -> finalInstance.register(f));
+            cachedInstances.put(isBatchMode, finalInstance);
         }
         return instance;
+    }
+
+    public static List<SqlFunction> dynamicFunctions(boolean isBatchMode) {
+        return Arrays.asList(
+                new FlinkTimestampDynamicFunction(
+                        SqlStdOperatorTable.LOCALTIME.getName(), SqlTypeName.TIME, isBatchMode),
+                new FlinkTimestampDynamicFunction(
+                        SqlStdOperatorTable.CURRENT_TIME.getName(), SqlTypeName.TIME, isBatchMode),
+                new FlinkCurrentDateDynamicFunction(isBatchMode),
+                new FlinkTimestampWithPrecisionDynamicFunction(
+                        SqlStdOperatorTable.LOCALTIMESTAMP.getName(),
+                        SqlTypeName.TIMESTAMP,
+                        isBatchMode,
+                        3),
+                new FlinkTimestampWithPrecisionDynamicFunction(
+                        SqlStdOperatorTable.CURRENT_TIMESTAMP.getName(),
+                        SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        isBatchMode,
+                        3),
+                new FlinkTimestampWithPrecisionDynamicFunction(
+                        FlinkTimestampWithPrecisionDynamicFunction.NOW,
+                        SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
+                        isBatchMode,
+                        3) {
+                    @Override
+                    public SqlSyntax getSyntax() {
+                        return SqlSyntax.FUNCTION;
+                    }
+                });
+    }
+
+    private static void validateNoDynamicFunction(FlinkSqlOperatorTable instance)
+            throws TableException {
+        instance.getOperatorList()
+                .forEach(
+                        op -> {
+                            if (op.isDynamicFunction() && op.isDeterministic()) {
+                                throw new TableException(
+                                        String.format(
+                                                "Dynamic function: %s is not allowed declaring directly, please add it to initializing.",
+                                                op.getName()));
+                            }
+                        });
     }
 
     private static final SqlReturnTypeInference PROCTIME_TYPE_INFERENCE =
@@ -560,28 +615,9 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                     SqlFunctionCategory.STRING);
 
     // Flink timestamp functions
-    public static final SqlFunction LOCALTIMESTAMP =
-            new FlinkSqlTimestampFunction("LOCALTIMESTAMP", SqlTypeName.TIMESTAMP, 3);
-
-    public static final SqlFunction CURRENT_TIMESTAMP =
-            new FlinkSqlTimestampFunction(
-                    "CURRENT_TIMESTAMP", SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3);
-
-    public static final SqlFunction NOW =
-            new FlinkSqlTimestampFunction("NOW", SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3) {
-                @Override
-                public SqlSyntax getSyntax() {
-                    return SqlSyntax.FUNCTION;
-                }
-            };
     public static final SqlFunction CURRENT_ROW_TIMESTAMP =
-            new FlinkSqlTimestampFunction(
+            new FlinkCurrentRowTimestampFunction(
                     "CURRENT_ROW_TIMESTAMP", SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE, 3) {
-
-                @Override
-                public boolean isDeterministic() {
-                    return false;
-                }
 
                 @Override
                 public SqlSyntax getSyntax() {
@@ -1132,9 +1168,6 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
     public static final SqlFunction NULLIF = SqlStdOperatorTable.NULLIF;
     public static final SqlFunction FLOOR = SqlStdOperatorTable.FLOOR;
     public static final SqlFunction CEIL = SqlStdOperatorTable.CEIL;
-    public static final SqlFunction LOCALTIME = SqlStdOperatorTable.LOCALTIME;
-    public static final SqlFunction CURRENT_TIME = SqlStdOperatorTable.CURRENT_TIME;
-    public static final SqlFunction CURRENT_DATE = SqlStdOperatorTable.CURRENT_DATE;
     public static final SqlFunction CAST = SqlStdOperatorTable.CAST;
     public static final SqlOperator SCALAR_QUERY = SqlStdOperatorTable.SCALAR_QUERY;
     public static final SqlOperator EXISTS = SqlStdOperatorTable.EXISTS;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampDynamicFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampDynamicFunction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.calcite.sql.fun.SqlAbstractTimeFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Function that used to define SQL time functions like LOCALTIME, CURRENT_TIME(these are all
+ * dynamic functions in Calcite's {@link SqlStdOperatorTable}) in Flink, the difference from the
+ * parent {@link SqlAbstractTimeFunction} is this function class be aware of whether it is used in
+ * batch mode, if true it will act totally same as the parent {@link SqlAbstractTimeFunction}, but
+ * will be a non-deterministic function if not in batch mode.
+ */
+@Internal
+public class FlinkTimestampDynamicFunction extends SqlAbstractTimeFunction {
+
+    protected final boolean isBatchMode;
+
+    public FlinkTimestampDynamicFunction(
+            String functionName, SqlTypeName returnTypeName, boolean isBatchMode) {
+        super(functionName, returnTypeName);
+        this.isBatchMode = isBatchMode;
+    }
+
+    @Override
+    public boolean isDynamicFunction() {
+        return isBatchMode && super.isDynamicFunction();
+    }
+
+    @Override
+    public boolean isDeterministic() {
+        // be a non-deterministic function in streaming mode
+        return isBatchMode;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (!(obj instanceof FlinkTimestampDynamicFunction)) {
+            return false;
+        }
+        if (!obj.getClass().equals(this.getClass())) {
+            return false;
+        }
+        FlinkTimestampDynamicFunction other = (FlinkTimestampDynamicFunction) obj;
+        return this.getName().equals(other.getName())
+                && kind == other.kind
+                && this.isBatchMode == other.isBatchMode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, this.getName(), isBatchMode);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampWithPrecisionDynamicFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkTimestampWithPrecisionDynamicFunction.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.functions.sql;
+
+import org.apache.flink.annotation.Internal;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlOperatorBinding;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.util.Objects;
+
+/**
+ * Function that used to define SQL time function like LOCALTIMESTAMP, CURRENT_TIMESTAMP, NOW() in
+ * Flink, the function support configuring the return type and the * precision of return type.
+ */
+@Internal
+public class FlinkTimestampWithPrecisionDynamicFunction extends FlinkTimestampDynamicFunction {
+    /** function name for 'NOW()'. */
+    public static final String NOW = "NOW";
+
+    private final SqlTypeName returnTypeName;
+
+    private final int precision;
+
+    public FlinkTimestampWithPrecisionDynamicFunction(
+            String name, SqlTypeName typeName, boolean isBatchMode, int precision) {
+        super(name, typeName, isBatchMode);
+        this.returnTypeName = typeName;
+        this.precision = precision;
+    }
+
+    @Override
+    public RelDataType inferReturnType(SqlOperatorBinding opBinding) {
+        return opBinding.getTypeFactory().createSqlType(returnTypeName, precision);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        if (!(obj instanceof FlinkTimestampWithPrecisionDynamicFunction)) {
+            return false;
+        }
+        if (!obj.getClass().equals(this.getClass())) {
+            return false;
+        }
+        FlinkTimestampWithPrecisionDynamicFunction other =
+                (FlinkTimestampWithPrecisionDynamicFunction) obj;
+        return this.getName().equals(other.getName())
+                && kind == other.kind
+                && this.isBatchMode == other.isBatchMode
+                && this.precision == other.precision
+                && this.returnTypeName.equals(other.returnTypeName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(kind, this.getName(), isBatchMode, precision, returnTypeName);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/optimize/StreamNonDeterministicUpdatePlanVisitor.java
@@ -259,8 +259,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                 // check if it is a non-deterministic function
                 int leftFieldCnt = correlate.inputRel().getRowType().getFieldCount();
                 Optional<String> ndCall =
-                        FlinkRexUtil.getNonDeterministicCallNameInStreaming(
-                                correlate.scan().getCall());
+                        FlinkRexUtil.getNonDeterministicCallName(correlate.scan().getCall());
                 if (ndCall.isPresent()) {
                     // all columns from table function scan cannot satisfy the required determinism
                     List<Integer> unsatisfiedColumns =
@@ -478,8 +477,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
              * PROCTIME_MATERIALIZE(PROCTIME())) is equal to a normal dynamic temporal function and
              * will be validated in calc node.
              */
-            Optional<String> ndCall =
-                    FlinkRexUtil.getNonDeterministicCallNameInStreaming(join.getCondition());
+            Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(join.getCondition());
             if ((leftInputHasUpdate || rightInputHasUpdate || !innerOrSemi) && ndCall.isPresent()) {
                 // when output has update, the join condition cannot be non-deterministic:
                 // 1. input has update -> output has update
@@ -783,8 +781,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
                         .collect(Collectors.toList());
         Map<Integer, String> nonDeterministicCols = new HashMap<>();
         for (int index = 0; index < projects.size(); index++) {
-            Optional<String> ndCall =
-                    FlinkRexUtil.getNonDeterministicCallNameInStreaming(projects.get(index));
+            Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(projects.get(index));
             if (ndCall.isPresent()) {
                 nonDeterministicCols.put(index, ndCall.get());
             } // else ignore
@@ -805,7 +802,7 @@ public class StreamNonDeterministicUpdatePlanVisitor {
 
     private void checkNonDeterministicCondition(
             final RexNode condition, final StreamPhysicalRel relatedRel) {
-        Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallNameInStreaming(condition);
+        Optional<String> ndCall = FlinkRexUtil.getNonDeterministicCallName(condition);
         if (ndCall.isPresent()) {
             throwNonDeterministicConditionError(ndCall.get(), condition, relatedRel);
         }
@@ -923,7 +920,6 @@ public class StreamNonDeterministicUpdatePlanVisitor {
             Arrays.stream(overSpec.getPartition().getFieldIndices())
                     .forEach(allRequiredInputSet::add);
             // add aggCall's input
-            overSpec.getGroups().forEach(OverSpec.GroupSpec::getAggCalls);
             int aggOutputIndex = inputFieldCnt;
             for (OverSpec.GroupSpec groupSpec : overSpec.getGroups()) {
                 for (AggregateCall aggCall : groupSpec.getAggCalls()) {

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeys.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/metadata/FlinkRelMdUpsertKeys.scala
@@ -32,7 +32,7 @@ import org.apache.calcite.plan.volcano.RelSubset
 import org.apache.calcite.rel.{RelDistribution, RelNode, SingleRel}
 import org.apache.calcite.rel.core.{Aggregate, Calc, Exchange, Filter, Join, JoinInfo, JoinRelType, Project, SetOp, Sort, TableScan, Window}
 import org.apache.calcite.rel.metadata._
-import org.apache.calcite.rex.RexNode
+import org.apache.calcite.rex.{RexNode, RexUtil}
 import org.apache.calcite.util.{Bug, ImmutableBitSet, Util}
 
 import java.util
@@ -237,9 +237,9 @@ class FlinkRelMdUpsertKeys private extends MetadataHandler[UpsertKeys] {
     val rightUniqueKeys = FlinkRelMdUniqueKeys.INSTANCE.getUniqueKeysOfTemporalTable(join)
 
     val remainingConditionNonDeterministic =
-      join.remainingCondition.exists(c => !FlinkRexUtil.isDeterministicInStreaming(c))
+      join.remainingCondition.exists(c => !RexUtil.isDeterministic(c))
     lazy val calcOnTemporalTableNonDeterministic =
-      join.calcOnTemporalTable.exists(p => !FlinkRexUtil.isDeterministicInStreaming(p))
+      join.calcOnTemporalTable.exists(p => !FlinkRexUtil.isDeterministic(p))
 
     val rightUpsertKeys =
       if (remainingConditionNonDeterministic || calcOnTemporalTableNonDeterministic) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/DynamicFunctionPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/DynamicFunctionPlanTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.batch.sql;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.plan.common.DynamicFunctionPlanTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+
+/** Plan test for queries contain dynamic functions in batch. */
+public class DynamicFunctionPlanTest extends DynamicFunctionPlanTestBase {
+    @Override
+    protected TableTestUtil getTableTestUtil() {
+        return batchTestUtil(TableConfig.getDefault());
+    }
+
+    @Override
+    protected boolean isBatchMode() {
+        return true;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/CalcMergeTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/CalcMergeTestBase.java
@@ -107,4 +107,10 @@ public abstract class CalcMergeTestBase extends TableTestBase {
         util.verifyExecPlan(
                 "SELECT a, c FROM (SELECT a, random_udf(a) as a1, c FROM MyTable) t WHERE c > 10");
     }
+
+    @Test
+    public void testCalcMergeWithNonDeterministicNestedExpr() {
+        util.verifyExecPlan(
+                "SELECT a, a1 FROM (SELECT a, substr(cast(random_udf(a) as varchar), 1, 2) AS a1 FROM MyTable) t WHERE a1 > '10'");
+    }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/DynamicFunctionPlanTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/common/DynamicFunctionPlanTestBase.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.common;
+
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/** Plan test for queries contain dynamic functions. */
+public abstract class DynamicFunctionPlanTestBase extends TableTestBase {
+
+    private TableTestUtil util;
+
+    protected abstract boolean isBatchMode();
+
+    protected abstract TableTestUtil getTableTestUtil();
+
+    @Before
+    public void setup() {
+        util = getTableTestUtil();
+
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE src (\n"
+                                + " a INTEGER,\n"
+                                + " b VARCHAR,\n"
+                                + " cat VARCHAR,\n"
+                                + " gmt_date DATE,\n"
+                                + " cnt BIGINT,\n"
+                                + " ts TIME,\n"
+                                + " PRIMARY KEY (cat) NOT ENFORCED\n"
+                                + ") WITH (\n"
+                                + " 'connector' = 'values'\n"
+                                + " ,'bounded' = '"
+                                + isBatchMode()
+                                + "'\n"
+                                + ")");
+    }
+
+    @Test
+    public void testAggregateReduceConstants() {
+        util.verifyExecPlan(
+                "SELECT\n"
+                        + "     cat, gmt_date, SUM(cnt), count(*)\n"
+                        + "FROM src\n"
+                        + "WHERE gmt_date = current_date\n"
+                        + "GROUP BY cat, gmt_date");
+    }
+
+    @Test
+    public void testAggregateReduceConstants2() {
+        // current RelMdPredicates only look at columns that are projected without any function
+        // applied, so 'SUBSTR(CAST(LOCALTIME AS VARCHAR), 1, 2)' will never be inferred as constant
+        util.verifyExecPlan(
+                "SELECT\n"
+                        + "cat, hh, SUM(cnt), COUNT(*)\n"
+                        + "FROM (SELECT *, SUBSTR(CAST(LOCALTIME AS VARCHAR), 1, 2) hh FROM src)\n"
+                        + "WHERE SUBSTR(CAST(ts AS VARCHAR), 1, 2) = hh\n"
+                        + "GROUP BY cat, hh");
+    }
+
+    @Test
+    public void testAggregateReduceConstants3() {
+        util.verifyExecPlan(
+                "SELECT\n"
+                        + "     gmt_date, ts, cat, SUBSTR(CAST(ts AS VARCHAR), 1, 2), SUM(cnt)\n"
+                        + "FROM src\n"
+                        + "WHERE gmt_date = CURRENT_DATE\n"
+                        + "  AND cat = 'fruit' AND ts = CURRENT_TIME\n"
+                        + "GROUP BY gmt_date, ts, cat");
+    }
+
+    @Test
+    public void testCalcMerge() {
+        util.verifyExecPlan(
+                "SELECT * FROM ( \n"
+                        + "   SELECT *, SUBSTR(CAST(LOCALTIME AS VARCHAR), 1, 2) hh\n"
+                        + "   FROM src\n"
+                        + " ) t1 WHERE hh > 12 AND cat LIKE 'fruit%'\n");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/DynamicFunctionPlanTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/stream/sql/DynamicFunctionPlanTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.stream.sql;
+
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.planner.plan.common.DynamicFunctionPlanTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+
+/** Plan test for queries contain dynamic functions in streaming. */
+public class DynamicFunctionPlanTest extends DynamicFunctionPlanTestBase {
+    @Override
+    protected TableTestUtil getTableTestUtil() {
+        return streamTestUtil(TableConfig.getDefault());
+    }
+
+    @Override
+    protected boolean isBatchMode() {
+        return false;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcMergeTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/CalcMergeTest.xml
@@ -92,6 +92,26 @@ Calc(select=[c], where=[(random_udf(a) > random_udf(b))])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCalcMergeWithNonDeterministicExpr1">
+    <Resource name="sql">
+      <![CDATA[SELECT a, a1 FROM (SELECT a, random_udf(a) AS a1 FROM MyTable) t WHERE a1 > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], a1=[$1])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalProject(a=[$0], a1=[random_udf($0)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, a1], where=[(a1 > 10)])
++- Calc(select=[a, random_udf(a) AS a1])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], metadata=[]]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCalcMergeWithNonDeterministicExpr2">
     <Resource name="sql">
       <![CDATA[SELECT random_udf(a1) as a2 FROM (SELECT random_udf(a) as a1, b FROM MyTable) t WHERE b > 10]]>
@@ -111,22 +131,23 @@ Calc(select=[random_udf(random_udf(a)) AS a2], where=[(b > 10)])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testCalcMergeWithoutInnerNonDeterministicExpr">
+  <TestCase name="testCalcMergeWithNonDeterministicNestedExpr">
     <Resource name="sql">
-      <![CDATA[SELECT a, c FROM (SELECT a, random_udf(a) as a1, c FROM MyTable) t WHERE c > 10]]>
+      <![CDATA[SELECT a, a1 FROM (SELECT a, substr(cast(random_udf(a) as varchar), 1, 2) AS a1 FROM MyTable) t WHERE a1 > '10']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], c=[$2])
-+- LogicalFilter(condition=[>(CAST($2):BIGINT, 10)])
-   +- LogicalProject(a=[$0], a1=[random_udf($0)], c=[$2])
+LogicalProject(a=[$0], a1=[$1])
++- LogicalFilter(condition=[>($1, _UTF-16LE'10')])
+   +- LogicalProject(a=[$0], a1=[SUBSTR(CAST(random_udf($0)):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, 1, 2)])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, c], where=[(CAST(c AS BIGINT) > 10)])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], project=[a, c], metadata=[]]], fields=[a, c])
+Calc(select=[a, a1], where=[(a1 > '10')])
++- Calc(select=[a, SUBSTR(CAST(random_udf(a) AS VARCHAR(2147483647)), 1, 2) AS a1])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], metadata=[]]], fields=[a])
 ]]>
     </Resource>
   </TestCase>
@@ -150,23 +171,22 @@ Calc(select=[a, b], where=[(a = b)])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testCalcMergeWithNonDeterministicExpr1">
+  <TestCase name="testCalcMergeWithoutInnerNonDeterministicExpr">
     <Resource name="sql">
-      <![CDATA[SELECT a, a1 FROM (SELECT a, random_udf(a) AS a1 FROM MyTable) t WHERE a1 > 10]]>
+      <![CDATA[SELECT a, c FROM (SELECT a, random_udf(a) as a1, c FROM MyTable) t WHERE c > 10]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], a1=[$1])
-+- LogicalFilter(condition=[>($1, 10)])
-   +- LogicalProject(a=[$0], a1=[random_udf($0)])
+LogicalProject(a=[$0], c=[$2])
++- LogicalFilter(condition=[>(CAST($2):BIGINT, 10)])
+   +- LogicalProject(a=[$0], a1=[random_udf($0)], c=[$2])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, a1], where=[(a1 > 10)])
-+- Calc(select=[a, random_udf(a) AS a1])
-   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], metadata=[]]], fields=[a])
+Calc(select=[a, c], where=[(CAST(c AS BIGINT) > 10)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], project=[a, c], metadata=[]]], fields=[a, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DynamicFunctionPlanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/DynamicFunctionPlanTest.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAggregateReduceConstants">
+    <Resource name="sql">
+      <![CDATA[SELECT
+     cat, gmt_date, SUM(cnt), count(*)
+FROM src
+WHERE gmt_date = current_date
+GROUP BY cat, gmt_date]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()])
++- LogicalProject(cat=[$2], gmt_date=[$3], cnt=[$4])
+   +- LogicalFilter(condition=[=($3, CURRENT_DATE)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[cat], auxGrouping=[gmt_date], select=[cat, gmt_date, SUM(cnt) AS EXPR$2, COUNT(*) AS EXPR$3])
++- Exchange(distribution=[hash[cat]])
+   +- Calc(select=[cat, gmt_date, cnt], where=[(gmt_date = CURRENT_DATE())])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, filter=[], project=[cat, gmt_date, cnt], metadata=[]]], fields=[cat, gmt_date, cnt])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcMerge">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM ( 
+   SELECT *, SUBSTR(CAST(LOCALTIME AS VARCHAR), 1, 2) hh
+   FROM src
+ ) t1 WHERE hh > 12 AND cat LIKE 'fruit%'
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], cat=[$2], gmt_date=[$3], cnt=[$4], ts=[$5], hh=[$6])
++- LogicalFilter(condition=[AND(>(CAST($6):BIGINT, 12), LIKE($2, _UTF-16LE'fruit%'))])
+   +- LogicalProject(a=[$0], b=[$1], cat=[$2], gmt_date=[$3], cnt=[$4], ts=[$5], hh=[SUBSTR(CAST(LOCALTIME):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, 1, 2)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, cat, gmt_date, cnt, ts, SUBSTR(CAST(LOCALTIME() AS VARCHAR(2147483647)), 1, 2) AS hh], where=[((CAST(SUBSTR(CAST(LOCALTIME() AS VARCHAR(2147483647)), 1, 2) AS BIGINT) > 12) AND LIKE(cat, 'fruit%'))])
++- TableSourceScan(table=[[default_catalog, default_database, src, filter=[]]], fields=[a, b, cat, gmt_date, cnt, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateReduceConstants2">
+    <Resource name="sql">
+      <![CDATA[SELECT
+cat, hh, SUM(cnt), COUNT(*)
+FROM (SELECT *, SUBSTR(CAST(LOCALTIME AS VARCHAR), 1, 2) hh FROM src)
+WHERE SUBSTR(CAST(ts AS VARCHAR), 1, 2) = hh
+GROUP BY cat, hh]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()])
++- LogicalProject(cat=[$2], hh=[$6], cnt=[$4])
+   +- LogicalFilter(condition=[=(SUBSTR(CAST($5):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", 1, 2), $6)])
+      +- LogicalProject(a=[$0], b=[$1], cat=[$2], gmt_date=[$3], cnt=[$4], ts=[$5], hh=[SUBSTR(CAST(LOCALTIME):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, 1, 2)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+HashAggregate(isMerge=[false], groupBy=[cat, hh], select=[cat, hh, SUM(cnt) AS EXPR$2, COUNT(*) AS EXPR$3])
++- Exchange(distribution=[hash[cat, hh]])
+   +- Calc(select=[cat, SUBSTR(CAST(LOCALTIME() AS VARCHAR(2147483647)), 1, 2) AS hh, cnt], where=[(SUBSTR(CAST(ts AS VARCHAR(2147483647)), 1, 2) = SUBSTR(CAST(LOCALTIME() AS VARCHAR(2147483647)), 1, 2))])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, filter=[], project=[cat, cnt, ts], metadata=[]]], fields=[cat, cnt, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateReduceConstants3">
+    <Resource name="sql">
+      <![CDATA[SELECT
+     gmt_date, ts, cat, SUBSTR(CAST(ts AS VARCHAR), 1, 2), SUM(cnt)
+FROM src
+WHERE gmt_date = CURRENT_DATE
+  AND cat = 'fruit' AND ts = CURRENT_TIME
+GROUP BY gmt_date, ts, cat]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(gmt_date=[$0], ts=[$1], cat=[$2], EXPR$3=[SUBSTR(CAST($1):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", 1, 2)], EXPR$4=[$3])
++- LogicalAggregate(group=[{0, 1, 2}], EXPR$4=[SUM($3)])
+   +- LogicalProject(gmt_date=[$3], ts=[$5], cat=[$2], cnt=[$4])
+      +- LogicalFilter(condition=[AND(=($3, CURRENT_DATE), =($2, _UTF-16LE'fruit'), =($5, CURRENT_TIME))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[gmt_date, CAST(CURRENT_TIME() AS TIME(0)) AS ts, 'fruit' AS cat, SUBSTR(CAST(CURRENT_TIME() AS VARCHAR(2147483647)), 1, 2) AS EXPR$3, EXPR$4])
++- HashAggregate(isMerge=[true], groupBy=[gmt_date], select=[gmt_date, Final_SUM(sum$0) AS EXPR$4])
+   +- Exchange(distribution=[hash[gmt_date]])
+      +- LocalHashAggregate(groupBy=[gmt_date], select=[gmt_date, Partial_SUM(cnt) AS sum$0])
+         +- Calc(select=[gmt_date, cnt], where=[((gmt_date = CURRENT_DATE()) AND (cat = 'fruit') AND (ts = CURRENT_TIME()))])
+            +- TableSourceScan(table=[[default_catalog, default_database, src, filter=[], project=[cat, gmt_date, cnt, ts], metadata=[]]], fields=[cat, gmt_date, cnt, ts])
+]]>
+    </Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcMergeTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/CalcMergeTest.xml
@@ -92,6 +92,26 @@ Calc(select=[c], where=[(random_udf(a) > random_udf(b))])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCalcMergeWithNonDeterministicExpr1">
+    <Resource name="sql">
+      <![CDATA[SELECT a, a1 FROM (SELECT a, random_udf(a) AS a1 FROM MyTable) t WHERE a1 > 10]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], a1=[$1])
++- LogicalFilter(condition=[>($1, 10)])
+   +- LogicalProject(a=[$0], a1=[random_udf($0)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, a1], where=[(a1 > 10)])
++- Calc(select=[a, random_udf(a) AS a1])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], metadata=[]]], fields=[a])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCalcMergeWithNonDeterministicExpr2">
     <Resource name="sql">
       <![CDATA[SELECT random_udf(a1) as a2 FROM (SELECT random_udf(a) as a1, b FROM MyTable) t WHERE b > 10]]>
@@ -111,22 +131,23 @@ Calc(select=[random_udf(random_udf(a)) AS a2], where=[(b > 10)])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testCalcMergeWithoutInnerNonDeterministicExpr">
+  <TestCase name="testCalcMergeWithNonDeterministicNestedExpr">
     <Resource name="sql">
-      <![CDATA[SELECT a, c FROM (SELECT a, random_udf(a) as a1, c FROM MyTable) t WHERE c > 10]]>
+      <![CDATA[SELECT a, a1 FROM (SELECT a, substr(cast(random_udf(a) as varchar), 1, 2) AS a1 FROM MyTable) t WHERE a1 > '10']]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], c=[$2])
-+- LogicalFilter(condition=[>(CAST($2):BIGINT, 10)])
-   +- LogicalProject(a=[$0], a1=[random_udf($0)], c=[$2])
+LogicalProject(a=[$0], a1=[$1])
++- LogicalFilter(condition=[>($1, _UTF-16LE'10')])
+   +- LogicalProject(a=[$0], a1=[SUBSTR(CAST(random_udf($0)):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, 1, 2)])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, c], where=[(CAST(c AS BIGINT) > 10)])
-+- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], project=[a, c], metadata=[]]], fields=[a, c])
+Calc(select=[a, a1], where=[(a1 > '10')])
++- Calc(select=[a, SUBSTR(CAST(random_udf(a) AS VARCHAR(2147483647)), 1, 2) AS a1])
+   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], metadata=[]]], fields=[a])
 ]]>
     </Resource>
   </TestCase>
@@ -150,23 +171,22 @@ Calc(select=[a, b], where=[(a = b)])
 ]]>
     </Resource>
   </TestCase>
-  <TestCase name="testCalcMergeWithNonDeterministicExpr1">
+  <TestCase name="testCalcMergeWithoutInnerNonDeterministicExpr">
     <Resource name="sql">
-      <![CDATA[SELECT a, a1 FROM (SELECT a, random_udf(a) AS a1 FROM MyTable) t WHERE a1 > 10]]>
+      <![CDATA[SELECT a, c FROM (SELECT a, random_udf(a) as a1, c FROM MyTable) t WHERE c > 10]]>
     </Resource>
     <Resource name="ast">
       <![CDATA[
-LogicalProject(a=[$0], a1=[$1])
-+- LogicalFilter(condition=[>($1, 10)])
-   +- LogicalProject(a=[$0], a1=[random_udf($0)])
+LogicalProject(a=[$0], c=[$2])
++- LogicalFilter(condition=[>(CAST($2):BIGINT, 10)])
+   +- LogicalProject(a=[$0], a1=[random_udf($0)], c=[$2])
       +- LogicalTableScan(table=[[default_catalog, default_database, MyTable]])
 ]]>
     </Resource>
     <Resource name="optimized exec plan">
       <![CDATA[
-Calc(select=[a, a1], where=[(a1 > 10)])
-+- Calc(select=[a, random_udf(a) AS a1])
-   +- TableSourceScan(table=[[default_catalog, default_database, MyTable, project=[a], metadata=[]]], fields=[a])
+Calc(select=[a, c], where=[(CAST(c AS BIGINT) > 10)])
++- TableSourceScan(table=[[default_catalog, default_database, MyTable, filter=[], project=[a, c], metadata=[]]], fields=[a, c])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DynamicFunctionPlanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/DynamicFunctionPlanTest.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testAggregateReduceConstants">
+    <Resource name="sql">
+      <![CDATA[SELECT
+     cat, gmt_date, SUM(cnt), count(*)
+FROM src
+WHERE gmt_date = current_date
+GROUP BY cat, gmt_date]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()])
++- LogicalProject(cat=[$2], gmt_date=[$3], cnt=[$4])
+   +- LogicalFilter(condition=[=($3, CURRENT_DATE)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(groupBy=[cat, gmt_date], select=[cat, gmt_date, SUM(cnt) AS EXPR$2, COUNT(*) AS EXPR$3])
++- Exchange(distribution=[hash[cat, gmt_date]])
+   +- Calc(select=[cat, gmt_date, cnt], where=[(gmt_date = CURRENT_DATE())])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, filter=[], project=[cat, gmt_date, cnt], metadata=[]]], fields=[cat, gmt_date, cnt])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCalcMerge">
+    <Resource name="sql">
+      <![CDATA[SELECT * FROM ( 
+   SELECT *, SUBSTR(CAST(LOCALTIME AS VARCHAR), 1, 2) hh
+   FROM src
+ ) t1 WHERE hh > 12 AND cat LIKE 'fruit%'
+]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], cat=[$2], gmt_date=[$3], cnt=[$4], ts=[$5], hh=[$6])
++- LogicalFilter(condition=[AND(>(CAST($6):BIGINT, 12), LIKE($2, _UTF-16LE'fruit%'))])
+   +- LogicalProject(a=[$0], b=[$1], cat=[$2], gmt_date=[$3], cnt=[$4], ts=[$5], hh=[SUBSTR(CAST(LOCALTIME):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, 1, 2)])
+      +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[a, b, cat, gmt_date, cnt, ts, hh], where=[((CAST(hh AS BIGINT) > 12) AND LIKE(cat, 'fruit%'))])
++- Calc(select=[a, b, cat, gmt_date, cnt, ts, SUBSTR(CAST(LOCALTIME() AS VARCHAR(2147483647)), 1, 2) AS hh])
+   +- TableSourceScan(table=[[default_catalog, default_database, src]], fields=[a, b, cat, gmt_date, cnt, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateReduceConstants2">
+    <Resource name="sql">
+      <![CDATA[SELECT
+cat, hh, SUM(cnt), COUNT(*)
+FROM (SELECT *, SUBSTR(CAST(LOCALTIME AS VARCHAR), 1, 2) hh FROM src)
+WHERE SUBSTR(CAST(ts AS VARCHAR), 1, 2) = hh
+GROUP BY cat, hh]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{0, 1}], EXPR$2=[SUM($2)], EXPR$3=[COUNT()])
++- LogicalProject(cat=[$2], hh=[$6], cnt=[$4])
+   +- LogicalFilter(condition=[=(SUBSTR(CAST($5):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", 1, 2), $6)])
+      +- LogicalProject(a=[$0], b=[$1], cat=[$2], gmt_date=[$3], cnt=[$4], ts=[$5], hh=[SUBSTR(CAST(LOCALTIME):VARCHAR(2147483647) CHARACTER SET "UTF-16LE" NOT NULL, 1, 2)])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(groupBy=[cat, hh], select=[cat, hh, SUM(cnt) AS EXPR$2, COUNT(*) AS EXPR$3])
++- Exchange(distribution=[hash[cat, hh]])
+   +- Calc(select=[cat, hh, cnt], where=[(SUBSTR(CAST(ts AS VARCHAR(2147483647)), 1, 2) = hh)])
+      +- Calc(select=[cat, cnt, ts, SUBSTR(CAST(LOCALTIME() AS VARCHAR(2147483647)), 1, 2) AS hh])
+         +- TableSourceScan(table=[[default_catalog, default_database, src, project=[cat, cnt, ts], metadata=[]]], fields=[cat, cnt, ts])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testAggregateReduceConstants3">
+    <Resource name="sql">
+      <![CDATA[SELECT
+     gmt_date, ts, cat, SUBSTR(CAST(ts AS VARCHAR), 1, 2), SUM(cnt)
+FROM src
+WHERE gmt_date = CURRENT_DATE
+  AND cat = 'fruit' AND ts = CURRENT_TIME
+GROUP BY gmt_date, ts, cat]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(gmt_date=[$0], ts=[$1], cat=[$2], EXPR$3=[SUBSTR(CAST($1):VARCHAR(2147483647) CHARACTER SET "UTF-16LE", 1, 2)], EXPR$4=[$3])
++- LogicalAggregate(group=[{0, 1, 2}], EXPR$4=[SUM($3)])
+   +- LogicalProject(gmt_date=[$3], ts=[$5], cat=[$2], cnt=[$4])
+      +- LogicalFilter(condition=[AND(=($3, CURRENT_DATE), =($2, _UTF-16LE'fruit'), =($5, CURRENT_TIME))])
+         +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+Calc(select=[gmt_date, ts, 'fruit' AS cat, SUBSTR(CAST(ts AS VARCHAR(2147483647)), 1, 2) AS EXPR$3, EXPR$4])
++- GroupAggregate(groupBy=[gmt_date, ts], select=[gmt_date, ts, SUM(cnt) AS EXPR$4])
+   +- Exchange(distribution=[hash[gmt_date, ts]])
+      +- Calc(select=[gmt_date, ts, cnt], where=[((gmt_date = CURRENT_DATE()) AND (cat = 'fruit') AND (ts = CURRENT_TIME()))])
+         +- TableSourceScan(table=[[default_catalog, default_database, src, filter=[], project=[cat, gmt_date, cnt, ts], metadata=[]]], fields=[cat, gmt_date, cnt, ts])
+]]>
+    </Resource>
+  </TestCase>
+</Root>


### PR DESCRIPTION
## What is the purpose of the change
Make all pure dynamic functions non-deterministic in streaming mode to avoid wrong plans

## Brief change log
* change all pure dynamic functions non-deterministic in streaming mode

## Verifying this change
TODO new tests to be added

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)