### PR TITLE
[FLINK-30685][runtime] Support mark the transformations whose parallelism is infected by the input transformation

### DIFF
--- a/docs/layouts/shortcodes/generated/batch_execution_configuration.html
+++ b/docs/layouts/shortcodes/generated/batch_execution_configuration.html
@@ -1,0 +1,18 @@
+<table class="configuration table table-bordered">
+    <thead>
+        <tr>
+            <th class="text-left" style="width: 20%">Key</th>
+            <th class="text-left" style="width: 15%">Default</th>
+            <th class="text-left" style="width: 10%">Type</th>
+            <th class="text-left" style="width: 55%">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><h5>execution.batch.adaptive.auto-parallelism.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If true, Flink will automatically decide the parallelism of operators in batch jobs.</td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/layouts/shortcodes/generated/expert_scheduling_section.html
+++ b/docs/layouts/shortcodes/generated/expert_scheduling_section.html
@@ -21,6 +21,12 @@
             <td>Defines whether the cluster uses fine-grained resource management.</td>
         </tr>
         <tr>
+            <td><h5>execution.batch.adaptive.auto-parallelism.enabled</h5></td>
+            <td style="word-wrap: break-word;">true</td>
+            <td>Boolean</td>
+            <td>If true, Flink will automatically decide the parallelism of operators in batch jobs.</td>
+        </tr>
+        <tr>
             <td><h5>fine-grained.shuffle-mode.all-blocking</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectAggITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectAggITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connectors.hive;
 
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableException;
@@ -56,6 +57,7 @@ public class HiveDialectAggITCase {
         hiveCatalog.getHiveConf().setVar(HiveConf.ConfVars.HIVE_QUOTEDID_SUPPORT, "none");
         hiveCatalog.open();
         tableEnv = getTableEnvWithHiveCatalog();
+        tableEnv.getConfig().set(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, false);
         // enable native hive agg function
         tableEnv.getConfig().set(TABLE_EXEC_HIVE_NATIVE_AGG_FUNCTION_ENABLED, true);
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveDialectQueryITCase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.connectors.hive;
 
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.table.HiveVersionTestUtil;
 import org.apache.flink.table.api.SqlDialect;
 import org.apache.flink.table.api.TableEnvironment;
@@ -92,6 +93,7 @@ public class HiveDialectQueryITCase {
         hiveCatalog.getHiveConf().setVar(HiveConf.ConfVars.HIVE_QUOTEDID_SUPPORT, "none");
         hiveCatalog.open();
         tableEnv = getTableEnvWithHiveCatalog();
+        tableEnv.getConfig().set(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, false);
         warehouse = hiveCatalog.getHiveConf().getVar(HiveConf.ConfVars.METASTOREWAREHOUSE);
 
         // create tables

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/shuffle/FlinkKafkaShuffle.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/shuffle/FlinkKafkaShuffle.java
@@ -377,7 +377,8 @@ public class FlinkKafkaShuffle {
                         inputStream.getTransformation(),
                         "kafka_shuffle",
                         shuffleSinkOperator,
-                        inputStream.getExecutionEnvironment().getParallelism());
+                        inputStream.getExecutionEnvironment().getParallelism(),
+                        false);
         inputStream.getExecutionEnvironment().addOperator(transformation);
         transformation.setParallelism(producerParallelism);
     }

--- a/flink-core/src/main/java/org/apache/flink/configuration/BatchExecutionOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/BatchExecutionOptions.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.configuration;
+
+import org.apache.flink.annotation.docs.Documentation;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+
+/** Configuration options for the batch job execution. */
+public class BatchExecutionOptions {
+
+    @Documentation.Section({Documentation.Sections.EXPERT_SCHEDULING})
+    public static final ConfigOption<Boolean> ADAPTIVE_AUTO_PARALLELISM_ENABLED =
+            key("execution.batch.adaptive.auto-parallelism.enabled")
+                    .booleanType()
+                    .defaultValue(true)
+                    .withDescription(
+                            "If true, Flink will automatically decide the parallelism of operators in batch jobs.");
+}

