### PR TITLE
[BP-1.15][FLINK-30474][runtime] Propagates leader information change only if the leadership is still acquired

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -245,7 +245,13 @@ public class DefaultMultipleComponentLeaderElectionService
             LeaderElectionEventHandler leaderElectionEventHandler,
             LeaderInformation leaderInformation) {
         leadershipOperationExecutor.execute(
-                () -> leaderElectionEventHandler.onLeaderInformationChange(leaderInformation));
+                () -> {
+                    synchronized (lock) {
+                        if (running && multipleComponentLeaderElectionDriver.hasLeadership()) {
+                            leaderElectionEventHandler.onLeaderInformationChange(leaderInformation);
+                        }
+                    }
+                });
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionServiceTest.java
@@ -33,7 +33,9 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -116,6 +118,108 @@ class DefaultMultipleComponentLeaderElectionServiceTest {
             for (SimpleTestingLeaderElectionEventListener eventListener : eventListeners) {
                 assertThat(eventListener.hasLeadership()).isFalse();
             }
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    @Test
+    public void testLeaderInformationChangeOnlyCalledOnLeaderForSingleComponent() throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            final SimpleTestingLeaderElectionEventListener leaderElectionEventHandler =
+                    new SimpleTestingLeaderElectionEventListener();
+            final String componentId = "test-component";
+            leaderElectionService.registerLeaderElectionEventHandler(
+                    componentId, leaderElectionEventHandler);
+
+            final LeaderInformation leaderInformation =
+                    LeaderInformation.known(UUID.randomUUID(), "leader-address");
+            leaderElectionService.notifyLeaderInformationChange(componentId, leaderInformation);
+
+            assertThat(leaderElectionEventHandler.getLeaderInformation())
+                    .as(
+                            "The leader information should not be updated because the leadership was not acquired, yet.")
+                    .isNull();
+
+            leaderElectionDriver.grantLeadership();
+
+            assertThat(leaderElectionEventHandler.getLeaderInformation())
+                    .as(
+                            "The leader information should not be updated because no change event was triggered after the leadership was granted.")
+                    .isNull();
+
+            leaderElectionService.notifyLeaderInformationChange(componentId, leaderInformation);
+
+            assertThat(leaderElectionEventHandler.getLeaderInformation())
+                    .isEqualTo(leaderInformation);
+        } finally {
+            leaderElectionService.close();
+        }
+    }
+
+    @Test
+    public void testLeaderInformationChangeOnlyCalledOnLeaderForAllKnownComponents()
+            throws Exception {
+        final TestingMultipleComponentLeaderElectionDriver leaderElectionDriver =
+                TestingMultipleComponentLeaderElectionDriver.newBuilder().build();
+
+        final DefaultMultipleComponentLeaderElectionService leaderElectionService =
+                createDefaultMultiplexingLeaderElectionService(leaderElectionDriver);
+
+        try {
+            final String componentWithChangeId = "component-with-change";
+            final SimpleTestingLeaderElectionEventListener componentWithChangeListener =
+                    new SimpleTestingLeaderElectionEventListener();
+            final String componentWithoutChangeId = "component-without-change";
+            final SimpleTestingLeaderElectionEventListener componentWithoutChangeListener =
+                    new SimpleTestingLeaderElectionEventListener();
+
+            final Map<String, SimpleTestingLeaderElectionEventListener> listeners = new HashMap<>();
+            listeners.put(componentWithChangeId, componentWithChangeListener);
+            listeners.put(componentWithoutChangeId, componentWithoutChangeListener);
+
+            listeners.forEach(leaderElectionService::registerLeaderElectionEventHandler);
+
+            final LeaderInformation leaderInformation =
+                    LeaderInformation.known(UUID.randomUUID(), "leader-address");
+            final Collection<LeaderInformationWithComponentId> componentsWithChange =
+                    Collections.singleton(
+                            LeaderInformationWithComponentId.create(
+                                    componentWithChangeId, leaderInformation));
+            leaderElectionService.notifyAllKnownLeaderInformation(componentsWithChange);
+
+            assertThat(listeners)
+                    .allSatisfy(
+                            (componentId, listener) ->
+                                    assertThat(listener.getLeaderInformation())
+                                            .as(
+                                                    "The leader information should not be updated for %s because the leadership was not acquired, yet.",
+                                                    componentId)
+                                            .isNull());
+
+            leaderElectionDriver.grantLeadership();
+
+            assertThat(listeners)
+                    .allSatisfy(
+                            (componentId, listener) ->
+                                    assertThat(listener.getLeaderInformation())
+                                            .as(
+                                                    "The leader information should not be updated for %s because no change event was triggered after the leadership was granted.",
+                                                    componentId)
+                                            .isNull());
+
+            leaderElectionService.notifyAllKnownLeaderInformation(componentsWithChange);
+
+            assertThat(componentWithChangeListener.getLeaderInformation())
+                    .isEqualTo(leaderInformation);
+            assertThat(componentWithoutChangeListener.getLeaderInformation())
+                    .isEqualTo(LeaderInformation.empty());
         } finally {
             leaderElectionService.close();
         }


### PR DESCRIPTION
LeaderElectionEventHandler.onLeaderInformationChange should only be called if the handler (i.e. DefaultLeaderElectionService) is actually the leader. This check is already implemented in the corresponding calling methods of the MultipleComponentLeaderElectionDriver implementations. But these methods only schedule the logic rather than executing it right away. The execution is handled in a separate thread (i.e. DefaultMultipleComponentLeaderElectionService#leadershipOperationExecutor). That might create a race condition if a leader change is queued up already but not performed, yet, before the leader information change event gets queued up as well.

1.15 backport PR of parent PR #21537