### PR TITLE
[FLINK-30637] [Python] Try to replace 'is' with '==' to ensure matching the window type of overwindow correctly

### DIFF
--- a/flink-python/pyflink/fn_execution/table/operations.py
+++ b/flink-python/pyflink/fn_execution/table/operations.py
@@ -197,9 +197,9 @@ class PandasBatchOverWindowAggregateFunctionOperation(BaseOperation):
         bounded_range_window_nums = 0
         for i, window in enumerate(self.windows):
             window_type = window.window_type
-            if (window_type is window_types.RANGE_UNBOUNDED_PRECEDING) or (
-                    window_type is window_types.RANGE_UNBOUNDED_FOLLOWING) or (
-                    window_type is window_types.RANGE_SLIDING):
+            if (window_type == window_types.RANGE_UNBOUNDED_PRECEDING) or (
+                    window_type == window_types.RANGE_UNBOUNDED_FOLLOWING) or (
+                    window_type == window_types.RANGE_SLIDING):
                 self.bounded_range_window_index[i] = bounded_range_window_nums
                 self.is_bounded_range_window.append(True)
                 bounded_range_window_nums += 1
@@ -238,13 +238,13 @@ class PandasBatchOverWindowAggregateFunctionOperation(BaseOperation):
             if self.is_bounded_range_window[window_index]:
                 window_boundaries = boundaries_series[
                     self.bounded_range_window_index[window_index]]
-                if window_type is OverWindow.RANGE_UNBOUNDED_PRECEDING:
+                if window_type == OverWindow.RANGE_UNBOUNDED_PRECEDING:
                     # range unbounded preceding window
                     for j in range(input_cnt):
                         end = window_boundaries[j]
                         series_slices = [s.iloc[:end] for s in input_series]
                         result.append(func(series_slices))
-                elif window_type is OverWindow.RANGE_UNBOUNDED_FOLLOWING:
+                elif window_type == OverWindow.RANGE_UNBOUNDED_FOLLOWING:
                     # range unbounded following window
                     for j in range(input_cnt):
                         start = window_boundaries[j]
@@ -259,19 +259,19 @@ class PandasBatchOverWindowAggregateFunctionOperation(BaseOperation):
                         result.append(func(series_slices))
             else:
                 # unbounded range window or unbounded row window
-                if (window_type is OverWindow.RANGE_UNBOUNDED) or (
-                        window_type is OverWindow.ROW_UNBOUNDED):
+                if (window_type == OverWindow.RANGE_UNBOUNDED) or (
+                        window_type == OverWindow.ROW_UNBOUNDED):
                     series_slices = [s.iloc[:] for s in input_series]
                     func_result = func(series_slices)
                     result = [func_result for _ in range(input_cnt)]
-                elif window_type is OverWindow.ROW_UNBOUNDED_PRECEDING:
+                elif window_type == OverWindow.ROW_UNBOUNDED_PRECEDING:
                     # row unbounded preceding window
                     window_end = window.upper_boundary
                     for j in range(input_cnt):
                         end = min(j + window_end + 1, input_cnt)
                         series_slices = [s.iloc[: end] for s in input_series]
                         result.append(func(series_slices))
-                elif window_type is OverWindow.ROW_UNBOUNDED_FOLLOWING:
+                elif window_type == OverWindow.ROW_UNBOUNDED_FOLLOWING:
                     # row unbounded following window
                     window_start = window.lower_boundary
                     for j in range(input_cnt):


### PR DESCRIPTION
Description: 
In linux-arch64 environment, “window_type is OverWindow.ROW_UNBOUNDED_FOLLOWING” in the PandasBatchOverWindowAggregateFunctionOperation class of the pyflink source code has returned the wrong result. For example, when window_type is 6, it represents the window type of ‘ROW_UNBOUNDED_FOLLOWING’, but “window_type is OverWindow.ROW_UNBOUNDED_FOLLOWING” return false because the memory address of window_type has changed. It will lead to the wrong type of window, such as row sliding window, so, the wrong results of pandas udf have appeared.

Solutions：
Since the window selections need to compare the values of two integer variables, I recommend replacing ‘is’ with ‘==’. That can also prevents erroneous results caused by Python small integer object pool failure. And it has been verified to perform correctly on both x86 and aarch64 environments.

Related Jira Issue:   FLINK-30637 (https://issues.apache.org/jira/browse/FLINK-30637)
