### PR TITLE
[hotfix] [docs] Fix a typo in a query that erroneously tries to perform an aggregation on a string column

### DIFF
--- a/docs/content/docs/dev/python/table/intro_to_table_api.md
+++ b/docs/content/docs/dev/python/table/intro_to_table_api.md
@@ -337,7 +337,7 @@ revenue = orders \
     .select(col("name"), col("country"), col("revenue")) \
     .where(col("country") == 'FRANCE') \
     .group_by(col("name")) \
-    .select(col("name"), col("country").sum.alias('rev_sum'))
+    .select(col("name"), col("revenue").sum.alias('rev_sum'))
 
 revenue.execute().print()
 ```


### PR DESCRIPTION
Fix a typo in a query that erroneously tries to perform an aggregation on a string column.