### PR TITLE
[FLINK-30910][runtime] Making test wait for stop to be called before finishing the bootstrap operation

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
@@ -350,8 +350,11 @@ class ApplicationDispatcherBootstrapTest {
 
         bootstrap.stop();
 
-        // the JobStatusFuture needs to be completed after stopping the bootstrap process to ensure
-        // that the process doesn't finish before explicitly stopping it
+        // EmbeddedExecutor calls getJobStatus after the job is submitted in a busy-waiting loop to
+        // wait for the job to pass the initialization phase. Only then, a JobClient is returned
+        // which finalizes the job submission. Completing the getJobStatusFuture after calling
+        // ApplicationDispatcherBootstrap#stop ensures that the applicationExecutionFuture doesn't
+        // complete before ApplicationDispatcherBootstrap#stop is called
         getJobStatusFuture.complete(JobStatus.RUNNING);
 
         // we didn't call the error handler


### PR DESCRIPTION
## What is the purpose of the change

This change prevents a race condition where the bootstrap process finishes before the test calls stop which results in an outcome that's not expected in this test.

## Brief change log

* Makes the getJobStatus method return an not-completed future which will halt the polling of the JobStatus until `stop` is called on the bootstrap process.

## Verifying this change

Adding `Thread.sleep(1000)` before the [stop call|https://github.com/apache/flink/blob/329848e953566d5e086bcd4fc72c2e926db84715/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java#L351] in the test code will simulate the issue. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
