### PR TITLE
[FLINK-26082][runtime] Initializing test netty server and client in the loop to avoid the probability of `Address already in use` problem.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -42,7 +42,6 @@ import org.apache.flink.shaded.netty4.io.netty.channel.ChannelPromise;
 import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
@@ -55,8 +54,8 @@ import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServer
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -102,9 +101,7 @@ class ClientTransportErrorHandlingTest {
 
                             @Override
                             public void write(
-                                    ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
-                                    throws Exception {
-
+                                    ChannelHandlerContext ctx, Object msg, ChannelPromise promise) {
                                 if (writeNum >= 1) {
                                     throw new RuntimeException("Expected test exception.");
                                 }
@@ -124,17 +121,15 @@ class ClientTransportErrorHandlingTest {
 
         final CountDownLatch sync = new CountDownLatch(1);
 
-        // Do this with explicit synchronization. Otherwise this is not robust against slow timings
+        // Do this with explicit synchronization. Otherwise, this is not robust against slow timings
         // of the callback (e.g. we cannot just verify that it was called once, because there is
         // a chance that we do this too early).
         doAnswer(
-                        new Answer<Void>() {
-                            @Override
-                            public Void answer(InvocationOnMock invocation) throws Throwable {
-                                sync.countDown();
-                                return null;
-                            }
-                        })
+                        (Answer<Void>)
+                                invocation -> {
+                                    sync.countDown();
+                                    return null;
+                                })
                 .when(rich[1])
                 .onError(isA(LocalTransportException.class));
 
@@ -143,7 +138,7 @@ class ClientTransportErrorHandlingTest {
 
         // Second request is *not* successful
         requestClient.requestSubpartition(new ResultPartitionID(), 0, rich[1], 0);
-        // Wait for the notification and it could confirm all the request operations are done
+        // Wait for the notification, and it could confirm all the request operations are done
         assertThat(sync.await(TestingUtils.TESTING_DURATION.toMillis(), TimeUnit.MILLISECONDS))
                 .withFailMessage(
                         "Timed out after waiting for "
@@ -227,9 +222,7 @@ class ClientTransportErrorHandlingTest {
                             // Close on read
                             new ChannelInboundHandlerAdapter() {
                                 @Override
-                                public void channelRead(ChannelHandlerContext ctx, Object msg)
-                                        throws Exception {
-
+                                public void channelRead(ChannelHandlerContext ctx, Object msg) {
                                     ctx.channel().close();
                                 }
                             }
@@ -250,12 +243,9 @@ class ClientTransportErrorHandlingTest {
         final CountDownLatch sync = new CountDownLatch(rich.length);
 
         Answer<Void> countDownLatch =
-                new Answer<Void>() {
-                    @Override
-                    public Void answer(InvocationOnMock invocation) throws Throwable {
-                        sync.countDown();
-                        return null;
-                    }
+                invocation -> {
+                    sync.countDown();
+                    return null;
                 };
 
         for (RemoteInputChannel r : rich) {
@@ -329,26 +319,27 @@ class ClientTransportErrorHandlingTest {
 
         // Verify the Exception
         doAnswer(
-                        new Answer<Void>() {
-                            @Override
-                            public Void answer(InvocationOnMock invocation) throws Throwable {
-                                Throwable cause = (Throwable) invocation.getArguments()[0];
+                        (Answer<Void>)
+                                invocation -> {
+                                    Throwable cause = (Throwable) invocation.getArguments()[0];
 
-                                try {
-                                    assertThat(cause).isInstanceOf(RemoteTransportException.class);
-                                    assertThat(cause)
-                                            .hasMessageNotContaining("Connection reset by peer");
+                                    try {
+                                        assertThat(cause)
+                                                .isInstanceOf(RemoteTransportException.class);
+                                        assertThat(cause)
+                                                .hasMessageNotContaining(
+                                                        "Connection reset by peer");
 
-                                    assertThat(cause.getCause()).isInstanceOf(IOException.class);
-                                    assertThat(cause.getCause())
-                                            .hasMessage("Connection reset by peer");
-                                } catch (Throwable t) {
-                                    error[0] = t;
-                                }
+                                        assertThat(cause.getCause())
+                                                .isInstanceOf(IOException.class);
+                                        assertThat(cause.getCause())
+                                                .hasMessage("Connection reset by peer");
+                                    } catch (Throwable t) {
+                                        error[0] = t;
+                                    }
 
-                                return null;
-                            }
-                        })
+                                    return null;
+                                })
                 .when(rich)
                 .onError(any(Throwable.class));
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/ClientTransportErrorHandlingTest.java
@@ -51,7 +51,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.connect;
-import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.createConfig;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.initServerAndClient;
 import static org.apache.flink.runtime.io.network.netty.NettyTestUtil.shutdown;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -89,7 +88,7 @@ class ClientTransportErrorHandlingTest {
 
         // We need a real server and client in this test, because Netty's EmbeddedChannel is
         // not failing the ChannelPromise of failed writes.
-        NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+        NettyServerAndClient serverAndClient = initServerAndClient(protocol);
 
         Channel ch = connect(serverAndClient);
 
@@ -238,7 +237,7 @@ class ClientTransportErrorHandlingTest {
                     }
                 };
 
-        NettyServerAndClient serverAndClient = initServerAndClient(protocol, createConfig());
+        NettyServerAndClient serverAndClient = initServerAndClient(protocol);
 
         Channel ch = connect(serverAndClient);
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/netty/NettyTestUtil.java
@@ -27,6 +27,7 @@ import org.apache.flink.shaded.netty4.io.netty.buffer.ByteBuf;
 import org.apache.flink.shaded.netty4.io.netty.channel.Channel;
 import org.apache.flink.shaded.netty4.io.netty.channel.embedded.EmbeddedChannel;
 
+import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.TimeUnit;
@@ -35,6 +36,7 @@ import java.util.function.Function;
 import static junit.framework.TestCase.assertEquals;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.BufferResponse;
 import static org.apache.flink.runtime.io.network.netty.NettyMessage.ErrorResponse;
+import static org.apache.flink.util.ExceptionUtils.findThrowableWithMessage;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertTrue;
@@ -96,7 +98,23 @@ public class NettyTestUtil {
     }
 
     static NettyServerAndClient initServerAndClient(NettyProtocol protocol) throws Exception {
-        return initServerAndClient(protocol, createConfig());
+        // It is possible that between checking a port available and binding to the port something
+        // takes this port. So we initialize a server in the loop to decrease the probability of it.
+        int attempts = 42; // The arbitrary number of attempts to avoid an infinity loop.
+        while (true) {
+            try {
+                return initServerAndClient(protocol, createConfig());
+            } catch (Exception ex) {
+                if (!(ex instanceof BindException)
+                        && !findThrowableWithMessage(ex, "Address already in use").isPresent()) {
+                    throw ex;
+                }
+
+                if (attempts-- < 0) {
+                    throw new Exception("Failed to initialize netty server and client", ex);
+                }
+            }
+        }
     }
 
     static NettyServerAndClient initServerAndClient(NettyProtocol protocol, NettyConfig config)


### PR DESCRIPTION
## What is the purpose of the change

This fix initializes test netty server in the loop in order to decrease probability of `Address already in use` problem.

## Brief change log

  - *Initializing test netty server and client in the loop to avoid the probability of `Address already in use` problem.*


## Verifying this change

It is a test itself

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
