### PR TITLE
[FLINK-29558][table-planner] Fix projection pushdown rule select nothing from source when no column is needed logically

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRule.java
@@ -147,7 +147,9 @@ public class PushProjectIntoTableSourceScanRule
         // in such case
         if (projectedSchema.columns().isEmpty()) {
             if (scan.getRowType().getFieldCount() == 0) {
-                return;
+                throw new TableException(
+                        "Unexpected empty row type of source table:"
+                                + String.join(".", scan.getTable().getQualifiedName()));
             }
             RexInputRef firstFieldRef = RexInputRef.of(0, scan.getRowType());
             projectedSchema =

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.java
@@ -312,7 +312,7 @@ public class PushProjectIntoTableSourceScanRuleTest
         util().tableEnv().createTable("T3", sourceDescriptor);
 
         util().verifyRelPlan("SELECT 1 FROM T3");
-        assertThat(appliedKeys.get()).hasSize(0);
+        assertThat(appliedKeys.get()).hasSize(1);
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/TableSourceTest.xml
@@ -133,7 +133,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
       <![CDATA[
 HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0])
 +- Exchange(distribution=[single])
-   +- TableSourceScan(table=[[default_catalog, default_database, ProjectableTable, project=[], metadata=[], aggregates=[grouping=[], aggFunctions=[Count1AggFunction()]]]], fields=[count1$0])
+   +- TableSourceScan(table=[[default_catalog, default_database, ProjectableTable, project=[a], metadata=[], aggregates=[grouping=[], aggFunctions=[Count1AggFunction()]]]], fields=[count1$0])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/HashAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/HashAggregateTest.xml
@@ -598,6 +598,68 @@ HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCountStartWithProjectPushDown[aggStrategy=AUTO]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]]), rowType=[RecordType(VARCHAR(2147483647) id, BIGINT cnt)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id]), rowType=[RecordType(VARCHAR(2147483647) id)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStartWithProjectPushDown[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]]), rowType=[RecordType(VARCHAR(2147483647) id, BIGINT cnt)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashAggregate(isMerge=[false], select=[COUNT(*) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(INTEGER $f0)]
+   +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id]), rowType=[RecordType(VARCHAR(2147483647) id)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStartWithProjectPushDown[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]]), rowType=[RecordType(VARCHAR(2147483647) id, BIGINT cnt)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+HashAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalHashAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id]), rowType=[RecordType(VARCHAR(2147483647) id)]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testGroupAggregate[aggStrategy=ONE_PHASE]">
     <Resource name="sql">
       <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/SortAggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/batch/sql/agg/SortAggregateTest.xml
