### PR TITLE
[hotfix] Set HybridPartitionDataConsumeConstraint to ALL_PRODUCERS_FINISHED for auto parallelism.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
+import org.apache.flink.configuration.BatchExecutionOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions.HybridPartitionDataConsumeConstraint;
@@ -52,6 +53,17 @@ class AdaptiveBatchSchedulerFactoryTest {
         HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint =
                 getOrDecideHybridPartitionDataConsumeConstraint(new Configuration(), true);
         assertThat(hybridPartitionDataConsumeConstraint.isOnlyConsumeFinishedPartition()).isTrue();
+    }
+
+    @Test
+    void testAllProducerFinishedWillSetForAutoParallelismEnabled() {
+        Configuration configuration = new Configuration();
+        configuration.set(
+                JobManagerOptions.HYBRID_PARTITION_DATA_CONSUME_CONSTRAINT, UNFINISHED_PRODUCERS);
+        configuration.set(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED, true);
+        HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint =
+                getOrDecideHybridPartitionDataConsumeConstraint(configuration, true);
+        assertThat(hybridPartitionDataConsumeConstraint).isEqualTo(ALL_PRODUCERS_FINISHED);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

*In auto parallelism mode, If we set `HybridPartitionDataConsumeConstraint` to `ONLY_FINISHED_PRODUCERS` or `UNFINISHED_PRODUCERS`,  the task scheduling behavior is actually consistent with `ALL_PRODUCERS_FINISHED` as consumer's parallelism is decided only when all producer finished, which will confuse users.*


## Brief change log

  - *Set HybridPartitionDataConsumeConstraint to `ALL_PRODUCERS_FINISHED` and print log when auto parallelism enabled.*


## Verifying this change


This change added test in `AdaptiveBatchSchedulerFactoryTest`.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers:: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
