### PR TITLE
[FLINK-31086][DOC]update connector lable for blackhole and kafka

### DIFF
--- a/docs/content.zh/docs/connectors/table/kafka.md
+++ b/docs/content.zh/docs/connectors/table/kafka.md
@@ -26,6 +26,7 @@ under the License.
 
 # Apache Kafka SQL 连接器
 
+{{< label "Scan Source: Bounded" >}}
 {{< label "Scan Source: Unbounded" >}}
 {{< label "Sink: Streaming Append Mode" >}}
 

--- a/docs/content/docs/connectors/table/blackhole.md
+++ b/docs/content/docs/connectors/table/blackhole.md
@@ -26,8 +26,8 @@ under the License.
 
 # BlackHole SQL Connector
 
-{{< label "Sink" >}}
-{{< label "Sink" >}}
+{{< label "Sink: Bounded" >}}
+{{< label "Sink: UnBounded" >}}
 
 The BlackHole connector allows for swallowing all input records. It is designed for:
 

--- a/docs/content/docs/connectors/table/kafka.md
+++ b/docs/content/docs/connectors/table/kafka.md
@@ -27,6 +27,7 @@ under the License.
 
 # Apache Kafka SQL Connector
 
+{{< label "Scan Source: Bounded" >}}
 {{< label "Scan Source: Unbounded" >}}
 {{< label "Sink: Streaming Append Mode" >}}
 


### PR DESCRIPTION

## What is the purpose of the change

Update connector label for kafka and blackhole.

Blackhole: sink:bounded unbounded

Kafka: source bounded

![image](https://user-images.githubusercontent.com/18002496/216600374-5c9d16db-66ac-42a4-8b21-16245a71f9ef.png)