@@ -715,6 +715,68 @@ SortAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCountStartWithProjectPushDown[aggStrategy=AUTO]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]]), rowType=[RecordType(VARCHAR(2147483647) id, BIGINT cnt)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalSortAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id]), rowType=[RecordType(VARCHAR(2147483647) id)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStartWithProjectPushDown[aggStrategy=ONE_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]]), rowType=[RecordType(VARCHAR(2147483647) id, BIGINT cnt)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[false], select=[COUNT(*) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(INTEGER $f0)]
+   +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id]), rowType=[RecordType(VARCHAR(2147483647) id)]
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStartWithProjectPushDown[aggStrategy=TWO_PHASE]">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()]), rowType=[RecordType(BIGINT EXPR$0)]
++- LogicalProject($f0=[0]), rowType=[RecordType(INTEGER $f0)]
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]]), rowType=[RecordType(VARCHAR(2147483647) id, BIGINT cnt)]
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+SortAggregate(isMerge=[true], select=[Final_COUNT(count1$0) AS EXPR$0]), rowType=[RecordType(BIGINT EXPR$0)]
++- Exchange(distribution=[single]), rowType=[RecordType(BIGINT count1$0)]
+   +- LocalSortAggregate(select=[Partial_COUNT(*) AS count1$0]), rowType=[RecordType(BIGINT count1$0)]
+      +- Calc(select=[0 AS $f0]), rowType=[RecordType(INTEGER $f0)]
+         +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id]), rowType=[RecordType(VARCHAR(2147483647) id)]
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testGroupAggregate[aggStrategy=ONE_PHASE]">
     <Resource name="sql">
       <![CDATA[SELECT a, SUM(b), COUNT(c) FROM MyTable1 GROUP BY a]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
@@ -347,7 +347,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
       <![CDATA[
 LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
 +- LogicalProject($f0=[0])
-   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, project=[], metadata=[]]])
+   +- LogicalTableScan(table=[[default_catalog, default_database, MyTable, project=[a], metadata=[]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PushProjectIntoTableSourceScanRuleTest.xml
@@ -132,7 +132,7 @@ LogicalProject(EXPR$0=[1])
     <Resource name="optimized rel plan">
       <![CDATA[
 LogicalProject(EXPR$0=[1])
-+- LogicalTableScan(table=[[default_catalog, default_database, T3, metadata=[]]])
++- LogicalTableScan(table=[[default_catalog, default_database, T3, metadata=[m1]]])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableScanTest.xml
@@ -678,7 +678,7 @@ LogicalProject(EXPR$0=[TUMBLE_START($0)], EXPR$1=[$1])
 Calc(select=[w$start AS EXPR$0, EXPR$1], changelogMode=[I])
 +- GroupWindowAggregate(window=[TumblingGroupWindow('w$, $f2, 10000)], properties=[w$start, w$end, w$proctime], select=[COUNT(*) AS EXPR$1, start('w$) AS w$start, end('w$) AS w$end, proctime('w$) AS w$proctime], changelogMode=[I])
    +- Exchange(distribution=[single], changelogMode=[I,UB,UA])
-      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[], metadata=[]]], fields=[], changelogMode=[I,UB,UA])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[a], metadata=[]]], fields=[a], changelogMode=[I,UB,UA])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/TableSourceTest.xml
@@ -157,7 +157,7 @@ LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
       <![CDATA[
 GroupAggregate(select=[COUNT(*) AS EXPR$0])
 +- Exchange(distribution=[single])
-   +- TableSourceScan(table=[[default_catalog, default_database, T, project=[], metadata=[]]], fields=[])
+   +- TableSourceScan(table=[[default_catalog, default_database, T, project=[id], metadata=[]]], fields=[id])
 ]]>
     </Resource>
   </TestCase>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
@@ -276,6 +276,26 @@ GroupAggregate(select=[COUNT(*) AS EXPR$0])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCountStartWithMetadataOnly">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(select=[COUNT(*) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[0 AS $f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[], metadata=[cnt]]], fields=[cnt])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testCountStartWithNestedRow">
     <Resource name="sql">
       <![CDATA[SELECT COUNT(*) FROM src]]>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.xml
