### PR TITLE
[FLINK-30761][coordination,test] Replaces JVM assert with Preconditions in leader election code

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalListener;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.FlinkException;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.concurrent.FutureUtils;
 
 import org.slf4j.Logger;
@@ -124,7 +125,7 @@ public class EmbeddedLeaderService {
 
     @GuardedBy("lock")
     private void shutdownInternally(Exception exceptionForHandlers) {
-        assert Thread.holdsLock(lock);
+        Preconditions.checkState(Thread.holdsLock(lock));
 
         if (!shutdown) {
             // clear all leader status
@@ -289,7 +290,7 @@ public class EmbeddedLeaderService {
     @GuardedBy("lock")
     private CompletableFuture<Void> updateLeader() {
         // this must be called under the lock
-        assert Thread.holdsLock(lock);
+        Preconditions.checkState(Thread.holdsLock(lock));
 
         if (currentLeaderConfirmed == null && currentLeaderProposed == null) {
             // we need a new leader

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -22,6 +22,7 @@ import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.runtime.rpc.FatalErrorHandler;
 import org.apache.flink.runtime.util.ZooKeeperUtils;
 import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.CuratorFramework;
 import org.apache.flink.shaded.curator5.org.apache.curator.framework.recipes.cache.ChildData;
@@ -149,8 +150,7 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
 
     @Override
     public boolean hasLeadership() {
-        assert (running);
-        return leaderLatch.hasLeadership();
+        return running && leaderLatch.hasLeadership();
     }
 
     @Override
@@ -177,7 +177,10 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
     /** Writes the current leader's address as well the given leader session ID to ZooKeeper. */
     @Override
     public void writeLeaderInformation(LeaderInformation leaderInformation) {
-        assert (running);
+        Preconditions.checkState(
+                running,
+                "Leader information can be only written if the driver hasn't been closed, yet.");
+
         // this method does not have to be synchronized because the curator framework client
         // is thread-safe. We do not write the empty data to ZooKeeper here. Because
         // check-leadership-and-update

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/ManualLeaderService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/ManualLeaderService.java
@@ -90,8 +90,9 @@ public class ManualLeaderService {
     }
 
     public void revokeLeadership() {
-        assert (currentLeaderId != null);
-        assert (0 <= currentLeaderIndex && currentLeaderIndex < leaderElectionServices.size());
+        Preconditions.checkState(currentLeaderId != null);
+        Preconditions.checkState(
+                0 <= currentLeaderIndex && currentLeaderIndex < leaderElectionServices.size());
 
         TestingLeaderElectionService testingLeaderElectionService =
                 leaderElectionServices.get(currentLeaderIndex);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.leaderelection;
 
 import org.apache.flink.runtime.util.LeaderConnectionInfo;
+import org.apache.flink.util.Preconditions;
 
 import javax.annotation.Nonnull;
 
@@ -48,7 +49,7 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 
     @Override
     public synchronized void start(LeaderContender contender) {
-        assert (!getStartFuture().isDone());
+        Preconditions.checkState(getStartFuture().isDone());
 
         this.contender = contender;
 


### PR DESCRIPTION
## What is the purpose of the change

The intention is to make the code more robust to test failures. We do no enable asserts in the test runs. The JVM has asserts disabled by default. That would mean that invalid state would go unnoticed if we continue to use assert instead of Preconditions.

## Brief change log

* replaced `assert` with Precondition checks

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
