### PR TITLE
[FLINK-28440][state/changelog] record reference count of StreamStateHandle in TaskChangelogRegistry

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -288,9 +288,9 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
                             } else {
                                 // uploaded already truncated, i.e. materialized state changes,
                                 // or closed
-                                changelogRegistry.notUsed(result.streamStateHandle, logId);
+                                changelogRegistry.release(result.streamStateHandle);
                                 if (result.localStreamHandle != null) {
-                                    changelogRegistry.notUsed(result.localStreamHandle, logId);
+                                    changelogRegistry.release(result.localStreamHandle);
                                 }
                             }
                         }
@@ -517,9 +517,9 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
     private void notifyStateNotUsed(Map<SequenceNumber, UploadResult> notUsedState) {
         LOG.trace("Uploaded state to discard: {}", notUsedState);
         for (UploadResult result : notUsedState.values()) {
-            changelogRegistry.notUsed(result.streamStateHandle, logId);
+            changelogRegistry.release(result.streamStateHandle);
             if (result.localStreamHandle != null) {
-                changelogRegistry.notUsed(result.localStreamHandle, logId);
+                changelogRegistry.release(result.localStreamHandle);
             }
         }
     }

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/DiscardRecordableStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/DiscardRecordableStateChangeUploader.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.changelog.fs.StateChangeUploadScheduler.UploadTask;
+import org.apache.flink.runtime.state.StreamStateHandle;
+import org.apache.flink.runtime.state.TestingStreamStateHandle;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * {@link StateChangeUploader} implementation which can verify that the returned StreamStateHandle
+ * was deleted.
+ */
+public class DiscardRecordableStateChangeUploader implements StateChangeUploader {
+    private final TaskChangelogRegistry changelogRegistry;
+
+    public DiscardRecordableStateChangeUploader(TaskChangelogRegistry changelogRegistry) {
+        this.changelogRegistry = changelogRegistry;
+    }
+
+    @Override
+    public UploadTasksResult upload(Collection<UploadTask> tasks) throws IOException {
+        Map<UploadTask, Map<StateChangeSet, Tuple2<Long, Long>>> tasksOffsets = new HashMap<>();
+
+        for (UploadTask task : tasks) {
+            Map<StateChangeSet, Tuple2<Long, Long>> offsets = new HashMap<>();
+            for (StateChangeSet changeSet : task.getChangeSets()) {
+                offsets.put(changeSet, Tuple2.of(0L, 0L)); // fake offsets
+            }
+            tasksOffsets.put(task, offsets);
+        }
+
+        long numOfChangeSets = tasks.stream().flatMap(t -> t.getChangeSets().stream()).count();
+
+        // fake StreamStateHandle without data, just for discarding records
+        StreamStateHandle handle = new TestingStreamStateHandle();
+        changelogRegistry.startTracking(handle, numOfChangeSets);
+        return new UploadTasksResult(tasksOffsets, handle);
+    }
+
+    public boolean isDiscarded(StreamStateHandle handle) {
+        if (handle instanceof TestingStreamStateHandle) {
+            return ((TestingStreamStateHandle) handle).isDisposed();
+        } else {
+            throw new IllegalStateException(
+                    "only accept StreamStateHandle created by DiscardRecordableStateChangeUploader");
+        }
+    }
+
+    @Override
+    public void close() throws Exception {}
+}

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterTest.java
@@ -17,13 +17,16 @@
 
 package org.apache.flink.changelog.fs;
 
+import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.mailbox.SyncMailboxExecutor;
 import org.apache.flink.runtime.state.KeyGroupRange;
 import org.apache.flink.runtime.state.SnapshotResult;
+import org.apache.flink.runtime.state.StreamStateHandle;
 import org.apache.flink.runtime.state.TestLocalRecoveryConfig;
 import org.apache.flink.runtime.state.changelog.ChangelogStateHandleStreamImpl;
 import org.apache.flink.runtime.state.changelog.LocalChangelogRegistry;
 import org.apache.flink.runtime.state.changelog.SequenceNumber;
