### PR TITLE
[FLINK-15325][coordination] Ignores the input locations of a ConsumePartitionGroup if the corresponding ConsumerVertexGroup is too large

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtil.java
@@ -174,6 +174,9 @@ public class EdgeManagerBuildUtil {
         for (IntermediateResultPartition partition : partitions) {
             partition.addConsumers(consumerVertexGroup);
         }
+
+        consumedPartitionGroup.setConsumerVertexGroup(consumerVertexGroup);
+        consumerVertexGroup.setConsumedPartitionGroup(consumedPartitionGroup);
     }
 
     private static ConsumedPartitionGroup createAndRegisterConsumedPartitionGroupToEdgeManager(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -33,6 +33,7 @@ import org.apache.flink.runtime.checkpoint.MasterTriggerRestoreHook;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
@@ -123,6 +124,15 @@ public interface ExecutionGraph extends AccessExecutionGraph {
     long getNumberOfRestarts();
 
     Map<IntermediateDataSetID, IntermediateResult> getAllIntermediateResults();
+
+    /**
+     * Gets the intermediate result partition by the given partition ID, or throw an exception if
+     * the partition is not found.
+     *
+     * @param id of the intermediate result partition
+     * @return intermediate result partition
+     */
+    IntermediateResultPartition getResultPartitionOrThrow(final IntermediateResultPartitionID id);
 
     /**
      * Merges all accumulator results from the tasks previously executed in the Executions.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionVertex.java
@@ -62,8 +62,6 @@ public class ExecutionVertex
 
     public static final long NUM_BYTES_UNKNOWN = -1;
 
-    public static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
-
     // --------------------------------------------------------------------------------------------
 
     final ExecutionJobVertex jobVertex;

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/AvailableInputsLocationsRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/AvailableInputsLocationsRetriever.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -34,9 +35,16 @@ class AvailableInputsLocationsRetriever implements InputsLocationsRetriever {
     }
 
     @Override
-    public Collection<Collection<ExecutionVertexID>> getConsumedResultPartitionsProducers(
+    public Collection<ConsumedPartitionGroup> getConsumedPartitionGroups(
             ExecutionVertexID executionVertexId) {
-        return inputsLocationsRetriever.getConsumedResultPartitionsProducers(executionVertexId);
+        return inputsLocationsRetriever.getConsumedPartitionGroups(executionVertexId);
+    }
+
+    @Override
+    public Collection<ExecutionVertexID> getProducersOfConsumedPartitionGroup(
+            ConsumedPartitionGroup consumedPartitionGroup) {
+        return inputsLocationsRetriever.getProducersOfConsumedPartitionGroup(
+                consumedPartitionGroup);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetriever.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.apache.flink.util.concurrent.FutureUtils;
@@ -30,7 +31,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
-import static org.apache.flink.runtime.executiongraph.ExecutionVertex.MAX_DISTINCT_LOCATIONS_TO_CONSIDER;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -38,6 +38,10 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  * returned if exist. Otherwise locations based on inputs will be returned.
  */
 public class DefaultPreferredLocationsRetriever implements PreferredLocationsRetriever {
+
+    static final int MAX_DISTINCT_LOCATIONS_TO_CONSIDER = 8;
+
+    static final int MAX_DISTINCT_CONSUMERS_TO_CONSIDER = 8;
 
     private final StateLocationRetriever stateLocationRetriever;
 
@@ -84,11 +88,24 @@ public class DefaultPreferredLocationsRetriever implements PreferredLocationsRet
         CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
                 CompletableFuture.completedFuture(Collections.emptyList());
 
-        final Collection<Collection<ExecutionVertexID>> allProducers =
-                inputsLocationsRetriever.getConsumedResultPartitionsProducers(executionVertexId);
-        for (Collection<ExecutionVertexID> producers : allProducers) {
+        final Collection<ConsumedPartitionGroup> consumedPartitionGroups =
+                inputsLocationsRetriever.getConsumedPartitionGroups(executionVertexId);
+        for (ConsumedPartitionGroup consumedPartitionGroup : consumedPartitionGroups) {
+            // Ignore the location of a consumed partition group if it has too many distinct
+            // consumers compared to the consumed partition group size. This is to avoid tasks
+            // unevenly distributed on nodes when running batch jobs or running jobs in
+            // session/standalone mode.
+            if ((double) consumedPartitionGroup.getConsumerVertexGroup().size()
+                            / consumedPartitionGroup.size()
+                    > MAX_DISTINCT_CONSUMERS_TO_CONSIDER) {
+                continue;
+            }
+
             final Collection<CompletableFuture<TaskManagerLocation>> locationsFutures =
-                    getInputLocationFutures(producersToIgnore, producers);
+                    getInputLocationFutures(
+                            producersToIgnore,
+                            inputsLocationsRetriever.getProducersOfConsumedPartitionGroup(
+                                    consumedPartitionGroup));
 
             preferredLocations = combineLocations(preferredLocations, locationsFutures);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -44,6 +44,7 @@ import org.apache.flink.runtime.jobmanager.scheduler.CoLocationGroup;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.scheduler.exceptionhistory.FailureHandlingResultSnapshot;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategy;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
@@ -511,9 +512,16 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         }
 
         @Override
-        public Collection<Collection<ExecutionVertexID>> getConsumedResultPartitionsProducers(
+        public Collection<ConsumedPartitionGroup> getConsumedPartitionGroups(
                 ExecutionVertexID executionVertexId) {
-            return inputsLocationsRetriever.getConsumedResultPartitionsProducers(executionVertexId);
+            return inputsLocationsRetriever.getConsumedPartitionGroups(executionVertexId);
+        }
+
+        @Override
+        public Collection<ExecutionVertexID> getProducersOfConsumedPartitionGroup(
+                ConsumedPartitionGroup consumedPartitionGroup) {
+            return inputsLocationsRetriever.getProducersOfConsumedPartitionGroup(
+                    consumedPartitionGroup);
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InputsLocationsRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/InputsLocationsRetriever.java
@@ -18,7 +18,8 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.runtime.executiongraph.Execution;
+import org.apache.flink.runtime.executiongraph.ExecutionVertex;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
@@ -26,22 +27,31 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-/** Component to retrieve the inputs locations of a {@link Execution}. */
+/** Component to retrieve the inputs locations of an {@link ExecutionVertex}. */
 public interface InputsLocationsRetriever {
 
     /**
-     * Get the producers of the result partitions consumed by an execution.
+     * Get the consumed result partition groups of an execution vertex.
      *
-     * @param executionVertexId identifies the execution
-     * @return the producers of the result partitions group by job vertex id
+     * @param executionVertexId identifies the execution vertex
+     * @return the consumed result partition groups
      */
-    Collection<Collection<ExecutionVertexID>> getConsumedResultPartitionsProducers(
+    Collection<ConsumedPartitionGroup> getConsumedPartitionGroups(
             ExecutionVertexID executionVertexId);
 
     /**
-     * Get the task manager location future for an execution.
+     * Get the producer execution vertices of a consumed result partition group.
      *
-     * @param executionVertexId identifying the execution
+     * @param consumedPartitionGroup the consumed result partition group
+     * @return the ids of producer execution vertices
+     */
+    Collection<ExecutionVertexID> getProducersOfConsumedPartitionGroup(
+            ConsumedPartitionGroup consumedPartitionGroup);
+
+    /**
+     * Get the task manager location future for an execution vertex.
+     *
+     * @param executionVertexId identifying the execution vertex
      * @return the task manager location future
      */
     Optional<CompletableFuture<TaskManagerLocation>> getTaskManagerLocation(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumedPartitionGroup.java
@@ -23,14 +23,21 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.util.Preconditions;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.util.Preconditions.checkArgument;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
 
-/** Group of consumed {@link IntermediateResultPartitionID}s. */
+/**
+ * Group of consumed {@link IntermediateResultPartitionID}s. One such a group corresponds to one
+ * {@link ConsumerVertexGroup}.
+ */
 public class ConsumedPartitionGroup implements Iterable<IntermediateResultPartitionID> {
 
     private final List<IntermediateResultPartitionID> resultPartitions;
@@ -43,6 +50,8 @@ public class ConsumedPartitionGroup implements Iterable<IntermediateResultPartit
 
     /** Number of consumer tasks in the corresponding {@link ConsumerVertexGroup}. */
     private final int numConsumers;
+
+    @Nullable private ConsumerVertexGroup consumerVertexGroup;
 
     private ConsumedPartitionGroup(
             int numConsumers,
@@ -129,5 +138,14 @@ public class ConsumedPartitionGroup implements Iterable<IntermediateResultPartit
 
     public ResultPartitionType getResultPartitionType() {
         return resultPartitionType;
+    }
+
+    public ConsumerVertexGroup getConsumerVertexGroup() {
+        return checkNotNull(consumerVertexGroup, "ConsumerVertexGroup is not properly set.");
+    }
+
+    public void setConsumerVertexGroup(ConsumerVertexGroup consumerVertexGroup) {
+        checkState(this.consumerVertexGroup == null);
+        this.consumerVertexGroup = checkNotNull(consumerVertexGroup);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumerVertexGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/strategy/ConsumerVertexGroup.java
@@ -20,15 +20,25 @@ package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 
+import javax.annotation.Nullable;
+
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-/** Group of consumer {@link ExecutionVertexID}s. */
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.Preconditions.checkState;
+
+/**
+ * Group of consumer {@link ExecutionVertexID}s. One such a group corresponds to one {@link
+ * ConsumedPartitionGroup}.
+ */
 public class ConsumerVertexGroup implements Iterable<ExecutionVertexID> {
     private final List<ExecutionVertexID> vertices;
 
     private final ResultPartitionType resultPartitionType;
+
+    @Nullable private ConsumedPartitionGroup consumedPartitionGroup;
 
     private ConsumerVertexGroup(
             List<ExecutionVertexID> vertices, ResultPartitionType resultPartitionType) {
@@ -65,5 +75,14 @@ public class ConsumerVertexGroup implements Iterable<ExecutionVertexID> {
 
     public ExecutionVertexID getFirst() {
         return iterator().next();
+    }
+
+    public ConsumedPartitionGroup getConsumedPartitionGroup() {
+        return checkNotNull(consumedPartitionGroup, "ConsumedPartitionGroup is not properly set.");
+    }
+
+    public void setConsumedPartitionGroup(ConsumedPartitionGroup consumedPartitionGroup) {
+        checkState(this.consumedPartitionGroup == null);
+        this.consumedPartitionGroup = checkNotNull(consumedPartitionGroup);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/AvailableInputsLocationsRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/AvailableInputsLocationsRetrieverTest.java
@@ -18,7 +18,10 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterables;
 
 import org.junit.jupiter.api.Test;
 
@@ -68,15 +71,20 @@ class AvailableInputsLocationsRetrieverTest {
     }
 
     @Test
-    void testConsumedResultPartitionsProducers() {
+    void testGetConsumedPartitionGroupAndProducers() {
         TestingInputsLocationsRetriever originalLocationRetriever = getOriginalLocationRetriever();
         InputsLocationsRetriever availableInputsLocationsRetriever =
                 new AvailableInputsLocationsRetriever(originalLocationRetriever);
-        Collection<Collection<ExecutionVertexID>> producers =
-                availableInputsLocationsRetriever.getConsumedResultPartitionsProducers(EV2);
-        assertThat(producers).hasSize(1);
-        Collection<ExecutionVertexID> resultProducers = producers.iterator().next();
-        assertThat(resultProducers).containsExactly(EV1);
+
+        ConsumedPartitionGroup consumedPartitionGroup =
+                Iterables.getOnlyElement(
+                        (availableInputsLocationsRetriever.getConsumedPartitionGroups(EV2)));
+        assertThat(consumedPartitionGroup).hasSize(1);
+
+        Collection<ExecutionVertexID> producers =
+                availableInputsLocationsRetriever.getProducersOfConsumedPartitionGroup(
+                        consumedPartitionGroup);
+        assertThat(producers).containsExactly(EV1);
     }
 
     private static TestingInputsLocationsRetriever getOriginalLocationRetriever() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/AvailableInputsLocationsRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/AvailableInputsLocationsRetrieverTest.java
@@ -19,75 +19,64 @@
 package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createRandomExecutionVertexId;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link AvailableInputsLocationsRetriever}. */
-public class AvailableInputsLocationsRetrieverTest extends TestLogger {
+class AvailableInputsLocationsRetrieverTest {
     private static final ExecutionVertexID EV1 = createRandomExecutionVertexId();
     private static final ExecutionVertexID EV2 = createRandomExecutionVertexId();
 
     @Test
-    public void testNoInputLocation() {
+    void testNoInputLocation() {
         TestingInputsLocationsRetriever originalLocationRetriever = getOriginalLocationRetriever();
         InputsLocationsRetriever availableInputsLocationsRetriever =
                 new AvailableInputsLocationsRetriever(originalLocationRetriever);
-        assertThat(
-                availableInputsLocationsRetriever.getTaskManagerLocation(EV1).isPresent(),
-                is(false));
+        assertThat(availableInputsLocationsRetriever.getTaskManagerLocation(EV1)).isNotPresent();
     }
 
     @Test
-    public void testNoInputLocationIfNotDone() {
+    void testNoInputLocationIfNotDone() {
         TestingInputsLocationsRetriever originalLocationRetriever = getOriginalLocationRetriever();
         originalLocationRetriever.markScheduled(EV1);
         InputsLocationsRetriever availableInputsLocationsRetriever =
                 new AvailableInputsLocationsRetriever(originalLocationRetriever);
-        assertThat(
-                availableInputsLocationsRetriever.getTaskManagerLocation(EV1).isPresent(),
-                is(false));
+        assertThat(availableInputsLocationsRetriever.getTaskManagerLocation(EV1)).isNotPresent();
     }
 
     @Test
-    public void testNoInputLocationIfFailed() {
+    void testNoInputLocationIfFailed() {
         TestingInputsLocationsRetriever originalLocationRetriever = getOriginalLocationRetriever();
         originalLocationRetriever.failTaskManagerLocation(EV1, new Throwable());
         InputsLocationsRetriever availableInputsLocationsRetriever =
                 new AvailableInputsLocationsRetriever(originalLocationRetriever);
-        assertThat(
-                availableInputsLocationsRetriever.getTaskManagerLocation(EV1).isPresent(),
-                is(false));
+        assertThat(availableInputsLocationsRetriever.getTaskManagerLocation(EV1)).isNotPresent();
     }
 
     @Test
-    public void testInputLocationIfDone() {
+    void testInputLocationIfDone() {
         TestingInputsLocationsRetriever originalLocationRetriever = getOriginalLocationRetriever();
         originalLocationRetriever.assignTaskManagerLocation(EV1);
         InputsLocationsRetriever availableInputsLocationsRetriever =
                 new AvailableInputsLocationsRetriever(originalLocationRetriever);
-        assertThat(
-                availableInputsLocationsRetriever.getTaskManagerLocation(EV1).isPresent(),
-                is(true));
+        assertThat(availableInputsLocationsRetriever.getTaskManagerLocation(EV1)).isPresent();
     }
 
     @Test
-    public void testConsumedResultPartitionsProducers() {
+    void testConsumedResultPartitionsProducers() {
         TestingInputsLocationsRetriever originalLocationRetriever = getOriginalLocationRetriever();
         InputsLocationsRetriever availableInputsLocationsRetriever =
                 new AvailableInputsLocationsRetriever(originalLocationRetriever);
         Collection<Collection<ExecutionVertexID>> producers =
                 availableInputsLocationsRetriever.getConsumedResultPartitionsProducers(EV2);
-        assertThat(producers.size(), is(1));
+        assertThat(producers).hasSize(1);
         Collection<ExecutionVertexID> resultProducers = producers.iterator().next();
-        assertThat(resultProducers, contains(EV1));
+        assertThat(resultProducers).containsExactly(EV1);
     }
 
     private static TestingInputsLocationsRetriever getOriginalLocationRetriever() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetrieverTest.java
@@ -23,9 +23,8 @@ import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,16 +33,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests {@link DefaultPreferredLocationsRetriever}. */
-public class DefaultPreferredLocationsRetrieverTest extends TestLogger {
+class DefaultPreferredLocationsRetrieverTest {
 
     @Test
-    public void testStateLocationsWillBeReturnedIfExist() {
+    void testStateLocationsWillBeReturnedIfExist() {
         final TaskManagerLocation stateLocation = new LocalTaskManagerLocation();
 
         final TestingInputsLocationsRetriever.Builder locationRetrieverBuilder =
@@ -65,11 +61,11 @@ public class DefaultPreferredLocationsRetrieverTest extends TestLogger {
         final CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
                 locationsRetriever.getPreferredLocations(consumerId, Collections.emptySet());
 
-        assertThat(preferredLocations.getNow(null), contains(stateLocation));
+        assertThat(preferredLocations.getNow(null)).containsExactly(stateLocation);
     }
 
     @Test
-    public void testInputLocationsIgnoresEdgeOfTooManyLocations() {
+    void testInputLocationsIgnoresEdgeOfTooManyLocations() {
         final TestingInputsLocationsRetriever.Builder locationRetrieverBuilder =
                 new TestingInputsLocationsRetriever.Builder();
 
@@ -98,11 +94,11 @@ public class DefaultPreferredLocationsRetrieverTest extends TestLogger {
         final CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
                 locationsRetriever.getPreferredLocations(consumerId, Collections.emptySet());
 
-        assertThat(preferredLocations.getNow(null), hasSize(0));
+        assertThat(preferredLocations.getNow(null)).isEmpty();
     }
 
     @Test
-    public void testInputLocationsChoosesInputOfFewerLocations() {
+    void testInputLocationsChoosesInputOfFewerLocations() {
         final TestingInputsLocationsRetriever.Builder locationRetrieverBuilder =
                 new TestingInputsLocationsRetriever.Builder();
 
@@ -150,12 +146,12 @@ public class DefaultPreferredLocationsRetrieverTest extends TestLogger {
         final CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
                 locationsRetriever.getPreferredLocations(consumerId, Collections.emptySet());
 
-        assertThat(
-                preferredLocations.getNow(null), containsInAnyOrder(expectedLocations.toArray()));
+        assertThat(preferredLocations.getNow(null))
+                .containsExactlyInAnyOrderElementsOf(expectedLocations);
     }
 
     @Test
-    public void testInputLocationsIgnoresExcludedProducers() {
+    void testInputLocationsIgnoresExcludedProducers() {
         final TestingInputsLocationsRetriever.Builder locationRetrieverBuilder =
                 new TestingInputsLocationsRetriever.Builder();
 
@@ -186,10 +182,10 @@ public class DefaultPreferredLocationsRetrieverTest extends TestLogger {
                 locationsRetriever.getPreferredLocations(
                         consumerId, Collections.singleton(producerId1));
 
-        assertThat(preferredLocations.getNow(null), hasSize(1));
+        assertThat(preferredLocations.getNow(null)).hasSize(1);
 
         final TaskManagerLocation producerLocation2 =
                 inputsLocationsRetriever.getTaskManagerLocation(producerId2).get().getNow(null);
-        assertThat(preferredLocations.getNow(null), contains(producerLocation2));
+        assertThat(preferredLocations.getNow(null)).containsExactly(producerLocation2);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetrieverTest.java
@@ -18,7 +18,6 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
@@ -27,12 +26,18 @@ import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
+import static org.apache.flink.runtime.scheduler.DefaultPreferredLocationsRetriever.MAX_DISTINCT_CONSUMERS_TO_CONSIDER;
+import static org.apache.flink.runtime.scheduler.DefaultPreferredLocationsRetriever.MAX_DISTINCT_LOCATIONS_TO_CONSIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests {@link DefaultPreferredLocationsRetriever}. */
@@ -65,36 +70,38 @@ class DefaultPreferredLocationsRetrieverTest {
     }
 
     @Test
-    void testInputLocationsIgnoresEdgeOfTooManyLocations() {
-        final TestingInputsLocationsRetriever.Builder locationRetrieverBuilder =
-                new TestingInputsLocationsRetriever.Builder();
-
-        final ExecutionVertexID consumerId = new ExecutionVertexID(new JobVertexID(), 0);
-
-        final int producerParallelism = ExecutionVertex.MAX_DISTINCT_LOCATIONS_TO_CONSIDER + 1;
-        final List<ExecutionVertexID> producerIds = new ArrayList<>(producerParallelism);
-        final JobVertexID producerJobVertexId = new JobVertexID();
-        for (int i = 0; i < producerParallelism; i++) {
-            final ExecutionVertexID producerId = new ExecutionVertexID(producerJobVertexId, i);
-            locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId);
-            producerIds.add(producerId);
+    void testInputLocations() {
+        {
+            final List<TaskManagerLocation> producerLocations =
+                    Collections.singletonList(new LocalTaskManagerLocation());
+            testInputLocationsInternal(
+                    1,
+                    MAX_DISTINCT_CONSUMERS_TO_CONSIDER,
+                    producerLocations,
+                    producerLocations,
+                    Collections.emptySet());
         }
-
-        final TestingInputsLocationsRetriever inputsLocationsRetriever =
-                locationRetrieverBuilder.build();
-
-        for (int i = 0; i < producerParallelism; i++) {
-            inputsLocationsRetriever.markScheduled(producerIds.get(i));
+        {
+            final List<TaskManagerLocation> producerLocations =
+                    Arrays.asList(new LocalTaskManagerLocation(), new LocalTaskManagerLocation());
+            testInputLocationsInternal(
+                    2,
+                    MAX_DISTINCT_CONSUMERS_TO_CONSIDER * 2,
+                    producerLocations,
+                    producerLocations,
+                    Collections.emptySet());
         }
+    }
 
-        final PreferredLocationsRetriever locationsRetriever =
-                new DefaultPreferredLocationsRetriever(
-                        id -> Optional.empty(), inputsLocationsRetriever);
+    @Test
+    void testInputLocationsIgnoresEdgeOfTooManyProducers() {
+        testNoPreferredInputLocationsInternal(MAX_DISTINCT_LOCATIONS_TO_CONSIDER + 1, 1);
+    }
 
-        final CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
-                locationsRetriever.getPreferredLocations(consumerId, Collections.emptySet());
-
-        assertThat(preferredLocations.getNow(null)).isEmpty();
+    @Test
+    void testInputLocationsIgnoresEdgeOfTooManyConsumers() {
+        testNoPreferredInputLocationsInternal(1, MAX_DISTINCT_CONSUMERS_TO_CONSIDER + 1);
+        testNoPreferredInputLocationsInternal(2, MAX_DISTINCT_CONSUMERS_TO_CONSIDER * 2 + 1);
     }
 
     @Test
@@ -110,8 +117,8 @@ class DefaultPreferredLocationsRetrieverTest {
         for (int i = 0; i < parallelism1; i++) {
             final ExecutionVertexID producerId = new ExecutionVertexID(jobVertexId1, i);
             producers1.add(producerId);
-            locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId);
         }
+        locationRetrieverBuilder.connectConsumerToProducers(consumerId, producers1);
 
         final JobVertexID jobVertexId2 = new JobVertexID();
         int parallelism2 = 5;
@@ -119,8 +126,8 @@ class DefaultPreferredLocationsRetrieverTest {
         for (int i = 0; i < parallelism2; i++) {
             final ExecutionVertexID producerId = new ExecutionVertexID(jobVertexId2, i);
             producers2.add(producerId);
-            locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId);
         }
+        locationRetrieverBuilder.connectConsumerToProducers(consumerId, producers2);
 
         final TestingInputsLocationsRetriever inputsLocationsRetriever =
                 locationRetrieverBuilder.build();
@@ -152,40 +159,83 @@ class DefaultPreferredLocationsRetrieverTest {
 
     @Test
     void testInputLocationsIgnoresExcludedProducers() {
-        final TestingInputsLocationsRetriever.Builder locationRetrieverBuilder =
-                new TestingInputsLocationsRetriever.Builder();
+        final List<TaskManagerLocation> producerLocations =
+                Arrays.asList(new LocalTaskManagerLocation(), new LocalTaskManagerLocation());
+        final Set<Integer> producersToIgnore = Collections.singleton(0);
+        testInputLocationsInternal(
+                2, 1, producerLocations, producerLocations.subList(1, 2), producersToIgnore);
+    }
 
-        final ExecutionVertexID consumerId = new ExecutionVertexID(new JobVertexID(), 0);
+    private void testNoPreferredInputLocationsInternal(
+            final int producerParallelism, final int consumerParallelism) {
+        testInputLocationsInternal(
+                producerParallelism,
+                consumerParallelism,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptySet());
+    }
+
+    private void testInputLocationsInternal(
+            final int producerParallelism,
+            final int consumerParallelism,
+            final List<TaskManagerLocation> producerLocations,
+            final List<TaskManagerLocation> expectedPreferredLocations,
+            final Set<Integer> indicesOfProducersToIgnore) {
 
         final JobVertexID producerJobVertexId = new JobVertexID();
+        final List<ExecutionVertexID> producerIds =
+                IntStream.range(0, producerParallelism)
+                        .mapToObj(i -> new ExecutionVertexID(producerJobVertexId, i))
+                        .collect(Collectors.toList());
 
-        final ExecutionVertexID producerId1 = new ExecutionVertexID(producerJobVertexId, 0);
-        locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId1);
+        final JobVertexID consumerJobVertexId = new JobVertexID();
+        final List<ExecutionVertexID> consumerIds =
+                IntStream.range(0, consumerParallelism)
+                        .mapToObj(i -> new ExecutionVertexID(consumerJobVertexId, i))
+                        .collect(Collectors.toList());
 
-        final ExecutionVertexID producerId2 = new ExecutionVertexID(producerJobVertexId, 1);
-        locationRetrieverBuilder.connectConsumerToProducer(consumerId, producerId2);
+        final TestingInputsLocationsRetriever.Builder locationRetrieverBuilder =
+                new TestingInputsLocationsRetriever.Builder();
+        locationRetrieverBuilder.connectConsumersToProducers(consumerIds, producerIds);
 
         final TestingInputsLocationsRetriever inputsLocationsRetriever =
                 locationRetrieverBuilder.build();
+        for (int i = 0; i < producerParallelism; i++) {
+            TaskManagerLocation producerLocation;
+            if (producerLocations.isEmpty()) {
+                // generate a random location if not specified
+                producerLocation = new LocalTaskManagerLocation();
+            } else {
+                producerLocation = producerLocations.get(i);
+            }
+            inputsLocationsRetriever.assignTaskManagerLocation(
+                    producerIds.get(i), producerLocation);
+        }
 
-        inputsLocationsRetriever.markScheduled(producerId1);
-        inputsLocationsRetriever.markScheduled(producerId2);
+        checkInputLocations(
+                consumerIds.get(0),
+                inputsLocationsRetriever,
+                expectedPreferredLocations,
+                indicesOfProducersToIgnore.stream()
+                        .map(index -> new ExecutionVertexID(producerJobVertexId, index))
+                        .collect(Collectors.toSet()));
+    }
 
-        inputsLocationsRetriever.assignTaskManagerLocation(producerId1);
-        inputsLocationsRetriever.assignTaskManagerLocation(producerId2);
+    private void checkInputLocations(
+            final ExecutionVertexID consumerId,
+            final TestingInputsLocationsRetriever inputsLocationsRetriever,
+            final List<TaskManagerLocation> expectedPreferredLocations,
+            final Set<ExecutionVertexID> producersToIgnore) {
 
         final PreferredLocationsRetriever locationsRetriever =
                 new DefaultPreferredLocationsRetriever(
                         id -> Optional.empty(), inputsLocationsRetriever);
 
         final CompletableFuture<Collection<TaskManagerLocation>> preferredLocations =
-                locationsRetriever.getPreferredLocations(
-                        consumerId, Collections.singleton(producerId1));
+                locationsRetriever.getPreferredLocations(consumerId, producersToIgnore);
 
-        assertThat(preferredLocations.getNow(null)).hasSize(1);
-
-        final TaskManagerLocation producerLocation2 =
-                inputsLocationsRetriever.getTaskManagerLocation(producerId2).get().getNow(null);
-        assertThat(preferredLocations.getNow(null)).containsExactly(producerLocation2);
+        assertThat(preferredLocations.getNow(null))
+                .containsExactlyInAnyOrderElementsOf(expectedPreferredLocations);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSyncPreferredLocationsRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSyncPreferredLocationsRetrieverTest.java
@@ -18,49 +18,48 @@
 
 package org.apache.flink.runtime.scheduler;
 
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
-import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createRandomExecutionVertexId;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DefaultSyncPreferredLocationsRetriever}. */
 class DefaultSyncPreferredLocationsRetrieverTest {
-    private static final ExecutionVertexID EV1 = createRandomExecutionVertexId();
-    private static final ExecutionVertexID EV2 = createRandomExecutionVertexId();
-    private static final ExecutionVertexID EV3 = createRandomExecutionVertexId();
-    private static final ExecutionVertexID EV4 = createRandomExecutionVertexId();
-    private static final ExecutionVertexID EV5 = createRandomExecutionVertexId();
+    private static final JobVertexID JV1 = new JobVertexID();
+    private static final ExecutionVertexID EV11 = new ExecutionVertexID(JV1, 0);
+    private static final ExecutionVertexID EV12 = new ExecutionVertexID(JV1, 1);
+    private static final ExecutionVertexID EV13 = new ExecutionVertexID(JV1, 2);
+    private static final ExecutionVertexID EV14 = new ExecutionVertexID(JV1, 3);
+    private static final ExecutionVertexID EV21 = new ExecutionVertexID(new JobVertexID(), 0);
 
     @Test
     void testAvailableInputLocationRetrieval() {
         TestingInputsLocationsRetriever originalLocationRetriever =
                 new TestingInputsLocationsRetriever.Builder()
-                        .connectConsumerToProducer(EV5, EV1)
-                        .connectConsumerToProducer(EV5, EV2)
-                        .connectConsumerToProducer(EV5, EV3)
-                        .connectConsumerToProducer(EV5, EV4)
+                        .connectConsumerToProducers(EV21, Arrays.asList(EV11, EV12, EV13, EV14))
                         .build();
 
-        originalLocationRetriever.assignTaskManagerLocation(EV1);
-        originalLocationRetriever.markScheduled(EV2);
-        originalLocationRetriever.failTaskManagerLocation(EV3, new Throwable());
-        originalLocationRetriever.cancelTaskManagerLocation(EV4);
+        originalLocationRetriever.assignTaskManagerLocation(EV11);
+        originalLocationRetriever.markScheduled(EV12);
+        originalLocationRetriever.failTaskManagerLocation(EV13, new Throwable());
+        originalLocationRetriever.cancelTaskManagerLocation(EV14);
 
         SyncPreferredLocationsRetriever locationsRetriever =
                 new DefaultSyncPreferredLocationsRetriever(
                         executionVertexId -> Optional.empty(), originalLocationRetriever);
 
         Collection<TaskManagerLocation> preferredLocations =
-                locationsRetriever.getPreferredLocations(EV5, Collections.emptySet());
+                locationsRetriever.getPreferredLocations(EV21, Collections.emptySet());
         TaskManagerLocation expectedLocation =
-                originalLocationRetriever.getTaskManagerLocation(EV1).get().join();
+                originalLocationRetriever.getTaskManagerLocation(EV11).get().join();
 
         assertThat(preferredLocations).containsExactly(expectedLocation);
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSyncPreferredLocationsRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSyncPreferredLocationsRetrieverTest.java
@@ -20,20 +20,18 @@ package org.apache.flink.runtime.scheduler;
 
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionGraphTestUtils.createRandomExecutionVertexId;
-import static org.hamcrest.Matchers.contains;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link DefaultSyncPreferredLocationsRetriever}. */
-public class DefaultSyncPreferredLocationsRetrieverTest extends TestLogger {
+class DefaultSyncPreferredLocationsRetrieverTest {
     private static final ExecutionVertexID EV1 = createRandomExecutionVertexId();
     private static final ExecutionVertexID EV2 = createRandomExecutionVertexId();
     private static final ExecutionVertexID EV3 = createRandomExecutionVertexId();
@@ -41,7 +39,7 @@ public class DefaultSyncPreferredLocationsRetrieverTest extends TestLogger {
     private static final ExecutionVertexID EV5 = createRandomExecutionVertexId();
 
     @Test
-    public void testAvailableInputLocationRetrieval() {
+    void testAvailableInputLocationRetrieval() {
         TestingInputsLocationsRetriever originalLocationRetriever =
                 new TestingInputsLocationsRetriever.Builder()
                         .connectConsumerToProducer(EV5, EV1)
@@ -64,6 +62,6 @@ public class DefaultSyncPreferredLocationsRetrieverTest extends TestLogger {
         TaskManagerLocation expectedLocation =
                 originalLocationRetriever.getTaskManagerLocation(EV1).get().join();
 
-        assertThat(preferredLocations, contains(expectedLocation));
+        assertThat(preferredLocations).containsExactly(expectedLocation);
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInputsLocationsRetriever.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/TestingInputsLocationsRetriever.java
@@ -18,10 +18,15 @@
 
 package org.apache.flink.runtime.scheduler;
 
-import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
+import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
+import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
+import org.apache.flink.runtime.scheduler.strategy.TestingSchedulingTopology;
 import org.apache.flink.runtime.taskmanager.LocalTaskManagerLocation;
 import org.apache.flink.runtime.taskmanager.TaskManagerLocation;
+import org.apache.flink.util.IterableUtils;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,28 +38,40 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.runtime.scheduler.strategy.TestingSchedulingTopology.connectConsumersToProducersById;
+
 /** A simple inputs locations retriever for testing purposes. */
 class TestingInputsLocationsRetriever implements InputsLocationsRetriever {
 
-    private final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByConsumer;
+    private final Map<ExecutionVertexID, Collection<ConsumedPartitionGroup>>
+            vertexToConsumedPartitionGroups;
+
+    private final Map<IntermediateResultPartitionID, ExecutionVertexID> partitionToProducer;
 
     private final Map<ExecutionVertexID, CompletableFuture<TaskManagerLocation>>
             taskManagerLocationsByVertex = new HashMap<>();
 
     TestingInputsLocationsRetriever(
-            final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByConsumer) {
-        this.producersByConsumer = new HashMap<>(producersByConsumer);
+            final Map<ExecutionVertexID, Collection<ConsumedPartitionGroup>>
+                    vertexToConsumedPartitionGroups,
+            final Map<IntermediateResultPartitionID, ExecutionVertexID> partitionToProducer) {
+
+        this.vertexToConsumedPartitionGroups = vertexToConsumedPartitionGroups;
+        this.partitionToProducer = partitionToProducer;
     }
 
     @Override
-    public Collection<Collection<ExecutionVertexID>> getConsumedResultPartitionsProducers(
+    public Collection<ConsumedPartitionGroup> getConsumedPartitionGroups(
             final ExecutionVertexID executionVertexId) {
-        final Map<JobVertexID, List<ExecutionVertexID>> executionVerticesByJobVertex =
-                producersByConsumer.getOrDefault(executionVertexId, Collections.emptyList())
-                        .stream()
-                        .collect(Collectors.groupingBy(ExecutionVertexID::getJobVertexId));
+        return vertexToConsumedPartitionGroups.get(executionVertexId);
+    }
 
-        return new ArrayList<>(executionVerticesByJobVertex.values());
+    @Override
+    public Collection<ExecutionVertexID> getProducersOfConsumedPartitionGroup(
+            ConsumedPartitionGroup consumedPartitionGroup) {
+        return IterableUtils.toStream(consumedPartitionGroup)
+                .map(partitionToProducer::get)
+                .collect(Collectors.toList());
     }
 
     @Override
@@ -68,13 +85,18 @@ class TestingInputsLocationsRetriever implements InputsLocationsRetriever {
     }
 
     public void assignTaskManagerLocation(final ExecutionVertexID executionVertexId) {
+        assignTaskManagerLocation(executionVertexId, new LocalTaskManagerLocation());
+    }
+
+    public void assignTaskManagerLocation(
+            final ExecutionVertexID executionVertexId, TaskManagerLocation location) {
         taskManagerLocationsByVertex.compute(
                 executionVertexId,
                 (key, future) -> {
                     if (future == null) {
-                        return CompletableFuture.completedFuture(new LocalTaskManagerLocation());
+                        return CompletableFuture.completedFuture(location);
                     }
-                    future.complete(new LocalTaskManagerLocation());
+                    future.complete(location);
                     return future;
                 });
     }
@@ -107,17 +129,49 @@ class TestingInputsLocationsRetriever implements InputsLocationsRetriever {
 
     static class Builder {
 
-        private final Map<ExecutionVertexID, List<ExecutionVertexID>> producersByConsumer =
+        private final Map<ExecutionVertexID, Collection<ConsumedPartitionGroup>>
+                vertexToConsumedPartitionGroups = new HashMap<>();
+
+        private final Map<IntermediateResultPartitionID, ExecutionVertexID> partitionToProducer =
                 new HashMap<>();
 
         public Builder connectConsumerToProducer(
                 final ExecutionVertexID consumer, final ExecutionVertexID producer) {
-            producersByConsumer.computeIfAbsent(consumer, (key) -> new ArrayList<>()).add(producer);
+            return connectConsumerToProducers(consumer, Collections.singletonList(producer));
+        }
+
+        public Builder connectConsumerToProducers(
+                final ExecutionVertexID consumer, final List<ExecutionVertexID> producers) {
+            return connectConsumersToProducers(Collections.singletonList(consumer), producers);
+        }
+
+        public Builder connectConsumersToProducers(
+                final List<ExecutionVertexID> consumers, final List<ExecutionVertexID> producers) {
+            TestingSchedulingTopology.ConnectionResult connectionResult =
+                    connectConsumersToProducersById(
+                            consumers,
+                            producers,
+                            new IntermediateDataSetID(),
+                            ResultPartitionType.PIPELINED);
+
+            for (int i = 0; i < producers.size(); i++) {
+                partitionToProducer.put(
+                        connectionResult.getResultPartitions().get(i), producers.get(i));
+            }
+
+            for (ExecutionVertexID consumer : consumers) {
+                final Collection<ConsumedPartitionGroup> consumedPartitionGroups =
+                        vertexToConsumedPartitionGroups.computeIfAbsent(
+                                consumer, ignore -> new ArrayList<>());
+                consumedPartitionGroups.add(connectionResult.getConsumedPartitionGroup());
+            }
+
             return this;
         }
 
         public TestingInputsLocationsRetriever build() {
-            return new TestingInputsLocationsRetriever(producersByConsumer);
+            return new TestingInputsLocationsRetriever(
+                    vertexToConsumedPartitionGroups, partitionToProducer);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -43,11 +43,13 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.executiongraph.IntermediateResult;
+import org.apache.flink.runtime.executiongraph.IntermediateResultPartition;
 import org.apache.flink.runtime.executiongraph.JobStatusListener;
 import org.apache.flink.runtime.executiongraph.JobVertexInputInfo;
 import org.apache.flink.runtime.executiongraph.TaskExecutionStateTransition;
 import org.apache.flink.runtime.executiongraph.failover.flip1.ResultPartitionAvailabilityChecker;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
+import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
@@ -311,6 +313,11 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
 
     @Override
     public Map<IntermediateDataSetID, IntermediateResult> getAllIntermediateResults() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IntermediateResultPartition getResultPartitionOrThrow(IntermediateResultPartitionID id) {
         throw new UnsupportedOperationException();
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingExecutionVertex.java
@@ -19,7 +19,6 @@
 package org.apache.flink.runtime.scheduler.strategy;
 
 import org.apache.flink.runtime.execution.ExecutionState;
-import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.util.IterableUtils;
@@ -29,8 +28,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** A simple scheduling execution vertex for testing purposes. */
 public class TestingSchedulingExecutionVertex implements SchedulingExecutionVertex {
@@ -47,17 +44,12 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
     private ExecutionState executionState;
 
     public TestingSchedulingExecutionVertex(
-            JobVertexID jobVertexId,
-            int subtaskIndex,
-            List<ConsumedPartitionGroup> consumedPartitionGroups,
-            Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
-                    resultPartitionsById,
-            ExecutionState executionState) {
+            JobVertexID jobVertexId, int subtaskIndex, ExecutionState executionState) {
 
         this.executionVertexId = new ExecutionVertexID(jobVertexId, subtaskIndex);
-        this.consumedPartitionGroups = checkNotNull(consumedPartitionGroups);
+        this.consumedPartitionGroups = new ArrayList<>();
         this.producedPartitions = new ArrayList<>();
-        this.resultPartitionsById = checkNotNull(resultPartitionsById);
+        this.resultPartitionsById = new HashMap<>();
         this.executionState = executionState;
     }
 
@@ -90,22 +82,6 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
         return consumedPartitionGroups;
     }
 
-    void addConsumedPartition(TestingSchedulingResultPartition consumedPartition) {
-        final ConsumedPartitionGroup consumedPartitionGroup =
-                ConsumedPartitionGroup.fromSinglePartition(
-                        consumedPartition.getNumConsumers(),
-                        consumedPartition.getId(),
-                        consumedPartition.getResultType());
-
-        consumedPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
-        if (consumedPartition.getState() == ResultPartitionState.ALL_DATA_PRODUCED) {
-            consumedPartitionGroup.partitionFinished();
-        }
-
-        this.consumedPartitionGroups.add(consumedPartitionGroup);
-        this.resultPartitionsById.putIfAbsent(consumedPartition.getId(), consumedPartition);
-    }
-
     void addConsumedPartitionGroup(
             ConsumedPartitionGroup consumedPartitionGroup,
             Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
@@ -131,35 +107,11 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
     public static class Builder {
         private JobVertexID jobVertexId = new JobVertexID();
         private int subtaskIndex = 0;
-        private final List<ConsumedPartitionGroup> consumedPartitionGroups = new ArrayList<>();
-        private final Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
-                resultPartitionsById = new HashMap<>();
         private ExecutionState executionState = ExecutionState.CREATED;
 
         Builder withExecutionVertexID(JobVertexID jobVertexId, int subtaskIndex) {
             this.jobVertexId = jobVertexId;
             this.subtaskIndex = subtaskIndex;
-            return this;
-        }
-
-        public Builder withConsumedPartitionGroups(
-                List<ConsumedPartitionGroup> consumedPartitionGroups,
-                Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
-                        resultPartitionsById) {
-            this.resultPartitionsById.putAll(resultPartitionsById);
-            final ResultPartitionType resultType =
-                    resultPartitionsById.values().iterator().next().getResultType();
-
-            for (ConsumedPartitionGroup partitionGroup : consumedPartitionGroups) {
-                List<IntermediateResultPartitionID> partitionIds =
-                        new ArrayList<>(partitionGroup.size());
-                for (IntermediateResultPartitionID partitionId : partitionGroup) {
-                    partitionIds.add(partitionId);
-                }
-                this.consumedPartitionGroups.add(
-                        ConsumedPartitionGroup.fromMultiplePartitions(
-                                partitionGroup.getNumConsumers(), partitionIds, resultType));
-            }
             return this;
         }
 
@@ -169,12 +121,7 @@ public class TestingSchedulingExecutionVertex implements SchedulingExecutionVert
         }
 
         public TestingSchedulingExecutionVertex build() {
-            return new TestingSchedulingExecutionVertex(
-                    jobVertexId,
-                    subtaskIndex,
-                    consumedPartitionGroups,
-                    resultPartitionsById,
-                    executionState);
+            return new TestingSchedulingExecutionVertex(jobVertexId, subtaskIndex, executionState);
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingResultPartition.java
@@ -25,10 +25,8 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
@@ -102,18 +100,8 @@ public class TestingSchedulingResultPartition implements SchedulingResultPartiti
         return Collections.unmodifiableList(consumedPartitionGroups);
     }
 
-    void addConsumerGroup(
-            Collection<TestingSchedulingExecutionVertex> consumerVertices,
-            ResultPartitionType resultPartitionType) {
+    void addConsumerGroup(ConsumerVertexGroup consumerVertexGroup) {
         checkState(this.consumerVertexGroup == null);
-
-        final ConsumerVertexGroup consumerVertexGroup =
-                ConsumerVertexGroup.fromMultipleVertices(
-                        consumerVertices.stream()
-                                .map(TestingSchedulingExecutionVertex::getId)
-                                .collect(Collectors.toList()),
-                        resultPartitionType);
-
         this.consumerVertexGroup = consumerVertexGroup;
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/strategy/TestingSchedulingTopology.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** A simple scheduling topology for testing purposes. */
@@ -189,17 +190,12 @@ public class TestingSchedulingTopology implements SchedulingTopology {
             TestingSchedulingExecutionVertex consumer,
             ResultPartitionType resultPartitionType) {
 
-        final TestingSchedulingResultPartition resultPartition =
-                new TestingSchedulingResultPartition.Builder()
-                        .withResultPartitionType(resultPartitionType)
-                        .build();
-
-        resultPartition.addConsumerGroup(
-                Collections.singleton(consumer), resultPartition.getResultType());
-        resultPartition.setProducer(producer);
-
-        producer.addProducedPartition(resultPartition);
-        consumer.addConsumedPartition(resultPartition);
+        connectConsumersToProducers(
+                Collections.singletonList(consumer),
+                Collections.singletonList(producer),
+                new IntermediateDataSetID(),
+                resultPartitionType,
+                ResultPartitionState.ALL_DATA_PRODUCED);
 
         updateVertexResultPartitions(producer);
         updateVertexResultPartitions(consumer);
@@ -221,6 +217,142 @@ public class TestingSchedulingTopology implements SchedulingTopology {
             final List<TestingSchedulingExecutionVertex> consumers) {
 
         return new ProducerConsumerAllToAllConnectionBuilder(producers, consumers);
+    }
+
+    private static List<TestingSchedulingResultPartition> connectConsumersToProducers(
+            final List<TestingSchedulingExecutionVertex> consumers,
+            final List<TestingSchedulingExecutionVertex> producers,
+            final IntermediateDataSetID intermediateDataSetId,
+            final ResultPartitionType resultPartitionType,
+            final ResultPartitionState resultPartitionState) {
+
+        final List<TestingSchedulingResultPartition> resultPartitions = new ArrayList<>();
+
+        final ConnectionResult connectionResult =
+                connectConsumersToProducersById(
+                        consumers.stream()
+                                .map(SchedulingExecutionVertex::getId)
+                                .collect(Collectors.toList()),
+                        producers.stream()
+                                .map(SchedulingExecutionVertex::getId)
+                                .collect(Collectors.toList()),
+                        intermediateDataSetId,
+                        resultPartitionType);
+
+        final ConsumedPartitionGroup consumedPartitionGroup =
+                connectionResult.getConsumedPartitionGroup();
+        final ConsumerVertexGroup consumerVertexGroup = connectionResult.getConsumerVertexGroup();
+
+        final TestingSchedulingResultPartition.Builder resultPartitionBuilder =
+                new TestingSchedulingResultPartition.Builder()
+                        .withIntermediateDataSetID(intermediateDataSetId)
+                        .withResultPartitionType(resultPartitionType)
+                        .withResultPartitionState(resultPartitionState);
+
+        for (int i = 0; i < producers.size(); i++) {
+            final TestingSchedulingExecutionVertex producer = producers.get(i);
+            final IntermediateResultPartitionID partitionId =
+                    connectionResult.getResultPartitions().get(i);
+            final TestingSchedulingResultPartition resultPartition =
+                    resultPartitionBuilder
+                            .withPartitionNum(partitionId.getPartitionNumber())
+                            .build();
+
+            producer.addProducedPartition(resultPartition);
+
+            resultPartition.setProducer(producer);
+            resultPartitions.add(resultPartition);
+            resultPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
+            resultPartition.addConsumerGroup(consumerVertexGroup);
+
+            if (resultPartition.getState() == ResultPartitionState.ALL_DATA_PRODUCED) {
+                consumedPartitionGroup.partitionFinished();
+            }
+        }
+
+        final Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
+                consumedPartitionById =
+                        resultPartitions.stream()
+                                .collect(
+                                        Collectors.toMap(
+                                                TestingSchedulingResultPartition::getId,
+                                                Function.identity()));
+        for (TestingSchedulingExecutionVertex consumer : consumers) {
+            consumer.addConsumedPartitionGroup(consumedPartitionGroup, consumedPartitionById);
+        }
+
+        return resultPartitions;
+    }
+
+    public static ConnectionResult connectConsumersToProducersById(
+            final List<ExecutionVertexID> consumers,
+            final List<ExecutionVertexID> producers,
+            final IntermediateDataSetID intermediateDataSetId,
+            final ResultPartitionType resultPartitionType) {
+
+        final List<IntermediateResultPartitionID> resultPartitions = new ArrayList<>();
+        for (ExecutionVertexID producer : producers) {
+            final IntermediateResultPartitionID resultPartition =
+                    new IntermediateResultPartitionID(
+                            intermediateDataSetId, producer.getSubtaskIndex());
+            resultPartitions.add(resultPartition);
+        }
+
+        final ConsumedPartitionGroup consumedPartitionGroup =
+                createConsumedPartitionGroup(
+                        consumers.size(), resultPartitions, resultPartitionType);
+        final ConsumerVertexGroup consumerVertexGroup =
+                createConsumerVertexGroup(consumers, resultPartitionType);
+
+        consumedPartitionGroup.setConsumerVertexGroup(consumerVertexGroup);
+        consumerVertexGroup.setConsumedPartitionGroup(consumedPartitionGroup);
+
+        return new ConnectionResult(resultPartitions, consumedPartitionGroup, consumerVertexGroup);
+    }
+
+    private static ConsumedPartitionGroup createConsumedPartitionGroup(
+            final int numConsumers,
+            final List<IntermediateResultPartitionID> consumedPartitions,
+            final ResultPartitionType resultPartitionType) {
+        return ConsumedPartitionGroup.fromMultiplePartitions(
+                numConsumers, consumedPartitions, resultPartitionType);
+    }
+
+    private static ConsumerVertexGroup createConsumerVertexGroup(
+            final List<ExecutionVertexID> consumers,
+            final ResultPartitionType resultPartitionType) {
+        return ConsumerVertexGroup.fromMultipleVertices(consumers, resultPartitionType);
+    }
+
+    /**
+     * The result of connecting a set of consumers to their producers, including the created result
+     * partitions and the consumption groups.
+     */
+    public static class ConnectionResult {
+        private final List<IntermediateResultPartitionID> resultPartitions;
+        private final ConsumedPartitionGroup consumedPartitionGroup;
+        private final ConsumerVertexGroup consumerVertexGroup;
+
+        public ConnectionResult(
+                final List<IntermediateResultPartitionID> resultPartitions,
+                final ConsumedPartitionGroup consumedPartitionGroup,
+                final ConsumerVertexGroup consumerVertexGroup) {
+            this.resultPartitions = checkNotNull(resultPartitions);
+            this.consumedPartitionGroup = checkNotNull(consumedPartitionGroup);
+            this.consumerVertexGroup = checkNotNull(consumerVertexGroup);
+        }
+
+        public List<IntermediateResultPartitionID> getResultPartitions() {
+            return resultPartitions;
+        }
+
+        public ConsumedPartitionGroup getConsumedPartitionGroup() {
+            return consumedPartitionGroup;
+        }
+
+        public ConsumerVertexGroup getConsumerVertexGroup() {
+            return consumerVertexGroup;
+        }
     }
 
     /** Builder for {@link TestingSchedulingResultPartition}. */
@@ -265,11 +397,6 @@ public class TestingSchedulingTopology implements SchedulingTopology {
             return resultPartitions;
         }
 
-        TestingSchedulingResultPartition.Builder initTestingSchedulingResultPartitionBuilder() {
-            return new TestingSchedulingResultPartition.Builder()
-                    .withResultPartitionType(resultPartitionType);
-        }
-
         protected abstract List<TestingSchedulingResultPartition> connect();
     }
 
@@ -292,25 +419,15 @@ public class TestingSchedulingTopology implements SchedulingTopology {
         protected List<TestingSchedulingResultPartition> connect() {
             final List<TestingSchedulingResultPartition> resultPartitions = new ArrayList<>();
             final IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
-
             for (int idx = 0; idx < producers.size(); idx++) {
-                final TestingSchedulingExecutionVertex producer = producers.get(idx);
-                final TestingSchedulingExecutionVertex consumer = consumers.get(idx);
-
-                final TestingSchedulingResultPartition resultPartition =
-                        initTestingSchedulingResultPartitionBuilder()
-                                .withIntermediateDataSetID(intermediateDataSetId)
-                                .withResultPartitionState(resultPartitionState)
-                                .withPartitionNum(idx)
-                                .build();
-                resultPartition.setProducer(producer);
-                producer.addProducedPartition(resultPartition);
-                consumer.addConsumedPartition(resultPartition);
-                resultPartition.addConsumerGroup(
-                        Collections.singleton(consumer), resultPartitionType);
-                resultPartitions.add(resultPartition);
+                resultPartitions.addAll(
+                        connectConsumersToProducers(
+                                Collections.singletonList(consumers.get(idx)),
+                                Collections.singletonList(producers.get(idx)),
+                                intermediateDataSetId,
+                                resultPartitionType,
+                                resultPartitionState));
             }
-
             return resultPartitions;
         }
     }
@@ -330,53 +447,12 @@ public class TestingSchedulingTopology implements SchedulingTopology {
 
         @Override
         protected List<TestingSchedulingResultPartition> connect() {
-            final List<TestingSchedulingResultPartition> resultPartitions = new ArrayList<>();
-            final IntermediateDataSetID intermediateDataSetId = new IntermediateDataSetID();
-
-            TestingSchedulingResultPartition.Builder resultPartitionBuilder =
-                    initTestingSchedulingResultPartitionBuilder()
-                            .withIntermediateDataSetID(intermediateDataSetId)
-                            .withResultPartitionState(resultPartitionState);
-
-            int partitionNum = 0;
-
-            for (TestingSchedulingExecutionVertex producer : producers) {
-
-                final TestingSchedulingResultPartition resultPartition =
-                        resultPartitionBuilder.withPartitionNum(partitionNum++).build();
-                resultPartition.setProducer(producer);
-                producer.addProducedPartition(resultPartition);
-
-                resultPartition.addConsumerGroup(consumers, resultPartitionType);
-                resultPartitions.add(resultPartition);
-            }
-
-            ConsumedPartitionGroup consumedPartitionGroup =
-                    ConsumedPartitionGroup.fromMultiplePartitions(
-                            consumers.size(),
-                            resultPartitions.stream()
-                                    .map(TestingSchedulingResultPartition::getId)
-                                    .collect(Collectors.toList()),
-                            resultPartitions.get(0).getResultType());
-            Map<IntermediateResultPartitionID, TestingSchedulingResultPartition>
-                    consumedPartitionById =
-                            resultPartitions.stream()
-                                    .collect(
-                                            Collectors.toMap(
-                                                    TestingSchedulingResultPartition::getId,
-                                                    Function.identity()));
-            for (TestingSchedulingExecutionVertex consumer : consumers) {
-                consumer.addConsumedPartitionGroup(consumedPartitionGroup, consumedPartitionById);
-            }
-
-            for (TestingSchedulingResultPartition resultPartition : resultPartitions) {
-                resultPartition.registerConsumedPartitionGroup(consumedPartitionGroup);
-                if (resultPartition.getState() == ResultPartitionState.ALL_DATA_PRODUCED) {
-                    consumedPartitionGroup.partitionFinished();
-                }
-            }
-
-            return resultPartitions;
+            return connectConsumersToProducers(
+                    consumers,
+                    producers,
+                    new IntermediateDataSetID(),
+                    resultPartitionType,
+                    resultPartitionState);
         }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This change improves the `DefaultPreferredLocationsRetriever` so that it ignores the input locations of a ConsumePartitionGroup if the corresponding ConsumerVertexGroup is too large. This helps to avoid tasks to be unevenly distributed on nodes when running batch jobs or running jobs in session/standalone mode, because the consumers in this case will tend to be placed on the same node of the input vertex.

## Brief change log

*(for example:)*
  - Changed `EdgeManagerBuildUtil` to set the ConsumedPartitionGroup/ConsumerVertexGroup to its corresponding ConsumerVertexGroup/ConsumedPartitionGroup
  - Changed `DefaultPreferredLocationsRetriever` to ignore the input locations of a ConsumePartitionGroup if the corresponding ConsumerVertexGroup is too large(compared to the ConsumePartitionGroup)

## Verifying this change

  - *Added unit tests in EdgeManagerBuildUtilTest and DefaultPreferredLocationsRetrieverTest*
  - *The change is also covered by existing tests of preferred location retriever*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**yes** / no / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
