### PR TITLE
[FLINK-30928][tests] Change to eclipse-temurin due to openjdk deprecation

### DIFF
--- a/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/hadoop/Dockerfile
+++ b/flink-end-to-end-tests/test-scripts/docker-hadoop-secure-cluster/hadoop/Dockerfile
@@ -24,7 +24,7 @@
 #
 # Creates multi-node, kerberized Hadoop cluster on Docker
 
-FROM openjdk:8
+FROM eclipse-temurin:8-jdk-jammy
 
 RUN set -x \
     && addgroup hadoop \
@@ -35,7 +35,9 @@ RUN set -x \
 
 # install dev tools
 RUN set -x \
-    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl tar sudo openssh-server openssh-client rsync unzip krb5-user net-tools build-essential
 
 # Kerberos client


### PR DESCRIPTION
## Brief change log

Migrate from OpenJDK which is announced to be deprecated [here](https://hub.docker.com/_/openjdk). In this PR I've migrated to temurin JRE like we have in `flink-docker`.

## Verifying this change

Compile docker images.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: no
  - Core observer or reconciler logic that is regularly executed: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
