### PR TITLE
[FLIP-278][connector] Add hybrid source connector for table & sql

### DIFF
--- a/flink-connectors/flink-connector-hybrid/pom.xml
+++ b/flink-connectors/flink-connector-hybrid/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connectors</artifactId>
+		<version>1.18-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-connector-hybrid</artifactId>
+	<name>Flink : Connectors : Hybrid</name>
+
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-base</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-core</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-runtime</artifactId>
+			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
+		<!-- test dependency -->
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-common</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+			<version>${project.version}</version>
+			<type>test-jar</type>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<version>${project.version}</version>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+</project>

--- a/flink-connectors/flink-connector-hybrid/src/main/java/org/apache/flink/connector/hybrid/table/HybridConnectorOptions.java
+++ b/flink-connectors/flink-connector-hybrid/src/main/java/org/apache/flink/connector/hybrid/table/HybridConnectorOptions.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hybrid.table;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/** Hybrid source options. */
+public class HybridConnectorOptions {
+
+    public static final String SOURCE_IDENTIFIER_REGEX = "[A-Za-z0-9_]+";
+    public static final String SOURCE_IDENTIFIER_DELIMITER = ".";
+
+    public static final ConfigOption<String> SOURCE_IDENTIFIERS =
+            ConfigOptions.key("source-identifiers")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "Use comma delimiter and identifier indicate child sources that need to be concatenated. "
+                                    + "e.g. source-identifiers='historical,realtime'");
+
+    public static final ConfigOption<Boolean> OPTIONAL_SWITCHED_START_POSITION_ENABLED =
+            ConfigOptions.key("switched-start-position-enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether to enable switched start position, default is false for using fixed start position. "
+                                    + "If it is true, then hybrid source will call the previous source SplitEnumerator#getEndTimestamp "
+                                    + "to get end timestamp and pass to next unbounded streaming source. ");
+
+    private HybridConnectorOptions() {}
+}

