### PR TITLE
[FLINK-30556][hive] Introduce the StaticHivePartitionSplitEnumerator

### DIFF
--- a/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-files/src/test/java/org/apache/flink/connector/file/src/impl/StaticFileSplitEnumeratorTest.java
@@ -32,7 +32,7 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Unit tests for the {@link ContinuousFileSplitEnumerator}. */
+/** Unit tests for the {@link StaticFileSplitEnumerator}. */
 class StaticFileSplitEnumeratorTest {
 
     // this is no JUnit temporary folder, because we don't create actual files, we just

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/StaticHivePartitionSplitEnumerator.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/StaticHivePartitionSplitEnumerator.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.connector.file.src.FileSourceSplit;
+import org.apache.flink.connector.file.src.PendingSplitsCheckpoint;
+import org.apache.flink.connector.file.src.assigners.FileSplitAssigner;
+import org.apache.flink.connector.file.src.impl.StaticFileSplitEnumerator;
+import org.apache.flink.connectors.hive.read.HiveSourceSplit;
+import org.apache.flink.core.fs.Path;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.apache.hadoop.mapred.JobConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.Optional;
+
+import static org.apache.flink.connectors.hive.HiveOptions.TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * An improved {@link SplitEnumerator} for hive source with bounded / batch input. Comparing with
+ * the {@link StaticFileSplitEnumerator}, This enumerator will generate splits at the partition
+ * level, which helps to avoid Java's out-of-memory (OOM) issue.
+ */
+public class StaticHivePartitionSplitEnumerator<T extends Comparable<T>>
+        implements SplitEnumerator<HiveSourceSplit, PendingSplitsCheckpoint<HiveSourceSplit>> {
+
+    private static final Logger LOG =
+            LoggerFactory.getLogger(StaticHivePartitionSplitEnumerator.class);
+
+    private final Deque<HiveTablePartition> remainPartitions;
+
+    private final Collection<Path> processedPaths;
+
+    private final FileSplitAssigner splitAssigner;
+
+    private final SplitEnumeratorContext<HiveSourceSplit> enumeratorContext;
+
+    private final JobConf jobConf;
+
+    private final int currentParallelism;
+
+    public StaticHivePartitionSplitEnumerator(
+            SplitEnumeratorContext<HiveSourceSplit> enumeratorContext,
+            Deque<HiveTablePartition> allPartitions,
+            FileSplitAssigner splitAssigner,
+            JobConf jobConf) {
+        this.splitAssigner = splitAssigner;
+        this.remainPartitions = allPartitions;
+        this.enumeratorContext = enumeratorContext;
+        this.processedPaths = new ArrayList<>();
+        this.jobConf = jobConf;
+        this.currentParallelism = enumeratorContext.currentParallelism();
+    }
+
+    @Override
+    public void start() {
+        // nothing to do.
+    }
+
+    @Override
+    public void handleSplitRequest(int subtaskId, @Nullable String hostName) {
+
+        if (LOG.isInfoEnabled()) {
+            final String hostInfo =
+                    hostName == null ? "(no host locality info)" : "(on host '" + hostName + "')";
+            LOG.info("Subtask {} {} is requesting a file source split", subtaskId, hostInfo);
+        }
+
+        final Optional<FileSourceSplit> nextSplit = splitAssigner.getNext(hostName);
+        if (nextSplit.isPresent()) {
+            final FileSourceSplit split = nextSplit.get();
+            enumeratorContext.assignSplit((HiveSourceSplit) split, subtaskId);
+            processedPaths.add(split.path());
+            LOG.info("Assigned split to subtask {} : {}", subtaskId, split);
+        } else {
+            if (remainPartitions.isEmpty()) {
+                enumeratorContext.signalNoMoreSplits(subtaskId);
+                LOG.info("No more splits available for subtask {}", subtaskId);
+            } else {
+                LOG.info("Generating more splits for subtask {}", subtaskId);
+                assignSplits();
+                handleSplitRequest(subtaskId, hostName);
+            }
+        }
+    }
+
+    private void assignSplits() {
+        int threadNumToSplitHiveFile = getThreadNumToSplitHiveFile();
+        checkState(
+                threadNumToSplitHiveFile > 0,
+                TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM.description());
+        List<HiveTablePartition> partitions = new ArrayList<>();
+        while (!remainPartitions.isEmpty() && threadNumToSplitHiveFile > 0) {
+            partitions.add(remainPartitions.poll());
+            threadNumToSplitHiveFile--;
+        }
+        try {
+            Collection<FileSourceSplit> splits =
+                    new ArrayList<>(
+                            HiveSourceFileEnumerator.createInputSplits(
+                                    currentParallelism, partitions, jobConf, false));
+            splitAssigner.addSplits(splits);
+        } catch (IOException e) {
+            ExceptionUtils.rethrow(e, "Failed to create input splits.");
+        }
+    }
+
+    private int getThreadNumToSplitHiveFile() {
+        return jobConf.getInt(
+                TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM.key(),
+                TABLE_EXEC_HIVE_LOAD_PARTITION_SPLITS_THREAD_NUM.defaultValue());
+    }
+
+    @Override
+    public void handleSourceEvent(int subtaskId, SourceEvent sourceEvent) {
+        LOG.error("Received unrecognized event: {}", sourceEvent);
+    }
+
+    @Override
+    public void addSplitsBack(List<HiveSourceSplit> splits, int subtaskId) {
+        LOG.debug("Adding splits back: {}", splits);
+        splitAssigner.addSplits(new ArrayList<>(splits));
+    }
+
+    @Override
+    public void addReader(int subtaskId) {
+        // this source is purely lazy-pull-based, nothing to do upon registration
+    }
+
+    @Override
+    public PendingSplitsCheckpoint<HiveSourceSplit> snapshotState(long checkpointId)
+            throws Exception {
+        // remain split
+        Collection<HiveSourceSplit> remainingSplits = new ArrayList<>();
+        for (FileSourceSplit fileSourceSplit : splitAssigner.remainingSplits()) {
+            remainingSplits.add((HiveSourceSplit) fileSourceSplit);
+        }
+        // processed partitions
+        return PendingSplitsCheckpoint.fromCollectionSnapshot(
+                new ArrayList<>(remainingSplits), processedPaths);
+    }
+
+    @Override
+    public void close() throws IOException {
+        // nothing to do
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/StaticHivePartitionSplitEnumeratorTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/StaticHivePartitionSplitEnumeratorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.connector.file.src.assigners.SimpleSplitAssigner;
+import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.flink.connectors.hive.read.HiveSourceSplit;
+import org.apache.flink.core.fs.Path;
+
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.mapred.JobConf;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Unit tests for the {@link StaticHivePartitionSplitEnumerator}. */
+class StaticHivePartitionSplitEnumeratorTest {
+
+    private static final int PARALLELISM = 10;
+    private TemporaryFolder temporaryFolder;
+
+    @BeforeEach
+    void setup() throws IOException {
+        temporaryFolder = new TemporaryFolder();
+        temporaryFolder.create();
+    }
+
+    @Test
+    void testDiscoverSplitWhenNoReaderRegistered() throws Exception {
+        final TestingSplitEnumeratorContext<HiveSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(PARALLELISM);
+        final HiveSourceSplit split = createSplit();
+        final StaticHivePartitionSplitEnumerator<Long> enumerator =
+                new StaticHivePartitionSplitEnumerator<>(
+                        context,
+                        new ArrayDeque<>(),
+                        new SimpleSplitAssigner(Collections.singletonList(split)),
+                        new JobConf());
+        enumerator.start();
+        assertThat(enumerator.snapshotState(1L).getSplits()).contains(split);
+    }
+
+    @Test
+    public void testRequestSplitWhenReaderRegistered() throws Exception {
+        TestingSplitEnumeratorContext<HiveSourceSplit> enumeratorContext =
+                new TestingSplitEnumeratorContext<>(PARALLELISM);
+        List<HiveTablePartition> partitions = testCreateHiveTablePartitions(PARALLELISM);
+        JobConf jobConf = new JobConf();
+        jobConf.set(HiveOptions.TABLE_EXEC_HIVE_CALCULATE_PARTITION_SIZE_THREAD_NUM.key(), "1");
+        final StaticHivePartitionSplitEnumerator<Long> enumerator =
+                new StaticHivePartitionSplitEnumerator<>(
+                        enumeratorContext,
+                        new ArrayDeque<>(partitions),
+                        new SimpleSplitAssigner(Collections.emptyList()),
+                        jobConf);
+        // register multi readers, and let them request a split
+        enumeratorContext.registerReader(1, "localhost");
+        assertThat(enumeratorContext.registeredReaders()).hasSize(1);
+        for (int num = 0; num < PARALLELISM; ++num) {
+            enumerator.handleSplitRequest(1, "localhost");
+        }
+        assertThat(enumeratorContext.getSplitAssignments().get(1).getAssignedSplits())
+                .hasSize(PARALLELISM);
+        enumerator.handleSplitRequest(1, "localhost");
+        assertThat(enumeratorContext.getSplitAssignments().get(1).hasReceivedNoMoreSplitsSignal())
+                .isTrue();
+    }
+
+    @Test
+    public void testAddSplitsBack() throws Exception {
+        final TestingSplitEnumeratorContext<HiveSourceSplit> context =
+                new TestingSplitEnumeratorContext<>(PARALLELISM);
+        final StaticHivePartitionSplitEnumerator<Long> enumerator =
+                new StaticHivePartitionSplitEnumerator<>(
+                        context,
+                        new ArrayDeque<>(),
+                        new SimpleSplitAssigner(Collections.emptyList()),
+                        new JobConf());
+        final HiveSourceSplit split = createSplit();
+        enumerator.addSplitsBack(Collections.singletonList(split), 0);
+        assertThat(enumerator.snapshotState(0).getSplits()).contains(split);
+        assertThat(enumerator.snapshotState(0).getAlreadyProcessedPaths()).isEmpty();
+    }
+
+    private HiveSourceSplit createSplit() {
+        StorageDescriptor sd = new StorageDescriptor();
+        sd.setLocation("/tmp");
+        return new HiveSourceSplit(
+                "1",
+                new Path("/tmp"),
+                0,
+                0,
+                0,
+                0,
+                new String[] {"host1"},
+                null,
+                new HiveTablePartition(sd, new HashMap<>(), new Properties()));
+    }
+
+    public List<HiveTablePartition> testCreateHiveTablePartitions(int partitionNumber)
+            throws Exception {
+        List<HiveTablePartition> partitions = new ArrayList<>();
+        StorageDescriptor sd = new StorageDescriptor();
+        // set orc format
+        SerDeInfo serdeInfo = new SerDeInfo();
+        serdeInfo.setSerializationLib(OrcSerde.class.getName());
+        File wareHouse = temporaryFolder.newFolder("testCreateInputSplits");
+        sd.setSerdeInfo(serdeInfo);
+        sd.setInputFormat(OrcInputFormat.class.getName());
+        sd.setLocation(wareHouse.toString());
+        String baseFilePath =
+                Objects.requireNonNull(this.getClass().getResource("/orc/test.orc")).getPath();
+        Files.copy(Paths.get(baseFilePath), Paths.get(wareHouse.toString(), "t.orc"));
+        for (int num = 0; num < partitionNumber; ++num) {
+            partitions.add(new HiveTablePartition(sd, new Properties()));
+        }
+        return partitions;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Introduce the StaticHivePartitionSplitEnumerator


## Brief change log

  - *Introduce the StaticPartitionFileSplitEnumerator with the ability to create splitAssigner repeatedly.*


## Verifying this change

This change added tests and can be verified as follows:

  - *Existing UT tests.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
