### PR TITLE
[BP-1.16][FLINK-27848][runtime] Fix the problem that ZooKeeperLeaderElectionDriver keeps writing leader information, using up zxid.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionDriver.java
@@ -166,11 +166,10 @@ public class ZooKeeperLeaderElectionDriver implements LeaderElectionDriver, Lead
     private void retrieveLeaderInformationFromZooKeeper() throws Exception {
         if (leaderLatch.hasLeadership()) {
             ChildData childData = cache.getCurrentData(connectionInformationPath);
-            if (childData != null) {
-                leaderElectionEventHandler.onLeaderInformationChange(
-                        ZooKeeperUtils.readLeaderInformation(childData.getData()));
-            }
-            leaderElectionEventHandler.onLeaderInformationChange(LeaderInformation.empty());
+            leaderElectionEventHandler.onLeaderInformationChange(
+                    childData == null
+                            ? LeaderInformation.empty()
+                            : ZooKeeperUtils.readLeaderInformation(childData.getData()));
         }
     }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/TestingLeaderElectionEventHandler.java
@@ -39,6 +39,8 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
 
     private final OneShotLatch initializationLatch;
 
+    private final Consumer<LeaderInformation> leaderInformationConsumer;
+
     @Nullable private LeaderElectionDriver initializedLeaderElectionDriver = null;
 
     private LeaderInformation confirmedLeaderInformation = LeaderInformation.empty();
@@ -48,6 +50,14 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
     public TestingLeaderElectionEventHandler(String leaderAddress) {
         this.leaderAddress = leaderAddress;
         this.initializationLatch = new OneShotLatch();
+        this.leaderInformationConsumer = (ignore) -> {};
+    }
+
+    public TestingLeaderElectionEventHandler(
+            String leaderAddress, Consumer<LeaderInformation> leaderInformationConsumer) {
+        this.leaderAddress = leaderAddress;
+        this.initializationLatch = new OneShotLatch();
+        this.leaderInformationConsumer = leaderInformationConsumer;
     }
 
     public void init(LeaderElectionDriver leaderElectionDriver) {
@@ -98,6 +108,7 @@ public class TestingLeaderElectionEventHandler extends TestingLeaderBase
                 () ->
                         waitForInitialization(
                                 leaderElectionDriver -> {
+                                    leaderInformationConsumer.accept(leaderInformation);
                                     if (confirmedLeaderInformation.getLeaderSessionID() != null
                                             && !this.confirmedLeaderInformation.equals(
                                                     leaderInformation)) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -50,6 +50,7 @@ import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 import org.apache.flink.shaded.zookeeper3.org.apache.zookeeper.data.ACL;
 
 import org.apache.curator.test.TestingServer;
+import org.assertj.core.api.Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -70,6 +71,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -359,6 +362,42 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                 if (electionService != null) {
                     electionService.stop();
                 }
+            }
+        }
+    }
+
+    /** Tests that the leader update information will not be notified repeatedly. */
+    @Test
+    public void testLeaderChangeWriteLeaderInformationOnlyOnce() throws Exception {
+        final LeaderInformationConsumer leaderInformationConsumer = new LeaderInformationConsumer();
+        final TestingLeaderElectionEventHandler electionEventHandler =
+                new TestingLeaderElectionEventHandler(LEADER_ADDRESS, leaderInformationConsumer);
+
+        @SuppressWarnings("deprecation")
+        ZooKeeperLeaderElectionDriver leaderElectionDriver = null;
+        try {
+            leaderElectionDriver =
+                    createAndInitLeaderElectionDriver(
+                            curatorFrameworkWrapper.asCuratorFramework(), electionEventHandler);
+
+            electionEventHandler.waitForLeader();
+            final LeaderInformation confirmedLeaderInformation =
+                    electionEventHandler.getConfirmedLeaderInformation();
+            Assertions.assertThat(confirmedLeaderInformation.getLeaderAddress())
+                    .isEqualTo(LEADER_ADDRESS);
+
+            // First update will successfully complete.
+            Assertions.assertThat(leaderInformationConsumer.getFirstUpdateFuture())
+                    .succeedsWithin(5, TimeUnit.SECONDS);
+            // Wait for a while to make sure other updates don't appear.
+            Assertions.assertThat(leaderInformationConsumer.getAnotherUpdateFuture())
+                    .withFailMessage("Another leader information update is not expected.")
+                    .failsWithin(5, TimeUnit.MILLISECONDS)
+                    .withThrowableOfType(TimeoutException.class);
+        } finally {
+            electionEventHandler.close();
+            if (leaderElectionDriver != null) {
+                leaderElectionDriver.close();
             }
         }
     }
@@ -757,5 +796,29 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
                                 LEADER_ADDRESS);
         electionEventHandler.init(leaderElectionDriver);
         return leaderElectionDriver;
+    }
+
+    private static class LeaderInformationConsumer implements Consumer<LeaderInformation> {
+
+        final CompletableFuture<Void> firstUpdateFuture = new CompletableFuture<>();
+
+        final CompletableFuture<Void> anotherUpdateFuture = new CompletableFuture<>();
+
+        @Override
+        public void accept(LeaderInformation leaderInformation) {
+            if (!firstUpdateFuture.isDone()) {
+                firstUpdateFuture.complete(null);
+            } else {
+                anotherUpdateFuture.complete(null);
+            }
+        }
+
+        public CompletableFuture<Void> getFirstUpdateFuture() {
+            return firstUpdateFuture;
+        }
+
+        public CompletableFuture<Void> getAnotherUpdateFuture() {
+            return anotherUpdateFuture;
+        }
     }
 }


### PR DESCRIPTION
1.16 "forwardport" PR for the 1.15 parent PR #19853

This change fixes a bug in dead code. The bug is not relevant right now because we deactivated the legacy leader election completely with FLINK-25806

Why do we need this?
Refactoring the leader election for [FLIP-285](https://cwiki.apache.org/confluence/display/FLINK/FLIP-285%3A+Refactoring+LeaderElection+to+make+Flink+support+multi-component+leader+election+out-of-the-box)/[FLINK-26522](https://issues.apache.org/jira/browse/FLINK-26522) is kind of tricky. I'm trying to slice the code changes into meaningful commits (and ideally dedicated PRs) to make the review process easier.

I ran into this issue when refactoring the code and merging classes into one which also required adapting tests. This revealed the inconsistency/bug in the `ZooKeeperLeaderElectionDriver` implementation. Merging the bugfixes into 1.17 and 1.16 makes the other changes more reasonable/consistent.

More specifically, this bug was revealed in `ZooKeeperLeaderElectionTest.testLeaderShouldBeCorrectedWhenOverwritten` when changing from the deprecated `NodeCache` to `CuratorCache`. The new `CuratorCacheListener` allows to be more selective on whether we expect a node creation or change which causes a test failure. The previous test implementation worked because we sent the 2nd write operation after writing the leader information which caused a node-change event and, after all, made the test pass.