### PR TITLE
[FLINK-30709][runtime] NetworkInput#emitNext() should push records to DataOutput within a while loop

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -47,6 +47,7 @@ import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
 import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.tasks.WatermarkGaugeExposingOutput;
 import org.apache.flink.streaming.runtime.watermarkstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
@@ -84,7 +85,8 @@ public class StreamMultipleInputProcessorFactory {
             OperatorChain<?, ?> operatorChain,
             InflightDataRescalingDescriptor inflightDataRescalingDescriptor,
             Function<Integer, StreamPartitioner<?>> gatePartitioners,
-            TaskInfo taskInfo) {
+            TaskInfo taskInfo,
+            CanEmitBatchOfRecordsChecker canEmitBatchOfRecords) {
         checkNotNull(operatorChain);
 
         List<Input> operatorInputs = mainOperator.getInputs();
@@ -116,7 +118,8 @@ public class StreamMultipleInputProcessorFactory {
                                 i,
                                 inflightDataRescalingDescriptor,
                                 gatePartitioners,
-                                taskInfo);
+                                taskInfo,
+                                canEmitBatchOfRecords);
             } else if (configuredInput instanceof StreamConfig.SourceInputConfig) {
                 StreamConfig.SourceInputConfig sourceInput =
                         (StreamConfig.SourceInputConfig) configuredInput;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInput.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.plugable.DeserializationDelegate;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
+import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.watermarkstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 
@@ -65,13 +66,15 @@ public final class StreamTaskNetworkInput<T>
             TypeSerializer<T> inputSerializer,
             IOManager ioManager,
             StatusWatermarkValve statusWatermarkValve,
-            int inputIndex) {
+            int inputIndex,
+            CanEmitBatchOfRecordsChecker canEmitBatchOfRecords) {
         super(
                 checkpointedInputGate,
                 inputSerializer,
                 statusWatermarkValve,
                 inputIndex,
-                getRecordDeserializers(checkpointedInputGate, ioManager));
+                getRecordDeserializers(checkpointedInputGate, ioManager),
+                canEmitBatchOfRecords);
     }
 
     // Initialize one deserializer per input channel

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputFactory.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.disk.iomanager.IOManager;
 import org.apache.flink.streaming.runtime.io.checkpointing.CheckpointedInputGate;
 import org.apache.flink.streaming.runtime.io.recovery.RescalingStreamTaskNetworkInput;
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
+import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.watermarkstatus.StatusWatermarkValve;
 
 import java.util.function.Function;