+import org.apache.flink.util.concurrent.Executors;
 import org.apache.flink.util.function.BiConsumerWithException;
 
 import org.junit.jupiter.api.Test;
@@ -104,6 +107,143 @@ class FsStateChangelogWriterTest {
                     writer.persist(sqn);
                     assertNoUpload(uploader, "confirmed changes shouldn't be re-uploaded");
                 });
+    }
+
+    @Test
+    void testFileAvailableAfterPreUpload() throws Exception {
+        long appendPersistThreshold = 100;
+
+        TaskChangelogRegistry taskChangelogRegistry =
+                new TaskChangelogRegistryImpl(Executors.directExecutor());
+
+        try (DiscardRecordableStateChangeUploader uploader =
+                        new DiscardRecordableStateChangeUploader(taskChangelogRegistry);
+                TestingBatchingUploadScheduler uploadScheduler =
+                        new TestingBatchingUploadScheduler(uploader);
+                FsStateChangelogWriter writer =
+                        new FsStateChangelogWriter(
+                                UUID.randomUUID(),
+                                KeyGroupRange.of(KEY_GROUP, KEY_GROUP),
+                                uploadScheduler,
+                                appendPersistThreshold,
+                                new SyncMailboxExecutor(),
+                                taskChangelogRegistry,
+                                TestLocalRecoveryConfig.disabled(),
+                                LocalChangelogRegistry.NO_OP)) {
+            SequenceNumber initialSqn = writer.initialSequenceNumber();
+
+            writer.append(KEY_GROUP, getBytes(10)); // sqn: 0
+
+            // checkpoint 1 trigger
+            SequenceNumber checkpoint1sqn = writer.nextSequenceNumber();
+            writer.persist(initialSqn);
+            uploadScheduler.scheduleAll(); // checkpoint 1 completed
+            writer.confirm(initialSqn, checkpoint1sqn, 1);
+
+            writer.append(KEY_GROUP, getBytes(10)); // sqn: 1
+
+            // materialization 1 trigger
+            SequenceNumber materializationSqn = writer.nextSequenceNumber();
+
+            writer.append(KEY_GROUP, getBytes(10)); // sqn: 2
+
+            // materialization 1 completed
+            // checkpoint 2 trigger
+            SequenceNumber checkpoint2sqn = writer.nextSequenceNumber();
+            writer.persist(materializationSqn);
+            uploadScheduler.scheduleAll(); // checkpoint 2 completed
+            writer.confirm(materializationSqn, checkpoint2sqn, 2);
+
+            // checkpoint 1 subsumed
+            writer.truncate(
+                    materializationSqn.compareTo(checkpoint1sqn) < 0
+                            ? materializationSqn
+                            : checkpoint1sqn);
+
+            writer.append(KEY_GROUP, getBytes(10)); // sqn: 3
+
+            // checkpoint 3 trigger
+            SequenceNumber checkpoint3sqn = writer.nextSequenceNumber();
+            writer.persist(materializationSqn);
+            uploadScheduler.scheduleAll(); // checkpoint 3 completed
+            writer.confirm(materializationSqn, checkpoint3sqn, 3);
+
+            // trigger pre-emptive upload
+            writer.append(KEY_GROUP, getBytes(100)); // sqn: 4
+            uploadScheduler.scheduleAll();
+
+            // checkpoint 2 subsumed
+            writer.truncate(
+                    materializationSqn.compareTo(checkpoint2sqn) < 0
+                            ? materializationSqn
+                            : checkpoint2sqn);
+
+            // checkpoint 4 trigger
+            SequenceNumber checkpoint4sqn = writer.nextSequenceNumber();
+            CompletableFuture<SnapshotResult<ChangelogStateHandleStreamImpl>> future =
+                    writer.persist(materializationSqn);
+            uploadScheduler.scheduleAll(); // checkpoint 4 completed
+            writer.confirm(materializationSqn, checkpoint4sqn, 4);
+
+            SnapshotResult<ChangelogStateHandleStreamImpl> result = future.get();
+            ChangelogStateHandleStreamImpl resultHandle = result.getJobManagerOwnedSnapshot();
+
+            for (Tuple2<StreamStateHandle, Long> handleAndOffset :
+                    resultHandle.getHandlesAndOffsets()) {
+                assertThat(uploader.isDiscarded(handleAndOffset.f0))
+                        .isFalse(); // all handles should not be discarded
+            }
+        }
+    }
+
+    @Test
+    void testFileAvailableAfterClose() throws Exception {
+        long appendPersistThreshold = 100;
+
+        TaskChangelogRegistry taskChangelogRegistry =
+                new TaskChangelogRegistryImpl(Executors.directExecutor());
+
+        try (DiscardRecordableStateChangeUploader uploader =
+                        new DiscardRecordableStateChangeUploader(taskChangelogRegistry);
+                TestingBatchingUploadScheduler uploadScheduler =
+                        new TestingBatchingUploadScheduler(uploader)) {
+            FsStateChangelogWriter writer =
+                    new FsStateChangelogWriter(
+                            UUID.randomUUID(),
+                            KeyGroupRange.of(KEY_GROUP, KEY_GROUP),
+                            uploadScheduler,
+                            appendPersistThreshold,
+                            new SyncMailboxExecutor(),
+                            taskChangelogRegistry,
+                            TestLocalRecoveryConfig.disabled(),
+                            LocalChangelogRegistry.NO_OP);
+
+            SequenceNumber initialSqn = writer.initialSequenceNumber();
+
+            writer.append(KEY_GROUP, getBytes(10)); // sqn: 0
+
+            // checkpoint 1 trigger
+            SequenceNumber checkpoint1sqn = writer.nextSequenceNumber();
+            CompletableFuture<SnapshotResult<ChangelogStateHandleStreamImpl>> future =
+                    writer.persist(initialSqn);
+
+            // trigger pre-emptive upload
+            writer.append(KEY_GROUP, getBytes(100)); // sqn: 1
+
+            uploadScheduler.scheduleAll(); // checkpoint 1 completed
+
+            // close task before confirm checkpoint 1
+            writer.truncateAndClose(checkpoint1sqn);
+
+            SnapshotResult<ChangelogStateHandleStreamImpl> result = future.get();
+            ChangelogStateHandleStreamImpl resultHandle = result.getJobManagerOwnedSnapshot();
+
+            for (Tuple2<StreamStateHandle, Long> handleAndOffset :
+                    resultHandle.getHandlesAndOffsets()) {
+                assertThat(uploader.isDiscarded(handleAndOffset.f0))
+                        .isFalse(); // all handles should not be discarded
+            }
+        }
     }
 
     @Test

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingBatchingUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/TestingBatchingUploadScheduler.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.changelog.fs;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.Queue;
+
+/** Implementation class for {@link StateChangeUploadScheduler} to test. */
+class TestingBatchingUploadScheduler implements StateChangeUploadScheduler {
+    private final Queue<UploadTask> tasks;
+    private final StateChangeUploader uploader;
+
+    public TestingBatchingUploadScheduler(StateChangeUploader uploader) {
+        this.tasks = new LinkedList<>();
+        this.uploader = uploader;
+    }
+
+    @Override
+    public void upload(UploadTask uploadTask) throws IOException {
+        tasks.add(uploadTask);
+    }
+
+    public void scheduleAll() throws IOException {
+        if (tasks.size() > 0) {
+            uploader.upload(tasks).complete();
+        }
+        tasks.clear();
+    }
+
+    @Override
+    public void close() throws Exception {
+        tasks.clear();
+        uploader.close();
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Fix state changelog file not found exception decripted in [FLINK-28440
](https://issues.apache.org/jira/browse/FLINK-28440)

## Brief change log
  - record reference count of *StreamStateHandle* in *TaskChangelogRegistry*
  - when *UploadResult* not used, decrement the reference count of the corresponding *StreamStateHandle* by one
  - delete the *StreamStateHandle* after the reference count is zeroed


## Verifying this change
This change added tests and can be verified as follows:
  - FsStateChangelogWriterTest#testChangelogFileAvailable
  - FsStateChangelogWriterTest#testChangelogFileAvailableAgain

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

