### PR TITLE
[BP-1.15][FLINK-30878][runtime] Revert "[FLINK-30474][runtime] Propagates leader information change only if the leadership is still acquired"

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/leaderelection/DefaultMultipleComponentLeaderElectionService.java
@@ -248,13 +248,7 @@ public class DefaultMultipleComponentLeaderElectionService
             LeaderElectionEventHandler leaderElectionEventHandler,
             LeaderInformation leaderInformation) {
         leadershipOperationExecutor.execute(
-                () -> {
-                    synchronized (lock) {
-                        if (running && multipleComponentLeaderElectionDriver.hasLeadership()) {
-                            leaderElectionEventHandler.onLeaderInformationChange(leaderInformation);
-                        }
-                    }
-                });
+                () -> leaderElectionEventHandler.onLeaderInformationChange(leaderInformation));
     }
 
     @Override


### PR DESCRIPTION
This reverts commit ce38381c15ee83fad782677d51b10941c843b82e. The correlated PR on `master` is #21830.
## What is the purpose of the change

See FLINK-30878 for analysis. PR #21818 caused this.

## Brief change log

Reverting the FLINK-30474 change.

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: yes
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented?not applicable
