### PR TITLE
[FLINK-30927][TableSQL/Runtime][1.17][bugfix] - Bug fix for FLINK-30927 - non-abstract methods have the same parameter types, declaring type and return type

### DIFF
--- a/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementRewriter.java
+++ b/flink-table/flink-table-code-splitter/src/main/java/org/apache/flink/table/codesplit/BlockStatementRewriter.java
@@ -176,6 +176,7 @@ public class BlockStatementRewriter implements CodeRewriter {
                         " throws " + CodeSplitUtil.getContextString(ctx.qualifiedNameList());
             }
 
+            int counter = 0;
             for (JavaParser.BlockStatementContext blockStatementContext :
                     ctx.methodBody().block().blockStatement()) {
 
@@ -191,8 +192,12 @@ public class BlockStatementRewriter implements CodeRewriter {
                                     CodeSplitUtil.getContextString(statement),
                                     String.join(", ", declarationContext));
 
+                    // create rewrite context for every block that will be rewritten. This is for
+                    // case
+                    // when we can have many IF/ELSE/WHILE blocks in single method and
+                    String context = String.format(functionName + "_%d", counter++);
                     // Rewrite function's body to include calls to extracted methods.
-                    String blockRewrittenBody = splitter.rewriteBlock(functionName);
+                    String blockRewrittenBody = splitter.rewriteBlock(context);
 
                     // Get extract methods from block's original body.
                     Map<String, List<String>> newMethods = splitter.extractBlocks();
@@ -205,7 +210,7 @@ public class BlockStatementRewriter implements CodeRewriter {
                                     maxMethodLength,
                                     String.join(", ", declarationContext));
 
-                    RewriteGroupedCode groupedCode = statementGrouper.rewrite(functionName);
+                    RewriteGroupedCode groupedCode = statementGrouper.rewrite(context);
                     // add new methods, representing extracted groups.
                     newMethods.putAll(groupedCode.getGroups());
 

--- a/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/BlockStatementRewriterTest.java
+++ b/flink-table/flink-table-code-splitter/src/test/java/org/apache/flink/table/codesplit/BlockStatementRewriterTest.java
@@ -76,6 +76,11 @@ class BlockStatementRewriterTest extends CodeRewriterTestBase<BlockStatementRewr
         runTest("TestRewriteInnerClass");
     }
 
