### PR TITLE
[FLINK-30795][tests] StreamingWithStateTestBase of win not correct

### DIFF
--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.typeinfo.{TypeInformation, Types}
 import org.apache.flink.api.common.typeutils.CompositeType
 import org.apache.flink.configuration.{CheckpointingOptions, Configuration}
 import org.apache.flink.contrib.streaming.state.RocksDBStateBackend
+import org.apache.flink.core.fs.local.LocalFileSystem
 import org.apache.flink.runtime.state.memory.MemoryStateBackend
 import org.apache.flink.streaming.api.CheckpointingMode
 import org.apache.flink.streaming.api.functions.source.FromElementsFunction
@@ -35,13 +36,11 @@ import org.apache.flink.table.planner.utils.TableTestUtil
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
-
 import org.junit.{After, Assert, Before}
 import org.junit.runners.Parameterized
 
 import java.io.File
 import java.util
-
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -66,12 +65,12 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
       case HEAP_BACKEND =>
         val conf = new Configuration()
         env.setStateBackend(
-          new MemoryStateBackend("file://" + baseCheckpointPath, null).configure(conf, classLoader))
+          new MemoryStateBackend(LocalFileSystem.getLocalFsURI.toString + baseCheckpointPath, null).configure(conf, classLoader))
       case ROCKSDB_BACKEND =>
         val conf = new Configuration()
         conf.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true)
         env.setStateBackend(
-          new RocksDBStateBackend("file://" + baseCheckpointPath).configure(conf, classLoader))
+          new RocksDBStateBackend(LocalFileSystem.getLocalFsURI.toString + baseCheckpointPath).configure(conf, classLoader))
     }
     this.tEnv = StreamTableEnvironment.create(env, TableTestUtil.STREAM_SETTING)
     FailingCollectionSource.failedBefore = true

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamingWithStateTestBase.scala
@@ -36,11 +36,13 @@ import org.apache.flink.table.planner.utils.TableTestUtil
 import org.apache.flink.table.runtime.types.TypeInfoLogicalTypeConverter
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo
 import org.apache.flink.table.types.logical.RowType
+
 import org.junit.{After, Assert, Before}
 import org.junit.runners.Parameterized
 
 import java.io.File
 import java.util
+
 import scala.collection.JavaConversions._
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
@@ -65,12 +67,14 @@ class StreamingWithStateTestBase(state: StateBackendMode) extends StreamingTestB
       case HEAP_BACKEND =>
         val conf = new Configuration()
         env.setStateBackend(
-          new MemoryStateBackend(LocalFileSystem.getLocalFsURI.toString + baseCheckpointPath, null).configure(conf, classLoader))
+          new MemoryStateBackend(LocalFileSystem.getLocalFsURI.toString + baseCheckpointPath, null)
+            .configure(conf, classLoader))
       case ROCKSDB_BACKEND =>
         val conf = new Configuration()
         conf.setBoolean(CheckpointingOptions.INCREMENTAL_CHECKPOINTS, true)
         env.setStateBackend(
-          new RocksDBStateBackend(LocalFileSystem.getLocalFsURI.toString + baseCheckpointPath).configure(conf, classLoader))
+          new RocksDBStateBackend(LocalFileSystem.getLocalFsURI.toString + baseCheckpointPath)
+            .configure(conf, classLoader))
     }
     this.tEnv = StreamTableEnvironment.create(env, TableTestUtil.STREAM_SETTING)
     FailingCollectionSource.failedBefore = true


### PR DESCRIPTION
## What is the purpose of the change
Fix test case broken in win os.


## Brief change log
Change "file://" to LocalFileSystem.getLocalFsURI.toString.


## Verifying this change

org.apache.flink.table.planner.runtime.stream.sql.WindowAggregateITCase case work correctly in win os.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
