### PR TITLE
[FLINK-30623][runtime][bug] The canEmitBatchOfRecords should check recordWriter and changelogWriterAvailabilityProvider are available

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriterWithAvailabilityHelper.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/api/writer/ResultPartitionWriterWithAvailabilityHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.io.network.api.writer;
+
+import org.apache.flink.runtime.io.network.partition.MockResultPartitionWriter;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * A specific result partition writer implementation only used to control the output availability
+ * state in tests.
+ */
+public class ResultPartitionWriterWithAvailabilityHelper extends MockResultPartitionWriter {
+
+    private final AvailabilityHelper availabilityHelper;
+
+    public ResultPartitionWriterWithAvailabilityHelper(AvailabilityHelper availabilityHelper) {
+        this.availabilityHelper = availabilityHelper;
+    }
+
+    @Override
+    public CompletableFuture<?> getAvailableFuture() {
+        return availabilityHelper.getAvailableFuture();
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return availabilityHelper.isAvailable();
+    }
+}

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperator.java
@@ -170,7 +170,6 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
     private int numSplits;
     private final Map<String, Long> splitCurrentWatermarks = new HashMap<>();
     private final Set<String> currentlyPausedSplits = new HashSet<>();
-    private boolean isEmitNextLoopDisabled = false;
 
     private enum OperatingMode {
         READING,
@@ -412,9 +411,6 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         if (operatingMode != OperatingMode.READING) {
             return emitNextNotReading(output);
         }
-        if (isEmitNextLoopDisabled) {
-            return convertToInternalStatus(sourceReader.pollNext(currentMainOutput));
-        }
 
         InputStatus status;
         do {
@@ -570,11 +566,6 @@ public class SourceOperator<OUT, SplitT extends SourceSplit> extends AbstractStr
         } else {
             throw new IllegalStateException("Received unexpected operator event " + event);
         }
-    }
-
-    // Configure SourceOperator#emitNext to emit at most one record to the given DataOutput.
-    public void disableEmitNextLoop() {
-        isEmitNextLoopDisabled = true;
     }
 
     private void handleAddSplitsEvent(AddSplitEvent<SplitT> event) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/SourceOperatorFactory.java
@@ -32,11 +32,10 @@ import org.apache.flink.runtime.operators.coordination.OperatorEventGateway;
 import org.apache.flink.runtime.source.coordinator.SourceCoordinatorProvider;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeServiceAware;
+import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.util.function.FunctionWithException;
 
 import javax.annotation.Nullable;
-
-import java.util.function.Supplier;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -116,7 +115,7 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
                                 .getTaskManagerInfo()
                                 .getTaskManagerExternalAddress(),
                         emitProgressiveWatermarks,
-                        parameters.getContainingTask().getMailboxHasMail());
+                        parameters.getContainingTask().getCanEmitBatchOfRecords());
 
         sourceOperator.setup(
                 parameters.getContainingTask(),
@@ -172,7 +171,7 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
                     Configuration config,
                     String localHostName,
                     boolean emitProgressiveWatermarks,
-                    Supplier<Boolean> mailboxHasMail) {
+                    CanEmitBatchOfRecordsChecker canEmitBatchOfRecords) {
 
         // jumping through generics hoops: cast the generics away to then cast them back more
         // strictly typed
@@ -194,6 +193,6 @@ public class SourceOperatorFactory<OUT> extends AbstractStreamOperatorFactory<OU
                 config,
                 localHostName,
                 emitProgressiveWatermarks,
-                mailboxHasMail);
+                canEmitBatchOfRecords);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskSourceInput.java
@@ -157,9 +157,4 @@ public class StreamTaskSourceInput<T> implements StreamTaskInput<T>, Checkpointa
     public SourceOperator<T, ?> getOperator() {
         return operator;
     }
