### PR TITLE
[FLINK-30662][table] Planner supports delete

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -721,7 +721,8 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         } else {
             if (operations.size() > 1
                     && operations.stream().anyMatch(this::isRowLevelModification)) {
-                throw new TableException("Only single UPDATE/DELETE statement is supported.");
+                throw new TableException(
+                        "Unsupported SQL query! Only accept a single SQL statement of type DELETE, UPDATE.");
             }
             return planner.explain(operations, format, extraDetails);
         }
@@ -784,6 +785,7 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
 
         if (operations.size() != 1
                 || !(operations.get(0) instanceof ModifyOperation)
+                || isRowLevelModification(operations.get(0))
                 || operations.get(0) instanceof CreateTableASOperation) {
             throw new TableException(UNSUPPORTED_QUERY_IN_COMPILE_PLAN_SQL_MSG);
         }
@@ -859,7 +861,8 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                     if (operations.size() > 1) {
                         throw new TableException(
                                 String.format(
-                                        "Only single %s statement is supported.", modifyType));
+                                        "Unsupported SQL query! Only accept a single SQL statement of type %s.",
+                                        modifyType));
                     }
                     if (isStreamingMode) {
                         throw new TableException(

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -89,6 +89,7 @@ import org.apache.flink.table.module.ModuleManager;
 import org.apache.flink.table.operations.CollectModifyOperation;
 import org.apache.flink.table.operations.CompileAndExecutePlanOperation;
 import org.apache.flink.table.operations.CreateTableASOperation;
+import org.apache.flink.table.operations.DeleteFromFilterOperation;
 import org.apache.flink.table.operations.DescribeTableOperation;
 import org.apache.flink.table.operations.ExplainOperation;
 import org.apache.flink.table.operations.LoadModuleOperation;
@@ -718,6 +719,10 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
         if (operations.isEmpty()) {
             return "";
         } else {
+            if (operations.size() > 1
+                    && operations.stream().anyMatch(this::isRowLevelModification)) {
+                throw new TableException("Only single UPDATE/DELETE statement is supported.");
+            }
             return planner.explain(operations, format, extraDetails);
         }
     }
@@ -847,6 +852,25 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
                 executeInternal(ctasOperation.getCreateTableOperation());
                 mapOperations.add(ctasOperation.toSinkModifyOperation(catalogManager));
             } else {
+                boolean isRowLevelModification = isRowLevelModification(modify);
+                if (isRowLevelModification) {
+                    String modifyType =
+                            ((SinkModifyOperation) modify).isDelete() ? "DELETE" : "UPDATE";
+                    if (operations.size() > 1) {
+                        throw new TableException(
+                                String.format(
+                                        "Only single %s statement is supported.", modifyType));
+                    }
+                    if (isStreamingMode) {
+                        throw new TableException(
+                                String.format(
+                                        "%s statement is not supported for streaming mode now.",
+                                        modifyType));
+                    }
+                    if (modify instanceof DeleteFromFilterOperation) {
+                        return executeInternal((DeleteFromFilterOperation) modify);
+                    }
+                }
                 mapOperations.add(modify);
             }
         }
@@ -863,6 +887,21 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
             }
         }
         return result;
