### PR TITLE
[FLINK-30942][runtime] Eagerly sets the parallelism of job vertices in the parallelism-decided forward groups.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -62,7 +62,6 @@ import org.apache.flink.runtime.scheduler.ExecutionSlotAllocatorFactory;
 import org.apache.flink.runtime.scheduler.ExecutionVertexVersioner;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.adaptivebatch.forwardgroup.ForwardGroup;
-import org.apache.flink.runtime.scheduler.adaptivebatch.forwardgroup.ForwardGroupComputeUtil;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingStrategyFactory;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -127,7 +126,8 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
             final Time rpcTimeout,
             final VertexParallelismAndInputInfosDecider vertexParallelismAndInputInfosDecider,
             int defaultMaxParallelism,
-            HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint)
+            final HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint,
+            final Map<JobVertexID, ForwardGroup> forwardGroupsByJobVertexId)
             throws Exception {
 
         super(
@@ -162,10 +162,7 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
         this.vertexParallelismAndInputInfosDecider =
                 checkNotNull(vertexParallelismAndInputInfosDecider);
 
-        this.forwardGroupsByJobVertexId =
-                ForwardGroupComputeUtil.computeForwardGroups(
-                        jobGraph.getVerticesSortedTopologicallyFromSources(),
-                        getExecutionGraph()::getJobVertex);
+        this.forwardGroupsByJobVertexId = checkNotNull(forwardGroupsByJobVertexId);
 
         this.blockingResultInfos = new HashMap<>();
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeScheduler.java
@@ -44,12 +44,14 @@ import org.apache.flink.runtime.executiongraph.failover.flip1.FailureHandlingRes
 import org.apache.flink.runtime.executiongraph.failover.flip1.RestartBackoffTimeStrategy;
 import org.apache.flink.runtime.io.network.partition.PartitionException;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.metrics.MetricNames;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.scheduler.ExecutionGraphFactory;
 import org.apache.flink.runtime.scheduler.ExecutionOperations;
 import org.apache.flink.runtime.scheduler.ExecutionSlotAllocatorFactory;
 import org.apache.flink.runtime.scheduler.ExecutionVertexVersioner;
+import org.apache.flink.runtime.scheduler.adaptivebatch.forwardgroup.ForwardGroup;
 import org.apache.flink.runtime.scheduler.slowtaskdetector.ExecutionTimeBasedSlowTaskDetector;
 import org.apache.flink.runtime.scheduler.slowtaskdetector.SlowTaskDetector;
 import org.apache.flink.runtime.scheduler.slowtaskdetector.SlowTaskDetectorListener;
@@ -124,7 +126,8 @@ public class SpeculativeScheduler extends AdaptiveBatchScheduler
             final VertexParallelismAndInputInfosDecider vertexParallelismAndInputInfosDecider,
             final int defaultMaxParallelism,
             final BlocklistOperations blocklistOperations,
-            final HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint)
+            final HybridPartitionDataConsumeConstraint hybridPartitionDataConsumeConstraint,
+            final Map<JobVertexID, ForwardGroup> forwardGroupsByJobVertexId)
             throws Exception {
 
         super(
@@ -152,7 +155,8 @@ public class SpeculativeScheduler extends AdaptiveBatchScheduler
                 rpcTimeout,
                 vertexParallelismAndInputInfosDecider,
                 defaultMaxParallelism,
-                hybridPartitionDataConsumeConstraint);
+                hybridPartitionDataConsumeConstraint,
+                forwardGroupsByJobVertexId);
 
         this.maxConcurrentExecutions =
                 jobMasterConfiguration.getInteger(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/forwardgroup/ForwardGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/forwardgroup/ForwardGroup.java
@@ -20,7 +20,7 @@
 package org.apache.flink.runtime.scheduler.adaptivebatch.forwardgroup;
 
 import org.apache.flink.api.common.ExecutionConfig;
-import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 
 import java.util.HashSet;
@@ -40,17 +40,17 @@ public class ForwardGroup {
 
     private final Set<JobVertexID> jobVertexIds = new HashSet<>();
 
-    public ForwardGroup(final Set<ExecutionJobVertex> jobVertices) {
+    public ForwardGroup(final Set<JobVertex> jobVertices) {
         checkNotNull(jobVertices);
 
         Set<Integer> decidedParallelisms =
                 jobVertices.stream()
                         .filter(
                                 jobVertex -> {
-                                    jobVertexIds.add(jobVertex.getJobVertexId());
-                                    return jobVertex.isParallelismDecided();
+                                    jobVertexIds.add(jobVertex.getID());
+                                    return jobVertex.getParallelism() > 0;
                                 })
-                        .map(ExecutionJobVertex::getParallelism)
+                        .map(JobVertex::getParallelism)
                         .collect(Collectors.toSet());
 
         checkState(decidedParallelisms.size() <= 1);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBuilder.java
@@ -41,12 +41,14 @@ import org.apache.flink.runtime.executiongraph.failover.flip1.RestartPipelinedRe
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
 import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTracker;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmaster.DefaultExecutionDeploymentTracker;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
 import org.apache.flink.runtime.scheduler.adaptivebatch.SpeculativeScheduler;
 import org.apache.flink.runtime.scheduler.adaptivebatch.VertexParallelismAndInputInfosDecider;
+import org.apache.flink.runtime.scheduler.adaptivebatch.forwardgroup.ForwardGroupComputeUtil;
 import org.apache.flink.runtime.scheduler.strategy.AllFinishedInputConsumableDecider;
 import org.apache.flink.runtime.scheduler.strategy.InputConsumableDecider;
 import org.apache.flink.runtime.scheduler.strategy.PipelinedRegionSchedulingStrategy;
@@ -63,6 +65,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Collections;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
 
 import static org.apache.flink.runtime.scheduler.SchedulerBase.computeVertexParallelismStore;
 
@@ -331,7 +334,9 @@ public class DefaultSchedulerBuilder {
                 rpcTimeout,
                 vertexParallelismAndInputInfosDecider,
                 defaultMaxParallelism,
-                hybridPartitionDataConsumeConstraint);
+                hybridPartitionDataConsumeConstraint,
+                ForwardGroupComputeUtil.computeForwardGroupsAndSetVertexParallelismsIfNecessary(
+                        jobGraph.getVerticesSortedTopologicallyFromSources()));
     }
 
     public SpeculativeScheduler buildSpeculativeScheduler() throws Exception {
@@ -361,7 +366,9 @@ public class DefaultSchedulerBuilder {
                 vertexParallelismAndInputInfosDecider,
                 defaultMaxParallelism,
                 blocklistOperations,
-                HybridPartitionDataConsumeConstraint.ALL_PRODUCERS_FINISHED);
+                HybridPartitionDataConsumeConstraint.ALL_PRODUCERS_FINISHED,
+                ForwardGroupComputeUtil.computeForwardGroupsAndSetVertexParallelismsIfNecessary(
+                        jobGraph.getVerticesSortedTopologicallyFromSources()));
     }
 
     private ExecutionGraphFactory createExecutionGraphFactory(boolean isDynamicGraph) {
@@ -390,8 +397,16 @@ public class DefaultSchedulerBuilder {
 
     public static VertexParallelismAndInputInfosDecider createCustomParallelismDecider(
             int expectParallelism) {
+        return createCustomParallelismDecider(ignore -> expectParallelism);
+    }
+
+    public static VertexParallelismAndInputInfosDecider createCustomParallelismDecider(
+            Function<JobVertexID, Integer> parallelismFunction) {
         return (jobVertexId, consumedResults, initialParallelism) -> {
-            int parallelism = initialParallelism > 0 ? initialParallelism : expectParallelism;
+            int parallelism =
+                    initialParallelism > 0
+                            ? initialParallelism
+                            : parallelismFunction.apply(jobVertexId);
             return new ParallelismAndInputInfos(
                     parallelism,
                     consumedResults.isEmpty()

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchSchedulerTest.java
@@ -93,7 +93,7 @@ class AdaptiveBatchSchedulerTest {
 
     @Test
     void testAdaptiveBatchScheduler() throws Exception {
-        JobGraph jobGraph = createJobGraph(false);
+        JobGraph jobGraph = createJobGraph();
         Iterator<JobVertex> jobVertexIterator = jobGraph.getVertices().iterator();
         JobVertex source1 = jobVertexIterator.next();
         JobVertex source2 = jobVertexIterator.next();
@@ -118,44 +118,68 @@ class AdaptiveBatchSchedulerTest {
         // check that the jobGraph is updated
         assertThat(sink.getParallelism()).isEqualTo(10);
 
-        // check aggregatedInputDataBytes of each ExecutionVertex calculated.
-        checkAggregatedInputDataBytesIsCalculated(sinkExecutionJobVertex);
+        // check aggregatedInputDataBytes of each ExecutionVertex calculated. Total number of
+        // subpartitions of source1 is ceil(128 / 6) * 6 = 132, total number of subpartitions of
+        // source2 is ceil(128 / 4) * 4 = 128, so total bytes is (132 + 128) * SUBPARTITION_BYTES =
+        // 26_000L.
+        checkAggregatedInputDataBytesIsCalculated(sinkExecutionJobVertex, 26_000L);
     }
 
     @Test
     void testDecideParallelismForForwardTarget() throws Exception {
-        JobGraph jobGraph = createJobGraph(true);
-        Iterator<JobVertex> jobVertexIterator = jobGraph.getVertices().iterator();
-        JobVertex source1 = jobVertexIterator.next();
-        JobVertex source2 = jobVertexIterator.next();
-        JobVertex sink = jobVertexIterator.next();
+        final JobVertex source = createJobVertex("source", SOURCE_PARALLELISM_1);
+        final JobVertex map = createJobVertex("map", -1);
+        final JobVertex sink = createJobVertex("sink", -1);
 
-        SchedulerBase scheduler = createScheduler(jobGraph);
+        map.connectNewDataSetAsInput(
+                source, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
+        sink.connectNewDataSetAsInput(
+                map, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
+        map.getProducedDataSets().get(0).getConsumers().get(0).setForward(true);
+
+        SchedulerBase scheduler =
+                createScheduler(
+                        new JobGraph(new JobID(), "test job", source, map, sink),
+                        createCustomParallelismDecider(
+                                jobVertexId -> {
+                                    if (jobVertexId.equals(map.getID())) {
+                                        return 5;
+                                    } else {
+                                        return 10;
+                                    }
+                                }),
+                        128);
 
         final DefaultExecutionGraph graph = (DefaultExecutionGraph) scheduler.getExecutionGraph();
+        final ExecutionJobVertex mapExecutionJobVertex = graph.getJobVertex(map.getID());
         final ExecutionJobVertex sinkExecutionJobVertex = graph.getJobVertex(sink.getID());
 
         scheduler.startScheduling();
+        assertThat(mapExecutionJobVertex.getParallelism()).isEqualTo(-1);
         assertThat(sinkExecutionJobVertex.getParallelism()).isEqualTo(-1);
 
-        // trigger source1 finished.
-        transitionExecutionsState(scheduler, ExecutionState.FINISHED, source1);
+        // trigger source finished.
+        transitionExecutionsState(scheduler, ExecutionState.FINISHED, source);
+        assertThat(mapExecutionJobVertex.getParallelism()).isEqualTo(5);
         assertThat(sinkExecutionJobVertex.getParallelism()).isEqualTo(-1);
 
-        // trigger source2 finished.
-        transitionExecutionsState(scheduler, ExecutionState.FINISHED, source2);
-        assertThat(sinkExecutionJobVertex.getParallelism()).isEqualTo(SOURCE_PARALLELISM_1);
+        // trigger map finished.
+        transitionExecutionsState(scheduler, ExecutionState.FINISHED, map);
+        assertThat(mapExecutionJobVertex.getParallelism()).isEqualTo(5);
+        assertThat(sinkExecutionJobVertex.getParallelism()).isEqualTo(5);
 
         // check that the jobGraph is updated
-        assertThat(sink.getParallelism()).isEqualTo(SOURCE_PARALLELISM_1);
+        assertThat(sink.getParallelism()).isEqualTo(5);
 
-        // check aggregatedInputDataBytes of each ExecutionVertex calculated.
-        checkAggregatedInputDataBytesIsCalculated(sinkExecutionJobVertex);
+        // check aggregatedInputDataBytes of each ExecutionVertex calculated. Total number of
+        // subpartitions of map is ceil(128 / 5) * 5 = 130, so total bytes sink consume is 130 *
+        // SUBPARTITION_BYTES = 13_000L.
+        checkAggregatedInputDataBytesIsCalculated(sinkExecutionJobVertex, 13_000L);
     }
 
     @Test
     void testUpdateBlockingResultInfoWhileScheduling() throws Exception {
-        JobGraph jobGraph = createJobGraph(false);
+        JobGraph jobGraph = createJobGraph();
         Iterator<JobVertex> jobVertexIterator = jobGraph.getVertices().iterator();
         JobVertex source1 = jobVertexIterator.next();
         JobVertex source2 = jobVertexIterator.next();
@@ -281,7 +305,7 @@ class AdaptiveBatchSchedulerTest {
     }
 
     private void checkAggregatedInputDataBytesIsCalculated(
-            ExecutionJobVertex sinkExecutionJobVertex) {
+            ExecutionJobVertex sinkExecutionJobVertex, long expectedTotalBytes) {
         final ExecutionVertex[] executionVertices = sinkExecutionJobVertex.getTaskVertices();
         long totalInputBytes = 0;
         for (ExecutionVertex ev : executionVertices) {
@@ -290,7 +314,7 @@ class AdaptiveBatchSchedulerTest {
             totalInputBytes += executionInputBytes;
         }
 
-        assertThat(totalInputBytes).isEqualTo(26_000L);
+        assertThat(totalInputBytes).isEqualTo(expectedTotalBytes);
     }
 
     private void triggerFailedByPartitionNotFound(
@@ -375,7 +399,7 @@ class AdaptiveBatchSchedulerTest {
         return jobVertex;
     }
 
-    public JobGraph createJobGraph(boolean withForwardEdge) {
+    public JobGraph createJobGraph() {
         final JobVertex source1 = createJobVertex("source1", SOURCE_PARALLELISM_1);
         final JobVertex source2 = createJobVertex("source2", SOURCE_PARALLELISM_2);
         final JobVertex sink = createJobVertex("sink", -1);
@@ -383,9 +407,6 @@ class AdaptiveBatchSchedulerTest {
                 source1, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
         sink.connectNewDataSetAsInput(
                 source2, DistributionPattern.POINTWISE, ResultPartitionType.BLOCKING);
-        if (withForwardEdge) {
-            source1.getProducedDataSets().get(0).getConsumers().get(0).setForward(true);
-        }
         return new JobGraph(new JobID(), "test job", source1, source2, sink);
     }
 

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -31,10 +31,9 @@ import org.apache.flink.configuration.TaskManagerOptions;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.util.TestLogger;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -45,11 +44,10 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
-import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT case for {@link AdaptiveBatchScheduler}. */
-public class AdaptiveBatchSchedulerITCase extends TestLogger {
+class AdaptiveBatchSchedulerITCase {
 
     private static final int DEFAULT_MAX_PARALLELISM = 4;
     private static final int SOURCE_PARALLELISM_1 = 2;
@@ -60,8 +58,8 @@ public class AdaptiveBatchSchedulerITCase extends TestLogger {
 
     private Map<Long, Long> expectedResult;
 
-    @Before
-    public void setUp() {
+    @BeforeEach
+    void setUp() {
         expectedResult =
                 LongStream.range(0, NUMBERS_TO_PRODUCE)
                         .boxed()
@@ -71,16 +69,16 @@ public class AdaptiveBatchSchedulerITCase extends TestLogger {
     }
 
     @Test
-    public void testSchedulingWithUnknownResource() throws Exception {
+    void testSchedulingWithUnknownResource() throws Exception {
         testScheduling(false);
     }
 
     @Test
-    public void testSchedulingWithFineGrainedResource() throws Exception {
+    void testSchedulingWithFineGrainedResource() throws Exception {
         testScheduling(true);
     }
 
-    public void testScheduling(Boolean isFineGrained) throws Exception {
+    private void testScheduling(Boolean isFineGrained) throws Exception {
         executeJob(isFineGrained);
 
         Map<Long, Long> numberCountResultMap =
@@ -97,7 +95,7 @@ public class AdaptiveBatchSchedulerITCase extends TestLogger {
                 System.out.println(i + ": " + numberCountResultMap.get(i));
             }
         }
-        assertThat(numberCountResultMap, equalTo(expectedResult));
+        assertThat(numberCountResultMap).isEqualTo(expectedResult);
     }
 
     private void executeJob(Boolean isFineGrained) throws Exception {

--- a/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/scheduling/AdaptiveBatchSchedulerITCase.java
@@ -78,6 +78,24 @@ class AdaptiveBatchSchedulerITCase {
         testScheduling(true);
     }
 
+    @Test
+    void testParallelismOfForwardGroupLargerThanGlobalMaxParallelism() throws Exception {
+        final Configuration configuration = createConfiguration();
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.createLocalEnvironment(configuration);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        env.setParallelism(4);
+
+        final DataStream<Long> source =
+                env.fromSequence(0, NUMBERS_TO_PRODUCE - 1)
+                        .setParallelism(4)
+                        .name("source")
+                        .slotSharingGroup("group1");
+
+        source.forward().map(new NumberCounter()).name("map").slotSharingGroup("group2");
+        env.execute();
+    }
+
     private void testScheduling(Boolean isFineGrained) throws Exception {
         executeJob(isFineGrained);
 
@@ -99,18 +117,7 @@ class AdaptiveBatchSchedulerITCase {
     }
 
     private void executeJob(Boolean isFineGrained) throws Exception {
-        final Configuration configuration = new Configuration();
-        configuration.setString(RestOptions.BIND_PORT, "0");
-        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
-        configuration.setInteger(
-                BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM,
-                DEFAULT_MAX_PARALLELISM);
-        configuration.set(
-                BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_AVG_DATA_VOLUME_PER_TASK,
-                MemorySize.parse("150kb"));
-        configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
-        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 1);
-
+        final Configuration configuration = createConfiguration();
         if (isFineGrained) {
             configuration.set(ClusterOptions.ENABLE_FINE_GRAINED_RESOURCE_MANAGEMENT, true);
             configuration.set(ClusterOptions.FINE_GRAINED_SHUFFLE_MODE_ALL_BLOCKING, true);
@@ -155,6 +162,21 @@ class AdaptiveBatchSchedulerITCase {
                 .slotSharingGroup(slotSharingGroups.get(2));
 
         env.execute();
+    }
+
+    private static Configuration createConfiguration() {
+        final Configuration configuration = new Configuration();
+        configuration.setString(RestOptions.BIND_PORT, "0");
+        configuration.setLong(JobManagerOptions.SLOT_REQUEST_TIMEOUT, 5000L);
+        configuration.setInteger(
+                BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_MAX_PARALLELISM, 2);
+        configuration.set(
+                BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_AVG_DATA_VOLUME_PER_TASK,
+                MemorySize.parse("150kb"));
+        configuration.set(TaskManagerOptions.MEMORY_SEGMENT_SIZE, MemorySize.parse("4kb"));
+        configuration.set(TaskManagerOptions.NUM_TASK_SLOTS, 1);
+
+        return configuration;
     }
 
     private static class NumberCounter extends RichMapFunction<Long, Long> {


### PR DESCRIPTION
## What is the purpose of the change
Currently, when using the adaptive batch scheduler, the vertex parallelism decided by forward group may be larger than the global max parallelism(which is configured by option parallelism.default or execution.batch.adaptive.auto-parallelism.max-parallelism, see FLINK-30686 for details). We will fix it in this PR.

## Verifying this change
Add test `testParallelismOfForwardGroupLargerThanGlobalMaxParallelism`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
