### PR TITLE
[FLINK-30647] Add readable datetime column for watermark in WEB UI

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/components/humanize-watermark.pipe.ts
+++ b/flink-runtime-web/web-dashboard/src/app/components/humanize-watermark.pipe.ts
@@ -35,3 +35,19 @@ export class HumanizeWatermarkPipe implements PipeTransform {
     }
   }
 }
+
+@Pipe({
+  name: 'humanizeWatermarkToDatetime',
+  standalone: true
+})
+export class HumanizeWatermarkToDatetimePipe implements PipeTransform {
+  constructor(private readonly configService: ConfigService) {}
+
+  public transform(value: number): number | string {
+    if (isNaN(value) || value <= this.configService.LONG_MIN_VALUE) {
+      return '-';
+    } else {
+      return new Date(value).toLocaleString();
+    }
+  }
+}

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.html
@@ -31,8 +31,18 @@
 >
   <thead>
     <tr>
-      <th nzWidth="50%">SubTask</th>
-      <th nzWidth="50%">Watermark</th>
+      <th nzWidth="33%">SubTask</th>
+      <th nzWidth="33%">Watermark</th>
+      <th nzWidth="34%">
+        Datetime of Watermark Timestamp
+        <i
+          class="header-icon"
+          nz-icon
+          nz-tooltip
+          nzTooltipTitle="This column shows the datetime that is parsed from watermark timestamp with local time zone. Note that the time zone is obtained through your browser. "
+          nzType="info-circle"
+        ></i>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -41,6 +51,7 @@
         <tr>
           <td>{{ watermark.subTaskIndex }}</td>
           <td>{{ watermark.watermark | humanizeWatermark }}</td>
+          <td>{{ watermark.watermark | humanizeWatermarkToDatetime }}</td>
         </tr>
       </ng-container>
     </ng-template>

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/watermarks/job-overview-drawer-watermarks.component.ts
@@ -21,10 +21,15 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnIni
 import { of, Subject } from 'rxjs';
 import { catchError, map, mergeMap, takeUntil } from 'rxjs/operators';
 
-import { HumanizeWatermarkPipe } from '@flink-runtime-web/components/humanize-watermark.pipe';
+import {
+  HumanizeWatermarkPipe,
+  HumanizeWatermarkToDatetimePipe
+} from '@flink-runtime-web/components/humanize-watermark.pipe';
 import { MetricsService } from '@flink-runtime-web/services';
 import { typeDefinition } from '@flink-runtime-web/utils/strong-type';
+import { NzIconModule } from 'ng-zorro-antd/icon';
 import { NzTableModule } from 'ng-zorro-antd/table';
+import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 
 import { JobLocalService } from '../../job-local.service';
 
@@ -38,7 +43,7 @@ interface WatermarkData {
   templateUrl: './job-overview-drawer-watermarks.component.html',
   styleUrls: ['./job-overview-drawer-watermarks.component.less'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NzTableModule, NgIf, HumanizeWatermarkPipe],
+  imports: [NzTableModule, NgIf, HumanizeWatermarkPipe, HumanizeWatermarkToDatetimePipe, NzIconModule, NzToolTipModule],
   standalone: true
 })
 export class JobOverviewDrawerWatermarksComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
## What is the purpose of the change

This pull request adds a new column called `Date of Watermark Timestamp` in the Watermark Tab of Flink Web.
It helps users to have a more intuitive view of the current consumption of the selected operator.

## Brief change log

  - Add a column in Watermark Tab, which parsed the watermark timestamp to datetime with local time zone.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable

<img width="862" alt="Pic with Date of Watermark" src="https://user-images.githubusercontent.com/19743175/212060346-936f66f7-fcbe-43d1-b23f-9feab13c89fb.png">

<img width="867" alt="Hint for Date of Watermark" src="https://user-images.githubusercontent.com/19743175/212060428-c832045b-5ce2-4b5e-8fb8-4757ee0361c6.png">
