### PR TITLE
[FLINK-30633][Connectors/AWS] Update AWS SDKv2 to v2.19.14 for Flink 1.17

### DIFF
--- a/flink-connectors/flink-connector-aws-base/pom.xml
+++ b/flink-connectors/flink-connector-aws-base/pom.xml
@@ -32,7 +32,7 @@ under the License.
 	<artifactId>flink-connector-aws-base</artifactId>
 	<name>Flink : Connectors : AWS Base</name>
 	<properties>
-		<aws.sdk.version>2.17.247</aws.sdk.version>
+		<aws.sdk.version>2.19.14</aws.sdk.version>
 	</properties>
 
 	<packaging>jar</packaging>

--- a/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-avro-test/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
 	<properties>
 		<aws.sdk.version>1.12.276</aws.sdk.version>
-		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
+		<aws.sdkv2.version>2.19.14</aws.sdkv2.version>
 		<kotlin.version>1.7.10</kotlin.version>
 	</properties>
 

--- a/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
+++ b/flink-end-to-end-tests/flink-glue-schema-registry-json-test/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
 	<properties>
 		<aws.sdk.version>1.12.276</aws.sdk.version>
-		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
+		<aws.sdkv2.version>2.19.14</aws.sdkv2.version>
 		<kotlin.version>1.7.10</kotlin.version>
 	</properties>
 

--- a/flink-formats/flink-avro-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-avro-glue-schema-registry/pom.xml
@@ -34,7 +34,7 @@ under the License.
 
 	<properties>
 		<glue.schema.registry.version>1.1.14</glue.schema.registry.version>
-		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
+		<aws.sdkv2.version>2.19.14</aws.sdkv2.version>
 		<kotlin.version>1.7.10</kotlin.version>
 	</properties>
 

--- a/flink-formats/flink-json-glue-schema-registry/pom.xml
+++ b/flink-formats/flink-json-glue-schema-registry/pom.xml
@@ -33,7 +33,7 @@ under the License.
 
 	<properties>
 		<glue.schema.registry.version>1.1.14</glue.schema.registry.version>
-		<aws.sdkv2.version>2.17.247</aws.sdkv2.version>
+		<aws.sdkv2.version>2.19.14</aws.sdkv2.version>
 		<netty.version>4.1.68.Final</netty.version>
 		<kotlin.version>1.7.10</kotlin.version>
 		<classgraph.version>4.8.120</classgraph.version>


### PR DESCRIPTION
## What is the purpose of the change

Update AWS SDKv2 to v2.19.14

## Brief change log

- Update AWS SDKv2 to v2.19.14

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): yes
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