--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -60,13 +60,12 @@ function run_test() {
     set_config_key "jobmanager.scheduler" "${scheduler}"
     set_config_key "taskmanager.memory.process.size" "4096m"
     set_config_key "taskmanager.memory.network.fraction" "0.2"
+    set_config_key "parallelism.default" "4"
 
     if [ "${scheduler}" == "Default" ]; then
         set_config_key "taskmanager.numberOfTaskSlots" "4"
-        set_config_key "parallelism.default" "4"
     elif [ "${scheduler}" == "AdaptiveBatch" ]; then
         set_config_key "taskmanager.numberOfTaskSlots" "8"
-        set_config_key "parallelism.default" "-1"
         set_config_key "jobmanager.adaptive-batch-scheduler.max-parallelism" "8"
         set_config_key "jobmanager.adaptive-batch-scheduler.avg-data-volume-per-task" "6m"
         set_config_key "jobmanager.adaptive-batch-scheduler.speculative.enabled" "true"

--- a/flink-end-to-end-tests/test-scripts/test_tpch.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpch.sh
@@ -40,6 +40,7 @@ java -cp "$TARGET_DIR/TpchTestProgram.jar:$TARGET_DIR/lib/*" org.apache.flink.ta
 echo "Preparing Flink..."
 
 set_config_key "taskmanager.memory.managed.fraction" "0.55f"
+set_config_key "execution.batch.adaptive.auto-parallelism.enabled" "false"
 start_cluster
 
 ################################################################################

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -307,7 +307,8 @@ public class PythonOperatorChainingOptimizer {
                             upTransform.getName() + ", " + downTransform.getName(),
                             (OneInputStreamOperator<?, ?>) chainedOperator,
                             downTransform.getOutputType(),
-                            upTransform.getParallelism());
+                            upTransform.getParallelism(),
+                            false);
 
             ((OneInputTransformation<?, ?>) chainedTransformation)
                     .setStateKeySelector(
@@ -323,7 +324,8 @@ public class PythonOperatorChainingOptimizer {
                             upTransform.getName() + ", " + downTransform.getName(),
                             (TwoInputStreamOperator<?, ?, ?>) chainedOperator,
                             downTransform.getOutputType(),
-                            upTransform.getParallelism());
+                            upTransform.getParallelism(),
+                            false);
 
             ((TwoInputTransformation<?, ?, ?>) chainedTransformation)
                     .setStateKeySelectors(

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -189,7 +189,7 @@ public class PythonConfigUtil {
                 .getSlotSharingGroup()
                 .ifPresent(firstTransformation::setSlotSharingGroup);
         firstTransformation.setCoLocationGroupKey(secondTransformation.getCoLocationGroupKey());
-        firstTransformation.setParallelism(secondTransformation.getParallelism());
+        firstTransformation.setParallelism(secondTransformation.getParallelism(), false);
     }
 
     private static void configForwardPartitioner(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -155,6 +155,8 @@ public class JobVertex implements java.io.Serializable {
      */
     private boolean supportsConcurrentExecutionAttempts = true;
 
+    private boolean parallelismConfigured = false;
+
     // --------------------------------------------------------------------------------------------
 
     /**
@@ -260,6 +262,15 @@ public class JobVertex implements java.io.Serializable {
     public void setInvokableClass(Class<? extends TaskInvokable> invokable) {
         Preconditions.checkNotNull(invokable);
         this.invokableClassName = invokable.getName();
+    }
+
+    // This method can only be called once when jobGraph generated
+    public void setParallelismConfigured(boolean parallelismConfigured) {
+        this.parallelismConfigured = parallelismConfigured;
+    }
+
+    public boolean isParallelismConfigured() {
+        return parallelismConfigured;
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactory.java
@@ -22,6 +22,7 @@ package org.apache.flink.runtime.scheduler.adaptivebatch;
 import org.apache.flink.api.common.BatchShuffleMode;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.ExecutionOptions;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions.HybridPartitionDataConsumeConstraint;
@@ -168,6 +169,17 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                 new VertexwiseSchedulingStrategy.Factory(
                         loadInputConsumableDeciderFactory(hybridPartitionDataConsumeConstraint));
 
+        int defaultMaxParallelism =
+                jobMasterConfiguration
+                        .getOptional(JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM)
+                        .orElse(
+                                jobMasterConfiguration
+                                        .getOptional(CoreOptions.DEFAULT_PARALLELISM)
+                                        .orElse(
+                                                JobManagerOptions
+                                                        .ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM
+                                                        .defaultValue()));
+
         if (enableSpeculativeExecution) {
             return new SpeculativeScheduler(
                     log,
@@ -194,8 +206,7 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                     shuffleMaster,
                     rpcTimeout,
                     DefaultVertexParallelismAndInputInfosDecider.from(jobMasterConfiguration),
-                    jobMasterConfiguration.getInteger(
-                            JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM),
+                    defaultMaxParallelism,
                     blocklistOperations,
                     hybridPartitionDataConsumeConstraint);
         } else {
@@ -224,8 +235,7 @@ public class AdaptiveBatchSchedulerFactory implements SchedulerNGFactory {
                     shuffleMaster,
                     rpcTimeout,
                     DefaultVertexParallelismAndInputInfosDecider.from(jobMasterConfiguration),
-                    jobMasterConfiguration.getInteger(
-                            JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM),
+                    defaultMaxParallelism,
                     hybridPartitionDataConsumeConstraint);
         }
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/BroadcastConnectedStream.java
@@ -235,7 +235,8 @@ public class BroadcastConnectedStream<IN1, IN2> {
                         clean(userFunction),
                         broadcastStateDescriptors,
                         outTypeInfo,
-                        environment.getParallelism());
+                        environment.getParallelism(),
+                        false);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         final SingleOutputStreamOperator<OUT> returnStream =
@@ -266,7 +267,8 @@ public class BroadcastConnectedStream<IN1, IN2> {
                         keyedInputStream.getKeyType(),
                         keyedInputStream.getKeySelector(),
                         outTypeInfo,
-                        environment.getParallelism());
+                        environment.getParallelism(),
+                        false);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         final SingleOutputStreamOperator<OUT> returnStream =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/CoGroupedStreams.java
@@ -371,14 +371,15 @@ public class CoGroupedStreams<T1, T2> {
             UnionKeySelector<T1, T2, KEY> unionKeySelector =
                     new UnionKeySelector<>(keySelector1, keySelector2);
 
-            DataStream<TaggedUnion<T1, T2>> taggedInput1 =
-                    input1.map(new Input1Tagger<T1, T2>())
-                            .setParallelism(input1.getParallelism())
-                            .returns(unionType);
-            DataStream<TaggedUnion<T1, T2>> taggedInput2 =
-                    input2.map(new Input2Tagger<T1, T2>())
-                            .setParallelism(input2.getParallelism())
-                            .returns(unionType);
+            SingleOutputStreamOperator<TaggedUnion<T1, T2>> taggedInput1 =
+                    input1.map(new Input1Tagger<T1, T2>());
+            taggedInput1.getTransformation().setParallelism(input1.getParallelism(), false);
+            taggedInput1.returns(unionType);
+
+            SingleOutputStreamOperator<TaggedUnion<T1, T2>> taggedInput2 =
+                    input2.map(new Input2Tagger<T1, T2>());
+            taggedInput2.getTransformation().setParallelism(input2.getParallelism(), false);
+            taggedInput2.returns(unionType);
 
             DataStream<TaggedUnion<T1, T2>> unionStream = taggedInput1.union(taggedInput2);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/ConnectedStreams.java
@@ -452,7 +452,8 @@ public class ConnectedStreams<IN1, IN2> {
                         functionName,
                         operatorFactory,
                         outTypeInfo,
-                        environment.getParallelism());
+                        environment.getParallelism(),
+                        false);
 
         TypeInformation<?> keyType = null;
         if (inputStream1 instanceof KeyedStream) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -865,7 +865,8 @@ public class DataStream<T> {
                         "Timestamps/Watermarks",
                         inputParallelism,
                         getTransformation(),
-                        cleanedStrategy);
+                        cleanedStrategy,
+                        false);
         getExecutionEnvironment().addOperator(transformation);
         return new SingleOutputStreamOperator<>(getExecutionEnvironment(), transformation);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStream.java
@@ -1199,7 +1199,8 @@ public class DataStream<T> {
                         operatorName,
                         operatorFactory,
                         outTypeInfo,
-                        environment.getParallelism());
+                        environment.getParallelism(),
+                        false);
 
         @SuppressWarnings({"unchecked", "rawtypes"})
         SingleOutputStreamOperator<R> returnStream =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSink.java
@@ -59,7 +59,8 @@ public class DataStreamSink<T> {
                         inputStream.getTransformation(),
                         "Unnamed",
                         sinkOperator,
-                        executionEnvironment.getParallelism());
+                        executionEnvironment.getParallelism(),
+                        false);
         executionEnvironment.addOperator(transformation);
         return new DataStreamSink<>(transformation);
     }
@@ -78,6 +79,7 @@ public class DataStreamSink<T> {
                         inputStream.getType(),
                         "Sink",
                         executionEnvironment.getParallelism(),
+                        false,
                         customSinkOperatorUidHashes);
         executionEnvironment.addOperator(transformation);
         return new DataStreamSink<>(transformation);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamSource.java
@@ -69,7 +69,8 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
                         operator,
                         outTypeInfo,
                         environment.getParallelism(),
-                        boundedness));
+                        boundedness,
+                        false));
 
         this.isParallel = isParallel;
         if (!isParallel) {
@@ -100,7 +101,8 @@ public class DataStreamSource<T> extends SingleOutputStreamOperator<T> {
                         source,
                         watermarkStrategy,
                         outTypeInfo,
-                        environment.getParallelism()));
+                        environment.getParallelism(),
+                        false));
         this.isParallel = true;
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -776,7 +776,8 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
                         transformation,
                         clean(reducer),
                         keySelector,
-                        getKeyType());
+                        getKeyType(),
+                        false);
 
         getExecutionEnvironment().addOperator(reduce);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -51,6 +51,7 @@ import org.apache.flink.api.java.typeutils.MissingTypeInfo;
 import org.apache.flink.api.java.typeutils.PojoTypeInfo;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.api.java.typeutils.TypeExtractor;
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
@@ -1042,6 +1043,14 @@ public class StreamExecutionEnvironment implements AutoCloseable {
         configuration
                 .getOptional(PipelineOptions.JARS)
                 .ifPresent(jars -> this.configuration.set(PipelineOptions.JARS, jars));
+
+        configuration
+                .getOptional(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED)
+                .ifPresent(
+                        flag ->
+                                this.configuration.set(
+                                        BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED,
+                                        flag));
 
         config.configure(configuration, classLoader);
         checkpointCfg.configure(configuration);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java
@@ -141,6 +141,8 @@ public class StreamGraph implements Pipeline {
 
     private boolean dynamic;
 
+    private boolean autoParallelismEnabled;
+
     public StreamGraph(
             ExecutionConfig executionConfig,
             CheckpointConfig checkpointConfig,
@@ -755,6 +757,12 @@ public class StreamGraph implements Pipeline {
         return dynamic;
     }
 
+    public void setParallelism(Integer vertexId, int parallelism, boolean parallelismConfigured) {
+        if (getStreamNode(vertexId) != null) {
+            getStreamNode(vertexId).setParallelism(parallelism, parallelismConfigured);
+        }
+    }
+
     public void setDynamic(boolean dynamic) {
         this.dynamic = dynamic;
     }
@@ -1036,6 +1044,14 @@ public class StreamGraph implements Pipeline {
 
     public JobType getJobType() {
         return jobType;
+    }
+
+    public boolean isAutoParallelismEnabled() {
+        return autoParallelismEnabled;
+    }
+
+    public void setAutoParallelismEnabled(boolean autoParallelismEnabled) {
+        this.autoParallelismEnabled = autoParallelismEnabled;
     }
 
     public PipelineOptions.VertexDescriptionMode getVertexDescriptionMode() {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.common.operators.util.SlotSharingGroupUtils;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.ClusterOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ExecutionOptions;
@@ -309,6 +310,8 @@ public class StreamGraphGenerator {
 
     public StreamGraph generate() {
         streamGraph = new StreamGraph(executionConfig, checkpointConfig, savepointRestoreSettings);
+        streamGraph.setAutoParallelismEnabled(
+                configuration.get(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED));
         streamGraph.setEnableCheckpointsAfterTasksFinish(
                 configuration.get(
                         ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamNode.java
@@ -19,6 +19,7 @@ package org.apache.flink.streaming.api.graph;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.io.InputFormat;
 import org.apache.flink.api.common.io.OutputFormat;
 import org.apache.flink.api.common.operators.ResourceSpec;
@@ -94,6 +95,8 @@ public class StreamNode {
     private @Nullable IntermediateDataSetID consumeClusterDatasetId;
 
     private boolean supportsConcurrentExecutionAttempts = true;
+
+    private boolean parallelismConfigured = false;
 
     @VisibleForTesting
     public StreamNode(
@@ -191,7 +194,13 @@ public class StreamNode {
     }
 
     public void setParallelism(Integer parallelism) {
+        setParallelism(parallelism, true);
+    }
+
+    void setParallelism(Integer parallelism, boolean parallelismConfigured) {
         this.parallelism = parallelism;
+        this.parallelismConfigured =
+                parallelismConfigured && parallelism != ExecutionConfig.PARALLELISM_DEFAULT;
     }
 
     /**
@@ -391,6 +400,10 @@ public class StreamNode {
         } else {
             return Optional.empty();
         }
+    }
+
+    boolean isParallelismConfigured() {
+        return parallelismConfigured;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractBroadcastStateTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractBroadcastStateTransformation.java
@@ -67,6 +67,20 @@ public class AbstractBroadcastStateTransformation<IN1, IN2, OUT>
         this.broadcastStateDescriptors = broadcastStateDescriptors;
     }
 
+    protected AbstractBroadcastStateTransformation(
+            final String name,
+            final Transformation<IN1> regularInput,
+            final Transformation<IN2> broadcastInput,
+            final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors,
+            final TypeInformation<OUT> outTypeInfo,
+            final int parallelism,
+            final boolean parallelismConfigured) {
+        super(name, outTypeInfo, parallelism, parallelismConfigured);
+        this.regularInput = checkNotNull(regularInput);
+        this.broadcastInput = checkNotNull(broadcastInput);
+        this.broadcastStateDescriptors = broadcastStateDescriptors;
+    }
+
     public Transformation<IN2> getBroadcastInput() {
         return broadcastInput;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/AbstractMultipleInputTransformation.java
@@ -50,6 +50,16 @@ public abstract class AbstractMultipleInputTransformation<OUT> extends PhysicalT
         this.operatorFactory = operatorFactory;
     }
 
+    public AbstractMultipleInputTransformation(
+            String name,
+            StreamOperatorFactory<OUT> operatorFactory,
+            TypeInformation<OUT> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, outputType, parallelism, parallelismConfigured);
+        this.operatorFactory = operatorFactory;
+    }
+
     @Override
     public List<Transformation<?>> getInputs() {
         return inputs;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/BroadcastStateTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/BroadcastStateTransformation.java
@@ -40,14 +40,16 @@ public class BroadcastStateTransformation<IN1, IN2, OUT>
             final BroadcastProcessFunction<IN1, IN2, OUT> userFunction,
             final List<MapStateDescriptor<?, ?>> broadcastStateDescriptors,
             final TypeInformation<OUT> outTypeInfo,
-            final int parallelism) {
+            final int parallelism,
+            final boolean parallelismConfigured) {
         super(
                 name,
                 inputStream,
                 broadcastStream,
                 broadcastStateDescriptors,
                 outTypeInfo,
-                parallelism);
+                parallelism,
+                parallelismConfigured);
         this.userFunction = userFunction;
         updateManagedMemoryStateBackendUseCase(false /* not keyed */);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CacheTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CacheTransformation.java
@@ -45,7 +45,11 @@ public class CacheTransformation<T> extends Transformation<T> {
      *     the Log
      */
     public CacheTransformation(Transformation<T> transformationToCache, String name) {
-        super(name, transformationToCache.getOutputType(), transformationToCache.getParallelism());
+        super(
+                name,
+                transformationToCache.getOutputType(),
+                transformationToCache.getParallelism(),
+                transformationToCache.isParallelismConfigured());
         this.transformationToCache = transformationToCache;
 
         this.datasetId = new AbstractID();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/CoFeedbackTransformation.java
@@ -66,7 +66,7 @@ public class CoFeedbackTransformation<F> extends Transformation<F> {
      */
     public CoFeedbackTransformation(
             int parallelism, TypeInformation<F> feedbackType, Long waitTime) {
-        super("CoFeedback", feedbackType, parallelism);
+        super("CoFeedback", feedbackType, parallelism, false);
         this.waitTime = waitTime;
         this.feedbackEdges = Lists.newArrayList();
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/FeedbackTransformation.java
@@ -60,7 +60,7 @@ public class FeedbackTransformation<T> extends Transformation<T> {
      *     will close and not receive any more feedback elements.
      */
     public FeedbackTransformation(Transformation<T> input, Long waitTime) {
-        super("Feedback", input.getOutputType(), input.getParallelism());
+        super("Feedback", input.getOutputType(), input.getParallelism(), false);
         this.input = input;
         this.waitTime = waitTime;
         this.feedbackEdges = Lists.newArrayList();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedBroadcastStateTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/KeyedBroadcastStateTransformation.java
@@ -47,14 +47,16 @@ public class KeyedBroadcastStateTransformation<KEY, IN1, IN2, OUT>
             final TypeInformation<KEY> keyType,
             final KeySelector<IN1, KEY> keySelector,
             final TypeInformation<OUT> outTypeInfo,
-            final int parallelism) {
+            final int parallelism,
+            final boolean parallelismConfigured) {
         super(
                 name,
                 inputStream,
                 broadcastStream,
                 broadcastStateDescriptors,
                 outTypeInfo,
-                parallelism);
+                parallelism,
+                parallelismConfigured);
         this.userFunction = userFunction;
 
         this.stateKeyType = keyType;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySinkTransformation.java
@@ -65,10 +65,16 @@ public class LegacySinkTransformation<T> extends PhysicalTransformation<T> {
      *     the Log
      * @param operator The sink operator
      * @param parallelism The parallelism of this {@code LegacySinkTransformation}
+     * @param parallelismConfigured If true, the parallelism of the transformation is explicitly set
+     *     and should be respected. Otherwise the parallelism can be changed at runtime.
      */
     public LegacySinkTransformation(
-            Transformation<T> input, String name, StreamSink<T> operator, int parallelism) {
-        this(input, name, SimpleOperatorFactory.of(operator), parallelism);
+            Transformation<T> input,
+            String name,
+            StreamSink<T> operator,
+            int parallelism,
+            boolean parallelismConfigured) {
+        this(input, name, SimpleOperatorFactory.of(operator), parallelism, parallelismConfigured);
     }
 
     public LegacySinkTransformation(
@@ -77,6 +83,17 @@ public class LegacySinkTransformation<T> extends PhysicalTransformation<T> {
             StreamOperatorFactory<Object> operatorFactory,
             int parallelism) {
         super(name, input.getOutputType(), parallelism);
+        this.input = input;
+        this.operatorFactory = operatorFactory;
+    }
+
+    public LegacySinkTransformation(
+            Transformation<T> input,
+            String name,
+            StreamOperatorFactory<Object> operatorFactory,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, input.getOutputType(), parallelism, parallelismConfigured);
         this.input = input;
         this.operatorFactory = operatorFactory;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/LegacySourceTransformation.java
@@ -56,24 +56,18 @@ public class LegacySourceTransformation<T> extends PhysicalTransformation<T>
      * @param outputType The type of the elements produced by this {@code
      *     LegacySourceTransformation}
      * @param parallelism The parallelism of this {@code LegacySourceTransformation}
+     * @param parallelismConfigured If true, the parallelism of the transformation is explicitly set
+     *     and should be respected. Otherwise the parallelism can be changed at runtime.
      */
     public LegacySourceTransformation(
             String name,
             StreamSource<T, ?> operator,
             TypeInformation<T> outputType,
             int parallelism,
-            Boundedness boundedness) {
-        this(name, SimpleOperatorFactory.of(operator), outputType, parallelism, boundedness);
-    }
-
-    public LegacySourceTransformation(
-            String name,
-            StreamOperatorFactory<T> operatorFactory,
-            TypeInformation<T> outputType,
-            int parallelism,
-            Boundedness boundedness) {
-        super(name, outputType, parallelism);
-        this.operatorFactory = checkNotNull(operatorFactory);
+            Boundedness boundedness,
+            boolean parallelismConfigured) {
+        super(name, outputType, parallelism, parallelismConfigured);
+        this.operatorFactory = checkNotNull(SimpleOperatorFactory.of(operator));
         this.boundedness = checkNotNull(boundedness);
     }
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/MultipleInputTransformation.java
@@ -34,6 +34,15 @@ public class MultipleInputTransformation<OUT> extends AbstractMultipleInputTrans
         super(name, operatorFactory, outputType, parallelism);
     }
 
+    public MultipleInputTransformation(
+            String name,
+            StreamOperatorFactory<OUT> operatorFactory,
+            TypeInformation<OUT> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, operatorFactory, outputType, parallelism, parallelismConfigured);
+    }
+
     public MultipleInputTransformation<OUT> addInput(Transformation<?> input) {
         inputs.add(input);
         return this;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -74,6 +74,22 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
     public OneInputTransformation(
             Transformation<IN> input,
             String name,
+            OneInputStreamOperator<IN, OUT> operator,
+            TypeInformation<OUT> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        this(
+                input,
+                name,
+                SimpleOperatorFactory.of(operator),
+                outputType,
+                parallelism,
+                parallelismConfigured);
+    }
+
+    public OneInputTransformation(
+            Transformation<IN> input,
+            String name,
             StreamOperatorFactory<OUT> operatorFactory,
             TypeInformation<OUT> outputType,
             int parallelism) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -82,6 +82,30 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
         this.operatorFactory = operatorFactory;
     }
 
+    /**
+     * Creates a new {@code LegacySinkTransformation} from the given input {@code Transformation}.
+     *
+     * @param input The input {@code Transformation}
+     * @param name The name of the {@code Transformation}, this will be shown in Visualizations and
+     *     the Log
+     * @param operatorFactory The {@code TwoInputStreamOperator} factory
+     * @param outputType The type of the elements produced by this {@code OneInputTransformation}
+     * @param parallelism The parallelism of this {@code OneInputTransformation}
+     * @param parallelismConfigured If true, the parallelism of the transformation is explicitly set
+     *     and should be respected. Otherwise the parallelism can be changed at runtime.
+     */
+    public OneInputTransformation(
+            Transformation<IN> input,
+            String name,
+            StreamOperatorFactory<OUT> operatorFactory,
+            TypeInformation<OUT> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, outputType, parallelism, parallelismConfigured);
+        this.input = input;
+        this.operatorFactory = operatorFactory;
+    }
+
     /** Returns the {@code TypeInformation} for the elements of the input. */
     public TypeInformation<IN> getInputType() {
         return input.getOutputType();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PhysicalTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/PhysicalTransformation.java
@@ -47,6 +47,24 @@ public abstract class PhysicalTransformation<T> extends Transformation<T> {
         super(name, outputType, parallelism);
     }
 
+    /**
+     * Creates a new {@code Transformation} with the given name, output type and parallelism.
+     *
+     * @param name The name of the {@code Transformation}, this will be shown in Visualizations and
+     *     the Log
+     * @param outputType The output type of this {@code Transformation}
+     * @param parallelism The parallelism of this {@code Transformation}
+     * @param parallelismConfigured If true, the parallelism of the transformation is explicitly set
+     *     and should be respected. Otherwise the parallelism can be changed at runtime.
+     */
+    PhysicalTransformation(
+            String name,
+            TypeInformation<T> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, outputType, parallelism, parallelismConfigured);
+    }
+
     /** Sets the chaining strategy of this {@code Transformation}. */
     public abstract void setChainingStrategy(ChainingStrategy strategy);
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/ReduceTransformation.java
@@ -51,8 +51,9 @@ public final class ReduceTransformation<IN, K> extends PhysicalTransformation<IN
             Transformation<IN> input,
             ReduceFunction<IN> reducer,
             KeySelector<IN, K> keySelector,
-            TypeInformation<K> keyTypeInfo) {
-        super(name, input.getOutputType(), parallelism);
+            TypeInformation<K> keyTypeInfo,
+            boolean parallelismConfigured) {
+        super(name, input.getOutputType(), parallelism, parallelismConfigured);
         this.input = input;
         this.reducer = reducer;
         this.keySelector = keySelector;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SinkTransformation.java
@@ -58,8 +58,9 @@ public class SinkTransformation<InputT, OutputT> extends PhysicalTransformation<
             TypeInformation<OutputT> outputType,
             String name,
             int parallelism,
+            boolean parallelismConfigured,
             CustomSinkOperatorUidHashes customSinkOperatorUidHashes) {
-        super(name, outputType, parallelism);
+        super(name, outputType, parallelism, parallelismConfigured);
         this.inputStream = checkNotNull(inputStream);
         this.sink = checkNotNull(sink);
         this.input = inputStream.getTransformation();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/SourceTransformation.java
@@ -66,6 +66,18 @@ public class SourceTransformation<OUT, SplitT extends SourceSplit, EnumChkT>
         this.watermarkStrategy = watermarkStrategy;
     }
 
+    public SourceTransformation(
+            String name,
+            Source<OUT, SplitT, EnumChkT> source,
+            WatermarkStrategy<OUT> watermarkStrategy,
+            TypeInformation<OUT> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, outputType, parallelism, parallelismConfigured);
+        this.source = source;
+        this.watermarkStrategy = watermarkStrategy;
+    }
+
     public Source<OUT, SplitT, EnumChkT> getSource() {
         return source;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TimestampsAndWatermarksTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TimestampsAndWatermarksTransformation.java
@@ -59,8 +59,9 @@ public class TimestampsAndWatermarksTransformation<IN> extends PhysicalTransform
             String name,
             int parallelism,
             Transformation<IN> input,
-            WatermarkStrategy<IN> watermarkStrategy) {
-        super(name, input.getOutputType(), parallelism);
+            WatermarkStrategy<IN> watermarkStrategy,
+            boolean parallelismConfigured) {
+        super(name, input.getOutputType(), parallelism, parallelismConfigured);
         this.input = input;
         this.watermarkStrategy = watermarkStrategy;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -80,6 +80,24 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends PhysicalTransformatio
             Transformation<IN1> input1,
             Transformation<IN2> input2,
             String name,
+            TwoInputStreamOperator<IN1, IN2, OUT> operator,
+            TypeInformation<OUT> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        this(
+                input1,
+                input2,
+                name,
+                SimpleOperatorFactory.of(operator),
+                outputType,
+                parallelism,
+                parallelismConfigured);
+    }
+
+    public TwoInputTransformation(
+            Transformation<IN1> input1,
+            Transformation<IN2> input2,
+            String name,
             StreamOperatorFactory<OUT> operatorFactory,
             TypeInformation<OUT> outputType,
             int parallelism) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/TwoInputTransformation.java
@@ -89,6 +89,33 @@ public class TwoInputTransformation<IN1, IN2, OUT> extends PhysicalTransformatio
         this.operatorFactory = operatorFactory;
     }
 
+    /**
+     * Creates a new {@code TwoInputTransformation} from the given inputs and operator.
+     *
+     * @param input1 The first input {@code Transformation}
+     * @param input2 The second input {@code Transformation}
+     * @param name The name of the {@code Transformation}, this will be shown in Visualizations and
+     *     the Log
+     * @param operatorFactory The {@code TwoInputStreamOperator} factory
+     * @param outputType The type of the elements produced by this Transformation
+     * @param parallelism The parallelism of this Transformation
+     * @param parallelismConfigured If true, the parallelism of the transformation is explicitly set
+     *     and should be respected. Otherwise the parallelism can be changed at runtime.
+     */
+    public TwoInputTransformation(
+            Transformation<IN1> input1,
+            Transformation<IN2> input2,
+            String name,
+            StreamOperatorFactory<OUT> operatorFactory,
+            TypeInformation<OUT> outputType,
+            int parallelism,
+            boolean parallelismConfigured) {
+        super(name, outputType, parallelism, parallelismConfigured);
+        this.input1 = input1;
+        this.input2 = input2;
+        this.operatorFactory = operatorFactory;
+    }
+
     /** Returns the first input {@code Transformation} of this {@code TwoInputTransformation}. */
     public Transformation<IN1> getInput1() {
         return input1;

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractOneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractOneInputTransformationTranslator.java
@@ -79,7 +79,8 @@ abstract class AbstractOneInputTransformationTranslator<IN, OUT, OP extends Tran
                 transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
                         ? transformation.getParallelism()
                         : executionConfig.getParallelism();
-        streamGraph.setParallelism(transformationId, parallelism);
+        streamGraph.setParallelism(
+                transformationId, parallelism, transformation.isParallelismConfigured());
         streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
 
         final List<Transformation<?>> parentTransformations = transformation.getInputs();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractTwoInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/AbstractTwoInputTransformationTranslator.java
@@ -90,7 +90,8 @@ public abstract class AbstractTwoInputTransformationTranslator<
                 transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
                         ? transformation.getParallelism()
                         : executionConfig.getParallelism();
-        streamGraph.setParallelism(transformationId, parallelism);
+        streamGraph.setParallelism(
+                transformationId, parallelism, transformation.isParallelismConfigured());
         streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
 
         for (Integer inputId : context.getStreamNodeIds(firstInputTransformation)) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/CacheTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/CacheTransformationTranslator.java
@@ -142,7 +142,10 @@ public class CacheTransformationTranslator<OUT, T extends CacheTransformation<OU
                 null,
                 CACHE_PRODUCER_OPERATOR_NAME);
 
-        streamGraph.setParallelism(cacheTransformation.getId(), input.getParallelism());
+        streamGraph.setParallelism(
+                cacheTransformation.getId(),
+                input.getParallelism(),
+                input.isParallelismConfigured());
         streamGraph.setMaxParallelism(cacheTransformation.getId(), input.getMaxParallelism());
     }
 
@@ -161,7 +164,9 @@ public class CacheTransformationTranslator<OUT, T extends CacheTransformation<OU
                 outputType,
                 CACHE_CONSUMER_OPERATOR_NAME);
         streamGraph.setParallelism(
-                transformation.getId(), transformation.getTransformationToCache().getParallelism());
+                transformation.getId(),
+                transformation.getTransformationToCache().getParallelism(),
+                transformation.isParallelismConfigured());
         streamGraph.setMaxParallelism(
                 transformation.getId(),
                 transformation.getTransformationToCache().getMaxParallelism());

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySinkTransformationTranslator.java
@@ -92,7 +92,8 @@ public class LegacySinkTransformationTranslator<IN>
                 transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
                         ? transformation.getParallelism()
                         : executionConfig.getParallelism();
