### PR TITLE
[FLINK-22320][docs][table] Add documentation for new introduced ALTER TABLE statements

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/alter.md
+++ b/docs/content.zh/docs/dev/table/sql/alter.md
@@ -78,8 +78,26 @@ tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount 
 String[] tables = tableEnv.listTables();
 // or tableEnv.executeSql("SHOW TABLES").print();
 
+// 新增列 `order` 并置于第一位
+tableEnv.executeSql("ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST");
+
+// 新增更多列, 以及主键和 watermark
+tableEnv.executeSql("ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR)");
+
+// 修改列类型, 注释及 watermark 策略
+tableEnv.executeSql("ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts)");
+
+// 删除 watermark
+tableEnv.executeSql("ALTER TABLE Orders DROP WATERMARK");
+
+// 删除列
+tableEnv.executeSql("ALTER TABLE Orders DROP (amount, ts, category)");
+
+// 重命名列
+tableEnv.executeSql("ALTER TABLE Orders RENAME `order` TO order_id");
+
 // 把 “Orders” 的表名改为 “NewOrders”
-tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders;");
+tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders");
 
 // 字符串数组：["NewOrders"]
 String[] tables = tableEnv.listTables();
@@ -93,12 +111,30 @@ val tableEnv = TableEnvironment.create(...)
 // 注册名为 “Orders” 的表
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
 
+// 新增列 `order` 并置于第一位
+tableEnv.executeSql("ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST")
+
+// 新增更多列, 以及主键和 watermark
+tableEnv.executeSql("ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR)")
+
+// 修改列类型, 注释, 以及主键和 watermark
+tableEnv.executeSql("ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts)")
+
+// 删除 watermark
+tableEnv.executeSql("ALTER TABLE Orders DROP WATERMARK")
+
+// 删除列
+tableEnv.executeSql("ALTER TABLE Orders DROP (amount, ts, category)")
+
+// 重命名列
+tableEnv.executeSql("ALTER TABLE Orders RENAME `order` TO order_id")
+
 // 字符串数组： ["Orders"]
 val tables = tableEnv.listTables()
 // or tableEnv.executeSql("SHOW TABLES").print()
 
-// 把 “Orders” 的表名改为 “NewOrders”
-tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders;")
+// rename "Orders" to "NewOrders"
+tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders")
 
 // 字符串数组：["NewOrders"]
 val tables = tableEnv.listTables()
@@ -113,8 +149,26 @@ table_env = TableEnvironment.create(...)
 tables = table_env.list_tables()
 # or table_env.execute_sql("SHOW TABLES").print()
 
+# 新增列 `order` 并置于第一位
+table_env.execute_sql("ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST");
+
+# 新增更多列, 主键及 watermark
+table_env.execute_sql("ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR)");
+
+# 修改列类型, 列注释, 主键及 watermark
+table_env.execute_sql("ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts)");
+
+# 删除 watermark
+table_env.execute_sql("ALTER TABLE Orders DROP WATERMARK");
+
+# 删除列
+table_env.execute_sql("ALTER TABLE Orders DROP (amount, ts, category)");
+
+# 重命名列
+table_env.execute_sql("ALTER TABLE Orders RENAME `order` TO order_id");
+
 # 把 “Orders” 的表名改为 “NewOrders”
-table_env.execute_sql("ALTER TABLE Orders RENAME TO NewOrders;")
+table_env.execute_sql("ALTER TABLE Orders RENAME TO NewOrders");
 
 # 字符串数组：["NewOrders"]
 tables = table_env.list_tables()