-
-    // Configure StreamTaskSourceInput#emitNext to emit at most one record to the given DataOutput.
-    public void disableEmitNextLoop() {
-        operator.disableEmitNextLoop();
-    }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -547,9 +547,7 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         DataInputStatus status = inputProcessor.processInput();
         switch (status) {
             case MORE_AVAILABLE:
-                if (recordWriter.isAvailable()
-                        && (changelogWriterAvailabilityProvider == null
-                                || changelogWriterAvailabilityProvider.isAvailable())) {
+                if (taskIsAvailable()) {
                     return;
                 }
                 break;
@@ -994,8 +992,14 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         return this.mailboxProcessor::getMailboxExecutor;
     }
 
+    private boolean taskIsAvailable() {
+        return recordWriter.isAvailable()
+                && (changelogWriterAvailabilityProvider == null
+                        || changelogWriterAvailabilityProvider.isAvailable());
+    }
+
     public CanEmitBatchOfRecordsChecker getCanEmitBatchOfRecords() {
-        return () -> !this.mailboxProcessor.hasMail();
+        return () -> !this.mailboxProcessor.hasMail() && taskIsAvailable();
     }
 
     public final boolean isRunning() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -137,7 +137,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
-import java.util.function.Supplier;
 
 import static org.apache.flink.configuration.TaskManagerOptions.BUFFER_DEBLOAT_PERIOD;
 import static org.apache.flink.util.ExceptionUtils.firstOrSuppressed;
@@ -995,8 +994,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
         return this.mailboxProcessor::getMailboxExecutor;
     }
 
-    public Supplier<Boolean> getMailboxHasMail() {
-        return this.mailboxProcessor::hasMail;
+    public CanEmitBatchOfRecordsChecker getCanEmitBatchOfRecords() {
+        return () -> !this.mailboxProcessor.hasMail();
     }
 
     public final boolean isRunning() {
@@ -1768,5 +1767,12 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
     @Override
     public final Environment getEnvironment() {
         return environment;
+    }
+
+    /** Check whether records can be emitted in batch. */
+    @FunctionalInterface
+    public interface CanEmitBatchOfRecordsChecker {
+
+        boolean check();
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -21,7 +21,6 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.io.network.partition.consumer.IndexedInputGate;
 import org.apache.flink.streaming.api.operators.TwoInputStreamOperator;
-import org.apache.flink.streaming.runtime.io.StreamTaskSourceInput;
 import org.apache.flink.streaming.runtime.io.StreamTwoInputProcessorFactory;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointBarrierHandler;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate;
@@ -61,14 +60,6 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
             List<IndexedInputGate> inputGates1,
             List<IndexedInputGate> inputGates2,
             Function<Integer, StreamPartitioner<?>> gatePartitioners) {
-
-        // This is needed for StreamMultipleInputProcessor#processInput to preserve the existing
-        // behavior of choosing an input every time a record is emitted. This behavior is good for
-        // fairness between input consumption. But it can reduce throughput due to added control
-        // flow cost on the per-record code path.
-        for (StreamTaskSourceInput<?> input : operatorChain.getSourceTaskInputs()) {
-            input.disableEmitNextLoop();
-        }
 
         // create an input instance for each input
         checkpointBarrierHandler =
@@ -112,5 +103,14 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
                         getEnvironment().getTaskStateManager().getInputRescalingDescriptor(),
                         gatePartitioners,
                         getEnvironment().getTaskInfo());
+    }
+
+    // This is needed for StreamMultipleInputProcessor#processInput to preserve the existing
+    // behavior of choosing an input every time a record is emitted. This behavior is good for
+    // fairness between input consumption. But it can reduce throughput due to added control
+    // flow cost on the per-record code path.
+    @Override
+    public CanEmitBatchOfRecordsChecker getCanEmitBatchOfRecords() {
+        return () -> false;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/source/TestingSourceOperator.java
@@ -90,7 +90,7 @@ public class TestingSourceOperator<T> extends SourceOperator<T, MockSourceSplit>
                 new Configuration(),
                 "localhost",
                 emitProgressiveWatermarks,
-                () -> true);
+                () -> false);
 
         this.subtaskIndex = subtaskIndex;
         this.parallelism = parallelism;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTaskTest.java
