### PR TITLE
[FLINK-29801][runtime] FLIP-274: Introduce metric group for OperatorCoordinator

### DIFF
--- a/docs/layouts/shortcodes/generated/metric_configuration.html
+++ b/docs/layouts/shortcodes/generated/metric_configuration.html
@@ -123,6 +123,12 @@
             <td>Defines the scope format string that is applied to all metrics scoped to a job on a JobManager. Only effective when a identifier-based reporter is configured</td>
         </tr>
         <tr>
+            <td><h5>metrics.scope.jm-operator</h5></td>
+            <td style="word-wrap: break-word;">"&lt;host&gt;.jobmanager.&lt;job_name&gt;.&lt;operator_name&gt;"</td>
+            <td>String</td>
+            <td>Defines the scope format string that is applied to all metrics scoped to the components running on a JobManager of an Operator, like OperatorCoordinator.</td>
+        </tr>
+        <tr>
             <td><h5>metrics.scope.operator</h5></td>
             <td style="word-wrap: break-word;">"&lt;host&gt;.taskmanager.&lt;tm_id&gt;.&lt;job_name&gt;.&lt;operator_name&gt;.&lt;subtask_index&gt;"</td>
             <td>String</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/MetricOptions.java
@@ -272,6 +272,17 @@ public class MetricOptions {
                     .withDescription(
                             "Defines the scope format string that is applied to all metrics scoped to a job on a JobManager. Only effective when a identifier-based reporter is configured");
 
+    /**
+     * The scope format string that is applied to all metrics scoped to the components running on a
+     * JobManager of an operator.
+     */
+    public static final ConfigOption<String> SCOPE_NAMING_JM_OPERATOR =
+            key("metrics.scope.jm-operator")
+                    .stringType()
+                    .defaultValue("<host>.jobmanager.<job_name>.<operator_name>")
+                    .withDescription(
+                            "Defines the scope format string that is applied to all metrics scoped to the components running on a JobManager of an Operator, like OperatorCoordinator.");
+
     /** The scope format string that is applied to all metrics scoped to a job on a TaskManager. */
     public static final ConfigOption<String> SCOPE_NAMING_TM_JOB =
             key("metrics.scope.tm-job")

--- a/flink-docs/README.md
+++ b/flink-docs/README.md
@@ -37,7 +37,7 @@ The documentation must be regenerated whenever
 
 ## Configuration documentation
 
-The `ConfigOptionsDocGenerator` can be use to generate a reference of `ConfigOptions`. By default, a separate file is generated for each `*Options` class found in `org.apache.flink.configuration` and `org.apache.flink.yarn.configuration`. The `@ConfigGroups` annotation can be used to generate multiple files from a single class.
+The `ConfigOptionsDocGenerator` can be used to generate a reference of `ConfigOptions`. By default, a separate file is generated for each `*Options` class found in `org.apache.flink.configuration` and `org.apache.flink.yarn.configuration`. The `@ConfigGroups` annotation can be used to generate multiple files from a single class.
 
 To integrate an `*Options` class from another package, add another module-package argument pair to `ConfigurationOptionLocator#LOCATIONS`.
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertex.java
@@ -284,7 +284,7 @@ public class ExecutionJobVertex
             CoordinatorStore coordinatorStore)
             throws Exception {
         return OperatorCoordinatorHolder.create(
-                provider, this, classLoader, coordinatorStore, false);
+                provider, this, classLoader, coordinatorStore, false, getTaskInformation());
     }
 
     public boolean isInitialized() {
@@ -407,22 +407,23 @@ public class ExecutionJobVertex
         synchronized (stateMonitor) {
             if (taskInformationOrBlobKey == null) {
                 final BlobWriter blobWriter = graph.getBlobWriter();
-
-                final TaskInformation taskInformation =
-                        new TaskInformation(
-                                jobVertex.getID(),
-                                jobVertex.getName(),
-                                parallelismInfo.getParallelism(),
-                                parallelismInfo.getMaxParallelism(),
-                                jobVertex.getInvokableClassName(),
-                                jobVertex.getConfiguration());
-
+                final TaskInformation taskInformation = getTaskInformation();
                 taskInformationOrBlobKey =
                         BlobWriter.serializeAndTryOffload(taskInformation, getJobId(), blobWriter);
             }
 
             return taskInformationOrBlobKey;
         }
+    }
+
+    public TaskInformation getTaskInformation() {
+        return new TaskInformation(
+                jobVertex.getID(),
+                jobVertex.getName(),
+                parallelismInfo.getParallelism(),
+                parallelismInfo.getMaxParallelism(),
+                jobVertex.getInvokableClassName(),
+                jobVertex.getConfiguration());
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
@@ -64,7 +64,7 @@ public class SpeculativeExecutionJobVertex extends ExecutionJobVertex {
             CoordinatorStore coordinatorStore)
             throws Exception {
         return OperatorCoordinatorHolder.create(
-                provider, this, classLoader, coordinatorStore, true);
+                provider, this, classLoader, coordinatorStore, true, getTaskInformation());
     }
 
     /** Factory to create {@link SpeculativeExecutionJobVertex}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/MetricDumpSerialization.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.flink.runtime.metrics.dump.QueryScopeInfo.INFO_CATEGORY_JM;
+import static org.apache.flink.runtime.metrics.dump.QueryScopeInfo.INFO_CATEGORY_JM_OPERATOR;
 import static org.apache.flink.runtime.metrics.dump.QueryScopeInfo.INFO_CATEGORY_JOB;
 import static org.apache.flink.runtime.metrics.dump.QueryScopeInfo.INFO_CATEGORY_OPERATOR;
 import static org.apache.flink.runtime.metrics.dump.QueryScopeInfo.INFO_CATEGORY_TASK;
@@ -251,6 +252,13 @@ public class MetricDumpSerialization {
                 out.writeInt(operatorInfo.attemptNumber);
                 out.writeUTF(operatorInfo.operatorName);
                 break;
+            case INFO_CATEGORY_JM_OPERATOR:
+                QueryScopeInfo.JobManagerOperatorQueryScopeInfo jmOperatorInfo =
+                        (QueryScopeInfo.JobManagerOperatorQueryScopeInfo) info;
+                out.writeUTF(jmOperatorInfo.jobID);
+                out.writeUTF(jmOperatorInfo.vertexID);
+                out.writeUTF(jmOperatorInfo.operatorName);
+                break;
             default:
                 throw new IOException("Unknown scope category: " + info.getCategory());
         }
@@ -439,6 +447,7 @@ public class MetricDumpSerialization {
         String vertexID;
         int subtaskIndex;
         int attemptNumber;
+        String operatorName;
 
         String scope = dis.readUTF();
         byte cat = dis.readByte();
@@ -463,9 +472,15 @@ public class MetricDumpSerialization {
                 vertexID = dis.readUTF();
                 subtaskIndex = dis.readInt();
                 attemptNumber = dis.readInt();
-                String operatorName = dis.readUTF();
+                operatorName = dis.readUTF();
                 return new QueryScopeInfo.OperatorQueryScopeInfo(
                         jobID, vertexID, subtaskIndex, attemptNumber, operatorName, scope);
+            case INFO_CATEGORY_JM_OPERATOR:
+                jobID = dis.readUTF();
+                vertexID = dis.readUTF();
+                operatorName = dis.readUTF();
+                return new QueryScopeInfo.JobManagerOperatorQueryScopeInfo(
+                        jobID, vertexID, operatorName, scope);
             default:
                 throw new IOException("Unknown scope category: " + cat);
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/QueryScopeInfo.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/dump/QueryScopeInfo.java
@@ -29,6 +29,7 @@ public abstract class QueryScopeInfo {
     public static final byte INFO_CATEGORY_JOB = 2;
     public static final byte INFO_CATEGORY_TASK = 3;
     public static final byte INFO_CATEGORY_OPERATOR = 4;
+    public static final byte INFO_CATEGORY_JM_OPERATOR = 5;
 
     /** The remaining scope not covered by specific fields. */
     public final String scope;