--- a/flink-connectors/flink-connector-hybrid/src/main/java/org/apache/flink/connector/hybrid/table/HybridTableSource.java
+++ b/flink-connectors/flink-connector-hybrid/src/main/java/org/apache/flink/connector/hybrid/table/HybridTableSource.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hybrid.table;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.api.connector.source.SupportsGetEndTimestamp;
+import org.apache.flink.api.connector.source.SupportsSwitchedStartTimestamp;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DataStreamScanSourceAbilityProvider;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.connector.source.abilities.SupportsProjectionPushDown;
+import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.InstantiationUtil;
+import org.apache.flink.util.Preconditions;
+
+import javax.annotation.Nonnull;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.flink.connector.hybrid.table.HybridConnectorOptions.OPTIONAL_SWITCHED_START_POSITION_ENABLED;
+
+/**
+ * A {@link ScanTableSource} that connect several numbers child sources to be a mixed hybrid source.
+ * See {@link HybridSource}.
+ */
+public class HybridTableSource
+        implements ScanTableSource, SupportsReadingMetadata, SupportsProjectionPushDown {
+
+    private final String tableName;
+    private final ResolvedSchema tableSchema;
+    private final List<ScanTableSource> childTableSources;
+    private final Configuration configuration;
+
+    public HybridTableSource(
+            String tableName,
+            @Nonnull List<ScanTableSource> childTableSources,
+            Configuration configuration,
+            ResolvedSchema tableSchema) {
+        this.tableName = tableName;
+        this.tableSchema = tableSchema;
+        Preconditions.checkArgument(
+                childTableSources.size() >= 2, "child table sources must at least 2 sources.");
+        this.childTableSources = childTableSources;
+        this.configuration = configuration;
+    }
+
+    @Override
+    public DynamicTableSource copy() {
+        return new HybridTableSource(tableName, childTableSources, configuration, tableSchema);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "HybridTableSource";
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode() {
+        Set<RowKind> kinds = new HashSet<>();
+        for (ScanTableSource childSource : childTableSources) {
+            kinds.addAll(childSource.getChangelogMode().getContainedKinds());
+        }
+        ChangelogMode.Builder builder = ChangelogMode.newBuilder();
+        for (RowKind kind : kinds) {
+            builder.addContainedKind(kind);
+        }
+        return builder.build();
+    }
+
+    @Override
+    public ScanRuntimeProvider getScanRuntimeProvider(ScanContext runtimeProviderContext) {
+        HybridSource.HybridSourceBuilder<RowData, SplitEnumerator> builder;
+        ScanTableSource firstTableSource = childTableSources.get(0);
+        ScanTableSource.ScanRuntimeProvider firstProvider =
+                validateAndGetProvider(firstTableSource);
+        Source<RowData, ?, ?> firstSource = validateAndGetSource(firstProvider);
+        builder = HybridSource.builder(firstSource);
+
+        if (configuration.getBoolean(OPTIONAL_SWITCHED_START_POSITION_ENABLED)) {
+            // switched start position
+            for (int i = 1; i < childTableSources.size(); i++) {
+                ScanTableSource nextTableSource = childTableSources.get(i);
+                ScanTableSource.ScanRuntimeProvider nextProvider =
+                        validateAndGetProvider(nextTableSource);
+                Source<RowData, ?, ?> nextSource = validateAndGetSource(nextProvider);
+                Boundedness boundedness = nextSource.getBoundedness();
+                final Source<RowData, ?, ?> localCopySource;
+                try {
+                    localCopySource = InstantiationUtil.clone(nextSource);
+                } catch (ClassNotFoundException | IOException e) {
+                    throw new IllegalStateException("Unable to clone the hybrid child source.", e);
+                }
+                // builder#addSource below is a serialized-lambda. if we use nextSource, the
+                // lambda captured variables will be HybridTableSource and nextSource
+                // while nextSource can be serialized, but HybridTableSource can not be
+                // serialized, it will cause serialized exception. So here we do a deepCopy to
+                // address it.
+                builder.addSource(
+                        switchContext -> {
+                            SplitEnumerator previousEnumerator =
+                                    switchContext.getPreviousEnumerator();
+                            // how to get and apply timestamp depends on specific enumerator
+                            long switchedTimestamp =
+                                    validateAndCastSplitEnumerator(previousEnumerator)
+                                            .getEndTimestamp();
+                            validateAndCastSource(localCopySource)
+                                    .applySwitchedStartTimestamp(switchedTimestamp);
+                            return localCopySource;
+                        },
+                        boundedness);
+            }
+        } else {
+            // fixed start position
+            for (int i = 1; i < childTableSources.size(); i++) {
+                ScanTableSource.ScanRuntimeProvider provider =
+                        validateAndGetProvider(childTableSources.get(i));
+                builder.addSource(validateAndGetSource(provider));
+            }
+        }
+
+        return SourceProvider.of(builder.build());
+    }
+
+    @Override
+    public Map<String, DataType> listReadableMetadata() {
+        final Map<String, DataType> metadataMap = new HashMap<>();
+        tableSchema.getColumns().stream()
+                .filter(column -> column instanceof Column.MetadataColumn)
+                .forEach(
+                        column ->
+                                metadataMap.put(
+                                        ((Column.MetadataColumn) column)
+                                                .getMetadataKey()
+                                                .orElse(column.getName()),
+                                        column.getDataType()));
+        return metadataMap;
+    }
+
+    @Override
+    public void applyReadableMetadata(List<String> metadataKeys, DataType producedDataType) {
+        // we pass the ddl metadata fields to each child sources, if child source has this
+        // metadata then return its value else metadata value is null.
+        for (ScanTableSource childSource : childTableSources) {
+            Preconditions.checkState(
+                    childSource instanceof SupportsReadingMetadata,
+                    "The table source %s must implement "
+                            + "SupportsReadingMetadata interface to be used in hybrid source.",
+                    childSource.getClass().getName());
+            ((SupportsReadingMetadata) childSource)
+                    .applyReadableMetadata(metadataKeys, producedDataType);
+        }
+    }
+
+    @Override
+    public void applyProjection(int[][] projectedFields, DataType producedDataType) {
+        for (ScanTableSource childSource : childTableSources) {
+            Preconditions.checkState(
+                    childSource instanceof SupportsProjectionPushDown,
+                    "The table source %s must implement "
+                            + "SupportsProjectionPushDown interface to be used in hybrid source.",
+                    childSource.getClass().getName());
+            ((SupportsProjectionPushDown) childSource)
+                    .applyProjection(projectedFields, producedDataType);
+        }
+    }
+
+    @Override
+    public boolean supportsNestedProjection() {
+        return false;
+    }
+
+    // ------------------------------------------------------------------------
+
+    private static ScanTableSource.ScanRuntimeProvider validateAndGetProvider(
+            ScanTableSource tableSource) {
+        ScanTableSource.ScanRuntimeProvider provider =
+                tableSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+        Preconditions.checkState(
+                provider instanceof SourceProvider
+                        || provider instanceof DataStreamScanSourceAbilityProvider,
+                "Provider %s is not a SourceProvider or DataStreamScanSourceAbilityProvider.",
+                provider.getClass().getName());
+        return provider;
+    }
+
+    private static Source<RowData, ?, ?> validateAndGetSource(
+            ScanTableSource.ScanRuntimeProvider provider) {
+        if (provider instanceof DataStreamScanSourceAbilityProvider) {
+            Object source = ((DataStreamScanSourceAbilityProvider<?>) provider).createSource();
+            Preconditions.checkState(
+                    source instanceof Source,
+                    "Child source %s is not a new Source.",
+                    source.getClass().getName());
+            return (Source<RowData, ?, ?>) source;
+        } else {
+            return ((SourceProvider) provider).createSource();
+        }
+    }
+
+    private static SupportsGetEndTimestamp validateAndCastSplitEnumerator(
+            SplitEnumerator splitEnumerator) {
+        Preconditions.checkState(
+                splitEnumerator instanceof SupportsGetEndTimestamp,
+                "The split enumerator %s must implement "
+                        + "SupportsGetEndTimestamp interface to be used in hybrid source when %s "
+                        + "is true.",
+                splitEnumerator.getClass().getName(),
+                OPTIONAL_SWITCHED_START_POSITION_ENABLED.key());
+        return (SupportsGetEndTimestamp) splitEnumerator;
+    }
+
+    private static SupportsSwitchedStartTimestamp validateAndCastSource(Source source) {
+        Preconditions.checkState(
+                source instanceof SupportsSwitchedStartTimestamp,
+                "The dynamic table source %s must implement "
+                        + "SupportsSwitchedStartTimestamp interface"
+                        + "to be used in hybrid source when %s is true.",
+                source.getClass().getName(),
+                OPTIONAL_SWITCHED_START_POSITION_ENABLED.key());
+        return (SupportsSwitchedStartTimestamp) source;
+    }
+}

--- a/flink-connectors/flink-connector-hybrid/src/main/java/org/apache/flink/connector/hybrid/table/HybridTableSourceFactory.java
+++ b/flink-connectors/flink-connector-hybrid/src/main/java/org/apache/flink/connector/hybrid/table/HybridTableSourceFactory.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hybrid.table;
+
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.factories.DynamicTableSourceFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.Preconditions;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.configuration.ConfigOptions.key;
+import static org.apache.flink.connector.hybrid.table.HybridConnectorOptions.SOURCE_IDENTIFIERS;
+import static org.apache.flink.connector.hybrid.table.HybridConnectorOptions.SOURCE_IDENTIFIER_REGEX;
+import static org.apache.flink.table.factories.FactoryUtil.CONNECTOR;
+
+/**
+ * Factory for creating {@link HybridTableSource} based-on FLIP-27 source API. It means that all
+ * hybrid child source must be {@link Source}. Note some limitations:
+ *
+ * <ol>
+ *   <li>1.hybrid source must specify at least 2 child sources.
+ *   <li>2.hybrid source works in batch mode * then all child sources must be bounded.
+ *   <li>3.the first child source must be bounded (otherwise first child source never end).
+ * </ol>
+ */
+public class HybridTableSourceFactory implements DynamicTableSourceFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HybridTableSourceFactory.class);
+    public static final String IDENTIFIER = "hybrid";
+
+    @Override
+    public DynamicTableSource createDynamicTableSource(Context context) {
+        final FactoryUtil.TableFactoryHelper helper =
+                FactoryUtil.createTableFactoryHelper(this, context);
+        final Configuration tableOptions = (Configuration) helper.getOptions();
+
+        String tableName = context.getObjectIdentifier().toString();
+        ResolvedCatalogTable hybridCatalogTable = context.getCatalogTable();
+        ResolvedSchema tableSchema = hybridCatalogTable.getResolvedSchema();
+
+        // process and check source identifiers
+        String sourceIdentifiersStr = tableOptions.get(SOURCE_IDENTIFIERS);
+        List<String> sourceIdentifiers = Arrays.asList(sourceIdentifiersStr.split(","));
+        sourceIdentifiers.forEach(
+                identifier ->
+                        Preconditions.checkArgument(
+                                identifier.matches(SOURCE_IDENTIFIER_REGEX),
+                                "source-identifier pattern must be " + SOURCE_IDENTIFIER_REGEX));
+        Preconditions.checkArgument(
+                sourceIdentifiers.size() >= 2,
+                String.format(
+                        "hybrid source '%s' option must specify at least 2 sources",
+                        SOURCE_IDENTIFIERS.key()));
+        Preconditions.checkArgument(
+                sourceIdentifiers.stream().distinct().count() == sourceIdentifiers.size(),
+                "each source identifier must not be the same");
+
+        // validate params
+        Set<ConfigOption<?>> optionalOptions = new HashSet<>();
+        for (String optionKey : tableOptions.toMap().keySet()) {
+            if (sourceIdentifiers.stream().anyMatch(optionKey::startsWith)) {
+                ConfigOption<String> childOption = key(optionKey).stringType().noDefaultValue();
+                optionalOptions.add(childOption);
+            }
+        }
+        optionalOptions.addAll(optionalOptions());
+        FactoryUtil.validateFactoryOptions(requiredOptions(), optionalOptions, tableOptions);
+
+        Set<String> consumedOptionKeys = new HashSet<>();
+        consumedOptionKeys.add(CONNECTOR.key());
+        consumedOptionKeys.add(SOURCE_IDENTIFIERS.key());
+        optionalOptions.stream().map(ConfigOption::key).forEach(consumedOptionKeys::add);
+        FactoryUtil.validateUnconsumedKeys(
+                factoryIdentifier(), tableOptions.keySet(), consumedOptionKeys);
+
+        // generate each child table sources & concat sources to hybrid table source
+        List<ScanTableSource> childTableSources = new ArrayList<>();
+        ClassLoader cl = HybridTableSourceFactory.class.getClassLoader();
+        for (String sourceIdentifier : sourceIdentifiers) {
+            ResolvedCatalogTable childCatalogTable =
+                    hybridCatalogTable.copy(
+                            extractChildSourceOptions(
+                                    hybridCatalogTable.getOptions(), sourceIdentifier));
+            String newTableName =
+                    String.join(
+                            "_", context.getObjectIdentifier().getObjectName(), sourceIdentifier);
+            DynamicTableSource tableSource =
+                    FactoryUtil.createDynamicTableSource(
+                            null,
+                            ObjectIdentifier.of(
+                                    context.getObjectIdentifier().getCatalogName(),
+                                    context.getObjectIdentifier().getDatabaseName(),
+                                    newTableName),
+                            childCatalogTable,
+                            Collections.emptyMap(),
+                            context.getConfiguration(),
+                            cl,
+                            true);
+            childTableSources.add(validateAndCastTableSource(tableSource));
+        }
+
+        LOG.info("Generate hybrid child sources with: {}.", childTableSources);
+
+        Preconditions.checkArgument(
+                sourceIdentifiers.size() == childTableSources.size(),
+                "unmatched source identifiers size and generated child sources size");
+
+        return new HybridTableSource(tableName, childTableSources, tableOptions, tableSchema);
+    }
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> requiredOptions = new HashSet<>();
+        requiredOptions.add(SOURCE_IDENTIFIERS);
+        return requiredOptions;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> optionalOptions = new HashSet<>();
+        optionalOptions.add(HybridConnectorOptions.OPTIONAL_SWITCHED_START_POSITION_ENABLED);
+        return optionalOptions;
+    }
+
+    @VisibleForTesting
+    protected Map<String, String> extractChildSourceOptions(
+            Map<String, String> originalOptions, String sourceIdentifier) {
+        if (originalOptions == null || originalOptions.isEmpty()) {
+            return originalOptions;
+        }
+        String optionPrefix = sourceIdentifier + HybridConnectorOptions.SOURCE_IDENTIFIER_DELIMITER;
+        Map<String, String> sourceOptions =
+                originalOptions.entrySet().stream()
+                        .filter(entry -> entry.getKey().startsWith(optionPrefix))
+                        .collect(
+                                Collectors.toMap(
+                                        entry ->
+                                                StringUtils.removeStart(
+                                                        entry.getKey(), optionPrefix),
+                                        Map.Entry::getValue));
+        String connectorType = originalOptions.get(optionPrefix + FactoryUtil.CONNECTOR.key());
+        sourceOptions.put(FactoryUtil.CONNECTOR.key(), connectorType);
+
+        return sourceOptions;
+    }
+
+    private ScanTableSource validateAndCastTableSource(DynamicTableSource tableSource) {
+        Preconditions.checkState(
+                tableSource instanceof ScanTableSource,
+                "HybridSource child source only support ScanTableSource but %s is not, please "
+                        + "check it.",
+                tableSource.getClass().getName());
+        return (ScanTableSource) tableSource;
+    }
+}

