### PR TITLE
[FLINK-30513] Cleanup HA storage path on cluster termination

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
@@ -48,11 +48,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class AbstractHaServicesTest {
 
     /**
-     * Tests that we first delete all pointers from the HA services before deleting the blobs. See
-     * FLINK-22014 for more details.
+     * Tests that we first delete all pointers from the HA services before deleting the blobs and HA
+     * storage path. See FLINK-22014 for more details.
      */
     @Test
-    void testCloseAndCleanupAllDataDeletesBlobsAfterCleaningUpHAData() throws Exception {
+    void testCloseAndCleanupAllDataDeletesBlobsAndHaStoragePathAfterCleaningUpHAData()
+            throws Exception {
         final Queue<CloseOperations> closeOperations = new ArrayDeque<>(3);
 
         final TestingBlobStoreService testingBlobStoreService =
@@ -69,18 +70,20 @@ class AbstractHaServicesTest {
 
         haServices.closeAndCleanupAllData();
 
-        assertThat(closeOperations).contains(
-                CloseOperations.HA_CLEANUP,
-                CloseOperations.HA_CLOSE,
-                CloseOperations.BLOB_CLEANUP_AND_CLOSE);
+        assertThat(closeOperations)
+                .contains(
+                        CloseOperations.HA_CLEANUP,
+                        CloseOperations.HA_CLOSE,
+                        CloseOperations.BLOB_CLEANUP_AND_CLOSE,
+                        CloseOperations.HA_STORAGE_PATH_CLEANUP);
     }
 
     /**
-     * Tests that we don't delete the HA blobs if we could not clean up the pointers from the HA
-     * services. See FLINK-22014 for more details.
+     * Tests that we don't delete the HA blobs and HA storage path if we could not clean up the
+     * pointers from the HA services. See FLINK-22014 for more details.
      */
     @Test
-    void testCloseAndCleanupAllDataDoesNotDeleteBlobsIfCleaningUpHADataFails() {
+    void testCloseAndCleanupAllDataDoesNotDeleteBlobsAndHaStoragePathIfCleaningUpHADataFails() {
         final Queue<CloseOperations> closeOperations = new ArrayDeque<>(3);
 
         final TestingBlobStoreService testingBlobStoreService =
@@ -99,6 +102,7 @@ class AbstractHaServicesTest {
 
         assertThatThrownBy(haServices::closeAndCleanupAllData).isInstanceOf(FlinkException.class);
         assertThat(closeOperations).contains(CloseOperations.HA_CLOSE, CloseOperations.BLOB_CLOSE);
+        assertThat(closeOperations).doesNotContain(CloseOperations.HA_STORAGE_PATH_CLEANUP);
     }
 
     @Test
@@ -129,6 +133,7 @@ class AbstractHaServicesTest {
         HA_CLOSE,
         BLOB_CLEANUP_AND_CLOSE,
         BLOB_CLOSE,
+        HA_STORAGE_PATH_CLEANUP,
     }
 
     private static final class TestingBlobStoreService implements BlobStoreService {
@@ -232,6 +237,11 @@ class AbstractHaServicesTest {
         @Override
         protected void internalCleanupJobData(JobID jobID) throws Exception {
             internalJobCleanupConsumer.accept(jobID);
+        }
+
+        @Override
+        protected void cleanupClusterHaStoragePath() {
+            closeOperations.offer(CloseOperations.HA_STORAGE_PATH_CLEANUP);
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderretrieval/ZooKeeperLeaderRetrievalTest.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -48,6 +49,7 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.UnknownHostException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -66,6 +68,8 @@ class ZooKeeperLeaderRetrievalTest {
     private final TestingFatalErrorHandlerExtension testingFatalErrorHandlerResource =
             new TestingFatalErrorHandlerExtension();
 
+    @TempDir private Path tempDir;
+
     private TestingServer testingServer;
 
     private Configuration config;
@@ -80,6 +84,7 @@ class ZooKeeperLeaderRetrievalTest {
         config.setString(HighAvailabilityOptions.HA_MODE, "zookeeper");
         config.setString(
                 HighAvailabilityOptions.HA_ZOOKEEPER_QUORUM, testingServer.getConnectString());
+        config.setString(HighAvailabilityOptions.HA_STORAGE_PATH, tempDir.toString());
 
         highAvailabilityServices =
                 new ZooKeeperMultipleComponentLeaderElectionHaServices(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Cleanup HA storage path on cluster termination to avoid leakage when using non-object file system like HDFS.

## Brief change log

Cleanup HA storage path on cluster termination. Cleanup will only be performed when the pointers in the HA store are successfully deleted to avoid dangling pointers in HA store.

## Verifying this change

Extended AbstractHaServicesTest and manually verified the change.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) yes, affects HA
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