@@ -37,8 +37,10 @@ import org.apache.flink.runtime.checkpoint.CheckpointMetaData;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriterWithAvailabilityHelper;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
@@ -61,6 +63,7 @@ import org.apache.flink.streaming.api.operators.StreamMap;
 import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.streaming.util.TestHarnessUtil;
 import org.apache.flink.util.Preconditions;
@@ -87,6 +90,7 @@ import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.cr
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -952,6 +956,44 @@ public class OneInputStreamTaskTest extends TestLogger {
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
+    }
+
+    @Test
+    public void testCanEmitBatchOfRecords() throws Exception {
+        AvailabilityProvider.AvailabilityHelper availabilityHelper =
+                new AvailabilityProvider.AvailabilityHelper();
+        try (StreamTaskMailboxTestHarness<Integer> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO)
+                        .addAdditionalOutput(
+                                new ResultPartitionWriterWithAvailabilityHelper(availabilityHelper))
+                        .setupOperatorChain(new TestOperator())
+                        .finishForSingletonOperatorChain(IntSerializer.INSTANCE)
+                        .build()) {
+            CanEmitBatchOfRecordsChecker canEmitBatchOfRecordsChecker =
+                    testHarness.streamTask.getCanEmitBatchOfRecords();
+            testHarness.processAll();
+
+            availabilityHelper.resetAvailable();
+            assertTrue(canEmitBatchOfRecordsChecker.check());
+
+            // The canEmitBatchOfRecordsChecker should be the false after the record writer is
+            // unavailable.
+            availabilityHelper.resetUnavailable();
+            assertFalse(canEmitBatchOfRecordsChecker.check());
+
+            // Restore record writer to available
+            availabilityHelper.resetAvailable();
+            assertTrue(canEmitBatchOfRecordsChecker.check());
+
+            // The canEmitBatchOfRecordsChecker should be the false after add the mail to mail box.
+            testHarness.streamTask.mainMailboxExecutor.execute(() -> {}, "mail");
+            assertFalse(canEmitBatchOfRecordsChecker.check());
+
+            testHarness.processAll();
+            assertTrue(canEmitBatchOfRecordsChecker.check());
+        }
     }
 
     static class WatermarkMetricOperator extends AbstractStreamOperator<String>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTaskTest.java
@@ -21,6 +21,7 @@ package org.apache.flink.streaming.runtime.tasks;
 import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
+import org.apache.flink.api.common.typeutils.base.IntSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.metrics.Counter;
@@ -29,10 +30,12 @@ import org.apache.flink.metrics.Metric;
 import org.apache.flink.runtime.checkpoint.CheckpointOptions;
 import org.apache.flink.runtime.checkpoint.TaskStateSnapshot;
 import org.apache.flink.runtime.clusterframework.types.ResourceID;
+import org.apache.flink.runtime.io.AvailabilityProvider;
 import org.apache.flink.runtime.io.network.api.CancelCheckpointMarker;
 import org.apache.flink.runtime.io.network.api.CheckpointBarrier;
 import org.apache.flink.runtime.io.network.api.EndOfData;
 import org.apache.flink.runtime.io.network.api.StopMode;
