### PR TITLE
[FLINK-30752][python] Support 'EXPLAIN PLAN_ADVICE' statement in PyFlink

### DIFF
--- a/flink-python/pyflink/table/explain_detail.py
+++ b/flink-python/pyflink/table/explain_detail.py
@@ -37,3 +37,6 @@ class ExplainDetail(object):
 
     # The execution plan in json format of the program.
     JSON_EXECUTION_PLAN = 2
+
+    # The potential risk warnings and SQL optimizer tuning advice analyzed from the physical plan.
+    PLAN_ADVICE = 3

--- a/flink-python/pyflink/table/tests/test_explain.py
+++ b/flink-python/pyflink/table/tests/test_explain.py
@@ -26,9 +26,15 @@ class StreamTableExplainTests(PyFlinkStreamTableTestCase):
     def test_explain(self):
         t = self.t_env.from_elements([(1, 'Hi', 'Hello')], ['a', 'b', 'c'])
         result = t.group_by(t.c).select(t.a.sum, t.c.alias('b')).explain(
-            ExplainDetail.CHANGELOG_MODE)
-
+            ExplainDetail.CHANGELOG_MODE, ExplainDetail.PLAN_ADVICE)
         assert isinstance(result, str)
+        self.assertGreaterEqual(result.find('== Optimized Physical Plan With Advice =='), 0)
+        self.assertGreaterEqual(result.find('advice[1]: [ADVICE] You might want to enable '
+                                            'local-global two-phase optimization by configuring ('
+                                            '\'table.exec.mini-batch.enabled\' to \'true\', '
+                                            '\'table.exec.mini-batch.allow-latency\' to a '
+                                            'positive long value, \'table.exec.mini-batch.size\' '
+                                            'to a positive long value).'), 0)
 
         result = t.group_by(t.c).select(t.a.sum, t.c.alias('b')).explain(
             ExplainDetail.JSON_EXECUTION_PLAN)

--- a/flink-python/pyflink/table/tests/test_sql.py
+++ b/flink-python/pyflink/table/tests/test_sql.py
@@ -21,7 +21,7 @@ import subprocess
 
 from pyflink.find_flink_home import _find_flink_source_root
 from pyflink.java_gateway import get_gateway
-from pyflink.table import ResultKind
+from pyflink.table import ResultKind, ExplainDetail
 from pyflink.table import expressions as expr
 from pyflink.testing import source_sink_utils
 from pyflink.testing.test_case_utils import PyFlinkStreamTableTestCase, \
@@ -37,7 +37,12 @@ class StreamSqlTests(PyFlinkStreamTableTestCase):
             .alias("a", "b") \
             .select(expr.call("func1", expr.col("a"), expr.col("b")))
         plan = table.explain()
-        self.assertTrue(plan.find("PythonCalc(select=[func1(f0, f1) AS _c0])") >= 0)
+        self.assertGreaterEqual(plan.find("== Optimized Physical Plan =="), 0)
+        self.assertGreaterEqual(plan.find("PythonCalc(select=[func1(f0, f1) AS _c0])"), 0)
+
+        plan = table.explain(ExplainDetail.PLAN_ADVICE)
+        self.assertGreaterEqual(plan.find("== Optimized Physical Plan With Advice =="), 0)
+        self.assertGreaterEqual(plan.find("No available advice..."), 0)
 
     def test_sql_query(self):
         t_env = self.t_env

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -77,7 +77,7 @@ class TableEnvironmentTest(PyFlinkUTTestCase):
         result = t.select(t.a + 1, t.b, t.c)
 
         actual = result.explain(ExplainDetail.ESTIMATED_COST, ExplainDetail.CHANGELOG_MODE,
-                                ExplainDetail.JSON_EXECUTION_PLAN)
+                                ExplainDetail.JSON_EXECUTION_PLAN, ExplainDetail.PLAN_ADVICE)
 
         assert isinstance(actual, str)
 

--- a/flink-python/pyflink/util/java_utils.py
+++ b/flink-python/pyflink/util/java_utils.py
@@ -184,8 +184,10 @@ def to_j_explain_detail_arr(p_extra_details):
             return gateway.jvm.org.apache.flink.table.api.ExplainDetail.JSON_EXECUTION_PLAN
         elif p_extra_detail == ExplainDetail.CHANGELOG_MODE:
             return gateway.jvm.org.apache.flink.table.api.ExplainDetail.CHANGELOG_MODE
-        else:
+        elif p_extra_detail == ExplainDetail.ESTIMATED_COST:
             return gateway.jvm.org.apache.flink.table.api.ExplainDetail.ESTIMATED_COST
+        else:
+            return gateway.jvm.org.apache.flink.table.api.ExplainDetail.PLAN_ADVICE
 
     _len = len(p_extra_details) if p_extra_details else 0
     j_arr = gateway.new_array(gateway.jvm.org.apache.flink.table.api.ExplainDetail, _len)


### PR DESCRIPTION
## What is the purpose of the change

This PR supports the `EXPLAIN PLAN_ADVICE` statement in PyFlink.

## Brief change log

Introduce the `ExplainDetail#PLAN_ADVICE` conversion between Python and Java.


## Verifying this change

This change added tests and can be verified as follows:
- `test_explain`
- `test_sql`
- `basic_operations`
- `test_table_environment_api`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduces a new feature? Yes
  - If yes, how is the feature documented? FLINK-30673