@@ -236,6 +236,66 @@ GroupAggregate(groupBy=[b], select=[b, SUM(a) AS EXPR$1])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testCountStart">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(select=[COUNT(*) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[0 AS $f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStartWithMetadata">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(select=[COUNT(*) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[0 AS $f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[id], metadata=[]]], fields=[id])
+]]>
+    </Resource>
+  </TestCase>
+  <TestCase name="testCountStartWithNestedRow">
+    <Resource name="sql">
+      <![CDATA[SELECT COUNT(*) FROM src]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalAggregate(group=[{}], EXPR$0=[COUNT()])
++- LogicalProject($f0=[0])
+   +- LogicalTableScan(table=[[default_catalog, default_database, src]])
+]]>
+    </Resource>
+    <Resource name="optimized exec plan">
+      <![CDATA[
+GroupAggregate(select=[COUNT(*) AS EXPR$0])
++- Exchange(distribution=[single])
+   +- Calc(select=[0 AS $f0])
+      +- TableSourceScan(table=[[default_catalog, default_database, src, project=[nested], metadata=[]]], fields=[nested])
+]]>
+    </Resource>
+  </TestCase>
   <TestCase name="testFilteredColumnIntervalValidation">
     <Resource name="sql">
       <![CDATA[

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/AggregateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/batch/sql/agg/AggregateTestBase.scala
@@ -119,6 +119,21 @@ abstract class AggregateTestBase extends TableTestBase {
   }
 
   @Test
+  def testCountStartWithProjectPushDown(): Unit = {
+    // the test values table source supports projection push down by default
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE src (
+                               | id VARCHAR,
+                               | cnt BIGINT
+                               |) WITH (
+                               | 'connector' = 'values'
+                               | ,'bounded' = 'true'
+                               |)
+                               |""".stripMargin)
+    util.verifyRelPlanWithType("SELECT COUNT(*) FROM src")
+  }
+
+  @Test
   def testCannotCountOnMultiFields(): Unit = {
     val sql = "SELECT b, COUNT(a, c) FROM MyTable1 GROUP BY b"
     thrown.expect(classOf[TableException])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
@@ -425,6 +425,21 @@ class AggregateTest extends TableTestBase {
   }
 
   @Test
+  def testCountStartWithMetadataOnly(): Unit = {
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE src (
+                               | sys_col VARCHAR METADATA,
+                               | id VARCHAR METADATA,
+                               | cnt BIGINT METADATA
+                               |) WITH (
+                               | 'connector' = 'values',
+                               | 'readable-metadata' = 'sys_col:STRING,id:STRING,cnt:BIGINT'
+                               |)
+                               |""".stripMargin)
+    util.verifyExecPlan("SELECT COUNT(*) FROM src")
+  }
+
+  @Test
   def testCountStartWithNestedRow(): Unit = {
     util.tableEnv.executeSql("""
                                |CREATE TABLE src (

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/stream/sql/agg/AggregateTest.scala
@@ -395,4 +395,48 @@ class AggregateTest extends TableTestBase {
   def testApproximateCountDistinct(): Unit = {
     util.verifyExecPlan("SELECT APPROX_COUNT_DISTINCT(b) FROM MyTable")
   }
+
+  @Test
+  def testCountStart(): Unit = {
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE src (
+                               | id VARCHAR,
+                               | cnt BIGINT
+                               |) WITH (
+                               | 'connector' = 'values'
+                               |)
+                               |""".stripMargin)
+    util.verifyExecPlan("SELECT COUNT(*) FROM src")
+  }
+
+  @Test
+  def testCountStartWithMetadata(): Unit = {
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE src (
+                               | sys_col VARCHAR METADATA,
+                               | id VARCHAR,
+                               | cnt BIGINT
+                               |) WITH (
+                               | 'connector' = 'values',
+                               | 'readable-metadata' = 'sys_col:STRING'
+                               |)
+                               |""".stripMargin)
+    util.verifyExecPlan("SELECT COUNT(*) FROM src")
+  }
+
+  @Test
+  def testCountStartWithNestedRow(): Unit = {
+    util.tableEnv.executeSql("""
+                               |CREATE TABLE src (
+                               | nested row<name string, `value` int>,
+                               | sys_col VARCHAR METADATA,
+                               | id VARCHAR,
+                               | cnt BIGINT
+                               |) WITH (
+                               | 'connector' = 'values',
+                               | 'readable-metadata' = 'sys_col:STRING'
+                               |)
+                               |""".stripMargin)
+    util.verifyExecPlan("SELECT COUNT(*) FROM src")
+  }
 }


### PR DESCRIPTION
## What is the purpose of the change
Current `PushProjectIntoTableSourceScanRule` doesn't process the case properly when no column is needed from source logically, it will generagte a plan that selects nothing from a source (which supports projection push down) , this will not work with real connectors.
In this pr we will always choose the first (physical) column from the source in such a case (Note that `LegacyTableSource` is not fixed since it is deprecated so long)

## Brief change log
Fix PushProjectIntoTableSourceScanRule to always choose the first (physical) column from the source when no column is needed from source logically

## Verifying this change
newly added countStar related cases in AggregateTest、AggregateITCase (both streaming and batch modes covered)

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
  - The serializers: (no )
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation
  - Does this pull request introduce a new feature? (no)