### PR TITLE
[hotfix][flink-core][doc] add javadoc to improve the code readability

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -705,9 +705,12 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * sure there will be at least one value available. Otherwise, a NPE will be thrown by Flink
      * when the value is used.
      *
+     * <p>NOTE: current logic is not able to get the default value of the fallback key's
+     * ConfigOption, in case the given ConfigOption has no default value. If you want to use
+     * fallback key, please make sure its value could be found in {@link Configuration} at runtime.
+     *
      * @param option metadata of the option to read
-     * @return the vaule of the given option
-     * @param <T>
+     * @return the value of the given option
      */
     @Override
     public <T> T get(ConfigOption<T> option) {
@@ -842,10 +845,7 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
      * <p>1. get the value from {@link Configuration}. <br>
      * 2. if key is not found, try to get the value with fallback keys from {@link Configuration}
      * <br>
-     * 3. if no fallback keys are found, return {@link Optional#empty()}.
-     *
-     * <p>Current logic is not able to get the default value of the fallback key's ConfigOption, if
-     * the given ConfigOption has no default value.
+     * 3. if no fallback keys are found, return {@link Optional#empty()}. <br>
      *
      * @return the value of the configuration or {@link Optional#empty()}.
      */

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -700,10 +700,10 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
     }
 
     /**
-     * Please check the java doc of {@link #getRawValueFromOption(ConfigOption)}. If no keys
-     * are found in {@link Configuration}, default value of the given option will return. Please
-     * make sure there will be at least one value available. Otherwise, a NPE will be thrown by
-     * Flink when the value is used.
+     * Please check the java doc of {@link #getRawValueFromOption(ConfigOption)}. If no keys are
+     * found in {@link Configuration}, default value of the given option will return. Please make
+     * sure there will be at least one value available. Otherwise, a NPE will be thrown by Flink
+     * when the value is used.
      *
      * @param option metadata of the option to read
      * @return the vaule of the given option
@@ -839,14 +839,13 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
     /**
      * This method will do the following steps to get the value of a config option:
      *
-     * <p/>1. get the value from {@link Configuration}.
+     * <p>1. get the value from {@link Configuration}. <br>
+     * 2. if key is not found, try to get the value with fallback keys from {@link Configuration}
+     * <br>
+     * 3. if no fallback keys are found, return {@link Optional#empty()}.
      *
-     * <br/>2. if key is not found, try to get the value with fallback keys from {@link Configuration}
-     *
-     * <br/>3. if no fallback keys are found, return {@link Optional#empty()}.
-     * <p/>
-     * Current logic is not able to get the default value of the fallback key's ConfigOption, if the given ConfigOption has no
-     * default value.
+     * <p>Current logic is not able to get the default value of the fallback key's ConfigOption, if
+     * the given ConfigOption has no default value.
      *
      * @return the value of the configuration or {@link Optional#empty()}.
      */

--- a/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/Configuration.java
@@ -699,6 +699,16 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         return Optional.empty();
     }
 
+    /**
+     * Please check the java doc of {@link #getRawValueFromOption(ConfigOption)}. If no keys
+     * are found in {@link Configuration}, default value of the given option will return. Please
+     * make sure there will be at least one value available. Otherwise, a NPE will be thrown by
+     * Flink when the value is used.
+     *
+     * @param option metadata of the option to read
+     * @return the vaule of the given option
+     * @param <T>
+     */
     @Override
     public <T> T get(ConfigOption<T> option) {
         return getOptional(option).orElseGet(option::defaultValue);
@@ -826,6 +836,20 @@ public class Configuration extends ExecutionConfig.GlobalJobParameters
         }
     }
 
+    /**
+     * This method will do the following steps to get the value of a config option:
+     *
+     * <p/>1. get the value from {@link Configuration}.
+     *
+     * <br/>2. if key is not found, try to get the value with fallback keys from {@link Configuration}
+     *
+     * <br/>3. if no fallback keys are found, return {@link Optional#empty()}.
+     * <p/>
+     * Current logic is not able to get the default value of the fallback key's ConfigOption, if the given ConfigOption has no
+     * default value.
+     *
+     * @return the value of the configuration or {@link Optional#empty()}.
+     */
     private Optional<Object> getRawValueFromOption(ConfigOption<?> configOption) {
         return applyWithOption(configOption, this::getRawValue);
     }


### PR DESCRIPTION
Only added java doc to improve the readability. The code itself did tell enough information wrt the logic. I got understand it via long time debug. It is good to document it for helping developers understand the logic and also for me, since I might forget it after a few months.

No java logic has been changed.