+    }
+
+    private TableResultInternal executeInternal(
+            DeleteFromFilterOperation deleteFromFilterOperation) {
+        Optional<Long> rows =
+                deleteFromFilterOperation.getSupportsDeletePushDownSink().executeDeletion();
+        if (rows.isPresent()) {
+            return TableResultImpl.builder()
+                    .resultKind(ResultKind.SUCCESS)
+                    .schema(ResolvedSchema.of(Column.physical("result", DataTypes.STRING())))
+                    .data(Arrays.asList(Row.of(String.valueOf(rows.get())), Row.of("OK")))
+                    .build();
+        } else {
+            return TableResultImpl.TABLE_RESULT_OK;
+        }
     }
 
     private TableResultInternal executeInternal(
@@ -1972,5 +2011,13 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
     @Override
     public String explainPlan(InternalPlan compiledPlan, ExplainDetail... extraDetails) {
         return planner.explainPlan(compiledPlan, extraDetails);
+    }
+
+    private boolean isRowLevelModification(Operation operation) {
+        if (operation instanceof SinkModifyOperation) {
+            SinkModifyOperation sinkModifyOperation = (SinkModifyOperation) operation;
+            return sinkModifyOperation.isDelete() || sinkModifyOperation.isUpdate();
+        }
+        return true;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ContextResolvedTable.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/catalog/ContextResolvedTable.java
@@ -157,6 +157,15 @@ public final class ContextResolvedTable {
                 false);
     }
 
+    /** Copy the {@link ContextResolvedTable}, replacing the underlying {@link ResolvedSchema}. */
+    public ContextResolvedTable copy(ResolvedSchema newSchema) {
+        return new ContextResolvedTable(
+                objectIdentifier,
+                catalog,
+                new ResolvedCatalogTable((CatalogTable) resolvedTable.getOrigin(), newSchema),
+                false);
+    }
+
     /**
      * This method tries to return the connector name of the table, trying to provide a bit more
      * helpful toString for anonymous tables. It's only to help users to debug, and its return value

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DeleteFromFilterOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/DeleteFromFilterOperation.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.connector.sink.abilities.SupportsDeletePushDown;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** The operation for deleting data in a table according to filters directly. */
+@Internal
+public class DeleteFromFilterOperation extends SinkModifyOperation {
+
+    @Nonnull private final SupportsDeletePushDown supportsDeletePushDownSink;
+    @Nonnull private final List<ResolvedExpression> filters;
+
+    public DeleteFromFilterOperation(
+            ContextResolvedTable contextResolvedTable,
+            @Nonnull SupportsDeletePushDown supportsDeletePushDownSink,
+            @Nonnull List<ResolvedExpression> filters) {
+        super(contextResolvedTable, null, ModifyType.DELETE);
+        this.supportsDeletePushDownSink = Preconditions.checkNotNull(supportsDeletePushDownSink);
+        this.filters = Preconditions.checkNotNull(filters);
+    }
+
+    @Nonnull
+    public SupportsDeletePushDown getSupportsDeletePushDownSink() {
+        return supportsDeletePushDownSink;
+    }
+
+    @Nonnull
+    public List<ResolvedExpression> getFilters() {
+        return filters;
+    }
+
+    @Override
+    public String asSummaryString() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("identifier", getContextResolvedTable().getIdentifier().asSummaryString());
+        params.put("filters", filters);
+        return OperationUtils.formatWithChildren(
+                "DeleteFromFilter", params, Collections.emptyList(), Operation::asSummaryString);
+    }
+
+    @Override
+    public QueryOperation getChild() {
+        throw new UnsupportedOperationException("This shouldn't be called");
+    }
+
+    @Override
+    public <T> T accept(ModifyOperationVisitor<T> visitor) {
+        throw new UnsupportedOperationException("This shouldn't be called");
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/DynamicSourceUtils.java
@@ -33,15 +33,18 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.WatermarkSpec;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.RowLevelModificationScanContext;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource.ScanRuntimeProvider;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.connector.source.abilities.SupportsRowLevelModificationScan;
 import org.apache.flink.table.planner.calcite.FlinkRelBuilder;
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
 import org.apache.flink.table.planner.plan.stats.FlinkStatistic;
+import org.apache.flink.table.planner.utils.RowLevelModificationContextUtils;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
 import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
 import org.apache.flink.table.types.DataType;
@@ -157,6 +160,7 @@ public final class DynamicSourceUtils {
         if (source instanceof ScanTableSource) {
             validateScanSource(
                     tableDebugName, schema, (ScanTableSource) source, isBatchMode, config);
+            prepareRowLevelModificationScan(source);
         }
 
         // lookup table source is validated in LookupJoin node
@@ -378,7 +382,7 @@ public final class DynamicSourceUtils {
                 .collect(Collectors.toList());
     }
 
-    private static void validateAndApplyMetadata(
+    public static void validateAndApplyMetadata(
             String tableDebugName, ResolvedSchema schema, DynamicTableSource source) {
         final List<MetadataColumn> metadataColumns = extractMetadataColumns(schema);
 
@@ -552,6 +556,26 @@ public final class DynamicSourceUtils {
                     String.format(
                             "A nested field '%s' cannot be declared as rowtime attribute for table '%s' right now.",
                             rowtimeAttribute, tableDebugName));
+        }
+    }
+
+    private static void prepareRowLevelModificationScan(DynamicTableSource dynamicTableSource) {
+        // if the modification type has been set and the dynamic source supports row-level
+        // modification scan
+        if (RowLevelModificationContextUtils.getModificationType() != null
+                && dynamicTableSource instanceof SupportsRowLevelModificationScan) {
+            SupportsRowLevelModificationScan modificationScan =
+                    (SupportsRowLevelModificationScan) dynamicTableSource;
+            // get the previous scan context
+            RowLevelModificationScanContext scanContext =
+                    RowLevelModificationContextUtils.getScanContext();
+            // pass the previous scan context to current table soruce and
+            // get a new scan context
+            RowLevelModificationScanContext newScanContext =
+                    modificationScan.applyRowLevelModificationScan(
+                            RowLevelModificationContextUtils.getModificationType(), scanContext);
+            // set the scan context
+            RowLevelModificationContextUtils.setScanContext(newScanContext);
         }
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/DeletePushDownUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/DeletePushDownUtils.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogBaseTable;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.resolver.ExpressionResolver;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.factories.TableFactoryUtil;
+import org.apache.flink.table.module.Module;
+import org.apache.flink.table.planner.calcite.FlinkContext;
+import org.apache.flink.table.planner.plan.rules.logical.SimplifyFilterConditionRule;
+import org.apache.flink.table.planner.plan.utils.FlinkRexUtil;
+import org.apache.flink.table.planner.plan.utils.RexNodeToExpressionConverter;
+import org.apache.flink.table.planner.utils.ShortcutUtils;
+import org.apache.flink.table.planner.utils.TableConfigUtils;
+
+import org.apache.calcite.plan.RelOptPredicateList;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalTableModify;
+import org.apache.calcite.rel.logical.LogicalTableScan;
+import org.apache.calcite.rel.rules.ReduceExpressionsRule;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.stream.Collectors;
+
+import scala.Option;
+import scala.Tuple2;
+
+/** A utility class for delete push down. */
+public class DeletePushDownUtils {
+
+    /**
+     * Get the {@link DynamicTableSink} for the table to be modified. Return Optional.empty() if it
+     * can't get the {@link DynamicTableSink}.
+     */
+    public static Optional<DynamicTableSink> getDynamicTableSink(
+            ContextResolvedTable contextResolvedTable,
+            LogicalTableModify tableModify,
+            CatalogManager catalogManager) {
+        final FlinkContext context = ShortcutUtils.unwrapContext(tableModify.getCluster());
+
+        CatalogBaseTable catalogBaseTable = contextResolvedTable.getTable();
+        // only consider DynamicTableSink
+        if (catalogBaseTable instanceof CatalogTable) {
+            ResolvedCatalogTable resolvedTable = contextResolvedTable.getResolvedTable();
+            Optional<Catalog> optionalCatalog = contextResolvedTable.getCatalog();
+            ObjectIdentifier objectIdentifier = contextResolvedTable.getIdentifier();
+            boolean isTemporary = contextResolvedTable.isTemporary();
+            // only consider the CatalogTable that doesn't use legacy connector sink option
+            if (!contextResolvedTable.isAnonymous()
+                    && !TableFactoryUtil.isLegacyConnectorOptions(
+                            catalogManager
+                                    .getCatalog(objectIdentifier.getCatalogName())
+                                    .orElse(null),
+                            context.getTableConfig(),
+                            !context.isBatchMode(),
+                            objectIdentifier,
+                            resolvedTable,
+                            isTemporary)) {
+                DynamicTableSinkFactory dynamicTableSinkFactory = null;
+                if (optionalCatalog.isPresent()
+                        && optionalCatalog.get().getFactory().isPresent()
+                        && optionalCatalog.get().getFactory().get()
+                                instanceof DynamicTableSinkFactory) {
+                    // try get from catalog
+                    dynamicTableSinkFactory =
+                            (DynamicTableSinkFactory) optionalCatalog.get().getFactory().get();
+                }
+
+                if (dynamicTableSinkFactory == null) {
+                    Optional<DynamicTableSinkFactory> factoryFromModule =
+                            context.getModuleManager().getFactory((Module::getTableSinkFactory));
+                    // then try get from module
+                    dynamicTableSinkFactory = factoryFromModule.orElse(null);
+                }
+                // create table dynamic table sink
+                DynamicTableSink tableSink =
+                        FactoryUtil.createDynamicTableSink(
+                                dynamicTableSinkFactory,
+                                objectIdentifier,
+                                resolvedTable,
+                                Collections.emptyMap(),
+                                context.getTableConfig(),
+                                context.getClassLoader(),
+                                contextResolvedTable.isTemporary());
+                return Optional.of(tableSink);
+            }
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Get the resolved filter expressions from the {@code WHERE} clause in DELETE statement, return
+     * Optional.empty() if {@code WHERE} clause contains sub-query.
+     */
+    public static Optional<List<ResolvedExpression>> getResolvedFilterExpressions(
+            LogicalTableModify tableModify) {
+        FlinkContext context = ShortcutUtils.unwrapContext(tableModify.getCluster());
+        RelNode input = tableModify.getInput().getInput(0);
+        // no WHERE clause, return an empty list
+        if (input instanceof LogicalTableScan) {
+            return Optional.of(Collections.emptyList());
+        }
+        if (!(input instanceof LogicalFilter)) {
+            return Optional.empty();
+        }
+
+        Filter filter = (Filter) input;
+        if (RexUtil.SubQueryFinder.containsSubQuery(filter)) {
+            return Optional.empty();
+        }
+
+        // optimize the filter
+        filter = prepareFilter(filter);
+
+        // resolve the filter to get resolved expression
+        List<ResolvedExpression> resolveExpression = resolveFilter(context, filter);
+        return Optional.ofNullable(resolveExpression);
+    }
+
+    /** Prepare the filter with reducing && simplifying. */
+    private static Filter prepareFilter(Filter filter) {
+        // we try to reduce and simplify the filter
+        ReduceExpressionsRuleProxy reduceExpressionsRuleProxy = ReduceExpressionsRuleProxy.INSTANCE;
+        SimplifyFilterConditionRule simplifyFilterConditionRule =
+                SimplifyFilterConditionRule.INSTANCE();
+        // max iteration num for reducing and simplifying filter,
+        // we use 5 as the max iteration num which is same with the iteration num in Flink's plan
+        // optimizing.
+        int maxIteration = 5;
+
+        boolean changed = true;
+        int iteration = 1;
+        // iterate until it reaches max iteration num or there's no changes in one iterate
+        while (changed && iteration <= maxIteration) {
+            changed = false;
+            // first apply the rule to reduce condition in filter
+            RexNode newCondition = filter.getCondition();
+            List<RexNode> expList = new ArrayList<>();
+            expList.add(newCondition);
+            if (reduceExpressionsRuleProxy.reduce(filter, expList)) {
+                // get the new condition
+                newCondition = expList.get(0);
+                changed = true;
+            }
+            // create a new filter
+            filter = filter.copy(filter.getTraitSet(), filter.getInput(), newCondition);
+            // then apply the rule to simplify filter
+            Option<Filter> changedFilter =
+                    simplifyFilterConditionRule.simplify(filter, new boolean[] {false});
+            if (changedFilter.isDefined()) {
+                filter = changedFilter.get();
+                changed = true;
+            }
+            iteration += 1;
+        }
+        return filter;
+    }
+
+    /**
+     * A proxy for {@link ReduceExpressionsRule}, which enables us to call the method {@link
+     * ReduceExpressionsRule#reduceExpressions(RelNode, List, RelOptPredicateList)}.
+     */
+    private static class ReduceExpressionsRuleProxy
+            extends ReduceExpressionsRule<ReduceExpressionsRule.Config> {
+        private static final ReduceExpressionsRule.Config config =
+                FilterReduceExpressionsRule.FilterReduceExpressionsRuleConfig.DEFAULT;
+        private static final ReduceExpressionsRuleProxy INSTANCE = new ReduceExpressionsRuleProxy();
+
+        public ReduceExpressionsRuleProxy() {
+            super(config);
+        }
+
+        @Override
+        public void onMatch(RelOptRuleCall relOptRuleCall) {
+            throw new UnsupportedOperationException("This shouldn't be called");
+        }
+
+        private boolean reduce(RelNode rel, List<RexNode> expList) {
+            return reduceExpressions(
+                    rel,
+                    expList,
+                    RelOptPredicateList.EMPTY,
+                    true,
+                    config.matchNullability(),
+                    config.treatDynamicCallsAsConstant());
+        }
+    }
+
+    /** Return the ResolvedExpression according to Filter. */
+    private static List<ResolvedExpression> resolveFilter(FlinkContext context, Filter filter) {
+        Tuple2<RexNode[], RexNode[]> extractedPredicates =
+                FlinkRexUtil.extractPredicates(
+                        filter.getInput().getRowType().getFieldNames().toArray(new String[0]),
+                        filter.getCondition(),
+                        filter,
+                        filter.getCluster().getRexBuilder());
+        RexNode[] convertiblePredicates = extractedPredicates._1;
+        RexNode[] unconvertedPredicates = extractedPredicates._2;
+        if (unconvertedPredicates.length != 0) {
+            // if contain any unconverted condition, return null
+            return null;
+        }
+        RexNodeToExpressionConverter converter =
+                new RexNodeToExpressionConverter(
+                        filter.getCluster().getRexBuilder(),
+                        filter.getInput().getRowType().getFieldNames().toArray(new String[0]),
+                        context.getFunctionCatalog(),
+                        context.getCatalogManager(),
+                        TimeZone.getTimeZone(
+                                TableConfigUtils.getLocalTimeZone(context.getTableConfig())));
+        List<Expression> filters =
+                Arrays.stream(convertiblePredicates)
+                        .map(
+                                p -> {
+                                    Option<ResolvedExpression> expr = p.accept(converter);
+                                    if (expr.isDefined()) {
+                                        return expr.get();
+                                    } else {
+                                        throw new TableException(
+                                                String.format(
+                                                        "%s can not be converted to Expression",
+                                                        p));
+                                    }
+                                })
+                        .collect(Collectors.toList());
+        ExpressionResolver resolver =
+                ExpressionResolver.resolverFor(
+                                context.getTableConfig(),
+                                context.getClassLoader(),
+                                name -> Optional.empty(),
+                                context.getFunctionCatalog()
+                                        .asLookup(
+                                                str -> {
+                                                    throw new TableException(
+                                                            "We should not need to lookup any expressions at this point");
+                                                }),
+                                context.getCatalogManager().getDataTypeFactory(),
+                                (sqlExpression, inputRowType, outputType) -> {
+                                    throw new TableException(
+                                            "SQL expression parsing is not supported at this location.");
+                                })
+                        .build();
+        return resolver.resolve(filters);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/RowLevelDeleteSpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/RowLevelDeleteSpec.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.abilities.sink;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.connector.RowLevelModificationScanContext;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonCreator;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonIgnore;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTypeName;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/**
+ * A sub-class of {@link SinkAbilitySpec} that can not only serialize/deserialize the row-level
+ * delete mode to/from JSON, but also can delete existing data for {@link
+ * org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete}.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("RowLevelDelete")
+public class RowLevelDeleteSpec implements SinkAbilitySpec {
+    public static final String FIELD_NAME_ROW_LEVEL_DELETE_MODE = "rowLevelDeleteMode";
+
+    @JsonProperty(FIELD_NAME_ROW_LEVEL_DELETE_MODE)
+    @Nonnull
+    private final SupportsRowLevelDelete.RowLevelDeleteMode rowLevelDeleteMode;
+
+    @JsonIgnore @Nullable private final RowLevelModificationScanContext scanContext;
+
+    @JsonCreator
+    public RowLevelDeleteSpec(
+            @JsonProperty(FIELD_NAME_ROW_LEVEL_DELETE_MODE) @Nonnull
+                    SupportsRowLevelDelete.RowLevelDeleteMode rowLevelDeleteMode,
+            @Nullable RowLevelModificationScanContext scanContext) {
+        this.rowLevelDeleteMode = Preconditions.checkNotNull(rowLevelDeleteMode);
+        this.scanContext = scanContext;
+    }
+
+    @Override
+    public void apply(DynamicTableSink tableSink) {
+        if (tableSink instanceof SupportsRowLevelDelete) {
+            ((SupportsRowLevelDelete) tableSink).applyRowLevelDelete(scanContext);
+        } else {
+            throw new TableException(
+                    String.format(
+                            "%s does not support SupportsRowLevelDelete.",
+                            tableSink.getClass().getName()));
+        }
+    }
+
+    public SupportsRowLevelDelete.RowLevelDeleteMode getRowLevelDeleteMode() {
+        return rowLevelDeleteMode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        RowLevelDeleteSpec that = (RowLevelDeleteSpec) o;
+        return rowLevelDeleteMode == that.rowLevelDeleteMode
+                && Objects.equals(scanContext, that.scanContext);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rowLevelDeleteMode, scanContext);
+    }
+}

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/SinkAbilitySpec.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/abilities/sink/SinkAbilitySpec.java
@@ -34,7 +34,8 @@ import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.annotation.JsonTyp
 @JsonSubTypes({
     @JsonSubTypes.Type(value = OverwriteSpec.class),
     @JsonSubTypes.Type(value = PartitioningSpec.class),
-    @JsonSubTypes.Type(value = WritingMetadataSpec.class)
+    @JsonSubTypes.Type(value = WritingMetadataSpec.class),
+    @JsonSubTypes.Type(value = RowLevelDeleteSpec.class)
 })
 @Internal
 public interface SinkAbilitySpec {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterInCalcIntoTableSourceScanRule.java
@@ -85,7 +85,7 @@ public class PushFilterInCalcIntoTableSourceScanRule extends PushFilterIntoSourc
 
         RelBuilder relBuilder = call.builder();
         Tuple2<RexNode[], RexNode[]> extractedPredicates =
-                extractPredicates(
+                FlinkRexUtil.extractPredicates(
                         originProgram.getInputRowType().getFieldNames().toArray(new String[0]),
                         originProgram.expandLocalRef(originProgram.getCondition()),
                         scan,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoSourceScanRuleBase.java
@@ -22,29 +22,22 @@ import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.expressions.ResolvedExpression;
-import org.apache.flink.table.planner.calcite.FlinkContext;
 import org.apache.flink.table.planner.expressions.converter.ExpressionConverter;
 import org.apache.flink.table.planner.plan.abilities.source.FilterPushDownSpec;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilityContext;
 import org.apache.flink.table.planner.plan.abilities.source.SourceAbilitySpec;
 import org.apache.flink.table.planner.plan.schema.TableSourceTable;
-import org.apache.flink.table.planner.plan.utils.FlinkRelOptUtil;
-import org.apache.flink.table.planner.plan.utils.RexNodeExtractor;
-import org.apache.flink.table.planner.plan.utils.RexNodeToExpressionConverter;
 import org.apache.flink.table.planner.utils.ShortcutUtils;
-import org.apache.flink.table.planner.utils.TableConfigUtils;
 
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.plan.RelOptRuleOperand;
 import org.apache.calcite.rel.core.TableScan;
-import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilder;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 import scala.Tuple2;
@@ -118,23 +111,6 @@ public abstract class PushFilterIntoSourceScanRuleBase extends RelOptRule {
                         new SourceAbilitySpec[] {filterPushDownSpec});
 
         return new Tuple2<>(result, newTableSourceTable);
-    }
-
-    protected Tuple2<RexNode[], RexNode[]> extractPredicates(
-            String[] inputNames, RexNode filterExpression, TableScan scan, RexBuilder rexBuilder) {
-        FlinkContext context = ShortcutUtils.unwrapContext(scan);
-        int maxCnfNodeCount = FlinkRelOptUtil.getMaxCnfNodeCount(scan);
-        RexNodeToExpressionConverter converter =
-                new RexNodeToExpressionConverter(
-                        rexBuilder,
-                        inputNames,
-                        context.getFunctionCatalog(),
-                        context.getCatalogManager(),
-                        TimeZone.getTimeZone(
-                                TableConfigUtils.getLocalTimeZone(context.getTableConfig())));
-
-        return RexNodeExtractor.extractConjunctiveConditions(
-                filterExpression, maxCnfNodeCount, rexBuilder, converter);
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushFilterIntoTableSourceScanRule.java
@@ -78,7 +78,7 @@ public class PushFilterIntoTableSourceScanRule extends PushFilterIntoSourceScanR
 
         RelBuilder relBuilder = call.builder();
         Tuple2<RexNode[], RexNode[]> extractedPredicates =
-                extractPredicates(
+                FlinkRexUtil.extractPredicates(
                         filter.getInput().getRowType().getFieldNames().toArray(new String[0]),
                         filter.getCondition(),
                         scan,

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/RowLevelModificationContextUtils.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/utils/RowLevelModificationContextUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.utils;
+
+import org.apache.flink.table.connector.RowLevelModificationScanContext;
+import org.apache.flink.table.connector.source.abilities.SupportsRowLevelModificationScan;
+
+/**
+ * Utils for putting/getting {@link RowLevelModificationScanContext}/{@link
+ * SupportsRowLevelModificationScan.RowLevelModificationType} in current thread, it enables to
+ * put/get them in different methods.
+ */
+public class RowLevelModificationContextUtils {
+    private static final ThreadLocal<SupportsRowLevelModificationScan.RowLevelModificationType>
+            modificationTypeThreadLocal = new ThreadLocal<>();
+
+    private static final ThreadLocal<RowLevelModificationScanContext> scanContextThreadLocal =
+            new ThreadLocal<>();
+
+    public static void setModificationType(
+            SupportsRowLevelModificationScan.RowLevelModificationType rowLevelModificationType) {
+        modificationTypeThreadLocal.set(rowLevelModificationType);
+    }
+
+    public static SupportsRowLevelModificationScan.RowLevelModificationType getModificationType() {
+        return modificationTypeThreadLocal.get();
+    }
+
+    public static void setScanContext(RowLevelModificationScanContext scanContext) {
+        scanContextThreadLocal.set(scanContext);
+    }
+
+    public static RowLevelModificationScanContext getScanContext() {
+        return scanContextThreadLocal.get();
+    }
+
+    public static void clearContext() {
+        modificationTypeThreadLocal.remove();
+        scanContextThreadLocal.remove();
+    }
+}

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/delegation/PlannerBase.scala
@@ -237,6 +237,20 @@ abstract class PlannerBase(
           case (table, sink: TableSink[_]) =>
             // Legacy tables can't be anonymous
             val identifier = catalogSink.getContextResolvedTable.getIdentifier
+
+            // check it's not for UPDATE/DELETE because they're not supported for Legacy table
+            if (catalogSink.isDelete || catalogSink.isUpdate) {
+              throw new TableException(
+                String.format(
+                  "Can't perform %s operation of the table %s " +
+                    " because the corresponding table sink is the legacy TableSink," +
+                    " Please implement %s for it.",
+                  if (catalogSink.isDelete) "delete" else "update",
+                  identifier,
+                  classOf[DynamicTableSink].getName
+                ))
+            }
+
             // check the logical field type and physical field type are compatible
             val queryLogicalType = FlinkTypeFactory.toLogicalRowType(input.getRowType)
             // validate logical schema and physical schema are compatible

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/schema/TableSourceTable.scala
@@ -116,6 +116,36 @@ class TableSourceTable(
   }
 
   /**
+   * Creates a copy of this table with specified digest and context resolved table
+   *
+   * @param newTableSource
+   *   tableSource to replace
+   * @param newResolveTable
+   *   resolved table to replace
+   * @param newRowType
+   *   new row type
+   * @return
+   *   added TableSourceTable instance with specified digest
+   */
+  def copy(
+      newTableSource: DynamicTableSource,
+      newResolveTable: ContextResolvedTable,
+      newRowType: RelDataType,
+      newAbilitySpecs: Array[SourceAbilitySpec]): TableSourceTable = {
+    new TableSourceTable(
+      relOptSchema,
+      newRowType,
+      statistic,
+      newTableSource,
+      isStreamingMode,
+      newResolveTable,
+      flinkContext,
+      flinkTypeFactory,
+      abilitySpecs ++ newAbilitySpecs
+    )
+  }
+
+  /**
    * Creates a copy of this table with specified digest and statistic.
    *
    * @param newTableSource

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/FlinkRexUtil.scala
@@ -23,12 +23,14 @@ import org.apache.flink.configuration.ConfigOptions.key
 import org.apache.flink.table.planner.functions.sql.SqlTryCastFunction
 import org.apache.flink.table.planner.plan.utils.ExpressionDetail.ExpressionDetail
 import org.apache.flink.table.planner.plan.utils.ExpressionFormat.ExpressionFormat
+import org.apache.flink.table.planner.utils.{ShortcutUtils, TableConfigUtils}
 
 import com.google.common.base.Function
 import com.google.common.collect.{ImmutableList, Lists}
 import org.apache.calcite.avatica.util.ByteString
 import org.apache.calcite.plan.{RelOptPredicateList, RelOptUtil}
 import org.apache.calcite.rel.`type`.RelDataType
+import org.apache.calcite.rel.RelNode
 import org.apache.calcite.rex._
 import org.apache.calcite.sql.`type`.SqlTypeName
 import org.apache.calcite.sql.{SqlAsOperator, SqlKind, SqlOperator}
@@ -39,7 +41,7 @@ import org.apache.calcite.util._
 import java.lang.{Iterable => JIterable}
 import java.math.BigDecimal
 import java.util
-import java.util.Optional
+import java.util.{Optional, TimeZone}
 import java.util.function.Predicate
 
 import scala.collection.JavaConversions._
@@ -633,6 +635,31 @@ object FlinkRexUtil {
     }
     val projects = rexProgram.getProjectList.map(rexProgram.expandLocalRef)
     projects.forall(isDeterministicInStreaming)
+  }
+
+  /**
+   * Return convertible rex nodes and unconverted rex nodes extracted from the filter expression.
+   */
+  def extractPredicates(
+      inputNames: Array[String],
+      filterExpression: RexNode,
+      rel: RelNode,
+      rexBuilder: RexBuilder): (Array[RexNode], Array[RexNode]) = {
+    val context = ShortcutUtils.unwrapContext(rel)
+    val maxCnfNodeCount = FlinkRelOptUtil.getMaxCnfNodeCount(rel);
+    val converter =
+      new RexNodeToExpressionConverter(
+        rexBuilder,
+        inputNames,
+        context.getFunctionCatalog,
+        context.getCatalogManager,
+        TimeZone.getTimeZone(TableConfigUtils.getLocalTimeZone(context.getTableConfig)));
+
+    RexNodeExtractor.extractConjunctiveConditions(
+      filterExpression,
+      maxCnfNodeCount,
+      rexBuilder,
+      converter);
   }
 }
 

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
@@ -21,16 +21,31 @@ package org.apache.flink.table.planner.factories;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.DataStreamSink;
+import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
 import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.ProviderContext;
+import org.apache.flink.table.connector.RowLevelModificationScanContext;
+import org.apache.flink.table.connector.sink.DataStreamSinkProvider;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
 import org.apache.flink.table.connector.sink.abilities.SupportsDeletePushDown;
+import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.connector.source.abilities.SupportsRowLevelModificationScan;
+import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.FieldReferenceExpression;
@@ -41,6 +56,10 @@ import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.Preconditions;
+
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -82,6 +101,34 @@ public class TestUpdateDeleteTableFactory
                     .defaultValue(true)
                     .withDescription("Whether the table supports delete push down.");
 
+    private static final ConfigOption<Boolean> MIX_DELETE =
+            ConfigOptions.key("mix-delete")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether the table support both delete push down and row-level delete. "
+                                    + "Note: for supporting delete push down, only the filter pushed is empty, can the filter be accepted.");
+
+    private static final ConfigOption<SupportsRowLevelDelete.RowLevelDeleteMode> DELETE_MODE =
+            ConfigOptions.key("delete-mode")
+                    .enumType(SupportsRowLevelDelete.RowLevelDeleteMode.class)
+                    .defaultValue(SupportsRowLevelDelete.RowLevelDeleteMode.DELETED_ROWS)
+                    .withDescription("The delete mode for row level delete.");
+
+    private static final ConfigOption<List<String>> REQUIRED_COLUMNS_FOR_DELETE =
+            ConfigOptions.key("required-columns-for-delete")
+                    .stringType()
+                    .asList()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The columns' name for the required columns in row-level delete");
+
+    private static final List<Column.MetadataColumn> META_COLUMNS =
+            Arrays.asList(
+                    Column.metadata("g", DataTypes.STRING(), null, true),
+                    Column.metadata("meta_f1", DataTypes.INT().notNull(), null, false),
+                    Column.metadata("meta_f2", DataTypes.STRING().notNull(), "meta_k2", false));
+
     private static final AtomicInteger idCounter = new AtomicInteger(0);
     private static final Map<String, Collection<RowData>> registeredRowData = new HashMap<>();
 
@@ -97,13 +144,29 @@ public class TestUpdateDeleteTableFactory
         helper.validate();
         String dataId =
                 helper.getOptions().getOptional(DATA_ID).orElse(String.valueOf(idCounter.get()));
-        if (helper.getOptions().get(SUPPORT_DELETE_PUSH_DOWN)) {
-            return new SupportsDeletePushDownSink(
+        SupportsRowLevelDelete.RowLevelDeleteMode deleteMode = helper.getOptions().get(DELETE_MODE);
+        List<String> requireCols = helper.getOptions().get(REQUIRED_COLUMNS_FOR_DELETE);
+        if (helper.getOptions().get(MIX_DELETE)) {
+            return new SupportsDeleteSink(
+                    context.getObjectIdentifier(),
+                    context.getCatalogTable(),
+                    deleteMode,
                     dataId,
-                    helper.getOptions().get(ONLY_ACCEPT_EQUAL_PREDICATE),
-                    context.getCatalogTable());
+                    requireCols);
         } else {
-            return new TestSink();
+            if (helper.getOptions().get(SUPPORT_DELETE_PUSH_DOWN)) {
+                return new SupportsDeletePushDownSink(
+                        dataId,
+                        helper.getOptions().get(ONLY_ACCEPT_EQUAL_PREDICATE),
+                        context.getCatalogTable());
+            } else {
+                return new SupportsRowLevelDeleteSink(
+                        context.getObjectIdentifier(),
+                        context.getCatalogTable(),
+                        deleteMode,
+                        dataId,
+                        requireCols);
+            }
         }
     }
 
@@ -114,7 +177,7 @@ public class TestUpdateDeleteTableFactory
 
         String dataId =
                 helper.getOptions().getOptional(DATA_ID).orElse(String.valueOf(idCounter.get()));
-        return new TestTableSource(dataId);
+        return new TestTableSource(dataId, context.getObjectIdentifier());
     }
 
     @Override
@@ -130,20 +193,29 @@ public class TestUpdateDeleteTableFactory
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         return new HashSet<>(
-                Arrays.asList(DATA_ID, ONLY_ACCEPT_EQUAL_PREDICATE, SUPPORT_DELETE_PUSH_DOWN));
+                Arrays.asList(
+                        DATA_ID,
+                        ONLY_ACCEPT_EQUAL_PREDICATE,
+                        SUPPORT_DELETE_PUSH_DOWN,
+                        MIX_DELETE,
+                        DELETE_MODE,
+                        REQUIRED_COLUMNS_FOR_DELETE));
     }
 
     /** A test table source which supports reading metadata. */
-    private static class TestTableSource implements ScanTableSource {
+    private static class TestTableSource
+            implements ScanTableSource, SupportsReadingMetadata, SupportsRowLevelModificationScan {
         private final String dataId;
+        private final ObjectIdentifier tableIdentifier;
 
-        public TestTableSource(String dataId) {
+        public TestTableSource(String dataId, ObjectIdentifier tableIdentifier) {
             this.dataId = dataId;
+            this.tableIdentifier = tableIdentifier;
         }
 
         @Override
         public DynamicTableSource copy() {
-            return new TestTableSource(dataId);
+            return new TestTableSource(dataId, tableIdentifier);
         }
 
         @Override
@@ -175,6 +247,37 @@ public class TestUpdateDeleteTableFactory
                 }
             };
         }
+
+        @Override
+        public Map<String, DataType> listReadableMetadata() {
+            Map<String, DataType> metaData = new HashMap<>();
+            META_COLUMNS.forEach(
+                    column ->
+                            metaData.put(
+                                    column.getMetadataKey().orElse(column.getName()),
+                                    column.getDataType()));
+            return metaData;
+        }
+
+        @Override
+        public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {}
+
+        @Override
+        public RowLevelModificationScanContext applyRowLevelModificationScan(
+                RowLevelModificationType rowLevelModificationType,
+                @Nullable RowLevelModificationScanContext previousContext) {
+            TestScanContext scanContext =
+                    previousContext == null
+                            ? new TestScanContext()
+                            : (TestScanContext) previousContext;
+            scanContext.scanTables.add(tableIdentifier);
+            return scanContext;
+        }
+    }
+
+    /** A test scan context for row-level modification scan. */
+    private static class TestScanContext implements RowLevelModificationScanContext {
+        private final Set<ObjectIdentifier> scanTables = new HashSet<>();
     }
 
     /** A common test sink. */
@@ -192,12 +295,188 @@ public class TestUpdateDeleteTableFactory
 
         @Override
         public DynamicTableSink copy() {
-            return null;
+            return new TestSink();
         }
 
         @Override
         public String asSummaryString() {
-            return null;
+            return "Test Sink";
+        }
+    }
+
+    /** A sink that supports delete push down. */
+    private static class SupportsRowLevelDeleteSink extends TestSink
+            implements SupportsRowLevelDelete {
+
+        private final ObjectIdentifier tableIdentifier;
+        private final ResolvedCatalogTable resolvedCatalogTable;
+        private final RowLevelDeleteMode deleteMode;
+        protected final String dataId;
+        private final List<String> requireColumnsForDelete;
+
+        private boolean isDelete;
+
+        public SupportsRowLevelDeleteSink(
+                ObjectIdentifier tableIdentifier,
+                ResolvedCatalogTable resolvedCatalogTable,
+                RowLevelDeleteMode deleteMode,
+                String dataId,
+                List<String> requireColumnsForDelete) {
+            this(
+                    tableIdentifier,
+                    resolvedCatalogTable,
+                    deleteMode,
+                    dataId,
+                    requireColumnsForDelete,
+                    false);
+        }
+
+        public SupportsRowLevelDeleteSink(
+                ObjectIdentifier tableIdentifier,
+                ResolvedCatalogTable resolvedCatalogTable,
+                RowLevelDeleteMode deleteMode,
+                String dataId,
+                List<String> requireColumnsForDelete,
+                boolean isDelete) {
+            this.tableIdentifier = tableIdentifier;
+            this.resolvedCatalogTable = resolvedCatalogTable;
+            this.deleteMode = deleteMode;
+            this.dataId = dataId;
+            this.requireColumnsForDelete = requireColumnsForDelete;
+            this.isDelete = isDelete;
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+            return ChangelogMode.all();
+        }
+
+        @Override
+        public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+            return new DataStreamSinkProvider() {
+                @Override
+                public DataStreamSink<?> consumeDataStream(
+                        ProviderContext providerContext, DataStream<RowData> dataStream) {
+                    return dataStream
+                            .addSink(
+                                    new DeleteDataSinkFunction(
+                                            dataId,
+                                            getAllFieldGetter(
+                                                    resolvedCatalogTable.getResolvedSchema()),
+                                            deleteMode))
+                            .setParallelism(1);
+                }
+            };
+        }
+
+        @Override
+        public DynamicTableSink copy() {
+            return new SupportsRowLevelDeleteSink(
+                    tableIdentifier,
+                    resolvedCatalogTable,
+                    deleteMode,
+                    dataId,
+                    requireColumnsForDelete,
+                    isDelete);
+        }
+
+        @Override
+        public String asSummaryString() {
+            return "support row-level delete sink";
+        }
+
+        @Override
+        public RowLevelDeleteInfo applyRowLevelDelete(
+                @Nullable RowLevelModificationScanContext context) {
+            // the context should contain the object identifier of the table to be written
+            Preconditions.checkArgument(context instanceof TestScanContext);
+            TestScanContext scanContext = (TestScanContext) context;
+            Preconditions.checkArgument(
+                    scanContext.scanTables.contains(tableIdentifier),
+                    String.format(
+                            "The scan context should contains the object identifier for table %s in row-level delete.",
+                            tableIdentifier));
+
+            this.isDelete = true;
+            return new RowLevelDeleteInfo() {
+                @Override
+                public Optional<List<Column>> requiredColumns() {
+                    List<Column> requiredCols = null;
+                    if (requireColumnsForDelete != null) {
+                        requiredCols =
+                                getRequiredColumns(
+                                        requireColumnsForDelete,
+                                        resolvedCatalogTable.getResolvedSchema());
+                    }
+                    return Optional.ofNullable(requiredCols);
+                }
+
+                @Override
+                public RowLevelDeleteMode getRowLevelDeleteMode() {
+                    return deleteMode;
+                }
+            };
+        }
+    }
+
+    /** The sink for delete existing data. */
+    private static class DeleteDataSinkFunction extends RichSinkFunction<RowData> {
+        private final String dataId;
+        private final RowData.FieldGetter[] fieldGetters;
+        private final SupportsRowLevelDelete.RowLevelDeleteMode deleteMode;
+
+        private transient Collection<RowData> data;
+        private transient List<RowData> newData;
+
+        DeleteDataSinkFunction(
+                String dataId,
+                RowData.FieldGetter[] fieldGetters,
+                SupportsRowLevelDelete.RowLevelDeleteMode deleteMode) {
+            this.dataId = dataId;
+            this.fieldGetters = fieldGetters;
+            this.deleteMode = deleteMode;
+        }
+
+        @Override
+        public void open(Configuration parameters) {
+            data = registeredRowData.get(dataId);
+            newData = new ArrayList<>();
+        }
+
+        @Override
+        public void invoke(RowData value, Context context) {
+            if (deleteMode == SupportsRowLevelDelete.RowLevelDeleteMode.DELETED_ROWS) {
+                consumeDeletedRows(value);
+            } else if (deleteMode == SupportsRowLevelDelete.RowLevelDeleteMode.REMAINING_ROWS) {
+                consumeRemainingRows(value);
+            } else {
+                throw new TableException(String.format("Unknown delete mode: %s.", deleteMode));
+            }
+        }
+
+        private void consumeDeletedRows(RowData deletedRow) {
+            Preconditions.checkState(
+                    deletedRow.getRowKind() == RowKind.DELETE,
+                    String.format(
+                            "The RowKind for the coming rows should be %s in delete mode %s.",
+                            RowKind.DELETE, DELETE_MODE));
+            data.removeIf(rowData -> equal(rowData, deletedRow, fieldGetters));
+        }
+
+        private void consumeRemainingRows(RowData remainingRow) {
+            Preconditions.checkState(
+                    remainingRow.getRowKind() == RowKind.INSERT,
+                    String.format(
+                            "The RowKind for the coming rows should be %s in delete mode %s.",
+                            RowKind.INSERT, DELETE_MODE));
+            newData.add(copyRowData(remainingRow, fieldGetters));
+        }
+
+        @Override
+        public void finish() {
+            if (deleteMode == SupportsRowLevelDelete.RowLevelDeleteMode.REMAINING_ROWS) {
+                registeredRowData.put(dataId, newData);
+            }
         }
     }
 
@@ -315,6 +594,41 @@ public class TestUpdateDeleteTableFactory
         return true;
     }
 
