### PR TITLE
[bp-1.15][FLINK-30461][checkpoint] Fix the bug that the shared files will remain forever after the rocksdb incremental checkpoint exception

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/state/StateUtil.java
@@ -63,6 +63,17 @@ public class StateUtil {
                 handlesToDiscard, StateObject::discardState);
     }
 
+    public static void discardStateObjectQuietly(StateObject stateObject) {
+        if (stateObject == null) {
+            return;
+        }
+        try {
+            stateObject.discardState();
+        } catch (Exception exception) {
+            LOG.warn("Discard {} exception.", stateObject, exception);
+        }
+    }
+
     /**
      * Discards the given state future by first trying to cancel it. If this is not possible, then
      * the state object contained in the future is calculated and afterwards discarded.

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
@@ -140,7 +140,7 @@ public class RocksDBStateUploaderTest extends TestLogger {
         Map<StateHandleID, Path> filePaths =
                 generateRandomSstFiles(localFolder, sstFileCount, fileStateSizeThreshold);
         CloseableRegistry tmpResourcesRegistry = new CloseableRegistry();
-        try (RocksDBStateUploader rocksDBStateUploader = new RocksDBStateUploader(sstFileCount)) {
+        try (RocksDBStateUploader rocksDBStateUploader = new RocksDBStateUploader(1)) {
             rocksDBStateUploader.uploadFilesToCheckpointFs(
                     filePaths,
                     checkpointStreamFactory,

--- a/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
+++ b/flink-state-backends/flink-statebackend-rocksdb/src/test/java/org/apache/flink/contrib/streaming/state/RocksDBStateUploaderTest.java
@@ -42,14 +42,18 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static org.apache.flink.util.Preconditions.checkNotNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /** Test class for {@link RocksDBStateUploader}. */
@@ -96,10 +100,89 @@ public class RocksDBStateUploaderTest extends TestLogger {
                     filePaths,
                     checkpointStreamFactory,
                     CheckpointedStateScope.SHARED,
+                    new CloseableRegistry(),
                     new CloseableRegistry());
             fail();
         } catch (Exception e) {
             assertEquals(expectedException, e);
+        }
+    }
+
+    @Test
+    public void testUploadedSstCanBeCleanedUp() throws Exception {
+        SpecifiedException expectedException =
+                new SpecifiedException("throw exception while multi thread upload states.");
+
+        File checkpointPrivateFolder = temporaryFolder.newFolder("private");
+        org.apache.flink.core.fs.Path checkpointPrivateDirectory =
+                org.apache.flink.core.fs.Path.fromLocalFile(checkpointPrivateFolder);
+
+        File checkpointSharedFolder = temporaryFolder.newFolder("shared");
+        org.apache.flink.core.fs.Path checkpointSharedDirectory =
+                org.apache.flink.core.fs.Path.fromLocalFile(checkpointSharedFolder);
+
+        FileSystem fileSystem = checkpointPrivateDirectory.getFileSystem();
+
+        int sstFileCount = 6;
+        int fileStateSizeThreshold = 1024;
+        int writeBufferSize = 4096;
+        CheckpointStreamFactory checkpointStreamFactory =
+                new FsCheckpointStreamFactory(
+                        fileSystem,
+                        checkpointPrivateDirectory,
+                        checkpointSharedDirectory,
+                        fileStateSizeThreshold,
+                        writeBufferSize);
+
+        String localFolder = "local";
+        temporaryFolder.newFolder(localFolder);
+
+        Map<StateHandleID, Path> filePaths =
+                generateRandomSstFiles(localFolder, sstFileCount, fileStateSizeThreshold);
+        CloseableRegistry tmpResourcesRegistry = new CloseableRegistry();
+        try (RocksDBStateUploader rocksDBStateUploader = new RocksDBStateUploader(sstFileCount)) {
+            rocksDBStateUploader.uploadFilesToCheckpointFs(
+                    filePaths,
+                    checkpointStreamFactory,
+                    CheckpointedStateScope.SHARED,
+                    new CloseableRegistry(),
+                    tmpResourcesRegistry);
+
+            try {
+                rocksDBStateUploader.uploadFilesToCheckpointFs(
+                        filePaths,
+                        new LastFailingCheckpointStateOutputStreamFactory(
+                                checkpointStreamFactory, sstFileCount, expectedException),
+                        CheckpointedStateScope.SHARED,
+                        new CloseableRegistry(),
+                        tmpResourcesRegistry);
+                fail();
+            } catch (Exception e) {
+                assertEquals(expectedException, e);
+            }
+            assertEquals(0, checkNotNull(checkpointPrivateFolder.list()).length);
+            assertTrue(checkNotNull(checkpointSharedFolder.list()).length > 0);
+
+            tmpResourcesRegistry.close();
+            // Check whether the temporary file before the exception can be cleaned up
+            assertEquals(0, checkNotNull(checkpointPrivateFolder.list()).length);
+            assertEquals(0, checkNotNull(checkpointSharedFolder.list()).length);
+
+            Map.Entry<StateHandleID, Path> first = filePaths.entrySet().stream().findFirst().get();
+            try {
+                rocksDBStateUploader.uploadFilesToCheckpointFs(
+                        Collections.singletonMap(first.getKey(), first.getValue()),
+                        checkpointStreamFactory,
+                        CheckpointedStateScope.SHARED,
+                        new CloseableRegistry(),
+                        tmpResourcesRegistry);
+            } catch (Exception e) {
+                assertTrue(e instanceof IOException);
+            }
+
+            // Check whether the temporary file after the exception can be cleaned up.
+            assertEquals(0, checkNotNull(checkpointPrivateFolder.list()).length);
+            assertEquals(0, checkNotNull(checkpointSharedFolder.list()).length);
         }
     }
 
