### PR TITLE
[hotfix] Fix typo DataStream

### DIFF
--- a/docs/content/docs/dev/datastream/java_lambdas.md
+++ b/docs/content/docs/dev/datastream/java_lambdas.md
@@ -37,7 +37,7 @@ Flink supports the usage of lambda expressions for all operators of the Java API
 
 This document shows how to use lambda expressions and describes current
 limitations. For a general introduction to the Flink API, please refer to the
-[DataSteam API overview]({{< ref "docs/dev/datastream/overview" >}})
+[DataStream API overview]({{< ref "docs/dev/datastream/overview" >}})
 
 ### Examples and Limitations
 

--- a/flink-python/pyflink/datastream/window.py
+++ b/flink-python/pyflink/datastream/window.py
@@ -368,7 +368,7 @@ class Trigger(ABC, Generic[T, W]):
             """
             Returns the metric group for this :class:`Trigger`. This is the same metric group that
             would be returned from
-            :func:`~pyflink.datasteam.functions.RuntimeContext.get_metric_group` in a user function.
+            :func:`~pyflink.datastream.functions.RuntimeContext.get_metric_group` in a user function.
 
             :return: The metric group.
             """

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSink.java
@@ -119,12 +119,12 @@ final class ExternalDynamicSink implements DynamicTableSink, SupportsWritingMeta
     }
 
     private String generateOperatorName() {
-        return "TableToDataSteam";
+        return "TableToDataStream";
     }
 
     private String generateOperatorDesc() {
         return String.format(
-                "TableToDataSteam(type=%s, rowtime=%s)",
+                "TableToDataStream(type=%s, rowtime=%s)",
                 physicalDataType.toString(), consumeRowtimeMetadata);
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSource.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSource.java
@@ -155,12 +155,12 @@ final class ExternalDynamicSource<E>
     }
 
     private String generateOperatorName() {
-        return "DataSteamToTable";
+        return "DataStreamToTable";
     }
 
     private String generateOperatorDesc() {
         return String.format(
-                "DataSteamToTable(stream=%s, type=%s, rowtime=%s, watermark=%s)",
+                "DataStreamToTable(stream=%s, type=%s, rowtime=%s, watermark=%s)",
                 identifier.asSummaryString(),
                 physicalDataType.toString(),
                 produceRowtimeMetadata,


### PR DESCRIPTION
There are a few places where DataStream was spelled as DataSteam.
It occurs in doc, comment and also operator names. This fixes that.