### PR TITLE
[FLINK-30852][runtime] Checking task cancelation explicitly rather than failing the cancel method

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/taskmanager/TaskTest.java
@@ -158,31 +158,35 @@ public class TaskTest extends TestLogger {
 
     @Test
     public void testCleanupWhenAfterInvokeSucceeded() throws Exception {
-        createTaskBuilder()
-                .setInvokable(TestInvokableCorrect.class)
-                .build(Executors.directExecutor())
-                .run();
+        Task task =
+                createTaskBuilder()
+                        .setInvokable(TestInvokableCorrect.class)
+                        .build(Executors.directExecutor());
+        task.run();
         assertTrue(wasCleanedUp);
+        assertFalse(task.isCanceledOrFailed());
     }
 
     @Test
     public void testCleanupWhenSwitchToInitializationFails() throws Exception {
-        createTaskBuilder()
-                .setInvokable(TestInvokableCorrect.class)
-                .setTaskManagerActions(
-                        new NoOpTaskManagerActions() {
-                            @Override
-                            public void updateTaskExecutionState(
-                                    TaskExecutionState taskExecutionState) {
-                                if (taskExecutionState.getExecutionState()
-                                        == ExecutionState.INITIALIZING) {
-                                    throw new ExpectedTestException();
-                                }
-                            }
-                        })
-                .build(Executors.directExecutor())
-                .run();
+        Task task =
+                createTaskBuilder()
+                        .setInvokable(TestInvokableCorrect.class)
+                        .setTaskManagerActions(
+                                new NoOpTaskManagerActions() {
+                                    @Override
+                                    public void updateTaskExecutionState(
+                                            TaskExecutionState taskExecutionState) {
+                                        if (taskExecutionState.getExecutionState()
+                                                == ExecutionState.INITIALIZING) {
+                                            throw new ExpectedTestException();
+                                        }
+                                    }
+                                })
+                        .build(Executors.directExecutor());
+        task.run();
         assertTrue(wasCleanedUp);
+        assertTrue(task.isCanceledOrFailed());
     }
 
     @Test
@@ -1300,9 +1304,7 @@ public class TaskTest extends TestLogger {
         public void invoke() {}
 
         @Override
-        public void cancel() {
-            fail("This should not be called");
-        }
+        public void cancel() {}
 
         @Override
         public void cleanUp(Throwable throwable) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

These changes fix the exception from TestInvokableCorrect#cancel which is 1) incorrect 2) doesn't really fail test


## Brief change log

  - *Explicit assert for the task cancelation in tests*
  - *Removed the exception from TestInvokableCorrect#cancel since in some test it isn't correct*


## Verifying this change

It is test itself

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