@@ -124,37 +178,304 @@ tables = table_env.list_tables()
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...);
-[INFO] Table has been created.
+[INFO] Execute statement succeed.
+
+Flink SQL> ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST;
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++---------+--------+------+-----+--------+-----------+------------------+
+|    name |   type | null | key | extras | watermark |          comment |
++---------+--------+------+-----+--------+-----------+------------------+
+|   order |    INT | TRUE |     |        |           | order identifier |
+|    user | BIGINT | TRUE |     |        |           |                  |
+| product | STRING | TRUE |     |        |           |                  |
+|  amount |    INT | TRUE |     |        |           |                  |
++---------+--------+------+-----+--------+-----------+------------------+
+4 rows in set
+
+Flink SQL> ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR);
+[INFO] Execute statement succeed. 
+
+Flink SQL> DESCRIBE Orders;
++----------+------------------------+-------+------------+--------+--------------------------+------------------+
+|     name |                   type |  null |        key | extras |                watermark |          comment |
++----------+------------------------+-------+------------+--------+--------------------------+------------------+
+|    order |                    INT | FALSE | PRI(order) |        |                          | order identifier |
+|     user |                 BIGINT |  TRUE |            |        |                          |                  |
+|  product |                 STRING |  TRUE |            |        |                          |                  |
+| category |                 STRING |  TRUE |            |        |                          |                  |
+|   amount |                    INT |  TRUE |            |        |                          |                  |
+|       ts | TIMESTAMP(3) *ROWTIME* |  TRUE |            |        | `ts` - INTERVAL '1' HOUR |                  |
++----------+------------------------+-------+------------+--------+--------------------------+------------------+
+6 rows in set
+
+Flink SQL> ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts);
+[INFO] Execute statement succeed. 
+
+Flink SQL> DESCRIBE Orders;
++----------+------------------------+-------+------------+--------+-----------+---------------------+
+|     name |                   type |  null |        key | extras | watermark |             comment |
++----------+------------------------+-------+------------+--------+-----------+---------------------+
+|    order |                    INT | FALSE | PRI(order) |        |           |    order identifier |
+| category |                 STRING |  TRUE |            |        |           | category identifier |
+|     user |                 BIGINT |  TRUE |            |        |           |                     |
+|  product |                 STRING |  TRUE |            |        |           |                     |
+|   amount |                 DOUBLE | FALSE |            |        |           |                     |
+|       ts | TIMESTAMP(3) *ROWTIME* |  TRUE |            |        |      `ts` |                     |
++----------+------------------------+-------+------------+--------+-----------+---------------------+
+6 rows in set
+
+Flink SQL> ALTER TABLE Orders DROP WATERMARK;
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++----------+--------------+-------+------------+--------+-----------+---------------------+
+|     name |         type |  null |        key | extras | watermark |             comment |
++----------+--------------+-------+------------+--------+-----------+---------------------+
+|    order |          INT | FALSE | PRI(order) |        |           |    order identifier |
+| category |       STRING |  TRUE |            |        |           | category identifier |
+|     user |       BIGINT |  TRUE |            |        |           |                     |
+|  product |       STRING |  TRUE |            |        |           |                     |
+|   amount |       DOUBLE | FALSE |            |        |           |                     |
+|       ts | TIMESTAMP(3) |  TRUE |            |        |           |                     |
++----------+--------------+-------+------------+--------+-----------+---------------------+
+6 rows in set
+
+Flink SQL> ALTER TABLE Orders DROP (amount, ts, category);
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++---------+--------+-------+------------+--------+-----------+------------------+
+|    name |   type |  null |        key | extras | watermark |          comment |
++---------+--------+-------+------------+--------+-----------+------------------+
+|   order |    INT | FALSE | PRI(order) |        |           | order identifier |
+|    user | BIGINT |  TRUE |            |        |           |                  |
+| product | STRING |  TRUE |            |        |           |                  |
++---------+--------+-------+------------+--------+-----------+------------------+
+3 rows in set
+
+Flink SQL> ALTER TABLE Orders RENAME `order` to `order_id`;
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++----------+--------+-------+---------------+--------+-----------+------------------+
+|     name |   type |  null |           key | extras | watermark |          comment |
++----------+--------+-------+---------------+--------+-----------+------------------+
+| order_id |    INT | FALSE | PRI(order_id) |        |           | order identifier |
+|     user | BIGINT |  TRUE |               |        |           |                  |
+|  product | STRING |  TRUE |               |        |           |                  |
++----------+--------+-------+---------------+--------+-----------+------------------+
+3 rows in set
 
 Flink SQL> SHOW TABLES;
-Orders
++------------+
+| table name |
++------------+
+|     Orders |
++------------+
+1 row in set
 
 Flink SQL> ALTER TABLE Orders RENAME TO NewOrders;
-[INFO] Table has been removed.
+[INFO] Execute statement succeed.
 
 Flink SQL> SHOW TABLES;
-NewOrders
++------------+
+| table name |
++------------+
+|  NewOrders |
++------------+
+1 row in set
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
+{{< top >}}
+
 ## ALTER TABLE
 
-* 重命名表
+当前支持的 ALTER TABLE 语法如下
+```text
+ALTER TABLE [IF EXISTS] table_name {
+    ADD { <schema_component> | (<schema_component> [, ...]) }
+  | MODIFY { <schema_component> | (<schema_component> [, ...]) }
+  | DROP {column_name | (column_name, column_name, ....) | PRIMARY KEY | CONSTRAINT constraint_name | WATERMARK}
+  | RENAME old_column_name TO new_column_name
+  | RENAME TO new_table_name
+  | SET (key1=val1, ...)
+  | RESET (key1, ...)
+}
 
-```sql
-ALTER TABLE [catalog_name.][db_name.]table_name RENAME TO new_table_name
+<schema_component>:
+  { <column_component> | <constraint_component> | <watermark_component> }
+
+<column_component>:
+  column_name <column_definition> [FIRST | AFTER column_name]
+
+<constraint_component>:
+  [CONSTRAINT constraint_name] PRIMARY KEY (column_name, ...) NOT ENFORCED
+
+<watermark_component>:
+  WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
+
+<column_definition>:
+  { <physical_column_definition> | <metadata_column_definition> | <computed_column_definition> } [COMMENT column_comment]
+
+<physical_column_definition>:
+  column_type
+
+<metadata_column_definition>:
+  column_type METADATA [ FROM metadata_key ] [ VIRTUAL ]
+
+<computed_column_definition>:
+  AS computed_column_expression
 ```
 
-把原有的表名更改为新的表名。
+<span class="label label-info">注意</span> 如果表不存在且未指定 `IF EXISTS` 时将会抛出 `ValidationException`。
 
-* 设置或修改表属性
+**新增列**
 
-```sql
-ALTER TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2, ...)
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name ADD (<column_component>[, <column_component>, ...])
+```
+
+向表中新增一列或多列至指定位置，包括
+- 将新增列置于最后
+- 将新增列置于最前
+- 将新增列置于指定列后
+
+在触发以下任一条件时将抛出 `ValidationException`
+- 新增列列名已存在
+- `AFTER` 指向不存在的列
+- 新增计算列的表达式引用了其它计算列或不存在的列
+- 新增计算列的表达式非法
+
+**新增主键约束**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name ADD [CONSTRAINT constraint_name] PRIMARY KEY(col1[, col2, ...]) NOT ENFORCED
+```
+
+向表中新增主键约束。当表中已存在主键、指定列不存在或为非物理列时抛出 `ValidationException`。
+
+<span class="label label-danger">注意</span> 指定列为主键列时会隐式修改该列的 nullability 为 false。
+
+**新增 Watermark**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name ADD WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
+```
+
+向表中新增 Watermark。当表中已存在 Watermark、指定的 row-time 列不存在或表达式非法时抛出 `ValidationException`。
+
+**修改列**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name MODIFY (<column_component>[, <column_component>, ...])
+```
+
+修改表中已存在的一列或多列，包括
+- 修改列的类型
+- 修改列的注释
+- 修改列的 nullability
+- 修改列的位置
+
+在触发以下任一条件时将抛出 `ValidationException`
+- 修改不存在的列名
+- `AFTER` 指向不存在的列
+- 修改列类型，导致引用其的计算列或 watermark 表达式非法
+- 将主键列修改为计算列或 metadata 列
+
+
+**修改主键约束**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name MODIFY [CONSTRAINT constraint_name] PRIMARY KEY(col1[, col2, ...]) NOT ENFORCED
+```
+
+修改表的主键约束。在触发以下任一条件时将抛出 `ValidationException`
+- 源表未定义主键
+- 指定不存在的列
+- 指定非物理列
+
+<span class="label label-danger">注意</span> 指定列为主键列时会隐式修改该列的 nullability 为 false。
+
+**修改 Watermark**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name MODIFY WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
+```
+
+修改 watermark 表达式或重新指定 row-time 列。在触发以下任一条件时将抛出 `ValidationException`
+- 源表未定义 watermark
+- 指定不存在的 row-time 列，或 watermark 表达式非法
+
+**删除列**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name DROP (col1[, col2, ...])
+```
+
+删除表中一列或多列。在触发以下任一条件时将抛出 `ValidationException`
+- 指定列不存在
+- 指定列存在计算列引用，且计算列不随指定列一起删除
+- 指定列是主键列
+- 指定列定义了 watermark 策略
+
+**删除主键约束**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name DROP <constraint_definition>
+
+<constraint_definition>:
+{
+    PRIMARY KEY | CONSTRAINT constraint_name
+}
+```
+
+使用关键字 `PRIMARY KEY` 或约束名删除主键约束。如果表中不存在主键或指定错误的约束名时抛出 `ValidationException`。
+
+**删除 Watermark**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name DROP WATERMARK
+```
+
+使用关键字 `WATERMARK` 删除 watermark。如果表中不存在 watermark 时抛出 `ValidationException`。
+
+**重命名列**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name RENAME old_column_name TO new_column_name
+```
+
+把原有的列名更改为新的列名。若指定的原有列名不存在或新列名已存在时抛出 `ValidationException`。
+
+**重命名表**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name RENAME TO new_table_name
+```
+
+把原有的表名更改为新的表名。 若新表名已存在则抛出 `TableAlreadyExistException`。
+
+**设置或修改表属性**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2, ...)
 ```
 
 为指定的表设置一个或多个属性。若个别属性已经存在于表中，则使用新的值覆盖旧的值。
