### PR TITLE
[FLINK-30751] [docs] Remove references to disableDataSync in RocksDB documentation

### DIFF
--- a/flink-python/pyflink/datastream/state_backend.py
+++ b/flink-python/pyflink/datastream/state_backend.py
@@ -956,16 +956,16 @@ class PredefinedOptions(Enum):
     determined to be beneficial for performance under different settings.
 
     Some of these settings are based on experiments by the Flink community, some follow
-    guides from the RocksDB project.
+    guides from the RocksDB project. If some configurations should be enabled unconditionally, they
+    are not included in any of the pre-defined options. See the documentation for
+    RocksDBResourceContainer in the Java API for further details. Note that setUseFsync(false) is
+    set by default irrespective of the :class:`PredefinedOptions` setting. Because Flink does not
+    rely on RocksDB data on disk for recovery, there is no need to sync data to stable storage.
 
     :data:`DEFAULT`:
 
-    Default options for all settings, except that writes are not forced to the
-    disk.
+    Default options for all settings. No additional options are set.
 
-    .. note::
-        Because Flink does not rely on RocksDB data on disk for recovery,
-        there is no need to sync data to stable storage.
 
     :data:`SPINNING_DISK_OPTIMIZED`:
 
@@ -979,14 +979,10 @@ class PredefinedOptions(Enum):
 
     - setCompactionStyle(CompactionStyle.LEVEL)
     - setLevelCompactionDynamicLevelBytes(true)
-    - setIncreaseParallelism(4)
-    - setUseFsync(false)
-    - setDisableDataSync(true)
+    - setMaxBackgroundJobs(4)
     - setMaxOpenFiles(-1)
 
-    .. note::
-        Because Flink does not rely on RocksDB data on disk for recovery,
-        there is no need to sync data to stable storage.
+
 
     :data:`SPINNING_DISK_OPTIMIZED_HIGH_MEM`:
 
@@ -1000,21 +996,24 @@ class PredefinedOptions(Enum):
 
     The following options are set:
 
-    - setLevelCompactionDynamicLevelBytes(true)
-    - setTargetFileSizeBase(256 MBytes)
-    - setMaxBytesForLevelBase(1 GByte)
-    - setWriteBufferSize(64 MBytes)
-    - setIncreaseParallelism(4)
-    - setMinWriteBufferNumberToMerge(3)
-    - setMaxWriteBufferNumber(4)
-    - setUseFsync(false)
-    - setMaxOpenFiles(-1)
     - BlockBasedTableConfig.setBlockCacheSize(256 MBytes)
