### PR TITLE
[FLINK-30713][k8s] Add Hadoop related k8s decorators exclude possibility

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -63,6 +63,18 @@
             <td>The desired context from your Kubernetes config file used to configure the Kubernetes client for interacting with the cluster. This could be helpful if one has multiple contexts configured and wants to administrate different Flink clusters on different Kubernetes clusters/contexts.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.decorator.hadoop-conf-mount.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable Hadoop configuration mount decorator. This must be set to false when Hadoop config is mounted outside of Flink. A typical use-case is when one uses Flink Kubernetes Operator.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.decorator.kerberos-mount.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>Whether to enable Kerberos mount decorator. This must be set to false when Kerberos config and keytab is mounted outside of Flink. A typical use-case is when one uses Flink Kubernetes Operator.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.entry.path</h5></td>
             <td style="word-wrap: break-word;">"/docker-entrypoint.sh"</td>
             <td>String</td>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -485,6 +485,26 @@ public class KubernetesConfigOptions {
                     .withDescription(
                             "The user agent to be used for contacting with Kubernetes APIServer.");
 
+    public static final ConfigOption<Boolean> KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED =
+            key("kubernetes.decorator.hadoop-conf-mount.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable Hadoop configuration mount decorator. This "
+                                    + "must be set to false when Hadoop config is mounted outside of "
+                                    + "Flink. A typical use-case is when one uses Flink Kubernetes "
+                                    + "Operator.");
+
+    public static final ConfigOption<Boolean> KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED =
+            key("kubernetes.decorator.kerberos-mount.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "Whether to enable Kerberos mount decorator. This must be set "
+                                    + "to false when Kerberos config and keytab is mounted outside of "
+                                    + "Flink. A typical use-case is when one uses Flink Kubernetes "
+                                    + "Operator.");
+
     /**
      * This will only be used to support blocklist mechanism, which is experimental currently, so we
      * do not want to expose this option in the documentation.

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.kubernetes.kubeclient.factory;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.decorators.CmdTaskManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.EnvSecretsDecorator;
@@ -34,6 +35,13 @@ import org.apache.flink.util.Preconditions;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.apache.flink.kubernetes.configuration.KubernetesConfigOptions.KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED;
+import static org.apache.flink.kubernetes.configuration.KubernetesConfigOptions.KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED;
+
 /** Utility class for constructing the TaskManager Pod on the JobManager. */
 public class KubernetesTaskManagerFactory {
 
@@ -41,16 +49,23 @@ public class KubernetesTaskManagerFactory {
             FlinkPod podTemplate, KubernetesTaskManagerParameters kubernetesTaskManagerParameters) {
         FlinkPod flinkPod = Preconditions.checkNotNull(podTemplate).copy();
 
-        final KubernetesStepDecorator[] stepDecorators =
-                new KubernetesStepDecorator[] {
-                    new InitTaskManagerDecorator(kubernetesTaskManagerParameters),
-                    new EnvSecretsDecorator(kubernetesTaskManagerParameters),
-                    new MountSecretsDecorator(kubernetesTaskManagerParameters),
-                    new CmdTaskManagerDecorator(kubernetesTaskManagerParameters),
-                    new HadoopConfMountDecorator(kubernetesTaskManagerParameters),
-                    new KerberosMountDecorator(kubernetesTaskManagerParameters),
-                    new FlinkConfMountDecorator(kubernetesTaskManagerParameters)
-                };
+        final List<KubernetesStepDecorator> stepDecorators =
+                new ArrayList<>(
+                        Arrays.asList(
+                                new InitTaskManagerDecorator(kubernetesTaskManagerParameters),
+                                new EnvSecretsDecorator(kubernetesTaskManagerParameters),
+                                new MountSecretsDecorator(kubernetesTaskManagerParameters),
+                                new CmdTaskManagerDecorator(kubernetesTaskManagerParameters)));
+
+        Configuration configuration = kubernetesTaskManagerParameters.getFlinkConfiguration();
+        if (configuration.getBoolean(KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED)) {
+            stepDecorators.add(new HadoopConfMountDecorator(kubernetesTaskManagerParameters));
+        }
+        if (configuration.getBoolean(KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED)) {
+            stepDecorators.add(new KerberosMountDecorator(kubernetesTaskManagerParameters));
+        }
+
+        stepDecorators.add(new FlinkConfMountDecorator(kubernetesTaskManagerParameters));
 
         for (KubernetesStepDecorator stepDecorator : stepDecorators) {
             flinkPod = stepDecorator.decorateFlinkPod(flinkPod);

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactoryTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.kubeclient.factory;
 
 import org.apache.flink.configuration.SecurityOptions;
 import org.apache.flink.kubernetes.KubernetesTestUtils;
+import org.apache.flink.kubernetes.configuration.KubernetesConfigOptions;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.KubernetesTaskManagerTestBase;
 import org.apache.flink.kubernetes.utils.Constants;
@@ -97,5 +98,18 @@ class KubernetesTaskManagerFactoryTest extends KubernetesTaskManagerTestBase {
         // The args list is [bash, -c, 'java -classpath $FLINK_CLASSPATH ...'].
         assertThat(resultMainContainer.getArgs()).hasSize(3);
         assertThat(resultMainContainer.getVolumeMounts()).hasSize(4);
+    }
+
+    @Test
+    void testHadoopDecoratorsCanBeTurnedOff() {
+        flinkConfig.set(
+                KubernetesConfigOptions.KUBERNETES_HADOOP_CONF_MOUNT_DECORATOR_ENABLED, false);
+        flinkConfig.set(KubernetesConfigOptions.KUBERNETES_KERBEROS_MOUNT_DECORATOR_ENABLED, false);
+
+        Pod pod =
+                KubernetesTaskManagerFactory.buildTaskManagerKubernetesPod(
+                                new FlinkPod.Builder().build(), kubernetesTaskManagerParameters)
+                        .getInternalResource();
+        assertThat(pod.getSpec().getVolumes()).hasSize(1);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Hadoop related k8s decorators are making a lot of assumptions. There are some users who mount Hadoop specific things (like Hadoop config, Kerberos config/keytab) in a custom way and not depending on Flink. In this PR I've added Hadoop related k8s decorators exclude possibility not to fail those use-cases.

## Brief change log

* Added Hadoop related k8s decorators exclude possibility
* Added automated tests

## Verifying this change

New unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? docs
