### PR TITLE
[FLINK-30744][docs]Translate "Window Top-N" page of "Querys"

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/queries/window-topn.md
+++ b/docs/content.zh/docs/dev/table/sql/queries/window-topn.md
@@ -22,20 +22,20 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-# Window Top-N
+# 窗口 Top-N
 {{< label Batch >}} {{< label Streaming >}}
 
-Window Top-N is a special [Top-N]({{< ref "docs/dev/table/sql/queries/topn" >}}) which returns the N smallest or largest values for each window and other partitioned keys.
+窗口 Top-N 是特殊的 [Top-N]({{< ref "docs/dev/table/sql/queries/topn" >}})，它返回每个窗口和其他分区键的N个最小或最大值。
 
-For streaming queries, unlike regular Top-N on continuous tables, window Top-N does not emit intermediate results but only a final result, the total top N records at the end of the window. Moreover, window Top-N purges all intermediate state when no longer needed.
-Therefore, window Top-N queries have better performance if users don't need results updated per record. Usually, Window Top-N is used with [Windowing TVF]({{< ref "docs/dev/table/sql/queries/window-tvf" >}}) directly. Besides, Window Top-N could be used with other operations based on [Windowing TVF]({{< ref "docs/dev/table/sql/queries/window-tvf" >}}), such as [Window Aggregation]({{< ref "docs/dev/table/sql/queries/window-agg" >}}), [Window TopN]({{< ref "docs/dev/table/sql/queries/window-topn">}}) and [Window Join]({{< ref "docs/dev/table/sql/queries/window-join">}}). 
+对于流式查询，与持续查询的普通Top-N不同，它只在窗口最后返回汇总的Top-N数据，不会产生中间结果。窗口 Top-N 会清除不需要的中间状态。
+因此，窗口 Top-N 查询在用户不需要更新结果时，性能较好。通常，窗口 Top-N 直接用于 [窗口表值函数]({{< ref "docs/dev/table/sql/queries/window-tvf" >}})上，另外，窗口 Top-N 可以用于基于 [窗口表值函数]({{< ref "docs/dev/table/sql/queries/window-tvf" >}}) 的操作。比如 [窗口聚合]({{< ref "docs/dev/table/sql/queries/window-agg" >}})，[窗口 Top-N]({{< ref "docs/dev/table/sql/queries/window-topn">}}) 和 [窗口关联]({{< ref "docs/dev/table/sql/queries/window-join">}})。
 
-Window Top-N can be defined in the same syntax as regular Top-N, see [Top-N documentation]({{< ref "docs/dev/table/sql/queries/topn" >}}) for more information.
-Besides that, Window Top-N requires the `PARTITION BY` clause contains `window_start` and `window_end` columns of the relation applied [Windowing TVF]({{< ref "docs/dev/table/sql/queries/window-tvf" >}}) or [Window Aggregation]({{< ref "docs/dev/table/sql/queries/window-agg" >}}).
-Otherwise, the optimizer won’t be able to translate the query.
+窗口 Top-N 的语法和普通的 Top-N 相同，更多信息参见：[Top-N 文档]({{< ref "docs/dev/table/sql/queries/topn" >}})。
+除此之外，窗口 Top-N 需要 `PARTITION BY` 子句包含 [窗口表值函数]({{< ref "docs/dev/table/sql/queries/window-tvf" >}}) 或 [窗口聚合]({{< ref "docs/dev/table/sql/queries/window-agg" >}}) 产生的 `window_start` 和 `window_end`。
+否则优化器无法翻译。
 
 
-The following shows the syntax of the Window Top-N statement:
+下面展示了窗口 Top-N 的语法：
 
 ```sql
 SELECT [column_list]
@@ -47,11 +47,11 @@ FROM (
 WHERE rownum <= N [AND conditions]
 ```
 
-## Example
+## 示例
 
-### Window Top-N follows after Window Aggregation
+### 在窗口聚合后进行窗口 Top-N
 
-The following example shows how to calculate Top 3 suppliers who have the highest sales for every tumbling 10 minutes window.
+下面的示例展示了在10分钟的滚动窗口上计算销售额位列前三的供应商。
 
 ```sql
 -- tables must have time attribute, e.g. `bidtime` in this table
@@ -102,11 +102,11 @@ Flink SQL> SELECT *
 +------------------+------------------+-------------+-------+-----+--------+
 ```
 
-*Note: in order to better understand the behavior of windowing, we simplify the displaying of timestamp values to not show the trailing zeros, e.g. `2020-04-15 08:05` should be displayed as `2020-04-15 08:05:00.000` in Flink SQL Client if the type is `TIMESTAMP(3)`.*
+*注意： 为了更好地理解窗口行为，这里把 timestamp 值后面的0去掉了。例如：在 Flink SQL Client 中，如果类型是 `TIMESTAMP(3)` ，`2020-04-15 08:05` 应该显示成 `2020-04-15 08:05:00.000` 。*
 
-### Window Top-N follows after Windowing TVF
+### 在窗口表值函数后进行窗口 Top-N
 
-The following example shows how to calculate Top 3 items which have the highest price for every tumbling 10 minutes window.
+下面的示例展示了在10分钟的滚动窗口上计算价格位列前三的数据。
 
 ```sql
 Flink SQL> SELECT *
@@ -127,11 +127,11 @@ Flink SQL> SELECT *
 +------------------+-------+------+-------------+------------------+------------------+--------+
 ```
 
-*Note: in order to better understand the behavior of windowing, we simplify the displaying of timestamp values to not show the trailing zeros, e.g. `2020-04-15 08:05` should be displayed as `2020-04-15 08:05:00.000` in Flink SQL Client if the type is `TIMESTAMP(3)`.*
+*注意： 为了更好地理解窗口行为，这里把 timestamp 值后面的0去掉了。例如：在 Flink SQL Client 中，如果类型是 `TIMESTAMP(3)` ，`2020-04-15 08:05` 应该显示成 `2020-04-15 08:05:00.000` 。*
 
-## Limitation
+## 限制
 
-Currently, Flink only supports Window Top-N follows after [Windowing TVF]({{< ref "docs/dev/table/sql/queries/window-tvf" >}}) with Tumble Windows, Hop Windows and Cumulate Windows. Window Top-N follows after [Windowing TVF]({{< ref "docs/dev/table/sql/queries/window-tvf" >}}) with Session windows will be supported in the near future.
+目前，Flink只支持在滚动，滑动和累计 [窗口表值函数]({{< ref "docs/dev/table/sql/queries/window-tvf" >}})后进行窗口 Top-N。会话窗口不久之后就会支持。
 
 
 {{< top >}}


### PR DESCRIPTION
Translate "Window Top-N" page of "Querys" into Chinese

## What is the purpose of the change

Translate /dev/table/sql/queries/window-topn.md

## Brief change log

Translate /dev/table/sql/queries/window-topn.md

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature?  no