### PR TITLE
[FLINK-30792][state/changelog] make state changelog pre-emptively upl…

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/FsStateChangelogWriter.java
@@ -216,7 +216,7 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
             LOG.debug(
                     "pre-emptively flush {}MB of appended changes to the common store",
                     activeChangeSetSize / 1024 / 1024);
-            persistInternal(notUploaded.isEmpty() ? activeSequenceNumber : notUploaded.firstKey());
+            persistInternal(activeSequenceNumber);
         }
     }
 
@@ -433,6 +433,11 @@ class FsStateChangelogWriter implements StateChangelogWriter<ChangelogStateHandl
     @VisibleForTesting
     SequenceNumber lastAppendedSqnUnsafe() {
         return activeSequenceNumber;
+    }
+
+    @VisibleForTesting
+    public NavigableMap<SequenceNumber, StateChangeSet> getNotUploaded() {
+        return notUploaded;
     }
 
     private void ensureCanPersist(SequenceNumber from) throws IOException {


### PR DESCRIPTION
…oad not persisted older data


## What is the purpose of the change
make state changelog pre-emptively upload not persisted older data, discussed in [FLINK-30792](https://issues.apache.org/jira/browse/FLINK-30792)


## Verifying this change
This change added tests and can be verified as follows:
  - *FsStateChangelogWriterTest#testPreEmptivelyUpload*
 
## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes, checkpointing)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)

