### PR TITLE
[FLINK-30914][runtime] Hardens tests against ConnectionLossExceptions

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/leaderelection/ZooKeeperLeaderElectionTest.java
@@ -76,6 +76,7 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -723,8 +724,12 @@ public class ZooKeeperLeaderElectionTest extends TestLogger {
             leaderElectionDriver =
                     createAndInitLeaderElectionDriver(clientWithErrorHandler, electionEventHandler);
             assertThat(
+                    "We either expected the exception injected by this test or a connection loss due to an unstable connection which might be caused by a fsync operation taking too long (FLINK-30914).",
                     fatalErrorHandler.getErrorFuture().join(),
-                    FlinkMatchers.containsCause(testException));
+                    either(FlinkMatchers.containsCause(testException))
+                            .or(
+                                    FlinkMatchers.containsCause(
+                                            KeeperException.ConnectionLossException.class)));
         } finally {
             electionEventHandler.close();
 


### PR DESCRIPTION
## What is the purpose of the change

We experienced a test failure where the fatal error was not caused by the injected expected exception but a `ConnectionLossException`. The connection was lost because the `fsync` operation done by ZooKeeper took longer (29858ms) than the specified session timeout (20000ms).
The `ConnectionLossException` can be still considered a fatal error and, therefore, is actually not indicating an unexpected behavior. The exception was properly forwarded to the error handler. We should allow this error to happen here.

## Brief change log

The test excepts `ConnectionLossExceptions` besides the test-internal expected exception.

## Verifying this change

I added a `testingServer.stop();` before running the assert to simulate the connection loss verifying that the exception is handled properly by the test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
