### PR TITLE
[FLINK-30277][python]Allow PYTHONPATH of Python Worker configurable

### DIFF
--- a/docs/layouts/shortcodes/generated/python_configuration.html
+++ b/docs/layouts/shortcodes/generated/python_configuration.html
@@ -99,6 +99,12 @@
             <td>Specifies whether to enable Python worker profiling. The profile result will be displayed in the log file of the TaskManager periodically. The interval between each profiling is determined by the config options python.fn-execution.bundle.size and python.fn-execution.bundle.time.</td>
         </tr>
         <tr>
+            <td><h5>python.pythonpath</h5></td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>Specify the path on the Worker Node where the Flink Python Dependencies are installed, which gets added into the PYTHONPATH of the Python Worker. </td>
+        </tr>
+        <tr>
             <td><h5>python.requirements</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/static/generated/rest_v2_sql_gateway.yml
+++ b/docs/static/generated/rest_v2_sql_gateway.yml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v2/1.17-SNAPSHOT
+  version: v2/1.18-SNAPSHOT
 paths:
   /api_versions:
     get:

--- a/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
+++ b/flink-python/src/main/java/org/apache/flink/client/python/PythonEnvUtils.java
@@ -70,6 +70,7 @@ import java.util.stream.Collectors;
 import static org.apache.flink.python.PythonOptions.PYTHON_ARCHIVES;
 import static org.apache.flink.python.PythonOptions.PYTHON_CLIENT_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_FILES;
+import static org.apache.flink.python.PythonOptions.PYTHON_PATH;
 import static org.apache.flink.python.util.PythonDependencyUtils.FILE_DELIMITER;
 
 /** The util class help to prepare Python env and run the python process. */
@@ -210,6 +211,15 @@ final class PythonEnvUtils {
                                     }
                                 }
                             });
+        }
+
+        // 4. append configured python.pythonpath to the PYTHONPATH.
+        if (config.getOptional(PYTHON_PATH).isPresent()) {
+            env.pythonPath =
+                    String.join(
+                            File.pathSeparator,
+                            config.getOptional(PYTHON_PATH).get(),
+                            env.pythonPath);
         }
 
         if (entryPointScript != null) {

--- a/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
+++ b/flink-python/src/main/java/org/apache/flink/python/PythonOptions.java
@@ -122,6 +122,18 @@ public class PythonOptions {
                                     + "optional parameter exists. The option is equivalent to the command line option "
                                     + "\"-pyreq\".");
 
+    /** The configuration allows user to define python path for client and workers. */
+    public static final ConfigOption<String> PYTHON_PATH =
+            ConfigOptions.key("python.pythonpath")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            Description.builder()
+                                    .text(
+                                            "Specify the path on the Worker Node where the Flink Python Dependencies are installed, which "
+                                                    + "gets added into the PYTHONPATH of the Python Worker. ")
+                                    .build());
+
     public static final ConfigOption<String> PYTHON_ARCHIVES =
             ConfigOptions.key("python.archives")
                     .stringType()

--- a/flink-python/src/main/java/org/apache/flink/python/env/AbstractPythonEnvironmentManager.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/AbstractPythonEnvironmentManager.java
@@ -43,6 +43,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -165,6 +166,13 @@ public abstract class AbstractPythonEnvironmentManager implements PythonEnvironm
         Map<String, String> env = new HashMap<>(this.systemEnv);
 
         constructFilesDirectory(env, baseDirectory);
+
+        if (dependencyInfo.getPythonPath().isPresent()) {
+            appendToPythonPath(
+                    env, Collections.singletonList(dependencyInfo.getPythonPath().get()));
+        }
+
+        LOG.info("PYTHONPATH of python worker: {}", env.get("PYTHONPATH"));
 
         constructRequirementsDirectory(env, baseDirectory);
 
@@ -294,7 +302,6 @@ public abstract class AbstractPythonEnvironmentManager implements PythonEnvironm
             pythonFilePaths.add(pythonPath);
         }
         appendToPythonPath(env, pythonFilePaths);
