### PR TITLE
[FLINK-29720][hive] Supports hive average function by native implemetatoin

### DIFF
--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveAvgAggFunction.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/functions/hive/HiveAvgAggFunction.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.functions.hive;
+
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.TableException;
+import org.apache.flink.table.expressions.Expression;
+import org.apache.flink.table.expressions.UnresolvedCallExpression;
+import org.apache.flink.table.expressions.UnresolvedReferenceExpression;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.logical.LogicalType;
+
+import java.math.BigDecimal;
+
+import static org.apache.flink.connectors.hive.HiveOptions.TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED;
+import static org.apache.flink.table.expressions.ApiExpressionUtils.unresolvedRef;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.cast;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.div;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.equalTo;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.hiveAggDecimalPlus;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.ifThenElse;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.isNull;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.literal;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.nullOf;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.plus;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.tryCast;
+import static org.apache.flink.table.planner.expressions.ExpressionBuilder.typeLiteral;
+import static org.apache.flink.table.types.logical.DecimalType.MAX_PRECISION;
+import static org.apache.flink.table.types.logical.LogicalTypeRoot.DECIMAL;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getPrecision;
+import static org.apache.flink.table.types.logical.utils.LogicalTypeChecks.getScale;
+
+/** built-in hive avg aggregate function. */
+public class HiveAvgAggFunction extends HiveDeclarativeAggregateFunction {
+
+    private final UnresolvedReferenceExpression sum = unresolvedRef("sum");
+    private final UnresolvedReferenceExpression count = unresolvedRef("count");
+    private DataType resultType;
+    private DataType sumType;
+
+    @Override
+    public int operandCount() {
+        return 1;
+    }
+
+    @Override
+    public UnresolvedReferenceExpression[] aggBufferAttributes() {
+        return new UnresolvedReferenceExpression[] {sum, count};
+    }
+
+    @Override
+    public DataType[] getAggBufferTypes() {
+        return new DataType[] {getResultType(), DataTypes.BIGINT()};
+    }
+
+    @Override
+    public DataType getResultType() {
+        return resultType;
+    }
+
+    @Override
+    public Expression[] initialValuesExpressions() {
+        switch (resultType.getLogicalType().getTypeRoot()) {
+            case DECIMAL:
+                return new Expression[] {literal(BigDecimal.ZERO, sumType.notNull()), literal(0L)};
+            case DOUBLE:
+            case FLOAT:
+                return new Expression[] {literal(0D), literal(0L)};
+            default:
+                return new Expression[] {
+                    /* sum = */ literal(0L, sumType.notNull()), /* count = */ literal(0L)
+                };
+        }
+    }
+
+    @Override
+    public Expression[] accumulateExpressions() {
+        Expression tryCastOperand = tryCast(operand(0), typeLiteral(getResultType()));
+        return new Expression[] {
+            /* sum = */ ifThenElse(isNull(tryCastOperand), sum, adjustedPlus(sum, tryCastOperand)),
+            /* count = */ ifThenElse(isNull(tryCastOperand), count, plus(count, literal(1L))),
+        };
+    }
+
+    @Override
+    public Expression[] retractExpressions() {
+        throw new TableException("Avg aggregate function does not support retraction.");
+    }
+
+    @Override
+    public Expression[] mergeExpressions() {
+        return new Expression[] {
+            /* sum = */ adjustedPlus(sum, mergeOperand(sum)),
+            /* count = */ plus(count, mergeOperand(count))
+        };
+    }
+
+    @Override
+    public Expression getValueExpression() {
+        Expression ifTrue = nullOf(getResultType());
+        Expression ifFalse = cast(div(sum, count), typeLiteral(getResultType()));
+        return ifThenElse(equalTo(count, literal(0L)), ifTrue, ifFalse);
+    }
+
+    @Override
+    public void setArguments(CallContext callContext) {
+        if (resultType == null) {
+            // check argument type firstly
+            checkArgumentType(callContext.getArgumentDataTypes().get(0).getLogicalType());
+            resultType = initResultType(callContext.getArgumentDataTypes().get(0));
+            sumType = resultType;
+        }
+    }
+
+    private DataType initResultType(DataType argsType) {
+        switch (argsType.getLogicalType().getTypeRoot()) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+                return DataTypes.BIGINT();
+            case FLOAT:
+            case DOUBLE:
+            case CHAR:
+            case VARCHAR:
+                return DataTypes.DOUBLE();
+            case DECIMAL:
+                int precision =
+                        Math.min(MAX_PRECISION, getPrecision(argsType.getLogicalType()) + 10);
+                return DataTypes.DECIMAL(precision, getScale(argsType.getLogicalType()));
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                throw new TableException(
+                        String.format(
+                                "Native hive avg aggregate function does not support type: %s. Please set option '%s' to false.",
+                                argsType, TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED.key()));
+            default:
+                throw new TableException(
+                        String.format(
+                                "Only numeric type arguments are accepted but %s is passed.",
+                                argsType));
+        }
+    }
+
+    private void checkArgumentType(LogicalType logicalType) {
+        switch (logicalType.getTypeRoot()) {
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+            case DECIMAL:
+                return;
+            default:
+                throw new TableException(
+                        String.format(
+                                "Only numeric type arguments are accepted but %s is passed.",
+                                logicalType.getTypeRoot()));
+        }
+    }
+
+    private UnresolvedCallExpression adjustedPlus(Expression arg1, Expression arg2) {
+        if (getResultType().getLogicalType().is(DECIMAL)) {
+            return hiveAggDecimalPlus(arg1, arg2);
+        } else {
+            return plus(arg1, arg2);
+        }
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/table/module/hive/HiveModule.java
@@ -26,6 +26,7 @@ import org.apache.flink.table.catalog.hive.client.HiveShimLoader;
 import org.apache.flink.table.catalog.hive.factories.HiveFunctionDefinitionFactory;
 import org.apache.flink.table.factories.FunctionDefinitionFactory;
 import org.apache.flink.table.functions.FunctionDefinition;
+import org.apache.flink.table.functions.hive.HiveAvgAggFunction;
 import org.apache.flink.table.functions.hive.HiveMinAggFunction;
 import org.apache.flink.table.functions.hive.HiveSumAggFunction;
 import org.apache.flink.table.module.Module;
@@ -86,7 +87,7 @@ public class HiveModule implements Module {
                                     "tumble_start")));
 
     static final Set<String> BUILTIN_NATIVE_AGG_FUNC =