+    /** A sink that supports both delete push down and row-level delete. */
+    private static class SupportsDeleteSink extends SupportsRowLevelDeleteSink
+            implements SupportsDeletePushDown {
+
+        public SupportsDeleteSink(
+                ObjectIdentifier tableIdentifier,
+                ResolvedCatalogTable resolvedCatalogTable,
+                SupportsRowLevelDelete.RowLevelDeleteMode deleteMode,
+                String dataId,
+                List<String> requireColumnsForDelete) {
+            super(
+                    tableIdentifier,
+                    resolvedCatalogTable,
+                    deleteMode,
+                    dataId,
+                    requireColumnsForDelete);
+        }
+
+        @Override
+        public boolean applyDeleteFilters(List<ResolvedExpression> filters) {
+            // only accept when the filters are empty
+            return filters.isEmpty();
+        }
+
+        @Override
+        public Optional<Long> executeDeletion() {
+            Collection<RowData> oldRows = registeredRowData.get(dataId);
+            if (oldRows != null) {
+                registeredRowData.put(dataId, new ArrayList<>());
+                return Optional.of((long) oldRows.size());
+            }
+            return Optional.empty();
+        }
+    }
+
     private static RowData.FieldGetter[] getAllFieldGetter(ResolvedSchema resolvedSchema) {
         List<DataType> dataTypes = resolvedSchema.getColumnDataTypes();
         RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[dataTypes.size()];
@@ -322,5 +636,51 @@ public class TestUpdateDeleteTableFactory
             fieldGetters[i] = createFieldGetter(dataTypes.get(i).getLogicalType(), i);
         }
         return fieldGetters;