+
+**重置表属性**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name RESET (key1, key2, ...)
+```
+
+为指定的表重置一个或多个属性。不支持设置 `connector` 属性, 会抛出 `ValidationException`。
+
+{{< top >}}
 
 ## ALTER VIEW
 
@@ -170,6 +491,8 @@ ALTER VIEW [catalog_name.][db_name.]view_name AS new_query_expression
 
 Changes the underlying query defining the given view to a new query.
 
+{{< top >}}
+
 ## ALTER DATABASE
 
 ```sql
@@ -177,6 +500,8 @@ ALTER DATABASE [catalog_name.]db_name SET (key1=val1, key2=val2, ...)
 ```
 
 在数据库中设置一个或多个属性。若个别属性已经在数据库中设定，将会使用新值覆盖旧值。
+
+{{< top >}}
 
 ## ALTER FUNCTION
 

--- a/docs/content.zh/docs/dev/table/sql/alter.md
+++ b/docs/content.zh/docs/dev/table/sql/alter.md
@@ -354,11 +354,12 @@ ALTER TABLE MyTable ADD (
     WATERMARK FOR ts AS ts - INTERVAL '3' SECOND
 );
 ```
+<span class="label label-danger">注意</span> 指定列为主键列时会隐式修改该列的 nullability 为 false。
 
 ### MODIFY
 使用 `MODIFY` 语句修改列的位置 、类型 、注释 、nullability，主键或 watermark。
 
-可使用 `FIRST` 或 `AFTER col_name` 将已有列移动至指定位置。
+可使用 `FIRST` 或 `AFTER col_name` 将已有列移动至指定位置，不指定时默认保持位置不变。
 
 `MODIFY` 语句示例如下。
 
@@ -374,6 +375,7 @@ ALTER TABLE MyTable MODIFY (
     WATERMARK FOR ts AS ts -- modify watermark strategy
 );
 ```
+<span class="label label-danger">注意</span> 指定列为主键列时会隐式修改该列的 nullability 为 false。
 
 ### DROP
 使用 `DROP` 语句删除列 、主键或 watermark。
@@ -400,7 +402,7 @@ ALTER TABLE MyTable DROP WATERMARK;
 `RENAME` 语句示例如下。
 ```sql
 -- rename column
-ALTER TABLE MyTable RENAME `data` TO payload;
+ALTER TABLE MyTable RENAME request_body TO payload;
 
 -- rename table
 ALTER TABLE MyTable RENAME TO MyTable2;

--- a/docs/content/docs/dev/table/sql/alter.md
+++ b/docs/content/docs/dev/table/sql/alter.md
@@ -79,8 +79,26 @@ tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount 
 String[] tables = tableEnv.listTables();
 // or tableEnv.executeSql("SHOW TABLES").print();
 
+// add a new column `order` to the first position
+tableEnv.executeSql("ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST");
+
+// add more columns, primary key and watermark
+tableEnv.executeSql("ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR)");
+
+// modify column type, column comment and watermark
+tableEnv.executeSql("ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts)");
+
+// drop watermark
+tableEnv.executeSql("ALTER TABLE Orders DROP WATERMARK");
+
+// drop column
+tableEnv.executeSql("ALTER TABLE Orders DROP (amount, ts, category)");
+
+// rename column
+tableEnv.executeSql("ALTER TABLE Orders RENAME `order` TO order_id");
+
 // rename "Orders" to "NewOrders"
-tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders;");
+tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders");
 
 // a string array: ["NewOrders"]
 String[] tables = tableEnv.listTables();
@@ -94,12 +112,30 @@ val tableEnv = TableEnvironment.create(...)
 // register a table named "Orders"
 tableEnv.executeSql("CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...)")
 
+// add a new column `order` to the first position
+tableEnv.executeSql("ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST")
+
+// add more columns, primary key and watermark
+tableEnv.executeSql("ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR)")
+
+// modify column type, column comment and watermark
+tableEnv.executeSql("ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts)")
+
+// drop watermark
+tableEnv.executeSql("ALTER TABLE Orders DROP WATERMARK")
+
+// drop column
+tableEnv.executeSql("ALTER TABLE Orders DROP (amount, ts, category)")
+
+// rename column
+tableEnv.executeSql("ALTER TABLE Orders RENAME `order` TO order_id")
+
 // a string array: ["Orders"]
 val tables = tableEnv.listTables()
 // or tableEnv.executeSql("SHOW TABLES").print()
 
 // rename "Orders" to "NewOrders"
-tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders;")
+tableEnv.executeSql("ALTER TABLE Orders RENAME TO NewOrders")
 
 // a string array: ["NewOrders"]
 val tables = tableEnv.listTables()
@@ -114,8 +150,26 @@ table_env = TableEnvironment.create(...)
 tables = table_env.list_tables()
 # or table_env.execute_sql("SHOW TABLES").print()
 
+# add a new column `order` to the first position
+table_env.execute_sql("ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST");
+
+# add more columns, primary key and watermark
+table_env.execute_sql("ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR)");
+
+# modify column type, column comment and watermark
+table_env.execute_sql("ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts)");
+
+# drop watermark
+table_env.execute_sql("ALTER TABLE Orders DROP WATERMARK");
+
+# drop column
+table_env.execute_sql("ALTER TABLE Orders DROP (amount, ts, category)");
+
+# rename column
+table_env.execute_sql("ALTER TABLE Orders RENAME `order` TO order_id");
+
 # rename "Orders" to "NewOrders"
-table_env.execute_sql("ALTER TABLE Orders RENAME TO NewOrders;")
+table_env.execute_sql("ALTER TABLE Orders RENAME TO NewOrders");
 
 # a string array: ["NewOrders"]
 tables = table_env.list_tables()
