### PR TITLE
[hotfix][docs][table] Fix broken links in determinism.md

### DIFF
--- a/docs/content/docs/dev/table/concepts/determinism.md
+++ b/docs/content/docs/dev/table/concepts/determinism.md
@@ -136,7 +136,7 @@ The non-deterministic functions are executed at runtime (in clusters, evaluated 
 For more information see [System (Built-in) Function Determinism]( {{< ref "docs/dev/table/functions/udfs" >}}#system-built-in-function-determinism).
 
 ## 3. Determinism In Streaming Processing
-A core difference between streaming and batch is the unboundedness of the data. Flink SQL abstracts streaming processing as the [continuous query on dynamic tables]({{< ref "docs/dev/table/concepts/dynamic_tables" >}}#dynamic-tables- amp-continuous-queries).
+A core difference between streaming and batch is the unboundedness of the data. Flink SQL abstracts streaming processing as the [continuous query on dynamic tables]({{< ref "docs/dev/table/concepts/dynamic_tables" >}}#dynamic-tables-amp-continuous-queries).
 So the dynamic function in the batch query example is equivalent to a non-deterministic function in a streaming processing(where logically every change in the base table triggers the query to be executed).
 If the `clicks` log table in the example is from a Kafka topic that is continuously written, the same query in stream mode will return `CURRENT_TIMESTAMP` that will change over time
 ```sql


### PR DESCRIPTION
## What is the purpose of the change

This is a trivial change to fix the broken link in page [determinism/#3-determinism-in-streaming-processing](https://nightlies.apache.org/flink/flink-docs-master/docs/dev/table/concepts/determinism/#3-determinism-in-streaming-processing)
![image](https://user-images.githubusercontent.com/55568005/211709281-2dd84f52-ab44-40fb-9a38-e49bbc091b31.png)


## Brief change log

- Fix broken links in determinism.md


## Verifying this change

This change is a trivial fix and can be verified by building the docs locally at http://localhost:1313/
![image](https://user-images.githubusercontent.com/55568005/211709761-74729eda-4781-4248-b033-4712526007d4.png)


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
