### PR TITLE
[FLINK-30785][tests] Ignore completeExceptionally in e2e test logs

### DIFF
--- a/flink-end-to-end-tests/test-scripts/common.sh
+++ b/flink-end-to-end-tests/test-scripts/common.sh
@@ -428,6 +428,7 @@ function internal_check_logs_for_exceptions {
   "org.apache.flink.runtime.JobException: Recovery is suppressed" \
   "WARN  akka.remote.ReliableDeliverySupervisor" \
   "RecipientUnreachableException" \
+  "completeExceptionally" \
   "SerializedCheckpointException.unwrap")
 
   local all_allowed_exceptions=("${default_allowed_exceptions[@]}" "${additional_allowed_exceptions[@]}")


### PR DESCRIPTION
Some stacktraces of passed tests may contain `completeExceptionally`, which might fail the e2e (bash) tests.
This PR adds `completeExceptionally` to the list of ignored patterns.

Please see https://issues.apache.org/jira/browse/FLINK-30785?focusedCommentId=17682143&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17682143 for more details