### PR TITLE
[FLINK-30674] Enabling consume partial finished partition by default for speculative execution in hybrid shuffle mode

### DIFF
--- a/docs/layouts/shortcodes/generated/common_memory_section.html
+++ b/docs/layouts/shortcodes/generated/common_memory_section.html
@@ -78,7 +78,7 @@
             <td><h5>taskmanager.memory.framework.off-heap.batch-shuffle.size</h5></td>
             <td style="word-wrap: break-word;">64 mb</td>
             <td>MemorySize</td>
-            <td>Size of memory used by blocking shuffle for shuffle data read (currently only used by sort-shuffle and hybrid shuffle). Notes: 1) The memory is cut from 'taskmanager.memory.framework.off-heap.size' so must be smaller than that, which means you may also need to increase 'taskmanager.memory.framework.off-heap.size' after you increase this config value; 2) This memory size can influence the shuffle performance and you can increase this config value for large-scale batch jobs (for example, to 128M or 256M).</td>
+            <td>Size of memory used by batch shuffle for shuffle data read (currently only used by sort-shuffle and hybrid shuffle). Notes: 1) The memory is cut from 'taskmanager.memory.framework.off-heap.size' so must be smaller than that, which means you may also need to increase 'taskmanager.memory.framework.off-heap.size' after you increase this config value; 2) This memory size can influence the shuffle performance and you can increase this config value for large-scale batch jobs (for example, to 128M or 256M).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.framework.off-heap.size</h5></td>

--- a/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
+++ b/docs/layouts/shortcodes/generated/task_manager_memory_configuration.html
@@ -24,7 +24,7 @@
             <td><h5>taskmanager.memory.framework.off-heap.batch-shuffle.size</h5></td>
             <td style="word-wrap: break-word;">64 mb</td>
             <td>MemorySize</td>
-            <td>Size of memory used by blocking shuffle for shuffle data read (currently only used by sort-shuffle and hybrid shuffle). Notes: 1) The memory is cut from 'taskmanager.memory.framework.off-heap.size' so must be smaller than that, which means you may also need to increase 'taskmanager.memory.framework.off-heap.size' after you increase this config value; 2) This memory size can influence the shuffle performance and you can increase this config value for large-scale batch jobs (for example, to 128M or 256M).</td>
+            <td>Size of memory used by batch shuffle for shuffle data read (currently only used by sort-shuffle and hybrid shuffle). Notes: 1) The memory is cut from 'taskmanager.memory.framework.off-heap.size' so must be smaller than that, which means you may also need to increase 'taskmanager.memory.framework.off-heap.size' after you increase this config value; 2) This memory size can influence the shuffle performance and you can increase this config value for large-scale batch jobs (for example, to 128M or 256M).</td>
         </tr>
         <tr>
             <td><h5>taskmanager.memory.framework.off-heap.size</h5></td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/TaskManagerOptions.java
@@ -580,8 +580,8 @@ public class TaskManagerOptions {
                                     + "Can be used to avoid constant back and forth small adjustments.");
 
     /**
-     * Size of direct memory used by blocking shuffle for shuffle data read (currently only used by
-     * sort-shuffle).
+     * Size of direct memory used by batch shuffle for shuffle data read (currently only used by
+     * sort-shuffle and hybrid shuffle).
      */
     @Documentation.Section(Documentation.Sections.COMMON_MEMORY)
     public static final ConfigOption<MemorySize> NETWORK_BATCH_SHUFFLE_READ_MEMORY =
