### PR TITLE
[FLINK-30863][state] Register local recovery files of changelog before notifyCheckpointComplete()

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/DuplicatingStateChangeFsUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/DuplicatingStateChangeFsUploader.java
@@ -52,14 +52,13 @@ import static org.apache.flink.runtime.state.ChangelogTaskLocalStateStore.getLoc
  *       <li>Store the meta of files into {@link ChangelogTaskLocalStateStore} by
  *           AsyncCheckpointRunnable#reportCompletedSnapshotStates().
  *       <li>Pass control of the file to {@link LocalChangelogRegistry#register} when
- *           ChangelogKeyedStateBackend#buildSnapshotResult , files of the previous checkpoint will
- *           be deleted by {@link LocalChangelogRegistry#discardUpToCheckpoint} when the previous
- *           checkpoint is subsumed.
+ *           FsStateChangelogWriter#persist , files of the previous checkpoint will be deleted by
+ *           {@link LocalChangelogRegistry#discardUpToCheckpoint} when the checkpoint is confirmed.
  *       <li>When ChangelogTruncateHelper#materialized() or
  *           ChangelogTruncateHelper#checkpointSubsumed() is called, {@link
  *           TaskChangelogRegistry#release} is responsible for deleting local files.
- *       <li>When one checkpoint is aborted, the dstl files of this checkpoint will be deleted by
- *           {@link LocalChangelogRegistry#prune} in {@link FsStateChangelogWriter#reset}.
+ *       <li>When one checkpoint is aborted, all accumulated local dstl files will be deleted at
+ *           once.
  *     </ol>
  */
 public class DuplicatingStateChangeFsUploader extends AbstractStateChangeFsUploader {

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/DuplicatingStateChangeFsUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/DuplicatingStateChangeFsUploader.java
@@ -26,6 +26,7 @@ import org.apache.flink.core.fs.Path;
 import org.apache.flink.runtime.state.ChangelogTaskLocalStateStore;
 import org.apache.flink.runtime.state.LocalRecoveryDirectoryProvider;
 import org.apache.flink.runtime.state.SharedStateRegistry;
+import org.apache.flink.runtime.state.changelog.LocalChangelogRegistry;
 import org.apache.flink.runtime.state.filesystem.FileStateHandle;
 
 import org.slf4j.Logger;
@@ -51,12 +52,12 @@ import static org.apache.flink.runtime.state.ChangelogTaskLocalStateStore.getLoc
  *       <li>Store the meta of files into {@link ChangelogTaskLocalStateStore} by
  *           AsyncCheckpointRunnable#reportCompletedSnapshotStates().
  *       <li>Pass control of the file to {@link LocalChangelogRegistry#register} when
- *           ChangelogKeyedStateBackend#notifyCheckpointComplete() , files of the previous
- *           checkpoint will be deleted by {@link LocalChangelogRegistry#discardUpToCheckpoint} at
- *           the same time.
+ *           ChangelogKeyedStateBackend#buildSnapshotResult , files of the previous checkpoint will
+ *           be deleted by {@link LocalChangelogRegistry#discardUpToCheckpoint} when the previous
+ *           checkpoint is subsumed.
  *       <li>When ChangelogTruncateHelper#materialized() or
  *           ChangelogTruncateHelper#checkpointSubsumed() is called, {@link
- *           TaskChangelogRegistry#notUsed} is responsible for deleting local files.
+ *           TaskChangelogRegistry#release} is responsible for deleting local files.
  *       <li>When one checkpoint is aborted, the dstl files of this checkpoint will be deleted by
  *           {@link LocalChangelogRegistry#prune} in {@link FsStateChangelogWriter#reset}.
  *     </ol>

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
@@ -32,6 +32,7 @@ import org.apache.flink.runtime.state.changelog.LocalChangelogRegistry;
 import org.apache.flink.runtime.state.changelog.LocalChangelogRegistryImpl;
 import org.apache.flink.runtime.state.changelog.StateChangelogStorage;
 
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,7 +168,7 @@ public class FsStateChangelogStorage extends FsStateChangelogStorageForRecovery
     @Override
     public void close() throws Exception {
         uploader.close();
-        localChangelogRegistry.close();
+        IOUtils.closeQuietly(localChangelogRegistry);
     }
 
     @Override

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogStorage.java
@@ -167,6 +167,7 @@ public class FsStateChangelogStorage extends FsStateChangelogStorageForRecovery
     @Override
     public void close() throws Exception {
         uploader.close();
+        localChangelogRegistry.close();
     }
 
     @Override

--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -63,9 +63,9 @@ import static org.apache.flink.util.Preconditions.checkState;
  * thread synchronization); {@link SequenceNumber} is not changed.
  *
  * <p>However, if they exceed {@link #preEmptivePersistThresholdInBytes} then {@link
- * #persistInternal(SequenceNumber) persist} is called.
+ * #persistInternal(SequenceNumber, long) persist} is called.
  *
- * <p>On {@link #persist(SequenceNumber) persist}, accumulated changes are sent to the {@link
+ * <p>On {@link #persist(SequenceNumber, long) persist}, accumulated changes are sent to the {@link
  * StateChangeUploadScheduler} as an immutable {@link StateChangeUploadScheduler.UploadTask task}.
  * An {@link FsStateChangelogWriter.UploadCompletionListener upload listener} is also registered.
  * Upon notification it updates the Writer local state (for future persist calls) and completes the
@@ -90,6 +90,7 @@ import static org.apache.flink.util.Preconditions.checkState;
 @NotThreadSafe
 class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandleStreamImpl> {
     private static final Logger LOG = LoggerFactory.getLogger(FsStateChangelogWriter.class);
+    private static final long DUMMY_PERSIST_CHECKPOINT = -1L;
     private static final SequenceNumber INITIAL_SQN = SequenceNumber.of(0L);
 
     private final UUID logId;
@@ -205,15 +206,21 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
         return activeSequenceNumber;
     }
 
+    @VisibleForTesting
+    CompletableFuture<SnapshotResult<ChangelogStateHandleStreamImpl>> persist(SequenceNumber from)
+            throws IOException {
+        return persist(from, DUMMY_PERSIST_CHECKPOINT);
+    }
+
     @Override
     public CompletableFuture<SnapshotResult<ChangelogStateHandleStreamImpl>> persist(
-            SequenceNumber from) throws IOException {
+            SequenceNumber from, long checkpointId) throws IOException {
         LOG.debug(
                 "persist {} starting from sqn {} (incl.), active sqn: {}",
                 logId,
                 from,
                 activeSequenceNumber);
-        return persistInternal(from);
+        return persistInternal(from, checkpointId);
     }
 
     private void preEmptiveFlushIfNeeded(byte[] value) throws IOException {
@@ -222,17 +229,27 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
             LOG.debug(
                     "pre-emptively flush {}MB of appended changes to the common store",
                     activeChangeSetSize / 1024 / 1024);
-            persistInternal(notUploaded.isEmpty() ? activeSequenceNumber : notUploaded.firstKey());
+            persistInternal(
+                    notUploaded.isEmpty() ? activeSequenceNumber : notUploaded.firstKey(),
+                    DUMMY_PERSIST_CHECKPOINT);
         }
     }
 
     private CompletableFuture<SnapshotResult<ChangelogStateHandleStreamImpl>> persistInternal(
-            SequenceNumber from) throws IOException {
+            SequenceNumber from, long checkpointId) throws IOException {
         ensureCanPersist(from);
         rollover();
         Map<SequenceNumber, StateChangeSet> toUpload = drainTailMap(notUploaded, from);
         NavigableMap<SequenceNumber, UploadResult> readyToReturn = uploaded.tailMap(from, true);
         LOG.debug("collected readyToReturn: {}, toUpload: {}", readyToReturn, toUpload);
+
+        if (checkpointId != DUMMY_PERSIST_CHECKPOINT) {
+            for (UploadResult uploadResult : readyToReturn.values()) {
+                if (uploadResult.localStreamHandle != null) {
+                    localChangelogRegistry.register(uploadResult.localStreamHandle, checkpointId);
+                }
+            }
+        }
 
         SequenceNumberRange range = SequenceNumberRange.generic(from, activeSequenceNumber);
         if (range.size() == readyToReturn.size()) {
@@ -248,7 +265,7 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
                 UploadTask uploadTask =
                         new UploadTask(
                                 toUpload.values(),
-                                this::handleUploadSuccess,
+                                uploadResults -> handleUploadSuccess(uploadResults, checkpointId),
                                 this::handleUploadFailure);
                 uploader.upload(uploadTask);
             }
@@ -276,7 +293,7 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
                 "handleUploadFailure");
     }
 
-    private void handleUploadSuccess(List<UploadResult> results) {
+    private void handleUploadSuccess(List<UploadResult> results, long checkpointId) {
         mailboxExecutor.execute(
                 () -> {
                     if (closed) {
@@ -287,6 +304,10 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
                     } else {
                         uploadCompletionListeners.removeIf(listener -> listener.onSuccess(results));
                         for (UploadResult result : results) {
+                            if (checkpointId != DUMMY_PERSIST_CHECKPOINT) {
+                                localChangelogRegistry.register(
+                                        result.localStreamHandle, checkpointId);
+                            }
                             SequenceNumber resultSqn = result.sequenceNumber;
                             if (resultSqn.compareTo(lowestSequenceNumber) >= 0
                                     && resultSqn.compareTo(highestSequenceNumber) < 0) {
@@ -375,7 +396,6 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
                             changelogRegistry.stopTracking(localHandle);
                             localChangelogRegistry.register(localHandle, checkpointId);
                         });
-        localChangelogRegistry.discardUpToCheckpoint(checkpointId);
     }
 
     @Override

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/ChangelogStorageMetricsTest.java
@@ -78,7 +78,7 @@ public class ChangelogStorageMetricsTest {
             for (int i = 0; i < numUploads; i++) {
                 SequenceNumber from = writer.nextSequenceNumber();
                 writer.append(0, new byte[] {0, 1, 2, 3});
-                writer.persist(from).get();
+                writer.persist(from, 1L).get();
             }
             assertThat(metrics.getUploadsCounter().getCount()).isEqualTo(numUploads);
             assertThat(metrics.getUploadLatenciesNanos().getStatistics().getMin()).isGreaterThan(0);
@@ -104,14 +104,14 @@ public class ChangelogStorageMetricsTest {
             // upload single byte to infer header size
             SequenceNumber from = writer.nextSequenceNumber();
             writer.append(0, new byte[] {0});
-            writer.persist(from).get();
+            writer.persist(from, 1L).get();
             long headerSize = metrics.getUploadSizes().getStatistics().getMin() - 1;
 
             byte[] upload = new byte[33];
             for (int i = 0; i < 5; i++) {
                 from = writer.nextSequenceNumber();
                 writer.append(0, upload);
-                writer.persist(from).get();
+                writer.persist(from, 1L).get();
             }
             long expected = upload.length + headerSize;
             assertThat(metrics.getUploadSizes().getStatistics().getMax()).isEqualTo(expected);
@@ -140,7 +140,7 @@ public class ChangelogStorageMetricsTest {
                 SequenceNumber from = writer.nextSequenceNumber();
                 writer.append(0, new byte[] {0, 1, 2, 3});
                 try {
-                    writer.persist(from).get();
+                    writer.persist(from, 1L).get();
                 } catch (IOException e) {
                     // ignore
                 }
@@ -201,7 +201,7 @@ public class ChangelogStorageMetricsTest {
                     // cause actual uploads
                     SequenceNumber from = writers[writer].nextSequenceNumber();
                     writers[writer].append(0, new byte[] {0, 1, 2, 3});
-                    writers[writer].persist(from);
+                    writers[writer].persist(from, 1L);
                 }
                 // now the uploads should be grouped and executed at once
                 scheduler.triggerScheduledTasks();
@@ -248,7 +248,7 @@ public class ChangelogStorageMetricsTest {
             for (int upload = 0; upload < numUploads; upload++) {
                 SequenceNumber from = writer.nextSequenceNumber();
                 writer.append(0, new byte[] {0, 1, 2, 3});
-                writer.persist(from).get();
+                writer.persist(from, 1L).get();
             }
         } finally {
             storage.close();
@@ -293,7 +293,7 @@ public class ChangelogStorageMetricsTest {
             for (int upload = 0; upload < numUploads; upload++) {
                 SequenceNumber from = writer.nextSequenceNumber();
                 writer.append(0, new byte[] {0, 1, 2, 3});
-                writer.persist(from).get();
+                writer.persist(from, 1L).get();
             }
         } finally {
             storage.close();
@@ -359,7 +359,7 @@ public class ChangelogStorageMetricsTest {
             for (int i = 0; i < numUploads; i++) {
                 SequenceNumber from = writer.nextSequenceNumber();
                 writer.append(0, new byte[] {0});
-                writer.persist(from);
+                writer.persist(from, 1L);
             }
             assertThat((int) queueSizeGauge.get().getValue()).isEqualTo(numUploads);
             scheduler.triggerScheduledTasks();

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/DiscardRecordableStateChangeUploader.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/DiscardRecordableStateChangeUploader.java
@@ -55,8 +55,9 @@ public class DiscardRecordableStateChangeUploader implements StateChangeUploader
 
         // fake StreamStateHandle without data, just for discarding records
         StreamStateHandle handle = new TestingStreamStateHandle();
+        StreamStateHandle localHandle = new TestingStreamStateHandle();
         changelogRegistry.startTracking(handle, numOfChangeSets);
-        return new UploadTasksResult(tasksOffsets, handle);
+        return new UploadTasksResult(tasksOffsets, handle, localHandle);
     }
 
     public boolean isDiscarded(StreamStateHandle handle) {

--- a/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
+++ b/flink-dstl/flink-dstl-dfs/src/test/java/org/apache/flink/changelog/fs/FsStateChangelogWriterSqnTest.java
@@ -153,6 +153,6 @@ public class FsStateChangelogWriterSqnTest {
     }
 
     private static void persistAll(FsStateChangelogWriter writer) throws IOException {
-        writer.persist(writer.initialSequenceNumber());
+        writer.persist(writer.initialSequenceNumber(), 1L);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/LocalChangelogRegistry.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/LocalChangelogRegistry.java
@@ -34,10 +34,7 @@ public interface LocalChangelogRegistry extends Closeable {
                 public void register(StreamStateHandle handle, long checkpointID) {}
 
                 @Override
-                public void discardUpToCheckpoint(long latestSubsumedId) {}
-
-                @Override
-                public void prune(long checkpointID) {}
+                public void discardUpToCheckpoint(long upTo) {}
 
                 @Override
                 public void close() throws IOException {}
@@ -58,14 +55,7 @@ public interface LocalChangelogRegistry extends Closeable {
      * are unregistered when the checkpoint completes, because only one checkpoint is kept for local
      * recovery.
      *
-     * @param latestSubsumedId latest subsumed checkpointId.
+     * @param upTo lowest CheckpointID which is still valid.
      */
-    void discardUpToCheckpoint(long latestSubsumedId);
-
-    /**
-     * Called upon ChangelogKeyedStateBackend#notifyCheckpointAborted.
-     *
-     * @param checkpointID to abort
-     */
-    void prune(long checkpointID);
+    void discardUpToCheckpoint(long upTo);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -50,6 +50,7 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
      * be called for the corresponding change set. with reset/truncate/confirm methods?
      *
      * @param from inclusive
+     * @param checkpointId to persist
      */
     CompletableFuture<SnapshotResult<Handle>> persist(SequenceNumber from, long checkpointId)
             throws IOException;
@@ -79,13 +80,6 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
      * @param checkpointId to confirm
      */
     void confirm(SequenceNumber from, SequenceNumber to, long checkpointId);
-
-    /**
-     * Mark the state changes of the given checkpoint as subsumed.
-     *
-     * @param checkpointId
-     */
-    void subsume(long checkpointId);
 
     /**
      * Reset the state the given state changes. Called upon abortion so that if requested later then

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/StateChangelogWriter.java
@@ -51,7 +51,8 @@ public interface StateChangelogWriter<Handle extends ChangelogStateHandle> exten
      *
      * @param from inclusive
      */
-    CompletableFuture<SnapshotResult<Handle>> persist(SequenceNumber from) throws IOException;
+    CompletableFuture<SnapshotResult<Handle>> persist(SequenceNumber from, long checkpointId)
+            throws IOException;
 
     /**
      * Truncate this state changelog to free up the resources and collect any garbage. That means:

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -95,7 +95,7 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
 
     @Override
     public CompletableFuture<SnapshotResult<InMemoryChangelogStateHandle>> persist(
-            SequenceNumber from) {
+            SequenceNumber from, long checkpointId) {
         LOG.debug("Persist after {}", from);
         Preconditions.checkNotNull(from);
         return completedFuture(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/changelog/inmemory/InMemoryStateChangelogWriter.java
@@ -146,8 +146,5 @@ class InMemoryStateChangelogWriter implements StateChangelogWriter<InMemoryChang
     public void confirm(SequenceNumber from, SequenceNumber to, long checkpointID) {}
 
     @Override
-    public void subsume(long checkpointId) {}
-
-    @Override
     public void reset(SequenceNumber from, SequenceNumber to, long checkpointID) {}
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestLocalRecoveryConfig.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/TestLocalRecoveryConfig.java
@@ -27,6 +27,10 @@ public class TestLocalRecoveryConfig {
         return new LocalRecoveryConfig(null);
     }
 
+    public static LocalRecoveryConfig enabledForTest() {
+        return new LocalRecoveryConfig(new TestDummyLocalDirectoryProvider());
+    }
+
     public static class TestDummyLocalDirectoryProvider implements LocalRecoveryDirectoryProvider {
 
         private TestDummyLocalDirectoryProvider() {}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/LocalChangelogRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/LocalChangelogRegistryTest.java
@@ -33,7 +33,7 @@ public class LocalChangelogRegistryTest extends TestLogger {
     @Test
     public void testRegistryNormal() {
         LocalChangelogRegistry localStateRegistry =
-                new LocalChangelogRegistryImpl(Executors.directExecutor());
+                new LocalChangelogRegistryImpl(Executors.newDirectExecutorService());
         TestingStreamStateHandle handle1 = new TestingStreamStateHandle();
         TestingStreamStateHandle handle2 = new TestingStreamStateHandle();
         // checkpoint 1: handle1, handle2
@@ -45,11 +45,11 @@ public class LocalChangelogRegistryTest extends TestLogger {
         localStateRegistry.register(handle2, 2);
         localStateRegistry.register(handle3, 2);
 
-        localStateRegistry.discardUpToCheckpoint(2);
+        localStateRegistry.discardUpToCheckpoint(1);
         assertTrue(handle1.isDisposed());
         assertFalse(handle2.isDisposed());
 
-        localStateRegistry.discardUpToCheckpoint(3);
+        localStateRegistry.discardUpToCheckpoint(2);
         assertTrue(handle2.isDisposed());
         assertTrue(handle3.isDisposed());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/LocalChangelogRegistryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/LocalChangelogRegistryTest.java
@@ -45,11 +45,11 @@ public class LocalChangelogRegistryTest extends TestLogger {
         localStateRegistry.register(handle2, 2);
         localStateRegistry.register(handle3, 2);
 
-        localStateRegistry.discardUpToCheckpoint(1);
+        localStateRegistry.discardUpToCheckpoint(2);
         assertTrue(handle1.isDisposed());
         assertFalse(handle2.isDisposed());
 
-        localStateRegistry.discardUpToCheckpoint(2);
+        localStateRegistry.discardUpToCheckpoint(3);
         assertTrue(handle2.isDisposed());
         assertTrue(handle3.isDisposed());
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/changelog/inmemory/StateChangelogStorageTest.java
@@ -100,7 +100,7 @@ public class StateChangelogStorageTest<T extends ChangelogStateHandle> {
                 writer.nextSequenceNumber();
             }
 
-            SnapshotResult<T> res = writer.persist(prev).get();
+            SnapshotResult<T> res = writer.persist(prev, 1).get();
             T jmHandle = res.getJobManagerOwnedSnapshot();
             StateChangelogHandleReader<T> reader = client.createReader();
             assertByteMapsEqual(appendsByKeyGroup, extract(jmHandle, reader));

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogKeyedStateBackend.java
@@ -399,7 +399,7 @@ public class ChangelogKeyedStateBackend<K>
 
         return toRunnableFuture(
                 stateChangelogWriter
-                        .persist(lastUploadedFrom)
+                        .persist(lastUploadedFrom, checkpointId)
                         .thenApply(
                                 delta ->
                                         buildSnapshotResult(

--- a/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogTruncateHelper.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/main/java/org/apache/flink/state/changelog/ChangelogTruncateHelper.java
@@ -70,7 +70,6 @@ class ChangelogTruncateHelper {
             subsumedUpTo = sqn;
             checkpointedUpTo.headMap(checkpointId, true).clear();
             truncate();
-            stateChangelogWriter.subsume(checkpointId);
         }
     }
 

--- a/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
+++ b/flink-state-backends/flink-statebackend-changelog/src/test/java/org/apache/flink/state/changelog/StateChangeLoggerTestBase.java
@@ -125,7 +125,8 @@ abstract class StateChangeLoggerTestBase<Namespace> {
         }
 
         @Override
-        public CompletableFuture<?> persist(SequenceNumber from) throws IOException {
+        public CompletableFuture<?> persist(SequenceNumber from, long checkpointId)
+                throws IOException {
             throw new UnsupportedOperationException();
         }
 
@@ -134,9 +135,6 @@ abstract class StateChangeLoggerTestBase<Namespace> {
 
         @Override
         public void confirm(SequenceNumber from, SequenceNumber to, long checkpointId) {}
-
-        @Override
-        public void subsume(long checkpointId) {}
 
         @Override
         public void reset(SequenceNumber from, SequenceNumber to, long checkpointId) {}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

If TM is materialized before receiving confirm(), the previously uploaded queue in `FsStateChangelogWriter` will be cleared, so the local files of the completed checkpoint will not be registered again, while the JM owned files are registered before confirm(), and do not depend on the uploaded queue, so the local files are deleted, and the DFS files are still there. 
This PR makes the local recovery files registered before confirm() to avoid this problem. 

## Brief change log
  - Replace registering local files in confirm() with  registering local files in buildSnapshotResult().
 


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing


This change is already covered by existing tests, such as `ChangelogLocalRecoveryITCase`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