@@ -125,37 +179,309 @@ tables = table_env.list_tables()
 {{< tab "SQL CLI" >}}
 ```sql
 Flink SQL> CREATE TABLE Orders (`user` BIGINT, product STRING, amount INT) WITH (...);
-[INFO] Table has been created.
+[INFO] Execute statement succeed.
+
+Flink SQL> ALTER TABLE Orders ADD `order` INT COMMENT 'order identifier' FIRST;
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++---------+--------+------+-----+--------+-----------+------------------+
+|    name |   type | null | key | extras | watermark |          comment |
++---------+--------+------+-----+--------+-----------+------------------+
+|   order |    INT | TRUE |     |        |           | order identifier |
+|    user | BIGINT | TRUE |     |        |           |                  |
+| product | STRING | TRUE |     |        |           |                  |
+|  amount |    INT | TRUE |     |        |           |                  |
++---------+--------+------+-----+--------+-----------+------------------+
+4 rows in set
+
+Flink SQL> ALTER TABLE Orders ADD (ts TIMESTAMP(3), category STRING AFTER product, PRIMARY KEY(`order`) NOT ENFORCED, WATERMARK FOR ts AS ts - INTERVAL '1' HOUR);
+[INFO] Execute statement succeed. 
+
+Flink SQL> DESCRIBE Orders;
++----------+------------------------+-------+------------+--------+--------------------------+------------------+
+|     name |                   type |  null |        key | extras |                watermark |          comment |
++----------+------------------------+-------+------------+--------+--------------------------+------------------+
+|    order |                    INT | FALSE | PRI(order) |        |                          | order identifier |
+|     user |                 BIGINT |  TRUE |            |        |                          |                  |
+|  product |                 STRING |  TRUE |            |        |                          |                  |
+| category |                 STRING |  TRUE |            |        |                          |                  |
+|   amount |                    INT |  TRUE |            |        |                          |                  |
+|       ts | TIMESTAMP(3) *ROWTIME* |  TRUE |            |        | `ts` - INTERVAL '1' HOUR |                  |
++----------+------------------------+-------+------------+--------+--------------------------+------------------+
+6 rows in set
+
+Flink SQL> ALTER TABLE Orders MODIFY (amount DOUBLE NOT NULL, category STRING COMMENT 'category identifier' AFTER `order`, WATERMARK FOR ts AS ts);
+[INFO] Execute statement succeed. 
+
+Flink SQL> DESCRIBE Orders;
++----------+------------------------+-------+------------+--------+-----------+---------------------+
+|     name |                   type |  null |        key | extras | watermark |             comment |
++----------+------------------------+-------+------------+--------+-----------+---------------------+
+|    order |                    INT | FALSE | PRI(order) |        |           |    order identifier |
+| category |                 STRING |  TRUE |            |        |           | category identifier |
+|     user |                 BIGINT |  TRUE |            |        |           |                     |
+|  product |                 STRING |  TRUE |            |        |           |                     |
+|   amount |                 DOUBLE | FALSE |            |        |           |                     |
+|       ts | TIMESTAMP(3) *ROWTIME* |  TRUE |            |        |      `ts` |                     |
++----------+------------------------+-------+------------+--------+-----------+---------------------+
+6 rows in set
+
+Flink SQL> ALTER TABLE Orders DROP WATERMARK;
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++----------+--------------+-------+------------+--------+-----------+---------------------+
+|     name |         type |  null |        key | extras | watermark |             comment |
++----------+--------------+-------+------------+--------+-----------+---------------------+
+|    order |          INT | FALSE | PRI(order) |        |           |    order identifier |
+| category |       STRING |  TRUE |            |        |           | category identifier |
+|     user |       BIGINT |  TRUE |            |        |           |                     |
+|  product |       STRING |  TRUE |            |        |           |                     |
+|   amount |       DOUBLE | FALSE |            |        |           |                     |
+|       ts | TIMESTAMP(3) |  TRUE |            |        |           |                     |
++----------+--------------+-------+------------+--------+-----------+---------------------+
+6 rows in set
+
+Flink SQL> ALTER TABLE Orders DROP (amount, ts, category);
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++---------+--------+-------+------------+--------+-----------+------------------+
+|    name |   type |  null |        key | extras | watermark |          comment |
++---------+--------+-------+------------+--------+-----------+------------------+
+|   order |    INT | FALSE | PRI(order) |        |           | order identifier |
+|    user | BIGINT |  TRUE |            |        |           |                  |
+| product | STRING |  TRUE |            |        |           |                  |
++---------+--------+-------+------------+--------+-----------+------------------+
+3 rows in set
+
+Flink SQL> ALTER TABLE Orders RENAME `order` to `order_id`;
+[INFO] Execute statement succeed.
+
+Flink SQL> DESCRIBE Orders;
++----------+--------+-------+---------------+--------+-----------+------------------+
+|     name |   type |  null |           key | extras | watermark |          comment |
++----------+--------+-------+---------------+--------+-----------+------------------+
+| order_id |    INT | FALSE | PRI(order_id) |        |           | order identifier |
+|     user | BIGINT |  TRUE |               |        |           |                  |
+|  product | STRING |  TRUE |               |        |           |                  |
++----------+--------+-------+---------------+--------+-----------+------------------+
+3 rows in set
 
 Flink SQL> SHOW TABLES;
-Orders
++------------+
+| table name |
++------------+
+|     Orders |
++------------+
+1 row in set
 
 Flink SQL> ALTER TABLE Orders RENAME TO NewOrders;
-[INFO] Table has been removed.
+[INFO] Execute statement succeed.
 
 Flink SQL> SHOW TABLES;
-NewOrders
++------------+
+| table name |
++------------+
+|  NewOrders |
++------------+
+1 row in set
 ```
 {{< /tab >}}
 {{< /tabs >}}
 
+{{< top >}}
+
 ## ALTER TABLE
 