-        streamGraph.setParallelism(transformationId, parallelism);
+        streamGraph.setParallelism(
+                transformationId, parallelism, transformation.isParallelismConfigured());
         streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
 
         streamGraph.setSupportsConcurrentExecutionAttempts(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySourceTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/LegacySourceTransformationTranslator.java
@@ -83,7 +83,8 @@ public class LegacySourceTransformationTranslator<OUT>
                 transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
                         ? transformation.getParallelism()
                         : executionConfig.getParallelism();
-        streamGraph.setParallelism(transformationId, parallelism);
+        streamGraph.setParallelism(
+                transformationId, parallelism, transformation.isParallelismConfigured());
         streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
 
         streamGraph.setSupportsConcurrentExecutionAttempts(

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/MultiInputTransformationTranslator.java
@@ -113,7 +113,8 @@ public class MultiInputTransformationTranslator<OUT>
                 transformation.getParallelism() != ExecutionConfig.PARALLELISM_DEFAULT
                         ? transformation.getParallelism()
                         : executionConfig.getParallelism();
-        streamGraph.setParallelism(transformationId, parallelism);
+        streamGraph.setParallelism(
+                transformationId, parallelism, transformation.isParallelismConfigured());
         streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
 
         if (transformation instanceof KeyedMultipleInputTransformation) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SourceTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/SourceTransformationTranslator.java
@@ -93,7 +93,8 @@ public class SourceTransformationTranslator<OUT, SplitT extends SourceSplit, Enu
                         ? transformation.getParallelism()
                         : executionConfig.getParallelism();
 
-        streamGraph.setParallelism(transformationId, parallelism);
+        streamGraph.setParallelism(
+                transformationId, parallelism, transformation.isParallelismConfigured());
         streamGraph.setMaxParallelism(transformationId, transformation.getMaxParallelism());
 
         streamGraph.setSupportsConcurrentExecutionAttempts(

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/CsvTableSink.java
@@ -129,8 +129,8 @@ public class CsvTableSink implements AppendStreamTableSink<Row> {
             sink.setParallelism(numFiles);
         } else {
             // if file number is not set, use input parallelism to make it chained.
-            csvRows.setParallelism(dataStream.getParallelism());
-            sink.setParallelism(dataStream.getParallelism());
+            csvRows.getTransformation().setParallelism(dataStream.getParallelism(), false);
+            sink.getTransformation().setParallelism(dataStream.getParallelism(), false);
         }
 
         sink.name(TableConnectorUtils.generateRuntimeName(CsvTableSink.class, fieldNames));

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/sinks/OutputFormatTableSink.java
@@ -42,8 +42,8 @@ public abstract class OutputFormatTableSink<T> implements StreamTableSink<T> {
 
     @Override
     public final DataStreamSink<T> consumeDataStream(DataStream<T> dataStream) {
-        return dataStream
-                .writeUsingOutputFormat(getOutputFormat())
-                .setParallelism(dataStream.getParallelism());
+        DataStreamSink<T> streamSink = dataStream.writeUsingOutputFormat(getOutputFormat());
+        streamSink.getTransformation().setParallelism(dataStream.getParallelism(), false);
+        return streamSink;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSink.java
@@ -113,7 +113,8 @@ final class ExternalDynamicSink implements DynamicTableSink, SupportsWritingMeta
                                     transformationContext.getRowtimeIndex(),
                                     consumeRowtimeMetadata),
                             ExternalTypeInfo.of(physicalDataType),
-                            input.getParallelism());
+                            input.getParallelism(),
+                            false);
                 };
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSource.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/connectors/ExternalDynamicSource.java
@@ -138,7 +138,8 @@ final class ExternalDynamicSource<E>
                                 propagateWatermark,
                                 changelogMode.containsOnly(RowKind.INSERT)),
                         null, // will be filled by the framework
