### PR TITLE
[bp-1.16][FLINK-30477][datastream] Fix AsyncWaitOperator that not properly blocking retries when timeout occurs

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperator.java
@@ -47,6 +47,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
 import org.apache.flink.util.Preconditions;
+import org.apache.flink.util.function.ThrowingConsumer;
 
 import javax.annotation.Nonnull;
 
@@ -359,6 +360,9 @@ public class AsyncWaitOperator<IN, OUT>
             if (inFlightDelayRetryHandlers.size() > 0) {
                 for (RetryableResultHandlerDelegator delegator : inFlightDelayRetryHandlers) {
                     assert delegator.delayedRetryTimer != null;
+                    // cancel delayedRetryTimer timer first
+                    delegator.cancelRetryTimer();
+
                     // fire an attempt intermediately not rely on successfully canceling the retry
                     // timer for two reasons: 1. cancel retry timer can not be 100% safe 2. there's
                     // protection for repeated retries
@@ -409,11 +413,21 @@ public class AsyncWaitOperator<IN, OUT>
     private void tryOnce(RetryableResultHandlerDelegator resultHandlerDelegator) throws Exception {
         // increment current attempt number
         resultHandlerDelegator.currentAttempts++;
-
         // fire a new attempt
         userFunction.asyncInvoke(
                 resultHandlerDelegator.resultHandler.inputRecord.getValue(),
                 resultHandlerDelegator);
+    }
+
+    /** Utility method to register timeout timer. */
+    private ScheduledFuture<?> registerTimer(
+            ProcessingTimeService processingTimeService,
+            long timeout,
+            ThrowingConsumer<Void, Exception> callback) {
+        final long timeoutTimestamp = timeout + processingTimeService.getCurrentProcessingTime();
+
+        return processingTimeService.registerTimer(
+                timeoutTimestamp, timestamp -> callback.accept(null));
     }
 
     /** A delegator holds the real {@link ResultHandler} to handle retries. */
@@ -442,8 +456,29 @@ public class AsyncWaitOperator<IN, OUT>
             this.processingTimeService = processingTimeService;
         }
 
-        public void registerTimeout(long timeout) {
-            resultHandler.registerTimeout(processingTimeService, timeout);
+        private void registerTimeout(long timeout) {
+            resultHandler.timeoutTimer =
+                    registerTimer(processingTimeService, timeout, t -> timerTriggered());
+        }
+
+        private void cancelRetryTimer() {
+            if (delayedRetryTimer != null) {
+                // do not interrupt task thread, just try to cancel the timer
+                delayedRetryTimer.cancel(false);
+            }
+        }
+
+        /** Rewrite the timeout process to deal with retry state. */
+        private void timerTriggered() throws Exception {
+            if (!resultHandler.completed.get()) {
+                // cancel delayed retry timer first
+                cancelRetryTimer();
+
+                // force reset retryAwaiting to prevent the handler to trigger retry unnecessarily
+                retryAwaiting.set(false);
+
+                userFunction.timeout(resultHandler.inputRecord.getValue(), this);
+            }
         }
 
         @Override
@@ -451,13 +486,10 @@ public class AsyncWaitOperator<IN, OUT>
             Preconditions.checkNotNull(
                     results, "Results must not be null, use empty collection to emit nothing");
             if (!retryDisabledOnFinish.get() && resultHandler.inputRecord.isRecord()) {
-                // ignore repeated call(s)
-                if (!retryAwaiting.compareAndSet(false, true)) {
-                    return;
-                }
-
                 processRetryInMailBox(results, null);
             } else {
+                cancelRetryTimer();
+
                 resultHandler.complete(results);
             }
         }
@@ -465,13 +497,10 @@ public class AsyncWaitOperator<IN, OUT>
         @Override
         public void completeExceptionally(Throwable error) {
             if (!retryDisabledOnFinish.get() && resultHandler.inputRecord.isRecord()) {
-                // ignore repeated call(s)
-                if (!retryAwaiting.compareAndSet(false, true)) {
-                    return;
-                }
-
                 processRetryInMailBox(null, error);
             } else {
+                cancelRetryTimer();
+
                 resultHandler.completeExceptionally(error);
             }
         }
@@ -481,6 +510,11 @@ public class AsyncWaitOperator<IN, OUT>
         }
 
         private void processRetry(Collection<OUT> results, Throwable error) {
+            // ignore repeated call(s) and only called in main thread can be safe
+            if (!retryAwaiting.compareAndSet(false, true)) {
+                return;
+            }
+
             boolean satisfy =
                     (null != results && retryResultPredicate.test(results))
                             || (null != error && retryExceptionPredicate.test(error));
@@ -519,11 +553,10 @@ public class AsyncWaitOperator<IN, OUT>
         }
 
         private void doRetry() throws Exception {
-            // fire the retry
-            tryOnce(this);
-
-            // reset for next possible retry
-            retryAwaiting.set(false);
+            // fire a retry only when it is in awaiting state, otherwise timeout may already happen
+            if (retryAwaiting.compareAndSet(true, false)) {
+                tryOnce(this);
+            }
         }
     }
 
@@ -610,12 +643,7 @@ public class AsyncWaitOperator<IN, OUT>
         }
 
         private void registerTimeout(ProcessingTimeService processingTimeService, long timeout) {
-            final long timeoutTimestamp =
-                    timeout + processingTimeService.getCurrentProcessingTime();
-
-            timeoutTimer =
-                    processingTimeService.registerTimer(
-                            timeoutTimestamp, timestamp -> timerTriggered());
+            timeoutTimer = registerTimer(processingTimeService, timeout, t -> timerTriggered());
         }
 
         private void timerTriggered() throws Exception {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.operators.async;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
 import org.apache.flink.api.common.time.Deadline;
@@ -78,9 +79,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
@@ -1260,6 +1263,80 @@ public class AsyncWaitOperatorTest extends TestLogger {
         }
     }
 