+import org.apache.flink.runtime.io.network.api.writer.ResultPartitionWriterWithAvailabilityHelper;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
@@ -75,6 +78,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Tests for {@link TwoInputStreamTask}.
@@ -779,6 +783,46 @@ public class TwoInputStreamTaskTest {
 
         testHarness.endInput();
         testHarness.waitForTaskCompletion();
+    }
+
+    /** The CanEmitBatchOfRecords should always be false for {@link TwoInputStreamTask}. */
+    @Test
+    public void testCanEmitBatchOfRecords() throws Exception {
+        AvailabilityProvider.AvailabilityHelper availabilityHelper =
+                new AvailabilityProvider.AvailabilityHelper();
+        try (StreamTaskMailboxTestHarness<String> testHarness =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                TwoInputStreamTask::new, BasicTypeInfo.STRING_TYPE_INFO)
+                        .addInput(BasicTypeInfo.STRING_TYPE_INFO)
+                        .addInput(BasicTypeInfo.STRING_TYPE_INFO)
+                        .addAdditionalOutput(
+                                new ResultPartitionWriterWithAvailabilityHelper(availabilityHelper))
+                        .setupOperatorChain(new DuplicatingOperator())
+                        .finishForSingletonOperatorChain(IntSerializer.INSTANCE)
+                        .build()) {
+            StreamTask.CanEmitBatchOfRecordsChecker canEmitBatchOfRecordsChecker =
+                    testHarness.streamTask.getCanEmitBatchOfRecords();
+            testHarness.processAll();
+
+            availabilityHelper.resetAvailable();
+            assertFalse(canEmitBatchOfRecordsChecker.check());
+
+            // The canEmitBatchOfRecordsChecker should be the false after the record writer is
+            // unavailable.
+            availabilityHelper.resetUnavailable();
+            assertFalse(canEmitBatchOfRecordsChecker.check());
+
+            // Restore record writer to available
+            availabilityHelper.resetAvailable();
+            assertFalse(canEmitBatchOfRecordsChecker.check());
+
+            // The canEmitBatchOfRecordsChecker should be the false after add the mail to mail box.
+            testHarness.streamTask.mainMailboxExecutor.execute(() -> {}, "mail");
+            assertFalse(canEmitBatchOfRecordsChecker.check());
+
+            testHarness.processAll();
+            assertFalse(canEmitBatchOfRecordsChecker.check());
+        }
     }
 
     // This must only be used in one test, otherwise the static fields will be changed


### PR DESCRIPTION
## What is the purpose of the change

[FLINK-30533](https://issues.apache.org/jira/browse/FLINK-30533) doesn't check `recordWriter.isAvailable()` in the loop of SourceOperator.

## Brief change log

  - 1st commit: [FLINK-30623][runtime][refactor] Using the `CanEmitBatchOfRecordsChecker` instead of `Supplier<Boolean>`
  - 2nd commit: [FLINK-30623][runtime][refactor] Using the `canEmitBatchOfRecords` instead of `isEmitNextLoopDisabled` in the SourceOperator
  - 3rd commit: [FLINK-30623][runtime][bug] The `canEmitBatchOfRecords` should check recordWriter and changelogWriterAvailabilityProvider are available


I ran the checkpoint benchmark in my local, and here is the performance report, I think the performance is recovered after this PR.

```
Before 2nd commit:

Benchmark                                              (mode)   Mode  Cnt   Score   Error  Units
CheckpointingTimeBenchmark.checkpointSingleInput      ALIGNED  thrpt   30   1.247 ± 0.177  ops/s
CheckpointingTimeBenchmark.checkpointSingleInput    UNALIGNED  thrpt   30  65.063 ± 9.090  ops/s
CheckpointingTimeBenchmark.checkpointSingleInput  UNALIGNED_1  thrpt   30  35.096 ± 4.313  ops/s

After 2nd commit:

Benchmark                                              (mode)   Mode  Cnt    Score    Error  Units
CheckpointingTimeBenchmark.checkpointSingleInput      ALIGNED  thrpt   30    1.345 ±  0.111  ops/s
CheckpointingTimeBenchmark.checkpointSingleInput    UNALIGNED  thrpt   30  299.665 ± 36.048  ops/s
CheckpointingTimeBenchmark.checkpointSingleInput  UNALIGNED_1  thrpt   30  183.998 ± 24.652  ops/s
```


## Verifying this change

- OneInputStreamTaskTest#testCanEmitBatchOfRecords
- TwoInputStreamTaskTest#testCanEmitBatchOfRecords
- MultipleInputStreamTaskTest#testCanEmitBatchOfRecords


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
