### PR TITLE
[hotfix][table-planner] Fix ITCase IOException due to network buffer insufficient while the default parallelism don't set manually in test

### DIFF
--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/sql/join/JoinReorderITCase.java
@@ -19,7 +19,6 @@
 package org.apache.flink.table.planner.runtime.stream.sql.join;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.EnvironmentSettings;
@@ -33,7 +32,6 @@ import org.apache.flink.table.planner.utils.JavaScalaConversionUtil;
 import org.apache.flink.types.Row;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,14 +44,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JoinReorderITCase extends JoinReorderITCaseBase {
 
     private StreamExecutionEnvironment env;
-
-    @BeforeEach
-    public void before() throws Exception {
-        super.before();
-        // This conf is aims to fix IOException due to timeout occurring while requesting exclusive
-        // NetworkBuffer (see https://issues.apache.org/jira/browse/FLINK-30727).
-        tEnv.getConfig().getConfiguration().set(TaskManagerOptions.NETWORK_MEMORY_FRACTION, 0.4f);
-    }
 
     @AfterEach
     public void after() {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/utils/JoinReorderITCaseBase.java
@@ -19,6 +19,7 @@
 package org.apache.flink.table.planner.runtime.utils;
 
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.config.OptimizerConfigOptions;
 import org.apache.flink.table.catalog.Catalog;
 import org.apache.flink.table.catalog.ObjectPath;
@@ -49,6 +50,9 @@ import java.util.Map;
  * isBushyJoinReorder.
  */
 public abstract class JoinReorderITCaseBase extends TestLogger {
+
+    private static final int DEFAULT_PARALLELISM = 4;
+
     protected TableEnvironment tEnv;
     private Catalog catalog;
 
@@ -64,6 +68,11 @@ public abstract class JoinReorderITCaseBase extends TestLogger {
         tEnv.getConfig()
                 .getConfiguration()
                 .set(OptimizerConfigOptions.TABLE_OPTIMIZER_JOIN_REORDER_ENABLED, true);
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM,
+                        DEFAULT_PARALLELISM);
 
         // Test data
         String dataId2 = TestValuesTableFactory.registerData(TestData.data2());

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StatisticsReportTestBase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/utils/StatisticsReportTestBase.java
@@ -20,6 +20,7 @@ package org.apache.flink.table.planner.utils;
 
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.ExecutionConfigOptions;
 import org.apache.flink.table.api.internal.TableEnvironmentImpl;
 import org.apache.flink.table.planner.delegation.PlannerBase;
 import org.apache.flink.table.planner.factories.TestValuesTableFactory;
@@ -54,6 +55,8 @@ import static java.util.stream.Collectors.toList;
 /** The base class for statistics report testing. */
 public abstract class StatisticsReportTestBase extends TestLogger {
 
+    private static final int DEFAULT_PARALLELISM = 4;
+
     protected TableEnvironment tEnv;
     protected File folder;
 
@@ -61,6 +64,11 @@ public abstract class StatisticsReportTestBase extends TestLogger {
     public void setup(@TempDir File file) throws Exception {
         folder = file;
         tEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
+        tEnv.getConfig()
+                .getConfiguration()
+                .set(
+                        ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM,
+                        DEFAULT_PARALLELISM);
     }
 
     @AfterEach


### PR DESCRIPTION
…insufficient while the default parallelism don't set manually in test

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pr is aims to fix IOException due to network buffer insufficient for jira: [https://issues.apache.org/jira/projects/FLINK/issues/FLINK-30727?filter=allopenissues](url).  This error is caused by some ITCase neither extends `StreamingTestBase`/`BatchTestBase`  nor sets the default parallelism manually in ITCase.  


## Brief change log

Modify ITCase  base `JoinReorderITCaseBase` and `StatisticsReportTestBase`.


## Verifying this change

I run `mvn verify` with this pr in a machine with high cpu cores many times. The result is stable.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
