### PR TITLE
[FLINK-30618][Python] Remove SNAPSHOT reference to Pulsar connector

### DIFF
--- a/flink-python/pom.xml
+++ b/flink-python/pom.xml
@@ -290,7 +290,7 @@ under the License.
 			<!-- Indirectly accessed in pyflink_gateway_server -->
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-sql-connector-pulsar</artifactId>
-			<version>4.0-SNAPSHOT</version>
+			<version>3.0.0-1.16</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
## What is the purpose of the change

* Since there are no SNAPSHOTs created for connectors, lookup to SNAPSHOT versions of connector in Flink itself should not be present

## Brief change log

* Changed Python reference to Pulsar connector to release version

## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable