### PR TITLE
[FLINK-30636] [docs]: Typo fix; 'to to' -> 'to'

### DIFF
--- a/docs/content.zh/docs/dev/table/hive-compatibility/hive-dialect/insert.md
+++ b/docs/content.zh/docs/dev/table/hive-compatibility/hive-dialect/insert.md
@@ -74,7 +74,7 @@ The dynamic partition columns must be specified last among the columns in the `S
 **Note:**
 
 In Hive, by default, users must specify at least one static partition in case of accidentally overwriting all partitions, and users can
-set the configuration `hive.exec.dynamic.partition.mode` to `nonstrict` to to allow all partitions to be dynamic.
+set the configuration `hive.exec.dynamic.partition.mode` to `nonstrict` to allow all partitions to be dynamic.
 
 But in Flink's Hive dialect, it'll always be `nonstrict` mode which means all partitions are allowed to be dynamic.
 {{< /hint >}}

--- a/docs/content/docs/dev/table/hive-compatibility/hive-dialect/insert.md
+++ b/docs/content/docs/dev/table/hive-compatibility/hive-dialect/insert.md
@@ -74,7 +74,7 @@ The dynamic partition columns must be specified last among the columns in the `S
 **Note:**
 
 In Hive, by default, users must specify at least one static partition in case of accidentally overwriting all partitions, and users can
-set the configuration `hive.exec.dynamic.partition.mode` to `nonstrict` to to allow all partitions to be dynamic.
+set the configuration `hive.exec.dynamic.partition.mode` to `nonstrict` to allow all partitions to be dynamic.
 
 But in Flink's Hive dialect, it'll always be `nonstrict` mode which means all partitions are allowed to be dynamic.
 {{< /hint >}}