-* Rename Table
+The following grammar gives an overview about the available syntax:
+```text
+ALTER TABLE [IF EXISTS] table_name {
+    ADD { <schema_component> | (<schema_component> [, ...]) }
+  | MODIFY { <schema_component> | (<schema_component> [, ...]) }
+  | DROP {column_name | (column_name, column_name, ....) | PRIMARY KEY | CONSTRAINT constraint_name | WATERMARK}
+  | RENAME old_column_name TO new_column_name
+  | RENAME TO new_table_name
+  | SET (key1=val1, ...)
+  | RESET (key1, ...)
+}
 
-```sql
-ALTER TABLE [catalog_name.][db_name.]table_name RENAME TO new_table_name
+<schema_component>:
+  { <column_component> | <constraint_component> | <watermark_component> }
+
+<column_component>:
+  column_name <column_definition> [FIRST | AFTER column_name]
+
+<constraint_component>:
+  [CONSTRAINT constraint_name] PRIMARY KEY (column_name, ...) NOT ENFORCED
+
+<watermark_component>:
+  WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
+
+<column_definition>:
+  { <physical_column_definition> | <metadata_column_definition> | <computed_column_definition> } [COMMENT column_comment]
+
+<physical_column_definition>:
+  column_type
+
+<metadata_column_definition>:
+  column_type METADATA [ FROM metadata_key ] [ VIRTUAL ]
+
+<computed_column_definition>:
+  AS computed_column_expression
 ```
 
-Rename the given table name to another new table name.
+<span class="label label-info">Note</span> If the table does not exist, `ValidationException` is thrown unless `IF EXISTS` is specified.
 
-* Set or Alter Table Properties
+**Add Table Column**
 
-```sql
-ALTER TABLE [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2, ...)
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name ADD (<column_component>[, <column_component>, ...])
+```
+
+Add table column(s) to the specified position, which includes
+- Append the column to the last position
+- Insert the column to the first position
+- Insert the column after the specified column
+
+Throws `ValidationException` when either of following conditions are met
+- Add a column name which is already defined in the table schema
+- Add a column which refers to a nonexistent column by `AFTER`
+- Add a computed column which is derived from another computed or nonexistent columns
+- Add a computed column with invalid expression
+
+**Add Table Constraint**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name ADD [CONSTRAINT constraint_name] PRIMARY KEY(col1[, col2, ...]) NOT ENFORCED
+```
+
+Add primary key to the table. Throws `ValidationException` when either of following conditions are met
+- The table already defines primary key
+- The specified column does not exist or is not a physical column
+
+<span class="label label-danger">Note</span> Add a column to be primary key will change the column's nullability to false implicitly.
+
+**Add Table Watermark**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name ADD WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
+```
+
+Add a watermark to the table. Add primary key to the table. Throws `ValidationException` when either of following conditions are met
+- The table already defines watermark 
+- The specified row-time field does not exist
+- The watermark strategy expression is invalid.
+
+**Modify Table Column**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name MODIFY (<column_component>[, <column_component>, ...])
+```
+
+Modify table column(s), which includes
+- Change column type
+- Change column comment
+- Change column nullability
+- Change column position
+
+Throws `ValidationException` when either of following conditions are met
+- Modify a nonexistent column
+- Modify a column which refers to a nonexistent column by `AFTER`
+- Modify a physical/metadata column type which renders the derived computed column expression invalid
+- Modify a physical column which defines primary key to computed/metadata column
+- Modify a column which renders the derived watermark strategy invalid
+
+**Modify Table Constraint**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name MODIFY [CONSTRAINT constraint_name] PRIMARY KEY(col1[, col2, ...]) NOT ENFORCED
+```
+
+Modify the primary key definition. Throws `ValidationException` when either of following conditions are met
+- The table does not define primary key
+- Specify a nonexistent column
+- The column is computed/metadata column
+
+<span class="label label-danger">Note</span> Modify a column to be primary key will change the column's nullability to false implicitly.
+
+**Modify Table Watermark**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name MODIFY WATERMARK FOR rowtime_column_name AS watermark_strategy_expression
+```
+
+Modify the watermark strategy or change row-time column. Throws `ValidationException` when either of following conditions are met
+- The table does not define watermark
+- Specify a nonexistent row-time column, or the watermark strategy expression is invalid
+
+**Drop Table Column**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name DROP (col1[, col2, ...])
+```
+
+Drop the column(s) by the specified column name(s). Throws `ValidationException` when either of following conditions are met
+- The table does not contain the specified column
+- The column to be dropped derives computed column(s), and the computed column is not to be dropped together
+- The column to be dropped defines primary key
+- The column to be dropped defines watermark strategy
+
+**Drop Table Constraint**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name DROP <constraint_definition>
+
+<constraint_definition>:
+{
+    PRIMARY KEY | CONSTRAINT constraint_name
+}
+```
+
+Drop the table constraint by keyword `PRIMARY KEY` or constraint name. Throws `ValidationException` if the table does not define primary key or the specified constraint name is not correct.
+
+**Drop Table Watermark**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name DROP WATERMARK
+```
+
+Drop table's watermark by keyword `WATERMARK`. Throws `ValidationException` if the table does not define a watermark strategy.
+
+**Rename Table Column**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name RENAME old_column_name TO new_column_name
+```
+
+Rename the given column name to the specified new column name. Throws `ValidationException` if the given column name does not exist in the table, or the new column name already exists in the table.
+
+**Rename Table**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name RENAME TO new_table_name
+```
+
+Rename the given table name to another new table name. Throws `TableAlreadyExistException` if the new table exists.
+
+**Set Table Properties**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name SET (key1=val1, key2=val2, ...)
 ```
 
 Set one or more properties in the specified table. If a particular property is already set in the table, override the old value with the new one.
