### PR TITLE
[FLINK-30876][table-planner] Fix ResetTransformationProcessor don't reset the transformation of ExecNode in BatchExecMultiInput.rootNode

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
@@ -275,5 +276,10 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
 
     public void resetTransformation() {
         this.transformation = null;
+    }
+
+    @VisibleForTesting
+    public boolean isTransformationNull() {
+        return this.transformation == null;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -279,6 +279,7 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
     }
 
     @VisibleForTesting
+    @JsonIgnore
     public Transformation<T> getTransformation() {
         return this.transformation;
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/ExecNodeBase.java
@@ -279,7 +279,7 @@ public abstract class ExecNodeBase<T> implements ExecNode<T> {
     }
 
     @VisibleForTesting
-    public boolean isTransformationNull() {
-        return this.transformation == null;
+    public Transformation<T> getTransformation() {
+        return this.transformation;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -152,4 +152,8 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
     public List<ExecEdge> getOriginalEdges() {
         return originalEdges;
     }
+
+    public ExecNode<?> getRootNode() {
+        return rootNode;
+    }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/batch/BatchExecMultipleInput.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.table.planner.plan.nodes.exec.batch;
 
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.operators.ChainingStrategy;
@@ -32,6 +33,7 @@ import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeContext;
 import org.apache.flink.table.planner.plan.nodes.exec.InputProperty;
 import org.apache.flink.table.planner.plan.nodes.exec.SingleTransformationTranslator;
 import org.apache.flink.table.planner.plan.nodes.exec.utils.ExecNodeUtil;
+import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
 import org.apache.flink.table.runtime.operators.multipleinput.BatchMultipleInputStreamOperatorFactory;
 import org.apache.flink.table.runtime.operators.multipleinput.TableOperatorWrapperGenerator;
 import org.apache.flink.table.runtime.operators.multipleinput.input.InputSpec;
@@ -149,10 +151,28 @@ public class BatchExecMultipleInput extends ExecNodeBase<RowData>
         return multipleInputTransform;
     }
 
+    @Override
+    public void resetTransformation() {
+        super.resetTransformation();
+        // For BatchExecMultipleInput, we also need to reset transformation for
+        // rootNode in BatchExecMultipleInput.
+        AbstractExecNodeExactlyOnceVisitor visitor =
+                new AbstractExecNodeExactlyOnceVisitor() {
+
+                    @Override
+                    protected void visitNode(ExecNode<?> node) {
+                        ((ExecNodeBase<?>) node).resetTransformation();
+                        visitInputs(node);
+                    }
+                };
+        rootNode.accept(visitor);
+    }
+
     public List<ExecEdge> getOriginalEdges() {
         return originalEdges;
     }
 
+    @VisibleForTesting
     public ExecNode<?> getRootNode() {
         return rootNode;
     }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ResetTransformationProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ResetTransformationProcessor.java
@@ -21,7 +21,6 @@ package org.apache.flink.table.planner.plan.nodes.exec.processor;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
-import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecMultipleInput;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
 
 /**
@@ -39,13 +38,6 @@ public class ResetTransformationProcessor implements ExecNodeGraphProcessor {
                     protected void visitNode(ExecNode<?> node) {
                         ((ExecNodeBase<?>) node).resetTransformation();
                         visitInputs(node);
-                        // For BatchExecMultipleInput, we also need to reset transformation for
-                        // rootNode in BatchExecMultipleInput.
-                        if (node instanceof BatchExecMultipleInput) {
-                            ExecNode<?> rootNode = ((BatchExecMultipleInput) node).getRootNode();
-                            ((ExecNodeBase<?>) rootNode).resetTransformation();
-                            visitInputs(rootNode);
-                        }
                     }
                 };
         execGraph.getRootNodes().forEach(r -> r.accept(visitor));

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ResetTransformationProcessor.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ResetTransformationProcessor.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.planner.plan.nodes.exec.processor;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecMultipleInput;
 import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
 
 /**
@@ -38,6 +39,13 @@ public class ResetTransformationProcessor implements ExecNodeGraphProcessor {
                     protected void visitNode(ExecNode<?> node) {
                         ((ExecNodeBase<?>) node).resetTransformation();
                         visitInputs(node);
+                        // For BatchExecMultipleInput, we also need to reset transformation for
+                        // rootNode in BatchExecMultipleInput.
+                        if (node instanceof BatchExecMultipleInput) {
+                            ExecNode<?> rootNode = ((BatchExecMultipleInput) node).getRootNode();
+                            ((ExecNodeBase<?>) rootNode).resetTransformation();
+                            visitInputs(rootNode);
+                        }
                     }
                 };
         execGraph.getRootNodes().forEach(r -> r.accept(visitor));

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
@@ -22,7 +22,6 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.connector.source.Boundedness;
 import org.apache.flink.api.connector.source.mocks.MockSource;
 import org.apache.flink.streaming.api.datastream.DataStreamSource;
-import org.apache.flink.table.api.Table;
 import org.apache.flink.table.api.TableConfig;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.expressions.ApiExpressionUtils;
@@ -97,7 +96,6 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
 
     private void assertChainableSource(String name, TableTestUtil util, boolean expected) {
         String sql = "SELECT * FROM " + name;
-        Table table = util.tableEnv().sqlQuery(sql);
         ExecNodeGraph execGraph = TableTestUtil.toExecNodeGraph(util.tableEnv(), sql);
         ExecNode<?> execNode = execGraph.getRootNodes().get(0);
         while (!execNode.getInputEdges().isEmpty()) {

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/MultipleInputNodeCreationProcessorTest.java
@@ -29,20 +29,16 @@ import org.apache.flink.table.expressions.ApiExpressionUtils;
 import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
 import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
-import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraphGenerator;
-import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel;
 import org.apache.flink.table.planner.utils.BatchTableTestUtil;
 import org.apache.flink.table.planner.utils.StreamTableTestUtil;
 import org.apache.flink.table.planner.utils.TableTestBase;
 import org.apache.flink.table.planner.utils.TableTestUtil;
 import org.apache.flink.util.FileUtils;
 
-import org.apache.calcite.rel.RelNode;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,11 +98,7 @@ public class MultipleInputNodeCreationProcessorTest extends TableTestBase {
     private void assertChainableSource(String name, TableTestUtil util, boolean expected) {
         String sql = "SELECT * FROM " + name;
         Table table = util.tableEnv().sqlQuery(sql);
-        RelNode relNode = TableTestUtil.toRelNode(table);
-        FlinkPhysicalRel optimizedRel = (FlinkPhysicalRel) util.getPlanner().optimize(relNode);
-        ExecNodeGraphGenerator generator = new ExecNodeGraphGenerator();
-        ExecNodeGraph execGraph =
-                generator.generate(Collections.singletonList(optimizedRel), false);
+        ExecNodeGraph execGraph = TableTestUtil.toExecNodeGraph(util.tableEnv(), sql);
         ExecNode<?> execNode = execGraph.getRootNodes().get(0);
         while (!execNode.getInputEdges().isEmpty()) {
             execNode = execNode.getInputEdges().get(0).getSource();

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ResetTransformationProcessorTest.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/plan/nodes/exec/processor/ResetTransformationProcessorTest.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.planner.plan.nodes.exec.processor;
+
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableConfig;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNode;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeBase;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraph;
+import org.apache.flink.table.planner.plan.nodes.exec.ExecNodeGraphGenerator;
+import org.apache.flink.table.planner.plan.nodes.exec.batch.BatchExecMultipleInput;
+import org.apache.flink.table.planner.plan.nodes.exec.visitor.AbstractExecNodeExactlyOnceVisitor;
+import org.apache.flink.table.planner.plan.nodes.physical.FlinkPhysicalRel;
+import org.apache.flink.table.planner.utils.BatchTableTestUtil;
+import org.apache.flink.table.planner.utils.TableTestBase;
+import org.apache.flink.table.planner.utils.TableTestUtil;
+
+import org.apache.calcite.rel.RelNode;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for {@link ResetTransformationProcessor}. */
+public class ResetTransformationProcessorTest extends TableTestBase {
+
+    private BatchTableTestUtil util;
+    private TableEnvironment tEnv;
+
+    @Before
+    public void begin() {
+        util = batchTestUtil(TableConfig.getDefault());
+        tEnv = util.tableEnv();
+
+        tEnv.executeSql(
+                "CREATE TABLE Source1 (\n"
+                        + "  a BIGINT,\n"
+                        + "  b BIGINT,\n"
+                        + "  c VARCHAR,\n"
+                        + "  d BIGINT\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")");
+
+        tEnv.executeSql(
+                "CREATE TABLE Source2 (\n"
+                        + "  a BIGINT,\n"
+                        + "  b BIGINT,\n"
+                        + "  c VARCHAR,\n"
+                        + "  d BIGINT\n"
+                        + ") WITH (\n"
+                        + " 'connector' = 'values',\n"
+                        + " 'bounded' = 'true'\n"
+                        + ")");
+    }
+
+    @Test
+    public void testResetTransformation() {
+        String query = "SELECT * FROM Source1 WHERE a > 100";
+        ExecNodeGraph execNodeGraph = createExecNodeGraph(query);
+        execNodeGraph.getRootNodes().forEach(node -> node.translateToPlan(util.getPlanner()));
+        assertAllTransformationsIsNotNull(execNodeGraph);
+
+        ResetTransformationProcessor resetTransformationProcessor =
+                new ResetTransformationProcessor();
+        resetTransformationProcessor.process(
+                execNodeGraph, new ProcessorContext(util.getPlanner()));
+        assertAllTransformationsIsNull(execNodeGraph);
+    }
+
+    @Test
+    public void testResetTransformationWithExecMultipleInputInExecGraph() {
+        String query =
+                "SELECT Source1.a FROM Source1, Source2 "
+                        + "WHERE Source1.a = Source2.a AND Source2.a = (SELECT Source2.a FROM Source2 WHERE b > 100)";
+        ExecNodeGraph execNodeGraph = createExecNodeGraph(query);
+
+        MultipleInputNodeCreationProcessor multipleInputNodeCreationProcessor =
+                new MultipleInputNodeCreationProcessor(false);
+        multipleInputNodeCreationProcessor.process(
+                execNodeGraph, new ProcessorContext(util.getPlanner()));
+        execNodeGraph.getRootNodes().forEach(node -> node.translateToPlan(util.getPlanner()));
+        assertAllTransformationsIsNotNull(execNodeGraph);
+
+        // If execNodeGraph include batchExecMultipleInput node. The ResetTransformationProcessor
+        // need to both set the transformation in each execNode and the transformation in
+        // batchExecMultipleInput.rootNode to null.
+        ResetTransformationProcessor resetTransformationProcessor =
+                new ResetTransformationProcessor();
+        resetTransformationProcessor.process(
+                execNodeGraph, new ProcessorContext(util.getPlanner()));
+        assertAllTransformationsIsNull(execNodeGraph);
+    }
+
+    private ExecNodeGraph createExecNodeGraph(String query) {
+        Table table = tEnv.sqlQuery(query);
+        RelNode relNode = TableTestUtil.toRelNode(table);
+        FlinkPhysicalRel optimizedRel = (FlinkPhysicalRel) util.getPlanner().optimize(relNode);
+        ExecNodeGraphGenerator generator = new ExecNodeGraphGenerator();
+        return generator.generate(Collections.singletonList(optimizedRel), false);
+    }
+
+    private void assertAllTransformationsIsNotNull(ExecNodeGraph execNodeGraph) {
+        AbstractExecNodeExactlyOnceVisitor visitor =
+                new AbstractExecNodeExactlyOnceVisitor() {
+                    @Override
+                    protected void visitNode(ExecNode<?> node) {
+                        assertFalse(((ExecNodeBase<?>) node).isTransformationNull());
+                        visitInputs(node);
+                        if (node instanceof BatchExecMultipleInput) {
+                            ExecNode<?> rootNode = ((BatchExecMultipleInput) node).getRootNode();
+                            assertFalse(((ExecNodeBase<?>) rootNode).isTransformationNull());
+                            visitInputs(rootNode);
+                        }
+                    }
+                };
+        execNodeGraph.getRootNodes().forEach(r -> r.accept(visitor));
+    }
+
+    private void assertAllTransformationsIsNull(ExecNodeGraph execNodeGraph) {
+        AbstractExecNodeExactlyOnceVisitor visitor =
+                new AbstractExecNodeExactlyOnceVisitor() {
+                    @Override
+                    protected void visitNode(ExecNode<?> node) {
+                        assertTrue(((ExecNodeBase<?>) node).isTransformationNull());
+                        visitInputs(node);
+                        if (node instanceof BatchExecMultipleInput) {
+                            ExecNode<?> rootNode = ((BatchExecMultipleInput) node).getRootNode();
+                            assertTrue(((ExecNodeBase<?>) rootNode).isTransformationNull());
+                            visitInputs(rootNode);
+                        }
+                    }
+                };
+        execNodeGraph.getRootNodes().forEach(r -> r.accept(visitor));
+    }
+}


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Now, ResetTransformationProcessor don't reset the transformation of ExecNode in BatchExecMultiInput.rootNode. This may cause error while creating StreamGraph for BatchExecMultiInput due to different id of rootNode and inputNode. This pr is aims to fix this error.


## Brief change log

- Change the visit method in `ResetTransformationProcessor`
- Add test `ResetTransformationProcessorTest`


## Verifying this change

- Add test `ResetTransformationProcessorTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?  no docs