+    }
+
+    private static boolean equal(
+            RowData value1, RowData value2, RowData.FieldGetter[] fieldGetters) {
+        for (RowData.FieldGetter fieldGetter : fieldGetters) {
+            if (!Objects.equals(
+                    fieldGetter.getFieldOrNull(value1), fieldGetter.getFieldOrNull(value2))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static RowData copyRowData(RowData rowData, RowData.FieldGetter[] fieldGetters) {
+        Object[] values = new Object[fieldGetters.length];
+        for (int i = 0; i < fieldGetters.length; i++) {
+            values[i] = fieldGetters[i].getFieldOrNull(rowData);
+        }
+        return GenericRowData.of(values);
+    }
+
+    private static List<Column> getRequiredColumns(
+            List<String> requiredColName, ResolvedSchema schema) {
+        List<Column> requiredCols = new ArrayList<>();
+        for (String colName : requiredColName) {
+            Optional<Column> optionalColumn = schema.getColumn(colName);
+            if (optionalColumn.isPresent()) {
+                requiredCols.add(optionalColumn.get());
+            } else {
+                Column metaCol = null;
+                for (Column.MetadataColumn metadataColumn : META_COLUMNS) {
+                    String metaColName =
+                            metadataColumn.getMetadataKey().orElse(metadataColumn.getName());
+                    if (metaColName.equals(colName)) {
+                        metaCol = metadataColumn;
+                        break;
+                    }
+                }
+                if (metaCol == null) {
+                    throw new TableException(
+                            String.format("Can't find the required column: `%s`.", colName));
+                }
+                requiredCols.add(metaCol);
+            }
+        }
+        return requiredCols;
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/factories/TestUpdateDeleteTableFactory.java
@@ -1,0 +1,326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.factories;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.streaming.api.functions.source.FromElementsFunction;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.abilities.SupportsDeletePushDown;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.expressions.CallExpression;
+import org.apache.flink.table.expressions.FieldReferenceExpression;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.expressions.ValueLiteralExpression;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.DataType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.apache.flink.table.data.RowData.createFieldGetter;
+
+/** A factory to create table to support update/delete for test purpose. */
+public class TestUpdateDeleteTableFactory
+        implements DynamicTableSourceFactory, DynamicTableSinkFactory {
+
+    public static final String IDENTIFIER = "test-update-delete";
+
+    private static final ConfigOption<String> DATA_ID =
+            ConfigOptions.key("data-id")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription("The data id used to read the rows.");
+
+    private static final ConfigOption<Boolean> ONLY_ACCEPT_EQUAL_PREDICATE =
+            ConfigOptions.key("only-accept-equal-predicate")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether only accept when the all predicates in filter is equal expression for delete statement.");
+
+    private static final ConfigOption<Boolean> SUPPORT_DELETE_PUSH_DOWN =
+            ConfigOptions.key("support-delete-push-down")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription("Whether the table supports delete push down.");
+
+    private static final AtomicInteger idCounter = new AtomicInteger(0);
+    private static final Map<String, Collection<RowData>> registeredRowData = new HashMap<>();
+
+    public static String registerRowData(Collection<RowData> data) {
+        String id = String.valueOf(idCounter.incrementAndGet());
+        registeredRowData.put(id, data);
+        return id;
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validate();
+        String dataId =
+                helper.getOptions().getOptional(DATA_ID).orElse(String.valueOf(idCounter.get()));
+        if (helper.getOptions().get(SUPPORT_DELETE_PUSH_DOWN)) {
+            return new SupportsDeletePushDownSink(
+                    dataId,
+                    helper.getOptions().get(ONLY_ACCEPT_EQUAL_PREDICATE),
+                    context.getCatalogTable());
+        } else {
+            return new TestSink();
+        }
+    }
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validate();
+
+        String dataId =
+                helper.getOptions().getOptional(DATA_ID).orElse(String.valueOf(idCounter.get()));
+        return new TestTableSource(dataId);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        return new HashSet<>(
+                Arrays.asList(DATA_ID, ONLY_ACCEPT_EQUAL_PREDICATE, SUPPORT_DELETE_PUSH_DOWN));
+    }
+
+    /** A test table source which supports reading metadata. */
+    private static class TestTableSource implements ScanTableSource {
+        private final String dataId;
+
+        public TestTableSource(String dataId) {
+            this.dataId = dataId;
+        }
+
+        @Override
+        public DynamicTableSource copy() {
+            return new TestTableSource(dataId);
+        }
+
+        @Override
+        public String asSummaryString() {
+            return "test table source";
+        }
+
+        @Override
+        public ChangelogMode getChangelogMode() {
+            return ChangelogMode.insertOnly();
+        }
+
+        @Override
+        public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+            return new SourceFunctionProvider() {
+                @Override
+                public SourceFunction<RowData> createSourceFunction() {
+                    Collection<RowData> rows = registeredRowData.get(dataId);
+                    if (rows != null) {
+                        return new FromElementsFunction<>(rows);
+                    } else {
+                        return new FromElementsFunction<>();
+                    }
+                }
+
+                @Override
+                public boolean isBounded() {
+                    return true;
+                }
+            };
+        }
+    }
+
+    /** A common test sink. */
+    private static class TestSink implements DynamicTableSink {
+
+        @Override
+        public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+            return ChangelogMode.insertOnly();
+        }
+
+        @Override
+        public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+            return null;
+        }
+
+        @Override
+        public DynamicTableSink copy() {
+            return null;
+        }
+
+        @Override
+        public String asSummaryString() {
+            return null;
+        }
+    }
+
+    /** A sink that supports delete push down. */
+    public static class SupportsDeletePushDownSink extends TestSink
+            implements SupportsDeletePushDown {
+
+        private final String dataId;
+        private final boolean onlyAcceptEqualPredicate;
+        private final ResolvedCatalogTable resolvedCatalogTable;
+        private final RowData.FieldGetter[] fieldGetters;
+        private final List<String> columns;
+
+        private List<Tuple2<String, Object>> equalPredicates;
+
+        public SupportsDeletePushDownSink(
+                String dataId,
+                boolean onlyAcceptEqualPredicate,
+                ResolvedCatalogTable resolvedCatalogTable) {
+            this.dataId = dataId;
+            this.onlyAcceptEqualPredicate = onlyAcceptEqualPredicate;
+            this.resolvedCatalogTable = resolvedCatalogTable;
+            this.fieldGetters = getAllFieldGetter(resolvedCatalogTable.getResolvedSchema());
+            this.columns = resolvedCatalogTable.getResolvedSchema().getColumnNames();
+        }
+
+        @Override
+        public DynamicTableSink copy() {
+            return new SupportsDeletePushDownSink(
+                    dataId, onlyAcceptEqualPredicate, resolvedCatalogTable);
+        }
+
+        @Override
+        public String asSummaryString() {
+            return "SupportDeletePushDownSink";
+        }
+
+        @Override
+        public boolean applyDeleteFilters(List<ResolvedExpression> filters) {
+            if (onlyAcceptEqualPredicate) {
+                Optional<List<Tuple2<String, Object>>> optionalEqualPredicates =
+                        getEqualPredicates(filters);
+                if (optionalEqualPredicates.isPresent()) {
+                    equalPredicates = optionalEqualPredicates.get();
+                    return true;
+                }
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public Optional<Long> executeDeletion() {
+            if (onlyAcceptEqualPredicate) {
+                Collection<RowData> existingRows = registeredRowData.get(dataId);
+                long rowsBefore = existingRows.size();
+                existingRows.removeIf(
+                        rowData ->
+                                satisfyEqualPredicate(
+                                        equalPredicates, rowData, fieldGetters, columns));
+                return Optional.of(rowsBefore - existingRows.size());
+            }
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Get a list of equal predicate from a list of filter, each contains [column, value]. Return
+     * Optional.empty() if it contains any non-equal predicate.
+     */
+    private static Optional<List<Tuple2<String, Object>>> getEqualPredicates(
+            List<ResolvedExpression> filters) {
+        List<Tuple2<String, Object>> equalPredicates = new ArrayList<>();
+        for (ResolvedExpression expression : filters) {
+            if (!(expression instanceof CallExpression)) {
+                return Optional.empty();
+            }
+            CallExpression callExpression = (CallExpression) expression;
+            if (callExpression.getFunctionDefinition() != BuiltInFunctionDefinitions.EQUALS) {
+                return Optional.empty();
+            }
+            String colName = getColumnName(callExpression);
+            Object value = getColumnValue(callExpression);
+            equalPredicates.add(Tuple2.of(colName, value));
+        }
+        return Optional.of(equalPredicates);
+    }
+
+    private static String getColumnName(CallExpression comp) {
+        return ((FieldReferenceExpression) comp.getChildren().get(0)).getName();
+    }
+
+    private static Object getColumnValue(CallExpression comp) {
+        ValueLiteralExpression valueLiteralExpression =
+                (ValueLiteralExpression) comp.getChildren().get(1);
+        return valueLiteralExpression
+                .getValueAs(valueLiteralExpression.getOutputDataType().getConversionClass())
+                .get();
+    }
+
+    /** Check the rowData satisfies the equal predicate. */
+    private static boolean satisfyEqualPredicate(
+            List<Tuple2<String, Object>> equalPredicates,
+            RowData rowData,
+            RowData.FieldGetter[] fieldGetters,
+            List<String> columns) {
+        for (Tuple2<String, Object> equalPredicate : equalPredicates) {
+            String colName = equalPredicate.f0;
+            Object value = equalPredicate.f1;
+            int colIndex = columns.indexOf(colName);
+            if (!(Objects.equals(value, fieldGetters[colIndex].getFieldOrNull(rowData)))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static RowData.FieldGetter[] getAllFieldGetter(ResolvedSchema resolvedSchema) {
+        List<DataType> dataTypes = resolvedSchema.getColumnDataTypes();
+        RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[dataTypes.size()];
+        for (int i = 0; i < dataTypes.size(); i++) {
+            fieldGetters[i] = createFieldGetter(dataTypes.get(i).getLogicalType(), i);
+        }
+        return fieldGetters;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/DeletePushDownUtilsTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/DeletePushDownUtilsTest.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.operations;
+
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.ExecutionOptions;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.catalog.Catalog;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.ContextResolvedTable;
+import org.apache.flink.table.catalog.GenericInMemoryCatalog;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.expressions.ResolvedExpression;
+import org.apache.flink.table.planner.calcite.FlinkPlannerImpl;
+import org.apache.flink.table.planner.catalog.CatalogManagerCalciteSchema;
+import org.apache.flink.table.planner.delegation.PlannerContext;
+import org.apache.flink.table.planner.factories.TestUpdateDeleteTableFactory;
+import org.apache.flink.table.planner.parse.CalciteParser;
+import org.apache.flink.table.planner.utils.PlannerMocks;
+import org.apache.flink.table.utils.CatalogManagerMocks;
+
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.logical.LogicalTableModify;
+import org.apache.calcite.sql.SqlNode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.apache.calcite.jdbc.CalciteSchemaBuilder.asRootSchema;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link DeletePushDownUtils}. */
+public class DeletePushDownUtilsTest {
+    private final TableConfig tableConfig = TableConfig.getDefault();
+    private final Catalog catalog = new GenericInMemoryCatalog("MockCatalog", "default");
+    private final CatalogManager catalogManager =
+            CatalogManagerMocks.preparedCatalogManager()
+                    .defaultCatalog("builtin", catalog)
+                    .config(
+                            Configuration.fromMap(
+                                    Collections.singletonMap(
+                                            ExecutionOptions.RUNTIME_MODE.key(),
+                                            RuntimeExecutionMode.BATCH.name())))
+                    .build();
+
+    private final PlannerMocks plannerMocks =
+            PlannerMocks.newBuilder()
+                    .withBatchMode(true)
+                    .withTableConfig(tableConfig)
+                    .withCatalogManager(catalogManager)
+                    .withRootSchema(
+                            asRootSchema(new CatalogManagerCalciteSchema(catalogManager, false)))
+                    .build();
+    private final PlannerContext plannerContext = plannerMocks.getPlannerContext();
+    private final CalciteParser parser = plannerContext.createCalciteParser();
+    private final FlinkPlannerImpl flinkPlanner = plannerContext.createFlinkPlanner();
+
+    @Test
+    public void testGetDynamicTableSink() {
+        // create a table with connector = test-update-delete
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "test-update-delete");
+        CatalogTable catalogTable = createTestCatalogTable(options);
+        ObjectIdentifier tableId = ObjectIdentifier.of("builtin", "default", "t");
+        catalogManager.createTable(catalogTable, tableId, false);
+        ContextResolvedTable resolvedTable =
+                ContextResolvedTable.permanent(
+                        tableId, catalog, catalogManager.resolveCatalogTable(catalogTable));
+        LogicalTableModify tableModify = getTableModifyFromSql("DELETE FROM t");
+        Optional<DynamicTableSink> optionalDynamicTableSink =
+                DeletePushDownUtils.getDynamicTableSink(resolvedTable, tableModify, catalogManager);
+        // verify we can get the dynamic table sink
+        assertThat(optionalDynamicTableSink).isPresent();
+        assertThat(optionalDynamicTableSink.get())
+                .isInstanceOf(TestUpdateDeleteTableFactory.SupportsDeletePushDownSink.class);
+
+        // create table with connector = COLLECTION, it's legacy table sink
+        options.put("connector", "COLLECTION");
+        catalogTable = createTestCatalogTable(options);
+        tableId = ObjectIdentifier.of("builtin", "default", "t1");
+        catalogManager.createTable(catalogTable, tableId, false);
+        resolvedTable =
+                ContextResolvedTable.permanent(
+                        tableId, catalog, catalogManager.resolveCatalogTable(catalogTable));
+        tableModify = getTableModifyFromSql("DELETE FROM t1");
+        optionalDynamicTableSink =
+                DeletePushDownUtils.getDynamicTableSink(resolvedTable, tableModify, catalogManager);
+        // verify it should be empty since it's not an instance of DynamicTableSink but is legacy
+        // TableSink
+        assertThat(optionalDynamicTableSink).isEmpty();
+    }
+
+    @Test
+    public void testGetResolveFilterExpressions() {
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        Schema.newBuilder()
+                                .column("f0", DataTypes.INT().notNull())
+                                .column("f1", DataTypes.STRING().nullable())
+                                .column("f2", DataTypes.BIGINT().nullable())
+                                .build(),
+                        null,
+                        Collections.emptyList(),
+                        Collections.emptyMap());
+        catalogManager.createTable(
+                catalogTable, ObjectIdentifier.of("builtin", "default", "t"), false);
+
+        // verify there's no where clause
+        LogicalTableModify tableModify = getTableModifyFromSql("DELETE FROM t");
+        Optional<List<ResolvedExpression>> optionalResolvedExpressions =
+                DeletePushDownUtils.getResolvedFilterExpressions(tableModify);
+        verifyExpression(optionalResolvedExpressions, "[]");
+
+        tableModify = getTableModifyFromSql("DELETE FROM t where f0 = 1 and f1 = '123'");
+        optionalResolvedExpressions = DeletePushDownUtils.getResolvedFilterExpressions(tableModify);
+        verifyExpression(optionalResolvedExpressions, "[equals(f0, 1), equals(f1, '123')]");
+
+        tableModify = getTableModifyFromSql("DELETE FROM t where f0 = 1 + 6 and f0 < 6");
+        optionalResolvedExpressions = DeletePushDownUtils.getResolvedFilterExpressions(tableModify);
+        assertThat(optionalResolvedExpressions).isPresent();
+        verifyExpression(optionalResolvedExpressions, "[false]");
+
+        tableModify = getTableModifyFromSql("DELETE FROM t where f0 = f2 + 1");
+        optionalResolvedExpressions = DeletePushDownUtils.getResolvedFilterExpressions(tableModify);
+        verifyExpression(
+                optionalResolvedExpressions, "[equals(cast(f0, BIGINT NOT NULL), plus(f2, 1))]");
+
+        // resolve filters is not available as it contains sub-query
+        tableModify = getTableModifyFromSql("DELETE FROM t where f0 > (select count(1) from t)");
+        optionalResolvedExpressions = DeletePushDownUtils.getResolvedFilterExpressions(tableModify);
+        assertThat(optionalResolvedExpressions).isEmpty();
+    }
+
+    private CatalogTable createTestCatalogTable(Map<String, String> options) {
+        return CatalogTable.of(
+                Schema.newBuilder()
+                        .column("f0", DataTypes.INT().notNull())
+                        .column("f1", DataTypes.STRING().nullable())
+                        .column("f2", DataTypes.BIGINT().nullable())
+                        .build(),
+                null,
+                Collections.emptyList(),
+                options);
+    }
+
+    private LogicalTableModify getTableModifyFromSql(String sql) {
+        SqlNode sqlNode = parser.parse(sql);
+        final SqlNode validated = flinkPlanner.validate(sqlNode);
+        RelRoot deleteRelational = flinkPlanner.rel(validated);
+        return (LogicalTableModify) deleteRelational.rel;
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private void verifyExpression(
+            Optional<List<ResolvedExpression>> optionalResolvedExpressions, String expected) {
+        assertThat(optionalResolvedExpressions).isPresent();
+        assertThat(optionalResolvedExpressions.get().toString()).isEqualTo(expected);
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -52,9 +52,11 @@ import org.apache.flink.table.catalog.exceptions.FunctionAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.delegation.Parser;
+import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.expressions.SqlCallExpression;
 import org.apache.flink.table.factories.TestManagedTableFactory;
 import org.apache.flink.table.operations.BeginStatementSetOperation;
+import org.apache.flink.table.operations.DeleteFromFilterOperation;
 import org.apache.flink.table.operations.EndStatementSetOperation;
 import org.apache.flink.table.operations.ExplainOperation;
 import org.apache.flink.table.operations.LoadModuleOperation;
@@ -96,6 +98,7 @@ import org.apache.flink.table.planner.delegation.PlannerContext;
 import org.apache.flink.table.planner.expressions.utils.Func0$;
 import org.apache.flink.table.planner.expressions.utils.Func1$;
 import org.apache.flink.table.planner.expressions.utils.Func8$;
+import org.apache.flink.table.planner.factories.TestUpdateDeleteTableFactory;
 import org.apache.flink.table.planner.parse.CalciteParser;
 import org.apache.flink.table.planner.parse.ExtendedParser;
 import org.apache.flink.table.planner.runtime.utils.JavaUserDefinedScalarFunctions;
@@ -2704,6 +2707,46 @@ public class SqlToOperationConverterTest {
         assertThat(extendedParser.parse(command)).get().isInstanceOf(QuitOperation.class);
     }
 
+    @Test
+    public void testDeletePushDown() throws Exception {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", TestUpdateDeleteTableFactory.IDENTIFIER);
+        CatalogTable catalogTable =
+                CatalogTable.of(
+                        Schema.newBuilder()
+                                .column("a", DataTypes.INT().notNull())
+                                .column("c", DataTypes.STRING().notNull())
+                                .build(),
+                        null,
+                        Collections.emptyList(),
+                        options);
+        ObjectIdentifier tableIdentifier =
+                ObjectIdentifier.of("builtin", "default", "test_push_down");
+        catalogManager.createTable(catalogTable, tableIdentifier, false);
+
+        // no filter in delete statement
+        Operation operation = parse("DELETE FROM test_push_down");
+        checkDeleteFromFilterOperation(operation, "[]");
+
+        // with filters in delete statement
+        operation = parse("DELETE FROM test_push_down where a = 1 and c = '123'");
+        checkDeleteFromFilterOperation(operation, "[equals(a, 1), equals(c, '123')]");
+
+        // with filter = false after reduced in delete statement
+        operation = parse("DELETE FROM test_push_down where a = 1 + 6 and a = 2");
+        checkDeleteFromFilterOperation(operation, "[false]");
+
+        assertThatThrownBy(
+                        () ->
+                                parse(
+                                        "DELETE FROM test_push_down where a = (select count(*) from test_push_down)"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage(
+                        String.format(
+                                "Only delete push down is supported currently, but the delete statement can't pushed to table sink %s.",
+                                tableIdentifier.asSerializableString()));
+    }
+
     // ~ Tool Methods ----------------------------------------------------------
 
     private static TestItem createTestItem(Object... args) {
@@ -2898,6 +2941,15 @@ public class SqlToOperationConverterTest {
                 .containsEntry(
                         TestManagedTableFactory.ENRICHED_KEY,
                         TestManagedTableFactory.ENRICHED_VALUE);
+    }
+
+    private static void checkDeleteFromFilterOperation(
+            Operation operation, String expectedFilters) {
+        assertThat(operation).isInstanceOf(DeleteFromFilterOperation.class);
+        DeleteFromFilterOperation deleteFromFiltersOperation =
+                (DeleteFromFilterOperation) operation;
+        List<ResolvedExpression> filters = deleteFromFiltersOperation.getFilters();
+        assertThat(filters.toString()).isEqualTo(expectedFilters);
     }
 
     // ~ Inner Classes ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/operations/SqlToOperationConverterTest.java
@@ -2708,7 +2708,7 @@ public class SqlToOperationConverterTest {
     }
 
     @Test
-    public void testDeletePushDown() throws Exception {
+    public void testDelete() throws Exception {
         Map<String, String> options = new HashMap<>();
         options.put("connector", TestUpdateDeleteTableFactory.IDENTIFIER);
         CatalogTable catalogTable =
@@ -2720,31 +2720,25 @@ public class SqlToOperationConverterTest {
                         null,
                         Collections.emptyList(),
                         options);
-        ObjectIdentifier tableIdentifier =
-                ObjectIdentifier.of("builtin", "default", "test_push_down");
+        ObjectIdentifier tableIdentifier = ObjectIdentifier.of("builtin", "default", "test_delete");
         catalogManager.createTable(catalogTable, tableIdentifier, false);
 
         // no filter in delete statement
-        Operation operation = parse("DELETE FROM test_push_down");
+        Operation operation = parse("DELETE FROM test_delete");
         checkDeleteFromFilterOperation(operation, "[]");
 
         // with filters in delete statement
-        operation = parse("DELETE FROM test_push_down where a = 1 and c = '123'");
+        operation = parse("DELETE FROM test_delete where a = 1 and c = '123'");
         checkDeleteFromFilterOperation(operation, "[equals(a, 1), equals(c, '123')]");
 
         // with filter = false after reduced in delete statement
-        operation = parse("DELETE FROM test_push_down where a = 1 + 6 and a = 2");
+        operation = parse("DELETE FROM test_delete where a = 1 + 6 and a = 2");
         checkDeleteFromFilterOperation(operation, "[false]");
 
-        assertThatThrownBy(
-                        () ->
-                                parse(
-                                        "DELETE FROM test_push_down where a = (select count(*) from test_push_down)"))
-                .isInstanceOf(UnsupportedOperationException.class)
-                .hasMessage(
-                        String.format(
-                                "Only delete push down is supported currently, but the delete statement can't pushed to table sink %s.",
-                                tableIdentifier.asSerializableString()));
+        operation = parse("DELETE FROM test_delete where a = (select count(*) from test_delete)");
+        assertThat(operation).isInstanceOf(SinkModifyOperation.class);
+        SinkModifyOperation modifyOperation = (SinkModifyOperation) operation;
+        assertThat(modifyOperation.isDelete()).isTrue();
     }
 
     // ~ Tool Methods ----------------------------------------------------------

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelDeleteTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/batch/sql/RowLevelDeleteTest.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.batch.sql;
+
+import org.apache.flink.table.api.ExplainDetail;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
+import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import scala.collection.Seq;
+
+/** Test for row-level delete. */
+@RunWith(Parameterized.class)
+public class RowLevelDeleteTest extends TableTestBase {
+
+    private final SupportsRowLevelDelete.RowLevelDeleteMode deleteMode;
+    private final Seq<ExplainDetail> explainDetails =
+            JavaScalaConversionUtil.toScala(
+                    Collections.singletonList(ExplainDetail.JSON_EXECUTION_PLAN));
+
+    private BatchTableTestUtil util;
+
+    @Parameterized.Parameters(name = "deleteMode = {0}")
+    public static Collection<SupportsRowLevelDelete.RowLevelDeleteMode> data() {
+        return Arrays.asList(
+                SupportsRowLevelDelete.RowLevelDeleteMode.DELETED_ROWS,
+                SupportsRowLevelDelete.RowLevelDeleteMode.REMAINING_ROWS);
+    }
+
+    public RowLevelDeleteTest(SupportsRowLevelDelete.RowLevelDeleteMode deleteMode) {
+        this.deleteMode = deleteMode;
+    }
+
+    @Before
+    public void before() {
+        util = batchTestUtil(TableConfig.getDefault());
+        util.tableEnv()
+                .getConfig()
+                .getConfiguration()
+                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 12);
+    }
+
+    @Test
+    public void testDeleteWithoutFilter() {
+        createTableForDelete();
+        util.verifyExplainInsert("DELETE FROM t", explainDetails);
+    }
+
+    @Test
+    public void testDeleteWithFilter() {
+        createTableForDelete();
+        util.verifyExplainInsert("DELETE FROM t where a = 1 and b = '123'", explainDetails);
+    }
+
+    @Test
+    public void testDeleteWithSubQuery() {
+        createTableForDelete();
+        util.verifyExplainInsert(
+                "DELETE FROM t where b = '123' and a = (select count(*) from t)", explainDetails);
+    }
+
+    @Test
+    public void testDeleteWithCustomColumns() {
+        util.tableEnv()
+                .executeSql(
+                        String.format(
+                                "CREATE TABLE t (a int, b string, c double) WITH"
+                                        + " ("
+                                        + "'connector' = 'test-update-delete', "
+                                        + "'required-columns-for-delete' = 'b;c', "
+                                        + "'delete-mode' = '%s', 'support-delete-push-down' = 'false'"
+                                        + ") ",
+                                deleteMode));
+        util.verifyExplainInsert("DELETE FROM t where b = '123'", explainDetails);
+    }
+
+    @Test
+    public void testDeleteWithMetaColumns() {
+        util.tableEnv()
+                .executeSql(
+                        String.format(
+                                "CREATE TABLE t (a int, b string, c double) WITH"
+                                        + " ("
+                                        + "'connector' = 'test-update-delete', "
+                                        + "'required-columns-for-delete' = 'meta_f1;meta_k2;b', "
+                                        + "'delete-mode' = '%s', 'support-delete-push-down' = 'false'"
+                                        + ") ",
+                                deleteMode));
+        util.verifyExplainInsert("DELETE FROM t where b = '123'", explainDetails);
+    }
+
+    private void createTableForDelete() {
+        util.tableEnv()
+                .executeSql(
+                        String.format(
+                                "CREATE TABLE t (a int, b string) WITH "
+                                        + "('connector' = 'test-update-delete',"
+                                        + " 'delete-mode' = '%s', 'support-delete-push-down' = 'false') ",
+                                deleteMode));
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/DeleteTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/DeleteTableITCase.java
@@ -18,6 +18,11 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql;
 
+import org.apache.flink.table.api.StatementSet;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.api.TableResult;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -27,16 +32,34 @@ import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** The IT case for DELETE statement in batch mode. */
+@RunWith(Parameterized.class)
 public class DeleteTableITCase extends BatchTestBase {
     private static final int ROW_NUM = 5;
+
+    private final SupportsRowLevelDelete.RowLevelDeleteMode deleteMode;
+
+    @Parameterized.Parameters(name = "deleteMode = {0}")
+    public static Collection<SupportsRowLevelDelete.RowLevelDeleteMode> data() {
+        return Arrays.asList(
+                SupportsRowLevelDelete.RowLevelDeleteMode.DELETED_ROWS,
+                SupportsRowLevelDelete.RowLevelDeleteMode.REMAINING_ROWS);
+    }
+
+    public DeleteTableITCase(SupportsRowLevelDelete.RowLevelDeleteMode deleteMode) {
+        this.deleteMode = deleteMode;
+    }
 
     @Test
     public void testDeletePushDown() throws Exception {
@@ -50,11 +73,9 @@ public class DeleteTableITCase extends BatchTestBase {
                                         + ")",
                                 dataId));
         // it only contains equal expression, should be pushed down
-        List<Row> rows =
-                CollectionUtil.iteratorToList(
-                        tEnv().executeSql("DELETE FROM t WHERE a = 1").collect());
+        List<Row> rows = toRows(tEnv().executeSql("DELETE FROM t where a = 1"));
         assertThat(rows.toString()).isEqualTo("[+I[1], +I[OK]]");
-        rows = CollectionUtil.iteratorToList(tEnv().executeSql("SELECT * FROM t").collect());
+        rows = toRows(tEnv().executeSql("SELECT * FROM t"));
         assertThat(rows.toString())
                 .isEqualTo("[+I[0, b_0, 0.0], +I[2, b_2, 4.0], +I[3, b_3, 6.0], +I[4, b_4, 8.0]]");
 
@@ -63,19 +84,98 @@ public class DeleteTableITCase extends BatchTestBase {
         assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t where a > 1"))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage(
-                        "Only delete push down is supported currently, "
-                                + "but the delete statement can't pushed to table sink `default_catalog`.`default_database`.`t`.");
+                        String.format(
+                                "Can't perform delete operation of the table %s because the corresponding dynamic table sink has not yet implemented %s.",
+                                "default_catalog.default_database.t",
+                                SupportsRowLevelDelete.class.getName()));
+    }
 
+    @Test
+    public void testRowLevelDelete() throws Exception {
+        String dataId = registerData();
         tEnv().executeSql(
-                        "CREATE TABLE t1 (a int) WITH"
-                                + " ('connector' = 'test-update-delete',"
-                                + " 'support-delete-push-down' = 'false')");
-        // should throw exception for sink that doesn't implement SupportsDeletePushDown interface
-        assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t1"))
-                .isInstanceOf(UnsupportedOperationException.class)
+                        String.format(
+                                "CREATE TABLE t (a int, b string, c double) WITH"
+                                        + " ('connector' = 'test-update-delete',"
+                                        + " 'data-id' = '%s',"
+                                        + " 'delete-mode' = '%s',"
+                                        + " 'support-delete-push-down' = 'false'"
+                                        + ")",
+                                dataId, deleteMode));
+        tEnv().executeSql("DELETE FROM t WHERE a > 1").await();
+        List<Row> rows = toRows(tEnv().executeSql("SELECT * FROM t"));
+        assertThat(rows.toString()).isEqualTo("[+I[0, b_0, 0.0], +I[1, b_1, 2.0]]");
+
+        tEnv().executeSql("DELETE FROM t WHERE a >= (select count(1) from t where c > 1)").await();
+        rows = toRows(tEnv().executeSql("SELECT * FROM t"));
+        assertThat(rows.toString()).isEqualTo("[+I[0, b_0, 0.0]]");
+    }
+
+    @Test
+    public void testMixDelete() throws Exception {
+        // test mix delete push down and row-level delete
+        String dataId = registerData();
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE t (a int, b string, c double) WITH"
+                                        + " ('connector' = 'test-update-delete',"
+                                        + " 'data-id' = '%s',"
+                                        + " 'mix-delete' = 'true')",
+                                dataId));
+        // the deletion can't be pushed down, but the deletion should still success.
+        tEnv().executeSql("DELETE FROM t WHERE a >= (select count(1) from t where c > 2)").await();
+        List<Row> rows = toRows(tEnv().executeSql("SELECT * FROM t"));
+        assertThat(rows.toString())
+                .isEqualTo("[+I[0, b_0, 0.0], +I[1, b_1, 2.0], +I[2, b_2, 4.0]]");
+
+        // should fall back to delete push down
+        rows = toRows(tEnv().executeSql("DELETE FROM t"));
+        assertThat(rows.toString()).isEqualTo("[+I[3], +I[OK]]");
+        rows = toRows(tEnv().executeSql("SELECT * FROM t"));
+        assertThat(rows).isEmpty();
+    }
+
+    @Test
+    public void testStatementSetContainDeleteAndInsert() throws Exception {
+        tEnv().executeSql(
+                        "CREATE TABLE t (a int, b string, c double) WITH"
+                                + " ('connector' = 'test-update-delete')");
+        StatementSet statementSet = tEnv().createStatementSet();
+        // should throw exception when statement set contains insert and delete statement
+        statementSet.addInsertSql("INSERT INTO t VALUES (1, 'v1', 1)");
+        statementSet.addInsertSql("DELETE FROM t");
+        assertThatThrownBy(statementSet::execute)
+                .isInstanceOf(TableException.class)
                 .hasMessage(
-                        "Only delete push down is supported currently, "
-                                + "but the delete statement can't pushed to table sink `default_catalog`.`default_database`.`t1`.");
+                        "Unsupported SQL query! Only accept a single SQL statement of type DELETE.");
+    }
+
+    @Test
+    public void testCompilePlanSql() throws Exception {
+        tEnv().executeSql(
+                        "CREATE TABLE t (a int, b string, c double) WITH"
+                                + " ('connector' = 'test-update-delete')");
+        // should throw exception when compile sql for delete statement
+        assertThatThrownBy(() -> tEnv().compilePlanSql("DELETE FROM t"))
+                .isInstanceOf(TableException.class)
+                .hasMessage(
+                        "Unsupported SQL query! compilePlanSql() only accepts a single SQL statement of type INSERT");
+    }
+
+    @Test
+    public void testDeleteWithLegacyTableSink() {
+        tEnv().executeSql(
+                        "CREATE TABLE t (a int, b string, c double) WITH"
+                                + " ('connector' = 'COLLECTION')");
+        assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t"))
+                .isInstanceOf(TableException.class)
+                .hasMessage(
+                        String.format(
+                                "Can't perform delete operation of the table %s "
+                                        + " because the corresponding table sink is the legacy TableSink,"
+                                        + " Please implement %s for it.",
+                                "`default_catalog`.`default_database`.`t`",
+                                DynamicTableSink.class.getName()));
     }
 
     private String registerData() {
@@ -89,5 +189,9 @@ public class DeleteTableITCase extends BatchTestBase {
             values.add(GenericRowData.of(i, StringData.fromString("b_" + i), i * 2.0));
         }
         return values;
+    }
+
+    private List<Row> toRows(TableResult result) {
+        return CollectionUtil.iteratorToList(result.collect());
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/DeleteTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/DeleteTableITCase.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.batch.sql;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.planner.factories.TestUpdateDeleteTableFactory;
+import org.apache.flink.table.planner.runtime.utils.BatchTestBase;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** The IT case for DELETE statement in batch mode. */
+public class DeleteTableITCase extends BatchTestBase {
+    private static final int ROW_NUM = 5;
+
+    @Test
+    public void testDeletePushDown() throws Exception {
+        String dataId = registerData();
+        tEnv().executeSql(
+                        String.format(
+                                "CREATE TABLE t (a int, b string, c double) WITH"
+                                        + " ('connector' = 'test-update-delete',"
+                                        + " 'data-id' = '%s',"
+                                        + " 'only-accept-equal-predicate' = 'true'"
+                                        + ")",
+                                dataId));
+        // it only contains equal expression, should be pushed down
+        List<Row> rows =
+                CollectionUtil.iteratorToList(
+                        tEnv().executeSql("DELETE FROM t WHERE a = 1").collect());
+        assertThat(rows.toString()).isEqualTo("[+I[1], +I[OK]]");
+        rows = CollectionUtil.iteratorToList(tEnv().executeSql("SELECT * FROM t").collect());
+        assertThat(rows.toString())
+                .isEqualTo("[+I[0, b_0, 0.0], +I[2, b_2, 4.0], +I[3, b_3, 6.0], +I[4, b_4, 8.0]]");
+
+        // should throw exception for the deletion can not be pushed down as it contains non-equal
+        // predicate and the table sink haven't implemented SupportsRowLevelDeleteInterface
+        assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t where a > 1"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage(
+                        "Only delete push down is supported currently, "
+                                + "but the delete statement can't pushed to table sink `default_catalog`.`default_database`.`t`.");
+
+        tEnv().executeSql(
+                        "CREATE TABLE t1 (a int) WITH"
+                                + " ('connector' = 'test-update-delete',"
+                                + " 'support-delete-push-down' = 'false')");
+        // should throw exception for sink that doesn't implement SupportsDeletePushDown interface
+        assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t1"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessage(
+                        "Only delete push down is supported currently, "
+                                + "but the delete statement can't pushed to table sink `default_catalog`.`default_database`.`t1`.");
+    }
+
+    private String registerData() {
+        List<RowData> values = createValue();
+        return TestUpdateDeleteTableFactory.registerRowData(values);
+    }
+
+    private List<RowData> createValue() {
+        List<RowData> values = new ArrayList<>();
+        for (int i = 0; i < ROW_NUM; i++) {
+            values.add(GenericRowData.of(i, StringData.fromString("b_" + i), i * 2.0));
+        }
+        return values;
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DeleteTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DeleteTableITCase.java
@@ -34,5 +34,12 @@ public class DeleteTableITCase extends StreamingTestBase {
         assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t"))
                 .isInstanceOf(TableException.class)
                 .hasMessage("DELETE statement is not supported for streaming mode now.");
+
+        tEnv().executeSql(
+                        "CREATE TABLE t1 (a int) WITH ('connector' = 'test-update-delete', "
+                                + "'support-delete-push-down' = 'false')");
+        assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t1"))
+                .isInstanceOf(TableException.class)
+                .hasMessage("DELETE statement is not supported for streaming mode now.");
     }
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DeleteTableITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/DeleteTableITCase.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.runtime.stream.sql;
+
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.planner.runtime.utils.StreamingTestBase;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** The IT case for DELETE statement in streaming mode. */
+public class DeleteTableITCase extends StreamingTestBase {
+
+    @Test
+    public void testDelete() {
+        tEnv().executeSql("CREATE TABLE t (a int) WITH ('connector' = 'test-update-delete')");
+        assertThatThrownBy(() -> tEnv().executeSql("DELETE FROM t"))
+                .isInstanceOf(TableException.class)
+                .hasMessage("DELETE statement is not supported for streaming mode now.");
+    }
+}

--- a/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-table/flink-table-planner/src/test/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -18,3 +18,4 @@ org.apache.flink.table.planner.factories.TestValuesTableFactory
 org.apache.flink.table.planner.factories.TestFileFactory
 org.apache.flink.table.planner.factories.TableFactoryHarness$Factory
 org.apache.flink.table.planner.plan.stream.sql.TestTableFactory
+org.apache.flink.table.planner.factories.TestUpdateDeleteTableFactory

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelDeleteTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/RowLevelDeleteTest.xml
@@ -1,0 +1,714 @@
+<?xml version="1.0" ?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to you under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<Root>
+  <TestCase name="testDeleteWithoutFilter[deleteMode = DELETED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[DELETE])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithFilter[deleteMode = DELETED_ROWS]">
+	<Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalFilter(condition=[AND(=($0, 1), =($1, _UTF-16LE'123'))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[CAST(1 AS INTEGER) AS a, CAST('123' AS VARCHAR(2147483647)) AS b], where=[AND(=(a, 1), =(b, '123'))])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[CAST(1 AS INTEGER) AS a, CAST('123' AS VARCHAR(2147483647)) AS b], where=[((a = 1) AND (b = '123'))])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[CAST(1 AS INTEGER) AS a, CAST('123' AS VARCHAR(2147483647)) AS b], where=[((a = 1) AND (b = '123'))])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[DELETE])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithSubQuery[deleteMode = DELETED_ROWS]">
+    <Resource name="explain">
+	  <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalFilter(condition=[AND(=($1, _UTF-16LE'123'), =(CAST($0):BIGINT, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalTableScan(table=[[default_catalog, default_database, t]])
+})))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, CAST('123' AS VARCHAR(2147483647)) AS b])
+   +- NestedLoopJoin(joinType=[InnerJoin], where=[=(a0, EXPR$0)], select=[a, a0, EXPR$0], build=[right], singleRowJoin=[true])
+      :- Calc(select=[a, CAST(a AS BIGINT) AS a0], where=[=(b, '123')])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+      +- Exchange(distribution=[broadcast])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- Calc(select=[0 AS $f0])
+                     +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, CAST('123' AS VARCHAR(2147483647)) AS b])
+   +- NestedLoopJoin(joinType=[InnerJoin], where=[(a0 = EXPR$0)], select=[a, a0, EXPR$0], build=[right], singleRowJoin=[true])
+      :- Exchange(distribution=[any], shuffle_mode=[BATCH])
+      :  +- Calc(select=[a, CAST(a AS BIGINT) AS a0], where=[(b = '123')])
+      :     +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])(reuse_id=[1])
+      +- Exchange(distribution=[broadcast])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- Calc(select=[0 AS $f0])
+                     +- Reused(reference_id=[1])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, CAST(a AS BIGINT) AS a0], where=[(b = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[0 AS $f0])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashAggregate[]",
+    "pact" : "Operator",
+    "contents" : "[]:LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashAggregate[]",
+    "pact" : "Operator",
+    "contents" : "[]:HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "GLOBAL",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "NestedLoopJoin[]",
+    "pact" : "Operator",
+    "contents" : "[]:NestedLoopJoin(joinType=[InnerJoin], where=[(a0 = EXPR$0)], select=[a, a0, EXPR$0], build=[right], singleRowJoin=[true])",
+    "parallelism" : 12,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "BROADCAST",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, CAST('123' AS VARCHAR(2147483647)) AS b])",
+    "parallelism" : 12,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[DELETE])",
+    "parallelism" : 12,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithCustomColumns[deleteMode = DELETED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
++- LogicalProject(b=[$1], c=[$2])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=[CAST('123' AS VARCHAR(2147483647)) AS b, c], where=[=(b, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=[CAST('123' AS VARCHAR(2147483647)) AS b, c], where=[(b = '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[CAST('123' AS VARCHAR(2147483647)) AS b, c], where=[(b = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[DELETE])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithMetaColumns[deleteMode = DELETED_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, b])
++- LogicalProject(meta_f1=[$3], meta_f2=[$4], b=[$1])
+   +- LogicalFilter(condition=[=($1, _UTF-16LE'123')])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, b])
++- Calc(select=[meta_f1, meta_f2, CAST('123' AS VARCHAR(2147483647)) AS b], where=[=(b, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, b])
++- Calc(select=[meta_f1, meta_f2, CAST('123' AS VARCHAR(2147483647)) AS b], where=[(b = '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[meta_f1, meta_f2, CAST('123' AS VARCHAR(2147483647)) AS b], where=[(b = '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "RowKindSetter[]",
+    "pact" : "Operator",
+    "contents" : "[]:RowKindSetter(TargetRowKind=[DELETE])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithoutFilter[deleteMode = REMAINING_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalFilter(condition=[false])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Values(tuples=[[]], values=[a, b])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Values(tuples=[[]], values=[a, b])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: Values[]",
+    "pact" : "Data Source",
+    "contents" : "[]:Values(tuples=[[]], values=[a, b])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithFilter[deleteMode = REMAINING_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalFilter(condition=[NOT(AND(=($0, 1), =($1, _UTF-16LE'123')))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, b], where=[OR(<>(a, 1), <>(b, '123'))])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, b], where=[((a <> 1) OR (b <> '123'))])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, b], where=[((a <> 1) OR (b <> '123'))])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithSubQuery[deleteMode = REMAINING_ROWS]">
+    <Resource name="explain">
+		<![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[a, b])
++- LogicalProject(a=[$0], b=[$1])
+   +- LogicalFilter(condition=[NOT(AND(=($1, _UTF-16LE'123'), =(CAST($0):BIGINT, $SCALAR_QUERY({
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
+  LogicalProject($f0=[0])
+    LogicalTableScan(table=[[default_catalog, default_database, t]])
+}))))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, b], where=[OR(<>(b, '123'), <>(CAST(a AS BIGINT), EXPR$0))])
+   +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
+      :- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+      +- Exchange(distribution=[broadcast])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- Calc(select=[0 AS $f0])
+                     +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[a, b])
++- Calc(select=[a, b], where=[((b <> '123') OR (CAST(a AS BIGINT) <> EXPR$0))])
+   +- NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])
+      :- Exchange(distribution=[any], shuffle_mode=[BATCH])
+      :  +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])(reuse_id=[1])
+      +- Exchange(distribution=[broadcast])
+         +- HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
+            +- Exchange(distribution=[single])
+               +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])
+                  +- Calc(select=[0 AS $f0])
+                     +- Reused(reference_id=[1])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[0 AS $f0])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashAggregate[]",
+    "pact" : "Operator",
+    "contents" : "[]:LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "HashAggregate[]",
+    "pact" : "Operator",
+    "contents" : "[]:HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "GLOBAL",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "NestedLoopJoin[]",
+    "pact" : "Operator",
+    "contents" : "[]:NestedLoopJoin(joinType=[LeftOuterJoin], where=[true], select=[a, b, EXPR$0], build=[right], singleRowJoin=[true])",
+    "parallelism" : 12,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    }, {
+      "id" : ,
+      "ship_strategy" : "BROADCAST",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[a, b], where=[((b <> '123') OR (CAST(a AS BIGINT) <> EXPR$0))])",
+    "parallelism" : 12,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "REBALANCE",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithCustomColumns[deleteMode = REMAINING_ROWS]">
+    <Resource name="explain">
+      <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[b, c])
++- LogicalProject(b=[$1], c=[$2])
+   +- LogicalFilter(condition=[NOT(=($1, _UTF-16LE'123'))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=[b, c], where=[<>(b, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[b, c])
++- Calc(select=[b, c], where=[(b <> '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[b, c], where=[(b <> '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+  <TestCase name="testDeleteWithMetaColumns[deleteMode = REMAINING_ROWS]">
+    <Resource name="explain">
+	  <![CDATA[== Abstract Syntax Tree ==
+LogicalSink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, b])
++- LogicalProject(meta_f1=[$3], meta_f2=[$4], b=[$1])
+   +- LogicalFilter(condition=[NOT(=($1, _UTF-16LE'123'))])
+      +- LogicalTableScan(table=[[default_catalog, default_database, t]])
+
+== Optimized Physical Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, b])
++- Calc(select=[meta_f1, meta_f2, b], where=[<>(b, '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Optimized Execution Plan ==
+Sink(table=[default_catalog.default_database.t], fields=[meta_f1, meta_f2, b])
++- Calc(select=[meta_f1, meta_f2, b], where=[(b <> '123')])
+   +- TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])
+
+== Physical Execution Plan ==
+{
+  "nodes" : [ {
+    "id" : ,
+    "type" : "Source: t[]",
+    "pact" : "Data Source",
+    "contents" : "[]:TableSourceScan(table=[[default_catalog, default_database, t]], fields=[a, b, c, meta_f1, meta_f2])",
+    "parallelism" : 1
+  }, {
+    "id" : ,
+    "type" : "Calc[]",
+    "pact" : "Operator",
+    "contents" : "[]:Calc(select=[meta_f1, meta_f2, b], where=[(b <> '123')])",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  }, {
+    "id" : ,
+    "type" : "Sink: Unnamed",
+    "pact" : "Data Sink",
+    "contents" : "Sink: Unnamed",
+    "parallelism" : 1,
+    "predecessors" : [ {
+      "id" : ,
+      "ship_strategy" : "FORWARD",
+      "side" : "second"
+    } ]
+  } ]
+}]]>
+	</Resource>
+  </TestCase>
+</Root>

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/RowKindSetter.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/operators/sink/RowKindSetter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sink;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.operators.TableStreamOperator;
+import org.apache.flink.types.RowKind;
+
+/** An operator that sets the row kind of the incoming records to a specific row kind. */
+@Internal
+public class RowKindSetter extends TableStreamOperator<RowData>
+        implements OneInputStreamOperator<RowData, RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final RowKind targetRowKind;
+
+    public RowKindSetter(RowKind targetRowKind) {
+        this.targetRowKind = targetRowKind;
+    }
+
+    @Override
+    public void processElement(StreamRecord<RowData> element) throws Exception {
+        element.getValue().setRowKind(targetRowKind);
+        output.collect(element);
+    }
+}

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/RowKindSetterTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/operators/sink/RowKindSetterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.operators.sink;
+
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.types.RowKind;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link RowKindSetter}. */
+public class RowKindSetterTest {
+
+    @Test
+    public void testSetRowKind() throws Exception {
+        // test set to all row kind
+        for (RowKind targetRowKind : RowKind.values()) {
+            RowKindSetter rowKindSetter = new RowKindSetter(targetRowKind);
+            try (OneInputStreamOperatorTestHarness<RowData, RowData> operatorTestHarness =
+                    new OneInputStreamOperatorTestHarness<>(rowKindSetter)) {
+                operatorTestHarness.open();
+
+                // get the rows with all row kind
+                List<RowData> rows = getRowsWithAllRowKind();
+                for (RowData row : rows) {
+                    operatorTestHarness.processElement(new StreamRecord<>(row));
+                }
+                // verify the row kind of output
+                verifyRowKind(operatorTestHarness.extractOutputValues(), targetRowKind);
+            }
+        }
+    }
+
+    private List<RowData> getRowsWithAllRowKind() {
+        List<RowData> rows = new ArrayList<>();
+        for (RowKind rowKind : RowKind.values()) {
+            rows.add(GenericRowData.of(rowKind, 1));
+        }
+        return rows;
+    }
+
+    private void verifyRowKind(List<RowData> rows, RowKind rowKind) {
+        for (RowData row : rows) {
+            assertThat(row.getRowKind()).isEqualTo(rowKind);
+        }
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
To make planner supports delete including delete push down and row-level delete


## Brief change log
It contains two commits:
- Planner supports delete push down
  - Convert the `SqlDelete` to `LogicalTableModify`, then get the `DynamicTableSInk` for the table to be deleted.
  - Extract  the predicate in `Filter` contained in `LogicalTableModify` and resolve it to a list of `ResolvedExpression`
  - if the `DynamicTableSInk`is instance of `SupportsDeletePushDown`, call method `SupportsDeletePushDown#applyDeleteFilters` to apply filters, if it returns true, create a `DeleteFromFilterOperation`.
  - Call method `DeleteFromFilterOperation#getSupportsDeletePushDown#executeDeletion` to do the deletion in `TableEnvironmentImpl#executeInternal`  if the operation is `DeleteFromFilterOperation`.
 
- Planner supports row-level delete
  - Add a field `isDelete` in `SinkModifyOperation` to represents it's for delete.
  - If the delete push down is not applicable for the cases where the table sink doesn't implement  `SupportsDeletePushDown` or `SupportsDeletePushDown#applyDeleteFilters`, return  a `SinkModifyOperation` with `isDelete=true` and the `LogicalTableModify` converted from `SqlDelete`. 
  - Rewrite the `LogicalTableModify` to a RelNode that insert into the sink with rows
    - If the delete mode is `REMAINING_ROWS`, negate the predicate in `Filter` node.
    - Get the required columns by calling method `SupportsRowLevelDelete#applyRowLevelDelete`. We may rewrite the `LogicaTableScan` to add extra meta cols to the underlying table. Then create a `Project` node that only select the  required columns.
   - If  the delete mode is `DELETED_ROWS`, add a operator to set the `RowKind` to `RowKind#Delete` in `CommonExecSink`


## Verifying this change
- The test in `SqlToOperationConverterTest#testDelete` to verify delete statement will be converted to `DeleteFromFilterOperation` if delete can be pushed down or `SinkModifyOperation`.
- The test in `RowLevelDeleteTest` to verify the plan for row-level delete.
- The IT case in `DeleteTableITCase` to verify delete can be performed normally.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
