### PR TITLE
fix(sec): upgrade org.apache.hadoop:hadoop-hdfs to 3.3.2

### DIFF
--- a/flink-connectors/flink-connector-hive/pom.xml
+++ b/flink-connectors/flink-connector-hive/pom.xml
@@ -44,7 +44,7 @@ under the License.
 		java.lang.NoClassDefFoundError: org/apache/hadoop/metrics/Updater errors
 		Using this dedicated property avoids CI failures with the Hadoop 3 profile
 		-->
-		<hive.hadoop.version>2.10.2</hive.hadoop.version>
+		<hive.hadoop.version>3.3.2</hive.hadoop.version>
 	</properties>
 
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ under the License.
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-		<flink.hadoop.version>2.10.2</flink.hadoop.version>
+		<flink.hadoop.version>3.3.2</flink.hadoop.version>
 		<flink.XmxMax>3072m</flink.XmxMax>
 		<!-- XmxMax / forkCountITCase -->
 		<flink.XmxITCase>1536m</flink.XmxITCase>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.apache.hadoop:hadoop-hdfs 2.10.2
- [MPS-2022-12474](https://www.oscs1024.com/hd/MPS-2022-12474)


### What did I do？
Upgrade org.apache.hadoop:hadoop-hdfs from 2.10.2 to 3.3.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS