### PR TITLE
[FLINK-30726][docs]Translate "Over Aggregation" page of "Querys" into…

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/over-agg.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/over-agg.md
@@ -23,11 +23,14 @@ under the License.
 -->
 
 # Over Aggregation
+
+# Over聚合
+
 {{< label Batch >}} {{< label Streaming >}}
 
-`OVER` aggregates compute an aggregated value for every input row over a range of ordered rows. In contrast to `GROUP BY` aggregates, `OVER` aggregates do not reduce the number of result rows to a single row for every group. Instead `OVER` aggregates produce an aggregated value for every input row.
+`OVER` 聚合通过排序后的范围数据为每行输入计算出聚合值.和`GROUP BY`聚合不同,`OVER`聚合不会把结果通过分组减少到一行,它会为每行输入增加一个聚合值.
 
-The following query computes for every order the sum of amounts of all orders for the same product that were received within one hour before the current order.
+下面这个查询为每个订单计算前一个小时之内接收到的同一产品所有订单的总金额.
 
 ```sql
 SELECT order_id, order_time, amount,
@@ -39,7 +42,7 @@ SELECT order_id, order_time, amount,
 FROM Orders
 ```
 
-The syntax for an `OVER` window is summarized below.
+下面总结了`OVER`窗口的语法.
 
 ```sql
 SELECT
@@ -51,26 +54,25 @@ SELECT
 FROM ...
 ```
 
-You can define multiple `OVER` window aggregates in a `SELECT` clause. However, for streaming queries, the `OVER` windows for all aggregates must be identical due to current limitation.
-
+一个`SELECT`子句可以定义多重`OVER`窗口聚合.但是,流式查询目前有个限制:所有聚合的`OVER`窗口必须相同.
 
 ### ORDER BY
 
-`OVER` windows are defined on an ordered sequence of rows. Since tables do not have an inherent order, the `ORDER BY` clause is mandatory. For streaming queries, Flink currently only supports `OVER` windows that are defined with an ascending [time attributes]({{< ref "docs/dev/table/concepts/time_attributes" >}}) order. Additional orderings are not supported.
+`OVER`窗口需要数据是有序的.因为表没有固定的排序,所以`ORDER BY`子句是强制的.对于流式查询,Flink目前只支持`OVER`窗口定义在升序(asc)的[时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}) 上.其他的排序不支持.
 
 ### PARTITION BY
 
-`OVER` windows can be defined on a partitioned table. In presence of a `PARTITION BY` clause, the aggregate is computed for each input row only over the rows of its partition.
+`OVER` 窗口可以定义在一个分区表上.`PARTITION BY`子句代表着每行数据只在其所属的数据分区进行聚合.
 
-### Range Definitions
+### 范围定义(Range Definitions)
 
-The range definition specifies how many rows are included in the aggregate. The range is defined with a `BETWEEN` clause that defines a lower and an upper boundary. All rows between these boundaries are included in the aggregate. Flink only supports `CURRENT ROW` as the upper boundary.
+范围定义指定了聚合中包含了多少行数据.范围通过`BETWEEN`子句定义上下边界,其内的所有行都会聚合.Flink只支持`CURRENT ROW`作为上边界.
 
-There are two options to define the range, `ROWS` intervals and `RANGE` intervals.
+有两种方法可以定义范围:`ROWS` intervals 和 `RANGE` intervals
 
 #### RANGE intervals
 
-A `RANGE` interval is defined on the values of the ORDER BY column, which is in case of Flink always a time attribute. The following RANGE interval defines that all rows with a time attribute of at most 30 minutes less than the current row are included in the aggregate.
+`RANGE` interval 是定义在排序列值上的,在Flink里,排序列总是一个时间属性.下面的`RANG` interval 定义了聚合会在比当前行的时间属性小30分钟的所有行上进行.
 
 ```sql
 RANGE BETWEEN INTERVAL '30' MINUTE PRECEDING AND CURRENT ROW
@@ -78,14 +80,14 @@ RANGE BETWEEN INTERVAL '30' MINUTE PRECEDING AND CURRENT ROW
 
 #### ROW intervals
 
-A `ROWS` interval is a count-based interval. It defines exactly how many rows are included in the aggregate. The following `ROWS` interval defines that the 10 rows preceding the current row and the current row (so 11 rows in total) are included in the aggregate.
+`ROWS` interval 基于计数.它定义了聚合操作包含的精确行数.下面的`ROWS`interval定义了当前行+之前的10行(也就是11行)都会被聚合.
 
 ```sql
 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW
 WINDOW
 ```
 
-The `WINDOW` clause can be used to define an `OVER` window outside of the `SELECT` clause. It can make queries more readable and also allows us to reuse the window definition for multiple aggregates.
+`WINDOW` 子句可用于在`SELECT`子句之外定义`OVER`窗口.它让查询可读性更好,也允许多个聚合共用一个窗口定义.
 
 ```sql
 SELECT order_id, order_time, amount,

--- a/docs/content.zh/docs/dev/table/sql/queries/over-agg.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/over-agg.md
@@ -22,8 +22,6 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Over Aggregation
-
 # Over聚合
 
 {{< label Batch >}} {{< label Streaming >}}

