### PR TITLE
[FLINK-30837] Remove use of MutableByteArrayInputStream

### DIFF
--- a/flink-formats/flink-avro-glue-schema-registry/src/main/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryInputStreamDeserializer.java
+++ b/flink-formats/flink-avro-glue-schema-registry/src/main/java/org/apache/flink/formats/avro/glue/schema/registry/GlueSchemaRegistryInputStreamDeserializer.java
@@ -20,7 +20,6 @@ package org.apache.flink.formats.avro.glue.schema.registry;
 
 import org.apache.flink.annotation.PublicEvolving;
 import org.apache.flink.connector.aws.util.AWSGeneralUtil;
-import org.apache.flink.formats.avro.utils.MutableByteArrayInputStream;
 
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryDeserializationFacade;
 import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
@@ -73,12 +72,8 @@ public class GlueSchemaRegistryInputStreamDeserializer {
         in.read(inputBytes);
         in.reset();
 
-        MutableByteArrayInputStream mutableByteArrayInputStream = (MutableByteArrayInputStream) in;
         String schemaDefinition =
                 glueSchemaRegistryDeserializationFacade.getSchemaDefinition(inputBytes);
-        byte[] deserializedBytes =
-                glueSchemaRegistryDeserializationFacade.getActualData(inputBytes);
-        mutableByteArrayInputStream.setBuffer(deserializedBytes);
 
         Schema schema;
         try {


### PR DESCRIPTION
## What is the purpose of the change
Remove reference of MutableByteArrayInputStream from flink-avro-glue-schema-registry so that it can be made @Internal to flink-avro.

## Brief change log
- Remove use of MutableByteArrayInputStream


## Verifying this change
This change is already covered by existing tests, such as end-to-end tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
