### PR TITLE
[FLINK-30700][docs]Translate "Deduplication" page of "Querys" into Ch…

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/deduplication.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/deduplication.md
@@ -27,9 +27,15 @@ under the License.
 
 Deduplication removes rows that duplicate over a set of columns, keeping only the first one or the last one. In some cases, the upstream ETL jobs are not end-to-end exactly-once; this may result in duplicate records in the sink in case of failover. However, the duplicate records will affect the correctness of downstream analytical jobs - e.g. `SUM`, `COUNT` - so deduplication is needed before further analysis.
 
+去重是去掉重复的行,只保留第一个或者最后一个.有时候,上游的ETL生成的数据不是端到端精确一次的(exactly-once); 在发生故障转移(failover)后,可能会导致Sink出现重复记录.这些重复记录会影响下游的分析工作,比如: `SUM`, `COUNT`,所以需要先去重再进行下一步的分析.
+
 Flink uses `ROW_NUMBER()` to remove duplicates, just like the way of Top-N query. In theory, deduplication is a special case of Top-N in which the N is one and order by the processing time or event time.
 
+Flink 使用`ROW_NUMBER()`移除重复数据,就像Top-N查询一样.理论上,去重是Top-N的特殊情况:N是1,并且是通过处理或者事件时间排序的.
+
 The following shows the syntax of the Deduplication statement:
