### PR TITLE
[FLINK-30735][docs]Translate "Top-N" page of "Querys" into Chinese

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/topn.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/topn.md
@@ -25,11 +25,11 @@ under the License.
 # Top-N
 {{< label Batch >}} {{< label Streaming >}}
 
-Top-N 查询可以获取多个排序列的N个的最大或最小的值.最大和最小值都被视为 Top-N 查询. 当需要在某个条件下仅显示 `批处理`/`流处理` 表中的N个底部或N个顶部记录时,Top-N查询非常有用.其结果集可以用于进一步分析.
+Top-N 查询可以获取多个排序列的 N 个的最大或最小的值。最大和最小值都被视为 Top-N 查询。 当需要在某个条件下仅显示 `批处理` / `流处理` 表中的 N 个底部或 N 个顶部记录时，Top-N 查询非常有用。其结果集可以用于进一步分析。
 
-Flink 使用`OVER`窗口子句和过滤条件来表示Top-N查询. 借助`OVER`窗口`PARTITION BY`子句的能力,FLink也支持分组Top-N.例如:实时显示每个分类下销售额最高的五个产品.Top-N 查询`批处理`和`流处理`表.
+Flink 使用 `OVER` 窗口子句和过滤条件来表示 Top-N 查询。 借助 `OVER` 窗口 `PARTITION BY` 子句的能力，FLink 也支持分组 Top-N。例如：实时显示每个分类下销售额最高的五个产品。Top-N 查询 `批处理` 和 `流处理` 表。
 
-下面展示了Top-N的语法:
+下面展示了 Top-N 的语法：
 
 ```sql
 SELECT [column_list]
@@ -41,29 +41,29 @@ FROM (
 WHERE rownum <= N [AND conditions]
 ```
 
-**参数说明:**
-- `ROW_NUMBER()`: 根据分区数据的排序,为每一行分配一个唯一且连续的序号,从1开始.目前,只支持`ROW_NUMBER`作为`OVER`窗口函数.未来会支持`RANK()`和`DENSE_RANK()`.
-- `PARTITION BY col1[, col2...]`: 指定分区字段,每个分区都会有一个Top-N的结果.
-- `ORDER BY col1 [asc|desc][, col2 [asc|desc]...]`: 指定排序列. 每个列的排序类型(ASC/DESC)可以不同.
-- `WHERE rownum <= N`: Flink需要`rownum<=N`才能识别此查询是Top-N查询. N表示将要保留N个最大或最小数据.
-- `[AND conditions]`: 可以在`WHERE`子句中添加其他条件,但是这些其他条件和`rownum <= N`需要使用`AND`结合.
+**参数说明：**
+- `ROW_NUMBER()`：根据分区数据的排序，为每一行分配一个唯一且连续的序号，从 1 开始。目前，只支持 `ROW_NUMBER` 作为 `OVER` 窗口函数。未来会支持 `RANK()` 和 `DENSE_RANK()`。
+- `PARTITION BY col1[, col2...]`：指定分区字段。每个分区都会有一个 Top-N 的结果。
+- `ORDER BY col1 [asc|desc][, col2 [asc|desc]...]`： 指定排序列。 每个列的排序类型（ASC/DESC）可以不同。
+- `WHERE rownum <= N`: Flink 需要 `rownum<=N` 才能识别此查询是 Top-N 查询。 N 表示将要保留 N 个最大或最小数据。
+- `[AND conditions]`: 可以在 `WHERE` 子句中添加其他条件，但是这些其他条件和 `rownum <= N` 需要使用 `AND` 结合。
 
 {{< hint info >}}
 
-注意: 必须严格遵循上述模式,否则优化器无法翻译查询.
+注意： 必须严格遵循上述模式，否则优化器无法翻译查询。
 
 {{< /hint >}}
 
 {{< hint info >}}
 
