### PR TITLE
[FLINK-30961][Python] Remove deprecated "tests_require" in setup.py

### DIFF
--- a/flink-python/dev/dev-requirements.txt
+++ b/flink-python/dev/dev-requirements.txt
@@ -31,3 +31,4 @@ grpcio-tools>=1.29.0,<=1.46.3
 pemja==0.3.0; platform_system != 'Windows'
 httplib2>=0.19.0,<=0.20.4
 protobuf>=3.19.0,<=3.21
+pytest~=7.0

--- a/flink-python/setup.py
+++ b/flink-python/setup.py
@@ -330,7 +330,6 @@ try:
         python_requires='>=3.7',
         install_requires=install_requires,
         cmdclass={'build_ext': build_ext},
-        tests_require=['pytest==4.4.1'],
         description='Apache Flink Python API',
         long_description=long_description,
         long_description_content_type='text/markdown',

--- a/flink-python/tox.ini
+++ b/flink-python/tox.ini
@@ -28,7 +28,6 @@ whitelist_externals=
     /bin/bash
 deps =
     -r dev/dev-requirements.txt
-    pytest
     apache-flink-libraries
 passenv = *
 commands =


### PR DESCRIPTION

## What is the purpose of the change

This PR removes deprecated "tests_require" from setup.py, which contains a old version of pytest requires python < 3.8.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