-            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("sum", "min")));
+            Collections.unmodifiableSet(new HashSet<>(Arrays.asList("sum", "min", "avg")));
 
     private final HiveFunctionDefinitionFactory factory;
     private final String hiveVersion;
@@ -209,6 +210,8 @@ public class HiveModule implements Module {
             case "min":
                 // We override Hive's min function by native implementation to supports hash-agg
                 return Optional.of(new HiveMinAggFunction());
+            case "avg":
+                return Optional.of(new HiveAvgAggFunction());
             default:
                 throw new UnsupportedOperationException(
                         String.format(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryPlanTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryPlanTest.java
@@ -93,6 +93,19 @@ public class HiveDialectQueryPlanTest {
                 .isEqualTo(readFromResource("/explain/testMinAggFunctionFallbackPlan.out"));
     }
 
+    @Test
+    public void testAvgAggFunctionPlan() {
+        // test explain
+        String actualPlan = explainSql("select x, avg(y) from foo group by x");
+        assertThat(actualPlan).isEqualTo(readFromResource("/explain/testAvgAggFunctionPlan.out"));
+
+        // test fallback to hive avg udaf
+        tableEnv.getConfig().set(TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED, false);
+        String actualSortAggPlan = explainSql("select x, avg(y) from foo group by x");
+        assertThat(actualSortAggPlan)
+                .isEqualTo(readFromResource("/explain/testAvgAggFunctionFallbackPlan.out"));
+    }
+
     private String explainSql(String sql) {
         return (String)
                 CollectionUtil.iteratorToList(tableEnv.executeSql("explain " + sql).collect())

--- a/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionFallbackPlan.out
+++ b/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionFallbackPlan.out
@@ -1,0 +1,21 @@
+== Abstract Syntax Tree ==
+LogicalProject(x=[$0], _o__c1=[$1])
++- LogicalAggregate(group=[{0}], agg#0=[avg($1)])
+   +- LogicalProject($f0=[$0], $f1=[$1])
+      +- LogicalTableScan(table=[[test-catalog, default, foo]])
+
+== Optimized Physical Plan ==
+SortAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg($f1) AS $f1])
++- Sort(orderBy=[x ASC])
+   +- Exchange(distribution=[hash[x]])
+      +- LocalSortAggregate(groupBy=[x], select=[x, Partial_avg(y) AS $f1])
+         +- Sort(orderBy=[x ASC])
+            +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])
+
+== Optimized Execution Plan ==
+SortAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg($f1) AS $f1])
++- Sort(orderBy=[x ASC])
+   +- Exchange(distribution=[hash[x]])
+      +- LocalSortAggregate(groupBy=[x], select=[x, Partial_avg(y) AS $f1])
+         +- Sort(orderBy=[x ASC])
+            +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])

--- a/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionPlan.out
+++ b/flink-connectors/flink-connector-hive/src/test/resources/explain/testAvgAggFunctionPlan.out
@@ -1,0 +1,17 @@
+== Abstract Syntax Tree ==
+LogicalProject(x=[$0], _o__c1=[$1])
++- LogicalAggregate(group=[{0}], agg#0=[avg($1)])
+   +- LogicalProject($f0=[$0], $f1=[$1])
+      +- LogicalTableScan(table=[[test-catalog, default, foo]])
+
+== Optimized Physical Plan ==
+HashAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg(sum$0, count$1) AS $f1])
++- Exchange(distribution=[hash[x]])
+   +- LocalHashAggregate(groupBy=[x], select=[x, Partial_avg(y) AS (sum$0, count$1)])
+      +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])
+
+== Optimized Execution Plan ==
+HashAggregate(isMerge=[true], groupBy=[x], select=[x, Final_avg(sum$0, count$1) AS $f1])
++- Exchange(distribution=[hash[x]])
+   +- LocalHashAggregate(groupBy=[x], select=[x, Partial_avg(y) AS (sum$0, count$1)])
+      +- TableSourceScan(table=[[test-catalog, default, foo]], fields=[x, y])


### PR DESCRIPTION
## What is the purpose of the change

Supports native hive avg function for hive dialect.


## Brief change log

* Supports native hive avg function for hive dialect


## Verifying this change

This change added tests and can be verified as follows:
* HiveDialectAggITCase
* HiveDialectQueryPlanTest

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
