### PR TITLE
[BP-1.15][FLINK-30462][runtime] The leader session ID is now saved properly

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -192,7 +192,10 @@ public class DefaultMultipleComponentLeaderElectionService
                 return;
             }
 
-            currentLeaderSessionId = UUID.randomUUID();
+            Preconditions.checkState(
+                    currentLeaderSessionId == null,
+                    "notLeader() wasn't called by the LeaderElection backend before assigning leadership to this LeaderElectionService.");
+            currentLeaderSessionId = newLeaderSessionId;
 
             forEachLeaderElectionEventHandler(
                     leaderElectionEventHandler ->


### PR DESCRIPTION
Previous to this fix, different components could have used different session IDs even though they belonged to the same session.

1.15 backport PR of parent PR https://github.com/apache/flink/pull/21537