+    /**
+     * Test the AsyncWaitOperator with an always-timeout async function under unordered mode and
+     * processing time.
+     */
+    @Test
+    public void testProcessingTimeWithTimeoutFunctionUnorderedWithRetry() throws Exception {
+        testProcessingTimeAlwaysTimeoutFunctionWithRetry(AsyncDataStream.OutputMode.UNORDERED);
+    }
+
+    /**
+     * Test the AsyncWaitOperator with an always-timeout async function under ordered mode and
+     * processing time.
+     */
+    @Test
+    public void testProcessingTimeWithTimeoutFunctionOrderedWithRetry() throws Exception {
+        testProcessingTimeAlwaysTimeoutFunctionWithRetry(AsyncDataStream.OutputMode.ORDERED);
+    }
+
+    private void testProcessingTimeAlwaysTimeoutFunctionWithRetry(AsyncDataStream.OutputMode mode)
+            throws Exception {
+
+        StreamTaskMailboxTestHarnessBuilder<Integer> builder =
+                new StreamTaskMailboxTestHarnessBuilder<>(
+                                OneInputStreamTask::new, BasicTypeInfo.INT_TYPE_INFO)
+                        .addInput(BasicTypeInfo.INT_TYPE_INFO);
+
+        AsyncRetryStrategy exceptionRetryStrategy =
+                new AsyncRetryStrategies.FixedDelayRetryStrategyBuilder(5, 100L)
+                        .ifException(RetryPredicates.HAS_EXCEPTION_PREDICATE)
+                        .build();
+        AlwaysTimeoutWithDefaultValueAsyncFunction asyncFunction =
+                new AlwaysTimeoutWithDefaultValueAsyncFunction();
+
+        try (StreamTaskMailboxTestHarness<Integer> testHarness =
+                builder.setupOutputForSingletonOperatorChain(
+                                new AsyncWaitOperatorFactory<>(
+                                        asyncFunction, TIMEOUT, 10, mode, exceptionRetryStrategy))
+                        .build()) {
+
+            final long initialTime = 0L;
+            final Queue<Object> expectedOutput = new ArrayDeque<>();
+
+            testHarness.processElement(new StreamRecord<>(1, initialTime + 1));
+            testHarness.processElement(new StreamRecord<>(2, initialTime + 2));
+
+            expectedOutput.add(new StreamRecord<>(-1, initialTime + 1));
+            expectedOutput.add(new StreamRecord<>(-1, initialTime + 2));
+
+            Deadline deadline = Deadline.fromNow(Duration.ofSeconds(10));
+            while (testHarness.getOutput().size() < expectedOutput.size()
+                    && deadline.hasTimeLeft()) {
+                testHarness.processAll();
+                //noinspection BusyWait
+                Thread.sleep(100);
+            }
+
+            if (mode == AsyncDataStream.OutputMode.ORDERED) {
+                TestHarnessUtil.assertOutputEquals(
+                        "ORDERED Output was not correct.", expectedOutput, testHarness.getOutput());
+            } else {
+                TestHarnessUtil.assertOutputEqualsSorted(
+                        "UNORDERED Output was not correct.",
+                        expectedOutput,
+                        testHarness.getOutput(),
+                        new StreamRecordComparator());
+            }
+
+            // verify the elements' try count never beyond 2 (use <= instead of == to avoid unstable
+            // case when test machine under high load)
+            assertTrue(asyncFunction.getTryCount(1) <= 2);
+            assertTrue(asyncFunction.getTryCount(2) <= 2);
+        }
+    }
+
     private static class CollectableFuturesAsyncFunction<IN> implements AsyncFunction<IN, IN> {
 
         private static final long serialVersionUID = -4214078239227288637L;
@@ -1326,5 +1403,45 @@ public class AsyncWaitOperatorTest extends TestLogger {
                 new AsyncWaitOperatorFactory<>(
                         function, timeout, capacity, outputMode, asyncRetryStrategy),
                 IntSerializer.INSTANCE);
+    }
+
+    private static class AlwaysTimeoutWithDefaultValueAsyncFunction
+            extends RichAsyncFunction<Integer, Integer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private static Map<Integer, Integer> tryCounts = new HashMap<>();
+
+        @VisibleForTesting
+        public int getTryCount(Integer item) {
+            return tryCounts.getOrDefault(item, 0);
+        }
+
+        @Override
+        public void open(Configuration parameters) throws Exception {
+            super.open(parameters);
+            tryCounts = new HashMap<>();
+        }
+
+        @Override
+        public void asyncInvoke(Integer input, ResultFuture<Integer> resultFuture) {
+            tryCounts.merge(input, 1, Integer::sum);
+
+            CompletableFuture.runAsync(
+                    () -> {
+                        try {
+                            Thread.sleep(501L);
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                        resultFuture.completeExceptionally(new Exception("Dummy error"));
+                    });
+        }
+
+        @Override
+        public void timeout(Integer input, ResultFuture<Integer> resultFuture) {
+            // collect a default value -1 when timeout
+            resultFuture.complete(Collections.singletonList(-1));
+        }
     }
 }


### PR DESCRIPTION
This is a backport pr of FLINK-30477 to release-1.16