--- a/flink-connectors/flink-connector-hybrid/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connectors/flink-connector-hybrid/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.connector.hybrid.table.HybridTableSourceFactory

--- a/flink-connectors/flink-connector-hybrid/src/test/java/org/apache/flink/connector/hybrid/table/HybridTableSourceFactoryTest.java
+++ b/flink-connectors/flink-connector-hybrid/src/test/java/org/apache/flink/connector/hybrid/table/HybridTableSourceFactoryTest.java
@@ -1,0 +1,242 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hybrid.table;
+
+import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.connector.base.source.hybrid.HybridSource;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.catalog.WatermarkSpec;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.ScanTableSource;
+import org.apache.flink.table.connector.source.SourceProvider;
+import org.apache.flink.table.expressions.utils.ResolvedExpressionMock;
+import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContext;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.util.ExceptionUtils;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/** Tests for the {@link HybridTableSourceFactory}. */
+@ExtendWith(TestLoggerExtension.class)
+public class HybridTableSourceFactoryTest {
+
+    private static final String COMPUTED_SQL = "orig_ts - INTERVAL '1' MINUTE";
+    private static final String WATERMARK_SQL = "ts - INTERVAL '5' SECOND";
+
+    private static ResolvedSchema tableSchema;
+
+    @BeforeAll
+    public static void before() {
+        tableSchema =
+                new ResolvedSchema(
+                        Arrays.asList(
+                                Column.physical("order_id", DataTypes.INT().notNull()),
+                                Column.physical("product_id", DataTypes.VARCHAR(200)),
+                                Column.physical("purchaser", DataTypes.VARCHAR(200)),
+                                Column.metadata("topic", DataTypes.VARCHAR(200), "topic", false),
+                                Column.metadata(
+                                        "orig_ts", DataTypes.TIMESTAMP(3), "timestamp", false),
+                                Column.computed(
+                                        "ts",
+                                        ResolvedExpressionMock.of(
+                                                DataTypes.TIMESTAMP(3), COMPUTED_SQL))),
+                        Collections.singletonList(
+                                WatermarkSpec.of(
+                                        "ts",
+                                        ResolvedExpressionMock.of(
+                                                DataTypes.TIMESTAMP(3), WATERMARK_SQL))),
+                        UniqueConstraint.primaryKey(
+                                "primary_constraint", Collections.singletonList("order_id")));
+    }
+
+    @Test
+    @SuppressWarnings("rawtypes")
+    public void testTableSourceFactoryCorrectly() {
+        DynamicTableSource source = createTableSource(tableSchema, getAllOptions());
+        assertTrue(source instanceof HybridTableSource);
+
+        HybridTableSource hybridTableSource = (HybridTableSource) source;
+        assertNotNull(hybridTableSource.copy());
+
+        assertEquals(
+                ChangelogMode.newBuilder()
+                        .addContainedKind(RowKind.INSERT)
+                        .addContainedKind(RowKind.DELETE)
+                        .build(),
+                hybridTableSource.getChangelogMode());
+
+        ScanTableSource.ScanRuntimeProvider provider =
+                hybridTableSource.getScanRuntimeProvider(ScanRuntimeProviderContext.INSTANCE);
+        assertTrue(provider instanceof SourceProvider);
+
+        SourceProvider sourceProvider = (SourceProvider) provider;
+        assertTrue(sourceProvider.createSource() instanceof HybridSource);
+        HybridSource hybridSource = (HybridSource) sourceProvider.createSource();
+        assertTrue(provider.isBounded());
+        assertEquals(hybridSource.getBoundedness(), Boundedness.BOUNDED);
+    }
+
+    @Test
+    public void testSourceIdentifierNums() {
+        Map<String, String> options = new HashMap<>(getAllOptions());
+        options.put("source-identifiers", "historical");
+
+        try {
+            createTableSource(tableSchema, options);
+            fail("Should fail");
+        } catch (Exception e) {
+            assertTrue(
+                    ExceptionUtils.findThrowableWithMessage(e, "must specify at least 2 sources")
+                            .isPresent());
+        }
+    }
+
+    @Test
+    public void testSourceIdentifierFormat() {
+        Map<String, String> options = new HashMap<>(getAllOptions());
+        options.put("source-identifiers", "historical#");
+
+        try {
+            createTableSource(tableSchema, options);
+            fail("Should fail");
+        } catch (Exception e) {
+            assertTrue(
+                    ExceptionUtils.findThrowableWithMessage(
+                                    e,
+                                    "source-identifier pattern must be "
+                                            + HybridConnectorOptions.SOURCE_IDENTIFIER_REGEX)
+                            .isPresent());
+        }
+    }
+
+    @Test
+    public void testSameSourceIdentifier() {
+        Map<String, String> options = new HashMap<>(getAllOptions());
+        options.put("source-identifiers", "historical,historical,realtime");
+
+        try {
+            createTableSource(tableSchema, options);
+            fail("Should fail");
+        } catch (Exception e) {
+            assertTrue(
+                    ExceptionUtils.findThrowableWithMessage(
+                                    e, "each source identifier must not be the same")
+                            .isPresent());
+        }
+    }
+
+    @Test
+    public void testNotExistedSourceIdentifier() {
+        Map<String, String> options = new HashMap<>(getAllOptions());
+        options.put("source-identifiers", "historical01,historical,realtime");
+
+        try {
+            createTableSource(tableSchema, options);
+            fail("Should fail");
+        } catch (Exception e) {
+            assertTrue(
+                    ExceptionUtils.findThrowableWithMessage(
+                                    e, "Options cannot have null keys or values")
+                            .isPresent());
+        }
+    }
+
+    @Test
+    public void testUnsupportedOptions() {
+        Map<String, String> options = new HashMap<>(getAllOptions());
+        options.put("key", "value");
+
+        try {
+            createTableSource(tableSchema, options);
+            fail("Should fail");
+        } catch (Exception e) {
+            assertTrue(
+                    ExceptionUtils.findThrowableWithMessage(
+                                    e, "Unsupported options found for 'hybrid'")
+                            .isPresent());
+        }
+    }
+
+    @Test
+    public void testExtractChildSourceOptions() {
+        Map<String, String> mockOptions = getAllOptions();
+        HybridTableSourceFactory mockFactory = new HybridTableSourceFactory();
+
+        assertEquals(
+                new HashMap<String, String>() {
+                    {
+                        put("connector", null);
+                    }
+                },
+                mockFactory.extractChildSourceOptions(mockOptions, "unknown"));
+
+        assertEquals(
+                new HashMap<String, String>() {
+                    {
+                        put("connector", "values");
+                        put("data-id", "1");
+                        put("bounded", "true");
+                        put("runtime-source", "NewSource");
+                    }
+                },
+                mockFactory.extractChildSourceOptions(mockOptions, "historical"));
+
+        assertEquals(
+                new HashMap<String, String>() {
+                    {
+                        put("connector", "values");
+                        put("changelog-mode", "I,D");
+                        put("runtime-source", "NewSource");
+                    }
+                },
+                mockFactory.extractChildSourceOptions(mockOptions, "realtime"));
+    }
+
+    private Map<String, String> getAllOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put("connector", "hybrid");
+        options.put("source-identifiers", "historical,realtime");
+        options.put("historical.connector", "values");
+        options.put("historical.data-id", "1");
+        options.put("historical.runtime-source", "NewSource");
+        options.put("historical.bounded", "true");
+        options.put("realtime.connector", "values");
+        options.put("realtime.changelog-mode", "I,D");
+        options.put("realtime.runtime-source", "NewSource");
+        return options;
+    }
+}

