### PR TITLE
[FLINK-30864][FLINK-30885][CEP] Fix wrong NFA related to optional decoration and group pattern

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/compiler/NFACompiler.java
@@ -613,9 +613,7 @@ public class NFACompiler {
                     proceedState,
                     takeCondition,
                     getIgnoreCondition(currentPattern),
-                    currentPattern
-                            .getQuantifier()
-                            .hasProperty(Quantifier.QuantifierProperty.OPTIONAL));
+                    isPatternOptional(currentPattern));
         }
 
         /**
@@ -659,14 +657,17 @@ public class NFACompiler {
          * pattern, the optional status depends on the group pattern.
          */
         private boolean isPatternOptional(Pattern<T, ?> pattern) {
-            if (headOfGroup(pattern)) {
-                return isCurrentGroupPatternFirstOfLoop()
-                        && currentGroupPattern
-                                .getQuantifier()
-                                .hasProperty(Quantifier.QuantifierProperty.OPTIONAL);
-            } else {
-                return pattern.getQuantifier().hasProperty(Quantifier.QuantifierProperty.OPTIONAL);
+            return pattern.getQuantifier().hasProperty(Quantifier.QuantifierProperty.OPTIONAL);
+        }
+
+        private boolean isHeadOfOptionalGroupPattern(Pattern<T, ?> pattern) {
+            if (!headOfGroup(pattern)) {
+                return false;
             }
+            return isCurrentGroupPatternFirstOfLoop()
+                    && currentGroupPattern
+                            .getQuantifier()
+                            .hasProperty(Quantifier.QuantifierProperty.OPTIONAL);
         }
 
         /**
@@ -723,7 +724,7 @@ public class NFACompiler {
             // following state of
             // that group pattern and the edge will be added at the end of creating the NFA for that
             // group pattern
-            if (isOptional && !headOfGroup(currentPattern)) {
+            if (isOptional) {
                 if (currentPattern
                         .getQuantifier()
                         .hasProperty(Quantifier.QuantifierProperty.GREEDY)) {
@@ -748,7 +749,7 @@ public class NFACompiler {
 
             if (ignoreCondition != null) {
                 final State<T> ignoreState;
-                if (isOptional) {
+                if (isOptional || isHeadOfOptionalGroupPattern(currentPattern)) {
                     ignoreState = createState(State.StateType.Normal, false);
                     ignoreState.addTake(sink, takeCondition);
                     ignoreState.addIgnore(ignoreCondition);


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes generating wrong NFA related to optional & followed-by semantics at the beginning of group pattern, e.g. optional pattern in a non-optional group pattern, non-optional pattern in optional group pattern with followed-by continuity.


## Verifying this change


This change added tests and can be verified as follows:
- testGroupStartsWithOptionalPattern() & testFollowedByOptionalGroupPattern() in GroupITCase.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
