### PR TITLE
[FLINK-30704][build] Skip SBOM creation in fast profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1122,6 +1122,13 @@ under the License.
 								<skip>true</skip>
 							</configuration>
 						</plugin>
+						<plugin>
+							<groupId>org.cyclonedx</groupId>
+							<artifactId>cyclonedx-maven-plugin</artifactId>
+							<configuration>
+								<skip>true</skip>
+							</configuration>
+						</plugin>
 					</plugins>
 				</pluginManagement>
 			</build>


### PR DESCRIPTION
Minor quality of life improvement. Enabling the fast profile now yields e.g. the following in the log:

```
[INFO] --- cyclonedx-maven-plugin:2.7.3:makeBom (default) @ flink-metrics-core ---
[INFO] Skipping CycloneDX

```