### PR TITLE
[FLINK-28326][test] fix unstable test testIdleAndBackPressuredTime.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionTest.java
@@ -399,6 +399,10 @@ class ResultPartitionTest {
         while (!isInBlockingBufferRequest(requestThread.getStackTrace())) {
             Thread.sleep(50);
         }
+        // there is an extreme case where the request thread recovers from blocking very
+        // quickly, resulting in a calculated back-pressure time is equal to 0. This is used to
+        // avoid this case.
+        Thread.sleep(5);
         // recycle the buffer
         buffer.recycleBuffer();
         requestThread.join();


### PR DESCRIPTION
## What is the purpose of the change

*Through the previous fix, we can ensure that the request thread must be blocked before the main thread recycle the buffer. However, there is still an extreme case where the request thread recovers from blocking very quickly, resulting in a calculated back-pressure time is equal to 0.*


## Brief change log

  - *fix unstable test testIdleAndBackPressuredTime.*

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
