### PR TITLE
[hotfix][javadocs]Fix javadoc in Catalog Interface

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/catalog/Catalog.java
@@ -548,7 +548,7 @@ public interface Catalog {
      * Drop a function. Function name should be handled in a case insensitive way.
      *
      * @param functionPath path of the function to be dropped
-     * @param ignoreIfNotExists plag to specify behavior if the function does not exist: if set to
+     * @param ignoreIfNotExists flag to specify behavior if the function does not exist: if set to
      *     false, throw an exception if set to true, nothing happens
      * @throws FunctionNotExistException if the function does not exist
      * @throws CatalogException in case of any runtime exception


### PR DESCRIPTION

## What is the purpose of the change

Fix typo in Catalog interface


## Brief change log

Fix typo in javadocs 


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no 
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) no