-                        externalTransformation.getParallelism());
+                        externalTransformation.getParallelism(),
+                        false);
             }
 
             @Override

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecDynamicFilteringDataCollector.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecDynamicFilteringDataCollector.java
@@ -102,6 +102,7 @@ public class BatchExecDynamicFilteringDataCollector extends ExecNodeBase<Object>
                 createTransformationDescription(config),
                 factory,
                 InternalTypeInfo.of(getOutputType()),
-                1); // parallelism should always be 1
+                1,
+                true); // parallelism should always be 1
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashAggregate.java
@@ -146,6 +146,7 @@ public class BatchExecHashAggregate extends ExecNodeBase<RowData>
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(outputRowType),
                 inputTransform.getParallelism(),
-                managedMemory);
+                managedMemory,
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashJoin.java
@@ -257,7 +257,8 @@ public class BatchExecHashJoin extends ExecNodeBase<RowData>
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 probeTransform.getParallelism(),
-                managedMemory);
+                managedMemory,
+                false);
     }
 
     private long getLargeManagedMemory(FlinkJoinType joinType, ExecNodeConfig config) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecHashWindowAggregate.java
@@ -156,6 +156,7 @@ public class BatchExecHashWindowAggregate extends ExecNodeBase<RowData>
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),
-                managedMemory);
+                managedMemory,
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecLimit.java
@@ -76,6 +76,7 @@ public class BatchExecLimit extends ExecNodeBase<RowData>
                 createTransformationDescription(config),
                 SimpleOperatorFactory.of(operator),
                 inputTransform.getOutputType(),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -127,7 +127,8 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
                                 generator.getHeadWrappers(),
                                 generator.getTailWrapper()),
                         InternalTypeInfo.of(getOutputType()),