-Top-N查询是<span class="label label-info">变更结果</span>的. Flink SQL会根据指定的规则排序输入数据流,如果Top-N的记录变更了,每个变更都会发送一个 撤回/更新 记录到下游.
-推荐使用支持更新的存储作为Top-N查询的sink.另外,如果Top-N的结果需要存储在外部存储中,结果表应该和Top-N查询的唯一键保持一致.
+Top-N 查询是<span class="label label-info">变更结果</span>的. Flink SQL 会根据指定的规则排序输入数据流，如果 Top-N 的记录变更了，每个变更都会发送一个 撤回/更新 记录到下游。
+推荐使用支持更新的存储作为 Top-N 查询的 sink。另外，如果 Top-N 的结果需要存储在外部存储中，结果表应该和 Top-N 查询的唯一键保持一致。
 
 {{< /hint >}}
 
-Top-N查询的唯一键是分区字段和rownum字段的组合.Top-N查询也可以获取上游的唯一键.用下面的job举例:比如`product_id`是`ShopSales`的唯一键,这时Top-N查询的唯一键是[`category`, `rownum`] 和 [`product_id`].
+Top-N 查询的唯一键是分区字段和 rownum 字段的组合。Top-N 查询也可以获取上游的唯一键。用下面的 job 举例:比如 `product_id` 是 `ShopSales` 的唯一键，这时 Top-N 查询的唯一键是[`category`, `rownum`] 和 [`product_id`]。
 
-下面的示例展示了在流式表上指定Top-N SQL查询.这也是上面提到的'实时显示每个分类下销售额最高的五个产品'的示例.
+下面的示例展示了在流式表上指定 Top-N SQL 查询。这也是上面提到的 '实时显示每个分类下销售额最高的五个产品' 的示例。
 
 ```sql
 CREATE TABLE ShopSales (
@@ -83,11 +83,11 @@ WHERE row_num <= 5
 
 #### 无排名输出优化
 
-如上所述, `rownum` 将作为唯一键的一个字段写入到结果表,这可能会导致大量数据写入到结果表.例如,排名第九(比如`product-1001`)的记录更新为1,排名1到9的所有记录都会作为更新信息逐条写入到结果表.如果结果表收到太多的数据,它将会成为这个SQL任务的瓶颈.
+如上所述， `rownum` 将作为唯一键的一个字段写入到结果表，这可能会导致大量数据写入到结果表。例如，排名第九（比如 `product-1001`）的记录更新为 1，排名 1 到 9 的所有记录都会作为更新信息逐条写入到结果表。如果结果表收到太多的数据，它将会成为这个 SQL 任务的瓶颈。
 
-优化的方法是在Top-N查询的外层`SELECT`子句中省略`rownum`字段.因为通常Top-N的数据量不大,消费端就可以快速地排序.下面的示例中就没有`rownum`字段,只需要发送变更数据(`product-1001`)到下游,这样可以减少结果表很多IO.
+优化的方法是在 Top-N 查询的外层 `SELECT` 子句中省略 `rownum` 字段。因为通常 Top-N 的数据量不大，消费端就可以快速地排序。下面的示例中就没有 `rownum` 字段，只需要发送变更数据（`product-1001`）到下游，这样可以减少结果表很多 IO。
 
-下面的示例展示了用这种方法怎样去优化上面的Top-N:
+下面的示例展示了用这种方法怎样去优化上面的 Top-N：
 
 ```sql
 CREATE TABLE ShopSales (
@@ -105,6 +105,6 @@ FROM (
   FROM ShopSales)
 WHERE row_num <= 5
 ```
-<span class="label label-danger">Attention in Streaming Mode</span> 为了上面的查询输出到外部存储的正确性,外部存储必须和Top-N查询拥有相同的唯一键.在上面的示例中,如果`product_id`是查询的唯一键,外部表应该也把`product_id`作为唯一键.
+<span class="label label-danger">Attention in Streaming Mode</span> 为了上面的查询输出到外部存储的正确性，外部存储必须和 Top-N 查询拥有相同的唯一键。在上面的示例中，如果 `product_id` 是查询的唯一键，外部表应该也把 `product_id` 作为唯一键。
 
 {{< top >}}


### PR DESCRIPTION
Translate "Top-N" page of "Querys" into Chinese

## What is the purpose of the change

Translate /dev/table/sql/queries/topn.md

## Brief change log

Translate /dev/table/sql/queries/topn.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no