### PR TITLE
[FLINK-30631][runtime] Limit the max number of subpartitons consumed by each downstream task

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
@@ -69,7 +69,7 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
                 decider.decideParallelism(
                         new JobVertexID(), Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism).isEqualTo(11);
+        assertThat(parallelism).isEqualTo(9);
     }
 
     @Test
@@ -103,21 +103,6 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
     }
 
     @Test
-    void testBroadcastRatioExceedsCapRatio() {
-        final DefaultVertexParallelismAndInputInfosDecider decider =
-                createDefaultVertexParallelismAndInputInfosDecider();
-
-        BlockingResultInfo resultInfo1 = createFromBroadcastResult(BYTE_1_GB);
-        BlockingResultInfo resultInfo2 = createFromNonBroadcastResult(BYTE_8_GB);
-
-        int parallelism =
-                decider.decideParallelism(
-                        new JobVertexID(), Arrays.asList(resultInfo1, resultInfo2));
-
-        assertThat(parallelism).isEqualTo(16);
-    }
-
-    @Test
     void testNonBroadcastBytesCanNotDividedEvenly() {
         final DefaultVertexParallelismAndInputInfosDecider decider =
                 createDefaultVertexParallelismAndInputInfosDecider();
@@ -129,7 +114,7 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
                 decider.decideParallelism(
                         new JobVertexID(), Arrays.asList(resultInfo1, resultInfo2));
 
-        assertThat(parallelism).isEqualTo(17);
+        assertThat(parallelism).isEqualTo(9);
     }
 
     @Test
@@ -257,7 +242,7 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
 
         checkAllToAllJobVertexInputInfo(
                 parallelismAndInputInfos.getJobVertexInputInfos().get(resultInfo1.getResultId()),
-                Arrays.asList(new IndexRange(0, 3), new IndexRange(4, 7), new IndexRange(8, 9)));
+                Arrays.asList(new IndexRange(0, 4), new IndexRange(5, 8), new IndexRange(9, 9)));
         checkAllToAllJobVertexInputInfo(
                 parallelismAndInputInfos.getJobVertexInputInfos().get(resultInfo2.getResultId()),
                 Arrays.asList(new IndexRange(0, 0), new IndexRange(0, 0), new IndexRange(0, 0)));


### PR DESCRIPTION
## What is the purpose of the change
In the current implementation([FLINK-25035](https://issues.apache.org/jira/browse/FLINK-25035)), when the upstream vertex parallelism is much greater than the downstream vertex parallelism, it may lead to a large number of channels in the downstream tasks(for example, A -> B, all to all edge, max parallelism is 1000. If parallelism of A is 1000, parallelism of B is decided to be 1, then the only subtask of B will consume 1000 * 1000 subpartitions), resulting in a large overhead for processing channels.

In this ticket, we temporarily address this issue by limiting the max number of subpartitons consumed by each downstream task. The ultimate solution should be to support single channel consume multiple subpartitons.

## Verifying this change
Unit tests:
`DefaultVertexParallelismAndInputInfosDeciderTest#testEvenlyDistributeDataWithMaxSubpartitionLimitation`
`DefaultVertexParallelismAndInputInfosDeciderTest#testDecideParallelismWithMaxSubpartitionLimitation`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
