### PR TITLE
[FLINK-30798][runtime] Make OutputFormat support speculative execution for batch jobs

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/common/io/FinalizeOnMaster.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/FinalizeOnMaster.java
@@ -35,6 +35,40 @@ public interface FinalizeOnMaster {
      *
      * @param parallelism The parallelism with which the format or functions was run.
      * @throws IOException The finalization may throw exceptions, which may cause the job to abort.
+     * @deprecated Use {@link #finalizeGlobal(FinalizationContext)} instead.
      */
-    void finalizeGlobal(int parallelism) throws IOException;
+    @Deprecated
+    default void finalizeGlobal(int parallelism) throws IOException {}
+
+    /**
+     * The method is invoked on the master (JobManager) after all (parallel) instances of an
+     * OutputFormat finished.
+     *
+     * @param context The context to get finalization infos.
+     * @throws IOException The finalization may throw exceptions, which may cause the job to abort.
+     */
+    default void finalizeGlobal(FinalizationContext context) throws IOException {
+        finalizeGlobal(context.getParallelism());
+    }
+
+    /** A context that provides parallelism and finished attempts infos. */
+    @Public
+    interface FinalizationContext {
+
+        /**
+         * Get the parallelism with which the format or functions was run.
+         *
+         * @return the parallelism.
+         */
+        int getParallelism();
+
+        /**
+         * Get the finished attempt number of subtask.
+         *
+         * @param subtaskIndex the subtask index.
+         * @return the finished attempt.
+         * @throws IllegalArgumentException Thrown, if subtaskIndex is invalid.
+         */
+        int getFinishedAttempt(int subtaskIndex);
+    }
 }

--- a/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormat.java
+++ b/flink-core/src/main/java/org/apache/flink/api/common/io/OutputFormat.java
@@ -62,9 +62,22 @@ public interface OutputFormat<IT> extends Serializable {
      * @param taskNumber The number of the parallel instance.
      * @param numTasks The number of parallel tasks.
      * @throws IOException Thrown, if the output could not be opened due to an I/O problem.
+     * @deprecated Use {@link #open(InitializationContext)} instead
      */
-    void open(int taskNumber, int numTasks) throws IOException;
+    @Deprecated
+    default void open(int taskNumber, int numTasks) throws IOException {}
 
+    /**
+     * Opens a parallel instance of the output format to store the result of its parallel instance.
+     *
+     * <p>When this method is called, the output format it guaranteed to be configured.
+     *
+     * @param context The context to get task parallel infos.
+     * @throws IOException Thrown, if the output could not be opened due to an I/O problem.
+     */
+    default void open(InitializationContext context) throws IOException {
+        open(context.getTaskNumber(), context.getNumTasks());
+    }
     /**
      * Adds a record to the output.
      *
@@ -85,4 +98,30 @@ public interface OutputFormat<IT> extends Serializable {
      * @throws IOException Thrown, if the input could not be closed properly.
      */
     void close() throws IOException;
+
+    /** The context exposes some runtime info for initializing output format. */
+    @Public
+    interface InitializationContext {
+        /**
+         * Gets the parallelism with which the parallel task runs.
+         *
+         * @return The parallelism with which the parallel task runs.
+         */
+        int getNumTasks();
+
+        /**
+         * Gets the number of this parallel subtask. The numbering starts from 0 and goes up to
+         * parallelism-1 (parallelism as returned by {@link #getNumTasks()}).
+         *
+         * @return The index of the parallel subtask.
+         */
+        int getTaskNumber();
+
+        /**
+         * Gets the attempt number of this parallel subtask. First attempt is numbered 0.
+         *
+         * @return Attempt number of the subtask.
+         */
+        int getAttemptNumber();
+    }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/jobgraph/JobVertex.java
@@ -564,7 +564,7 @@ public class JobVertex implements java.io.Serializable {
      * @param context Provides contextual information for the initialization
      * @throws Exception The method may throw exceptions which cause the job to fail immediately.
      */
-    public void finalizeOnMaster(InitializeOnMasterContext context) throws Exception {}
+    public void finalizeOnMaster(FinalizeOnMasterContext context) throws Exception {}
 
     public interface InitializeOnMasterContext {
         /** The class loader for user defined code. */
@@ -577,6 +577,29 @@ public class JobVertex implements java.io.Serializable {
          * org.apache.flink.runtime.scheduler.adaptive.AdaptiveScheduler}.
          */
         int getExecutionParallelism();
+    }
+
+    /** The context exposes some runtime infos for finalization. */
+    public interface FinalizeOnMasterContext {
+        /** The class loader for user defined code. */
+        ClassLoader getClassLoader();
+
+        /**
+         * The actual parallelism this vertex will be run with. In contrast, the {@link
+         * #getParallelism()} is the original parallelism set when creating the {@link JobGraph} and
+         * might be updated e.g. by the {@link
+         * org.apache.flink.runtime.scheduler.adaptive.AdaptiveScheduler}.
+         */
+        int getExecutionParallelism();
+
+        /**
+         * Get the finished attempt number of subtask.
+         *
+         * @param subtaskIndex the subtask index.
+         * @return the finished attempt.
+         * @throws IllegalArgumentException Thrown, if subtaskIndex is invalid.
+         */
+        int getFinishedAttempt(int subtaskIndex);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/DataSinkTask.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.io.CleanupWhenUnsuccessful;
 import org.apache.flink.api.common.io.OutputFormat;
+import org.apache.flink.api.common.io.OutputFormat.InitializationContext;
 import org.apache.flink.api.common.io.RichOutputFormat;
 import org.apache.flink.api.common.typeutils.TypeComparatorFactory;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
@@ -215,8 +216,22 @@ public class DataSinkTask<IT> extends AbstractInvokable {
 
             // open
             format.open(
-                    this.getEnvironment().getTaskInfo().getIndexOfThisSubtask(),
-                    this.getEnvironment().getTaskInfo().getNumberOfParallelSubtasks());
+                    new InitializationContext() {
+                        @Override
+                        public int getNumTasks() {
+                            return getEnvironment().getTaskInfo().getNumberOfParallelSubtasks();
+                        }
+
+                        @Override
+                        public int getTaskNumber() {
+                            return getEnvironment().getTaskInfo().getIndexOfThisSubtask();
+                        }
+
+                        @Override
+                        public int getAttemptNumber() {
+                            return getEnvironment().getTaskInfo().getAttemptNumber();
+                        }
+                    });
 
             if (objectReuseEnabled) {
                 IT record = serializer.createInstance();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/FinalizeOnMasterTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.api.common.JobStatus;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertex.FinalizeOnMasterContext;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.testutils.TestingUtils;
@@ -77,8 +78,8 @@ public class FinalizeOnMasterTest extends TestLogger {
         ExecutionGraphTestUtils.finishAllVertices(eg);
         assertEquals(JobStatus.FINISHED, eg.waitUntilTerminal());
 
-        verify(vertex1, times(1)).finalizeOnMaster(any(JobVertex.InitializeOnMasterContext.class));
-        verify(vertex2, times(1)).finalizeOnMaster(any(JobVertex.InitializeOnMasterContext.class));
+        verify(vertex1, times(1)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
+        verify(vertex2, times(1)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
 
         assertEquals(0, eg.getRegisteredExecutions().size());
     }
@@ -109,7 +110,7 @@ public class FinalizeOnMasterTest extends TestLogger {
 
         assertEquals(JobStatus.FAILED, eg.waitUntilTerminal());
 
-        verify(vertex, times(0)).finalizeOnMaster(any(JobVertex.InitializeOnMasterContext.class));
+        verify(vertex, times(0)).finalizeOnMaster(any(FinalizeOnMasterContext.class));
 
         assertEquals(0, eg.getRegisteredExecutions().size());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/minicluster/MiniClusterITCase.java
@@ -714,7 +714,7 @@ public class MiniClusterITCase extends TestLogger {
         }
 
         @Override
-        public void finalizeOnMaster(InitializeOnMasterContext context) throws Exception {
+        public void finalizeOnMaster(FinalizeOnMasterContext context) throws Exception {
             Thread.sleep(waitingTime);
             finalizedOnMaster.set(true);
         }
@@ -731,7 +731,7 @@ public class MiniClusterITCase extends TestLogger {
         }
 
         @Override
-        public void finalizeOnMaster(InitializeOnMasterContext context) {
+        public void finalizeOnMaster(FinalizeOnMasterContext context) {
             throw new OutOfMemoryError("Java heap space");
         }
     }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/runtime/utils/StreamTestSink.scala
@@ -386,7 +386,7 @@ class TestingOutputFormat[T](tz: TimeZone) extends OutputFormat[T] {
 
   def configure(var1: Configuration): Unit = {}
 
-  def open(taskNumber: Int, numTasks: Int): Unit = {
+  override def open(taskNumber: Int, numTasks: Int): Unit = {
     localRetractResults = mutable.ArrayBuffer.empty[String]
     StreamTestSink.synchronized {
       StreamTestSink.globalResults(index) += (taskNumber -> localRetractResults)

--- a/pom.xml
+++ b/pom.xml
@@ -2187,6 +2187,8 @@ under the License.
 								<exclude>org.apache.flink.api.connector.source.SourceReaderContext#currentParallelism()</exclude>
 								<exclude>org.apache.flink.api.common.io.OutputFormat#open(int,int)</exclude>
 								<exclude>org.apache.flink.api.common.io.OutputFormat#open(org.apache.flink.api.common.io.OutputFormat$InitializationContext)</exclude>
+								<exclude>org.apache.flink.api.common.io.FinalizeOnMaster#finalizeGlobal(int)</exclude>
+								<exclude>org.apache.flink.api.common.io.FinalizeOnMaster#finalizeGlobal(org.apache.flink.api.common.io.FinalizeOnMaster$FinalizationContext)</exclude>
 								<!-- MARKER: end exclusions -->
 							</excludes>
 							<accessModifier>public</accessModifier>

--- a/pom.xml
+++ b/pom.xml
@@ -2185,6 +2185,8 @@ under the License.
 								<!-- UnionSerializerConfigSnapshot was a PublicEvolving and Deprecated class that has been removed, embedded inside a Public CoGroupedStreams class, triggering this false failure -->
 								<exclude>org.apache.flink.streaming.api.datastream.CoGroupedStreams$UnionSerializerConfigSnapshot</exclude>
 								<exclude>org.apache.flink.api.connector.source.SourceReaderContext#currentParallelism()</exclude>
+								<exclude>org.apache.flink.api.common.io.OutputFormat#open(int,int)</exclude>
+								<exclude>org.apache.flink.api.common.io.OutputFormat#open(org.apache.flink.api.common.io.OutputFormat$InitializationContext)</exclude>
 								<!-- MARKER: end exclusions -->
 							</excludes>
 							<accessModifier>public</accessModifier>


### PR DESCRIPTION
## What is the purpose of the change

*This pull request introduces a way to enable speculative execution for `OutputFormat`*


## Brief change log

  - *Introduce context in `OutputFormat` and `FinalizeOnMaster` to expose necessary infos for speculative execution*
  - *Speculative execution would be enabled if a `OutputFormat` inherits SupportsConcurrentExecutionAttempts*


## Verifying this change

This change added tests:

  - *Add new test cases in `StreamingJobGraphGeneratorTest`*
  - *Add new test cases in `SpeculativeSchedulerITCase`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (JavaDocs)