--- a/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/state/ListState.java
@@ -44,7 +44,7 @@ import java.util.List;
 public interface ListState<T> extends MergingState<T, Iterable<T>> {
 
     /**
-     * Updates the operator state accessible by {@link #get()} by updating existing values to to the
+     * Updates the operator state accessible by {@link #get()} by updating existing values to the
      * given list of values. The next time {@link #get()} is called (for the same state partition)
      * the returned state will represent the updated list.
      *

--- a/flink-python/pyflink/datastream/state.py
+++ b/flink-python/pyflink/datastream/state.py
@@ -193,7 +193,7 @@ class ListState(MergingState[T, Iterable[T]]):
     @abstractmethod
     def update(self, values: List[T]) -> None:
         """
-        Updating existing values to to the given list of values.
+        Updating existing values to the given list of values.
         """
         pass
 

--- a/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/testutils/HttpTestClient.java
+++ b/flink-runtime-web/src/test/java/org/apache/flink/runtime/webmonitor/testutils/HttpTestClient.java
@@ -122,7 +122,7 @@ public class HttpTestClient implements AutoCloseable {
     }
 
     /**
-     * Sends a request to to the server.
+     * Sends a request to the server.
      *
      * <pre>
      * HttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/overview");

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/execution/Environment.java
@@ -186,7 +186,7 @@ public interface Environment {
     TaskKvStateRegistry getTaskKvStateRegistry();
 
     /**
-     * Confirms that the invokable has successfully completed all steps it needed to to for the
+     * Confirms that the invokable has successfully completed all steps it needed to for the
      * checkpoint with the give checkpoint-ID. This method does not include any state in the
      * checkpoint.
      *

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/TaskEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/api/TaskEventHandler.java
@@ -25,8 +25,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.HashMultimap;
 import org.apache.flink.shaded.guava30.com.google.common.collect.Multimap;
 
 /**
- * The event handler manages {@link EventListener} instances and allows to to publish events to
- * them.
+ * The event handler manages {@link EventListener} instances and allows to publish events to them.
  */
 public class TaskEventHandler {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/iterative/task/IterationHeadTask.java
@@ -74,7 +74,7 @@ import java.util.List;
  * will send a {@link TerminationEvent} to all it's connected tasks, signaling them to shutdown.
  *
  * <p>Assumption on the ordering of the outputs: - The first n output gates write to channels that
- * go to the tasks of the step function. - The next m output gates to to the tasks that consume the
+ * go to the tasks of the step function. - The next m output gates to the tasks that consume the
  * final solution. - The last output gate connects to the synchronization task.
  *
  * @param <X> The type of the bulk partial solution / solution set and the final output.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskOperatorEventGateway.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskOperatorEventGateway.java
@@ -30,8 +30,8 @@ import org.apache.flink.util.SerializedValue;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Gateway to send an {@link OperatorEvent} or {@link CoordinationRequest} from a Task to to the
- * {@link OperatorCoordinator} JobManager side.
+ * Gateway to send an {@link OperatorEvent} or {@link CoordinationRequest} from a Task to the {@link
+ * OperatorCoordinator} JobManager side.
  *
  * <p>This is the first step in the chain of sending Operator Events and Requests from Operator to
  * Coordinator. Each layer adds further context, so that the inner layers do not need to know about

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalListState.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/internal/InternalListState.java
@@ -35,7 +35,7 @@ public interface InternalListState<K, N, T>
         extends InternalMergingState<K, N, T, List<T>, Iterable<T>>, ListState<T> {
 
     /**
-     * Updates the operator state accessible by {@link #get()} by updating existing values to to the
+     * Updates the operator state accessible by {@link #get()} by updating existing values to the
      * given list of values. The next time {@link #get()} is called (for the same state partition)
      * the returned state will represent the updated list.
      *

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/LocalInputChannelTest.java
@@ -401,8 +401,8 @@ public class LocalInputChannelTest {
      * and has not much more general value. If it becomes obsolete at some point (future greatness
      * ;)), feel free to remove it.
      *
-     * <p>The fix in the end was to to not acquire the channels lock when releasing it and/or not
-     * doing any input gate callbacks while holding the channel's lock. I decided to do both.
+     * <p>The fix in the end was to not acquire the channels lock when releasing it and/or not doing
+     * any input gate callbacks while holding the channel's lock. I decided to do both.
      */
     @Test
     public void testConcurrentReleaseAndRetriggerPartitionRequest() throws Exception {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBFullSnapshotResources.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/snapshot/RocksDBFullSnapshotResources.java
@@ -90,7 +90,7 @@ public class RocksDBFullSnapshotResources<K> implements FullSnapshotResources<K>
         this.keySerializer = keySerializer;
         this.streamCompressionDecorator = streamCompressionDecorator;
 
-        // we need to to this in the constructor, i.e. in the synchronous part of the snapshot
+        // we need to do this in the constructor, i.e. in the synchronous part of the snapshot
         // TODO: better yet, we can do it outside the constructor
         this.metaData = fillMetaData(metaDataCopy);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/ContinuousFileReaderOperator.java
@@ -539,7 +539,7 @@ public class ContinuousFileReaderOperator<OUT, T extends TimestampedInputSplit>
             checkpointedState.clear();
 
             throw new Exception(
-                    "Could not add timestamped file input splits to to operator "
+                    "Could not add timestamped file input splits to operator "
                             + "state backend of operator "
                             + getOperatorName()
                             + '.',

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLegacySink.java
@@ -35,7 +35,7 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Modifier;
 
 /**
- * Batch {@link ExecNode} to to write data into an external sink defined by a {@link TableSink}.
+ * Batch {@link ExecNode} to write data into an external sink defined by a {@link TableSink}.
  *
  * @param <T> The return type of the {@link TableSink}.
  */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSink.java
@@ -35,8 +35,7 @@ import org.apache.flink.table.types.logical.LogicalType;
 import java.util.Collections;
 
 /**
- * Batch {@link ExecNode} to to write data into an external sink defined by a {@link
- * DynamicTableSink}.
+ * Batch {@link ExecNode} to write data into an external sink defined by a {@link DynamicTableSink}.
  */
 public class BatchExecSink extends CommonExecSink implements BatchExecNode<Object> {
     public BatchExecSink(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
@@ -57,7 +57,7 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * Base {@link ExecNode} to to write data into an external sink defined by a {@link TableSink}.
+ * Base {@link ExecNode} to write data into an external sink defined by a {@link TableSink}.
  *
  * @param <T> The return type of the {@link TableSink}.
  */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLegacySink.java
@@ -38,7 +38,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Stream {@link ExecNode} to to write data into an external sink defined by a {@link TableSink}.
+ * Stream {@link ExecNode} to write data into an external sink defined by a {@link TableSink}.
  *
  * @param <T> The return type of the {@link TableSink}.
  */

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSink.java
@@ -49,7 +49,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * Stream {@link ExecNode} to to write data into an external sink defined by a {@link
+ * Stream {@link ExecNode} to write data into an external sink defined by a {@link
  * DynamicTableSink}.
  */
 @ExecNodeMetadata(

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLegacySink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLegacySink.scala
@@ -32,7 +32,7 @@ import org.apache.calcite.rel.hint.RelHint
 import java.util
 
 /**
- * Batch physical RelNode to to write data into an external sink defined by a [[TableSink]].
+ * Batch physical RelNode to write data into an external sink defined by a [[TableSink]].
  *
  * @tparam T
  *   The return type of the [[TableSink]].

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSink.scala
@@ -33,9 +33,7 @@ import org.apache.calcite.rel.hint.RelHint
 
 import java.util
 
-/**
- * Batch physical RelNode to to write data into an external sink defined by a [[DynamicTableSink]].
- */
+/** Batch physical RelNode to write data into an external sink defined by a [[DynamicTableSink]]. */
 class BatchPhysicalSink(
     cluster: RelOptCluster,
     traitSet: RelTraitSet,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLegacySink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalLegacySink.scala
@@ -32,7 +32,7 @@ import org.apache.calcite.rel.hint.RelHint
 import java.util
 
 /**
- * Stream physical RelNode to to write data into an external sink defined by a [[TableSink]].
+ * Stream physical RelNode to write data into an external sink defined by a [[TableSink]].
  *
  * @tparam T
  *   The return type of the [[TableSink]].

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/stream/StreamPhysicalSink.scala
@@ -36,7 +36,7 @@ import org.apache.calcite.rel.hint.RelHint
 import java.util
 
 /**
- * Stream physical RelNode to to write data into an external sink defined by a [[DynamicTableSink]].
+ * Stream physical RelNode to write data into an external sink defined by a [[DynamicTableSink]].
  */
 class StreamPhysicalSink(
     cluster: RelOptCluster,

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelShuttles.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/RelShuttles.scala
@@ -47,7 +47,7 @@ class DefaultRelShuttle extends RelHomogeneousShuttle {
 }
 
 /**
- * Convert all [[QueryOperationCatalogViewTable]]s (including tables in [[RexSubQuery]]) to to a
+ * Convert all [[QueryOperationCatalogViewTable]]s (including tables in [[RexSubQuery]]) to a
  * relational expression.
  */
 class ExpandTableScanShuttle extends RelShuttleImpl {

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ProcessingTimeWindowCheckpointingITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/ProcessingTimeWindowCheckpointingITCase.java
@@ -52,7 +52,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * This test uses a custom non-serializable data type to to ensure that state serializability is
+ * This test uses a custom non-serializable data type to ensure that state serializability is
  * handled correctly.
  */
 @SuppressWarnings("serial")


### PR DESCRIPTION
Just a fix of a surprisingly common typo in JavaDoc etc.

https://issues.apache.org/jira/browse/FLINK-30636