-    - BlockBasedTableConfigsetBlockSize(128 KBytes)
+    - BlockBasedTableConfig.setBlockSize(128 KBytes)
+    - BlockBasedTableConfig.setFilterPolicy(BloomFilter(
+        `BLOOM_FILTER_BITS_PER_KEY`,
+        `BLOOM_FILTER_BLOCK_BASED_MODE`)
+    - setLevelCompactionDynamicLevelBytes(true)
+    - setMaxBackgroundJobs(4)
+    - setMaxBytesForLevelBase(1 GByte)
+    - setMaxOpenFiles(-1)
+    - setMaxWriteBufferNumber(4)
+    - setMinWriteBufferNumberToMerge(3)
+    - setTargetFileSizeBase(256 MBytes)
+    - setWriteBufferSize(64 MBytes)
 
-    .. note::
-        Because Flink does not rely on RocksDB data on disk for recovery,
-        there is no need to sync data to stable storage.
+    The BLOOM_FILTER_BITS_PER_KEY and BLOOM_FILTER_BLOCK_BASED_MODE options are set via
+    `state.backend.rocksdb.bloom-filter.bits-per-key` and
+    `state.backend.rocksdb.bloom-filter.block-based-mode`, respectively.
+
 
     :data:`FLASH_SSD_OPTIMIZED`:
 
@@ -1025,14 +1024,9 @@ class PredefinedOptions(Enum):
 
     The following options are set:
 
-    - setIncreaseParallelism(4)
-    - setUseFsync(false)
-    - setDisableDataSync(true)
+    - setMaxBackgroundJobs(4)
     - setMaxOpenFiles(-1)
 
-    .. note::
-        Because Flink does not rely on RocksDB data on disk for recovery,
-        there is no need to sync data to stable storage.
     """
     DEFAULT = 0
     SPINNING_DISK_OPTIMIZED = 1

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -48,10 +48,8 @@ import java.util.Map;
 public enum PredefinedOptions {
 
     /**
-     * Default options for all settings, except that writes are not forced to the disk.
+     * Default options for all settings.
      *
-     * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
-     * to sync data to stable storage.
      *
      * <p>There are no specified options here.
      */
@@ -72,8 +70,6 @@ public enum PredefinedOptions {
      *   <li>setMaxOpenFiles(-1)
      * </ul>
      *
-     * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
-     * to sync data to stable storage.
      */
     SPINNING_DISK_OPTIMIZED(
             new HashMap<ConfigOption<?>, Object>() {
@@ -110,8 +106,6 @@ public enum PredefinedOptions {
      *   <li>BlockBasedTableConfig.setBlockSize(128 KBytes)
      * </ul>
      *
-     * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
-     * to sync data to stable storage.
      */
     SPINNING_DISK_OPTIMIZED_HIGH_MEM(
             new HashMap<ConfigOption<?>, Object>() {
@@ -148,8 +142,6 @@ public enum PredefinedOptions {
      *   <li>setMaxOpenFiles(-1)
      * </ul>
      *
-     * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
-     * to sync data to stable storage.
      */
     FLASH_SSD_OPTIMIZED(
             new HashMap<ConfigOption<?>, Object>() {

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -43,13 +43,15 @@ import java.util.Map;
  * <p>The {@code PredefinedOptions} are designed to cope with different situations. If some
  * configurations should be enabled unconditionally, they are not included in any of the pre-defined
  * options. Please check {@link RocksDBResourceContainer#createBaseCommonDBOptions()} and {@link
- * RocksDBResourceContainer#createBaseCommonColumnOptions()} for common settings.
+ * RocksDBResourceContainer#createBaseCommonColumnOptions()} for common settings. Note that
+ * setUseFsync(false) is set by default irrespective of the {@code PredefinedOptions} setting.
+ * Because Flink does not rely on RocksDB data on disk for recovery, there is no need to sync data
+ * to stable storage.
  */
 public enum PredefinedOptions {
 
     /**
      * Default options for all settings.
-     *
      *
      * <p>There are no specified options here.
      */
@@ -69,11 +71,7 @@ public enum PredefinedOptions {
      *   <li>setMaxBackgroundJobs(4)
      *   <li>setMaxOpenFiles(-1)
      * </ul>
-     *
-     * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
-     * to sync data to stable storage.
      */
-
     SPINNING_DISK_OPTIMIZED(
             new HashMap<ConfigOption<?>, Object>() {
                 private static final long serialVersionUID = 1L;

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -69,7 +69,6 @@ public enum PredefinedOptions {
      *   <li>setCompactionStyle(CompactionStyle.LEVEL)
      *   <li>setLevelCompactionDynamicLevelBytes(true)
      *   <li>setMaxBackgroundJobs(4)
-     *   <li>setDisableDataSync(true)
      *   <li>setMaxOpenFiles(-1)
      * </ul>
      *
@@ -146,7 +145,6 @@ public enum PredefinedOptions {
      *
      * <ul>
      *   <li>setMaxBackgroundJobs(4)
-     *   <li>setDisableDataSync(true)
      *   <li>setMaxOpenFiles(-1)
      * </ul>
      *

--- a/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/main/java/org/apache/flink/contrib/streaming/state/PredefinedOptions.java
@@ -70,16 +70,19 @@ public enum PredefinedOptions {
      *   <li>setMaxOpenFiles(-1)
      * </ul>
      *
+     * <p>Note: Because Flink does not rely on RocksDB data on disk for recovery, there is no need
+     * to sync data to stable storage.
      */
+
     SPINNING_DISK_OPTIMIZED(
             new HashMap<ConfigOption<?>, Object>() {
                 private static final long serialVersionUID = 1L;
 
                 {
-                    put(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, 4);
-                    put(RocksDBConfigurableOptions.MAX_OPEN_FILES, -1);
                     put(RocksDBConfigurableOptions.COMPACTION_STYLE, CompactionStyle.LEVEL);
                     put(RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE, true);
+                    put(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, 4);
+                    put(RocksDBConfigurableOptions.MAX_OPEN_FILES, -1);
                 }
             }),
 
@@ -94,37 +97,41 @@ public enum PredefinedOptions {
      * <p>The following options are set:
      *
      * <ul>
-     *   <li>setLevelCompactionDynamicLevelBytes(true)
-     *   <li>setTargetFileSizeBase(256 MBytes)
-     *   <li>setMaxBytesForLevelBase(1 GByte)
-     *   <li>setWriteBufferSize(64 MBytes)
-     *   <li>setMaxBackgroundJobs(4)
-     *   <li>setMinWriteBufferNumberToMerge(3)
-     *   <li>setMaxWriteBufferNumber(4)
-     *   <li>setMaxOpenFiles(-1)
      *   <li>BlockBasedTableConfig.setBlockCacheSize(256 MBytes)
      *   <li>BlockBasedTableConfig.setBlockSize(128 KBytes)
+     *   <li>BlockBasedTableConfig.setFilterPolicy(BloomFilter( {@link
+     *       RocksDBConfigurableOptions#BLOOM_FILTER_BITS_PER_KEY}, {@link
+     *       RocksDBConfigurableOptions#BLOOM_FILTER_BLOCK_BASED_MODE})
+     *   <li>setLevelCompactionDynamicLevelBytes(true)
+     *   <li>setMaxBackgroundJobs(4)
+     *   <li>setMaxBytesForLevelBase(1 GByte)
+     *   <li>setMaxOpenFiles(-1)
+     *   <li>setMaxWriteBufferNumber(4)
+     *   <li>setMinWriteBufferNumberToMerge(3)
+     *   <li>setTargetFileSizeBase(256 MBytes)
+     *   <li>setWriteBufferSize(64 MBytes)
      * </ul>
      *
+     * <p>Enabling use of a Bloom filter here is equivalent to setting {@link
+     * RocksDBConfigurableOptions#USE_BLOOM_FILTER}.
      */
     SPINNING_DISK_OPTIMIZED_HIGH_MEM(
             new HashMap<ConfigOption<?>, Object>() {
                 private static final long serialVersionUID = 1L;
 
                 {
-                    put(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, 4);
-                    put(RocksDBConfigurableOptions.MAX_OPEN_FILES, -1);
-                    put(RocksDBConfigurableOptions.COMPACTION_STYLE, CompactionStyle.LEVEL);
+                    put(RocksDBConfigurableOptions.BLOCK_CACHE_SIZE, MemorySize.parse("256mb"));
+                    put(RocksDBConfigurableOptions.BLOCK_SIZE, MemorySize.parse("128kb"));
                     put(RocksDBConfigurableOptions.USE_DYNAMIC_LEVEL_SIZE, true);
+                    put(RocksDBConfigurableOptions.MAX_BACKGROUND_THREADS, 4);
+                    put(RocksDBConfigurableOptions.MAX_SIZE_LEVEL_BASE, MemorySize.parse("1gb"));
+                    put(RocksDBConfigurableOptions.MAX_OPEN_FILES, -1);
+                    put(RocksDBConfigurableOptions.MAX_WRITE_BUFFER_NUMBER, 4);
+                    put(RocksDBConfigurableOptions.MIN_WRITE_BUFFER_NUMBER_TO_MERGE, 3);
                     put(
                             RocksDBConfigurableOptions.TARGET_FILE_SIZE_BASE,
                             MemorySize.parse("256mb"));
-                    put(RocksDBConfigurableOptions.MAX_SIZE_LEVEL_BASE, MemorySize.parse("1gb"));
                     put(RocksDBConfigurableOptions.WRITE_BUFFER_SIZE, MemorySize.parse("64mb"));
-                    put(RocksDBConfigurableOptions.MIN_WRITE_BUFFER_NUMBER_TO_MERGE, 3);
-                    put(RocksDBConfigurableOptions.MAX_WRITE_BUFFER_NUMBER, 4);
-                    put(RocksDBConfigurableOptions.BLOCK_CACHE_SIZE, MemorySize.parse("256mb"));
-                    put(RocksDBConfigurableOptions.BLOCK_SIZE, MemorySize.parse("128kb"));
                     put(RocksDBConfigurableOptions.USE_BLOOM_FILTER, true);
                 }
             }),
@@ -141,7 +148,6 @@ public enum PredefinedOptions {
      *   <li>setMaxBackgroundJobs(4)
      *   <li>setMaxOpenFiles(-1)
      * </ul>
-     *
      */
     FLASH_SSD_OPTIMIZED(
             new HashMap<ConfigOption<?>, Object>() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR corrects and improves the readability of the documentation for RocksDB predefined option sets. References to `disableDataSync`, which is not set and has been removed from RocksDB for some time, are removed. 

While fixing this error, I also noticed other confusing aspects of this documentation. The options are not sorted, which makes it harder for a reader to find a particular one, and for maintainers to ensure the code & documentation match. I found an error of this kind in `SPINNING_DISK_OPTIMIZED_HIGH_MEM`, where Bloom filter usage is enabled but not documented. The unsorted documentation/code may have played a role in this accidental omission. I kept the Bloom filter setting, so that users' job performance does not change unexpectedly between versions, and I added the Bloom filter setting to the documentation along with a description of where its input parameters are set. 

References to Flink not needing to sync changes to the file system due to its checkpointing ability are also present, but it is confusing to a reader because this point isn't relevant to any of the listed options in the Java documentation. `setUseFsync(false)` is documented for each option set in the Python documentation, but isn't in the Java documentation. `setUseFsync(false)` is not set in the predefined options, so we should not emphasize it. Instead, I added a passing reference to it at the top of both Java and Python introductions.

## Brief change log


* Remove references to `disableDataSync` in RocksDB documentation. This is not set, and has been removed from RocksDB for some time.
* Sort options in both Java and Python documentation. Sort the code setting configuration to match the sorted-order documentation.
* Make Python documentation consistent with Java documentation by removing `setUseFsync` references on each option.
* Change use of `setIncreaseParallelism` in Python documentation to `setMaxBackgroundJobs`, which matches the Java usage.
* Add missing Bloom filter option to the `SPINNING_DISK_OPTIMIZED_HIGH_MEM` documentation, and describe where its parameters are set.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): **no**
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: **no**
  - The serializers: **no**
  - The runtime per-record code paths (performance sensitive): **no**
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: **no**
  - The S3 file system connector: **no**

## Documentation

  - Does this pull request introduce a new feature? **no**
  - If yes, how is the feature documented? **not applicable**
