### PR TITLE
[FLINK-30727][table-planner] Fix JoinReorderITCaseBase.testBushyTreeJoinReorder failed

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
@@ -26,9 +26,12 @@ import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.planner.runtime.utils.JoinReorderITCaseBase;
+import org.apache.flink.table.planner.runtime.utils.StreamTestSink;
 import org.apache.flink.table.planner.runtime.utils.TestingRetractSink;
 import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.types.Row;
+
+import org.junit.jupiter.api.AfterEach;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +44,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JoinReorderITCase extends JoinReorderITCaseBase {
 
     private StreamExecutionEnvironment env;
+
+    @AfterEach
+    public void after() {
+        super.after();
+        StreamTestSink.clear();
+    }
 
     @Override
     protected TableEnvironment getTableEnvironment() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.runtime.stream.sql.join;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -49,6 +50,9 @@ public class JoinReorderITCase extends JoinReorderITCaseBase {
     @BeforeEach
     public void before() throws Exception {
         super.before();
+        // This conf is aims to fix IOException due to timeout occurring while requesting exclusive
+        // NetworkBuffer (see https://issues.apache.org/jira/browse/FLINK-30727).
+        tEnv.getConfig().getConfiguration().set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.4f);
     }
 
     @AfterEach

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +45,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JoinReorderITCase extends JoinReorderITCaseBase {
 
     private StreamExecutionEnvironment env;
+
+    @BeforeEach
+    public void before() throws Exception {
+        super.before();
+    }
 
     @AfterEach
     public void after() {
@@ -66,8 +72,7 @@ public class JoinReorderITCase extends JoinReorderITCaseBase {
         streamTableEnvironment
                 .toRetractStream(table, Row.class)
                 .map(JavaScalaConversionUtil::toScala, TypeInformation.of(Tuple2.class))
-                .addSink((SinkFunction) sink)
-                .setParallelism(1);
+                .addSink((SinkFunction) sink);
         try {
             env.execute();
         } catch (Exception e) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.catalog.stats.CatalogTableStatistics;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
 import org.apache.flink.util.TestLogger;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -141,6 +142,11 @@ public abstract class JoinReorderITCaseBase extends TestLogger {
                 new ObjectPath(tEnv.getCurrentDatabase(), "T4"),
                 new CatalogTableStatistics(100, 1, 1, 1),
                 false);
+    }
+
+    @AfterEach
+    public void after() {
+        TestValuesTableFactory.clearAllData();
     }
 
     @ParameterizedTest(name = "Is bushy join reorder: {0}")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
@@ -147,6 +147,9 @@ public abstract class JoinReorderITCaseBase extends TestLogger {
     @AfterEach
     public void after() {
         TestValuesTableFactory.clearAllData();
+        if (catalog != null) {
+            catalog.close();
+        }
     }
 
     @ParameterizedTest(name = "Is bushy join reorder: {0}")

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
@@ -147,9 +147,6 @@ public abstract class JoinReorderITCaseBase extends TestLogger {
     @AfterEach
     public void after() {
         TestValuesTableFactory.clearAllData();
-        if (catalog != null) {
-            catalog.close();
-        }
     }
 
     @ParameterizedTest(name = "Is bushy join reorder: {0}")


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pr is aims to fix JoinReorderITCaseBase.testBushyTreeJoinReorder failed while running CI.  The failed CI link: [https://dev.azure.com/apache-flink/apache-flink/_build/results?buildId=44985&view=logs&j=7e1b167a-ddfd-53ed-4835-e68a01b608a7&t=434b1f2b-ca64-5a0b-f3a5-4a191160d4cb](url)


## Brief change log



## Verifying this change

No tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive):  no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector:  no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no docs