--- a/flink-connectors/flink-connector-hybrid/src/test/java/org/apache/flink/connector/hybrid/table/HybridTableSourceITCase.java
+++ b/flink-connectors/flink-connector-hybrid/src/test/java/org/apache/flink/connector/hybrid/table/HybridTableSourceITCase.java
@@ -1,0 +1,453 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.hybrid.table;
+
+import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.Schema;
+import org.apache.flink.table.api.Table;
+import org.apache.flink.table.api.TableDescriptor;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
+import org.apache.flink.table.planner.factories.TestValuesTableFactory;
+import org.apache.flink.test.junit5.MiniClusterExtension;
+import org.apache.flink.test.util.TestBaseUtils;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.apache.flink.table.api.Expressions.$;
+
+/** Integration test for the {@link HybridTableSource}. */
+@ExtendWith(TestLoggerExtension.class)
+public class HybridTableSourceITCase {
+
+    @RegisterExtension
+    private static final MiniClusterExtension MINI_CLUSTER_EXTENSION =
+            new MiniClusterExtension(
+                    new MiniClusterResourceConfiguration.Builder()
+                            .setNumberTaskManagers(1)
+                            .setNumberSlotsPerTaskManager(1)
+                            .build());
+
+    private static final List<String> DATA_IDS = new ArrayList<>();
+
+    static {
+        List<Row> data0 = new ArrayList<>();
+        data0.add(Row.of("hello_a", "flink_a", 0L));
+        data0.add(Row.of("hello_a", "hadoop_a", 1L));
+        data0.add(Row.of("hello_a", "world_a", 2L));
+
+        List<Row> data1 = new ArrayList<>();
+        data1.add(Row.of("hello_b", "flink_b", 3L));
+        data1.add(Row.of("hello_b", "hadoop_b", 4L));
+        data1.add(Row.of("hello_b", "world_b", 5L));
+
+        List<Row> data2 = new ArrayList<>();
+        data2.add(Row.of("hello_c", "flink_c", 6L));
+        data2.add(Row.of("hello_c", "hadoop_c", 7L));
+        data2.add(Row.of("hello_c", "world_c", 8L));
+
+        List<Row> dataWithMetadata0 = new ArrayList<>();
+        dataWithMetadata0.add(Row.of("hello_d", "flink_d", 9L, "meta0"));
+        dataWithMetadata0.add(Row.of("hello_d", "hadoop_d", 10L, "meta1"));
+        dataWithMetadata0.add(Row.of("hello_d", "world_d", 11L, "meta2"));
+
+        List<Row> dataWithMetadata1 = new ArrayList<>();
+        dataWithMetadata1.add(Row.of("hello_e", "flink_e", 12L, "meta3"));
+        dataWithMetadata1.add(Row.of("hello_e", "hadoop_e", 13L, "meta4"));
+        dataWithMetadata1.add(Row.of("hello_e", "world_e", 14L, "meta5"));
+
+        List<Row> dataWithMetadata2 = new ArrayList<>();
+        dataWithMetadata2.add(Row.of("hello_e", "flink_e", 15L, null));
+        dataWithMetadata2.add(Row.of("hello_e", "hadoop_e", 16L, null));
+        dataWithMetadata2.add(Row.of("hello_e", "world_e", 17L, null));
+
+        String dataId0 = TestValuesTableFactory.registerData(data0);
+        String dataId1 = TestValuesTableFactory.registerData(data1);
+        String dataId2 = TestValuesTableFactory.registerData(data2);
+        String dataId3 = TestValuesTableFactory.registerData(dataWithMetadata0);
+        String dataId4 = TestValuesTableFactory.registerData(dataWithMetadata1);
+        String dataId5 = TestValuesTableFactory.registerData(dataWithMetadata2);
+        DATA_IDS.add(dataId0);
+        DATA_IDS.add(dataId1);
+        DATA_IDS.add(dataId2);
+        DATA_IDS.add(dataId3);
+        DATA_IDS.add(dataId4);
+        DATA_IDS.add(dataId5);
+    }
+
+    private static Stream<EnvMode> envs() {
+        return Stream.of(EnvMode.Streaming, EnvMode.Batch);
+    }
+
+    private static TableEnvironment getTableEnv(EnvMode envMode) {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        if (envMode == EnvMode.Streaming) {
+            return StreamTableEnvironment.create(env, EnvironmentSettings.inStreamingMode());
+        } else {
+            return StreamTableEnvironment.create(env, EnvironmentSettings.inBatchMode());
+        }
+    }
+
+    // -------------------------------------------------------------------------------------
+    // HybridTableSource tests
+    // -------------------------------------------------------------------------------------
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void testHybridSourceWithDDL(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        tEnv.executeSql(
+                "CREATE TABLE hybrid_source("
+                        + "  f0 varchar,"
+                        + "  f1 varchar,"
+                        + "  f2 bigint"
+                        + ") WITH ("
+                        + "  'connector' = 'hybrid',"
+                        + "  'source-identifiers' = 'historical,realtime',"
+                        + "  'historical.connector' = 'values',"
+                        + "  'historical.data-id' = '"
+                        + DATA_IDS.get(0)
+                        + "',"
+                        + "  'historical.runtime-source' = 'NewSource',"
+                        + "  'historical.bounded' = 'true',"
+                        + "  'realtime.connector' = 'values',"
+                        + "  'realtime.data-id' = '"
+                        + DATA_IDS.get(1)
+                        + "',"
+                        + "  'realtime.runtime-source' = 'NewSource'"
+                        + ")");
+
+        Table table = tEnv.sqlQuery("SELECT * FROM hybrid_source");
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_a, flink_a, 0]\n"
+                        + "+I[hello_a, hadoop_a, 1]\n"
+                        + "+I[hello_a, world_a, 2]\n"
+                        + "+I[hello_b, flink_b, 3]\n"
+                        + "+I[hello_b, hadoop_b, 4]\n"
+                        + "+I[hello_b, world_b, 5]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void testHybridSourceWithTable(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        TableDescriptor tableDescriptor =
+                TableDescriptor.forConnector("hybrid")
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("f0", DataTypes.STRING())
+                                        .column("f1", DataTypes.STRING())
+                                        .column("f2", DataTypes.BIGINT())
+                                        .build())
+                        .option("source-identifiers", "historical,realtime")
+                        .option("historical.connector", "values")
+                        .option("historical.data-id", DATA_IDS.get(0))
+                        .option("historical.runtime-source", "NewSource")
+                        .option("historical.bounded", "true")
+                        .option("realtime.connector", "values")
+                        .option("realtime.data-id", DATA_IDS.get(1))
+                        .option("realtime.runtime-source", "NewSource")
+                        .build();
+        tEnv.createTable("hybrid_source", tableDescriptor);
+
+        Table table = tEnv.from("hybrid_source").select($("f0"), $("f1"), $("f2"));
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_a, flink_a, 0]\n"
+                        + "+I[hello_a, hadoop_a, 1]\n"
+                        + "+I[hello_a, world_a, 2]\n"
+                        + "+I[hello_b, flink_b, 3]\n"
+                        + "+I[hello_b, hadoop_b, 4]\n"
+                        + "+I[hello_b, world_b, 5]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void testMultiSourcesWithDDL(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        tEnv.executeSql(
+                "CREATE TABLE hybrid_source("
+                        + "  f0 varchar,"
+                        + "  f1 varchar,"
+                        + "  f2 bigint"
+                        + ") WITH ("
+                        + "  'connector' = 'hybrid',"
+                        + "  'source-identifiers' = 'historical01,historical02,realtime',"
+                        + "  'historical01.connector' = 'values',"
+                        + "  'historical01.data-id' = '"
+                        + DATA_IDS.get(0)
+                        + "',"
+                        + "  'historical01.runtime-source' = 'NewSource',"
+                        + "  'historical02.connector' = 'values',"
+                        + "  'historical02.data-id' = '"
+                        + DATA_IDS.get(1)
+                        + "',"
+                        + "  'historical02.runtime-source' = 'NewSource',"
+                        + "  'realtime.connector' = 'values',"
+                        + "  'realtime.data-id' = '"
+                        + DATA_IDS.get(2)
+                        + "',"
+                        + "  'realtime.runtime-source' = 'NewSource'"
+                        + ")");
+
+        Table table = tEnv.sqlQuery("SELECT * FROM hybrid_source");
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_a, flink_a, 0]\n"
+                        + "+I[hello_a, hadoop_a, 1]\n"
+                        + "+I[hello_a, world_a, 2]\n"
+                        + "+I[hello_b, flink_b, 3]\n"
+                        + "+I[hello_b, hadoop_b, 4]\n"
+                        + "+I[hello_b, world_b, 5]\n"
+                        + "+I[hello_c, flink_c, 6]\n"
+                        + "+I[hello_c, hadoop_c, 7]\n"
+                        + "+I[hello_c, world_c, 8]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void testMultiSourcesWithTableApi(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        TableDescriptor tableDescriptor =
+                TableDescriptor.forConnector("hybrid")
+                        .schema(
+                                Schema.newBuilder()
+                                        .column("f0", DataTypes.STRING())
+                                        .column("f1", DataTypes.STRING())
+                                        .column("f2", DataTypes.BIGINT())
+                                        .build())
+                        .option("source-identifiers", "historical01,historical02,realtime")
+                        .option("historical01.connector", "values")
+                        .option("historical01.data-id", DATA_IDS.get(0))
+                        .option("historical01.runtime-source", "NewSource")
+                        .option("historical02.connector", "values")
+                        .option("historical02.data-id", DATA_IDS.get(1))
+                        .option("historical02.runtime-source", "NewSource")
+                        .option("realtime.connector", "values")
+                        .option("realtime.data-id", DATA_IDS.get(2))
+                        .option("realtime.runtime-source", "NewSource")
+                        .build();
+        tEnv.createTable("hybrid_source", tableDescriptor);
+
+        Table table = tEnv.from("hybrid_source").select($("f0"), $("f1"), $("f2"));
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_a, flink_a, 0]\n"
+                        + "+I[hello_a, hadoop_a, 1]\n"
+                        + "+I[hello_a, world_a, 2]\n"
+                        + "+I[hello_b, flink_b, 3]\n"
+                        + "+I[hello_b, hadoop_b, 4]\n"
+                        + "+I[hello_b, world_b, 5]\n"
+                        + "+I[hello_c, flink_c, 6]\n"
+                        + "+I[hello_c, hadoop_c, 7]\n"
+                        + "+I[hello_c, world_c, 8]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void testSwitchedStartPosition(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        // when switched-start-position-enabled is ture, the first source enumerator need implement
+        // SupportsGetEndTimestamp, next source need implement SupportsSwitchedStartTimestamp
+        tEnv.executeSql(
+                "CREATE TABLE hybrid_source("
+                        + "  f0 varchar,"
+                        + "  f1 varchar,"
+                        + "  f2 bigint"
+                        + ") WITH ("
+                        + "  'connector' = 'hybrid',"
+                        + "  'source-identifiers' = 'historical,realtime',"
+                        + "  'switched-start-position-enabled' = 'true',"
+                        + "  'historical.connector' = 'values',"
+                        + "  'historical.data-id' = '"
+                        + DATA_IDS.get(0)
+                        + "',"
+                        + "  'historical.runtime-source' = 'NewSource',"
+                        + "  'realtime.connector' = 'values',"
+                        + "  'realtime.data-id' = '"
+                        + DATA_IDS.get(1)
+                        + "',"
+                        + "  'realtime.runtime-source' = 'NewSource'"
+                        + ")");
+
+        Table table = tEnv.sqlQuery("SELECT * FROM hybrid_source");
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_a, flink_a, 0]\n"
+                        + "+I[hello_a, hadoop_a, 1]\n"
+                        + "+I[hello_a, world_a, 2]\n"
+                        + "+I[hello_b, flink_b, 3]\n"
+                        + "+I[hello_b, hadoop_b, 4]\n"
+                        + "+I[hello_b, world_b, 5]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void tesHybridSourceProjectPushDown(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        // 2 sources both support project pushdown (pushdown option is true by default)
+        tEnv.executeSql(
+                "CREATE TABLE hybrid_source("
+                        + "  f0 varchar,"
+                        + "  f1 varchar,"
+                        + "  f2 bigint"
+                        + ") WITH ("
+                        + "  'connector' = 'hybrid',"
+                        + "  'source-identifiers' = 'historical,realtime',"
+                        + "  'historical.connector' = 'values',"
+                        + "  'historical.data-id' = '"
+                        + DATA_IDS.get(0)
+                        + "',"
+                        + "  'historical.runtime-source' = 'NewSource',"
+                        + "  'historical.bounded' = 'true',"
+                        + "  'realtime.connector' = 'values',"
+                        + "  'realtime.data-id' = '"
+                        + DATA_IDS.get(1)
+                        + "',"
+                        + "  'realtime.runtime-source' = 'NewSource'"
+                        + ")");
+
+        // just select 2 fields to test project pushdown
+        Table table = tEnv.sqlQuery("SELECT f0, f1 FROM hybrid_source");
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_a, flink_a]\n"
+                        + "+I[hello_a, hadoop_a]\n"
+                        + "+I[hello_a, world_a]\n"
+                        + "+I[hello_b, flink_b]\n"
+                        + "+I[hello_b, hadoop_b]\n"
+                        + "+I[hello_b, world_b]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void tesHybridSourceAllSourcesHasDDLMetaData(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        // 2 sources has a common metadata
+        tEnv.executeSql(
+                "CREATE TABLE hybrid_source("
+                        + "  f0 varchar,"
+                        + "  f1 varchar,"
+                        + "  f2 bigint,"
+                        + "  metadata_1 varchar metadata"
+                        + ") WITH ("
+                        + "  'connector' = 'hybrid',"
+                        + "  'source-identifiers' = 'historical,realtime',"
+                        + "  'historical.connector' = 'values',"
+                        + "  'historical.data-id' = '"
+                        + DATA_IDS.get(3)
+                        + "',"
+                        + "  'historical.runtime-source' = 'NewSource',"
+                        + "  'historical.bounded' = 'true',"
+                        + "  'historical.readable-metadata' = 'metadata_1:STRING,metadata_2:INT',"
+                        + "  'realtime.connector' = 'values',"
+                        + "  'realtime.data-id' = '"
+                        + DATA_IDS.get(4)
+                        + "',"
+                        + "  'realtime.runtime-source' = 'NewSource',"
+                        + "  'realtime.readable-metadata' = 'metadata_1:STRING,metadata_3:INT'"
+                        + ")");
+
+        Table table = tEnv.sqlQuery("SELECT * FROM hybrid_source");
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_d, flink_d, 9, meta0]\n"
+                        + "+I[hello_d, hadoop_d, 10, meta1]\n"
+                        + "+I[hello_d, world_d, 11, meta2]\n"
+                        + "+I[hello_e, flink_e, 12, meta3]\n"
+                        + "+I[hello_e, hadoop_e, 13, meta4]\n"
+                        + "+I[hello_e, world_e, 14, meta5]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    @ParameterizedTest
+    @MethodSource("envs")
+    void tesHybridSourceOneSourceHasDDLMetaData(EnvMode envMode) {
+        TableEnvironment tEnv = getTableEnv(envMode);
+        // the ddl metadata field just belongs first source,
+        // the second source without this metadata
+        tEnv.executeSql(
+                "CREATE TABLE hybrid_source("
+                        + "  f0 varchar,"
+                        + "  f1 varchar,"
+                        + "  f2 bigint,"
+                        + "  metadata_1 varchar metadata"
+                        + ") WITH ("
+                        + "  'connector' = 'hybrid',"
+                        + "  'source-identifiers' = 'historical,realtime',"
+                        + "  'historical.connector' = 'values',"
+                        + "  'historical.data-id' = '"
+                        + DATA_IDS.get(3)
+                        + "',"
+                        + "  'historical.runtime-source' = 'NewSource',"
+                        + "  'historical.bounded' = 'true',"
+                        + "  'historical.readable-metadata' = 'metadata_1:STRING,metadata_2:INT',"
+                        + "  'realtime.connector' = 'values',"
+                        + "  'realtime.data-id' = '"
+                        + DATA_IDS.get(5)
+                        + "',"
+                        + "  'realtime.runtime-source' = 'NewSource',"
+                        + "  'realtime.readable-metadata' = 'metadata_3:STRING,metadata_4:INT'"
+                        + ")");
+
+        Table table = tEnv.sqlQuery("SELECT * FROM hybrid_source");
+
+        List<Row> results = CollectionUtil.iteratorToList(table.execute().collect());
+        String expected =
+                "+I[hello_d, flink_d, 9, meta0]\n"
+                        + "+I[hello_d, hadoop_d, 10, meta1]\n"
+                        + "+I[hello_d, world_d, 11, meta2]\n"
+                        + "+I[hello_e, flink_e, 15, null]\n"
+                        + "+I[hello_e, hadoop_e, 16, null]\n"
+                        + "+I[hello_e, world_e, 17, null]\n";
+        TestBaseUtils.compareResultAsText(results, expected);
+    }
+
+    private enum EnvMode {
+        Streaming,
+        Batch
+    }
+}

