### PR TITLE
[FLINK-30760][runtime] Fixes wrongly used @GuardedBy annotation

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -48,9 +48,11 @@ public class DefaultLeaderElectionService
     private final LeaderElectionDriverFactory leaderElectionDriverFactory;
 
     /** The leader contender which applies for leadership. */
+    @GuardedBy("lock")
     private volatile LeaderContender leaderContender;
 
     @GuardedBy("lock")
+    @Nullable
     private volatile UUID issuedLeaderSessionID;
 
     @GuardedBy("lock")
@@ -187,7 +189,6 @@ public class DefaultLeaderElectionService
     }
 
     @Override
-    @GuardedBy("lock")
     public void onGrantLeadership(UUID newLeaderSessionId) {
         synchronized (lock) {
             if (running) {
@@ -214,7 +215,6 @@ public class DefaultLeaderElectionService
     }
 
     @Override
-    @GuardedBy("lock")
     public void onRevokeLeadership() {
         synchronized (lock) {
             if (running) {
@@ -248,7 +248,6 @@ public class DefaultLeaderElectionService
     }
 
     @Override
-    @GuardedBy("lock")
     public void onLeaderInformationChange(LeaderInformation leaderInformation) {
         synchronized (lock) {
             if (running) {


### PR DESCRIPTION
## What is the purpose of the change

The @GuardedBy annotations were assigned to some public methods which are not called under the specified lock. @GuardedBy should be used by methods that are only allowed to be called within the context of the lock that is specified in the annotation.

This is a preparation task for FLINK-26522/FLIP-285 where introduce new internal methods that actually need to be properly annotated by the `@GuardedBy` annotation.

## Brief change log

* removes the annotations in methods that are called outside of the lock

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
