### PR TITLE
[FLINK-29427][table] Fix unstable test LookupJoinITCase by compiling Projection class in advance and run reload task using userCodeClassLoader

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/CachingLookupFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/CachingLookupFunction.java
@@ -105,6 +105,8 @@ public class CachingLookupFunction extends LookupFunction {
             cacheMetricGroup.loadCounter(loadCounter);
             numLoadFailuresCounter = new SimpleCounter();
             cacheMetricGroup.numLoadFailuresCounter(numLoadFailuresCounter);
+        } else {
+            initializeFullCache(((LookupFullCache) cache), context);
         }
         // Initialize cache and the delegating function
         cache.open(cacheMetricGroup);
@@ -176,5 +178,9 @@ public class CachingLookupFunction extends LookupFunction {
             cacheMetricGroup.latestLoadTimeGauge(() -> latestLoadTime);
         }
         latestLoadTime = loadTime;
+    }
+
+    private void initializeFullCache(LookupFullCache lookupFullCache, FunctionContext context) {
+        lookupFullCache.setUserCodeClassLoader(context.getUserCodeClassLoader());
     }
 }

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/inputformat/InputFormatCacheLoader.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/table/lookup/fullcache/inputformat/InputFormatCacheLoader.java
@@ -65,8 +65,8 @@ public class InputFormatCacheLoader extends CacheLoader {
     }
 
     @Override
-    public void open(Configuration parameters) throws Exception {
-        super.open(parameters);
+    public void open(Configuration parameters, ClassLoader userCodeClassLoader) throws Exception {
+        super.open(parameters, userCodeClassLoader);
         this.parameters = parameters;
         this.initialInputFormat.configure(parameters);
     }

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/LookupFullCacheTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/LookupFullCacheTest.java
@@ -162,6 +162,8 @@ public class LookupFullCacheTest {
                         runAsync(
                                 ThrowingRunnable.unchecked(
                                         () -> {
+                                            cache.setUserCodeClassLoader(
+                                                    Thread.currentThread().getContextClassLoader());
                                             cache.open(metricGroup);
                                         }),
                                 executor);
@@ -203,6 +205,7 @@ public class LookupFullCacheTest {
         LookupFullCache fullCache = new LookupFullCache(cacheLoader, reloadTrigger);
         assertThat(cacheLoader.isAwaitTriggered()).isFalse();
         assertThat(cacheLoader.getNumLoads()).isZero();
+        fullCache.setUserCodeClassLoader(Thread.currentThread().getContextClassLoader());
         fullCache.open(metricGroup);
         assertThat(cacheLoader.isAwaitTriggered()).isTrue();
         assertThat(cacheLoader.getNumLoads()).isEqualTo(1);

--- a/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/inputformat/InputFormatCacheLoaderTest.java
+++ b/flink-table/flink-table-runtime/src/test/java/org/apache/flink/table/runtime/functions/table/fullcache/inputformat/InputFormatCacheLoaderTest.java
@@ -241,7 +241,7 @@ class InputFormatCacheLoaderTest {
                         generatedProjection);
         InputFormatCacheLoader cacheLoader =
                 new InputFormatCacheLoader(inputFormat, keySelector, rightRowSerializer);
-        cacheLoader.open(new Configuration());
+        cacheLoader.open(new Configuration(), Thread.currentThread().getContextClassLoader());
         return cacheLoader;
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

> The analysis below was initially made by @SmirAlex in #21365

This pull-request *tries to fix* unstable test `LookupJoinITCase` (error was not succeeded to be reproduced locally). An error contains the message 'Trying to access closed classloader'. However, test configured in the way that it loads cache only one time, and we wait until the end of this load in `LookupFullCache#open`. So `LookupFullCache#close` shouldn't somehow affect on cache load thread, if we assume that `close` is called only after `open`. 

During debugging it was found out that in `GenericRowDataKeySelector#open`, which executes inside separate reload thread, call of `Thread.currentThread().getContextClassLoader()` returns `SubmoduleClassLoader` rather than `FlinkUserCodeClassLoader`, which is being returned from the same method inside main thread. *Probably*, this ClassLoader should not be there, and this is the core of the problem. Also it closely relates to the problem about classloader leak, described in option `CoreOptions#CHECK_LEAKED_CLASSLOADER`, to which error points out. 

This change prevents from compiling a class in another separate thread, but rather do it just one time in main thread in `LookupFullCache#open` using provided userCodeClassLoader. Subsequent calls of `GeneratedProjection#newInstance` will end up with creating an instance from cached `Class<Projection>` without compilation or another interaction with context classloader. Note, that provided classloader is not stored anywhere, so classloader leak problem can't occur anymore.


## Brief change log

  - Compile Projection Class in main thread in `LookupFullCache#open` to avoid classloader leak
  - Set context classloader to UserCodeClassLoader in `InputSplitCacheLoadTask`


## Verifying this change

 - This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