--- a/docs/content.zh/docs/dev/table/sql/queries/over-agg.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/over-agg.md
@@ -28,9 +28,9 @@ under the License.
 
 {{< label Batch >}} {{< label Streaming >}}
 
-`OVER` 聚合通过排序后的范围数据为每行输入计算出聚合值.和`GROUP BY`聚合不同,`OVER`聚合不会把结果通过分组减少到一行,它会为每行输入增加一个聚合值.
+`OVER` 聚合通过排序后的范围数据为每行输入计算出聚合值。和 `GROUP BY` 聚合不同， `OVER` 聚合不会把结果通过分组减少到一行，它会为每行输入增加一个聚合值。
 
-下面这个查询为每个订单计算前一个小时之内接收到的同一产品所有订单的总金额.
+下面这个查询为每个订单计算前一个小时之内接收到的同一产品所有订单的总金额。
 
 ```sql
 SELECT order_id, order_time, amount,
@@ -42,7 +42,7 @@ SELECT order_id, order_time, amount,
 FROM Orders
 ```
 
-下面总结了`OVER`窗口的语法.
+下面总结了 `OVER` 窗口的语法。
 
 ```sql
 SELECT
@@ -54,25 +54,25 @@ SELECT
 FROM ...
 ```
 
-一个`SELECT`子句可以定义多重`OVER`窗口聚合.但是,流式查询目前有个限制:所有聚合的`OVER`窗口必须相同.
+一个 `SELECT` 子句可以定义多重 `OVER` 窗口聚合。但是，流式查询目前有个限制：所有聚合的 `OVER` 口必须相同。
 
 ### ORDER BY
 
-`OVER`窗口需要数据是有序的.因为表没有固定的排序,所以`ORDER BY`子句是强制的.对于流式查询,Flink目前只支持`OVER`窗口定义在升序(asc)的[时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}) 上.其他的排序不支持.
+`OVER` 窗口需要数据是有序的。因为表没有固定的排序，所以 `ORDER BY` 子句是强制的。对于流式查询，Flink 目前只支持 `OVER` 窗口定义在升序（asc）的 [时间属性]({{< ref "docs/dev/table/concepts/time_attributes" >}}) 上。其他的排序不支持。
 
 ### PARTITION BY
 
-`OVER` 窗口可以定义在一个分区表上.`PARTITION BY`子句代表着每行数据只在其所属的数据分区进行聚合.
+`OVER` 窗口可以定义在一个分区表上。`PARTITION BY` 子句代表着每行数据只在其所属的数据分区进行聚合。
 
 ### 范围定义(Range Definitions)
 
-范围定义指定了聚合中包含了多少行数据.范围通过`BETWEEN`子句定义上下边界,其内的所有行都会聚合.Flink只支持`CURRENT ROW`作为上边界.
+范围定义指定了聚合中包含了多少行数据。范围通过 `BETWEEN` 子句定义上下边界，其内的所有行都会聚合。Flink 只支持 `CURRENT ROW` 作为上边界。
 
-有两种方法可以定义范围:`ROWS` intervals 和 `RANGE` intervals
+有两种方法可以定义范围：`ROWS` intervals 和 `RANGE` intervals
 
 #### RANGE intervals
 
-`RANGE` interval 是定义在排序列值上的,在Flink里,排序列总是一个时间属性.下面的`RANG` interval 定义了聚合会在比当前行的时间属性小30分钟的所有行上进行.
+`RANGE` interval 是定义在排序列值上的，在 Flink 里，排序列总是一个时间属性。下面的 `RANG` interval 定义了聚合会在比当前行的时间属性小 30 分钟的所有行上进行。
 
 ```sql
 RANGE BETWEEN INTERVAL '30' MINUTE PRECEDING AND CURRENT ROW
@@ -80,14 +80,14 @@ RANGE BETWEEN INTERVAL '30' MINUTE PRECEDING AND CURRENT ROW
 
 #### ROW intervals
 
-`ROWS` interval 基于计数.它定义了聚合操作包含的精确行数.下面的`ROWS`interval定义了当前行+之前的10行(也就是11行)都会被聚合.
+`ROWS` interval 基于计数。它定义了聚合操作包含的精确行数。下面的 `ROWS` interval定义了当前行 + 之前的 10 行（也就是11行）都会被聚合。
 
 ```sql
 ROWS BETWEEN 10 PRECEDING AND CURRENT ROW
 WINDOW
 ```
 
-`WINDOW` 子句可用于在`SELECT`子句之外定义`OVER`窗口.它让查询可读性更好,也允许多个聚合共用一个窗口定义.
+`WINDOW` 子句可用于在 `SELECT` 子句之外定义 `OVER` 窗口。它让查询可读性更好，也允许多个聚合共用一个窗口定义。
 
 ```sql
 SELECT order_id, order_time, amount,


### PR DESCRIPTION
Page "Application Development"/"Table API&SQL"/"SQL"/"Queries"/Over Aggregation translate to chinese.

## What is the purpose of the change

Translate /dev/table/sql/queries/over-agg.md

## Brief change log

Translate /dev/table/sql/queries/over-agg.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no