### PR TITLE
[FLINK-30814][table-planner] Fix maxParallelism is not forced to 1 after global partitioner

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -21,6 +21,8 @@ package org.apache.flink.table.planner.plan.nodes.exec;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.streaming.api.transformations.PartitionTransformation;
+import org.apache.flink.streaming.runtime.partitioner.GlobalPartitioner;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.delegation.Planner;
 import org.apache.flink.table.planner.delegation.PlannerBase;
@@ -162,7 +164,7 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
                                     persistedConfig,
                                     isCompiled));
             if (this instanceof SingleTransformationTranslator) {
-                if (inputsContainSingleton()) {
+                if (inputsContainSingleton(transformation)) {
                     transformation.setParallelism(1);
                     transformation.setMaxParallelism(1);
                 }
@@ -192,6 +194,17 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
      */
     protected abstract Transformation<T> translateToPlanInternal(
             PlannerBase planner, ExecNodeConfig config);
+
+    private boolean inputsContainSingleton(Transformation<T> transformation) {
+        return inputsContainSingleton()
+                || transformation.getInputs().stream()
+                        .anyMatch(
+                                input ->
+                                        input instanceof PartitionTransformation
+                                                && ((PartitionTransformation<?>) input)
+                                                                .getPartitioner()
+                                                        instanceof GlobalPartitioner);
+    }
 
     /** Whether singleton distribution is required. */
     protected boolean inputsContainSingleton() {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
@@ -28,6 +28,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.runtime.operators.sort.LimitOperator;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -35,7 +36,8 @@ import org.apache.flink.table.types.logical.LogicalType;
 import java.util.Collections;
 
 /** Batch {@link ExecNode} for Limit. */
-public class BatchExecLimit extends ExecNodeBase<RowData> implements BatchExecNode<RowData> {
+public class BatchExecLimit extends ExecNodeBase<RowData>
+        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     private final long limitStart;
     private final long limitEnd;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.runtime.operators.CodeGenOperatorFactory;
 import org.apache.flink.table.runtime.operators.join.FlinkJoinType;
@@ -44,7 +45,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /** {@link BatchExecNode} for Nested-loop Join. */
 public class BatchExecNestedLoopJoin extends ExecNodeBase<RowData>
-        implements BatchExecNode<RowData> {
+        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     private final FlinkJoinType joinType;
     private final RexNode condition;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.planner.plan.utils.SortUtil;
 import org.apache.flink.table.runtime.operators.sort.RankOperator;
@@ -43,7 +44,8 @@ import java.util.Collections;
  *
  * <p>This node supports two-stage(local and global) rank to reduce data-shuffling.
  */
-public class BatchExecRank extends ExecNodeBase<RowData> implements InputSortedExecNode<RowData> {
+public class BatchExecRank extends ExecNodeBase<RowData>
+        implements InputSortedExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     private final int[] partitionFields;
     private final int[] sortFields;

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecScriptTransform.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecScriptTransform.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
 import org.apache.flink.table.runtime.script.ScriptTransformIOInfo;
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.LogicalType;
@@ -40,7 +41,7 @@ import java.util.Collections;
 
 /** Batch {@link ExecNode} for ScripTransform. */
 public class BatchExecScriptTransform extends ExecNodeBase<RowData>
-        implements BatchExecNode<RowData> {
+        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     // currently, only Hive dialect supports ScriptTransform,
     // so make the class name of the operator constructed from this ExecNode a static field

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
@@ -30,6 +30,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeConfig;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
+import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
 import org.apache.flink.table.planner.plan.nodes.exec.spec.SortSpec;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
 import org.apache.flink.table.runtime.operators.sort.SortOperator;
@@ -43,7 +44,8 @@ import java.util.Collections;
  *
  * <p>This node will output all data rather than `limit` records.
  */
-public class BatchExecSort extends ExecNodeBase<RowData> implements BatchExecNode<RowData> {
+public class BatchExecSort extends ExecNodeBase<RowData>
+        implements BatchExecNode<RowData>, SingleTransformationTranslator<RowData> {
 
     private final SortSpec sortSpec;
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLimit.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalLimit.scala
@@ -80,12 +80,18 @@ class BatchPhysicalLimit(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
+    val requiredDistribution = if (isGlobal) {
+      InputProperty.SINGLETON_DISTRIBUTION
+    } else {
+      InputProperty.UNKNOWN_DISTRIBUTION
+    }
+
     new BatchExecLimit(
       unwrapTableConfig(this),
       limitStart,
       limitEnd,
       isGlobal,
-      InputProperty.DEFAULT,
+      InputProperty.builder().requiredDistribution(requiredDistribution).build(),
       FlinkTypeFactory.toLogicalRowType(getRowType),
       getRelDetailedDescription)
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortLimit.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortLimit.scala
@@ -111,7 +111,8 @@ class BatchPhysicalSortLimit(
       limitStart,
       limitEnd,
       isGlobal,
-      InputProperty.builder()
+      InputProperty
+        .builder()
         .requiredDistribution(requiredDistribution)
         .damBehavior(InputProperty.DamBehavior.END_INPUT)
         .build(),

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortLimit.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/nodes/physical/batch/BatchPhysicalSortLimit.scala
@@ -99,13 +99,22 @@ class BatchPhysicalSortLimit(
   }
 
   override def translateToExecNode(): ExecNode[_] = {
+    val requiredDistribution = if (isGlobal) {
+      InputProperty.SINGLETON_DISTRIBUTION
+    } else {
+      InputProperty.UNKNOWN_DISTRIBUTION
+    }
+
     new BatchExecSortLimit(
       unwrapTableConfig(this),
       SortUtil.getSortSpec(sortCollation.getFieldCollations),
       limitStart,
       limitEnd,
       isGlobal,
-      InputProperty.builder().damBehavior(InputProperty.DamBehavior.END_INPUT).build(),
+      InputProperty.builder()
+        .requiredDistribution(requiredDistribution)
+        .damBehavior(InputProperty.DamBehavior.END_INPUT)
+        .build(),
       FlinkTypeFactory.toLogicalRowType(getRowType),
       getRelDetailedDescription)
   }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/ParallelismSettingTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/ParallelismSettingTest.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.runtime.batch;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.JobManagerOptions.SchedulerType;
 import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.operations.ModifyOperation;
 import org.apache.flink.table.operations.Operation;
 import org.apache.flink.table.planner.utils.BatchTableTestUtil;
@@ -41,8 +42,10 @@ public class ParallelismSettingTest extends TableTestBase {
     @Before
     public void before() {
         util = batchTestUtil(TableConfig.getDefault());
+        util.getTableEnv()
+                .getConfig()
+                .set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 4);
 
-        util.getStreamEnv().getConfig().setScheduler(SchedulerType.AdaptiveBatch);
         util.tableEnv()
                 .executeSql(
                         "CREATE TABLE MyTable (\n"
@@ -53,6 +56,11 @@ public class ParallelismSettingTest extends TableTestBase {
                                 + "  'connector' = 'filesystem',\n"
                                 + "  'format' = 'testcsv',\n"
                                 + "  'path' = '/tmp')");
+    }
+
+    @Test
+    public void testParallelismSettingAfterSingletonShuffleRemove() {
+        util.getStreamEnv().getConfig().setScheduler(SchedulerType.AdaptiveBatch);
         util.getTableEnv()
                 .executeSql(
                         "CREATE TABLE MySink (\n"
@@ -61,15 +69,7 @@ public class ParallelismSettingTest extends TableTestBase {
                                 + "  'connector' = 'values',\n"
                                 + "  'sink-insert-only' = 'false',\n"
                                 + "  'table-sink-class' = 'DEFAULT')");
-    }
 
-    @Test
-    public void testParallelismSettingAfterSingletonShuffleRemove() {
-        List<Operation> operations =
-                util.getPlanner()
-                        .getParser()
-                        .parse(
-                                "INSERT INTO MySink SELECT MAX(b) FROM (SELECT SUM(b) AS b FROM MyTable)");
         // the exec plan:
         // Sink(table=[default_catalog.default_database.MySink], fields=[EXPR$0])
         // +- HashAggregate(isMerge=[false], select=[MAX(b) AS EXPR$0])
@@ -78,17 +78,242 @@ public class ParallelismSettingTest extends TableTestBase {
         //         +- LocalHashAggregate(select=[Partial_SUM(b) AS sum$0])
         //            +- TableSourceScan(table=[[MyTable, project=[b])
 
-        List<Transformation<?>> transformations =
-                util.getPlanner()
-                        .translate(
-                                Collections.singletonList((ModifyOperation) (operations.get(0))));
-        assertThat(transformations).hasSize(1);
-        Transformation<?> sink = transformations.get(0);
+        Transformation<?> sink =
+                generateTransformation(
+                        "INSERT INTO MySink SELECT MAX(b) FROM (SELECT SUM(b) AS b FROM MyTable)");
         Transformation<?> topAgg = sink.getInputs().get(0);
         assertThat(topAgg.getParallelism()).isEqualTo(1);
         assertThat(topAgg.getMaxParallelism()).isEqualTo(1);
         Transformation<?> bottomAgg = topAgg.getInputs().get(0);
         assertThat(bottomAgg.getParallelism()).isEqualTo(1);
         assertThat(bottomAgg.getMaxParallelism()).isEqualTo(1);
+    }
+
+    @Test
+    public void testSortQuery() {
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE MySink (\n"
+                                + "  a bigint,\n"
+                                + "  b bigint,\n"
+                                + "  c varchar\n"
+                                + ") with (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'sink-insert-only' = 'false',\n"
+                                + "  'table-sink-class' = 'DEFAULT')");
+
+        // the exec plan:
+        // Sink(table=[default_catalog.default_database.MySink], fields=[EXPR$0])
+        // +- Sort(orderBy=[a ASC])
+        //    +- Exchange(distribution=[single])
+        //       +- TableSourceScan(table=[[default_catalog, default_database, MyTable]], fields=[a,
+        // b, c])
+
+        Transformation<?> sink =
+                generateTransformation("INSERT INTO MySink SELECT * FROM MyTable ORDER BY a");
+        Transformation<?> sort = sink.getInputs().get(0);
+        assertThat(sort.getParallelism()).isEqualTo(1);
+        assertThat(sort.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> exchange = sort.getInputs().get(0);
+        assertThat(exchange.getParallelism()).isEqualTo(1);
+        assertThat(exchange.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> source = exchange.getInputs().get(0);
+        assertThat(source.getParallelism()).isEqualTo(4);
+        assertThat(source.getMaxParallelism()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testLimitQuery() {
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE MySink (\n"
+                                + "  a bigint,\n"
+                                + "  b bigint,\n"
+                                + "  c varchar\n"
+                                + ") with (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'sink-insert-only' = 'false',\n"
+                                + "  'table-sink-class' = 'DEFAULT')");
+
+        // the exec plan:
+        // Sink(table=[default_catalog.default_database.MySink], fields=[EXPR$0])
+        // +- Limit(offset=[0], fetch=[5], global=[true])
+        //    +- Exchange(distribution=[single])
+        //       +- Limit(offset=[0], fetch=[5], global=[false])
+        //          +- TableSourceScan(table=[[default_catalog, default_database, MyTable]],
+        // fields=[a, b, c])
+
+        Transformation<?> sink =
+                generateTransformation("INSERT INTO MySink SELECT * FROM MyTable LIMIT 5");
+        Transformation<?> topLimit = sink.getInputs().get(0);
+        assertThat(topLimit.getParallelism()).isEqualTo(1);
+        assertThat(topLimit.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> exchange = topLimit.getInputs().get(0);
+        assertThat(exchange.getParallelism()).isEqualTo(1);
+        assertThat(exchange.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> bottomLimit = exchange.getInputs().get(0);
+        assertThat(bottomLimit.getParallelism()).isEqualTo(4);
+        assertThat(bottomLimit.getMaxParallelism()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testSortLimitQuery() {
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE MySink (\n"
+                                + "  a bigint,\n"
+                                + "  b bigint,\n"
+                                + "  c varchar\n"
+                                + ") with (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'sink-insert-only' = 'false',\n"
+                                + "  'table-sink-class' = 'DEFAULT')");
+
+        // the exec plan:
+        // Sink(table=[default_catalog.default_database.MySink], fields=[EXPR$0])
+        // +- SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], global=[true])
+        //    +- Exchange(distribution=[single])
+        //        +- SortLimit(orderBy=[a ASC], offset=[0], fetch=[5], global=[false])
+        //            +- TableSourceScan(table=[[default_catalog, default_database, MyTable]],
+        // fields=[a, b, c])
+
+        Transformation<?> sink =
+                generateTransformation(
+                        "INSERT INTO MySink SELECT * FROM MyTable ORDER BY a LIMIT 5");
+        Transformation<?> topSortLimit = sink.getInputs().get(0);
+        assertThat(topSortLimit.getParallelism()).isEqualTo(1);
+        assertThat(topSortLimit.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> exchange = topSortLimit.getInputs().get(0);
+        assertThat(exchange.getParallelism()).isEqualTo(1);
+        assertThat(exchange.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> bottomSortLimit = exchange.getInputs().get(0);
+        assertThat(bottomSortLimit.getParallelism()).isEqualTo(4);
+        assertThat(bottomSortLimit.getMaxParallelism()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testRankQuery() {
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE MySink (\n"
+                                + "  a bigint,\n"
+                                + "  b bigint,\n"
+                                + "  rk bigint\n"
+                                + ") with (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'sink-insert-only' = 'false',\n"
+                                + "  'table-sink-class' = 'DEFAULT')");
+
+        // the exec plan:
+        // Sink(table=[default_catalog.default_database.MySink], fields=[EXPR$0])
+        // +- Calc(select=[a, b, 2 AS $2])
+        //    +- Rank(rankType=[RANK], rankRange=[rankStart=2, rankEnd=2], partitionBy=[],
+        // orderBy=[a ASC, c ASC], global=[true], select=[a, b, c])
+        //       +- Sort(orderBy=[a ASC, c ASC])
+        //          +- Exchange(distribution=[single])
+        //             +- Rank(rankType=[RANK], rankRange=[rankStart=1, rankEnd=2], partitionBy=[],
+        // orderBy=[a ASC, c ASC], global=[false], select=[a, b, c])
+        //                +- Sort(orderBy=[a ASC, c ASC])
+        //                   +- TableSourceScan(table=[[default_catalog, default_database,
+        // MyTable]], fields=[a, b, c])
+
+        Transformation<?> sink =
+                generateTransformation(
+                        "INSERT INTO MySink SELECT * FROM "
+                                + "(SELECT a, b, RANK() OVER (ORDER BY a, c) rk FROM MyTable) t "
+                                + "WHERE rk = 2");
+        Transformation<?> calc = sink.getInputs().get(0);
+        assertThat(calc.getParallelism()).isEqualTo(1);
+        assertThat(calc.getMaxParallelism()).isEqualTo(-1);
+        Transformation<?> topRank = calc.getInputs().get(0);
+        assertThat(topRank.getParallelism()).isEqualTo(1);
+        assertThat(topRank.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> topSort = topRank.getInputs().get(0);
+        assertThat(topSort.getParallelism()).isEqualTo(1);
+        assertThat(topSort.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> exchange = topSort.getInputs().get(0);
+        assertThat(exchange.getParallelism()).isEqualTo(1);
+        assertThat(exchange.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> bottomRank = exchange.getInputs().get(0);
+        assertThat(bottomRank.getParallelism()).isEqualTo(4);
+        assertThat(bottomRank.getMaxParallelism()).isEqualTo(-1);
+        Transformation<?> bottomSort = bottomRank.getInputs().get(0);
+        assertThat(bottomSort.getParallelism()).isEqualTo(4);
+        assertThat(bottomSort.getMaxParallelism()).isEqualTo(-1);
+    }
+
+    @Test
+    public void testJoinQuery() {
+        util.tableEnv()
+                .executeSql(
+                        "CREATE TABLE MyTable2 (\n"
+                                + "  d BIGINT,\n"
+                                + "  e BIGINT,\n"
+                                + "  f VARCHAR\n"
+                                + ") WITH (\n"
+                                + "  'connector' = 'filesystem',\n"
+                                + "  'format' = 'testcsv',\n"
+                                + "  'path' = '/tmp')");
+
+        util.getTableEnv()
+                .executeSql(
+                        "CREATE TABLE MySink (\n"
+                                + "  a bigint,\n"
+                                + "  b bigint,\n"
+                                + "  d bigint,\n"
+                                + "  e bigint\n"
+                                + ") with (\n"
+                                + "  'connector' = 'values',\n"
+                                + "  'sink-insert-only' = 'false',\n"
+                                + "  'table-sink-class' = 'DEFAULT')");
+        util.getTableEnv()
+                .getConfig()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_DISABLED_OPERATORS,
+                        "HashJoin, SortMergeJoin");
+
+        // the exec plan:
+        // Sink(table=[default_catalog.default_database.MySink], fields=[EXPR$0])
+        // +- NestedLoopJoin(joinType=[FullOuterJoin], where=[(a = d)], select=[a, b, d, e],
+        // build=[left])
+        //    :- Exchange(distribution=[single])
+        //    :  +- Calc(select=[a, b])
+        //    :     +- TableSourceScan(table=[[default_catalog, default_database, MyTable]],
+        // fields=[a, b, c])
+        //    +- Exchange(distribution=[single])
+        //       +- Calc(select=[d, e])
+        //          +- +- TableSourceScan(table=[[default_catalog, default_database, MyTable2]],
+        // fields=[d, e, f])
+
+        Transformation<?> sink =
+                generateTransformation(
+                        "INSERT INTO MySink SELECT a, b, d, e FROM MyTable FULL JOIN MyTable2 on a = d");
+        Transformation<?> join = sink.getInputs().get(0);
+        assertThat(join.getParallelism()).isEqualTo(1);
+        assertThat(join.getMaxParallelism()).isEqualTo(1);
+
+        Transformation<?> leftExchange = join.getInputs().get(0);
+        assertThat(leftExchange.getParallelism()).isEqualTo(1);
+        assertThat(leftExchange.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> leftCalc = leftExchange.getInputs().get(0);
+        assertThat(leftCalc.getParallelism()).isEqualTo(4);
+        assertThat(leftCalc.getMaxParallelism()).isEqualTo(-1);
+
+        Transformation<?> rightExchange = join.getInputs().get(1);
+        assertThat(rightExchange.getParallelism()).isEqualTo(1);
+        assertThat(rightExchange.getMaxParallelism()).isEqualTo(1);
+        Transformation<?> rightCalc = rightExchange.getInputs().get(0);
+        assertThat(rightCalc.getParallelism()).isEqualTo(4);
+        assertThat(rightCalc.getMaxParallelism()).isEqualTo(-1);
+    }
+
+    private Transformation<?> generateTransformation(String statement) {
+        List<Operation> operations = util.getPlanner().getParser().parse(statement);
+        List<Transformation<?>> transformations =
+                util.getPlanner()
+                        .translate(
+                                Collections.singletonList((ModifyOperation) (operations.get(0))));
+        assertThat(transformations).hasSize(1);
+        return transformations.get(0);
     }
 }


### PR DESCRIPTION


## What is the purpose of the change

*Fix maxParallelism is not forced to 1 after global partitioner.
Currently, the parallelism of global sort is set as 1, but the max parallelism is not set because ExecNodeBase#inputsContainSingleton does not work for global sort.  This works fine for the default scheduler, but may occur wrong result if  adaptive batch scheduler changes the global sort parallelism.* 


## Brief change log

  - *Make sure all Batch Exec Nodes implements SingleTransformationTranslator or MultipleTransformationTranslator*
  - *set MaxParallelism to 1 if inputs has global partitioner in ExecNodeBase*


## Verifying this change

This change added tests and can be verified as follows:

  - *Extended ParallelismSettingTest to verify the changes*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
