### PR TITLE
[FLINK-30328][tests] Assert memory usage deviation is within bounds instead of min/max

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/DescriptiveStatisticsHistogramStatistics.java
@@ -45,7 +45,11 @@ public class DescriptiveStatisticsHistogramStatistics extends HistogramStatistic
 
     public DescriptiveStatisticsHistogramStatistics(
             DescriptiveStatisticsHistogram.CircularDoubleArray histogramValues) {
-        statisticsSummary.evaluate(histogramValues.toUnsortedArray());
+        this(histogramValues.toUnsortedArray());
+    }
+
+    public DescriptiveStatisticsHistogramStatistics(final double[] values) {
+        statisticsSummary.evaluate(values);
     }
 
     @Override


### PR DESCRIPTION
Fix unstable `TaskManagerWideRocksDbMemorySharingITCase` by using standard deviation of memory usage
instead of `max-min` of each iteration.

`TaskManagerWideRocksDbMemorySharingITCase` uses RocksDB metrics per task to verify that they are actually using the same underlying RocksDB shared resources (block cache and write buffer manager):
despite of (intentionally) varying speed of state size change, the metrics should report the same.

However, metric collection isn't synchronous across tasks, and also doesn't guarantee cross-thread visibility (for performance reasons). This causes the test to fail sometimes.

This PR tries to fix the test by collecting standard deviation across multiple rounds (100) and then verifying that percentiles are withing the bounds (found empirically).