### PR TITLE
[FLINK-30902][runtime] Partition reuse does not take effect on edges of hybrid selective type 

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactory.java
@@ -227,15 +227,6 @@ public class ResultPartitionFactory {
             }
         } else if (type == ResultPartitionType.HYBRID_FULL
                 || type == ResultPartitionType.HYBRID_SELECTIVE) {
-            if (type == ResultPartitionType.HYBRID_SELECTIVE && isBroadcast) {
-                // for broadcast result partition, it can be optimized to always use full spilling
-                // strategy to significantly reduce shuffle data writing cost.
-                LOG.info(
-                        "{} result partition has been replaced by {} result partition to reduce shuffle data writing cost.",
-                        type,
-                        ResultPartitionType.HYBRID_FULL);
-                type = ResultPartitionType.HYBRID_FULL;
-            }
             partition =
                     new HsResultPartition(
                             taskNameWithSubtaskAndId,

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/ResultPartitionFactoryTest.java
@@ -132,18 +132,6 @@ class ResultPartitionFactoryTest {
         assertThat(resultPartition.isReleased()).isFalse();
     }
 
-    @Test
-    public void testHybridBroadcastEdgeAlwaysUseFullResultPartition() {
-        ResultPartition resultPartition =
-                createResultPartition(
-                        ResultPartitionType.HYBRID_SELECTIVE, Integer.MAX_VALUE, true);
-        assertThat(resultPartition.partitionType).isEqualTo(ResultPartitionType.HYBRID_FULL);
-
-        resultPartition =
-                createResultPartition(ResultPartitionType.HYBRID_FULL, Integer.MAX_VALUE, true);
-        assertThat(resultPartition.partitionType).isEqualTo(ResultPartitionType.HYBRID_FULL);
-    }
-
     private static ResultPartition createResultPartition(ResultPartitionType partitionType) {
         return createResultPartition(partitionType, Integer.MAX_VALUE);
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/NonChainedOutput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/NonChainedOutput.java
@@ -62,7 +62,7 @@ public class NonChainedOutput implements Serializable {
     private StreamPartitioner<?> partitioner;
 
     /** Target {@link ResultPartitionType}. */
-    private final ResultPartitionType partitionType;
+    private ResultPartitionType partitionType;
 
     public NonChainedOutput(
             boolean supportsUnalignedCheckpoints,
@@ -121,6 +121,10 @@ public class NonChainedOutput implements Serializable {
 
     public void setPartitioner(StreamPartitioner<?> partitioner) {
         this.partitioner = partitioner;
+    }
+
+    public void setPartitionType(ResultPartitionType partitionType) {
+        this.partitionType = partitionType;
     }
 
     public StreamPartitioner<?> getPartitioner() {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -1755,7 +1755,8 @@ class StreamingJobGraphGeneratorTest {
         // this can not reuse the same intermediate dataset because of different partitioner
         source.broadcast().addSink(new DiscardingSink<>()).setParallelism(2);
 
-        // these two vertices can reuse the same intermediate dataset because of the pipelined edge
+        // these two vertices can not reuse the same intermediate dataset because of the pipelined
+        // edge
         source.forward().addSink(new DiscardingSink<>()).setParallelism(1).disableChaining();
         source.forward().addSink(new DiscardingSink<>()).setParallelism(1).disableChaining();
 


### PR DESCRIPTION
## What is the purpose of the change

*Partition reuse only take effect for re-consumable edge, but hybrid selective result partition is not re-consumable. This optimization is very important to reduce the cost of the shuffle write phase. In the previous implementation, we will only force the broadcast edge to be of hybrid full(re-consumable) in the 'ResultPartitionTypeFactory'. As a result, for `ALL_ EXCHANGE_HYBRID_SELECTIVE` job, partition reuse cannot take effect for non-broadcast edges.
In fact, we expected to replace all the edges that can be reused with hybrid full result partition.*


## Brief change log

  - *Change broadcast hybrid selective result partition type to hybrid full in compile phase instead of partition create phase.*
  - *Change reusable hybrid result partition to hybrid full to enable partition reuse optimization.*


## Verifying this change

This change added tests in `StreamingJobGraphGeneratorTest`.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