@@ -42,7 +43,8 @@ public class StreamTaskNetworkInputFactory {
             int inputIndex,
             InflightDataRescalingDescriptor rescalingDescriptorinflightDataRescalingDescriptor,
             Function<Integer, StreamPartitioner<?>> gatePartitioners,
-            TaskInfo taskInfo) {
+            TaskInfo taskInfo,
+            CanEmitBatchOfRecordsChecker canEmitBatchOfRecords) {
         return rescalingDescriptorinflightDataRescalingDescriptor.equals(
                         InflightDataRescalingDescriptor.NO_RESCALE)
                 ? new StreamTaskNetworkInput<>(
@@ -50,7 +52,8 @@ public class StreamTaskNetworkInputFactory {
                         inputSerializer,
                         ioManager,
                         statusWatermarkValve,
-                        inputIndex)
+                        inputIndex,
+                        canEmitBatchOfRecords)
                 : new RescalingStreamTaskNetworkInput<>(
                         checkpointedInputGate,
                         inputSerializer,
@@ -59,6 +62,7 @@ public class StreamTaskNetworkInputFactory {
                         inputIndex,
                         rescalingDescriptorinflightDataRescalingDescriptor,
                         gatePartitioners,
-                        taskInfo);
+                        taskInfo,
+                        canEmitBatchOfRecords);
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.LatencyMarker;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorChain;
+import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.watermarkstatus.StatusWatermarkValve;
 import org.apache.flink.streaming.runtime.watermarkstatus.WatermarkStatus;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -75,7 +76,8 @@ public class StreamTwoInputProcessorFactory {
             Counter numRecordsIn,
             InflightDataRescalingDescriptor inflightDataRescalingDescriptor,
             Function<Integer, StreamPartitioner<?>> gatePartitioners,
-            TaskInfo taskInfo) {
+            TaskInfo taskInfo,
+            CanEmitBatchOfRecordsChecker canEmitBatchOfRecords) {
 
         checkNotNull(operatorChain);
 
@@ -91,7 +93,8 @@ public class StreamTwoInputProcessorFactory {
                         0,
                         inflightDataRescalingDescriptor,
                         gatePartitioners,
-                        taskInfo);
+                        taskInfo,
+                        canEmitBatchOfRecords);
         TypeSerializer<IN2> typeSerializer2 = streamConfig.getTypeSerializerIn(1, userClassloader);
         StreamTaskInput<IN2> input2 =
                 StreamTaskNetworkInputFactory.create(
@@ -103,7 +106,8 @@ public class StreamTwoInputProcessorFactory {
                         1,
                         inflightDataRescalingDescriptor,
                         gatePartitioners,
-                        taskInfo);
+                        taskInfo,
+                        canEmitBatchOfRecords);
 
         InputSelectable inputSelectable =
                 streamOperator instanceof InputSelectable ? (InputSelectable) streamOperator : null;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RescalingStreamTaskNetworkInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/recovery/RescalingStreamTaskNetworkInput.java
@@ -41,6 +41,7 @@ import org.apache.flink.streaming.runtime.partitioner.ConfigurableStreamPartitio
 import org.apache.flink.streaming.runtime.partitioner.StreamPartitioner;
 import org.apache.flink.streaming.runtime.streamrecord.StreamElement;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.StreamTask.CanEmitBatchOfRecordsChecker;
 import org.apache.flink.streaming.runtime.watermarkstatus.StatusWatermarkValve;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Maps;
@@ -94,7 +95,8 @@ public final class RescalingStreamTaskNetworkInput<T>
             int inputIndex,
             InflightDataRescalingDescriptor inflightDataRescalingDescriptor,
             Function<Integer, StreamPartitioner<?>> gatePartitioners,
-            TaskInfo taskInfo) {
+            TaskInfo taskInfo,
+            CanEmitBatchOfRecordsChecker canEmitBatchOfRecords) {
         super(
                 checkpointedInputGate,
                 inputSerializer,
@@ -106,7 +108,8 @@ public final class RescalingStreamTaskNetworkInput<T>
                         ioManager,
                         inflightDataRescalingDescriptor,
                         gatePartitioners,
-                        taskInfo));
+                        taskInfo),
+                canEmitBatchOfRecords);
         this.ioManager = ioManager;
 
         LOG.info(
@@ -159,7 +162,8 @@ public final class RescalingStreamTaskNetworkInput<T>
                 inputSerializer,
                 ioManager,
                 statusWatermarkValve,
-                inputIndex);
+                inputIndex,
+                canEmitBatchOfRecords);
     }
 
     protected DemultiplexingRecordDeserializer<T> getActiveSerializer(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/MultipleInputStreamTask.java
@@ -177,7 +177,8 @@ public class MultipleInputStreamTask<OUT>
                         operatorChain,
                         getEnvironment().getTaskStateManager().getInputRescalingDescriptor(),
                         gatePartitioners,
-                        getEnvironment().getTaskInfo());
+                        getEnvironment().getTaskInfo(),
+                        getCanEmitBatchOfRecords());
     }
 
     protected Optional<CheckpointBarrierHandler> getCheckpointBarrierHandler() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -206,7 +206,8 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
                                 .getInPhysicalEdges(getUserCodeClassLoader())
                                 .get(gateIndex)
                                 .getPartitioner(),
-                getEnvironment().getTaskInfo());
+                getEnvironment().getTaskInfo(),
+                getCanEmitBatchOfRecords());
     }
 
     /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/TwoInputStreamTask.java
@@ -102,7 +102,8 @@ public class TwoInputStreamTask<IN1, IN2, OUT> extends AbstractTwoInputStreamTas
                         setupNumRecordsInCounter(mainOperator),
                         getEnvironment().getTaskStateManager().getInputRescalingDescriptor(),
                         gatePartitioners,