-                        generator.getParallelism());
+                        generator.getParallelism(),
+                        false);
         multipleInputTransform.setDescription(createTransformationDescription(config));
         inputTransformAndInputSpecPairs.forEach(
                 input -> multipleInputTransform.addInput(input.getKey()));

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecNestedLoopJoin.java
@@ -123,6 +123,7 @@ public class BatchExecNestedLoopJoin extends ExecNodeBase<RowData>
                 operator,
                 InternalTypeInfo.of(getOutputType()),
                 parallelism,
-                manageMem);
+                manageMem,
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecOverAggregate.java
@@ -192,7 +192,8 @@ public class BatchExecOverAggregate extends BatchExecOverAggregateBase {
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),
-                managedMemory);
+                managedMemory,
+                false);
     }
 
     private List<OverWindowFrame> createOverWindowFrames(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupAggregate.java
@@ -138,7 +138,8 @@ public class BatchExecPythonGroupAggregate extends ExecNodeBase<RowData>
                 createTransformationDescription(config),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonGroupWindowAggregate.java
@@ -188,7 +188,8 @@ public class BatchExecPythonGroupWindowAggregate extends ExecNodeBase<RowData>
                 createTransformationDescription(config),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecPythonOverAggregate.java
@@ -200,7 +200,8 @@ public class BatchExecPythonOverAggregate extends BatchExecOverAggregateBase {
                 createTransformationDescription(pythonConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecRank.java
@@ -114,6 +114,7 @@ public class BatchExecRank extends ExecNodeBase<RowData>
                 createTransformationDescription(config),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of((RowType) getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecScriptTransform.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecScriptTransform.java
@@ -87,7 +87,8 @@ public class BatchExecScriptTransform extends ExecNodeBase<RowData>
                 getDescription(),
                 SimpleOperatorFactory.of(scriptOperator),
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSort.java
@@ -91,6 +91,7 @@ public class BatchExecSort extends ExecNodeBase<RowData>
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of((RowType) getOutputType()),
                 inputTransform.getParallelism(),
-                sortMemory);
+                sortMemory,
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortAggregate.java
@@ -137,6 +137,7 @@ public class BatchExecSortAggregate extends ExecNodeBase<RowData>
                 createTransformationDescription(config),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(outputRowType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortLimit.java
@@ -107,6 +107,7 @@ public class BatchExecSortLimit extends ExecNodeBase<RowData>
                 createTransformationDescription(config),
                 SimpleOperatorFactory.of(operator),
                 InternalTypeInfo.of(inputType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortMergeJoin.java
@@ -154,6 +154,7 @@ public class BatchExecSortMergeJoin extends ExecNodeBase<RowData>
                 SimpleOperatorFactory.of(new SortMergeJoinOperator(sortMergeJoinFunction)),
                 InternalTypeInfo.of(getOutputType()),
                 rightInputTransform.getParallelism(),
-                managedMemory);
+                managedMemory,
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecSortWindowAggregate.java
@@ -158,6 +158,7 @@ public class BatchExecSortWindowAggregate extends ExecNodeBase<RowData>
                 createTransformationDescription(config),
                 new CodeGenOperatorFactory<>(generatedOperator),
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecTableSourceScan.java
@@ -136,7 +136,8 @@ public class BatchExecTableSourceScan extends CommonExecTableSourceScan
                             "Order-Enforcer",
                             new ExecutionOrderEnforcerOperatorFactory<>(),
                             transformation.getOutputType(),
-                            transformation.getParallelism());
+                            transformation.getParallelism(),
+                            false);
             multipleInputTransformation.addInput(dynamicFilteringInputTransform);
             multipleInputTransformation.addInput(transformation);
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCalc.java
@@ -110,6 +110,7 @@ public abstract class CommonExecCalc extends ExecNodeBase<RowData>
                 createTransformationMeta(CALC_TRANSFORMATION, config),
                 substituteStreamOperator,
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecCorrelate.java
@@ -113,6 +113,7 @@ public abstract class CommonExecCorrelate extends ExecNodeBase<RowData>
                 inputTransform.getParallelism(),
                 retainHeader,
                 getClass().getSimpleName(),
-                createTransformationMeta(CORRELATE_TRANSFORMATION, config));
+                createTransformationMeta(CORRELATE_TRANSFORMATION, config),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecExpand.java
@@ -100,6 +100,7 @@ public abstract class CommonExecExpand extends ExecNodeBase<RowData>
                 createTransformationMeta(EXPAND_TRANSFORMATION, config),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLegacySink.java
@@ -217,7 +217,8 @@ public abstract class CommonExecLegacySink<T> extends ExecNodeBase<T>
                     createFormattedTransformationDescription(description, config),
                     converterOperator,
                     outputTypeInfo,
-                    inputTransform.getParallelism());
+                    inputTransform.getParallelism(),
+                    false);
         }
     }
 

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecLookupJoin.java
@@ -329,7 +329,8 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                     createTransformationMeta(LOOKUP_JOIN_TRANSFORMATION, config),
                     operatorFactory,
                     InternalTypeInfo.of(resultRowType),
-                    inputTransformation.getParallelism());
+                    inputTransformation.getParallelism(),
+                    false);
         }
     }
 
@@ -409,7 +410,7 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
         if (singleParallelism) {
             setSingletonParallelism(partitionedTransform);
         } else {
-            partitionedTransform.setParallelism(inputTransformation.getParallelism());
+            partitionedTransform.setParallelism(inputTransformation.getParallelism(), false);
         }
 
         OneInputTransformation<RowData, RowData> transform =
@@ -418,7 +419,8 @@ public abstract class CommonExecLookupJoin extends ExecNodeBase<RowData>
                         createTransformationMeta(LOOKUP_JOIN_MATERIALIZE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(resultRowType),
-                        partitionedTransform.getParallelism());
+                        partitionedTransform.getParallelism(),
+                        false);
         transform.setStateKeySelector(keySelector);
         transform.setStateKeyType(keySelector.getProducedType());
         if (singleParallelism) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecMatch.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecMatch.java
@@ -180,7 +180,8 @@ public abstract class CommonExecMatch extends ExecNodeBase<RowData>
                         createTransformationMeta(MATCH_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        timestampedInputTransform.getParallelism());
+                        timestampedInputTransform.getParallelism(),
+                        false);
         final RowDataKeySelector selector =
                 KeySelectorUtil.getRowDataSelector(
                         planner.getFlinkContext().getClassLoader(), partitionKeys, inputTypeInfo);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCalc.java
