### PR TITLE
[FLINK-30962][Python] Improve error messaging when launching py4j gateway server

### DIFF
--- a/flink-python/pyflink/java_gateway.py
+++ b/flink-python/pyflink/java_gateway.py
@@ -109,7 +109,11 @@ def launch_gateway():
             time.sleep(0.1)
 
         if not os.path.isfile(conn_info_file):
-            raise Exception("Java gateway process exited before sending its port number")
+            stderr_info = p.stderr.read().decode('utf-8')
+            raise RuntimeError(
+                "Java gateway process exited before sending its port number.\nStderr:\n"
+                + stderr_info
+            )
 
         with open(conn_info_file, "rb") as info:
             gateway_port = struct.unpack("!I", info.read(4))[0]

--- a/flink-python/pyflink/pyflink_gateway_server.py
+++ b/flink-python/pyflink/pyflink_gateway_server.py
@@ -261,7 +261,7 @@ def launch_gateway_server_process(env, args):
             signal.signal(signal.SIGINT, signal.SIG_IGN)
         preexec_fn = preexec_func
     return Popen(list(filter(lambda c: len(c) != 0, command)),
-                 stdin=PIPE, preexec_fn=preexec_fn, env=env)
+                 stdin=PIPE, stderr=PIPE, preexec_fn=preexec_fn, env=env)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


## What is the purpose of the change

This PR prints stderr of py4j gateway java process in case it terminated unexpectedly.


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
