### PR TITLE
[FLINK-30787][ci] Removes dmesg code since it's failing constantly

### DIFF
--- a/flink-end-to-end-tests/run-nightly-tests.sh
+++ b/flink-end-to-end-tests/run-nightly-tests.sh
@@ -46,7 +46,6 @@ source "${END_TO_END_DIR}/test-scripts/test-runner-common.sh"
 
 function run_on_exit {
     collect_coredumps $(pwd) $DEBUG_FILES_OUTPUT_DIR
-    collect_dmesg $DEBUG_FILES_OUTPUT_DIR
 }
 
 on_exit run_on_exit

--- a/tools/ci/maven-utils.sh
+++ b/tools/ci/maven-utils.sh
@@ -80,10 +80,6 @@ function collect_coredumps {
 	done
 }
 
-function collect_dmesg {
-	local TARGET_DIR=$1
-	dmesg > $TARGET_DIR/dmesg.out
-}
 
 CI_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 


### PR DESCRIPTION
This draft adds dmesg to the `test_controller.sh` to check whether it would work on Alibaba instances to determine whether FLINK-13978 is the cause for the error in the e2e tests.