### PR TITLE
[FLINK-30765][runtime] Aligns the LeaderElectionService.stop() contract

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/nonha/embedded/EmbeddedLeaderService.java
@@ -211,6 +211,9 @@ public class EmbeddedLeaderService {
                 }
 
                 // stop the service
+                if (service.isLeader) {
+                    service.contender.revokeLeadership();
+                }
                 service.contender = null;
                 service.running = false;
                 service.isLeader = false;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java
@@ -115,10 +115,7 @@ public class DefaultLeaderElectionService
 
     @Override
     public void confirmLeadership(UUID leaderSessionID, String leaderAddress) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug(
-                    "Confirm leader session ID {} for leader {}.", leaderSessionID, leaderAddress);
-        }
+        LOG.debug("Confirm leader session ID {} for leader {}.", leaderSessionID, leaderAddress);
 
         checkNotNull(leaderSessionID);
 
@@ -127,23 +124,17 @@ public class DefaultLeaderElectionService
                 if (running) {
                     confirmLeaderInformation(leaderSessionID, leaderAddress);
                 } else {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Ignoring the leader session Id {} confirmation, since the "
-                                        + "LeaderElectionService has already been stopped.",
-                                leaderSessionID);
-                    }
+                    LOG.debug(
+                            "Ignoring the leader session Id {} confirmation, since the LeaderElectionService has already been stopped.",
+                            leaderSessionID);
                 }
             } else {
                 // Received an old confirmation call
                 if (!leaderSessionID.equals(this.issuedLeaderSessionID)) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Receive an old confirmation call of leader session ID {}, "
-                                        + "current issued session ID is {}",
-                                leaderSessionID,
-                                issuedLeaderSessionID);
-                    }
+                    LOG.debug(
+                            "Receive an old confirmation call of leader session ID {}, current issued session ID is {}",
+                            leaderSessionID,
+                            issuedLeaderSessionID);
                 } else {
                     LOG.warn(
                             "The leader session ID {} was confirmed even though the "
@@ -161,10 +152,7 @@ public class DefaultLeaderElectionService
                 return leaderElectionDriver.hasLeadership()
                         && leaderSessionId.equals(issuedLeaderSessionID);
             } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "hasLeadership is called after the service is stopped, returning false.");
-                }
+                LOG.debug("hasLeadership is called after the service is stopped, returning false.");
                 return false;
             }
         }
@@ -199,21 +187,16 @@ public class DefaultLeaderElectionService
                 issuedLeaderSessionID = newLeaderSessionId;
                 clearConfirmedLeaderInformation();
 
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Grant leadership to contender {} with session ID {}.",
-                            leaderContender.getDescription(),
-                            issuedLeaderSessionID);
-                }
+                LOG.debug(
+                        "Grant leadership to contender {} with session ID {}.",
+                        leaderContender.getDescription(),
+                        issuedLeaderSessionID);
 
                 leaderContender.grantLeadership(issuedLeaderSessionID);
             } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Ignoring the grant leadership notification since the {} has "
-                                    + "already been closed.",
-                            leaderElectionDriver);
-                }
+                LOG.debug(
+                        "Ignoring the grant leadership notification since the {} has already been closed.",
+                        leaderElectionDriver);
             }
         }
     }
@@ -222,31 +205,25 @@ public class DefaultLeaderElectionService
     public void onRevokeLeadership() {
         synchronized (lock) {
             if (running) {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Revoke leadership of {} ({}@{}).",
-                            leaderContender.getDescription(),
-                            confirmedLeaderInformation.getLeaderSessionID(),
-                            confirmedLeaderInformation.getLeaderAddress());
-                }
+                LOG.debug(
+                        "Revoke leadership of {} ({}@{}).",
+                        leaderContender.getDescription(),
+                        confirmedLeaderInformation.getLeaderSessionID(),
+                        confirmedLeaderInformation.getLeaderAddress());
 
                 issuedLeaderSessionID = null;
                 clearConfirmedLeaderInformation();
 
                 leaderContender.revokeLeadership();
 
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug("Clearing the leader information on {}.", leaderElectionDriver);
-                }
+                LOG.debug("Clearing the leader information on {}.", leaderElectionDriver);
                 // Clear the old leader information on the external storage
                 leaderElectionDriver.writeLeaderInformation(LeaderInformation.empty());
             } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Ignoring the revoke leadership notification since the {} "
-                                    + "has already been closed.",
-                            leaderElectionDriver);
-                }
+                LOG.debug(
+                        "Ignoring the revoke leadership notification since the {} "
+                                + "has already been closed.",
+                        leaderElectionDriver);
             }
         }
     }
