### PR TITLE
[BP-1.16][FLINK-30881][ci] Replaces optional minikube installation by mandatory removal

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
+++ b/flink-end-to-end-tests/test-scripts/common_kubernetes.sh
@@ -24,7 +24,7 @@ CONTAINER_SCRIPTS=${END_TO_END_DIR}/test-scripts/container-scripts
 MINIKUBE_START_RETRIES=3
 MINIKUBE_START_BACKOFF=5
 RESULT_HASH="e682ec6622b5e83f2eb614617d5ab2cf"
-MINIKUBE_VERSION="v1.8.2"
+MINIKUBE_VERSION="v1.28.0"
 
 NON_LINUX_ENV_NOTE="****** Please start/stop minikube manually in non-linux environment. ******"
 
@@ -43,11 +43,17 @@ function setup_kubernetes_for_linux {
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
     fi
     # Download minikube when it is not installed beforehand.
-    if ! [ -x "$(command -v minikube)" ]; then
-        echo "Installing minikube $MINIKUBE_VERSION ..."
-        curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-$arch && \
-            chmod +x minikube && sudo mv minikube /usr/bin/minikube
+    if [ -x "$(command -v minikube)" ] && [[ "$(minikube version | grep -c $MINIKUBE_VERSION)" == "0" ]]; then
+      echo "Removing any already installed minikube binaries ..."
+      sudo rm "$(which minikube)"
     fi
+
+    if ! [ -x "$(command -v minikube)" ]; then
+      echo "Installing minikube $MINIKUBE_VERSION ..."
+      curl -Lo minikube https://storage.googleapis.com/minikube/releases/$MINIKUBE_VERSION/minikube-linux-$arch && \
+          chmod +x minikube && sudo mv minikube /usr/bin/minikube
+    fi
+
     # conntrack is required for minikube 1.9 and later
     sudo apt-get install conntrack
     # crictl is required for cri-dockerd


### PR DESCRIPTION
1.16 backport PR of parent PR #21834

## What is the purpose of the change

The goal is to fix the Minikube version instead of relying on the Minikube version that's provided by the AzureCI Docker image.

## Brief change log

* Removes any minikube version that's not matching the required version
* Installs the expected minikube version

## Verifying this change

* Normal ci run with k8s tests should pass

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
