### PR TITLE
[FLINK-30749][security][runtime] Fix delegation token provider enabled flag documentation

### DIFF
--- a/docs/content/docs/deployment/security/security-kerberos.md
+++ b/docs/content/docs/deployment/security/security-kerberos.md
@@ -169,7 +169,7 @@ The following options provides more fine-grained control for this feature:
 <table class="table">
 <tr><th>Property Name</th><th>Default</th><th>Meaning</th></tr>
 <tr>
-  <td><code>security.kerberos.token.provider.${service}.enabled</code></td>
+  <td><code>security.delegation.token.provider.${service}.enabled</code></td>
   <td><code>true</code></td>
   <td>
     Controls whether to obtain credentials for services when security is enabled.


### PR DESCRIPTION
## What is the purpose of the change

Delegation token providers can be turned off with [`security.delegation.token.provider.{serviceName}.enabled`](https://github.com/apache/flink/blob/b35cef5997568d75611307d11fca0dec415f99b4/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/DefaultDelegationTokenManager.java#L151-L154). The documentation however still contains the old config. In this PR I've fixed the doc.

## Brief change log

Doc fix.

## Verifying this change

No need any test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
