### PR TITLE
[FLINK-30944] ExecutionGraphPartitionReleaseTest leaks threads

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
@@ -17,7 +17,6 @@
 
 package org.apache.flink.runtime.executiongraph;
 
-import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.executiongraph.failover.flip1.partitionrelease.PartitionGroupReleaseStrategy;
 import org.apache.flink.runtime.io.network.partition.JobMasterPartitionTracker;
@@ -40,7 +39,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,12 +53,12 @@ class ExecutionGraphPartitionReleaseTest {
     public static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
             TestingUtils.defaultExecutorExtension();
 
-    private static final ScheduledExecutorService scheduledExecutorService =
-            Executors.newSingleThreadScheduledExecutor();
-    private static final TestingComponentMainThreadExecutor mainThreadExecutor =
-            new TestingComponentMainThreadExecutor(
-                    ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
-                            scheduledExecutorService));
+    @RegisterExtension
+    public static final TestingComponentMainThreadExecutor.Extension MAIN_THREAD_EXTENSION =
+            new TestingComponentMainThreadExecutor.Extension();
+
+    private final TestingComponentMainThreadExecutor mainThreadExecutor =
+            MAIN_THREAD_EXTENSION.getComponentMainThreadTestExecutor();
 
     @Test
     void testStrategyNotifiedOfFinishedVerticesAndResultsRespected() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionGraphPartitionReleaseTest.java
@@ -33,31 +33,27 @@ import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.SchedulerTestingUtils;
 import org.apache.flink.runtime.taskmanager.TaskExecutionState;
 import org.apache.flink.testutils.TestingUtils;
-import org.apache.flink.testutils.executor.TestExecutorResource;
-import org.apache.flink.util.TestLogger;
+import org.apache.flink.testutils.executor.TestExecutorExtension;
 
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.util.ArrayDeque;
 import java.util.Queue;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.core.IsEqual.equalTo;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for the interactions of the {@link ExecutionGraph} and {@link
  * PartitionGroupReleaseStrategy}.
  */
-public class ExecutionGraphPartitionReleaseTest extends TestLogger {
+class ExecutionGraphPartitionReleaseTest {
 
-    @ClassRule
-    public static final TestExecutorResource<ScheduledExecutorService> EXECUTOR_RESOURCE =
-            TestingUtils.defaultExecutorResource();
+    @RegisterExtension
+    public static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_EXTENSION =
+            TestingUtils.defaultExecutorExtension();
 
     private static final ScheduledExecutorService scheduledExecutorService =
             Executors.newSingleThreadScheduledExecutor();
@@ -67,7 +63,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                             scheduledExecutorService));
 
     @Test
-    public void testStrategyNotifiedOfFinishedVerticesAndResultsRespected() throws Exception {
+    void testStrategyNotifiedOfFinishedVerticesAndResultsRespected() throws Exception {
         // setup a simple pipeline of 3 operators with blocking partitions
         final JobVertex sourceVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
         final JobVertex operatorVertex = ExecutionGraphTestUtils.createNoOpVertex(1);
@@ -98,7 +94,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
                                     sourceExecution.getAttemptId(), ExecutionState.FINISHED));
-                    assertThat(releasedPartitions, empty());
+                    assertThat(releasedPartitions).isEmpty();
                 });
 
         mainThreadExecutor.execute(
@@ -110,10 +106,9 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
                                     operatorExecution.getAttemptId(), ExecutionState.FINISHED));
-                    assertThat(releasedPartitions, hasSize(1));
-                    assertThat(
-                            releasedPartitions.remove(),
-                            equalTo(
+                    assertThat(releasedPartitions).hasSize(1);
+                    assertThat(releasedPartitions.remove())
+                            .isEqualTo(
                                     new ResultPartitionID(
                                             sourceExecution
                                                     .getVertex()
@@ -121,7 +116,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                                                     .keySet()
                                                     .iterator()
                                                     .next(),
-                                            sourceExecution.getAttemptId())));
+                                            sourceExecution.getAttemptId()));
                 });
 
         mainThreadExecutor.execute(
@@ -133,10 +128,9 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                             new TaskExecutionState(
                                     sinkExecution.getAttemptId(), ExecutionState.FINISHED));
 
-                    assertThat(releasedPartitions, hasSize(1));
-                    assertThat(
-                            releasedPartitions.remove(),
-                            equalTo(
+                    assertThat(releasedPartitions).hasSize(1);
+                    assertThat(releasedPartitions.remove())
+                            .isEqualTo(
                                     new ResultPartitionID(
                                             operatorExecution
                                                     .getVertex()
@@ -144,12 +138,12 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                                                     .keySet()
                                                     .iterator()
                                                     .next(),
-                                            operatorExecution.getAttemptId())));
+                                            operatorExecution.getAttemptId()));
                 });
     }
 
     @Test
