### PR TITLE
[FLINK-30812][yarn] Fix uploading local files when using YARN with S3

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -23,6 +23,7 @@ import org.apache.flink.client.deployment.ClusterDeploymentException;
 import org.apache.flink.configuration.ConfigConstants;
 import org.apache.flink.util.FileUtils;
 import org.apache.flink.util.IOUtils;
+import org.apache.flink.util.StringUtils;
 import org.apache.flink.util.function.FunctionUtils;
 import org.apache.flink.yarn.configuration.YarnConfigOptions;
 
@@ -389,7 +390,7 @@ class YarnApplicationFileUploader implements AutoCloseable {
         final Path dst = new Path(applicationDir, suffix);
 
         final Path localSrcPathWithScheme;
-        if (localSrcPath.toUri().getScheme() == null) {
+        if (StringUtils.isNullOrWhitespaceOnly(localSrcPath.toUri().getScheme())) {
             localSrcPathWithScheme = new Path(URI.create("file:///").resolve(localSrcPath.toUri()));
         } else {
             localSrcPathWithScheme = localSrcPath;

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnApplicationFileUploader.java
@@ -388,13 +388,20 @@ class YarnApplicationFileUploader implements AutoCloseable {
                 (relativeDstPath.isEmpty() ? "" : relativeDstPath + "/") + localSrcPath.getName();
         final Path dst = new Path(applicationDir, suffix);
 
+        final Path localSrcPathWithScheme;
+        if (localSrcPath.toUri().getScheme() == null) {
+            localSrcPathWithScheme = new Path(URI.create("file:///").resolve(localSrcPath.toUri()));
+        } else {
+            localSrcPathWithScheme = localSrcPath;
+        }
+
         LOG.debug(
                 "Copying from {} to {} with replication factor {}",
-                localSrcPath,
+                localSrcPathWithScheme,
                 dst,
                 replicationFactor);
 
-        fileSystem.copyFromLocalFile(false, true, localSrcPath, dst);
+        fileSystem.copyFromLocalFile(false, true, localSrcPathWithScheme, dst);
         fileSystem.setReplication(dst, (short) replicationFactor);
         return dst;
     }


### PR DESCRIPTION
  ## What is the purpose of the change

Hadoop versions starting from 3.3.2 have reworked copying local files to remote using S3AFileSystem. Now it requires the passed local Hadoop Path to have a `scheme` specified.


## Brief change log

YarnApplicationFileUploader will append `file://` scheme for local path if none specified


## Verifying this change

I manually tested on a local single-node Hadoop 3.3.4 cluster with `fs.defaultFS` pointing to a local Minio S3 server. Creating a Flink YARN session failed before the fix, but worked after.

Also added new unit test in `YarnApplicationFileUploaderTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) yes
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented) not applicable