@@ -138,6 +221,7 @@ public class RocksDBStateUploaderTest extends TestLogger {
                             sstFilePaths,
                             checkpointStreamFactory,
                             CheckpointedStateScope.SHARED,
+                            new CloseableRegistry(),
                             new CloseableRegistry());
 
             for (Map.Entry<StateHandleID, Path> entry : sstFilePaths.entrySet()) {
@@ -147,7 +231,7 @@ public class RocksDBStateUploaderTest extends TestLogger {
         }
     }
 
-    private CheckpointStateOutputStream createFailingCheckpointStateOutputStream(
+    private static CheckpointStateOutputStream createFailingCheckpointStateOutputStream(
             IOException failureException) {
         return new CheckpointStateOutputStream() {
             @Nullable
@@ -211,6 +295,48 @@ public class RocksDBStateUploaderTest extends TestLogger {
     private static class SpecifiedException extends IOException {
         SpecifiedException(String message) {
             super(message);
+        }
+    }
+
+    /** The last stream will be broken stream. */
+    private static class LastFailingCheckpointStateOutputStreamFactory
+            implements CheckpointStreamFactory {
+
+        private final CheckpointStreamFactory checkpointStreamFactory;
+        private final int streamTotalCount;
+        private final AtomicInteger streamCount;
+        private final IOException expectedException;
+
+        private LastFailingCheckpointStateOutputStreamFactory(
+                CheckpointStreamFactory checkpointStreamFactory,
+                int streamTotalCount,
+                IOException expectedException) {
+            this.checkpointStreamFactory = checkpointStreamFactory;
+            this.streamTotalCount = streamTotalCount;
+            this.expectedException = expectedException;
+            this.streamCount = new AtomicInteger();
+        }
+
+        @Override
+        public CheckpointStateOutputStream createCheckpointStateOutputStream(
+                CheckpointedStateScope scope) throws IOException {
+            if (streamCount.incrementAndGet() == streamTotalCount) {
+                return createFailingCheckpointStateOutputStream(expectedException);
+            }
+            return checkpointStreamFactory.createCheckpointStateOutputStream(scope);
+        }
+
+        @Override
+        public boolean canFastDuplicate(
+                StreamStateHandle stateHandle, CheckpointedStateScope scope) {
+            return false;
+        }
+
+        @Override
+        public List<StreamStateHandle> duplicate(
+                List<StreamStateHandle> stateHandles, CheckpointedStateScope scope)
+                throws IOException {
+            throw new UnsupportedOperationException();
         }
     }
 }


### PR DESCRIPTION
Backport the [FLINK-30461](https://issues.apache.org/jira/browse/FLINK-30461) to release-1.15