### PR TITLE
[BP-1.16][FLINK-30910][runtime] Making test wait for stop to be called before finishing the bootstrap operation (#21869)

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/deployment/application/ApplicationDispatcherBootstrapTest.java
@@ -46,6 +46,7 @@ import org.apache.flink.util.FlinkException;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.SerializedThrowable;
 import org.apache.flink.util.concurrent.FutureUtils;
+import org.apache.flink.util.concurrent.ManuallyTriggeredScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutor;
 import org.apache.flink.util.concurrent.ScheduledExecutorServiceAdapter;
 
@@ -331,6 +332,8 @@ class ApplicationDispatcherBootstrapTest {
                                     return CompletableFuture.completedFuture(Acknowledge.get());
                                 });
 
+        final ManuallyTriggeredScheduledExecutor manuallyTriggeredExecutor =
+                new ManuallyTriggeredScheduledExecutor();
         // we're "listening" on this to be completed to verify that the error handler is called.
         // In production, this will shut down the cluster with an exception.
         final CompletableFuture<Void> errorHandlerFuture = new CompletableFuture<>();
@@ -338,7 +341,7 @@ class ApplicationDispatcherBootstrapTest {
                 createApplicationDispatcherBootstrap(
                         3,
                         dispatcherBuilder.build(),
-                        scheduledExecutor,
+                        manuallyTriggeredExecutor,
                         errorHandlerFuture::completeExceptionally);
 
         final CompletableFuture<Acknowledge> completionFuture =
@@ -347,6 +350,11 @@ class ApplicationDispatcherBootstrapTest {
         ScheduledFuture<?> applicationExecutionFuture = bootstrap.getApplicationExecutionFuture();
 
         bootstrap.stop();
+
+        // Triggers the scheduled ApplicationDispatcherBootstrap process after calling stop. This
+        // ensures that the bootstrap task isn't completed before the stop method is called which
+        // would prevent the stop call from cancelling the task's future.
+        manuallyTriggeredExecutor.triggerNonPeriodicScheduledTask();
 
         // we didn't call the error handler
         assertThat(errorHandlerFuture.isDone()).isFalse();


### PR DESCRIPTION
1.16 backport for parent PR #21869 