### PR TITLE
[FLINK-29859][e2e] Add new allowed exceptions in logs for speculative execution e2e

### DIFF
--- a/flink-end-to-end-tests/test-scripts/test_tpcds.sh
+++ b/flink-end-to-end-tests/test-scripts/test_tpcds.sh
@@ -113,7 +113,9 @@ function check_logs_for_exceptions_for_adaptive_batch_scheduler {
     local additional_allowed_exceptions=("ExecutionGraphException: The execution attempt" \
     "Cannot find task to fail for execution" \
     "ExceptionInChainedOperatorException: Could not forward element to next operator" \
-    "CancelTaskException: Buffer pool has already been destroyed")
+    "CancelTaskException: Buffer pool has already been destroyed" \
+    "java.nio.channels.ClosedChannelException" \
+    "java.lang.IllegalStateException: File writer is already closed")
 
     internal_check_logs_for_exceptions "${additional_allowed_exceptions[@]}"
 }


### PR DESCRIPTION
## What is the purpose of the change
Add 2 more allowed exceptions in logs for speculative execution:
1. `java.nio.channels.ClosedChannelException`
2. `java.lang.IllegalStateException: File writer is already closed`

Both of these exceptions are caused by cancelling task:
1. The `java.nio.channels.ClosedChannelException` is because `IOManagerAsync` has an async reader thread, and the async reader thread has not completely exited when the main thead close the file
2. The `java.lang.IllegalStateException: File writer is already closed` is because the partition file was closed during writing. Currently in Flink, deploying a task and then immediately canceling it, the "cancel" may arrive before "deploy" because "cancel" and "deploy" are sent in two different threads. In this case, the JM thinks the task has been canceled, but the task deployment then reaches the TM and starts running the task. Then JM sends a release partitions call (because JM thinks the task is canceled), but at this time the task is running on TM, which will cause this exception.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
