### PR TITLE
[FLINK-30629][Client/Job Submission] Fix the unstable test ClientHeartbeatTest.testJobRunningIfClientReportHeartbeat

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.program.PerJobMiniClusterFactory;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.runtime.dispatcher.Dispatcher;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
@@ -30,7 +31,6 @@ import org.apache.flink.runtime.minicluster.MiniCluster;
 import org.apache.flink.runtime.testutils.WaitingCancelableInvokable;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
@@ -68,7 +68,6 @@ public class ClientHeartbeatTest {
     }
 
     @Test
-    @Disabled("Disable until FLINK-30629 is fixed.")
     void testJobRunningIfClientReportHeartbeat() throws Exception {
         JobClient jobClient = submitJob(createConfiguration(true));
 
@@ -93,6 +92,9 @@ public class ClientHeartbeatTest {
 
     private Configuration createConfiguration(boolean shutdownOnAttachedExit) {
         Configuration configuration = new Configuration();
+        configuration.set(
+                Dispatcher.CLIENT_ALIVENESS_CHECK_DURATION,
+                Duration.ofMillis(clientHeartbeatTimeout));
         if (shutdownOnAttachedExit) {
             configuration.setBoolean(DeploymentOptions.ATTACHED, true);
             configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, true);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/dispatcher/Dispatcher.java
@@ -128,8 +128,9 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 public abstract class Dispatcher extends FencedRpcEndpoint<DispatcherId>
         implements DispatcherGateway {
 
+    @VisibleForTesting
     public static final ConfigOption<Duration> CLIENT_ALIVENESS_CHECK_DURATION =
-            ConfigOptions.key("internal.client-aliveness-check.interval")
+            ConfigOptions.key("$internal.dispatcher.client-aliveness-check.interval")
                     .durationType()
                     .defaultValue(Duration.ofMinutes(1));
 


### PR DESCRIPTION
## What is the purpose of the change

*Fix the unstable test ClientHeartbeatTest.testJobRunningIfClientReportHeartbeat. In the test, the client will send the heartbeat after the job's initialization. Sometimes the initialization is very slow, then the dispatcher will not received the client heartbeat after timeout and cancel the job which cause the test to fail. To fix it, we can send the client heartbeat without waiting for the initialization.*


## Brief change log

  - *Send the client heartbeat without waiting for the initialization in the test.*
  - *Delay the process checkJobClientAliveness in Dispatcher after the job is submitted.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