-    public void testStrategyNotifiedOfUnFinishedVertices() throws Exception {
+    void testStrategyNotifiedOfUnFinishedVertices() throws Exception {
         // setup a pipeline of 2 failover regions (f1 -> f2), where
         // f1 is just a source
         // f2 consists of 3 operators (o1,o2,o3), where o1 consumes f1, and o2/o3 consume o1
@@ -190,7 +184,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
                                     sourceExecution.getAttemptId(), ExecutionState.FINISHED));
-                    assertThat(releasedPartitions, empty());
+                    assertThat(releasedPartitions).isEmpty();
                 });
 
         mainThreadExecutor.execute(
@@ -202,7 +196,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
                                     operator1Execution.getAttemptId(), ExecutionState.FINISHED));
-                    assertThat(releasedPartitions, empty());
+                    assertThat(releasedPartitions).isEmpty();
                 });
 
         mainThreadExecutor.execute(
@@ -214,7 +208,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
                                     operator2Execution.getAttemptId(), ExecutionState.FINISHED));
-                    assertThat(releasedPartitions, empty());
+                    assertThat(releasedPartitions).isEmpty();
                 });
 
         mainThreadExecutor.execute(
@@ -223,7 +217,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                             getCurrentExecution(operator2Vertex, executionGraph);
                     // reset o2
                     operator2Execution.getVertex().resetForNewExecution();
-                    assertThat(releasedPartitions, empty());
+                    assertThat(releasedPartitions).isEmpty();
                 });
 
         mainThreadExecutor.execute(
@@ -234,7 +228,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                     scheduler.updateTaskExecutionState(
                             new TaskExecutionState(
                                     operator3Execution.getAttemptId(), ExecutionState.FINISHED));
-                    assertThat(releasedPartitions, empty());
+                    assertThat(releasedPartitions).isEmpty();
                 });
     }
 
@@ -255,7 +249,7 @@ public class ExecutionGraphPartitionReleaseTest extends TestLogger {
                 new DefaultSchedulerBuilder(
                                 jobGraph,
                                 mainThreadExecutor.getMainThreadExecutor(),
-                                EXECUTOR_RESOURCE.getExecutor())
+                                EXECUTOR_EXTENSION.getExecutor())
                         .setExecutionSlotAllocatorFactory(
                                 SchedulerTestingUtils.newSlotSharingExecutionSlotAllocatorFactory())
                         .setPartitionTracker(partitionTracker)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingComponentMainThreadExecutor.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingComponentMainThreadExecutor.java
@@ -25,6 +25,9 @@ import org.apache.flink.util.function.FunctionUtils;
 import org.apache.flink.util.function.SupplierWithException;
 import org.apache.flink.util.function.ThrowingRunnable;
 
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.rules.ExternalResource;
 
 import javax.annotation.Nonnull;
@@ -95,6 +98,42 @@ public class TestingComponentMainThreadExecutor {
 
         @Override
         protected void after() {
+            ExecutorUtils.gracefulShutdown(
+                    shutdownTimeoutMillis, TimeUnit.MILLISECONDS, innerExecutorService);
+        }
+
+        public TestingComponentMainThreadExecutor getComponentMainThreadTestExecutor() {
+            return componentMainThreadTestExecutor;
+        }
+    }
+
+    /** Test extension for convenience. */
+    public static class Extension implements BeforeAllCallback, AfterAllCallback {
+        private final long shutdownTimeoutMillis;
+
+        private TestingComponentMainThreadExecutor componentMainThreadTestExecutor;
+
+        private ScheduledExecutorService innerExecutorService;
+
+        public Extension() {
+            this(500L);
+        }
+
+        public Extension(long shutdownTimeoutMillis) {
+            this.shutdownTimeoutMillis = shutdownTimeoutMillis;
+        }
+
+        @Override
+        public void beforeAll(ExtensionContext extensionContext) throws Exception {
+            this.innerExecutorService = Executors.newSingleThreadScheduledExecutor();
+            this.componentMainThreadTestExecutor =
+                    new TestingComponentMainThreadExecutor(
+                            ComponentMainThreadExecutorServiceAdapter.forSingleThreadExecutor(
+                                    innerExecutorService));
+        }
+
+        @Override
+        public void afterAll(ExtensionContext extensionContext) throws Exception {
             ExecutorUtils.gracefulShutdown(
                     shutdownTimeoutMillis, TimeUnit.MILLISECONDS, innerExecutorService);
         }


### PR DESCRIPTION
## What is the purpose of the change

*`ExecutionGraphPartitionReleaseTest` leaks threads through `ExecutionGraphPartitionReleaseTest.scheduledExecutorService`. The `ScheduledExecutorService` is instantiated but never shut down.*


## Brief change log

  - *Fix the problem of thread leaking for `ExecutionGraphPartitionReleaseTest`*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
