### PR TITLE
[FLINK-30917][runtime] Let adaptive batch scheduler also respect the user-configured max parallelism when deciding parallelism

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -320,7 +320,10 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
 
         final ParallelismAndInputInfos parallelismAndInputInfos =
                 vertexParallelismAndInputInfosDecider.decideParallelismAndInputInfosForVertex(
-                        jobVertex.getJobVertexId(), inputs, parallelism);
+                        jobVertex.getJobVertexId(),
+                        inputs,
+                        parallelism,
+                        jobVertex.getMaxParallelism());
 
         if (parallelism == ExecutionConfig.PARALLELISM_DEFAULT) {
             log.info(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismAndInputInfosDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismAndInputInfosDecider.java
@@ -37,14 +37,16 @@ public interface VertexParallelismAndInputInfosDecider {
      *
      * @param jobVertexId The job vertex id
      * @param consumedResults The information of consumed blocking results
-     * @param initialParallelism The initial parallelism of the job vertex. If it's a positive
+     * @param vertexInitialParallelism The initial parallelism of the job vertex. If it's a positive
      *     number, it will be respected. If it's not set(equals to {@link
      *     ExecutionConfig#PARALLELISM_DEFAULT}), a parallelism will be automatically decided for
      *     the vertex.
+     * @param vertexMaxParallelism The max parallelism of the job vertex.
      * @return the parallelism and vertex input infos.
      */
     ParallelismAndInputInfos decideParallelismAndInputInfosForVertex(
             JobVertexID jobVertexId,
             List<BlockingResultInfo> consumedResults,
-            int initialParallelism);
+            int vertexInitialParallelism,
+            int vertexMaxParallelism);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBuilder.java
@@ -402,10 +402,10 @@ public class DefaultSchedulerBuilder {
 
     public static VertexParallelismAndInputInfosDecider createCustomParallelismDecider(
             Function<JobVertexID, Integer> parallelismFunction) {
-        return (jobVertexId, consumedResults, initialParallelism) -> {
+        return (jobVertexId, consumedResults, vertexInitialParallelism, ignored) -> {
             int parallelism =
-                    initialParallelism > 0
-                            ? initialParallelism
+                    vertexInitialParallelism > 0
+                            ? vertexInitialParallelism
                             : parallelismFunction.apply(jobVertexId);
             return new ParallelismAndInputInfos(
                     parallelism,

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -84,11 +84,11 @@ class AdaptiveBatchSchedulerITCase {
         final StreamExecutionEnvironment env =
                 StreamExecutionEnvironment.createLocalEnvironment(configuration);
         env.setRuntimeMode(RuntimeExecutionMode.BATCH);
-        env.setParallelism(4);
+        env.setParallelism(8);
 
         final DataStream<Long> source =
                 env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
-                        .setParallelism(4)
+                        .setParallelism(8)
                         .name("source")
                         .slotSharingGroup("group1");
 
@@ -169,7 +169,8 @@ class AdaptiveBatchSchedulerITCase {
         configuration.setString(RestOptions.BIND_PORT, "0");
         configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
         configuration.setInteger(
-                BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM, 2);
+                BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM,
+                DEFAULT_MAX_PARALLELISM);
         configuration.set(
                 BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_AVG_DATA_VOLUME_PER_TASK,
                 MemorySize.parse("150kb"));


### PR DESCRIPTION
## What is the purpose of the change

Currently, the adaptive batch scheduler only respects the global maximum parallelism(which is configured by option parallelism.default or execution.batch.adaptive.auto-parallelism.max-parallelism, see [FLINK-30686](https://issues.apache.org/jira/browse/FLINK-30686) for details) when deciding parallelism for job vertices, the maximum parallelism of vertices configured by the user through setMaxParallelism will not be respected.

In this ticket, we will change the behavior so that the user-configured max parallelism also be respected.

## Verifying this change
Add tests in `DefaultVertexParallelismAndInputInfosDeciderTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
