### PR TITLE
[FLINK-30753][python] Fix the invocation process of Table.explain()

### DIFF
--- a/flink-python/pyflink/table/statement_set.py
+++ b/flink-python/pyflink/table/statement_set.py
@@ -17,6 +17,7 @@
 ################################################################################
 from typing import Union
 
+from pyflink.java_gateway import get_gateway
 from pyflink.table import ExplainDetail
 from pyflink.table.table_descriptor import TableDescriptor
 from pyflink.table.table_result import TableResult
@@ -138,8 +139,9 @@ class StatementSet(object):
 
         .. versionadded:: 1.11.0
         """
+        TEXT = get_gateway().jvm.org.apache.flink.table.api.ExplainFormat.TEXT
         j_extra_details = to_j_explain_detail_arr(extra_details)
-        return self._j_statement_set.explain(j_extra_details)
+        return self._j_statement_set.explain(TEXT, j_extra_details)
 
     def execute(self) -> TableResult:
         """

--- a/flink-python/pyflink/table/table.py
+++ b/flink-python/pyflink/table/table.py
@@ -1073,8 +1073,9 @@ class Table(object):
 
         .. versionadded:: 1.11.0
         """
+        TEXT = get_gateway().jvm.org.apache.flink.table.api.ExplainFormat.TEXT
         j_extra_details = to_j_explain_detail_arr(extra_details)
-        return self._j_table.explain(j_extra_details)
+        return self._j_table.explain(TEXT, j_extra_details)
 
 
 class GroupedTable(object):


### PR DESCRIPTION
## What is the purpose of the change

This PR fixes the bug that PyFlink cannot invoke `Explainable.explain()` method through py4j.


## Brief change log

- invoke
  `String explain(ExplainFormat format, ExplainDetail... extraDetails)`
  instead of 
  `String explain(ExplainDetail... extraDetails)`
  when PyFlink uses this function.


## Verifying this change

This change is already covered by existing tests, such as `pyflink/table/tests/test_explain.py::StreamTableExplainTests::test_explain`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