-        LOG.info("PYTHONPATH of python worker: {}", env.get("PYTHONPATH"));
     }
 
     private void constructRequirementsDirectory(Map<String, String> env, String baseDirectory)

--- a/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
+++ b/flink-python/src/main/java/org/apache/flink/python/env/PythonDependencyInfo.java
@@ -37,6 +37,7 @@ import static org.apache.flink.python.PythonOptions.PYTHON_ARCHIVES_DISTRIBUTED_
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTABLE;
 import static org.apache.flink.python.PythonOptions.PYTHON_EXECUTION_MODE;
 import static org.apache.flink.python.PythonOptions.PYTHON_FILES_DISTRIBUTED_CACHE_INFO;
+import static org.apache.flink.python.PythonOptions.PYTHON_PATH;
 import static org.apache.flink.python.PythonOptions.PYTHON_REQUIREMENTS_FILE_DISTRIBUTED_CACHE_INFO;
 
 /** PythonDependencyInfo contains the information of third-party dependencies. */
@@ -62,6 +63,8 @@ public final class PythonDependencyInfo {
      * support installing python packages offline.
      */
     @Nullable private final String requirementsCacheDir;
+
+    @Nullable private final String pythonPath;
 
     /**
      * The python archives uploaded by TableEnvironment#add_python_archive() or command line option
@@ -91,7 +94,8 @@ public final class PythonDependencyInfo {
                 requirementsCacheDir,
                 archives,
                 pythonExec,
-                PYTHON_EXECUTION_MODE.defaultValue());
+                PYTHON_EXECUTION_MODE.defaultValue(),
+                PYTHON_PATH.defaultValue());
     }
 
     public PythonDependencyInfo(
@@ -100,13 +104,15 @@ public final class PythonDependencyInfo {
             @Nullable String requirementsCacheDir,
             @Nonnull Map<String, String> archives,
             @Nonnull String pythonExec,
-            @Nonnull String executionMode) {
+            @Nonnull String executionMode,
+            @Nullable String pythonPath) {
         this.pythonFiles = Objects.requireNonNull(pythonFiles);
         this.requirementsFilePath = requirementsFilePath;
         this.requirementsCacheDir = requirementsCacheDir;
         this.pythonExec = Objects.requireNonNull(pythonExec);
         this.archives = Objects.requireNonNull(archives);
         this.executionMode = Objects.requireNonNull(executionMode);
+        this.pythonPath = pythonPath;
     }
 
     public Map<String, String> getPythonFiles() {
@@ -131,6 +137,10 @@ public final class PythonDependencyInfo {
 
     public String getExecutionMode() {
         return executionMode;
+    }
+
+    public Optional<String> getPythonPath() {
+        return Optional.ofNullable(pythonPath);
     }
 
     /**
@@ -190,6 +200,7 @@ public final class PythonDependencyInfo {
                 requirementsCacheDir,
                 archives,
                 pythonExec,
-                config.get(PYTHON_EXECUTION_MODE));
+                config.get(PYTHON_EXECUTION_MODE),
+                config.get(PYTHON_PATH));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, below are the ways Python Worker gets the Python Flink Dependencies.

1. Worker Node's System Python Path (/usr/local/lib64/python3.7/site-packages)
2. Client passes the python Dependencies through `-pyfs` and `--pyarch` which is localised into `PYTHONPATH` of Python Worker.
3. Client passes the requirements through `-requirement.txt` which gets installed on Worker Node and added into `PYTHONPATH` of Python Worker.

This change allow `PYTHONPATH` of Python Worker configurable where Admin/Service provider can install the required python Flink dependencies on a custom path (`/usr/lib/pyflink/lib/python3.7/site-packages`) on all Worker Nodes and then set the path in the client machine configuration `flink-conf.yaml`. This way it works without any configurations from the Application Users and also without affecting any other components dependent on System Python Path.


## Brief change log
add an option to add in flink conf to pick configurable python path in worker and client.

## Verifying this change

In `flink-conf.yaml` add the following configs:

1. `python.client.executable: python3`
2. `python.executable: python3`
3. `python.pythonpath: /tmp/PYTHONPATH/lib64/python3.7/site-packages/:/tmp/PYTHONPATH/lib/python3.7/site-packages/`


# Install PyFlink libraries on Client and Worker nodes
```
[hadoop@ip-172-1-2-3 flink]$ cat  /etc/flink/conf/req.txt
apache-flink==1.16.0
```
Install python in all  worker nodes 

```
python3 -m pip install --ignore-installed -r /tmp/req.txt --prefix /tmp/PYTHONPATH/
```

Run a job 

```
flink run -py /usr/lib/flink/examples/python/table/word_count.py
```

# LOG 

jobmanager log
 
```
obmanager.log:2023-02-23 07:09:30,931 INFO  org.apache.flink.configuration.GlobalConfiguration           [] - Loading configuration property: python.pythonpath, /tmp/PYTHONPATH/lib64/python3.7/site-packages/:/tmp/PYTHONPATH/lib/python3.7/site-packages/
jobmanager.log:2023-02-23 07:09:33,070 INFO  org.apache.flink.configuration.GlobalConfiguration           [] - Loading configuration property: python.pythonpath, /tmp/PYTHONPATH/lib64/python3.7/site-packages/:/tmp/PYTHONPATH/lib/python3.7/site-packages/
```

taskmanager log 

```
taskmanager.log:2023-02-23 07:14:50,549 INFO  org.apache.flink.configuration.GlobalConfiguration           [] - Loading configuration property: python.pythonpath, /tmp/PYTHONPATH/lib64/python3.7/site-packages/:/tmp/PYTHONPATH/lib/python3.7/site-packages/
taskmanager.log:2023-02-23 07:14:53,978 INFO  org.apache.flink.python.env.AbstractPythonEnvironmentManager [] - PYTHONPATH of python worker: /tmp/PYTHONPATH/lib64/python3.7/site-packages/:/tmp/PYTHONPATH/lib/python3.7/site-packages/
taskmanager.log:2023-02-23 07:14:56,039 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker_main.py:84 [] - Logging handler created.
taskmanager.log:2023-02-23 07:14:56,039 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker_main.py:107 [] - semi_persistent_directory: /tmp
taskmanager.log:2023-02-23 07:14:56,039 WARN  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker_main.py:281 [] - No session file found: /tmp/staged/pickled_main_session. Functions defined in __main__ (interactive session) may fail.
taskmanager.log:2023-02-23 07:14:56,039 WARN  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/options/pipeline_options.py:335 [] - Discarding unparseable args: ['--options_id=0.0', '--app_name=BeamPythonFunctionRunner']
taskmanager.log:2023-02-23 07:14:56,039 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker_main.py:125 [] - Pipeline_options: {'experiments': ['state_cache_size=1000']}
taskmanager.log:2023-02-23 07:14:56,039 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/statecache.py:172 [] - Creating state cache with size 1000
taskmanager.log:2023-02-23 07:14:56,039 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker.py:164 [] - Creating insecure control channel for localhost:43865.
taskmanager.log:2023-02-23 07:14:56,040 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker.py:172 [] - Control channel established.
taskmanager.log:2023-02-23 07:14:56,040 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker.py:215 [] - Initializing SDKHarness with unbounded number of workers.
taskmanager.log:2023-02-23 07:14:56,040 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker_main.py:179 [] - Python sdk harness starting.
taskmanager.log:2023-02-23 07:14:56,174 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker.py:840 [] - Creating insecure state channel for localhost:35489.
taskmanager.log:2023-02-23 07:14:56,174 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/sdk_worker.py:847 [] - State channel established.
taskmanager.log:2023-02-23 07:14:56,178 INFO  /tmp/PYTHONPATH/lib64/python3.7/site-packages/apache_beam/runners/worker/data_plane.py:750 [] - Creating client data channel for localhost:43911
```


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) don't know
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no 
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) yes
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) docs
