### PR TITLE
[FLINK-30799][runtime] Make SinkFunction support speculative execution for batch jobs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
@@ -20,13 +20,17 @@ package org.apache.flink.streaming.api.transformations;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.SupportsConcurrentExecutionAttempts;
+import org.apache.flink.api.common.functions.Function;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
 import org.apache.flink.streaming.api.operators.StreamSink;
+import org.apache.flink.streaming.api.operators.UserFunctionProvider;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 
@@ -131,6 +135,22 @@ public class LegacySinkTransformation<T> extends PhysicalTransformation<T> {
 
     @Override
     public boolean isSupportsConcurrentExecutionAttempts() {
+        // first, check if the feature is disabled in physical transformation
+        if (!super.isSupportsConcurrentExecutionAttempts()) {
+            return false;
+        }
+        // second, check if the feature can be supported
+        if (operatorFactory instanceof SimpleOperatorFactory) {
+            final StreamOperator<Object> operator =
+                    ((SimpleOperatorFactory<Object>) operatorFactory).getOperator();
+            if (operator instanceof UserFunctionProvider) {
+                final Function userFunction =
+                        ((UserFunctionProvider<?>) operator).getUserFunction();
+                if (userFunction instanceof SupportsConcurrentExecutionAttempts) {
+                    return true;
+                }
+            }
+        }
         return false;
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -143,7 +143,6 @@ import static org.apache.flink.streaming.api.graph.StreamingJobGraphGenerator.ar
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.InstanceOfAssertFactories.stream;
 
 /** Tests for {@link StreamingJobGraphGenerator}. */
 @ExtendWith(TestLoggerExtension.class)
@@ -1803,7 +1802,6 @@ class StreamingJobGraphGeneratorTest {
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
         final DataStream<Integer> source = env.fromElements(1, 2, 3).name("source");
-        // source -> (map1 -> map2) -> sink
         source.rebalance()
                 .sinkTo(new TestSinkWithSupportsConcurrentExecutionAttempts())
                 .name("sink");


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduces a way to enable speculative execution for `SinkFunction`*

## Brief change log

  - *Speculative execution would be enabled if a `SinkFunction` inherits `SupportsConcurrentExecutionAttempts`*

## Verifying this change

This change added tests:
  - *Add new test cases in `StreamingJobGraphGeneratorTest`*
  - *Add new test cases in `SpeculativeSchedulerITCase`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