@@ -187,7 +187,8 @@ public abstract class CommonExecPythonCalc extends ExecNodeBase<RowData>
                 createTransformationMeta(PYTHON_CALC_TRANSFORMATION, config),
                 pythonOperator,
                 pythonOperatorResultTyeInfo,
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     private Tuple2<int[], PythonFunctionInfo[]> extractPythonScalarFunctionInfos(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecPythonCorrelate.java
@@ -146,7 +146,8 @@ public abstract class CommonExecPythonCorrelate extends ExecNodeBase<RowData>
                 createTransformationMeta(PYTHON_CORRELATE_TRANSFORMATION, pythonNodeConfig),
                 pythonOperator,
                 pythonOperatorOutputRowType,
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     private Tuple2<int[], PythonFunctionInfo> extractPythonTableFunctionInfo(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecTableSourceScan.java
@@ -178,10 +178,12 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
         env.clean(function);
 
         final int parallelism;
+        boolean parallelismConfigured = false;
         if (function instanceof ParallelSourceFunction) {
             parallelism = env.getParallelism();
         } else {
             parallelism = 1;
+            parallelismConfigured = true;
         }
 
         final Boundedness boundedness;
@@ -193,7 +195,12 @@ public abstract class CommonExecTableSourceScan extends ExecNodeBase<RowData>
 
         final StreamSource<RowData, ?> sourceOperator = new StreamSource<>(function, !isBounded);
         return new LegacySourceTransformation<>(
-                operatorName, sourceOperator, outputTypeInfo, parallelism, boundedness);
+                operatorName,
+                sourceOperator,
+                outputTypeInfo,
+                parallelism,
+                boundedness,
+                parallelismConfigured);
     }
 
     /**

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/common/CommonExecWindowTableFunction.java
@@ -93,6 +93,7 @@ public abstract class CommonExecWindowTableFunction extends ExecNodeBase<RowData
                 createTransformationMeta(WINDOW_TRANSFORMATION, config),
                 windowTableFunctionOperator,
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecChangelogNormalize.java
@@ -170,7 +170,8 @@ public class StreamExecChangelogNormalize extends ExecNodeBase<RowData>
                         createTransformationMeta(CHANGELOG_NORMALIZE_TRANSFORMATION, config),
                         operator,
                         rowTypeInfo,
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         final RowDataKeySelector selector =
                 KeySelectorUtil.getRowDataSelector(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDeduplicate.java
@@ -190,7 +190,8 @@ public class StreamExecDeduplicate extends ExecNodeBase<RowData>
                         createTransformationMeta(DEDUPLICATE_TRANSFORMATION, config),
                         operator,
                         rowTypeInfo,
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         final RowDataKeySelector selector =
                 KeySelectorUtil.getRowDataSelector(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecDropUpdateBefore.java
@@ -95,6 +95,7 @@ public class StreamExecDropUpdateBefore extends ExecNodeBase<RowData>
                 createTransformationMeta(DROP_UPDATE_BEFORE_TRANSFORMATION, config),
                 operator,
                 inputTransform.getOutputType(),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalGroupAggregate.java
@@ -272,7 +272,8 @@ public class StreamExecGlobalGroupAggregate extends StreamExecAggregateBase {
                         createTransformationMeta(GLOBAL_GROUP_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         final RowDataKeySelector selector =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGlobalWindowAggregate.java
@@ -251,7 +251,8 @@ public class StreamExecGlobalWindowAggregate extends StreamExecWindowAggregateBa
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),
-                        WINDOW_AGG_MEMORY_RATIO);
+                        WINDOW_AGG_MEMORY_RATIO,
+                        false);
 
         // set KeyType and Selector for state
         transform.setStateKeySelector(selector);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupAggregate.java
@@ -243,7 +243,8 @@ public class StreamExecGroupAggregate extends StreamExecAggregateBase {
                         createTransformationMeta(GROUP_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         final RowDataKeySelector selector =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupTableAggregate.java
@@ -167,7 +167,8 @@ public class StreamExecGroupTableAggregate extends ExecNodeBase<RowData>
                         createTransformationMeta(GROUP_TABLE_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         final RowDataKeySelector selector =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecGroupWindowAggregate.java
@@ -288,7 +288,8 @@ public class StreamExecGroupWindowAggregate extends StreamExecAggregateBase {
                         createTransformationMeta(GROUP_WINDOW_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         final RowDataKeySelector selector =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIncrementalGroupAggregate.java
@@ -238,7 +238,8 @@ public class StreamExecIncrementalGroupAggregate extends StreamExecAggregateBase
                                 INCREMENTAL_GROUP_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         transform.setStateKeySelector(partialKeySelector);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecIntervalJoin.java
@@ -258,7 +258,8 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         "FilterLeft",
                         new StreamFlatMap<>(allFilter),
                         returnTypeInfo,
-                        leftParallelism);
+                        leftParallelism,
+                        false);
         if (shouldCreateUid) {
             filterAllLeftStream.setUid(createTransformationUid(FILTER_LEFT_TRANSFORMATION, config));
         }
@@ -275,7 +276,8 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         "FilterRight",
                         new StreamFlatMap<>(allFilter),
                         returnTypeInfo,
-                        rightParallelism);
+                        rightParallelism,
+                        false);
         if (shouldCreateUid) {
             filterAllRightStream.setUid(
                     createTransformationUid(FILTER_RIGHT_TRANSFORMATION, config));
@@ -293,7 +295,8 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         "PadLeft",
                         new StreamMap<>(leftPadder),
                         returnTypeInfo,
-                        leftParallelism);
+                        leftParallelism,
+                        false);
         if (shouldCreateUid) {
             padLeftStream.setUid(createTransformationUid(PAD_LEFT_TRANSFORMATION, config));
         }
@@ -309,7 +312,8 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                         "PadRight",
                         new StreamMap<>(rightPadder),
                         returnTypeInfo,
-                        rightParallelism);
+                        rightParallelism,
+                        false);
         if (shouldCreateUid) {
             padRightStream.setUid(createTransformationUid(PAD_RIGHT_TRANSFORMATION, config));
         }
@@ -363,7 +367,8 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                 createTransformationMeta(INTERVAL_JOIN_TRANSFORMATION, config),
                 new KeyedCoProcessOperator<>(procJoinFunc),
                 returnTypeInfo,
-                leftInputTransform.getParallelism());
+                leftInputTransform.getParallelism(),
+                false);
     }
 
     private TwoInputTransformation<RowData, RowData, RowData> createRowTimeJoin(
@@ -398,6 +403,7 @@ public class StreamExecIntervalJoin extends ExecNodeBase<RowData>
                 new KeyedCoProcessOperatorWithWatermarkDelay<>(
                         rowJoinFunc, rowJoinFunc.getMaxOutputDelay()),
                 returnTypeInfo,
-                leftInputTransform.getParallelism());
+                leftInputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecJoin.java
@@ -210,7 +210,8 @@ public class StreamExecJoin extends ExecNodeBase<RowData>
                         createTransformationMeta(JOIN_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(returnType),
-                        leftTransform.getParallelism());
+                        leftTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         RowDataKeySelector leftSelect =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalGroupAggregate.java
@@ -179,6 +179,7 @@ public class StreamExecLocalGroupAggregate extends StreamExecAggregateBase {
                 createTransformationMeta(LOCAL_GROUP_AGGREGATE_TRANSFORMATION, config),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecLocalWindowAggregate.java
@@ -189,7 +189,8 @@ public class StreamExecLocalWindowAggregate extends StreamExecWindowAggregateBas
                 InternalTypeInfo.of(getOutputType()),
                 inputTransform.getParallelism(),
                 // use less memory here to let the chained head operator can have more memory
-                WINDOW_AGG_MEMORY_RATIO / 2);
+                WINDOW_AGG_MEMORY_RATIO / 2,
+                false);
     }
 
     private GeneratedNamespaceAggsHandleFunction<Long> createAggsHandler(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMatch.java
@@ -141,7 +141,8 @@ public class StreamExecMatch extends CommonExecMatch
                                     config),
                             new StreamRecordTimestampInserter(timeOrderFieldIdx, precision),
                             inputTransform.getOutputType(),
-                            inputTransform.getParallelism());
+                            inputTransform.getParallelism(),
+                            false);
             if (inputsContainSingleton()) {
                 transform.setParallelism(1);
                 transform.setMaxParallelism(1);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecMiniBatchAssigner.java
@@ -126,6 +126,7 @@ public class StreamExecMiniBatchAssigner extends ExecNodeBase<RowData>
                 createTransformationMeta(MINI_BATCH_ASSIGNER_TRANSFORMATION, config),
                 operator,
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecOverAggregate.java
@@ -246,7 +246,8 @@ public class StreamExecOverAggregate extends ExecNodeBase<RowData>
                         createTransformationMeta(OVER_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         final RowDataKeySelector selector =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupAggregate.java
@@ -196,7 +196,8 @@ public class StreamExecPythonGroupAggregate extends StreamExecAggregateBase {
                         createTransformationMeta(PYTHON_GROUP_AGGREGATE_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(
                 pythonConfig, planner.getFlinkContext().getClassLoader())) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupTableAggregate.java
@@ -153,7 +153,8 @@ public class StreamExecPythonGroupTableAggregate extends ExecNodeBase<RowData>
                         createTransformationDescription(config),
                         pythonOperator,
                         InternalTypeInfo.of(getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         if (CommonPythonUtil.isPythonWorkerUsingManagedMemory(
                 pythonConfig, planner.getFlinkContext().getClassLoader())) {

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonGroupWindowAggregate.java
@@ -425,7 +425,8 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
                 createTransformationMeta(PYTHON_GROUP_WINDOW_AGGREGATE_TRANSFORMATION, config),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     private OneInputTransformation<RowData, RowData>
@@ -469,7 +470,8 @@ public class StreamExecPythonGroupWindowAggregate extends StreamExecAggregateBas
                         PYTHON_GROUP_WINDOW_AGGREGATE_TRANSFORMATION, pythonNodeConfig),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecPythonOverAggregate.java
@@ -267,7 +267,8 @@ public class StreamExecPythonOverAggregate extends ExecNodeBase<RowData>
                 createTransformationMeta(PYTHON_OVER_AGGREGATE_TRANSFORMATION, config),
                 pythonOperator,
                 InternalTypeInfo.of(outputRowType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 
     @SuppressWarnings("unchecked")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecRank.java
@@ -335,7 +335,8 @@ public class StreamExecRank extends ExecNodeBase<RowData>
                         createTransformationMeta(RANK_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of((RowType) getOutputType()),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         RowDataKeySelector selector =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecSort.java
@@ -95,6 +95,7 @@ public class StreamExecSort extends ExecNodeBase<RowData> implements StreamExecN
                 createTransformationMeta(SORT_TRANSFORMATION, config),
                 sortOperator,
                 InternalTypeInfo.of(inputType),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalJoin.java
@@ -193,7 +193,8 @@ public class StreamExecTemporalJoin extends ExecNodeBase<RowData>
                         createTransformationMeta(TEMPORAL_JOIN_TRANSFORMATION, config),
                         joinOperator,
                         InternalTypeInfo.of(returnType),
-                        leftTransform.getParallelism());
+                        leftTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         RowDataKeySelector leftKeySelector =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecTemporalSort.java
@@ -160,7 +160,8 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
                             createTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, config),
                             sortOperator,
                             InternalTypeInfo.of(inputType),
-                            inputTransform.getParallelism());
+                            inputTransform.getParallelism(),
+                            false);
 
             // as input node is singleton exchange, its parallelism is 1.
             if (inputsContainSingleton()) {
@@ -208,7 +209,8 @@ public class StreamExecTemporalSort extends ExecNodeBase<RowData>
                         createTransformationMeta(TEMPORAL_SORT_TRANSFORMATION, config),
                         sortOperator,
                         InternalTypeInfo.of(inputType),
-                        inputTransform.getParallelism());
+                        inputTransform.getParallelism(),
+                        false);
 
         if (inputsContainSingleton()) {
             transform.setParallelism(1);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWatermarkAssigner.java
@@ -135,6 +135,7 @@ public class StreamExecWatermarkAssigner extends ExecNodeBase<RowData>
                 createTransformationMeta(WATERMARK_ASSIGNER_TRANSFORMATION, config),
                 operatorFactory,
                 InternalTypeInfo.of(getOutputType()),
-                inputTransform.getParallelism());
+                inputTransform.getParallelism(),
+                false);
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowAggregate.java
@@ -207,7 +207,8 @@ public class StreamExecWindowAggregate extends StreamExecWindowAggregateBase {
                         SimpleOperatorFactory.of(windowOperator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),
-                        WINDOW_AGG_MEMORY_RATIO);
+                        WINDOW_AGG_MEMORY_RATIO,
+                        false);
 
         // set KeyType and Selector for state
         transform.setStateKeySelector(selector);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowDeduplicate.java
@@ -183,7 +183,8 @@ public class StreamExecWindowDeduplicate extends ExecNodeBase<RowData>
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),
-                        WINDOW_RANK_MEMORY_RATIO);
+                        WINDOW_RANK_MEMORY_RATIO,
+                        false);
 
         // set KeyType and Selector for state
         transform.setStateKeySelector(selector);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowJoin.java
@@ -192,7 +192,8 @@ public class StreamExecWindowJoin extends ExecNodeBase<RowData>
                         createTransformationMeta(WINDOW_JOIN_TRANSFORMATION, config),
                         operator,
                         InternalTypeInfo.of(returnType),
-                        leftTransform.getParallelism());
+                        leftTransform.getParallelism(),
+                        false);
 
         // set KeyType and Selector for state
         RowDataKeySelector leftSelect =

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/stream/StreamExecWindowRank.java
@@ -261,7 +261,8 @@ public class StreamExecWindowRank extends ExecNodeBase<RowData>
                         SimpleOperatorFactory.of(operator),
                         InternalTypeInfo.of(getOutputType()),
                         inputTransform.getParallelism(),
-                        WINDOW_RANK_MEMORY_RATIO);
+                        WINDOW_RANK_MEMORY_RATIO,
+                        false);
 
         // set KeyType and Selector for state
         transform.setStateKeySelector(selector);

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/utils/ExecNodeUtil.java
@@ -63,9 +63,16 @@ public class ExecNodeUtil {
             TransformationMetadata transformationMeta,
             StreamOperator<O> operator,
             TypeInformation<O> outputType,
-            int parallelism) {
+            int parallelism,
+            boolean parallelismConfigured) {
         return createOneInputTransformation(
-                input, transformationMeta, operator, outputType, parallelism, 0);
+                input,
+                transformationMeta,
+                operator,
+                outputType,
+                parallelism,
+                0,
+                parallelismConfigured);
     }
 
     /** Create a {@link OneInputTransformation}. */
