### PR TITLE
[FLINK-30830][docs] Temporal Table Function Samples for Java Do Not Work As-Is, And Some Functions Are Deprecated

### DIFF
--- a/docs/content.zh/docs/dev/table/concepts/temporal_table_function.md
+++ b/docs/content.zh/docs/dev/table/concepts/temporal_table_function.md
@@ -64,7 +64,7 @@ TemporalTableFunction rates = tEnv
     .from("currency_rates")
     .createTemporalTableFunction("update_time", "currency");
  
-tEnv.registerFunction("rates", rates);                                                        
+tEnv.createTemporarySystemFunction("rates", rates);                                                           
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -73,7 +73,7 @@ rates = tEnv
     .from("currency_rates")
     .createTemporalTableFunction("update_time", "currency")
  
-tEnv.registerFunction("rates", rates)
+tEnv.createTemporarySystemFunction("rates", rates);                                                           
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -120,8 +120,8 @@ WHERE
 {{< tab "Java" >}}
 ```java
 Table result = orders
-    .joinLateral($("rates(order_time)"), $("orders.currency = rates.currency"))
-    .select($("(o_amount * r_rate).sum as amount"));
+    .joinLateral(call("rates", $("o_proctime")), $("o_currency").isEqual($("r_currency")))
+    .select($("(o_amount").times($("r_rate")).sum().as("amount"));
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}

--- a/docs/content/docs/dev/table/concepts/temporal_table_function.md
+++ b/docs/content/docs/dev/table/concepts/temporal_table_function.md
@@ -64,7 +64,7 @@ TemporalTableFunction rates = tEnv
     .from("currency_rates")
     .createTemporalTableFunction("update_time", "currency");
  
-tEnv.registerFunction("rates", rates);                                                        
+tEnv.createTemporarySystemFunction("rates", rates);                                                        
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}
@@ -73,7 +73,7 @@ rates = tEnv
     .from("currency_rates")
     .createTemporalTableFunction("update_time", "currency")
  
-tEnv.registerFunction("rates", rates)
+tEnv.createTemporarySystemFunction("rates", rates)
 ```
 {{< /tab >}}
 {{< tab "Python" >}}
@@ -120,8 +120,8 @@ WHERE
 {{< tab "Java" >}}
 ```java
 Table result = orders
-    .joinLateral($("rates(order_time)"), $("orders.currency = rates.currency"))
-    .select($("(o_amount * r_rate).sum as amount"));
+    .joinLateral(call("rates", $("o_proctime")), $("o_currency").isEqual($("r_currency")))
+    .select($("(o_amount").times($("r_rate")).sum().as("amount"));
 ```
 {{< /tab >}}
 {{< tab "Scala" >}}


### PR DESCRIPTION

## What is the purpose of the change

This pull requests corrects java documentation for the Temporal Table Function samples.


## Brief change log

Modified documentation page covering the Temporal Table Function to specify the correct syntax.


## Verifying this change

This change is already covered by existing tests: 
- testLateralJoinWithScalarFunction



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): No
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: No
  - The serializers: No
  - The runtime per-record code paths (performance sensitive): No
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
  - The S3 file system connector: No

## Documentation

  - Does this pull request introduce a new feature? No
  - If yes, how is the feature documented? No