+    @Test
+    void testRewriteTwoStatements() {
+        runTest("TestRewriteTwoStatements");
+    }
+
     /**
      * Check whether the given and expected classes are actually a valid Java code -> it compiles.
      * If this test fails on "expected" files, it probably means that code split logic is invalid

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/code/TestRewriteTwoStatements.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/code/TestRewriteTwoStatements.java
@@ -1,0 +1,69 @@
+public class TestIfInsideWhileLoopRewrite {
+
+    int counter = 0;
+
+    public void myFun(int[] a, int[] b, int[] c ) throws RuntimeException {
+
+        a[0] += b[1];
+        b[1] += a[1];
+        while (counter < 10) {
+            c[counter] = a[0] + 1000;
+            System.out.println(c);
+            if (a[counter] > 0) {
+                b[counter] = a[counter] * 2;
+                c[counter] = b[counter] * 2;
+                System.out.println(b[counter]);
+            } else {
+                b[counter] = a[counter] * 3;
+                System.out.println(b[counter]);
+            }
+
+            a[2] += b[2];
+            b[3] += a[3];
+            if (a[0] > 0) {
+                System.out.println("Hello");
+            } else {
+                System.out.println("World");
+            }
+
+            counter--;
+        }
+
+        a[4] += b[4];
+        b[5] += a[5];
+
+        if (a.length < 100) {
+            while (counter < 10) {
+                c[counter] = a[0] + 1000;
+                System.out.println(c);
+                if (a[counter] > 0) {
+                    b[counter] = a[counter] * 2;
+                    c[counter] = b[counter] * 2;
+                    System.out.println(b[counter]);
+                } else {
+                    b[counter] = a[counter] * 3;
+                    System.out.println(b[counter]);
+                }
+
+                a[2] += b[2];
+                b[3] += a[3];
+                if (a[0] > 0) {
+                    System.out.println("Hello");
+                } else {
+                    System.out.println("World");
+                }
+
+                counter--;
+                System.out.println("World ffff");
+            }
+        } else {
+            while (counter < 10) {
+                b[counter] = b[counter]++;
+                counter++;
+            }
+
+            System.out.println("World Else");
+            System.out.println("World Else 2");
+        }
+    }
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfInsideWhileLoopRewrite.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfInsideWhileLoopRewrite.java
@@ -8,9 +8,9 @@ public class TestIfInsideWhileLoopRewrite {
         b[1] += a[1];
 
         while (counter < 10) {
-            myFun_0_rewriteGroup2(a, b, c);
+            myFun_0_0_rewriteGroup2(a, b, c);
 
-            myFun_0_rewriteGroup4(a, b, c);
+            myFun_0_0_rewriteGroup4(a, b, c);
 
             counter--;
         }
@@ -19,19 +19,8 @@ public class TestIfInsideWhileLoopRewrite {
         b[5] += a[5];
     }
 
-    void myFun_0_1(int[] a, int[] b, int[] c ) throws RuntimeException {
-        c[counter] = a[0] + 1000;
-        System.out.println(c);
-    }
-
-    void myFun_0_1_2(int[] a, int[] b, int[] c ) throws RuntimeException {
-        b[counter] = a[counter] * 2;
-        c[counter] = b[counter] * 2;
-        System.out.println(b[counter]);
-    }
-
-    void myFun_0_rewriteGroup4(int[] a, int[] b, int[] c ) throws RuntimeException {
-        myFun_0_4(a, b, c);
+    void myFun_0_0_rewriteGroup4(int[] a, int[] b, int[] c ) throws RuntimeException {
+        myFun_0_0_4(a, b, c);
         if (a[0] > 0) {
             System.out.println("Hello");
         } else {
@@ -39,23 +28,34 @@ public class TestIfInsideWhileLoopRewrite {
         }
     }
 
-    void myFun_0_1_3(int[] a, int[] b, int[] c ) throws RuntimeException {
+    void myFun_0_0_1_3(int[] a, int[] b, int[] c ) throws RuntimeException {
         b[counter] = a[counter] * 3;
         System.out.println(b[counter]);
     }
 
-    void myFun_0_rewriteGroup2(int[] a, int[] b, int[] c ) throws RuntimeException {
-        myFun_0_1(a, b, c);
+    void myFun_0_0_4(int[] a, int[] b, int[] c ) throws RuntimeException {
+        a[2] += b[2];
+        b[3] += a[3];
+    }
+
+    void myFun_0_0_rewriteGroup2(int[] a, int[] b, int[] c ) throws RuntimeException {
+        myFun_0_0_1(a, b, c);
         if (a[counter] > 0) {
-            myFun_0_1_2(a, b, c);
+            myFun_0_0_1_2(a, b, c);
         } else {
-            myFun_0_1_3(a, b, c);
+            myFun_0_0_1_3(a, b, c);
         }
     }
 
-    void myFun_0_4(int[] a, int[] b, int[] c ) throws RuntimeException {
-        a[2] += b[2];
-        b[3] += a[3];
+    void myFun_0_0_1_2(int[] a, int[] b, int[] c ) throws RuntimeException {
+        b[counter] = a[counter] * 2;
+        c[counter] = b[counter] * 2;
+        System.out.println(b[counter]);
+    }
+
+    void myFun_0_0_1(int[] a, int[] b, int[] c ) throws RuntimeException {
+        c[counter] = a[0] + 1000;
+        System.out.println(c);
     }
 
 

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfMultipleSingleLineStatementRewrite.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfMultipleSingleLineStatementRewrite.java
@@ -2,47 +2,47 @@ public class TestIfMultipleSingleLineStatementRewrite {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 
         if (a[0] == 0) {
-            myFun1_0_rewriteGroup2(a, b);
+            myFun1_0_0_rewriteGroup2(a, b);
 
-            myFun1_0(a, b);
+            myFun1_0_0(a, b);
         } else {
-            myFun1_4(a, b);
+            myFun1_0_4(a, b);
         }
     }
 
-    void myFun1_0_rewriteGroup2(int[] a, int[] b) throws RuntimeException {
-        myFun1_0_1(a, b);
-        if (a[2] == 0) {
-            myFun1_0_1_2(a, b);
-        } else {
-            myFun1_0_1_3(a, b);
-        }
-    }
-
-    void myFun1_0_1_2(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_0_1_2(int[] a, int[] b) throws RuntimeException {
         a[21] = 1;
         a[22] = 1;
     }
 
-    void myFun1_0_1_3(int[] a, int[] b) throws RuntimeException {
-        a[23] = b[2];
-        a[24] = b[2];
-    }
-
-    void myFun1_4(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_4(int[] a, int[] b) throws RuntimeException {
         a[0] = b[0];
         a[1] = b[1];
         a[2] = b[2];
     }
 
-    void myFun1_0_1(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_0_1_3(int[] a, int[] b) throws RuntimeException {
+        a[23] = b[2];
+        a[24] = b[2];
+    }
+
+    void myFun1_0_0_1(int[] a, int[] b) throws RuntimeException {
         a[11] = b[0];
         a[12] = b[0];
     }
 
-    void myFun1_0(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_0(int[] a, int[] b) throws RuntimeException {
         a[13] = b[0];
         a[14] = b[0];
+    }
+
+    void myFun1_0_0_rewriteGroup2(int[] a, int[] b) throws RuntimeException {
+        myFun1_0_0_1(a, b);
+        if (a[2] == 0) {
+            myFun1_0_0_1_2(a, b);
+        } else {
+            myFun1_0_0_1_3(a, b);
+        }
     }
 
 }

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite.java
@@ -2,38 +2,38 @@ public class TestIfStatementRewrite {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 
         if (a[0] == 0) {
-            myFun1_0_rewriteGroup5(a, b);
+            myFun1_0_0_rewriteGroup5(a, b);
         } else {
-            myFun1_7(a, b);
+            myFun1_0_7(a, b);
         }
     }
 
-    void myFun1_0_rewriteGroup5(int[] a, int[] b) throws RuntimeException {
-        a[0] = 1;
-        if (a[1] == 0) {
-            myFun1_0_rewriteGroup1_2_rewriteGroup4(a, b);
-        } else {
-            myFun1_0_1_6(a, b);
-        }
-    }
-
-    void myFun1_0_1_6(int[] a, int[] b) throws RuntimeException {
-        a[1] = b[1];
-        a[2] = b[2];
-    }
-
-    void myFun1_7(int[] a, int[] b) throws RuntimeException {
-        a[0] = b[0];
-        a[1] = b[1];
-        a[2] = b[2];
-    }
-
-    void myFun1_0_rewriteGroup1_2_rewriteGroup4(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4(int[] a, int[] b) throws RuntimeException {
         a[1] = 1;
         if (a[2] == 0) {
             a[2] = 1;
         } else {
             a[2] = b[2];
+        }
+    }
+
+    void myFun1_0_7(int[] a, int[] b) throws RuntimeException {
+        a[0] = b[0];
+        a[1] = b[1];
+        a[2] = b[2];
+    }
+
+    void myFun1_0_0_1_6(int[] a, int[] b) throws RuntimeException {
+        a[1] = b[1];
+        a[2] = b[2];
+    }
+
+    void myFun1_0_0_rewriteGroup5(int[] a, int[] b) throws RuntimeException {
+        a[0] = 1;
+        if (a[1] == 0) {
+            myFun1_0_0_rewriteGroup1_2_rewriteGroup4(a, b);
+        } else {
+            myFun1_0_0_1_6(a, b);
         }
     }
 
@@ -55,12 +55,12 @@ public class TestIfStatementRewrite {
                 return;
             }
         } else {
-            myFun2_0_rewriteGroup1(a, b);
+            myFun2_0_0_rewriteGroup1(a, b);
             a[2] = b[2];
         }
     }
 
-    void myFun2_0_rewriteGroup1(int[] a, int[] b) throws RuntimeException {
+    void myFun2_0_0_rewriteGroup1(int[] a, int[] b) throws RuntimeException {
         a[0] = b[0];
         a[1] = b[1];
     }

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite1.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite1.java
@@ -2,79 +2,79 @@ public class TestIfStatementRewrite1 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 
         if (a[0] == 0) {
-            myFun1_0_rewriteGroup5(a, b);
+            myFun1_0_0_rewriteGroup5(a, b);
         } else {
-            myFun1_6_rewriteGroup8(a, b);
+            myFun1_0_6_rewriteGroup8(a, b);
         }
     }
 
-    void myFun1_7_8_9(int[] a, int[] b) throws RuntimeException {
-        a[0] = b[0];
-        a[1] = b[1];
+    void myFun1_0_0_1_2_3_5(int[] a, int[] b) throws RuntimeException {
         a[2] = b[2];
+        a[22] = b[2];
     }
 
-    void myFun1_6_rewriteGroup8(int[] a, int[] b) throws RuntimeException {
-        myFun1_7_8(a, b);
-        if (a[1] == 1) {
-            myFun1_7_8_9(a, b);
-        } else {
-            myFun1_7_8_10(a, b);
-        }
+    void myFun1_0_0_1_2_3_4(int[] a, int[] b) throws RuntimeException {
+        a[2] = 1;
+        a[22] = 1;
     }
 
-    void myFun1_7_8(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_0_1(int[] a, int[] b) throws RuntimeException {
+        System.out.println("0");
+        System.out.println("0");
+    }
+
+    void myFun1_0_0_1_2_3(int[] a, int[] b) throws RuntimeException {
+        System.out.println("1");
+        System.out.println("2");
+    }
+
+    void myFun1_0_7_8(int[] a, int[] b) throws RuntimeException {
         System.out.println("3");
         System.out.println("3");
     }
 
-    void myFun1_7_8_10(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_7_8_10(int[] a, int[] b) throws RuntimeException {
         a[0] = 2 * b[0];
         a[1] = 2 * b[1];
         a[2] = 2 * b[2];
     }
 
-    void myFun1_0_rewriteGroup5(int[] a, int[] b) throws RuntimeException {
-        myFun1_0_1(a, b);
-        if (a[1] == 0) {
-            myFun1_0_rewriteGroup1_2_rewriteGroup4(a, b);
+    void myFun1_0_6_rewriteGroup8(int[] a, int[] b) throws RuntimeException {
+        myFun1_0_7_8(a, b);
+        if (a[1] == 1) {
+            myFun1_0_7_8_9(a, b);
         } else {
-            myFun1_0_1_6(a, b);
+            myFun1_0_7_8_10(a, b);
         }
     }
 
-    void myFun1_0_rewriteGroup1_2_rewriteGroup4(int[] a, int[] b) throws RuntimeException {
-        myFun1_0_1_2_3(a, b);
+    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4(int[] a, int[] b) throws RuntimeException {
+        myFun1_0_0_1_2_3(a, b);
         if (a[2] == 0) {
-            myFun1_0_1_2_3_4(a, b);
+            myFun1_0_0_1_2_3_4(a, b);
         } else {
-            myFun1_0_1_2_3_5(a, b);
+            myFun1_0_0_1_2_3_5(a, b);
         }
     }
 
-    void myFun1_0_1_2_3(int[] a, int[] b) throws RuntimeException {
-        System.out.println("1");
-        System.out.println("2");
-    }
-
-    void myFun1_0_1_2_3_5(int[] a, int[] b) throws RuntimeException {
-        a[2] = b[2];
-        a[22] = b[2];
-    }
-
-    void myFun1_0_1(int[] a, int[] b) throws RuntimeException {
-        System.out.println("0");
-        System.out.println("0");
-    }
-
-    void myFun1_0_1_6(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_0_1_6(int[] a, int[] b) throws RuntimeException {
         a[1] = b[1];
         a[2] = b[2];
     }
 
-    void myFun1_0_1_2_3_4(int[] a, int[] b) throws RuntimeException {
-        a[2] = 1;
-        a[22] = 1;
+    void myFun1_0_0_rewriteGroup5(int[] a, int[] b) throws RuntimeException {
+        myFun1_0_0_1(a, b);
+        if (a[1] == 0) {
+            myFun1_0_0_rewriteGroup1_2_rewriteGroup4(a, b);
+        } else {
+            myFun1_0_0_1_6(a, b);
+        }
+    }
+
+    void myFun1_0_7_8_9(int[] a, int[] b) throws RuntimeException {
+        a[0] = b[0];
+        a[1] = b[1];
+        a[2] = b[2];
     }
 
 }

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite2.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite2.java
@@ -2,63 +2,63 @@ public class TestIfStatementRewrite2 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 
         if (a[0] == 0) {
-            myFun1_0_rewriteGroup5(a, b);
+            myFun1_0_0_rewriteGroup5(a, b);
         } else if(a[1] == 22) {
-            myFun1_11_12(a, b);
+            myFun1_0_11_12(a, b);
         } else {
-            myFun1_11_13(a, b);
+            myFun1_0_11_13(a, b);
         }
     }
 
-    void myFun1_11_13(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_0_1_2_3_5_7_8(int[] a, int[] b) throws RuntimeException {
+        a[4] = b[4];
+        a[44] = b[44];
+    }
+
+    void myFun1_0_0_1_2_3_5_7_9(int[] a, int[] b) throws RuntimeException {
+        a[5] = 5;
+        System.out.println("nothing");
+    }
+
+    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4(int[] a, int[] b) throws RuntimeException {
+        a[1] = 1;
+        if (a[2] == 0) {
+            a[2] = 1;
+        } else if (a[3] == 0) {
+            myFun1_0_0_1_2_3_5_6(a, b);
+        } else if (a[4] == 0) {
+            myFun1_0_0_1_2_3_5_7_8(a, b);
+        } else {
+            myFun1_0_0_1_2_3_5_7_9(a, b);
+        }
+    }
+
+    void myFun1_0_0_1_10(int[] a, int[] b) throws RuntimeException {
+        a[1] = b[1];
+        a[2] = b[2];
+    }
+
+    void myFun1_0_0_rewriteGroup5(int[] a, int[] b) throws RuntimeException {
+        a[0] = 1;
+        if (a[1] == 0) {
+            myFun1_0_0_rewriteGroup1_2_rewriteGroup4(a, b);
+        } else {
+            myFun1_0_0_1_10(a, b);
+        }
+    }
+
+    void myFun1_0_0_1_2_3_5_6(int[] a, int[] b) throws RuntimeException {
+        a[3] = b[3];
+        a[33] = b[33];
+    }
+
+    void myFun1_0_11_13(int[] a, int[] b) throws RuntimeException {
         a[0] = b[0];
         a[1] = b[1];
         a[2] = b[2];
     }
 
-    void myFun1_0_1_2_3_5_7_9(int[] a, int[] b) throws RuntimeException {
-        a[5] = 5;
-        System.out.println("nothing");
-    }
-
-    void myFun1_0_rewriteGroup5(int[] a, int[] b) throws RuntimeException {
-        a[0] = 1;
-        if (a[1] == 0) {
-            myFun1_0_rewriteGroup1_2_rewriteGroup4(a, b);
-        } else {
-            myFun1_0_1_10(a, b);
-        }
-    }
-
-    void myFun1_0_rewriteGroup1_2_rewriteGroup4(int[] a, int[] b) throws RuntimeException {
-        a[1] = 1;
-        if (a[2] == 0) {
-            a[2] = 1;
-        } else if (a[3] == 0) {
-            myFun1_0_1_2_3_5_6(a, b);
-        } else if (a[4] == 0) {
-            myFun1_0_1_2_3_5_7_8(a, b);
-        } else {
-            myFun1_0_1_2_3_5_7_9(a, b);
-        }
-    }
-
-    void myFun1_0_1_2_3_5_7_8(int[] a, int[] b) throws RuntimeException {
-        a[4] = b[4];
-        a[44] = b[44];
-    }
-
-    void myFun1_0_1_10(int[] a, int[] b) throws RuntimeException {
-        a[1] = b[1];
-        a[2] = b[2];
-    }
-
-    void myFun1_0_1_2_3_5_6(int[] a, int[] b) throws RuntimeException {
-        a[3] = b[3];
-        a[33] = b[33];
-    }
-
-    void myFun1_11_12(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_11_12(int[] a, int[] b) throws RuntimeException {
         a[1] = b[12];
         a[2] = b[22];
     }

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite3.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestIfStatementRewrite3.java
@@ -2,42 +2,42 @@ public class TestIfStatementRewrite3 {
     public void myFun1(int[] a, int[] b) throws RuntimeException {
 
         if (a[0] == 0) {
-            myFun1_0(a, b);
+            myFun1_0_0(a, b);
         } else if (a[1] == 22) {
-            myFun1_1_2(a, b);
+            myFun1_0_1_2(a, b);
         } else if (a[3] == 0) {
-            myFun1_1_3_4(a, b);
+            myFun1_0_1_3_4(a, b);
         } else if (a[4] == 0) {
-            myFun1_1_3_5_6(a, b);
+            myFun1_0_1_3_5_6(a, b);
         } else {
-            myFun1_1_3_5_7(a, b);
+            myFun1_0_1_3_5_7(a, b);
         }
     }
 
-    void myFun1_1_3_5_6(int[] a, int[] b) throws RuntimeException {
-        a[4] = b[4];
-        a[44] = b[44];
-    }
-
-    void myFun1_1_3_4(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_1_3_4(int[] a, int[] b) throws RuntimeException {
         a[3] = b[3];
         a[33] = b[33];
     }
 
-    void myFun1_0(int[] a, int[] b) throws RuntimeException {
-        a[0] = 1;
-        a[1] = 1;
+    void myFun1_0_1_2(int[] a, int[] b) throws RuntimeException {
+        a[1] = b[12];
+        a[2] = b[22];
     }
 
-    void myFun1_1_3_5_7(int[] a, int[] b) throws RuntimeException {
+    void myFun1_0_1_3_5_6(int[] a, int[] b) throws RuntimeException {
+        a[4] = b[4];
+        a[44] = b[44];
+    }
+
+    void myFun1_0_1_3_5_7(int[] a, int[] b) throws RuntimeException {
         a[0] = b[0];
         a[1] = b[1];
         a[2] = b[2];
     }
 
-    void myFun1_1_2(int[] a, int[] b) throws RuntimeException {
-        a[1] = b[12];
-        a[2] = b[22];
+    void myFun1_0_0(int[] a, int[] b) throws RuntimeException {
+        a[0] = 1;
+        a[1] = 1;
     }
 
 }

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestRewriteInnerClass.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestRewriteInnerClass.java
@@ -2,20 +2,20 @@ public class TestRewriteInnerClass {
     public void myFun(int[] a, int[] b) {
 
         if (a[0] == 0) {
-            myFun_0(a, b);
+            myFun_0_0(a, b);
         } else {
-            myFun_1(a, b);
+            myFun_0_1(a, b);
         }
     }
 
-    void myFun_0(int[] a, int[] b) {
-        a[0] += b[0];
-        a[1] += b[1];
-    }
-
-    void myFun_1(int[] a, int[] b) {
+    void myFun_0_1(int[] a, int[] b) {
         a[0] += b[1];
         a[1] += b[0];
+    }
+
+    void myFun_0_0(int[] a, int[] b) {
+        a[0] += b[0];
+        a[1] += b[1];
     }
 
 
@@ -23,20 +23,20 @@ public class TestRewriteInnerClass {
         public void myFun(int[] a, int[] b) {
 
             if (a[0] == 0) {
-                myFun_0(a, b);
+                myFun_0_0(a, b);
             } else {
-                myFun_1(a, b);
+                myFun_0_1(a, b);
             }
         }
 
-        void myFun_0(int[] a, int[] b) {
-            a[0] += b[0];
-            a[1] += b[1];
-        }
-
-        void myFun_1(int[] a, int[] b) {
+        void myFun_0_1(int[] a, int[] b) {
             a[0] += b[1];
             a[1] += b[0];
+        }
+
+        void myFun_0_0(int[] a, int[] b) {
+            a[0] += b[0];
+            a[1] += b[1];
         }
 
     }

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestRewriteTwoStatements.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestRewriteTwoStatements.java
@@ -1,0 +1,129 @@
+public class TestIfInsideWhileLoopRewrite {
+
+    int counter = 0;
+
+    public void myFun(int[] a, int[] b, int[] c ) throws RuntimeException {
+
+        a[0] += b[1];
+        b[1] += a[1];
+
+        while (counter < 10) {
+            myFun_0_0_rewriteGroup2(a, b, c);
+
+            myFun_0_0_rewriteGroup4(a, b, c);
+
+            counter--;
+        }
+
+        a[4] += b[4];
+        b[5] += a[5];
+
+
+        if (a.length < 100) {
+            while (counter < 10) {
+                myFun_1_0_1_2_3(a, b, c);
+                if (a[counter] > 0) {
+                    myFun_1_0_1_2_3_4(a, b, c);
+                } else {
+                    myFun_1_0_1_2_3_5(a, b, c);
+                }
+
+                myFun_1_0_1_2_6(a, b, c);
+                if (a[0] > 0) {
+                    System.out.println("Hello");
+                } else {
+                    System.out.println("World");
+                }
+
+                myFun_1_0_1_2(a, b, c);
+            }
+        } else {
+            myFun_1_0_rewriteGroup2(a, b, c);
+
+            myFun_1_9(a, b, c);
+        }
+    }
+
+    void myFun_0_0_rewriteGroup4(int[] a, int[] b, int[] c ) throws RuntimeException {
+        myFun_0_0_4(a, b, c);
+        if (a[0] > 0) {
+            System.out.println("Hello");
+        } else {
+            System.out.println("World");
+        }
+    }
+
+    void myFun_0_0_1_3(int[] a, int[] b, int[] c ) throws RuntimeException {
+        b[counter] = a[counter] * 3;
+        System.out.println(b[counter]);
+    }
+
+    void myFun_0_0_4(int[] a, int[] b, int[] c ) throws RuntimeException {
+        a[2] += b[2];
+        b[3] += a[3];
+    }
+
+    void myFun_0_0_rewriteGroup2(int[] a, int[] b, int[] c ) throws RuntimeException {
+        myFun_0_0_1(a, b, c);
+        if (a[counter] > 0) {
+            myFun_0_0_1_2(a, b, c);
+        } else {
+            myFun_0_0_1_3(a, b, c);
+        }
+    }
+
+    void myFun_0_0_1_2(int[] a, int[] b, int[] c ) throws RuntimeException {
+        b[counter] = a[counter] * 2;
+        c[counter] = b[counter] * 2;
+        System.out.println(b[counter]);
+    }
+
+    void myFun_0_0_1(int[] a, int[] b, int[] c ) throws RuntimeException {
+        c[counter] = a[0] + 1000;
+        System.out.println(c);
+    }
+
+
+    void myFun_1_0_1_2_3_4(int[] a, int[] b, int[] c ) throws RuntimeException {
+        b[counter] = a[counter] * 2;
+        c[counter] = b[counter] * 2;
+        System.out.println(b[counter]);
+    }
+
+    void myFun_1_0_1_2(int[] a, int[] b, int[] c ) throws RuntimeException {
+        counter--;
+        System.out.println("World ffff");
+    }
+
+    void myFun_1_0_1_2_3_5(int[] a, int[] b, int[] c ) throws RuntimeException {
+        b[counter] = a[counter] * 3;
+        System.out.println(b[counter]);
+    }
+
+    void myFun_1_0_1_2_3(int[] a, int[] b, int[] c ) throws RuntimeException {
+        c[counter] = a[0] + 1000;
+        System.out.println(c);
+    }
+
+    void myFun_1_0_rewriteGroup2(int[] a, int[] b, int[] c ) throws RuntimeException {
+        while (counter < 10) {
+            myFun_1_9_10_11(a, b, c);
+        }
+    }
+
+    void myFun_1_9(int[] a, int[] b, int[] c ) throws RuntimeException {
+        System.out.println("World Else");
+        System.out.println("World Else 2");
+    }
+
+    void myFun_1_0_1_2_6(int[] a, int[] b, int[] c ) throws RuntimeException {
+        a[2] += b[2];
+        b[3] += a[3];
+    }
+
+    void myFun_1_9_10_11(int[] a, int[] b, int[] c ) throws RuntimeException {
+        b[counter] = b[counter]++;
+        counter++;
+    }
+
+}

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestWhileLoopInsideIfRewrite.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestWhileLoopInsideIfRewrite.java
@@ -9,72 +9,72 @@ public class TestWhileLoopInsideIfRewrite {
 
         if (a.length < 100) {
             while (counter < 10) {
-                myFun_0_1_2_3(a, b, c);
+                myFun_0_0_1_2_3(a, b, c);
                 if (a[counter] > 0) {
-                    myFun_0_1_2_3_4(a, b, c);
+                    myFun_0_0_1_2_3_4(a, b, c);
                 } else {
-                    myFun_0_1_2_3_5(a, b, c);
+                    myFun_0_0_1_2_3_5(a, b, c);
                 }
 
-                myFun_0_1_2_6(a, b, c);
+                myFun_0_0_1_2_6(a, b, c);
                 if (a[0] > 0) {
                     System.out.println("Hello");
                 } else {
                     System.out.println("World");
                 }
 
-                myFun_0_1_2(a, b, c);
+                myFun_0_0_1_2(a, b, c);
             }
         } else {
-            myFun_0_rewriteGroup2(a, b, c);
+            myFun_0_0_rewriteGroup2(a, b, c);
 
-            myFun_9(a, b, c);
+            myFun_0_9(a, b, c);
         }
 
         a[4] += b[4];
         b[5] += a[5];
     }
 
-    void myFun_0_rewriteGroup2(int[] a, int[] b, int[] c) {
+    void myFun_0_0_rewriteGroup2(int[] a, int[] b, int[] c) {
         while (counter < 10) {
-            myFun_9_10_11(a, b, c);
+            myFun_0_9_10_11(a, b, c);
         }
     }
 
-    void myFun_9_10_11(int[] a, int[] b, int[] c) {
-        b[counter] = b[counter]++;
-        counter++;
-    }
-
-    void myFun_0_1_2_6(int[] a, int[] b, int[] c) {
-        a[2] += b[2];
-        b[3] += a[3];
-    }
-
-    void myFun_0_1_2(int[] a, int[] b, int[] c) {
+    void myFun_0_0_1_2(int[] a, int[] b, int[] c) {
         counter--;
         System.out.println("World ffff");
     }
 
-    void myFun_0_1_2_3(int[] a, int[] b, int[] c) {
-        c[counter] = a[0] + 1000;
-        System.out.println(c);
+    void myFun_0_0_1_2_6(int[] a, int[] b, int[] c) {
+        a[2] += b[2];
+        b[3] += a[3];
     }
 
-    void myFun_0_1_2_3_5(int[] a, int[] b, int[] c) {
+    void myFun_0_9_10_11(int[] a, int[] b, int[] c) {
+        b[counter] = b[counter]++;
+        counter++;
+    }
+
+    void myFun_0_0_1_2_3_5(int[] a, int[] b, int[] c) {
         b[counter] = a[counter] * 3;
         System.out.println(b[counter]);
     }
 
-    void myFun_0_1_2_3_4(int[] a, int[] b, int[] c) {
+    void myFun_0_9(int[] a, int[] b, int[] c) {
+        System.out.println("World Else");
+        System.out.println("World Else 2");
+    }
+
+    void myFun_0_0_1_2_3(int[] a, int[] b, int[] c) {
+        c[counter] = a[0] + 1000;
+        System.out.println(c);
+    }
+
+    void myFun_0_0_1_2_3_4(int[] a, int[] b, int[] c) {
         b[counter] = a[counter] * 2;
         c[counter] = b[counter] * 2;
         System.out.println(b[counter]);
-    }
-
-    void myFun_9(int[] a, int[] b, int[] c) {
-        System.out.println("World Else");
-        System.out.println("World Else 2");
     }
 
 }

--- a/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestWhileLoopRewrite.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/block/expected/TestWhileLoopRewrite.java
@@ -9,9 +9,9 @@ public class TestWhileLoopRewrite {
 
 
         while (counter < 10) {
-            myFun_0_rewriteGroup2(a, b, c);
+            myFun_0_0_rewriteGroup2(a, b, c);
 
-            myFun_0_rewriteGroup4(a, b, c);
+            myFun_0_0_rewriteGroup4(a, b, c);
 
             counter--;
         }
@@ -20,19 +20,8 @@ public class TestWhileLoopRewrite {
         b[5] += a[5];
     }
 
-    void myFun_0_1(int[] a, int[] b, int[] c) {
-        c[counter] = a[0] + 1000;
-        System.out.println(c);
-    }
-
-    void myFun_0_1_2(int[] a, int[] b, int[] c) {
-        b[counter] = a[counter] * 2;
-        c[counter] = b[counter] * 2;
-        System.out.println(b[counter]);
-    }
-
-    void myFun_0_rewriteGroup4(int[] a, int[] b, int[] c) {
-        myFun_0_4(a, b, c);
+    void myFun_0_0_rewriteGroup4(int[] a, int[] b, int[] c) {
+        myFun_0_0_4(a, b, c);
         if (a[0] > 0) {
             System.out.println("Hello");
         } else {
@@ -40,23 +29,34 @@ public class TestWhileLoopRewrite {
         }
     }
 
-    void myFun_0_1_3(int[] a, int[] b, int[] c) {
+    void myFun_0_0_1_3(int[] a, int[] b, int[] c) {
         b[counter] = a[counter] * 3;
         System.out.println(b[counter]);
     }
 
-    void myFun_0_rewriteGroup2(int[] a, int[] b, int[] c) {
-        myFun_0_1(a, b, c);
+    void myFun_0_0_4(int[] a, int[] b, int[] c) {
+        a[2] += b[2];
+        b[3] += a[3];
+    }
+
+    void myFun_0_0_rewriteGroup2(int[] a, int[] b, int[] c) {
+        myFun_0_0_1(a, b, c);
         if (a[counter] > 0) {
-            myFun_0_1_2(a, b, c);
+            myFun_0_0_1_2(a, b, c);
         } else {
-            myFun_0_1_3(a, b, c);
+            myFun_0_0_1_3(a, b, c);
         }
     }
 
-    void myFun_0_4(int[] a, int[] b, int[] c) {
-        a[2] += b[2];
-        b[3] += a[3];
+    void myFun_0_0_1_2(int[] a, int[] b, int[] c) {
+        b[counter] = a[counter] * 2;
+        c[counter] = b[counter] * 2;
+        System.out.println(b[counter]);
+    }
+
+    void myFun_0_0_1(int[] a, int[] b, int[] c) {
+        c[counter] = a[0] + 1000;
+        System.out.println(c);
     }
 
 }

--- a/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
+++ b/flink-table/flink-table-code-splitter/src/test/resources/splitter/expected/TestSplitJavaCode.java
@@ -64,7 +64,7 @@ public class TestSplitJavaCode {
 
     void myFun1_split9(int a) {
         if (rewrite$18[0] > 0) {
-            myFun1_0_rewriteGroup5(a);
+            myFun1_0_0_rewriteGroup5(a);
         } else {
             rewrite$17[0][0] += 50;
             rewrite$17[0][1] += 100;
@@ -78,38 +78,38 @@ public class TestSplitJavaCode {
     }
 
 
-    void myFun1_0_rewriteGroup5(int a) {
-        myFun1_0_rewriteGroup5_split10(a);
+    void myFun1_0_0_rewriteGroup5(int a) {
+        myFun1_0_0_rewriteGroup5_split10(a);
 
-        myFun1_0_rewriteGroup5_split11(a);
+        myFun1_0_0_rewriteGroup5_split11(a);
 
     }
-    void myFun1_0_rewriteGroup5_split10(int a) {
+    void myFun1_0_0_rewriteGroup5_split10(int a) {
 
         rewrite$17[0][0] += 100;
     }
 
-    void myFun1_0_rewriteGroup5_split11(int a) {
+    void myFun1_0_0_rewriteGroup5_split11(int a) {
         if (rewrite$18[1] > 0) {
-            myFun1_0_rewriteGroup1_2_rewriteGroup4(a);
+            myFun1_0_0_rewriteGroup1_2_rewriteGroup4(a);
         } else {
             rewrite$17[0][1] += 50;
         }
     }
 
 
-    void myFun1_0_rewriteGroup1_2_rewriteGroup4(int a) {
-        myFun1_0_rewriteGroup1_2_rewriteGroup4_split12(a);
+    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4(int a) {
+        myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split12(a);
 
-        myFun1_0_rewriteGroup1_2_rewriteGroup4_split13(a);
+        myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split13(a);
 
     }
-    void myFun1_0_rewriteGroup1_2_rewriteGroup4_split12(int a) {
+    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split12(int a) {
 
         rewrite$17[0][1] += 100;
     }
 
-    void myFun1_0_rewriteGroup1_2_rewriteGroup4_split13(int a) {
+    void myFun1_0_0_rewriteGroup1_2_rewriteGroup4_split13(int a) {
         if (rewrite$18[2] > 0) {
             rewrite$17[0][2] += 100;
         } else {


### PR DESCRIPTION
## What is the purpose of the change
Unchanged backport of https://github.com/apache/flink/pull/21871

Bug fix for FLINK-30927

Rewritten code after code splitting could result in more than one method with the same signature and return type. The issue happens whenever split method had more than one IF/ELSE/WHILE statement in series (not tested). Issue was caused by bug in https://github.com/apache/flink/pull/21393.


## Brief change log

Fix bug in `BlockStatementRewriter.java` and add new test covering fixed problem `BlockStatementRewriterTest::testRewriteTwoStatements`


## Verifying this change

This change added tests and can be verified as follows:
- Added Junit test BlockStatementRewriterTest::testRewriteTwoStatements

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