@@ -75,14 +82,16 @@ public class ExecNodeUtil {
             String desc,
             StreamOperator<O> operator,
             TypeInformation<O> outputType,
-            int parallelism) {
+            int parallelism,
+            boolean parallelismConfigured) {
         return createOneInputTransformation(
                 input,
                 new TransformationMetadata(name, desc),
                 operator,
                 outputType,
                 parallelism,
-                0);
+                0,
+                parallelismConfigured);
     }
 
     /** Create a {@link OneInputTransformation} with memoryBytes. */
@@ -92,14 +101,16 @@ public class ExecNodeUtil {
             StreamOperator<O> operator,
             TypeInformation<O> outputType,
             int parallelism,
-            long memoryBytes) {
+            long memoryBytes,
+            boolean parallelismConfigured) {
         return createOneInputTransformation(
                 input,
                 transformationMeta,
                 SimpleOperatorFactory.of(operator),
                 outputType,
                 parallelism,
-                memoryBytes);
+                memoryBytes,
+                parallelismConfigured);
     }
 
     /** Create a {@link OneInputTransformation}. */
@@ -108,9 +119,16 @@ public class ExecNodeUtil {
             TransformationMetadata transformationMeta,
             StreamOperatorFactory<O> operatorFactory,
             TypeInformation<O> outputType,
-            int parallelism) {
+            int parallelism,
+            boolean parallelismConfigured) {
         return createOneInputTransformation(
-                input, transformationMeta, operatorFactory, outputType, parallelism, 0);
+                input,
+                transformationMeta,
+                operatorFactory,
+                outputType,
+                parallelism,
+                0,
+                parallelismConfigured);
     }
 
     /** Create a {@link OneInputTransformation}. */
@@ -120,14 +138,16 @@ public class ExecNodeUtil {
             String desc,
             StreamOperatorFactory<O> operatorFactory,
             TypeInformation<O> outputType,
-            int parallelism) {
+            int parallelism,
+            boolean parallelismConfigured) {
         return createOneInputTransformation(
                 input,
                 new TransformationMetadata(name, desc),
                 operatorFactory,
                 outputType,
                 parallelism,
-                0);
+                0,
+                parallelismConfigured);
     }
 
     /** Create a {@link OneInputTransformation} with memoryBytes. */
@@ -138,14 +158,16 @@ public class ExecNodeUtil {
             StreamOperatorFactory<O> operatorFactory,
             TypeInformation<O> outputType,
             int parallelism,
-            long memoryBytes) {
+            long memoryBytes,
+            boolean parallelismConfigured) {
         return createOneInputTransformation(
                 input,
                 new TransformationMetadata(name, desc),
                 operatorFactory,
                 outputType,
                 parallelism,
-                memoryBytes);
+                memoryBytes,
+                parallelismConfigured);
     }
 
     /** Create a {@link OneInputTransformation} with memoryBytes. */
@@ -155,14 +177,16 @@ public class ExecNodeUtil {
             StreamOperatorFactory<O> operatorFactory,
             TypeInformation<O> outputType,
             int parallelism,
-            long memoryBytes) {
+            long memoryBytes,
+            boolean parallelismConfigured) {
         OneInputTransformation<I, O> transformation =
                 new OneInputTransformation<>(
                         input,
                         transformationMeta.getName(),
                         operatorFactory,
                         outputType,
-                        parallelism);
+                        parallelism,
+                        parallelismConfigured);
         setManagedMemoryWeight(transformation, memoryBytes);
         transformationMeta.fill(transformation);
         return transformation;
@@ -175,9 +199,17 @@ public class ExecNodeUtil {
             TransformationMetadata transformationMeta,
             TwoInputStreamOperator<IN1, IN2, O> operator,
             TypeInformation<O> outputType,
-            int parallelism) {
+            int parallelism,
+            boolean parallelismConfigured) {
         return createTwoInputTransformation(
-                input1, input2, transformationMeta, operator, outputType, parallelism, 0);
+                input1,
+                input2,
+                transformationMeta,
+                operator,
+                outputType,
+                parallelism,
+                0,
+                parallelismConfigured);
     }
 
     /** Create a {@link TwoInputTransformation} with memoryBytes. */
@@ -216,6 +248,26 @@ public class ExecNodeUtil {
                 outputType,
                 parallelism,
                 memoryBytes);
+    }
+
+    public static <IN1, IN2, O> TwoInputTransformation<IN1, IN2, O> createTwoInputTransformation(
+            Transformation<IN1> input1,
+            Transformation<IN2> input2,
+            TransformationMetadata transformationMeta,
+            TwoInputStreamOperator<IN1, IN2, O> operator,
+            TypeInformation<O> outputType,
+            int parallelism,
+            long memoryBytes,
+            boolean parallelismConfigured) {
+        return createTwoInputTransformation(
+                input1,
+                input2,
+                transformationMeta,
+                SimpleOperatorFactory.of(operator),
+                outputType,
+                parallelism,
+                memoryBytes,
+                parallelismConfigured);
     }
 
     /** Create a {@link TwoInputTransformation} with memoryBytes. */
@@ -260,6 +312,29 @@ public class ExecNodeUtil {
         return transformation;
     }
 
+    public static <I1, I2, O> TwoInputTransformation<I1, I2, O> createTwoInputTransformation(
+            Transformation<I1> input1,
+            Transformation<I2> input2,
+            TransformationMetadata transformationMeta,
+            StreamOperatorFactory<O> operatorFactory,
+            TypeInformation<O> outputType,
+            int parallelism,
+            long memoryBytes,
+            boolean parallelismConfigured) {
+        TwoInputTransformation<I1, I2, O> transformation =
+                new TwoInputTransformation<>(
+                        input1,
+                        input2,
+                        transformationMeta.getName(),
+                        operatorFactory,
+                        outputType,
+                        parallelism,
+                        parallelismConfigured);
+        setManagedMemoryWeight(transformation, memoryBytes);
+        transformationMeta.fill(transformation);
+        return transformation;
+    }
+
     /** Create a {@link TwoInputTransformation} with memoryBytes. */
     public static <I1, I2, O> TwoInputTransformation<I1, I2, O> createTwoInputTransformation(
             Transformation<I1> input1,
@@ -269,7 +344,8 @@ public class ExecNodeUtil {
             StreamOperatorFactory<O> operatorFactory,
             TypeInformation<O> outputType,
             int parallelism,
-            long memoryBytes) {
+            long memoryBytes,
+            boolean parallelismConfigured) {
         return createTwoInputTransformation(
                 input1,
                 input2,
@@ -277,7 +353,8 @@ public class ExecNodeUtil {
                 operatorFactory,
                 outputType,
                 parallelism,
-                memoryBytes);
+                memoryBytes,
+                parallelismConfigured);
     }
 
     /** Return description for multiple input node. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CorrelateCodeGenerator.scala
@@ -51,7 +51,8 @@ object CorrelateCodeGenerator {
       parallelism: Int,
       retainHeader: Boolean,
       opName: String,
-      transformationMeta: TransformationMetadata): Transformation[RowData] = {
+      transformationMeta: TransformationMetadata,
+      parallelismConfigured: Boolean): Transformation[RowData] = {
 
     // according to the SQL standard, every scalar function should also be a table function
     // but we don't allow that for now
@@ -88,7 +89,8 @@ object CorrelateCodeGenerator {
       substituteStreamOperator,
       InternalTypeInfo.of(outputType),
       parallelism,
-      0)
+      0,
+      parallelismConfigured)
   }
 
   /** Generates the flat map operator to run the user-defined table function. */

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/utils/ScanUtil.scala
@@ -129,7 +129,8 @@ object ScanUtil {
       substituteStreamOperator,
       InternalTypeInfo.of(outputRowType),
       input.getParallelism,
-      0)
+      0,
+      false)
   }
 
   /** @param qualifiedName qualified name for table */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/MatchRecognizeITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/batch/sql/MatchRecognizeITCase.java
@@ -17,6 +17,7 @@
 
 package org.apache.flink.table.planner.runtime.batch.sql;
 
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -57,6 +58,7 @@ public class MatchRecognizeITCase {
     public void setup() {
         env = StreamExecutionEnvironment.getExecutionEnvironment();
         tEnv = StreamTableEnvironment.create(env, EnvironmentSettings.inBatchMode());
+        tEnv.getConfig().set(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, false);
     }
 
     @Test

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/batch/sql/PartitionableSinkITCase.scala
@@ -20,7 +20,7 @@ package org.apache.flink.table.planner.runtime.batch.sql
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo.{INT_TYPE_INFO, STRING_TYPE_INFO}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.typeutils.RowTypeInfo
-import org.apache.flink.configuration.Configuration
+import org.apache.flink.configuration.{BatchExecutionOptions, Configuration}
 import org.apache.flink.connector.file.table.FileSystemConnectorOptions
 import org.apache.flink.streaming.api.datastream.{DataStream, DataStreamSink}
 import org.apache.flink.streaming.api.functions.sink.RichSinkFunction
@@ -67,6 +67,7 @@ class PartitionableSinkITCase extends BatchTestBase {
     super.before()
     env.setParallelism(3)
     tEnv.getConfig.set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, Int.box(3))
+    tEnv.getConfig.set(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, Boolean.box(false))
     registerCollection("nonSortTable", testData, type3, "a, b, c", dataNullables)
     registerCollection("sortTable", testData1, type3, "a, b, c", dataNullables)
     registerCollection("starTable", testData2, type_int_string, "b, c", Array(true, true))

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/BatchTestBase.scala
@@ -19,6 +19,7 @@ package org.apache.flink.table.planner.runtime.utils
 
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.tuple.Tuple
+import org.apache.flink.configuration.BatchExecutionOptions
 import org.apache.flink.streaming.api.datastream.DataStream
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment
 import org.apache.flink.table.api._
@@ -59,6 +60,7 @@ class BatchTestBase extends BatchAbstractTestBase {
   protected var testingTableEnv: TestingTableEnvironment = TestingTableEnvironment
     .create(settings, catalogManager = None, TableConfig.getDefault)
   protected var tEnv: TableEnvironment = testingTableEnv
+  tEnv.getConfig.set(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, Boolean.box(false))
   protected var planner =
     tEnv.asInstanceOf[TableEnvironmentImpl].getPlanner.asInstanceOf[PlannerBase]
   protected var env: StreamExecutionEnvironment = planner.getExecEnv

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/utils/TableTestBase.scala
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.utils
 import org.apache.flink.api.common.typeinfo.{AtomicType, TypeInformation}
 import org.apache.flink.api.java.typeutils.{PojoTypeInfo, RowTypeInfo, TupleTypeInfo}
 import org.apache.flink.api.scala.typeutils.CaseClassTypeInfo
+import org.apache.flink.configuration.BatchExecutionOptions
 import org.apache.flink.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode
 import org.apache.flink.streaming.api.{environment, TimeCharacteristic}
 import org.apache.flink.streaming.api.datastream.DataStream
@@ -1106,6 +1107,9 @@ abstract class TableTestUtil(
   protected val testingTableEnv: TestingTableEnvironment =
     TestingTableEnvironment.create(setting, catalogManager, tableConfig)
   val tableEnv: TableEnvironment = testingTableEnv
+  tableEnv.getConfig.set(
+    BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED,
+    Boolean.box(false))
 
   private val env: StreamExecutionEnvironment = getPlanner.getExecEnv
 

--- a/flink-tests/src/test/java/org/apache/flink/test/runtime/BatchShuffleITCaseBase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/runtime/BatchShuffleITCaseBase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.ExecutionOptions;
@@ -79,6 +80,7 @@ class BatchShuffleITCaseBase {
             boolean failExecution,
             boolean deletePartitionFile,
             Configuration configuration) {
+        configuration.setBoolean(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, false);
         StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.getExecutionEnvironment(configuration);
         env.setRestartStrategy(RestartStrategies.fixedDelayRestart(10, 0L));

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -119,7 +119,6 @@ public class AdaptiveBatchSchedulerITCase extends TestLogger {
 
         final StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.createLocalEnvironment(configuration);
-        env.setParallelism(-1);
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
 
         List<SlotSharingGroup> slotSharingGroups = new ArrayList<>();

--- a/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/CacheITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/streaming/runtime/CacheITCase.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.FlatMapFunction;
 import org.apache.flink.api.common.serialization.SimpleStringEncoder;
 import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.sink.FileSink;
 import org.apache.flink.connector.file.src.FileSource;
@@ -83,7 +84,14 @@ public class CacheITCase extends AbstractTestBase {
                                 .build());
         miniClusterWithClientResource.before();
 
-        env = new TestStreamEnvironment(miniClusterWithClientResource.getMiniCluster(), 8);
+        configuration.set(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, false);
+        env =
+                new TestStreamEnvironment(
+                        miniClusterWithClientResource.getMiniCluster(),
+                        configuration,
+                        8,
+                        Collections.emptyList(),
+                        Collections.emptyList());
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In order to chain operators together as much as possible, many downstream operators will use the parallelism of upstream input operators in the table planner.

If some operators need to have their own defined parallelism, the parallelism will be explicitly set. Therefore, the operator that takes the parallelism of the upstream operator as its own parallelism should be automatically derived by the AdaptiveBatchScheduler.


## Brief change log

Set the parallelismConfigured of the operator whose parallelism is obtained from the parallelism of the upstream operator to false


## Verifying this change


This change is already covered by existing tests, such as e2e tpc-ds. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
