### PR TITLE
[FLINK-30896][table] Reduce usage of CatalogViewImpl in table-planner

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/operations/SqlToOperationConverter.java
@@ -105,7 +105,6 @@ import org.apache.flink.table.catalog.CatalogPartitionImpl;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CatalogView;
-import org.apache.flink.table.catalog.CatalogViewImpl;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ContextResolvedTable;
 import org.apache.flink.table.catalog.FunctionLanguage;
@@ -469,12 +468,12 @@ public class SqlToOperationConverter {
                     OperationConverterUtils.extractProperties(
                             alterViewProperties.getPropertyList()));
             CatalogView newView =
-                    new CatalogViewImpl(
+                    CatalogView.of(
+                            oldView.getUnresolvedSchema(),
+                            oldView.getComment(),
                             oldView.getOriginalQuery(),
                             oldView.getExpandedQuery(),
-                            oldView.getSchema(),
-                            newProperties,
-                            oldView.getComment());
+                            newProperties);
             return new AlterViewPropertiesOperation(viewIdentifier, newView);
         } else if (alterView instanceof SqlAlterViewAs) {
             SqlAlterViewAs alterViewAs = (SqlAlterViewAs) alterView;

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/api/TableEnvironmentTest.scala
@@ -2773,12 +2773,12 @@ class TableEnvironmentTest {
         new CatalogTableImpl(table.getSchema, table.getOptions, tableComment)
       } else {
         val view = table.asInstanceOf[CatalogView]
-        new CatalogViewImpl(
+        CatalogView.of(
+          view.getUnresolvedSchema,
+          tableComment,
           view.getOriginalQuery,
           view.getExpandedQuery,
-          view.getSchema,
-          view.getOptions,
-          tableComment)
+          view.getOptions)
       }
     }
 


### PR DESCRIPTION
## What is the purpose of the change

`CatalogViewImpl` is deprecated and it is suggested to use `CatalogView` in comments.
The PR replaces `CatalogViewImpl` usages in table-planner with `CatalogView`.
In fact most of the work has been already done within https://issues.apache.org/jira/browse/FLINK-21801
And this PR does replacement for probably missing

## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
