### PR TITLE
[FLINK-30788][runtime] Refactors AbstractHaServices.createLeaderElectionService to return LeaderElectionDriverFactory

### DIFF
--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/highavailability/KubernetesMultipleComponentLeaderElectionHaServices.java
@@ -30,9 +30,8 @@ import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.highavailability.AbstractHaServices;
 import org.apache.flink.runtime.highavailability.FileSystemJobResultStore;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
-import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.DefaultMultipleComponentLeaderElectionService;
-import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionDriverFactory;
 import org.apache.flink.runtime.leaderelection.MultipleComponentLeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.DefaultLeaderRetrievalService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -106,12 +105,11 @@ public class KubernetesMultipleComponentLeaderElectionHaServices extends Abstrac
     }
 
     @Override
-    protected LeaderElectionService createLeaderElectionService(String leaderName) {
+    protected LeaderElectionDriverFactory createLeaderElectionDriverFactory(String leaderName) {
         final MultipleComponentLeaderElectionService multipleComponentLeaderElectionService =
                 getOrInitializeSingleLeaderElectionService();
 
-        return new DefaultLeaderElectionService(
-                multipleComponentLeaderElectionService.createDriverFactory(leaderName));
+        return multipleComponentLeaderElectionService.createDriverFactory(leaderName);
     }
 
     private DefaultMultipleComponentLeaderElectionService

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/AbstractHaServices.java
@@ -24,6 +24,8 @@ import org.apache.flink.runtime.blob.BlobStore;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
+import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionDriverFactory;
 import org.apache.flink.runtime.leaderelection.LeaderElectionService;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.util.ExceptionUtils;
@@ -223,13 +225,19 @@ public abstract class AbstractHaServices implements HighAvailabilityServices {
                 executor);
     }
 
+    private LeaderElectionService createLeaderElectionService(String leaderName) {
+        return new DefaultLeaderElectionService(createLeaderElectionDriverFactory(leaderName));
+    }
+
     /**
-     * Create leader election service with specified leaderName.
+     * Create {@link LeaderElectionDriverFactory} instance for the specified leaderName.
      *
      * @param leaderName ConfigMap name in Kubernetes or child node path in Zookeeper.
-     * @return Return LeaderElectionService using Zookeeper or Kubernetes.
+     * @return Return {@code LeaderElectionDriverFactory} used for the {@link
+     *     LeaderElectionService}.
      */
-    protected abstract LeaderElectionService createLeaderElectionService(String leaderName);
+    protected abstract LeaderElectionDriverFactory createLeaderElectionDriverFactory(
+            String leaderName);
 
     /**
      * Create leader retrieval service with specified leaderName.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperMultipleComponentLeaderElectionHaServices.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/highavailability/zookeeper/ZooKeeperMultipleComponentLeaderElectionHaServices.java
@@ -21,9 +21,8 @@ package org.apache.flink.runtime.highavailability.zookeeper;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.runtime.blob.BlobStoreService;
-import org.apache.flink.runtime.leaderelection.DefaultLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.DefaultMultipleComponentLeaderElectionService;
-import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionDriverFactory;
 import org.apache.flink.runtime.leaderelection.MultipleComponentLeaderElectionService;
 import org.apache.flink.runtime.leaderelection.ZooKeeperMultipleComponentLeaderElectionDriverFactory;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
@@ -88,9 +87,8 @@ public class ZooKeeperMultipleComponentLeaderElectionHaServices
     }
 
     @Override
-    protected LeaderElectionService createLeaderElectionService(String leaderName) {
-        return new DefaultLeaderElectionService(
-                getOrInitializeSingleLeaderElectionService().createDriverFactory(leaderName));
+    protected LeaderElectionDriverFactory createLeaderElectionDriverFactory(String leaderName) {
+        return getOrInitializeSingleLeaderElectionService().createDriverFactory(leaderName);
     }
 
     private MultipleComponentLeaderElectionService getOrInitializeSingleLeaderElectionService() {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
@@ -24,7 +24,7 @@ import org.apache.flink.runtime.blob.BlobKey;
 import org.apache.flink.runtime.blob.BlobStoreService;
 import org.apache.flink.runtime.checkpoint.CheckpointRecoveryFactory;
 import org.apache.flink.runtime.jobmanager.JobGraphStore;
-import org.apache.flink.runtime.leaderelection.LeaderElectionService;
+import org.apache.flink.runtime.leaderelection.LeaderElectionDriverFactory;
 import org.apache.flink.runtime.leaderretrieval.LeaderRetrievalService;
 import org.apache.flink.runtime.testutils.TestingJobResultStore;
 import org.apache.flink.util.FlinkException;
@@ -211,7 +211,7 @@ public class AbstractHaServicesTest extends TestLogger {
         }
 
         @Override
-        protected LeaderElectionService createLeaderElectionService(String leaderName) {
+        protected LeaderElectionDriverFactory createLeaderElectionDriverFactory(String leaderName) {
             throw new UnsupportedOperationException("Not supported by this test implementation.");
         }
 


### PR DESCRIPTION
## What is the purpose of the change

The HA-backend-specific code is actually only the `LeaderElectionDriverFactory` creation rather than instantiating the `LeaderElectionService`. This is meant as a prep PR to reduce the code diff of the actual FLINK-26522 changes.

## Brief change log

* Introduces abstract method `createLeaderElectionDriverFactory(String)` that's called by `createLeaderElectionService(String)` 

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable