### PR TITLE
[FLINK-30958][rest][docs] Fix REST API doc generation failure caused by JobClientHeartbeatHeaders

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -615,6 +615,25 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/AsynchronousOperationResult'
+  /jobs/{jobid}/clientHeartbeat:
+    patch:
+      description: Report the jobClient's aliveness.
+      operationId: triggerHeartbeat
+      parameters:
+      - name: jobid
+        in: path
+        description: 32-character hexadecimal string value that identifies a job.
+        required: true
+        schema:
+          $ref: '#/components/schemas/JobID'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/JobClientHeartbeatRequestBody'
+      responses:
+        "202":
+          description: The request was successful.
   /jobs/{jobid}/config:
     get:
       description: Returns the configuration of a job.
@@ -1056,13 +1075,21 @@ paths:
         style: form
         schema:
           $ref: '#/components/schemas/Type'
+      - name: subtaskindex
+        in: query
+        description: Positive integer value that identifies a subtask.
+        required: false
+        style: form
+        schema:
+          type: integer
+          format: int32
       responses:
         "200":
           description: The request was successful.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/JobVertexFlameGraph'
+                $ref: '#/components/schemas/VertexFlameGraph'
   /jobs/{jobid}/vertices/{vertexid}/metrics:
     get:
       description: Provides access to task metrics.
@@ -1928,6 +1955,8 @@ components:
           type: string
         stacktrace:
           type: string
+        taskManagerId:
+          type: string
         taskName:
           type: string
         timestamp:
@@ -1957,6 +1986,8 @@ components:
         location:
           type: string
         task:
+          type: string
+        taskManagerId:
           type: string
         timestamp:
           type: integer
@@ -2183,6 +2214,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/UserTaskAccumulator'
+    JobClientHeartbeatRequestBody:
+      type: object
+      properties:
+        expiredTimestamp:
+          type: integer
+          format: int64
     JobConfigInfo:
       type: object
       properties:
@@ -2416,14 +2453,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/SubtaskExecutionAttemptDetailsInfo'
-    JobVertexFlameGraph:
-      type: object
-      properties:
-        data:
-          $ref: '#/components/schemas/Node'
-        endTimestamp:
-          type: integer
-          format: int64
     JobVertexID:
       pattern: "[0-9a-f]{32}"
       type: string
@@ -2595,6 +2624,8 @@ components:
         location:
           type: string
         stacktrace:
+          type: string
+        taskManagerId:
           type: string
         taskName:
           type: string
@@ -3167,3 +3198,11 @@ components:
       enum:
       - deprecated
       - ok
+    VertexFlameGraph:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Node'
+        endTimestamp:
+          type: integer
+          format: int64

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobClientHeartbeatHeaders.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/rest/messages/JobClientHeartbeatHeaders.java
@@ -72,4 +72,9 @@ public class JobClientHeartbeatHeaders
     public String getDescription() {
         return "Report the jobClient's aliveness.";
     }
+
+    @Override
+    public String operationId() {
+        return "triggerHeartbeat";
+    }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request fixes the REST API doc generation failure caused by `JobClientHeartbeatHeaders`. `JobClientHeartbeatHeaders` should override `operationId` since `getHttpMethod` returns `POST`. Otherwise `UnsupportedOperationException` is thrown at `OpenApiSpecGenerator` when generating the REST API doc.

## Brief change log

- Override `operationId` for `JobClientHeartbeatHeaders`.
- Regenerate the doc by `mvn package -Dgenerate-rest-docs -pl flink-docs -am -nsu -DskipTests`


## Verifying this change

The issue can be reproduced by rolling back the changes made on `JobClientHeartbeatHeaders` and running `mvn package -Dgenerate-rest-docs -pl flink-docs -am -nsu -DskipTests`. The fix can be verified by applying the changes and re-running the build command.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