@@ -255,39 +232,30 @@ public class DefaultLeaderElectionService
     public void onLeaderInformationChange(LeaderInformation leaderInformation) {
         synchronized (lock) {
             if (running) {
-                if (LOG.isTraceEnabled()) {
-                    LOG.trace(
-                            "Leader node changed while {} is the leader with session ID {}. New leader information {}.",
-                            leaderContender.getDescription(),
-                            confirmedLeaderInformation.getLeaderSessionID(),
-                            leaderInformation);
-                }
+                LOG.trace(
+                        "Leader node changed while {} is the leader with session ID {}. New leader information {}.",
+                        leaderContender.getDescription(),
+                        confirmedLeaderInformation.getLeaderSessionID(),
+                        leaderInformation);
                 if (!confirmedLeaderInformation.isEmpty()) {
                     final LeaderInformation confirmedLeaderInfo = this.confirmedLeaderInformation;
                     if (leaderInformation.isEmpty()) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug(
-                                    "Writing leader information by {} since the external storage is empty.",
-                                    leaderContender.getDescription());
-                        }
+                        LOG.debug(
+                                "Writing leader information by {} since the external storage is empty.",
+                                leaderContender.getDescription());
                         leaderElectionDriver.writeLeaderInformation(confirmedLeaderInfo);
                     } else if (!leaderInformation.equals(confirmedLeaderInfo)) {
                         // the data field does not correspond to the expected leader information
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug(
-                                    "Correcting leader information by {}.",
-                                    leaderContender.getDescription());
-                        }
+                        LOG.debug(
+                                "Correcting leader information by {}.",
+                                leaderContender.getDescription());
                         leaderElectionDriver.writeLeaderInformation(confirmedLeaderInfo);
                     }
                 }
             } else {
-                if (LOG.isDebugEnabled()) {
-                    LOG.debug(
-                            "Ignoring change notification since the {} has "
-                                    + "already been closed.",
-                            leaderElectionDriver);
-                }
+                LOG.debug(
+                        "Ignoring change notification since the {} has " + "already been closed.",
+                        leaderElectionDriver);
             }
         }
     }
@@ -298,10 +266,7 @@ public class DefaultLeaderElectionService
         public void onFatalError(Throwable throwable) {
             synchronized (lock) {
                 if (!running) {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug(
-                                "Ignoring error notification since the service has been stopped.");
-                    }
+                    LOG.debug("Ignoring error notification since the service has been stopped.");
                     return;
                 }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionEventHandler.java
@@ -39,7 +39,10 @@ public interface LeaderElectionEventHandler {
      */
     void onGrantLeadership(UUID newLeaderSessionId);
 
-    /** Called by specific {@link LeaderElectionDriver} when the leadership is revoked. */
+    /**
+     * Called by specific {@link LeaderElectionDriver} when the leadership is revoked. Updating the
+     * LeaderElection data at this point doesn't have any effect anymore.
+     */
     void onRevokeLeadership();
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/LeaderElectionService.java
@@ -45,9 +45,10 @@ public interface LeaderElectionService {
     void start(LeaderContender contender) throws Exception;
 
     /**
-     * Stops the leader election service.
+     * Stops the leader election service. Stopping the {@code LeaderElectionService} will trigger
+     * {@link LeaderContender#revokeLeadership()} if the service still holds the leadership.
      *
-     * @throws Exception
+     * @throws Exception if an error occurs while stopping the {@code LeaderElectionService}.
      */
     void stop() throws Exception;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionService.java
@@ -62,6 +62,10 @@ public class TestingLeaderElectionService implements LeaderElectionService {
 
     @Override
     public synchronized void stop() throws Exception {
+        if (hasLeadership && contender != null) {
+            contender.revokeLeadership();
+        }
+
         contender = null;
         hasLeadership = false;
         issuedLeaderSessionId = null;


### PR DESCRIPTION
PR order:
- [ ] **this** FLINK-30765 (PR https://github.com/apache/flink/pull/21742)
- [ ] FLINK-31768 (PR https://github.com/apache/flink/pull/22379)
- [ ] FLINK-31773 (PR https://github.com/apache/flink/pull/22380)
- [ ] FLINK-31776 (PR https://github.com/apache/flink/pull/22384)

## What is the purpose of the change

This PR is about hardening the `LeaderElectionService.stop()` contract.

The current implementations of LeaderElectionService do not implement the stop() call consistently. Some (e.g. [StandaloneLeaderElectionService](https://github.com/apache/flink/blob/c6997c97c575d334679915c328792b8a3067cfb5/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/StandaloneLeaderElectionService.java#L53) call revoke on the LeaderContender) whereas others don't (e.g. [DefaultLeaderElectionService](https://github.com/apache/flink/blob/6e1caa390882996bf2d602951b54e4bb2d9c90dc/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultLeaderElectionService.java#L96)). The [MultipleComponentLeaderElectionService](https://github.com/apache/flink/blob/0290715a57b8d243586ab747b0cd2416c8081012/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java#L166) does call revoke on the LeaderContender instances, though.

This PR makes the contract of the `LeaderElectionService.stop` call more consistent, i.e. aligning it more with what's happening if the leadership is revoked by the HA backend. The contract change reduces the assumptions that are made by the `LeaderElectionService` implementations (e.g. that the `LeaderContender` owns the `LeaderElectionService` and is, therefore, responsible for its lifecycle) which losens the coupling between the two components.

This should reduce noise when going ahead with refactoring the interfaces ([FLIP-285](https://cwiki.apache.org/confluence/display/FLINK/FLIP-285%3A+Refactoring+LeaderElection+to+make+Flink+support+multi-component+leader+election+out-of-the-box)).

## Brief change log

* Updated the JavaDoc in `LeaderElectionService.stop()` to specify the contract
* Add revoke call to `LeaderElectionService.stop()` implementations for the case where the individual instance still have the leadership acquired
* Additionally, a hotfix commit was added to remove obsolete log code (if statements)

## Verifying this change

The `LeaderContender.revokeLeadership()` call was also added to `TestingLeaderElectionService` to make each test rely on this contract.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? JavaDocs