+
+下面的例子展示了去重语句的语法:
 
 ```sql
 SELECT [column_list]
@@ -48,11 +54,22 @@ WHERE rownum = 1
 - `ORDER BY time_attr [asc|desc]`: Specifies the ordering column, it must be a [time attribute]({{< ref "docs/dev/table/concepts/time_attributes" >}}). Currently Flink supports [processing time attribute]({{< ref "docs/dev/table/concepts/time_attributes" >}}#processing-time) and [event time attribute]({{< ref "docs/dev/table/concepts/time_attributes" >}}#event-time). Ordering by ASC means keeping the first row, ordering by DESC means keeping the last row.
 - `WHERE rownum = 1`: The `rownum = 1` is required for Flink to recognize this query is deduplication.
 
+**参数说明:**
+
+- `ROW_NUMBER()`: 为每一行分配一个唯一且连续的数字,从1开始.
+- `PARTITION BY col1[, col2...]`: 指定分区列,即需要去重的列.
+- `ORDER BY time_attr [asc|desc]`:指定排序列,必须是[时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}). 目前Flink支持[处理时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}#processing-time) 和 [事件时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}#event-time).order by ASC保留第一行,DESC保留最后一行.
+- `WHERE rownum = 1`: Flink需要这个条件来识别去重语句.
+
 {{< hint info >}}
 Note: the above pattern must be followed exactly, otherwise the optimizer won’t be able to translate the query.
+
+注意: 上面的必须严格遵守,否则优化器不能识别.
 {{< /hint >}}
 
 The following examples show how to specify SQL queries with Deduplication on streaming tables.
+
+下面的例子展示了在流表上怎样指定去重SQL查询:
 
 ```sql
 CREATE TABLE Orders (
@@ -65,6 +82,8 @@ CREATE TABLE Orders (
 
 -- remove duplicate rows on order_id and keep the first occurrence row,
 -- because there shouldn't be two orders with the same order_id.
+-- 同一个order_id只保留第一次出现的行, 
+-- 因为订单号不能重复.
 SELECT order_id, user, product, num
 FROM (
   SELECT *,

--- a/docs/content.zh/docs/dev/table/sql/queries/deduplication.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/deduplication.md
@@ -22,20 +22,14 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Deduplication
+# 去重
 {{< label Batch >}} {{< label Streaming >}}
 
-Deduplication removes rows that duplicate over a set of columns, keeping only the first one or the last one. In some cases, the upstream ETL jobs are not end-to-end exactly-once; this may result in duplicate records in the sink in case of failover. However, the duplicate records will affect the correctness of downstream analytical jobs - e.g. `SUM`, `COUNT` - so deduplication is needed before further analysis.
+去重是去掉重复的行，只保留第一或者最后一行。有时，上游的 ETL 生成的数据不是端到端精确一次的（end-to-end exactly-once）； 在发生故障转移（failover）后，可能会导致 Sink 出现重复记录。这些重复记录会影响下游的分析工作，比如：`SUM`、`COUNT`，所以需要先去重再进行下一步的分析。
 
-去重是去掉重复的行,只保留第一个或者最后一个.有时候,上游的ETL生成的数据不是端到端精确一次的(exactly-once); 在发生故障转移(failover)后,可能会导致Sink出现重复记录.这些重复记录会影响下游的分析工作,比如: `SUM`, `COUNT`,所以需要先去重再进行下一步的分析.
+Flink 使用 `ROW_NUMBER()` 移除重复数据，就像 Top-N 查询一样。理论上，去重是 Top-N 的特殊情况：N 是 1 ，并且是通过处理或者事件时间排序的。
 
-Flink uses `ROW_NUMBER()` to remove duplicates, just like the way of Top-N query. In theory, deduplication is a special case of Top-N in which the N is one and order by the processing time or event time.
-
-Flink 使用`ROW_NUMBER()`移除重复数据,就像Top-N查询一样.理论上,去重是Top-N的特殊情况:N是1,并且是通过处理或者事件时间排序的.
-
-The following shows the syntax of the Deduplication statement:
-
-下面的例子展示了去重语句的语法:
+下面的例子展示了去重语句的语法：
 
 ```sql
 SELECT [column_list]
@@ -47,29 +41,18 @@ FROM (
 WHERE rownum = 1
 ```
 
-**Parameter Specification:**
+**参数说明：**
 
-- `ROW_NUMBER()`: Assigns an unique, sequential number to each row, starting with one.
-- `PARTITION BY col1[, col2...]`: Specifies the partition columns, i.e. the deduplicate key.
-- `ORDER BY time_attr [asc|desc]`: Specifies the ordering column, it must be a [time attribute]({{< ref "docs/dev/table/concepts/time_attributes" >}}). Currently Flink supports [processing time attribute]({{< ref "docs/dev/table/concepts/time_attributes" >}}#processing-time) and [event time attribute]({{< ref "docs/dev/table/concepts/time_attributes" >}}#event-time). Ordering by ASC means keeping the first row, ordering by DESC means keeping the last row.
-- `WHERE rownum = 1`: The `rownum = 1` is required for Flink to recognize this query is deduplication.
-
-**参数说明:**
-
-- `ROW_NUMBER()`: 为每一行分配一个唯一且连续的数字,从1开始.
-- `PARTITION BY col1[, col2...]`: 指定分区列,即需要去重的列.
-- `ORDER BY time_attr [asc|desc]`:指定排序列,必须是[时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}). 目前Flink支持[处理时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}#processing-time) 和 [事件时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}#event-time).order by ASC保留第一行,DESC保留最后一行.
-- `WHERE rownum = 1`: Flink需要这个条件来识别去重语句.
+- `ROW_NUMBER()`：为每一行分配一个唯一且连续的数字，从 1 开始。
+- `PARTITION BY col1[, col2...]`：指定分区列，即需要去重的列。
+- `ORDER BY time_attr [asc|desc]`：指定排序列，必须是 [时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}})。目前 Flink 支持 [处理时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}#processing-time) 和 [事件时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}#event-time)。order by ASC 保留第一行，DESC 保留最后一行。
+- `WHERE rownum = 1`：Flink 需要这个条件来识别去重语句。
 
 {{< hint info >}}
-Note: the above pattern must be followed exactly, otherwise the optimizer won’t be able to translate the query.
-
-注意: 上面的必须严格遵守,否则优化器不能识别.
+注意：上述格式必须严格遵守，否则优化器无法识别。
 {{< /hint >}}
 
-The following examples show how to specify SQL queries with Deduplication on streaming tables.
-
-下面的例子展示了在流表上怎样指定去重SQL查询:
+下面的例子展示了在流表上如何指定去重 SQL 查询：
 
 ```sql
 CREATE TABLE Orders (
@@ -82,8 +65,6 @@ CREATE TABLE Orders (
 
 -- remove duplicate rows on order_id and keep the first occurrence row,
 -- because there shouldn't be two orders with the same order_id.
--- 同一个order_id只保留第一次出现的行, 
--- 因为订单号不能重复.
 SELECT order_id, user, product, num
 FROM (
   SELECT *,


### PR DESCRIPTION
Page "Application Development"/"Table API&SQL"/"SQL"/"Queries"/deduplication translate to chinese.

## What is the purpose of the change

Translate /dev/table/sql/queries/deduplication.md

## Brief change log

Translate /dev/table/sql/queries/deduplication.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no