### PR TITLE
[FLINK-15550][runtime] The static latches in TaskTest were replaced by latches from invokable objects. 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -60,8 +60,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 
@@ -119,11 +117,6 @@ public class TaskTest extends TestLogger {
     public void setup() {
         awaitLatch = new OneShotLatch();
         triggerLatch = new OneShotLatch();
-        // Logging is only for debugging FLINK-15550.
-        log.info(
-                "Preparing trigger latch, {}, isTriggered = {}",
-                triggerLatch,
-                triggerLatch.isTriggered());
 
         shuffleEnvironment = new NettyShuffleEnvironmentBuilder().build();
         wasCleanedUp = false;
@@ -675,7 +668,6 @@ public class TaskTest extends TestLogger {
         awaitLatch.await();
 
         task.failExternally(new Exception("external"));
-        assertFalse(triggerLatch.isTriggered());
         assertEquals(ExecutionState.FAILED, task.getExecutionState());
 
         // Either we cause the CancelTaskException or the TaskCanceler
@@ -1469,23 +1461,13 @@ public class TaskTest extends TestLogger {
 
     /** {@link AbstractInvokable} which throws {@link CancelTaskException} on invoke. */
     public static final class InvokableWithCancelTaskExceptionInInvoke extends AbstractInvokable {
-        static final Logger LOG = LoggerFactory.getLogger(InvokableWithExceptionOnTrigger.class);
-
         public InvokableWithCancelTaskExceptionInInvoke(Environment environment) {
             super(environment);
         }
 
         @Override
         public void invoke() {
-            // Logging and try-catch block are only for debugging FLINK-15550.
-            LOG.info("Await for {}, isTriggered = {}", triggerLatch, triggerLatch.isTriggered());
-            try {
-                awaitTriggerLatch();
-            } catch (Throwable ex) {
-                LOG.error("Fail on awaiting trigger latch", ex);
-
-                throw ex;
-            }
+            awaitTriggerLatch();
 
             throw new CancelTaskException();
         }


### PR DESCRIPTION
## What is the purpose of the change

This change fixes the bug in a test which trigger the latch for the current test from the remaining thread of the previous test.


## Brief change log

  - *The static latches in TaskTest were replaced by latches from invokable objects in order to avoid accidental sharing latches between multiple tests*


## Verifying this change
It is a test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
