### PR TITLE
[FLINK-30677][Test] Fix unstable SqlGatewayServiceStatementITCase.testFlinkSqlStatements

### DIFF
--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -32,7 +32,6 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.table.api.CatalogNotExistException;
 import org.apache.flink.table.api.DataTypes;
-import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
@@ -411,7 +410,7 @@ public class OperationExecutor {
                 Collections.singletonList(
                         GenericRowData.of(StringData.fromString(jobID.toString()))),
                 jobID,
-                ResultKind.SUCCESS_WITH_CONTENT);
+                result.getResultKind());
     }
 
     private ResultFetcher callOperation(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/operation/OperationExecutor.java
@@ -32,6 +32,7 @@ import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.client.JobStatusMessage;
 import org.apache.flink.table.api.CatalogNotExistException;
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.internal.TableEnvironmentInternal;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.CatalogBaseTable.TableKind;
@@ -409,7 +410,8 @@ public class OperationExecutor {
                 ResolvedSchema.of(Column.physical(JOB_ID, DataTypes.STRING())),
                 Collections.singletonList(
                         GenericRowData.of(StringData.fromString(jobID.toString()))),
-                jobID);
+                jobID,
+                ResultKind.SUCCESS_WITH_CONTENT);
     }
 
     private ResultFetcher callOperation(

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/result/ResultFetcher.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/result/ResultFetcher.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.gateway.service.result;
 
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.table.api.ResultKind;
 import org.apache.flink.table.api.internal.TableResultInternal;
 import org.apache.flink.table.catalog.ResolvedSchema;
@@ -152,7 +153,7 @@ public class ResultFetcher {
                     tableResult.getResolvedSchema(),
                     tableResult.collectInternal(),
                     tableResult.getRowDataToStringConverter(),
-                    isQueryResult,
+                    true,
                     jobID,
                     tableResult.getResultKind());
         } else {
@@ -160,7 +161,7 @@ public class ResultFetcher {
                     operationHandle,
                     tableResult.getResolvedSchema(),
                     CollectionUtil.iteratorToList(tableResult.collectInternal()),
-                    null,
+                    tableResult.getJobClient().map(JobClient::getJobID).orElse(null),
                     tableResult.getResultKind());
         }
     }

--- a/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/result/ResultFetcher.java
+++ b/flink-table/flink-sql-gateway/src/main/java/org/apache/flink/table/gateway/service/result/ResultFetcher.java
@@ -120,7 +120,8 @@ public class ResultFetcher {
             OperationHandle operationHandle,
             ResolvedSchema resultSchema,
             List<RowData> rows,
-            @Nullable JobID jobID) {
+            @Nullable JobID jobID,
+            ResultKind resultKind) {
         this.operationHandle = operationHandle;
         this.resultSchema = resultSchema;
         this.bufferedResults.addAll(rows);
@@ -128,7 +129,7 @@ public class ResultFetcher {
         this.converter = SIMPLE_ROW_DATA_TO_STRING_CONVERTER;
         this.isQueryResult = false;
         this.jobID = jobID;
-        this.resultKind = ResultKind.SUCCESS_WITH_CONTENT;
+        this.resultKind = resultKind;
     }
 
     public static ResultFetcher fromTableResult(
@@ -159,21 +160,24 @@ public class ResultFetcher {
                     operationHandle,
                     tableResult.getResolvedSchema(),
                     CollectionUtil.iteratorToList(tableResult.collectInternal()),
-                    null);
+                    null,
+                    tableResult.getResultKind());
         }
     }
 
     public static ResultFetcher fromResults(
             OperationHandle operationHandle, ResolvedSchema resultSchema, List<RowData> results) {
-        return fromResults(operationHandle, resultSchema, results, null);
+        return fromResults(
+                operationHandle, resultSchema, results, null, ResultKind.SUCCESS_WITH_CONTENT);
     }
 
     public static ResultFetcher fromResults(
             OperationHandle operationHandle,
             ResolvedSchema resultSchema,
             List<RowData> results,
-            @Nullable JobID jobID) {
-        return new ResultFetcher(operationHandle, resultSchema, results, jobID);
+            @Nullable JobID jobID,
+            ResultKind resultKind) {
+        return new ResultFetcher(operationHandle, resultSchema, results, jobID, resultKind);
     }
 
     public void close() {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
@@ -320,10 +320,14 @@ public abstract class AbstractSqlGatewayStatementITCase extends AbstractTestBase
             Iterator<RowData> iterator)
             throws Exception {
         if (type.equals(StatementType.EXPLAIN) || type.equals(StatementType.SHOW_CREATE)) {
+            StringBuilder sb = new StringBuilder();
+            while (iterator.hasNext()) {
+                sb.append(iterator.next().getString(0).toString());
+            }
             return Tag.OK.addTag(
                     replaceStreamNodeId(
                                     replaceNodeIdInOperator(
-                                            iterator.next().getString(0).toString()))
+                                            sb.toString()))
                             + "\n");
         } else if (schema.getColumn(0)
                 .map(col -> col.getName().equals(Constants.JOB_ID))

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
@@ -325,10 +325,7 @@ public abstract class AbstractSqlGatewayStatementITCase extends AbstractTestBase
                 sb.append(iterator.next().getString(0).toString());
             }
             return Tag.OK.addTag(
-                    replaceStreamNodeId(
-                                    replaceNodeIdInOperator(
-                                            sb.toString()))
-                            + "\n");
+                    replaceStreamNodeId(replaceNodeIdInOperator(sb.toString())) + "\n");
         } else if (schema.getColumn(0)
                 .map(col -> col.getName().equals(Constants.JOB_ID))
                 .orElse(false)) {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointStatementITCase.java
@@ -47,6 +47,7 @@ import org.apache.flink.table.gateway.rest.util.TestingRestClient;
 import org.apache.flink.table.planner.functions.casting.RowDataToStringConverterImpl;
 import org.apache.flink.table.utils.DateTimeUtils;
 import org.apache.flink.testutils.junit.extensions.parameterized.Parameters;
+import org.apache.flink.util.StringUtils;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -216,6 +217,9 @@ public class SqlGatewayRestEndpointStatementITCase extends AbstractSqlGatewaySta
 
     @Override
     protected String stringifyException(Throwable t) {
+        if (StringUtils.isNullOrWhitespaceOnly(t.getMessage())) {
+            return t.getClass().getCanonicalName();
+        }
         String message = t.getMessage();
         String[] splitExceptions = message.split(PATTERN1);
         return splitExceptions[splitExceptions.length - 1].split(PATTERN2)[0];


### PR DESCRIPTION
## What is the purpose of the change

SqlGatewayServiceStatementITCase.testFlinkSqlStatements may fail due to `java.util.NoSuchElementException`. The cause is unsecured access to iterators in the test (not `hasNext()` before `next()`):

https://github.com/apache/flink/blob/4e3cd986cd4304c699d5c7d368ffd6e0ead5a096/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java#L286-L297


## Brief change log

- Call `iterato#next()`  only if `iterato#hasNext()`.
- Fix NPE in stringifying Exceptions.
- Use dumpy results for non-query operations.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
