### PR TITLE
[FLINK-30981][Python] Fix explain_sql throws method not exist

### DIFF
--- a/flink-python/pyflink/table/table_environment.py
+++ b/flink-python/pyflink/table/table_environment.py
@@ -792,8 +792,9 @@ class TableEnvironment(object):
         .. versionadded:: 1.11.0
         """
 
+        JExplainFormat = get_gateway().jvm.org.apache.flink.table.api.ExplainFormat
         j_extra_details = to_j_explain_detail_arr(extra_details)
-        return self._j_tenv.explainSql(stmt, j_extra_details)
+        return self._j_tenv.explainSql(stmt, JExplainFormat.TEXT, j_extra_details)
 
     def sql_query(self, query: str) -> Table:
         """

--- a/flink-python/pyflink/table/tests/test_table_environment_api.py
+++ b/flink-python/pyflink/table/tests/test_table_environment_api.py
@@ -67,6 +67,11 @@ class TableEnvironmentTest(PyFlinkUTTestCase):
 
         assert isinstance(actual, str)
 
+    def test_explain_sql(self):
+        t_env = self.t_env
+        actual = t_env.explain_sql("SELECT * FROM (VALUES ('a', 1))")
+        assert isinstance(actual, str)
+
     def test_explain_with_extended(self):
         schema = RowType() \
             .add('a', DataTypes.INT()) \
@@ -79,6 +84,17 @@ class TableEnvironmentTest(PyFlinkUTTestCase):
         actual = result.explain(ExplainDetail.ESTIMATED_COST, ExplainDetail.CHANGELOG_MODE,
                                 ExplainDetail.JSON_EXECUTION_PLAN, ExplainDetail.PLAN_ADVICE)
 
+        assert isinstance(actual, str)
+
+    def test_explain_sql_extended(self):
+        t_env = self.t_env
+        actual = t_env.explain_sql(
+            "SELECT * FROM (VALUES ('a', 1))",
+            ExplainDetail.ESTIMATED_COST,
+            ExplainDetail.CHANGELOG_MODE,
+            ExplainDetail.JSON_EXECUTION_PLAN,
+            ExplainDetail.PLAN_ADVICE
+        )
         assert isinstance(actual, str)
 
     def test_register_functions(self):


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes calling `TableEnvironment#explain_sql` with any valid sql string will throws `Method explainSql([class java.lang.String, class [Lorg.apache.flink.table.api.ExplainDetail;]) does not exist`.


## Verifying this change


This change added tests and can be verified as follows:
- unit test `test_explain_sql` and `test_explain_sql_extended` in test_table_environment_api.py


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)