-                        getEnvironment().getTaskInfo());
+                        getEnvironment().getTaskInfo(),
+                        getCanEmitBatchOfRecords());
     }
 
     // This is needed for StreamMultipleInputProcessor#processInput to preserve the existing

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/StreamTaskNetworkInputTest.java
@@ -71,14 +71,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link StreamTaskNetworkInput}. */
 public class StreamTaskNetworkInputTest {
@@ -101,7 +94,7 @@ public class StreamTaskNetworkInputTest {
 
         assertHasNextElement(input, output);
         assertHasNextElement(input, output);
-        assertEquals(2, output.getNumberOfEmittedRecords());
+        assertThat(output.getNumberOfEmittedRecords()).isEqualTo(2);
     }
 
     /**
@@ -122,7 +115,7 @@ public class StreamTaskNetworkInputTest {
         StreamTaskNetworkInput<Long> input = createStreamTaskNetworkInput(buffers);
 
         assertHasNextElement(input, output);
-        assertEquals(0, output.getNumberOfEmittedRecords());
+        assertThat(output.getNumberOfEmittedRecords()).isZero();
     }
 
     private Map<InputChannelInfo, TestRecordDeserializer> createDeserializers(
@@ -174,7 +167,7 @@ public class StreamTaskNetworkInputTest {
 
         assertHasNextElement(input, output);
         assertHasNextElement(input, output);
-        assertEquals(1, output.getNumberOfEmittedRecords());
+        assertThat(output.getNumberOfEmittedRecords()).isOne();
 
         // send EndOfPartitionEvent and ensure that deserializer has been released
         inputGate.sendEvent(EndOfPartitionEvent.INSTANCE, channelId);
@@ -204,11 +197,11 @@ public class StreamTaskNetworkInputTest {
                         inputGate, inSerializer, numInputChannels, deserializers);
 
         for (InputChannelInfo channelInfo : inputGate.getInputGate().getChannelInfos()) {
-            assertNotNull(deserializers.get(channelInfo));
+            assertThat(deserializers.get(channelInfo)).isNotNull();
             inputGate.sendEvent(EndOfPartitionEvent.INSTANCE, channelInfo.getInputChannelIdx());
             input.emitNext(output);
-            assertTrue(copiedDeserializers.get(channelInfo).isCleared());
-            assertNull(deserializers.get(channelInfo));
+            assertThat(copiedDeserializers.get(channelInfo).isCleared()).isTrue();
+            assertThat(deserializers.get(channelInfo)).isNull();
         }
     }
 
@@ -228,11 +221,11 @@ public class StreamTaskNetworkInputTest {
                         inputGate, inSerializer, numInputChannels, deserializers);
 
         inputGate.sendElement(new StreamRecord<>(42L), 0);
-        assertThat(input.emitNext(output), equalTo(DataInputStatus.MORE_AVAILABLE));
+        assertThat(input.emitNext(output)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
         inputGate.sendEvent(EndOfChannelStateEvent.INSTANCE, 0);
-        assertThat(input.emitNext(output), equalTo(DataInputStatus.MORE_AVAILABLE));
+        assertThat(input.emitNext(output)).isEqualTo(DataInputStatus.MORE_AVAILABLE);
         inputGate.sendEvent(EndOfChannelStateEvent.INSTANCE, 1);
-        assertThat(input.emitNext(output), equalTo(DataInputStatus.END_OF_RECOVERY));
+        assertThat(input.emitNext(output)).isEqualTo(DataInputStatus.END_OF_RECOVERY);
     }
 
     private BufferOrEvent createDataBuffer() throws IOException {
@@ -273,14 +266,14 @@ public class StreamTaskNetworkInputTest {
                 RecordWriter.serializeRecord(serializer, serializationDelegate);
         bufferBuilder.appendAndCommit(serializedRecord);
 
-        assertFalse(bufferBuilder.isFull());
+        assertThat(bufferBuilder.isFull()).isFalse();
     }
 
     private static <T> void assertHasNextElement(StreamTaskInput<T> input, DataOutput<T> output)
             throws Exception {
-        assertTrue(input.getAvailableFuture().isDone());
+        assertThat(input.getAvailableFuture().isDone()).isTrue();
         DataInputStatus status = input.emitNext(output);
-        assertThat(status, is(DataInputStatus.MORE_AVAILABLE));
+        assertThat(status).isEqualTo(DataInputStatus.MORE_AVAILABLE);
     }
 
     private static class TestRecordDeserializer


### PR DESCRIPTION
## What is the purpose of the change

Improve Flink performance by reducing the average depth of the call stack needed to produce a record for NetworkInput.

## Brief change log

- [hotfix] Migrate StreamTaskNetworkInputTest to Junit5 and AssertJ
- [FLINK-30709][runtime] NetworkInput#emitNext() should push records to DataOutput within a while loop.

## Verifying this change

- StreamTaskNetworkInputTest#testRecordsAreProcessedInBatches
- StreamTaskNetworkInputTest#testBatchProcessingRecordsCanBeInterrupted

Here are the benchmark results obtained by running the [InputBenchmark#mapSink](https://github.com/apache/flink-benchmarks/blob/0bafe0e85700c889894324aadb70302381f98e03/src/main/java/org/apache/flink/benchmark/InputBenchmark.java#L55) with env.disableOperatorChaining(). And I run it 4 times on My Mac.

 
```
Before the proposed change, the avg is 12429.0605 ops/ms, here is detailed results:

Benchmark                (sourceType)   Mode  Cnt      Score     Error   Units
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  12339.771 ± 414.649  ops/ms
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  12687.872 ± 320.084  ops/ms
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  12256.445 ± 512.219  ops/ms
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  12432.154 ± 405.083  ops/ms


After the proposed change, the avg is 13836.845 ops/ms, here is detailed results:

Benchmark                (sourceType)   Mode  Cnt      Score     Error   Units
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  13092.451 ± 490.886  ops/ms
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  13881.138 ± 370.249  ops/ms
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  13960.280 ± 389.505  ops/ms
InputBenchmark.mapSink  F27_UNBOUNDED  thrpt   30  14413.511 ± 727.844  ops/ms
 ```

The proposed change increases throughput by 11.3%.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