--- a/flink-connectors/flink-connector-hybrid/src/test/resources/log4j2-test.properties
+++ b/flink-connectors/flink-connector-hybrid/src/test/resources/log4j2-test.properties
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set root logger level to OFF to not flood build logs
+# set manually to INFO for debugging purposes
+rootLogger.level = OFF
+rootLogger.appenderRef.test.ref = TestLogger
+
+appender.testlogger.name = TestLogger
+appender.testlogger.type = CONSOLE
+appender.testlogger.target = SYSTEM_OUT
+appender.testlogger.layout.type = PatternLayout
+appender.testlogger.layout.pattern = %-4r [%t] %-5p %c %x - %m%n

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicSource.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.serialization.DeserializationSchema;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.connector.source.Boundedness;
+import org.apache.flink.api.connector.source.Source;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.KafkaSourceBuilder;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.NoStoppingOffsetsInitializer;
@@ -41,7 +42,7 @@ import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.Projection;
 import org.apache.flink.table.connector.ProviderContext;
 import org.apache.flink.table.connector.format.DecodingFormat;
-import org.apache.flink.table.connector.source.DataStreamScanProvider;
+import org.apache.flink.table.connector.source.DataStreamScanSourceAbilityProvider;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsReadingMetadata;
@@ -249,7 +250,7 @@ public class KafkaDynamicSource
         final KafkaSource<RowData> kafkaSource =
                 createKafkaSource(keyDeserialization, valueDeserialization, producedTypeInfo);
 
-        return new DataStreamScanProvider() {
+        return new DataStreamScanSourceAbilityProvider<Source<RowData, ?, ?>>() {
             @Override
             public DataStream<RowData> produceDataStream(
                     ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
@@ -261,6 +262,11 @@ public class KafkaDynamicSource
                                 kafkaSource, watermarkStrategy, "KafkaSource-" + tableIdentifier);
                 providerContext.generateUid(KAFKA_TRANSFORMATION).ifPresent(sourceStream::uid);
                 return sourceStream;
+            }
+
+            @Override
+            public Source<RowData, ?, ?> createSource() {
+                return kafkaSource;
             }
 
             @Override

--- a/flink-connectors/pom.xml
+++ b/flink-connectors/pom.xml
@@ -45,6 +45,7 @@ under the License.
 		<module>flink-file-sink-common</module>
 		<module>flink-connector-files</module>
 		<module>flink-connector-datagen</module>
+		<module>flink-connector-hybrid</module>
 	</modules>
 
 	<!-- override these root dependencies as 'provided', so they don't end up

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsGetEndTimestamp.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsGetEndTimestamp.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * A decorative interface of {@link SplitEnumerator} which allows to get end timestamp.
+ *
+ * <p>The split enumerator must implement this interface if it needs to support switched start
+ * position in hybrid source scenario and other needed situations.
+ */
+@PublicEvolving
+public interface SupportsGetEndTimestamp {
+
+    /** Get the end timestamp for current source or split enumerator. */
+    long getEndTimestamp();
+}

--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsSwitchedStartTimestamp.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/SupportsSwitchedStartTimestamp.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+
+/**
+ * Unlike predefined start offset in source, this interface allow to apply a dynamic switched
+ * timestamp to a source, then source can use this switched timestamp to re-initialize the start
+ * offsets. However, it depends on concrete source implementation. A common scenario is that
+ * HybridSource next source use this ability to switch from previous one.
+ */
+@PublicEvolving
+public interface SupportsSwitchedStartTimestamp {
+
+    /** Apply given switched start timestamp to source. */
+    void applySwitchedStartTimestamp(long startTimestamp);
+}

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanSourceAbilityProvider.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/table/connector/source/DataStreamScanSourceAbilityProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.connector.source;
+
+import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.io.InputFormat;
+import org.apache.flink.api.connector.source.Source;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+
+/**
+ * Provider that extends for {@link DataStreamScanProvider} to let DataStreamScanProvider support
+ * expose inner source.
+ *
+ * <p>Usually a {@link SourceProvider} expose {@link Source}, {@link SourceFunctionProvider} expose
+ * {@link SourceFunction} and {@link InputFormatProvider} expose {@link InputFormat}, but {@link
+ * DataStreamScanProvider} just produce datastream, we can not get the inner source(note this source
+ * could be SourceFunction or new Source or InputFormat). But sometimes we need it, a common
+ * scenario is HybridSource, we need to extract inner source from provider.
+ *
+ * @param <T> source type
+ */
+@PublicEvolving
+public interface DataStreamScanSourceAbilityProvider<T> extends DataStreamScanProvider {
+
+    /**
+     * Expose DataStreamScanProvider inner source.
+     *
+     * @return inner source
+     */
+    T createSource();
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/source/ValuesSource.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/source/ValuesSource.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SupportsSwitchedStartTimestamp;
 import org.apache.flink.connector.source.enumerator.NoOpEnumState;
 import org.apache.flink.connector.source.enumerator.NoOpEnumStateSerializer;
 import org.apache.flink.connector.source.enumerator.ValuesSourceEnumerator;
@@ -52,7 +53,9 @@ import java.util.stream.IntStream;
  * must be 1. RowData is not serializable and the parallelism of table source may not be 1, so we
  * introduce a new source for testing in table module.
  */
-public class ValuesSource implements Source<RowData, ValuesSourceSplit, NoOpEnumState> {
+public class ValuesSource
+        implements Source<RowData, ValuesSourceSplit, NoOpEnumState>,
+                SupportsSwitchedStartTimestamp {
     private final TypeSerializer<RowData> serializer;
 
     private final List<byte[]> serializedElements;
@@ -117,4 +120,7 @@ public class ValuesSource implements Source<RowData, ValuesSourceSplit, NoOpEnum
     public SimpleVersionedSerializer<NoOpEnumState> getEnumeratorCheckpointSerializer() {
         return new NoOpEnumStateSerializer();
     }
+
+    @Override
+    public void applySwitchedStartTimestamp(long startTimestamp) {}
 }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/source/enumerator/ValuesSourceEnumerator.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/connector/source/enumerator/ValuesSourceEnumerator.java
@@ -20,6 +20,7 @@ package org.apache.flink.connector.source.enumerator;
 
 import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SupportsGetEndTimestamp;
 import org.apache.flink.connector.source.ValuesSource;
 import org.apache.flink.connector.source.split.ValuesSourceSplit;
 
@@ -34,7 +35,8 @@ import java.util.Queue;
  * A {@link SplitEnumerator} for {@link ValuesSource}. Simply takes the pre-split set of splits and
  * assigns it first-come-first-serve.
  */
-public class ValuesSourceEnumerator implements SplitEnumerator<ValuesSourceSplit, NoOpEnumState> {
+public class ValuesSourceEnumerator
+        implements SplitEnumerator<ValuesSourceSplit, NoOpEnumState>, SupportsGetEndTimestamp {
 
     private final SplitEnumeratorContext<ValuesSourceSplit> context;
     private final Queue<ValuesSourceSplit> remainingSplits;
@@ -78,4 +80,9 @@ public class ValuesSourceEnumerator implements SplitEnumerator<ValuesSourceSplit
 
     @Override
     public void close() throws IOException {}
+
+    @Override
+    public long getEndTimestamp() {
+        return 0;
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

Implementation of FLIP-278. Add flink hybrid source table & sql support.

## Brief change log

Add flink hybrid source connector.

## Verifying this change

HybridTableSourceFactoryTest & HybridTableSourceITCases

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): yes (new connector)
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  yes
- If yes, how is the feature documented? to-be-added