### PR TITLE
[FLINK-30903][runtime] Fix the max parallelism used in adaptive batch scheduler doesn't fallbacks to default parallelism

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDecider.java
@@ -457,10 +457,10 @@ public class DefaultVertexParallelismAndInputInfosDecider
                 .collect(Collectors.toList());
     }
 
-    static DefaultVertexParallelismAndInputInfosDecider from(Configuration configuration) {
+    static DefaultVertexParallelismAndInputInfosDecider from(
+            int maxParallelism, Configuration configuration) {
         return new DefaultVertexParallelismAndInputInfosDecider(
-                configuration.getInteger(
-                        BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM),
+                maxParallelism,
                 configuration.getInteger(
                         BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MIN_PARALLELISM),
                 configuration.get(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactoryTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerFactoryTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
+import org.apache.flink.api.common.ExecutionConfig;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.configuration.JobManagerOptions.HybridPartitionDataConsumeConstraint;
@@ -62,6 +63,17 @@ class AdaptiveBatchSchedulerFactoryTest {
                 ONLY_FINISHED_PRODUCERS, PartialFinishedInputConsumableDecider.Factory.INSTANCE);
         assertAndLoadInputConsumableDecider(
                 ALL_PRODUCERS_FINISHED, AllFinishedInputConsumableDecider.Factory.INSTANCE);
+    }
+
+    @Test
+    void testMaxParallelismFallsBackToExecutionConfigDefaultParallelism() {
+        Configuration configuration = new Configuration();
+        ExecutionConfig executionConfig = new ExecutionConfig();
+        executionConfig.setParallelism(5);
+        assertThat(
+                        AdaptiveBatchSchedulerFactory.getDefaultMaxParallelism(
+                                configuration, executionConfig))
+                .isEqualTo(5);
     }
 
     private void assertAndLoadInputConsumableDecider(

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/DefaultVertexParallelismAndInputInfosDeciderTest.java
@@ -436,8 +436,6 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
         Configuration configuration = new Configuration();
 
         configuration.setInteger(
-                BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM, maxParallelism);
-        configuration.setInteger(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MIN_PARALLELISM, minParallelism);
         configuration.set(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_AVG_DATA_VOLUME_PER_TASK,
@@ -446,7 +444,7 @@ class DefaultVertexParallelismAndInputInfosDeciderTest {
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_DEFAULT_SOURCE_PARALLELISM,
                 DEFAULT_SOURCE_PARALLELISM);
 
-        return DefaultVertexParallelismAndInputInfosDecider.from(configuration);
+        return DefaultVertexParallelismAndInputInfosDecider.from(maxParallelism, configuration);
     }
 
     private AllToAllBlockingResultInfo createAllToAllBlockingResultInfo(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

In [FLINK-30684](https://issues.apache.org/jira/browse/FLINK-30684) we mark the vertices which use the default parallelism, and in AdaptiveBatchScheduler we allow users to use parallelism.default as the max parallelism if they don't configure the configuration item "execution.batch.adaptive.auto-parallelism.max-parallelism". This issue will fix the fallback logic.


## Brief change log

Fallback the max pararallelism to default parallelism in DefaultVertexParallelismAndInputInfosDecider if the max parallelism haven't been configured.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / **not documented**)
