### PR TITLE
 [FLINK-30935][connectors/kafka] Add Kafka serializers version check when using SimpleVersionedSerializer

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaCommittableSerializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaCommittableSerializer.java
@@ -46,6 +46,15 @@ class KafkaCommittableSerializer implements SimpleVersionedSerializer<KafkaCommi
 
     @Override
     public KafkaCommittable deserialize(int version, byte[] serialized) throws IOException {
+        switch (version) {
+            case 1:
+                return deserializeV1(serialized);
+            default:
+                throw new IOException("Unrecognized version or corrupt state: " + version);
+        }
+    }
+
+    private KafkaCommittable deserializeV1(byte[] serialized) throws IOException {
         try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
                 final DataInputStream in = new DataInputStream(bais)) {
             final short epoch = in.readShort();

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriterStateSerializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/KafkaWriterStateSerializer.java
@@ -45,6 +45,15 @@ class KafkaWriterStateSerializer implements SimpleVersionedSerializer<KafkaWrite
 
     @Override
     public KafkaWriterState deserialize(int version, byte[] serialized) throws IOException {
+        switch (version) {
+            case 1:
+                return deserializeV1(serialized);
+            default:
+                throw new IOException("Unrecognized version or corrupt state: " + version);
+        }
+    }
+
+    private KafkaWriterState deserializeV1(byte[] serialized) throws IOException {
         try (final ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
                 final DataInputStream in = new DataInputStream(bais)) {
             final String transactionalIdPrefx = in.readUTF();

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializer.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/split/KafkaPartitionSplitSerializer.java
@@ -59,6 +59,15 @@ public class KafkaPartitionSplitSerializer
 
     @Override
     public KafkaPartitionSplit deserialize(int version, byte[] serialized) throws IOException {
+        switch (version) {
+            case 0:
+                return deserializeV0(serialized);
+            default:
+                throw new IOException("Unrecognized version or corrupt state: " + version);
+        }
+    }
+
+    private KafkaPartitionSplit deserializeV0(byte[] serialized) throws IOException {
         try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
                 DataInputStream in = new DataInputStream(bais)) {
             String topic = in.readUTF();

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterStateSerializerTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/sink/KafkaWriterStateSerializerTest.java
@@ -23,7 +23,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for serializing and deserialzing {@link KafkaWriterState} with {@link
@@ -38,5 +40,13 @@ public class KafkaWriterStateSerializerTest extends TestLogger {
         final KafkaWriterState state = new KafkaWriterState("idPrefix");
         final byte[] serialized = SERIALIZER.serialize(state);
         assertThat(SERIALIZER.deserialize(1, serialized)).isEqualTo(state);
+    }
+
+    @Test
+    public void testStateSerDeWithUnsupportedVersion() throws IOException {
+        final KafkaWriterState state = new KafkaWriterState("idPrefix");
+        final byte[] serialized = SERIALIZER.serialize(state);
+        assertThatThrownBy(() -> SERIALIZER.deserialize(0, serialized))
+                .satisfies(anyCauseMatches("Unrecognized version or corrupt state"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Add deserialize version check for kafka simple versioned serializers in case of incompatible or corrupt state when restoring from checkpoint.

## Brief change log

Add deserialize version check logic for kafka simple versioned serializers.

## Verifying this change

Add cases in KafkaCommittableSerializerTest and KafkaWriterStateSerializerTest and KafkaPartitionSplitSerializerTest.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: yes
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable