### PR TITLE
[bp-1.16][FLINK-29038][datastream] Remove local timeout in AsyncWaitOperatorTest for testing guideline

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/async/AsyncWaitOperatorTest.java
@@ -21,7 +21,6 @@ package org.apache.flink.streaming.api.operators.async;
 import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.functions.RichMapFunction;
-import org.apache.flink.api.common.time.Deadline;
 import org.apache.flink.api.common.typeinfo.BasicTypeInfo;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
 import org.apache.flink.api.common.typeutils.base.IntSerializer;
@@ -73,7 +72,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
-import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1242,9 +1240,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
             expectedOutput.add(new StreamRecord<>(8, initialTime + 4));
             expectedOutput.add(new StreamRecord<>(12, initialTime + 6));
 
-            Deadline deadline = Deadline.fromNow(Duration.ofSeconds(10));
-            while (testHarness.getOutput().size() < expectedOutput.size()
-                    && deadline.hasTimeLeft()) {
+            while (testHarness.getOutput().size() < expectedOutput.size()) {
                 testHarness.processAll();
                 //noinspection BusyWait
                 Thread.sleep(100);
@@ -1311,9 +1307,7 @@ public class AsyncWaitOperatorTest extends TestLogger {
             expectedOutput.add(new StreamRecord<>(-1, initialTime + 1));
             expectedOutput.add(new StreamRecord<>(-1, initialTime + 2));
 
-            Deadline deadline = Deadline.fromNow(Duration.ofSeconds(10));
-            while (testHarness.getOutput().size() < expectedOutput.size()
-                    && deadline.hasTimeLeft()) {
+            while (testHarness.getOutput().size() < expectedOutput.size()) {
                 testHarness.processAll();
                 //noinspection BusyWait
                 Thread.sleep(100);


### PR DESCRIPTION
This is backport pr of  FLINK-29038 to 1.16, it aims to remove the local timeout in AsyncWaitOperatorTest which may cause instability for testing.
