### PR TITLE
[FLINK-30690][javadocs][spelling] Fix java documentation and some wor…

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -603,7 +603,7 @@ Flink 通过 Kafka 连接器提供了一流的支持，可以对 Kerberos 配置
 
 2. 将 `KafkaClient` 追加到 `security.kerberos.login.contexts`：这告诉 Flink 将配置的 Kerberos 票据提供给 Kafka 登录上下文以用于 Kafka 身份验证。
 
-一旦启用了基于 Kerberos 的 Flink 安全性后，只需在提供的属性配置中包含以下两个设置（通过传递给内部 Kafka 客户端），即可使用 Flink Kafka Consumer 或 Producer 向 Kafk a进行身份验证：
+一旦启用了基于 Kerberos 的 Flink 安全性后，只需在提供的属性配置中包含以下两个设置（通过传递给内部 Kafka 客户端），即可使用 Flink Kafka Consumer 或 Producer 向 Kafka进行身份验证：
 
 - 将 `security.protocol` 设置为 `SASL_PLAINTEXT`（默认为 `NONE`）：用于与 Kafka broker 进行通信的协议。使用独立 Flink 部署时，也可以使用 `SASL_SSL`；请在[此处](https://kafka.apache.org/documentation/#security_configclients)查看如何为 SSL 配置 Kafka 客户端。
 - 将 `sasl.kerberos.service.name` 设置为 `kafka`（默认为 `kafka`）：此值应与用于 Kafka broker 配置的 `sasl.kerberos.service.name` 相匹配。客户端和服务器配置之间的服务名称不匹配将导致身份验证失败。

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/BulkFormat.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/reader/BulkFormat.java
@@ -98,7 +98,7 @@ public interface BulkFormat<T, SplitT extends FileSourceSplit>
 
     /**
      * Creates a new reader that reads from the {@link FileSourceSplit#path() split's path} starting
-     * at the {@link FileSourceSplit#offset()} split's offset} and reads {@link
+     * at the {@link FileSourceSplit#offset() split's offset} and reads {@link
      * FileSourceSplit#length() length} bytes after the offset.
      */
     BulkFormat.Reader<T> createReader(Configuration config, SplitT split) throws IOException;

--- a/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/typeutils/CompositeTypeSerializerSnapshot.java
@@ -47,10 +47,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>Serializers that do have some outer snapshot needs to make sure to implement the methods
  * {@link #writeOuterSnapshot(DataOutputView)}, {@link #readOuterSnapshot(int, DataInputView,
- * ClassLoader)}, and {@link #resolveOuterSchemaCompatibility(TypeSerializer)} (TypeSerializer)}
- * when using this class as the base for its serializer snapshot class. By default, the base
- * implementations of these methods are empty, i.e. this class assumes that subclasses do not have
- * any outer snapshot that needs to be persisted.
+ * ClassLoader)}, and {@link #resolveOuterSchemaCompatibility(TypeSerializer)} when using this class
+ * as the base for its serializer snapshot class. By default, the base implementations of these
+ * methods are empty, i.e. this class assumes that subclasses do not have any outer snapshot that
+ * needs to be persisted.
  *
  * <h2>Snapshot Versioning</h2>
  *

--- a/flink-core/src/main/java/org/apache/flink/core/fs/LocatedFileStatus.java
+++ b/flink-core/src/main/java/org/apache/flink/core/fs/LocatedFileStatus.java
@@ -23,7 +23,7 @@ import org.apache.flink.annotation.Public;
 /**
  * A {@code LocatedFileStatus} is a {@link FileStatus} that contains additionally the location
  * information of the file directly. The information is accessible through the {@link
- * #getBlockLocations()} ()} method.
+ * #getBlockLocations()} method.
  *
  * <p>This class eagerly communicates the block information (including locations) when that
  * information is readily (or cheaply) available. That way users can avoid an additional call to

--- a/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
+++ b/flink-core/src/main/java/org/apache/flink/util/concurrent/FutureUtils.java
@@ -687,7 +687,7 @@ public class FutureUtils {
      * the Futures in the conjunction fails.
      *
      * <p>The advantage of using the ConjunctFuture over chaining all the futures (such as via
-     * {@link CompletableFuture#thenCombine(CompletionStage, BiFunction)} )}) is that ConjunctFuture
+     * {@link CompletableFuture#thenCombine(CompletionStage, BiFunction)}) is that ConjunctFuture
      * also tracks how many of the Futures are already complete.
      */
     public abstract static class ConjunctFuture<T> extends CompletableFuture<T> {

--- a/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
+++ b/flink-java/src/main/java/org/apache/flink/api/java/DataSet.java
@@ -1186,8 +1186,8 @@ public abstract class DataSet<T> {
      * Initiates a delta iteration. A delta iteration is similar to a regular iteration (as started
      * by {@link #iterate(int)}, but maintains state across the individual iteration steps. The
      * Solution set, which represents the current state at the beginning of each iteration can be
-     * obtained via {@link org.apache.flink.api.java.operators.DeltaIteration#getSolutionSet()} ()}.
-     * It can be be accessed by joining (or CoGrouping) with it. The DataSet that represents the
+     * obtained via {@link org.apache.flink.api.java.operators.DeltaIteration#getSolutionSet()}. It
+     * can be be accessed by joining (or CoGrouping) with it. The DataSet that represents the
      * workset of an iteration can be obtained via {@link
      * org.apache.flink.api.java.operators.DeltaIteration#getWorkset()}. The solution set is updated
      * by producing a delta for it, which is merged into the solution set at the end of each

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -97,7 +97,7 @@ public class NFA<T> {
 
     /**
      * The length of a windowed pattern, as specified using the {@link
-     * org.apache.flink.cep.pattern.Pattern#within(Time)} Pattern.within(Time)} method.
+     * org.apache.flink.cep.pattern.Pattern#within(Time) Pattern.within(Time)} method.
      */
     private final long windowTime;
 

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/KeyedStateBootstrapFunction.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/functions/KeyedStateBootstrapFunction.java
@@ -33,7 +33,7 @@ import org.apache.flink.streaming.api.TimerService;
  * org.apache.flink.api.common.functions.RichFunction}. Therefore, access to the {@link
  * org.apache.flink.api.common.functions.RuntimeContext} is always available and setup and teardown
  * methods can be implemented. See {@link
- * org.apache.flink.api.common.functions.RichFunction#open(Configuration)})} and {@link
+ * org.apache.flink.api.common.functions.RichFunction#open(Configuration)} and {@link
  * org.apache.flink.api.common.functions.RichFunction#close()}.
  *
  * @param <K> Type of the keys.

--- a/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/OperatorIDGenerator.java
+++ b/flink-libraries/flink-state-processing-api/src/main/java/org/apache/flink/state/api/runtime/OperatorIDGenerator.java
@@ -35,7 +35,7 @@ public final class OperatorIDGenerator {
      * Generate {@link OperatorID}'s from {@code uid}'s.
      *
      * <p>{@link
-     * org.apache.flink.streaming.api.graph.StreamGraphHasherV2#traverseStreamGraphAndGenerateHashes(StreamGraph)})}
+     * org.apache.flink.streaming.api.graph.StreamGraphHasherV2#traverseStreamGraphAndGenerateHashes(StreamGraph)}
      *
      * @param uid {@code DataStream} operator uid.
      * @return corresponding {@link OperatorID}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/channel/ChannelStateWriter.java
@@ -109,8 +109,8 @@ public interface ChannelStateWriter extends Closeable {
     /**
      * Add in-flight buffers from the {@link
      * org.apache.flink.runtime.io.network.partition.consumer.InputChannel InputChannel}. Must be
-     * called after {@link #start} (long)} and before {@link #finishInput(long)}. Buffers are
-     * recycled after they are written or exception occurs.
+     * called after {@link #start(long,CheckpointOptions)} and before {@link #finishInput(long)}.
+     * Buffers are recycled after they are written or exception occurs.
      *
      * @param startSeqNum sequence number of the 1st passed buffer. It is intended to use for
      *     incremental snapshots. If no data is passed it is ignored.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionType.java
@@ -189,7 +189,7 @@ public enum ResultPartitionType {
     }
 
     /**
-     * {@link #isHybridResultPartition()} ()} is used to judge whether it is the specified {@link
+     * {@link #isHybridResultPartition()} is used to judge whether it is the specified {@link
      * #HYBRID_FULL} or {@link #HYBRID_SELECTIVE} resultPartitionType.
      *
      * <p>this method suitable for judgment conditions related to the specific implementation of

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskInvokable.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/tasks/TaskInvokable.java
@@ -51,8 +51,8 @@ public interface TaskInvokable {
      *
      * <p>This method is called by the task manager when the actual execution of the task starts.
      *
-     * <p>All resources should be cleaned up by calling {@link #cleanUp(Throwable)} ()} after the
-     * method returns.
+     * <p>All resources should be cleaned up by calling {@link #cleanUp(Throwable)} after the method
+     * returns.
      */
     void invoke() throws Exception;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSerializerProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateSerializerProvider.java
@@ -214,9 +214,9 @@ public abstract class StateSerializerProvider<T> {
      * <ul>
      *   <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAsIs()}: nothing needs to be done.
      *       {@link #currentSchemaSerializer()} now returns the newly registered serializer.
-     *   <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAfterMigration()} ()}: state needs
-     *       to be migrated before the serializer returned by {@link #currentSchemaSerializer()} can
-     *       be used. The migration should be performed by reading the state with {@link
+     *   <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAfterMigration()}: state needs to
+     *       be migrated before the serializer returned by {@link #currentSchemaSerializer()} can be
+     *       used. The migration should be performed by reading the state with {@link
      *       #previousSchemaSerializer()}, and then writing it again with {@link
      *       #currentSchemaSerializer()}.
      *   <li>{@link TypeSerializerSchemaCompatibility#isIncompatible()}: the registered serializer
@@ -247,9 +247,9 @@ public abstract class StateSerializerProvider<T> {
      *   <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAsIs()}: nothing needs to be done.
      *       {@link #currentSchemaSerializer()} remains to return the initially registered
      *       serializer.
-     *   <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAfterMigration()} ()}: state needs
-     *       to be migrated before the serializer returned by {@link #currentSchemaSerializer()} can
-     *       be used. The migration should be performed by reading the state with {@link
+     *   <li>{@link TypeSerializerSchemaCompatibility#isCompatibleAfterMigration()}: state needs to
+     *       be migrated before the serializer returned by {@link #currentSchemaSerializer()} can be
+     *       used. The migration should be performed by reading the state with {@link
      *       #previousSchemaSerializer()}, and then writing it again with {@link
      *       #currentSchemaSerializer()}.
      *   <li>{@link TypeSerializerSchemaCompatibility#isIncompatible()}: the registered serializer

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMap.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/heap/StateMap.java
@@ -77,7 +77,7 @@ public abstract class StateMap<K, N, S> implements Iterable<StateEntry<K, N, S>>
 
     /**
      * Maps the specified key/namespace composite key to the specified value. This method should be
-     * preferred over {@link #putAndGetOld(K, N, S)} (Namespace, State)} when the caller is not
+     * preferred over {@link #putAndGetOld(K, N, S)} (key, Namespace, State) when the caller is not
      * interested in the old state.
      *
      * @param key the key. Not null.

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/SourceFunction.java
@@ -101,11 +101,11 @@ public interface SourceFunction<T> extends Function, Serializable {
     /**
      * Starts the source. Implementations use the {@link SourceContext} to emit elements. Sources
      * that checkpoint their state for fault tolerance should use the {@link
-     * SourceContext#getCheckpointLock()} checkpoint lock} to ensure consistency between the
+     * SourceContext#getCheckpointLock() checkpoint lock} to ensure consistency between the
      * bookkeeping and emitting the elements.
      *
      * <p>Sources that implement {@link CheckpointedFunction} must lock on the {@link
-     * SourceContext#getCheckpointLock()} checkpoint lock} checkpoint lock (using a synchronized
+     * SourceContext#getCheckpointLock() checkpoint lock} checkpoint lock (using a synchronized
      * block) before updating internal state and emitting elements, to make both an atomic
      * operation.
      *

--- a/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
+++ b/flink-table/flink-sql-parser/src/test/java/org/apache/flink/sql/parser/FlinkSqlParserImplTest.java
@@ -190,23 +190,24 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
     @Test
     void testAlterFunction() {
-        sql("alter function function1 as 'org.apache.fink.function.function1'")
-                .ok("ALTER FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1'");
+        sql("alter function function1 as 'org.apache.flink.function.function1'")
+                .ok("ALTER FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1'");
 
-        sql("alter temporary function function1 as 'org.apache.fink.function.function1'")
-                .ok("ALTER TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1'");
-
-        sql("alter temporary function function1 as 'org.apache.fink.function.function1' language scala")
+        sql("alter temporary function function1 as 'org.apache.flink.function.function1'")
                 .ok(
-                        "ALTER TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE SCALA");
+                        "ALTER TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1'");
 
-        sql("alter temporary system function function1 as 'org.apache.fink.function.function1'")
+        sql("alter temporary function function1 as 'org.apache.flink.function.function1' language scala")
                 .ok(
-                        "ALTER TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1'");
+                        "ALTER TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE SCALA");
 
-        sql("alter temporary system function function1 as 'org.apache.fink.function.function1' language java")
+        sql("alter temporary system function function1 as 'org.apache.flink.function.function1'")
                 .ok(
-                        "ALTER TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE JAVA");
+                        "ALTER TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1'");
+
+        sql("alter temporary system function function1 as 'org.apache.flink.function.function1' language java")
+                .ok(
+                        "ALTER TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA");
     }
 
     @Test
@@ -1882,70 +1883,70 @@ class FlinkSqlParserImplTest extends SqlParserTest {
 
     @Test
     void testCreateFunction() {
-        sql("create function catalog1.db1.function1 as 'org.apache.fink.function.function1'")
+        sql("create function catalog1.db1.function1 as 'org.apache.flink.function.function1'")
                 .ok(
-                        "CREATE FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+                        "CREATE FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.flink.function.function1'");
 
-        sql("create temporary function catalog1.db1.function1 as 'org.apache.fink.function.function1'")
+        sql("create temporary function catalog1.db1.function1 as 'org.apache.flink.function.function1'")
                 .ok(
-                        "CREATE TEMPORARY FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+                        "CREATE TEMPORARY FUNCTION `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.flink.function.function1'");
 
-        sql("create temporary function db1.function1 as 'org.apache.fink.function.function1'")
+        sql("create temporary function db1.function1 as 'org.apache.flink.function.function1'")
                 .ok(
-                        "CREATE TEMPORARY FUNCTION `DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+                        "CREATE TEMPORARY FUNCTION `DB1`.`FUNCTION1` AS 'org.apache.flink.function.function1'");
 
-        sql("create temporary function function1 as 'org.apache.fink.function.function1'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1'")
                 .ok(
-                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1'");
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1'");
 
-        sql("create temporary function if not exists catalog1.db1.function1 as 'org.apache.fink.function.function1'")
+        sql("create temporary function if not exists catalog1.db1.function1 as 'org.apache.flink.function.function1'")
                 .ok(
-                        "CREATE TEMPORARY FUNCTION IF NOT EXISTS `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.fink.function.function1'");
+                        "CREATE TEMPORARY FUNCTION IF NOT EXISTS `CATALOG1`.`DB1`.`FUNCTION1` AS 'org.apache.flink.function.function1'");
 
-        sql("create temporary function function1 as 'org.apache.fink.function.function1' language java")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language java")
                 .ok(
-                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE JAVA");
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA");
 
-        sql("create temporary system function  function1 as 'org.apache.fink.function.function1' language scala")
+        sql("create temporary system function  function1 as 'org.apache.flink.function.function1' language scala")
                 .ok(
-                        "CREATE TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE SCALA");
+                        "CREATE TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE SCALA");
 
         // Temporary system function always belongs to the system and current session.
-        sql("create temporary system function catalog1^.^db1.function1 as 'org.apache.fink.function.function1'")
+        sql("create temporary system function catalog1^.^db1.function1 as 'org.apache.flink.function.function1'")
                 .fails("(?s).*Encountered \".\" at.*");
 
-        sql("create ^system^ function function1 as 'org.apache.fink.function.function1'")
+        sql("create ^system^ function function1 as 'org.apache.flink.function.function1'")
                 .fails(
                         "CREATE SYSTEM FUNCTION is not supported, "
                                 + "system functions can only be registered as temporary "
                                 + "function, you can use CREATE TEMPORARY SYSTEM FUNCTION instead.");
 
         // test create function using jar
-        sql("create temporary function function1 as 'org.apache.fink.function.function1' language java using jar 'file:///path/to/test.jar'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language java using jar 'file:///path/to/test.jar'")
                 .ok(
-                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar'");
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar'");
 
-        sql("create temporary function function1 as 'org.apache.fink.function.function1' language scala using jar '/path/to/test.jar'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language scala using jar '/path/to/test.jar'")
                 .ok(
-                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE SCALA USING JAR '/path/to/test.jar'");
+                        "CREATE TEMPORARY FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE SCALA USING JAR '/path/to/test.jar'");
 
-        sql("create temporary system function function1 as 'org.apache.fink.function.function1' language scala using jar '/path/to/test.jar'")
+        sql("create temporary system function function1 as 'org.apache.flink.function.function1' language scala using jar '/path/to/test.jar'")
                 .ok(
-                        "CREATE TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE SCALA USING JAR '/path/to/test.jar'");
+                        "CREATE TEMPORARY SYSTEM FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE SCALA USING JAR '/path/to/test.jar'");
 
-        sql("create function function1 as 'org.apache.fink.function.function1' language java using jar 'file:///path/to/test.jar', jar 'hdfs:///path/to/test2.jar'")
+        sql("create function function1 as 'org.apache.flink.function.function1' language java using jar 'file:///path/to/test.jar', jar 'hdfs:///path/to/test2.jar'")
                 .ok(
-                        "CREATE FUNCTION `FUNCTION1` AS 'org.apache.fink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar', JAR 'hdfs:///path/to/test2.jar'");
+                        "CREATE FUNCTION `FUNCTION1` AS 'org.apache.flink.function.function1' LANGUAGE JAVA USING JAR 'file:///path/to/test.jar', JAR 'hdfs:///path/to/test2.jar'");
 
-        sql("create temporary function function1 as 'org.apache.fink.function.function1' language ^sql^ using jar 'file:///path/to/test.jar'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language ^sql^ using jar 'file:///path/to/test.jar'")
                 .fails("CREATE FUNCTION USING JAR syntax is not applicable to SQL language.");
 
-        sql("create temporary function function1 as 'org.apache.fink.function.function1' language ^python^ using jar 'file:///path/to/test.jar'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language ^python^ using jar 'file:///path/to/test.jar'")
                 .fails("CREATE FUNCTION USING JAR syntax is not applicable to PYTHON language.");
 
-        sql("create temporary function function1 as 'org.apache.fink.function.function1' language java using ^file^ 'file:///path/to/test'")
+        sql("create temporary function function1 as 'org.apache.flink.function.function1' language java using ^file^ 'file:///path/to/test'")
                 .fails(
-                        "Encountered \"file\" at line 1, column 97.\n"
+                        "Encountered \"file\" at line 1, column 98.\n"
                                 + "Was expecting:\n"
                                 + "    \"JAR\" ...\n"
                                 + "    .*");

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/utils/ProjectionOperationFactory.java
@@ -119,7 +119,7 @@ final class ProjectionOperationFactory {
      *
      * <ul>
      *   <li>{@link FieldReferenceExpression}, {@link TableReferenceExpression}, {@link
-     *       LocalReferenceExpression} and {@link BuiltInFunctionDefinitions#AS} are already named}
+     *       LocalReferenceExpression} and {@link BuiltInFunctionDefinitions#AS} are already named
      *   <li>{@link BuiltInFunctionDefinitions#CAST} use the name of underlying expression appended
      *       with the name of the type
      *   <li>{@link BuiltInFunctionDefinitions#GET} uses pattern <i>[underlying name][$fieldName]{1,

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/api/DataTypes.java
@@ -783,7 +783,7 @@ public final class DataTypes {
      * <p>Use {@link #FIELD(String, AbstractDataType)} or {@link #FIELD(String, AbstractDataType,
      * String)} to construct fields.
      *
-     * <p>Note: Compared to {@link #ROW(Field...)} )}, this method produces an {@link
+     * <p>Note: Compared to {@link #ROW(Field...)}, this method produces an {@link
      * UnresolvedDataType} with {@link UnresolvedField}s. In most of the cases, the {@link
      * UnresolvedDataType} will be automatically resolved by the API. At other locations, a {@link
      * DataTypeFactory} is provided.

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterJoinRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/FlinkFilterJoinRule.java
@@ -549,7 +549,7 @@ public abstract class FlinkFilterJoinRule<C extends FlinkFilterJoinRule.Config> 
         @Value.Parameter
         Predicate getPredicate();
 
-        /** Sets {@link #getPredicate()} ()}. */
+        /** Sets {@link #getPredicate()}. */
         Config withPredicate(Predicate predicate);
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowListState.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/window/state/WindowListState.java
@@ -44,7 +44,7 @@ public final class WindowListState<W> implements WindowState<W> {
     }
 
     /**
-     * Updates the operator state accessible by {@link #get(W)})} by adding the given value to the
+     * Updates the operator state accessible by {@link #get(W)} by adding the given value to the
      * list of values. The next time {@link #get(W)} is called (for the same state partition) the
      * returned state will represent the updated list.
      *

--- a/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SnapshotMigrationTestBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/checkpointing/utils/SnapshotMigrationTestBase.java
@@ -162,7 +162,7 @@ public abstract class SnapshotMigrationTestBase extends TestLogger {
          * @param snapshotType Specifies the snapshot type.
          * @param flinkVersions A collection of {@link FlinkVersion}.
          * @return A collection of {@link SnapshotSpec} that differ only by means of {@link
-         *     FlinkVersion} FlinkVersion}.
+         *     FlinkVersion}.
          */
         public static Collection<SnapshotSpec> withVersions(
                 String stateBackendType,

--- a/pom.xml
+++ b/pom.xml
@@ -1500,6 +1500,8 @@ under the License.
                         <exclude>flink-formats/flink-avro/src/test/resources/flink_11-kryo_registrations</exclude>
 						<exclude>flink-scala/src/test/resources/flink_11-kryo_registrations</exclude>
 						<exclude>flink-core/src/test/resources/kryo-serializer-config-snapshot-v1</exclude>
+						<exclude>flink-core/src/test/resources/abstractID-with-toString-field</exclude>
+						<exclude>flink-core/src/test/resources/abstractID-with-toString-field-set</exclude>
 						<exclude>flink-formats/flink-avro/src/test/resources/avro/*.avsc</exclude>
 						<exclude>out/test/flink-avro/avro/user.avsc</exclude>
 						<exclude>flink-table/flink-sql-client/src/test/resources/**/*.out</exclude>
@@ -1510,6 +1512,7 @@ under the License.
 						<exclude>flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/hadoop/config/keystore.jks</exclude>
 						<exclude>flink-connectors/flink-connector-kafka/src/test/resources/**</exclude>
 						<exclude>flink-connectors/flink-connector-hive/src/test/resources/**</exclude>
+						<exclude>flink-connectors/flink-file-sink-common/src/test/resources/recoverable-serializer-migration/**</exclude>
 						<exclude>flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/answer_set/*</exclude>
 						<exclude>flink-end-to-end-tests/flink-tpcds-test/tpcds-tool/query/*</exclude>
 						<exclude>flink-connectors/flink-connector-aws-base/src/test/resources/profile</exclude>


### PR DESCRIPTION
- java document {@link} is incorrectly used
- The Chinese document stream kafka connect has a spelling error
- An error spelling flink as fink occurred in FlinkSqlParserImplTest
Details are available at https://issues.apache.org/jira/browse/FLINK-30690