+
+**Reset Table Properties**
+
+```text
+ALTER TABLE [IF EXISTS] [catalog_name.][db_name.]table_name RESET (key1, key2, ...)
+```
+
+Reset one or more properties to its default value. Throws `ValidationException` if the property key to reset is `connector`.
+
+{{< top >}}
 
 ## ALTER VIEW
 
@@ -171,6 +497,8 @@ ALTER VIEW [catalog_name.][db_name.]view_name AS new_query_expression
 
 Changes the underlying query defining the given view to a new query.
 
+{{< top >}}
+
 ## ALTER DATABASE
 
 ```sql
@@ -178,6 +506,8 @@ ALTER DATABASE [catalog_name.]db_name SET (key1=val1, key2=val2, ...)
 ```
 
 Set one or more properties in the specified database. If a particular property is already set in the database, override the old value with the new one.
+
+{{< top >}}
 
 ## ALTER FUNCTION
 

--- a/docs/content/docs/dev/table/sql/alter.md
+++ b/docs/content/docs/dev/table/sql/alter.md
@@ -339,7 +339,7 @@ If the table does not exist, nothing happens.
 ### ADD
 Use `ADD` clause to add [columns]({{< ref "docs/dev/table/sql/create" >}}#columns), [constraints]({{< ref "docs/dev/table/sql/create" >}}#primary-key), [watermark]({{< ref "docs/dev/table/sql/create" >}}#watermark) to an existing table. 
 
-To add a column at the specified position, use `FIRST` or `AFTER col_name`. The default is to add the column last.
+To add a column at the specified position, use `FIRST` or `AFTER col_name`. By default, the column is appended at last.
 
 The following examples illustrate the usage of the `ADD` statements.
 
@@ -355,11 +355,12 @@ ALTER TABLE MyTable ADD (
     WATERMARK FOR ts AS ts - INTERVAL '3' SECOND
 );
 ```
+<span class="label label-danger">Note</span> Add a column to be primary key will change the column's nullability to false implicitly.
 
 ### MODIFY
 Use `MODIFY` clause to change column's position, type, comment or nullability, change primary key columns and watermark strategy to an existing table. 
 
-To modify an existent column to a new position, use `FIRST` or `AFTER col_name`.
+To modify an existent column to a new position, use `FIRST` or `AFTER col_name`. By default, the position remains unchanged. 
 
 The following examples illustrate the usage of the `MODIFY` statements.
 
@@ -375,6 +376,8 @@ ALTER TABLE MyTable MODIFY (
     WATERMARK FOR ts AS ts -- modify watermark strategy
 );
 ```
+
+<span class="label label-danger">Note</span> Modify a column to be primary key will change the column's nullability to false implicitly.
 
 ### DROP
 Use `DROP` clause to drop columns, primary key and watermark strategy to an existing table.
@@ -401,7 +404,7 @@ Use `RENAME` clause to rename column or an existing table.
 The following examples illustrate the usage of the `RENAME` statements.
 ```sql
 -- rename column
-ALTER TABLE MyTable RENAME `data` TO payload;
+ALTER TABLE MyTable RENAME request_body TO payload;
 
 -- rename table
 ALTER TABLE MyTable RENAME TO MyTable2;


### PR DESCRIPTION
## What is the purpose of the change

This PR is a subtask of FLINK-21634 to add documentation.


## Brief change log

Add documentation for `ALTER TALBE [IF EXISTS] <table_identifier>` statements.


## Verifying this change

This change can be verified by building the document locally at http://localhost:1313


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented?  docs
