### PR TITLE
[FLINK-29884][test] Fix flaky test SortMergeResultPartitionTest.testRelease

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionTest.java
@@ -361,7 +361,7 @@ public class SortMergeResultPartitionTest {
         ResultSubpartitionView view = partition.createSubpartitionView(0, listener);
         partition.release();
 
-        while (!view.isReleased()) {
+        while (!view.isReleased() && partition.getResultFile() != null) {
             ResultSubpartition.BufferAndBacklog bufferAndBacklog = view.getNextBuffer();
             if (bufferAndBacklog != null) {
                 bufferAndBacklog.buffer().recycleBuffer();


### PR DESCRIPTION
## What is the purpose of the change

*Fix flaky test `SortMergeResultPartitionTest#testRelease`*


## Brief change log

  - *Fix flaky test SortMergeResultPartitionTest.testRelease.*


## Verifying this change

This change is a fix for flaky test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