@@ -223,6 +224,40 @@ public abstract class QueryScopeInfo {
         @Override
         public byte getCategory() {
             return INFO_CATEGORY_OPERATOR;
+        }
+    }
+
+    /**
+     * Container for the job manager operator scope. Stores the ID of the job/vertex and the name of
+     * the operator.
+     */
+    public static class JobManagerOperatorQueryScopeInfo extends QueryScopeInfo {
+        public final String jobID;
+        public final String vertexID;
+        public final String operatorName;
+
+        public JobManagerOperatorQueryScopeInfo(
+                String jobID, String vertexID, String operatorName) {
+            this(jobID, vertexID, operatorName, "");
+        }
+
+        public JobManagerOperatorQueryScopeInfo(
+                String jobID, String vertexID, String operatorName, String scope) {
+            super(scope);
+            this.jobID = jobID;
+            this.vertexID = vertexID;
+            this.operatorName = operatorName;
+        }
+
+        @Override
+        public JobManagerOperatorQueryScopeInfo copy(String additionalScope) {
+            return new JobManagerOperatorQueryScopeInfo(
+                    this.jobID, this.vertexID, this.operatorName, concatScopes(additionalScope));
+        }
+
+        @Override
+        public byte getCategory() {
+            return INFO_CATEGORY_JM_OPERATOR;
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorCoordinatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalOperatorCoordinatorMetricGroup.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
+
+/** Special {@link org.apache.flink.metrics.MetricGroup} representing an OperatorCoordinator. */
+@Internal
+public class InternalOperatorCoordinatorMetricGroup extends ProxyMetricGroup<MetricGroup>
+        implements OperatorCoordinatorMetricGroup {
+
+    public InternalOperatorCoordinatorMetricGroup(MetricGroup parent) {
+        super(parent.addGroup("coordinator"));
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
@@ -93,11 +94,12 @@ public class JobManagerJobMetricGroup extends JobMetricGroup<JobManagerMetricGro
         }
     }
 
-    public int numRegisteredOperatorMetricGroups() {
+    @VisibleForTesting
+    int numRegisteredOperatorMetricGroups() {
         return operators.size();
     }
 
-    public void removeOperatorMetricGroup(OperatorID operatorID, String operatorName) {
+    void removeOperatorMetricGroup(OperatorID operatorID, String operatorName) {
         final String truncatedOperatorName = getTruncatedOperatorName(operatorName);
 
         // unique OperatorIDs only exist in streaming, so we have to rely on the name for batch

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerJobMetricGroup.java
@@ -20,12 +20,16 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.util.AbstractID;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
+import static org.apache.flink.runtime.metrics.groups.TaskMetricGroup.METRICS_OPERATOR_NAME_MAX_LENGTH;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
 /**
@@ -34,6 +38,8 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  */
 @Internal
 public class JobManagerJobMetricGroup extends JobMetricGroup<JobManagerMetricGroup> {
+    private final Map<String, JobManagerOperatorMetricGroup> operators = new HashMap<>();
+
     JobManagerJobMetricGroup(
             MetricRegistry registry,
             JobManagerMetricGroup parent,
@@ -53,12 +59,64 @@ public class JobManagerJobMetricGroup extends JobMetricGroup<JobManagerMetricGro
         return parent;
     }
 
+    public JobManagerOperatorMetricGroup getOrAddOperator(
+            AbstractID vertexId, String taskName, OperatorID operatorID, String operatorName) {
+        final String truncatedOperatorName = getTruncatedOperatorName(operatorName);
+
+        // unique OperatorIDs only exist in streaming, so we have to rely on the name for batch
+        // operators
+        final String key = operatorID + truncatedOperatorName;
+
+        synchronized (this) {
+            return operators.computeIfAbsent(
+                    key,
+                    operator ->
+                            new JobManagerOperatorMetricGroup(
+                                    this.registry,
+                                    this,
+                                    vertexId,
+                                    taskName,
+                                    operatorID,
+                                    truncatedOperatorName));
+        }
+    }
+
+    private String getTruncatedOperatorName(String operatorName) {
+        if (operatorName != null && operatorName.length() > METRICS_OPERATOR_NAME_MAX_LENGTH) {
+            LOG.warn(
+                    "The operator name {} exceeded the {} characters length limit and was truncated.",
+                    operatorName,
+                    METRICS_OPERATOR_NAME_MAX_LENGTH);
+            return operatorName.substring(0, METRICS_OPERATOR_NAME_MAX_LENGTH);
+        } else {
+            return operatorName;
+        }
+    }
+
+    public int numRegisteredOperatorMetricGroups() {
+        return operators.size();
+    }
+
+    public void removeOperatorMetricGroup(OperatorID operatorID, String operatorName) {
+        final String truncatedOperatorName = getTruncatedOperatorName(operatorName);
+
+        // unique OperatorIDs only exist in streaming, so we have to rely on the name for batch
+        // operators
+        final String key = operatorID + truncatedOperatorName;
+
+        synchronized (this) {
+            if (!isClosed()) {
+                operators.remove(key);
+            }
+        }
+    }
+
     // ------------------------------------------------------------------------
     //  Component Metric Group Specifics
     // ------------------------------------------------------------------------
 
     @Override
     protected Iterable<? extends ComponentMetricGroup> subComponents() {
-        return Collections.emptyList();
+        return operators.values();
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorMetricGroup.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.metrics.CharacterFilter;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.util.AbstractID;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/**
+ * Special {@link org.apache.flink.metrics.MetricGroup} representing everything belonging to the
+ * components running on the JobManager of an Operator.
+ */
+public class JobManagerOperatorMetricGroup extends ComponentMetricGroup<JobManagerJobMetricGroup> {
+    private final AbstractID vertexId;
+    private final String taskName;
+    private final String operatorName;
+    private final OperatorID operatorID;
+
+    public JobManagerOperatorMetricGroup(
+            MetricRegistry registry,
+            JobManagerJobMetricGroup parent,
+            AbstractID vertexId,
+            String taskName,
+            OperatorID operatorID,
+            String operatorName) {
+        super(
+                registry,
+                registry.getScopeFormats()
+                        .getJmOperatorFormat()
+                        .formatScope(
+                                checkNotNull(parent), vertexId, taskName, operatorID, operatorName),
+                parent);
+        this.vertexId = vertexId;
+        this.taskName = taskName;
+        this.operatorID = operatorID;
+        this.operatorName = operatorName;
+    }
+
+    @Override
+    protected String getGroupName(CharacterFilter filter) {
+        return "operator";
+    }
+
+    @Override
+    protected QueryScopeInfo.JobQueryScopeInfo createQueryServiceMetricInfo(
+            CharacterFilter filter) {
+        return new QueryScopeInfo.JobQueryScopeInfo(this.parent.jobId.toString());
+    }
+
+    @Override
+    protected void putVariables(Map<String, String> variables) {
+        variables.put(ScopeFormat.SCOPE_TASK_VERTEX_ID, vertexId.toString());
+        variables.put(ScopeFormat.SCOPE_TASK_NAME, taskName);
+        variables.put(ScopeFormat.SCOPE_OPERATOR_ID, String.valueOf(operatorID));
+        variables.put(ScopeFormat.SCOPE_OPERATOR_NAME, operatorName);
+    }
+
+    @Override
+    public void close() {
+        super.close();
+
+        parent.removeOperatorMetricGroup(operatorID, operatorName);
+    }
+
+    @Override
+    protected Iterable<? extends ComponentMetricGroup> subComponents() {
+        return Collections.emptyList();
+    }
+
+    public AbstractID getVertexId() {
+        return vertexId;
+    }
+
+    public String getTaskName() {
+        return taskName;
+    }
+
+    public String getOperatorName() {
+        return operatorName;
+    }
+
+    public OperatorID getOperatorID() {
+        return operatorID;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorMetricGroup.java
@@ -66,9 +66,12 @@ public class JobManagerOperatorMetricGroup extends ComponentMetricGroup<JobManag
     }
 
     @Override
-    protected QueryScopeInfo.JobQueryScopeInfo createQueryServiceMetricInfo(
+    protected QueryScopeInfo.JobManagerOperatorQueryScopeInfo createQueryServiceMetricInfo(
             CharacterFilter filter) {
-        return new QueryScopeInfo.JobQueryScopeInfo(this.parent.jobId.toString());
+        return new QueryScopeInfo.JobManagerOperatorQueryScopeInfo(
+                this.parent.jobId.toString(),
+                vertexId.toString(),
+                filter.filterCharacters(this.operatorName));
     }
 
     @Override
@@ -89,21 +92,5 @@ public class JobManagerOperatorMetricGroup extends ComponentMetricGroup<JobManag
     @Override
     protected Iterable<? extends ComponentMetricGroup> subComponents() {
         return Collections.emptyList();
-    }
-
-    public AbstractID getVertexId() {
-        return vertexId;
-    }
-
-    public String getTaskName() {
-        return taskName;
-    }
-
-    public String getOperatorName() {
-        return operatorName;
-    }
-
-    public OperatorID getOperatorID() {
-        return operatorID;
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/UnregisteredMetricGroups.java
@@ -20,8 +20,10 @@ package org.apache.flink.runtime.metrics.groups;
 
 import org.apache.flink.api.common.JobID;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.NoOpMetricRegistry;
+import org.apache.flink.util.AbstractID;
 
 import static org.apache.flink.runtime.executiongraph.ExecutionAttemptID.randomId;
 
@@ -69,6 +71,15 @@ public class UnregisteredMetricGroups {
     private static InternalOperatorMetricGroup createUnregisteredOperatorMetricGroup(
             TaskMetricGroup parent) {
         return new UnregisteredOperatorMetricGroup(parent);
+    }
+
+    public static JobManagerOperatorMetricGroup createUnregisteredJobManagerOperatorMetricGroup() {
+        return new UnregisteredJobMangerOperatorMetricGroup();
+    }
+
+    private static JobManagerOperatorMetricGroup createUnregisteredJobManagerOperatorMetricGroup(
+            JobManagerJobMetricGroup parent) {
+        return new UnregisteredJobMangerOperatorMetricGroup(parent);
     }
 
     /** A safe drop-in replacement for {@link ProcessMetricGroup ProcessMetricGroups}. */
@@ -126,6 +137,12 @@ public class UnregisteredMetricGroups {
                     new UnregisteredJobManagerMetricGroup(),
                     DEFAULT_JOB_ID,
                     DEFAULT_JOB_NAME);
+        }
+
+        @Override
+        public JobManagerOperatorMetricGroup getOrAddOperator(
+                AbstractID vertexId, String taskName, OperatorID operatorID, String operatorName) {
+            return createUnregisteredJobManagerOperatorMetricGroup(this);
         }
     }
 
@@ -189,6 +206,29 @@ public class UnregisteredMetricGroups {
 
         UnregisteredOperatorMetricGroup(TaskMetricGroup parent) {
             super(NoOpMetricRegistry.INSTANCE, parent, DEFAULT_OPERATOR_ID, DEFAULT_OPERATOR_NAME);
+        }
+    }
+
+    /** A safe drop-in replacement for {@link JobManagerOperatorMetricGroup}s. */
+    public static class UnregisteredJobMangerOperatorMetricGroup
+            extends JobManagerOperatorMetricGroup {
+        private static final JobVertexID DEFAULT_VERTEX_ID = new JobVertexID();
+        private static final String DEFAULT_TASK_NAME = "UnregisteredTask";
+        private static final OperatorID DEFAULT_OPERATOR_ID = new OperatorID(0, 0);
+        private static final String DEFAULT_OPERATOR_NAME = "UnregisteredOperator";
+
+        protected UnregisteredJobMangerOperatorMetricGroup() {
+            this(new UnregisteredJobManagerJobMetricGroup());
+        }
+
+        UnregisteredJobMangerOperatorMetricGroup(JobManagerJobMetricGroup parent) {
+            super(
+                    NoOpMetricRegistry.INSTANCE,
+                    parent,
+                    DEFAULT_VERTEX_ID,
+                    DEFAULT_TASK_NAME,
+                    DEFAULT_OPERATOR_ID,
+                    DEFAULT_OPERATOR_NAME);
         }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/JobManagerOperatorScopeFormat.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/JobManagerOperatorScopeFormat.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.scope;
+
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.util.AbstractID;
+
+/**
+ * The scope format for the {@link
+ * org.apache.flink.runtime.metrics.groups.JobManagerOperatorMetricGroup}.
+ */
+public class JobManagerOperatorScopeFormat extends ScopeFormat {
+    public JobManagerOperatorScopeFormat(String format, JobManagerJobScopeFormat parentFormat) {
+        super(
+                format,
+                parentFormat,
+                new String[] {
+                    SCOPE_HOST,
+                    SCOPE_JOB_ID,
+                    SCOPE_JOB_NAME,
+                    SCOPE_TASK_VERTEX_ID,
+                    SCOPE_TASK_NAME,
+                    SCOPE_OPERATOR_ID,
+                    SCOPE_OPERATOR_NAME
+                });
+    }
+
+    public String[] formatScope(
+            JobManagerJobMetricGroup parent,
+            AbstractID vertexId,
+            String taskName,
+            OperatorID operatorID,
+            String operatorName) {
+
+        final String[] template = copyTemplate();
+        final String[] values = {
+            parent.parent().hostname(),
+            valueOrNull(parent.jobId()),
+            valueOrNull(parent.jobName()),
+            valueOrNull(vertexId),
+            valueOrNull(taskName),
+            valueOrNull(operatorID),
+            valueOrNull(operatorName)
+        };
+        return bindVariables(template, values);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/scope/ScopeFormats.java
@@ -30,6 +30,7 @@ public final class ScopeFormats {
     private final TaskManagerJobScopeFormat taskManagerJobFormat;
     private final TaskScopeFormat taskFormat;
     private final OperatorScopeFormat operatorFormat;
+    private final JobManagerOperatorScopeFormat jmOperatorFormat;
 
     // ------------------------------------------------------------------------
 
@@ -40,7 +41,8 @@ public final class ScopeFormats {
             String taskManagerFormat,
             String taskManagerJobFormat,
             String taskFormat,
-            String operatorFormat) {
+            String operatorFormat,
+            String jmOperatorFormat) {
         this.jobManagerFormat = new JobManagerScopeFormat(jobManagerFormat);
         this.jobManagerJobFormat =
                 new JobManagerJobScopeFormat(jobManagerJobFormat, this.jobManagerFormat);
@@ -49,6 +51,8 @@ public final class ScopeFormats {
                 new TaskManagerJobScopeFormat(taskManagerJobFormat, this.taskManagerFormat);
         this.taskFormat = new TaskScopeFormat(taskFormat, this.taskManagerJobFormat);
         this.operatorFormat = new OperatorScopeFormat(operatorFormat, this.taskFormat);
+        this.jmOperatorFormat =
+                new JobManagerOperatorScopeFormat(jmOperatorFormat, this.jobManagerJobFormat);
     }
 
     // ------------------------------------------------------------------------
@@ -79,6 +83,9 @@ public final class ScopeFormats {
         return this.operatorFormat;
     }
 
+    public JobManagerOperatorScopeFormat getJmOperatorFormat() {
+        return jmOperatorFormat;
+    }
     // ------------------------------------------------------------------------
     //  Parsing from Config
     // ------------------------------------------------------------------------
@@ -96,8 +103,15 @@ public final class ScopeFormats {
         String tmJobFormat = config.getString(MetricOptions.SCOPE_NAMING_TM_JOB);
         String taskFormat = config.getString(MetricOptions.SCOPE_NAMING_TASK);
         String operatorFormat = config.getString(MetricOptions.SCOPE_NAMING_OPERATOR);
+        String jmOperatorFormat = config.getString(MetricOptions.SCOPE_NAMING_JM_OPERATOR);
 
         return new ScopeFormats(
-                jmFormat, jmJobFormat, tmFormat, tmJobFormat, taskFormat, operatorFormat);
+                jmFormat,
+                jmJobFormat,
+                tmFormat,
+                tmJobFormat,
+                taskFormat,
+                operatorFormat,
+                jmOperatorFormat);
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.CheckpointListener;
+import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
@@ -243,6 +244,9 @@ public interface OperatorCoordinator extends CheckpointListener, AutoCloseable {
 
         /** Gets the ID of the operator to which the coordinator belongs. */
         OperatorID getOperatorId();
+
+        /** Gets the metric group of the operator coordinator. */
+        OperatorCoordinatorMetricGroup metricGroup();
 
         /**
          * Fails the job and trigger a global failover operation.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -19,10 +19,15 @@
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.OperatorCoordinatorCheckpointContext;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.InternalOperatorCoordinatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.metrics.groups.JobManagerOperatorMetricGroup;
 import org.apache.flink.runtime.operators.coordination.util.IncompleteFuturesTracker;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.util.ExceptionUtils;
@@ -111,17 +116,20 @@ public class OperatorCoordinatorHolder
 
     private final IncompleteFuturesTracker unconfirmedEvents;
 
+    private final TaskInformation taskInformation;
     private final int operatorParallelism;
     private final int operatorMaxParallelism;
 
     private GlobalFailureHandler globalFailureHandler;
     private ComponentMainThreadExecutor mainThreadExecutor;
+    private OperatorCoordinatorMetricGroup operatorCoordinatorMetricGroup;
 
     private OperatorCoordinatorHolder(
             final OperatorID operatorId,
             final OperatorCoordinator coordinator,
             final LazyInitializedCoordinatorContext context,
             final SubtaskAccess.SubtaskAccessFactory taskAccesses,
+            final TaskInformation taskInformation,
             final int operatorParallelism,
             final int operatorMaxParallelism) {
 
@@ -131,6 +139,7 @@ public class OperatorCoordinatorHolder
         this.taskAccesses = checkNotNull(taskAccesses);
         this.operatorParallelism = operatorParallelism;
         this.operatorMaxParallelism = operatorMaxParallelism;
+        this.taskInformation = taskInformation;
 
         this.subtaskGatewayMap = new HashMap<>();
         this.unconfirmedEvents = new IncompleteFuturesTracker();
@@ -138,12 +147,22 @@ public class OperatorCoordinatorHolder
 
     public void lazyInitialize(
             GlobalFailureHandler globalFailureHandler,
-            ComponentMainThreadExecutor mainThreadExecutor) {
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
 
         this.globalFailureHandler = globalFailureHandler;
         this.mainThreadExecutor = mainThreadExecutor;
+        JobManagerOperatorMetricGroup parentMetricGroup =
+                jobManagerJobMetricGroup.getOrAddOperator(
+                        taskInformation.getJobVertexId(),
+                        taskInformation.getTaskName(),
+                        operatorId,
+                        context.operatorName);
+        this.operatorCoordinatorMetricGroup =
+                new InternalOperatorCoordinatorMetricGroup(parentMetricGroup);
 
-        context.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+        context.lazyInitialize(
+                globalFailureHandler, mainThreadExecutor, operatorCoordinatorMetricGroup);
 
         setupAllSubtaskGateways();
     }
@@ -463,7 +482,8 @@ public class OperatorCoordinatorHolder
             ExecutionJobVertex jobVertex,
             ClassLoader classLoader,
             CoordinatorStore coordinatorStore,
-            boolean supportsConcurrentExecutionAttempts)
+            boolean supportsConcurrentExecutionAttempts,
+            TaskInformation taskInformation)
             throws Exception {
 
         try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(classLoader)) {
@@ -483,7 +503,8 @@ public class OperatorCoordinatorHolder
                     jobVertex.getParallelism(),
                     jobVertex.getMaxParallelism(),
                     taskAccesses,
-                    supportsConcurrentExecutionAttempts);
+                    supportsConcurrentExecutionAttempts,
+                    taskInformation);
         }
     }
 
@@ -497,7 +518,8 @@ public class OperatorCoordinatorHolder
             final int operatorParallelism,
             final int operatorMaxParallelism,
             final SubtaskAccess.SubtaskAccessFactory taskAccesses,
-            final boolean supportsConcurrentExecutionAttempts)
+            final boolean supportsConcurrentExecutionAttempts,
+            final TaskInformation taskInformation)
             throws Exception {
 
         final LazyInitializedCoordinatorContext context =
@@ -516,6 +538,7 @@ public class OperatorCoordinatorHolder
                 coordinator,
                 context,
                 taskAccesses,
+                taskInformation,
                 operatorParallelism,
                 operatorMaxParallelism);
     }
@@ -548,6 +571,7 @@ public class OperatorCoordinatorHolder
 
         private GlobalFailureHandler globalFailureHandler;
         private Executor schedulerExecutor;
+        private OperatorCoordinatorMetricGroup metricGroup;
 
         private volatile boolean failed;
 
@@ -566,9 +590,13 @@ public class OperatorCoordinatorHolder
             this.supportsConcurrentExecutionAttempts = supportsConcurrentExecutionAttempts;
         }
 
-        void lazyInitialize(GlobalFailureHandler globalFailureHandler, Executor schedulerExecutor) {
+        void lazyInitialize(
+                GlobalFailureHandler globalFailureHandler,
+                Executor schedulerExecutor,
+                OperatorCoordinatorMetricGroup metricGroup) {
             this.globalFailureHandler = checkNotNull(globalFailureHandler);
             this.schedulerExecutor = checkNotNull(schedulerExecutor);
+            this.metricGroup = metricGroup;
         }
 
         void unInitialize() {
@@ -591,6 +619,11 @@ public class OperatorCoordinatorHolder
         @Override
         public OperatorID getOperatorId() {
             return operatorId;
+        }
+
+        @Override
+        public OperatorCoordinatorMetricGroup metricGroup() {
+            return metricGroup;
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/RecreateOnResetOperatorCoordinator.java
@@ -19,6 +19,7 @@ limitations under the License.
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.function.ThrowingConsumer;
@@ -227,6 +228,11 @@ public class RecreateOnResetOperatorCoordinator implements OperatorCoordinator {
         @Override
         public OperatorID getOperatorId() {
             return context.getOperatorId();
+        }
+
+        @Override
+        public OperatorCoordinatorMetricGroup metricGroup() {
+            return context.metricGroup();
         }
 
         @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
@@ -71,9 +72,12 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
     }
 
     @Override
-    public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
+    public void initializeOperatorCoordinators(
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
         for (OperatorCoordinatorHolder coordinatorHolder : coordinatorMap.values()) {
-            coordinatorHolder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+            coordinatorHolder.lazyInitialize(
+                    globalFailureHandler, mainThreadExecutor, jobManagerJobMetricGroup);
         }
     }
 
@@ -150,11 +154,13 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
     @Override
     public void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor) {
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
 
         for (OperatorCoordinatorHolder coordinator : coordinators) {
             coordinatorMap.put(coordinator.operatorId(), coordinator);
-            coordinator.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+            coordinator.lazyInitialize(
+                    globalFailureHandler, mainThreadExecutor, jobManagerJobMetricGroup);
         }
         startOperatorCoordinators(coordinators);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
@@ -39,7 +40,9 @@ public interface OperatorCoordinatorHandler {
      *
      * @param mainThreadExecutor Executor for submitting work to the main thread.
      */
-    void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor);
+    void initializeOperatorCoordinators(
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup);
 
     /** Start all operator coordinators. */
     void startAllOperatorCoordinators();
@@ -78,5 +81,6 @@ public interface OperatorCoordinatorHandler {
      */
     void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor);
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -230,7 +230,8 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
         this.operatorCoordinatorHandler =
                 new DefaultOperatorCoordinatorHandler(executionGraph, this::handleGlobalFailure);
-        operatorCoordinatorHandler.initializeOperatorCoordinators(this.mainThreadExecutor);
+        operatorCoordinatorHandler.initializeOperatorCoordinators(
+                this.mainThreadExecutor, jobManagerJobMetricGroup);
 
         this.exceptionHistory =
                 new BoundedFIFOQueue<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/AdaptiveScheduler.java
@@ -216,6 +216,8 @@ public class AdaptiveScheduler
 
     private final BoundedFIFOQueue<RootExceptionHistoryEntry> exceptionHistory;
 
+    private final JobManagerJobMetricGroup jobManagerJobMetricGroup;
+
     public AdaptiveScheduler(
             JobGraph jobGraph,
             Configuration configuration,
@@ -297,6 +299,7 @@ public class AdaptiveScheduler
         this.exceptionHistory =
                 new BoundedFIFOQueue<>(
                         configuration.getInteger(WebOptions.MAX_EXCEPTION_HISTORY_SIZE));
+        this.jobManagerJobMetricGroup = jobManagerJobMetricGroup;
     }
 
     private static void assertPreconditions(JobGraph jobGraph) throws RuntimeException {
@@ -1118,6 +1121,11 @@ public class AdaptiveScheduler
     @Override
     public ComponentMainThreadExecutor getMainThreadExecutor() {
         return componentMainThreadExecutor;
+    }
+
+    @Override
+    public JobManagerJobMetricGroup getMetricGroup() {
+        return jobManagerJobMetricGroup;
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -26,6 +26,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionVertex;
 import org.apache.flink.runtime.jobgraph.JobType;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.scheduler.DefaultOperatorCoordinatorHandler;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
@@ -116,7 +117,7 @@ public class CreatingExecutionGraph implements State {
                 final OperatorCoordinatorHandler operatorCoordinatorHandler =
                         operatorCoordinatorHandlerFactory.create(executionGraph, context);
                 operatorCoordinatorHandler.initializeOperatorCoordinators(
-                        context.getMainThreadExecutor());
+                        context.getMainThreadExecutor(), context.getMetricGroup());
                 operatorCoordinatorHandler.startAllOperatorCoordinators();
                 String updatedPlan =
                         JsonPlanGenerator.generatePlan(
@@ -231,6 +232,13 @@ public class CreatingExecutionGraph implements State {
          * @return the main thread executor
          */
         ComponentMainThreadExecutor getMainThreadExecutor();
+
+        /**
+         * Gets the {@link JobManagerJobMetricGroup}.
+         *
+         * @return the metric group
+         */
+        JobManagerJobMetricGroup getMetricGroup();
     }
 
     @FunctionalInterface

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -439,7 +439,9 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
 
     private void initializeOperatorCoordinatorsFor(ExecutionJobVertex vertex) {
         operatorCoordinatorHandler.registerAndStartNewCoordinators(
-                vertex.getOperatorCoordinators(), getMainThreadExecutor());
+                vertex.getOperatorCoordinators(),
+                getMainThreadExecutor(),
+                jobManagerJobMetricGroup);
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/QueryScopeInfoTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/dump/QueryScopeInfoTest.java
@@ -160,4 +160,38 @@ class QueryScopeInfoTest {
         assertThat(info.operatorName).isEqualTo("opname");
         assertThat(info.subtaskIndex).isEqualTo(2);
     }
+
+    @Test
+    void testJobManagerOperatorQueryScopeInfo() {
+        QueryScopeInfo.JobManagerOperatorQueryScopeInfo info =
+                new QueryScopeInfo.JobManagerOperatorQueryScopeInfo("jobid", "taskid", "opname");
+        assertThat(info.getCategory()).isEqualTo(QueryScopeInfo.INFO_CATEGORY_JM_OPERATOR);
+        assertThat(info.scope).isEmpty();
+        assertThat(info.jobID).isEqualTo("jobid");
+        assertThat(info.vertexID).isEqualTo("taskid");
+        assertThat(info.operatorName).isEqualTo("opname");
+
+        info = info.copy("world");
+        assertThat(info.getCategory()).isEqualTo(QueryScopeInfo.INFO_CATEGORY_JM_OPERATOR);
+        assertThat(info.scope).isEqualTo("world");
+        assertThat(info.jobID).isEqualTo("jobid");
+        assertThat(info.vertexID).isEqualTo("taskid");
+        assertThat(info.operatorName).isEqualTo("opname");
+
+        info =
+                new QueryScopeInfo.JobManagerOperatorQueryScopeInfo(
+                        "jobid", "taskid", "opname", "hello");
+        assertThat(info.getCategory()).isEqualTo(QueryScopeInfo.INFO_CATEGORY_JM_OPERATOR);
+        assertThat(info.scope).isEqualTo("hello");
+        assertThat(info.jobID).isEqualTo("jobid");
+        assertThat(info.vertexID).isEqualTo("taskid");
+        assertThat(info.operatorName).isEqualTo("opname");
+
+        info = info.copy("world");
+        assertThat(info.getCategory()).isEqualTo(QueryScopeInfo.INFO_CATEGORY_JM_OPERATOR);
+        assertThat(info.scope).isEqualTo("hello.world");
+        assertThat(info.jobID).isEqualTo("jobid");
+        assertThat(info.vertexID).isEqualTo("taskid");
+        assertThat(info.operatorName).isEqualTo("opname");
+    }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalOperatorCoordinatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalOperatorCoordinatorGroupTest.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.scope.ScopeFormat;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link InternalOperatorCoordinatorMetricGroup}. */
+class InternalOperatorCoordinatorGroupTest {
+
+    private static final MetricRegistry registry = TestingMetricRegistry.builder().build();
+
+    @Test
+    void testGenerateScopeDefault() {
+        final JobID jobId = new JobID();
+        final JobVertexID jobVertexId = new JobVertexID();
+        final OperatorID operatorId = new OperatorID();
+        JobManagerOperatorMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "localhost")
+                        .addJob(jobId, "myJobName")
+                        .getOrAddOperator(jobVertexId, "taskName", operatorId, "opName");
+        InternalOperatorCoordinatorMetricGroup operatorCoordinatorMetricGroup =
+                new InternalOperatorCoordinatorMetricGroup(jmJobGroup);
+
+        assertThat(operatorCoordinatorMetricGroup.getScopeComponents())
+                .containsExactly("localhost", "jobmanager", "myJobName", "opName", "coordinator");
+        assertThat(operatorCoordinatorMetricGroup.getMetricIdentifier("name"))
+                .isEqualTo("localhost.jobmanager.myJobName.opName.coordinator.name");
+    }
+
+    @Test
+    void testVariables() {
+        final JobID jobId = new JobID();
+        final JobVertexID jobVertexId = new JobVertexID();
+        final OperatorID operatorId = new OperatorID();
+        JobManagerOperatorMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "host")
+                        .addJob(jobId, "myJobName")
+                        .getOrAddOperator(jobVertexId, "taskName", operatorId, "opName");
+        InternalOperatorCoordinatorMetricGroup operatorCoordinatorMetricGroup =
+                new InternalOperatorCoordinatorMetricGroup(jmJobGroup);
+
+        Map<String, String> variables = operatorCoordinatorMetricGroup.getAllVariables();
+
+        testVariable(variables, ScopeFormat.SCOPE_HOST, "host");
+        testVariable(variables, ScopeFormat.SCOPE_JOB_ID, jobId.toString());
+        testVariable(variables, ScopeFormat.SCOPE_JOB_NAME, "myJobName");
+        testVariable(variables, ScopeFormat.SCOPE_TASK_VERTEX_ID, jobVertexId.toString());
+        testVariable(variables, ScopeFormat.SCOPE_TASK_NAME, "taskName");
+        testVariable(variables, ScopeFormat.SCOPE_OPERATOR_ID, operatorId.toString());
+        testVariable(variables, ScopeFormat.SCOPE_OPERATOR_NAME, "opName");
+    }
+
+    private static void testVariable(
+            Map<String, String> variables, String key, String expectedValue) {
+        String actualValue = variables.get(key);
+        assertThat(actualValue).isNotNull();
+        assertThat(actualValue).isEqualTo(expectedValue);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/JobManagerOperatorGroupTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.MetricRegistryImpl;
+import org.apache.flink.runtime.metrics.MetricRegistryTestUtils;
+import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
+import org.apache.flink.runtime.metrics.util.DummyCharacterFilter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** Tests for the {@link JobManagerOperatorMetricGroup}. */
+public class JobManagerOperatorGroupTest {
+    private MetricRegistryImpl registry;
+
+    @Before
+    public void setup() {
+        registry =
+                new MetricRegistryImpl(
+                        MetricRegistryTestUtils.defaultMetricRegistryConfiguration());
+    }
+
+    @After
+    public void teardown() throws Exception {
+        if (registry != null) {
+            registry.closeAsync().get();
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    //  adding and removing operators
+    // ------------------------------------------------------------------------
+
+    @Test
+    public void addOperators() throws Exception {
+        JobManagerJobMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "theHostName")
+                        .addJob(new JobID(), "myJobName");
+
+        final JobVertexID jobVertexId1 = new JobVertexID();
+        final JobVertexID jobVertexId2 = new JobVertexID();
+        final OperatorID operatorId1 = new OperatorID();
+        final OperatorID operatorId2 = new OperatorID();
+
+        JobManagerOperatorMetricGroup jmOperatorGroup11 =
+                jmJobGroup.getOrAddOperator(jobVertexId1, "taskName1", operatorId1, "opName1");
+        JobManagerOperatorMetricGroup jmOperatorGroup12 =
+                jmJobGroup.getOrAddOperator(jobVertexId1, "taskName1", operatorId1, "opName1");
+        JobManagerOperatorMetricGroup jmOperatorGroup21 =
+                jmJobGroup.getOrAddOperator(jobVertexId2, "taskName3", operatorId2, "opName3");
+
+        assertEquals(jmOperatorGroup11, jmOperatorGroup12);
+
+        assertEquals(2, jmJobGroup.numRegisteredOperatorMetricGroups());
+
+        jmOperatorGroup11.close();
+        assertTrue(jmOperatorGroup11.isClosed());
+        assertEquals(1, jmJobGroup.numRegisteredOperatorMetricGroups());
+
+        jmOperatorGroup21.close();
+        assertTrue(jmOperatorGroup21.isClosed());
+        assertEquals(0, jmJobGroup.numRegisteredOperatorMetricGroups());
+    }
+
+    @Test
+    public void testCloseClosesAll() throws Exception {
+        JobManagerJobMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "theHostName")
+                        .addJob(new JobID(), "myJobName");
+
+        final JobVertexID jobVertexId1 = new JobVertexID();
+        final JobVertexID jobVertexId2 = new JobVertexID();
+        final OperatorID operatorId1 = new OperatorID();
+        final OperatorID operatorId2 = new OperatorID();
+
+        JobManagerOperatorMetricGroup jmOperatorGroup11 =
+                jmJobGroup.getOrAddOperator(jobVertexId1, "taskName1", operatorId1, "opName1");
+        JobManagerOperatorMetricGroup jmOperatorGroup12 =
+                jmJobGroup.getOrAddOperator(jobVertexId1, "taskName1", operatorId1, "opName1");
+        JobManagerOperatorMetricGroup jmOperatorGroup21 =
+                jmJobGroup.getOrAddOperator(jobVertexId2, "taskName3", operatorId2, "opName3");
+
+        assertEquals(jmOperatorGroup11, jmOperatorGroup12);
+        assertEquals(2, jmJobGroup.numRegisteredOperatorMetricGroups());
+
+        jmJobGroup.close();
+
+        assertTrue(jmOperatorGroup11.isClosed());
+        assertTrue(jmOperatorGroup21.isClosed());
+    }
+
+    // ------------------------------------------------------------------------
+    //  scope name tests
+    // ------------------------------------------------------------------------
+
+    @Test
+    public void testGenerateScopeDefault() throws Exception {
+        final JobID jobId = new JobID();
+        final JobVertexID jobVertexId = new JobVertexID();
+        final OperatorID operatorId = new OperatorID();
+        JobManagerOperatorMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "localhost")
+                        .addJob(jobId, "myJobName")
+                        .getOrAddOperator(jobVertexId, "taskName", operatorId, "opName");
+
+        assertArrayEquals(
+                new String[] {"localhost", "jobmanager", "myJobName", "opName"},
+                jmJobGroup.getScopeComponents());
+        assertEquals(
+                "localhost.jobmanager.myJobName.opName.name",
+                jmJobGroup.getMetricIdentifier("name"));
+    }
+
+    @Test
+    public void testGenerateScopeCustom() throws Exception {
+        Configuration cfg = new Configuration();
+        cfg.setString(
+                MetricOptions.SCOPE_NAMING_JM_OPERATOR,
+                "constant.<host>.foo.<host>.<job_id>.<job_name>.<task_id>.<task_name>.<operator_id>.<operator_name>");
+        MetricRegistryImpl registry =
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
+
+        final JobID jobId = new JobID();
+        final JobVertexID jobVertexId = new JobVertexID();
+        final OperatorID operatorId = new OperatorID();
+        JobManagerOperatorMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "host")
+                        .addJob(jobId, "myJobName")
+                        .getOrAddOperator(jobVertexId, "taskName", operatorId, "opName");
+
+        assertArrayEquals(
+                new String[] {
+                    "constant",
+                    "host",
+                    "foo",
+                    "host",
+                    jobId.toString(),
+                    "myJobName",
+                    jobVertexId.toString(),
+                    "taskName",
+                    operatorId.toString(),
+                    "opName"
+                },
+                jmJobGroup.getScopeComponents());
+        assertEquals(
+                String.format(
+                        "constant.host.foo.host.%s.myJobName.%s.taskName.%s.opName.name",
+                        jobId, jobVertexId, operatorId),
+                jmJobGroup.getMetricIdentifier("name"));
+
+        registry.closeAsync().get();
+    }
+
+    @Test
+    public void testGenerateScopeCustomWildcard() throws Exception {
+        Configuration cfg = new Configuration();
+        cfg.setString(MetricOptions.SCOPE_NAMING_JM, "peter");
+        cfg.setString(MetricOptions.SCOPE_NAMING_JM_JOB, "*.some-constant.<job_id>");
+        cfg.setString(MetricOptions.SCOPE_NAMING_JM_OPERATOR, "*.other-constant.<operator_id>");
+        MetricRegistryImpl registry =
+                new MetricRegistryImpl(MetricRegistryTestUtils.fromConfiguration(cfg));
+
+        final JobID jobId = new JobID();
+        final JobVertexID jobVertexId = new JobVertexID();
+        final OperatorID operatorId = new OperatorID();
+        JobManagerOperatorMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "host")
+                        .addJob(jobId, "myJobName")
+                        .getOrAddOperator(jobVertexId, "taskName", operatorId, "opName");
+
+        assertArrayEquals(
+                new String[] {
+                    "peter",
+                    "some-constant",
+                    jobId.toString(),
+                    "other-constant",
+                    operatorId.toString()
+                },
+                jmJobGroup.getScopeComponents());
+
+        assertEquals(
+                String.format("peter.some-constant.%s.other-constant.%s.name", jobId, operatorId),
+                jmJobGroup.getMetricIdentifier("name"));
+
+        registry.closeAsync().get();
+    }
+
+    @Test
+    public void testCreateQueryServiceMetricInfo() {
+        final JobID jobId = new JobID();
+        final JobVertexID jobVertexId = new JobVertexID();
+        final OperatorID operatorId = new OperatorID();
+        JobManagerOperatorMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "host")
+                        .addJob(jobId, "myJobName")
+                        .getOrAddOperator(jobVertexId, "taskName", operatorId, "opName");
+
+        QueryScopeInfo.JobQueryScopeInfo info =
+                jmJobGroup.createQueryServiceMetricInfo(new DummyCharacterFilter());
+        assertEquals("", info.scope);
+        assertEquals(jobId.toString(), info.jobID);
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -18,6 +18,7 @@ limitations under the License.
 
 package org.apache.flink.runtime.operators.coordination;
 
+import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 
 import java.util.concurrent.CompletableFuture;
@@ -54,6 +55,11 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
     @Override
     public OperatorID getOperatorId() {
         return operatorID;
+    }
+
+    @Override
+    public OperatorCoordinatorMetricGroup metricGroup() {
+        return null;
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/MockOperatorCoordinatorContext.java
@@ -20,6 +20,8 @@ package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.InternalOperatorCoordinatorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -59,7 +61,8 @@ public class MockOperatorCoordinatorContext implements OperatorCoordinator.Conte
 
     @Override
     public OperatorCoordinatorMetricGroup metricGroup() {
-        return null;
+        return new InternalOperatorCoordinatorMetricGroup(
+                UnregisteredMetricGroups.createUnregisteredJobManagerOperatorMetricGroup());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -18,14 +18,19 @@
 
 package org.apache.flink.runtime.operators.coordination;
 
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.core.testutils.OneShotLatch;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAdapter;
 import org.apache.flink.runtime.concurrent.ManuallyTriggeredScheduledExecutorService;
+import org.apache.flink.runtime.executiongraph.TaskInformation;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.messages.Acknowledge;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.EventReceivingTasks.EventWithSubtask;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
+import org.apache.flink.runtime.testtasks.NoOpInvokable;
 import org.apache.flink.util.ExceptionUtils;
 import org.apache.flink.util.TestLogger;
 
@@ -514,9 +519,19 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                         3,
                         1775,
                         eventTarget,
-                        false);
+                        false,
+                        new TaskInformation(
+                                new JobVertexID(),
+                                "test task",
+                                1,
+                                1,
+                                NoOpInvokable.class.getName(),
+                                new Configuration()));
 
-        holder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
+        holder.lazyInitialize(
+                globalFailureHandler,
+                mainThreadExecutor,
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         holder.start();
 
         return holder;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricFetcherTest.java
@@ -109,6 +109,11 @@ class MetricFetcherTest {
                                     .metrics
                                     .get("2.opname.abc.oc"))
                     .isEqualTo("1");
+            assertThat(
+                            store.getTaskMetricStore(jobID.toString(), "taskid")
+                                    .getJobManagerOperatorMetricStores("opname")
+                                    .getMetric("abc.joc"))
+                    .isEqualTo("3");
         }
     }
 
@@ -121,9 +126,11 @@ class MetricFetcherTest {
 
         SimpleCounter c1 = new SimpleCounter();
         SimpleCounter c2 = new SimpleCounter();
+        SimpleCounter c3 = new SimpleCounter();
 
         c1.inc(1);
         c2.inc(2);
+        c3.inc(3);
 
         counters.put(
                 c1,
@@ -137,6 +144,12 @@ class MetricFetcherTest {
                         new QueryScopeInfo.TaskQueryScopeInfo(
                                 jobID.toString(), "taskid", 2, 0, "abc"),
                         "tc"));
+        counters.put(
+                c3,
+                new Tuple2<>(
+                        new QueryScopeInfo.JobManagerOperatorQueryScopeInfo(
+                                jobID.toString(), "taskid", "opname", "abc"),
+                        "joc"));
         meters.put(
                 new Meter() {
                     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/rest/handler/legacy/metrics/MetricStoreTest.java
@@ -27,7 +27,6 @@ import org.apache.flink.runtime.metrics.dump.QueryScopeInfo;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -43,7 +42,7 @@ class MetricStoreTest {
     private static final JobID JOB_ID = new JobID();
 
     @Test
-    void testAdd() throws IOException {
+    void testAdd() {
         MetricStore store = setupStore(new MetricStore());
 
         assertThat(store.getJobManagerMetricStore().getMetric("abc.metric1", "-1")).isEqualTo("0");
@@ -100,6 +99,18 @@ class MetricStoreTest {
                         store.getSubtaskAttemptMetricStore(JOB_ID.toString(), "taskid", 8, 4)
                                 .getMetric("opname.abc.metric7", "-1"))
                 .isEqualTo("16");
+
+        assertThat(
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
+                                .getJobManagerOperatorMetricStores("opname")
+                                .getMetric("abc.metric8", "-1"))
+                .isEqualTo("19");
+
+        assertThat(
+                        store.getTaskMetricStore(JOB_ID.toString(), "taskid")
+                                .getJobManagerOperatorMetricStores("opname")
+                                .getMetric("abc.metric9", "-1"))
+                .isEqualTo("20");
     }
 
     @Test
@@ -258,6 +269,12 @@ class MetricStoreTest {
         MetricDump.CounterDump cd74 =
                 new MetricDump.CounterDump(speculativeOperator3, "metric7", 18);
 
+        QueryScopeInfo.JobManagerOperatorQueryScopeInfo jmOperator =
+                new QueryScopeInfo.JobManagerOperatorQueryScopeInfo(
+                        JOB_ID.toString(), "taskid", "opname", "abc");
+        MetricDump.CounterDump jmCd8 = new MetricDump.CounterDump(jmOperator, "metric8", 19);
+        MetricDump.CounterDump jmCd9 = new MetricDump.CounterDump(jmOperator, "metric9", 20);
+
         store.add(cd1);
         store.add(cd2);
         store.add(cd2a);
@@ -279,6 +296,9 @@ class MetricStoreTest {
         store.add(cd73);
         store.add(cd64);
         store.add(cd74);
+
+        store.add(jmCd8);
+        store.add(jmCd9);
 
         return store;
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
@@ -28,6 +28,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.TestingOperatorCoordinator;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
@@ -71,7 +72,9 @@ public class DefaultOperatorCoordinatorHandlerTest {
 
         executionGraph.initializeJobVertex(ejv2, 0L);
         handler.registerAndStartNewCoordinators(
-                ejv2.getOperatorCoordinators(), executionGraph.getJobMasterMainThreadExecutor());
+                ejv2.getOperatorCoordinators(),
+                executionGraph.getJobMasterMainThreadExecutor(),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         assertThat(
                 handler.getCoordinatorMap().keySet(), containsInAnyOrder(operatorId1, operatorId2));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraphTest.java
@@ -26,6 +26,8 @@ import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutorServiceAda
 import org.apache.flink.runtime.executiongraph.ArchivedExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.runtime.scheduler.OperatorCoordinatorHandler;
@@ -329,6 +331,11 @@ public class CreatingExecutionGraphTest extends TestLogger {
         @Override
         public ComponentMainThreadExecutor getMainThreadExecutor() {
             return ComponentMainThreadExecutorServiceAdapter.forMainThread();
+        }
+
+        @Override
+        public JobManagerJobMetricGroup getMetricGroup() {
+            return UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup();
         }
 
         @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
@@ -44,7 +45,9 @@ class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
     }
 
     @Override
-    public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
+    public void initializeOperatorCoordinators(
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
         // No-op.
     }
 
@@ -69,7 +72,8 @@ class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
     @Override
     public void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor) {
+            ComponentMainThreadExecutor mainThreadExecutor,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
         throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This pull request introduces metric group for OperatorCoordinator.

## Brief change log

Please see the changes in the [FLIP-274](https://cwiki.apache.org/confluence/display/FLINK/FLIP-274%3A+Introduce+metric+group+for+OperatorCoordinator).

## Verifying this change

This change added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? not documented