@@ -590,7 +590,7 @@ public class TaskManagerOptions {
                     .defaultValue(MemorySize.parse("64m"))
                     .withDescription(
                             String.format(
-                                    "Size of memory used by blocking shuffle for shuffle data read "
+                                    "Size of memory used by batch shuffle for shuffle data read "
                                             + "(currently only used by sort-shuffle and hybrid shuffle)."
                                             + " Notes: 1) The memory is cut from '%s' so must be smaller than"
                                             + " that, which means you may also need to increase '%s' "

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateSpecUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateSpecUtils.java
@@ -84,6 +84,10 @@ public class InputGateSpecUtils {
         return configuredMaxRequiredBuffersPerGate.orElseGet(
                 () ->
                         partitionType.isPipelinedOrPipelinedBoundedResultPartition()
+                                        // hybrid partition may calculate a backlog that is larger
+                                        // than the accurate value. If all buffers are floating, it
+                                        // will seriously affect the performance.
+                                        || partitionType.isHybridResultPartition()
                                 ? DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM
                                 : DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateSpecUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/InputGateSpecUtils.java
@@ -27,7 +27,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /** Utils to manage the specs of the {@link InputGate}, for example, {@link GateBuffersSpec}. */
-public class InputGateSpecUitls {
+public class InputGateSpecUtils {
 
     public static final int DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH = 1000;
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateFactory.java
@@ -56,7 +56,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Optional;
 
-import static org.apache.flink.runtime.io.network.partition.consumer.InputGateSpecUitls.createGateBuffersSpec;
+import static org.apache.flink.runtime.io.network.partition.consumer.InputGateSpecUtils.createGateBuffersSpec;
 import static org.apache.flink.runtime.shuffle.ShuffleUtils.applyWithShuffleTypeCheck;
 
 /** Factory for {@link SingleInputGate} to use in {@link NettyShuffleEnvironment}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/shuffle/NettyShuffleUtils.java
@@ -28,7 +28,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.apache.flink.runtime.io.network.partition.consumer.InputGateSpecUitls.createGateBuffersSpec;
+import static org.apache.flink.runtime.io.network.partition.consumer.InputGateSpecUtils.createGateBuffersSpec;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.apache.flink.util.Preconditions.checkState;
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/GateBuffersSpecTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/GateBuffersSpecTest.java
@@ -27,7 +27,7 @@ import org.junit.runners.Parameterized;
 
 import java.util.Optional;
 
-import static org.apache.flink.runtime.io.network.partition.consumer.InputGateSpecUitls.getEffectiveMaxRequiredBuffersPerGate;
+import static org.apache.flink.runtime.io.network.partition.consumer.InputGateSpecUtils.getEffectiveMaxRequiredBuffersPerGate;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Tests for {@link GateBuffersSpec}. */
@@ -146,8 +146,8 @@ class GateBuffersSpecTest {
                 getEffectiveMaxRequiredBuffersPerGate(partitionType, emptyConfig);
         int expectEffectiveMaxRequiredBuffers =
                 isPipelineResultPartition(partitionType)
-                        ? InputGateSpecUitls.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM
-                        : InputGateSpecUitls.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH;
+                        ? InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM
+                        : InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH;
         assertThat(effectiveMaxRequiredBuffers).isEqualTo(expectEffectiveMaxRequiredBuffers);
 
         Optional<Integer> configuredMaxRequiredBuffers = Optional.of(100);
@@ -179,7 +179,7 @@ class GateBuffersSpecTest {
             int numInputChannels,
             ResultPartitionType partitionType,
             int numExclusiveBuffersPerChannel) {
-        return InputGateSpecUitls.createGateBuffersSpec(
+        return InputGateSpecUtils.createGateBuffersSpec(
                 getMaxRequiredBuffersPerGate(partitionType),
                 numExclusiveBuffersPerChannel,
                 8,
@@ -190,8 +190,8 @@ class GateBuffersSpecTest {
     private static Optional<Integer> getMaxRequiredBuffersPerGate(
             ResultPartitionType partitionType) {
         return isPipelineResultPartition(partitionType)
-                ? Optional.of(InputGateSpecUitls.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM)
-                : Optional.of(InputGateSpecUitls.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH);
+                ? Optional.of(InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM)
+                : Optional.of(InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH);
     }
 
     private static boolean isPipelineResultPartition(ResultPartitionType partitionType) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/GateBuffersSpecTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/GateBuffersSpecTest.java
@@ -63,10 +63,10 @@ class GateBuffersSpecTest {
         int numInputChannels = 500;
         GateBuffersSpec gateBuffersSpec = createGateBuffersSpec(numInputChannels, partitionType);
 
-        boolean isPipeline = isPipelineResultPartition(partitionType);
+        boolean isPipeline = isPipelinedOrHybridResultPartition(partitionType);
         int minFloating = isPipeline ? 1 : 500;
-        int maxFloating = isPipelineResultPartition(partitionType) ? 8 : 508;
-        int numExclusivePerChannel = isPipelineResultPartition(partitionType) ? 2 : 1;
+        int maxFloating = isPipelinedOrHybridResultPartition(partitionType) ? 8 : 508;
+        int numExclusivePerChannel = isPipelinedOrHybridResultPartition(partitionType) ? 2 : 1;
         int targetTotalBuffersPerGate = 1008;
 
         checkBuffersInGate(
@@ -84,8 +84,8 @@ class GateBuffersSpecTest {
         GateBuffersSpec gateBuffersSpec = createGateBuffersSpec(numInputChannels, partitionType);
 
         int minFloating = 1;
-        int maxFloating = isPipelineResultPartition(partitionType) ? 8 : 1007;
-        int numExclusivePerChannel = isPipelineResultPartition(partitionType) ? 2 : 1;
+        int maxFloating = isPipelinedOrHybridResultPartition(partitionType) ? 8 : 1007;
+        int numExclusivePerChannel = isPipelinedOrHybridResultPartition(partitionType) ? 2 : 1;
         int targetTotalBuffersPerGate = 2006;
 
         checkBuffersInGate(
@@ -102,7 +102,7 @@ class GateBuffersSpecTest {
         int numInputChannels = 1000;
         GateBuffersSpec gateBuffersSpec = createGateBuffersSpec(numInputChannels, partitionType);
 
-        boolean isPipeline = isPipelineResultPartition(partitionType);
+        boolean isPipeline = isPipelinedOrHybridResultPartition(partitionType);
         int minFloating = isPipeline ? 1 : 1000;
         int maxFloating = isPipeline ? 8 : numInputChannels * 2 + 8;
         int numExclusivePerChannel = isPipeline ? 2 : 0;
@@ -145,7 +145,7 @@ class GateBuffersSpecTest {
         int effectiveMaxRequiredBuffers =
                 getEffectiveMaxRequiredBuffersPerGate(partitionType, emptyConfig);
         int expectEffectiveMaxRequiredBuffers =
-                isPipelineResultPartition(partitionType)
+                isPipelinedOrHybridResultPartition(partitionType)
                         ? InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM
                         : InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH;
         assertThat(effectiveMaxRequiredBuffers).isEqualTo(expectEffectiveMaxRequiredBuffers);
@@ -189,12 +189,13 @@ class GateBuffersSpecTest {
 
     private static Optional<Integer> getMaxRequiredBuffersPerGate(
             ResultPartitionType partitionType) {
-        return isPipelineResultPartition(partitionType)
+        return isPipelinedOrHybridResultPartition(partitionType)
                 ? Optional.of(InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM)
                 : Optional.of(InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH);
     }
 
-    private static boolean isPipelineResultPartition(ResultPartitionType partitionType) {
-        return partitionType.isPipelinedOrPipelinedBoundedResultPartition();
+    private static boolean isPipelinedOrHybridResultPartition(ResultPartitionType partitionType) {
+        return partitionType.isPipelinedOrPipelinedBoundedResultPartition()
+                || partitionType.isHybridResultPartition();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/consumer/SingleInputGateTest.java
@@ -1223,9 +1223,9 @@ public class SingleInputGateTest extends InputGateTestBase {
         Optional<Integer> expectMaxRequiredBuffersPerGate =
                 isPipeline
                         ? Optional.of(
-                                InputGateSpecUitls.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM)
+                                InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_STREAM)
                         : Optional.of(
-                                InputGateSpecUitls.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH);
+                                InputGateSpecUtils.DEFAULT_MAX_REQUIRED_BUFFERS_PER_GATE_FOR_BATCH);
         nettyShuffleEnvironmentBuilder.setMaxRequiredBuffersPerGate(
                 expectMaxRequiredBuffersPerGate);
         NettyShuffleEnvironment netEnv = nettyShuffleEnvironmentBuilder.build();


### PR DESCRIPTION
## What is the purpose of the change

*At present, if hybrid shuffle enabled speculative execution, it will only consume all finished partition by default. It is better to change this default behavior to consume partial finished upstream partition.*


## Brief change log

  - *Enabling consume partial finished partition by default for speculative execution in hybrid shuffle mode.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
