### PR TITLE
[FLINK-30895][coordination] Dynamically adjust slot distribution

### DIFF
--- a/docs/content.zh/docs/deployment/elastic_scaling.md
+++ b/docs/content.zh/docs/deployment/elastic_scaling.md
@@ -145,7 +145,6 @@ Adaptive 调度器可以通过[所有在名字包含 `adaptive-scheduler` 的配
 - **只支持流式 Job**：Adaptive 调度器的第一个版本仅支持流式 Job。当提交的是一个批处理 Job 时，我们会自动换回默认调度器。
 - **不支持[本地恢复]({{< ref "docs/ops/state/large_state_tuning">}}#task-local-recovery)**：本地恢复是将 Task 调度到状态尽可能的被重用的机器上的功能。不支持这个功能意味着 Adaptive 调度器需要每次从 Checkpoint 的存储中下载整个 State。
 - **不支持部分故障恢复**: 部分故障恢复意味着调度器可以只重启失败 Job 其中某一部分（在 Flink 的内部结构中被称之为 Region）而不是重启整个 Job。这个限制只会影响那些独立并行（Embarrassingly Parallel）Job的恢复时长，默认的调度器可以重启失败的部分，然而 Adaptive 将需要重启整个 Job。
-- **空闲 Slot**: 如果 Slot 共享组的最大并行度不相等，提供给 Adaptive 调度器所使用的的 Slot 可能不会被使用。
 - 扩缩容事件会触发 Job 和 Task 重启，Task 重试的次数也会增加。
 
 ## Adaptive Batch Scheduler

--- a/docs/content/docs/deployment/elastic_scaling.md
+++ b/docs/content/docs/deployment/elastic_scaling.md
@@ -147,7 +147,6 @@ The behavior of Adaptive Scheduler is configured by [all configuration options c
 - **Streaming jobs only**: The first version of Adaptive Scheduler runs with streaming jobs only. When submitting a batch job, we will automatically fall back to the default scheduler.
 - **No support for [local recovery]({{< ref "docs/ops/state/large_state_tuning">}}#task-local-recovery)**: Local recovery is a feature that schedules tasks to machines so that the state on that machine gets re-used if possible. The lack of this feature means that Adaptive Scheduler will always need to download the entire state from the checkpoint storage.
 - **No support for partial failover**: Partial failover means that the scheduler is able to restart parts ("regions" in Flink's internals) of a failed job, instead of the entire job. This limitation impacts only recovery time of embarrassingly parallel jobs: Flink's default scheduler can restart failed parts, while Adaptive Scheduler will restart the entire job.
-- **Unused slots**: If the max parallelism for slot sharing groups is not equal, slots offered to Adaptive Scheduler might be unused.
 - Scaling events trigger job and task restarts, which will increase the number of Task attempts.
 
 ## Adaptive Batch Scheduler

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobGraphJobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/JobGraphJobInformation.java
@@ -73,6 +73,7 @@ public class JobGraphJobInformation implements JobInformation {
         return jobGraph.getCheckpointingSettings();
     }
 
+    @Override
     public Iterable<JobInformation.VertexInformation> getVertices() {
         return Iterables.transform(
                 jobGraph.getVertices(), (vertex) -> getVertexInformation(vertex.getID()));

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobInformation.java
@@ -36,6 +36,8 @@ public interface JobInformation {
 
     VertexInformation getVertexInformation(JobVertexID jobVertexId);
 
+    Iterable<VertexInformation> getVertices();
+
     /** Information about a single vertex. */
     interface VertexInformation {
         JobVertexID getJobVertexID();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocator.java
@@ -168,8 +168,7 @@ public class SlotSharingSlotAllocator implements SlotAllocator {
     private static List<Map.Entry<SlotSharingGroupId, Integer>>
             sortSlotSharingGroupsByDesiredParallelism(JobInformation jobInformation) {
 
-        return getMaxParallelismForSlotSharingGroups(jobInformation.getVertices())
-                .entrySet()
+        return getMaxParallelismForSlotSharingGroups(jobInformation.getVertices()).entrySet()
                 .stream()
                 .sorted(Comparator.comparingInt(Map.Entry::getValue))
                 .collect(Collectors.toList());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
@@ -278,6 +278,11 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         public VertexInformation getVertexInformation(JobVertexID jobVertexId) {
             return vertexIdToInformation.get(jobVertexId);
         }
+
+        @Override
+        public Iterable<VertexInformation> getVertices() {
+            return vertexIdToInformation.values();
+        }
     }
 
     private static class TestVertexInformation implements JobInformation.VertexInformation {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
@@ -27,6 +27,7 @@ import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.util.ResourceCounter;
 import org.apache.flink.util.TestLogger;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -132,6 +133,40 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         assertThat(
                 maxParallelismForVertices.get(vertex3.getJobVertexID()),
                 is(vertex3.getParallelism()));
+    }
+
+    @Test
+    public void testDetermineParallelismWithVariedParallelism() {
+        final SlotSharingSlotAllocator slotAllocator =
+                SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
+                        TEST_RESERVE_SLOT_FUNCTION,
+                        TEST_FREE_SLOT_FUNCTION,
+                        TEST_IS_SLOT_FREE_FUNCTION);
+        final SlotSharingGroup slotSharingGroup1 = new SlotSharingGroup();
+        final JobInformation.VertexInformation vertex11 =
+                new TestVertexInformation(new JobVertexID(), 4, slotSharingGroup1);
+        final JobInformation.VertexInformation vertex12 =
+                new TestVertexInformation(new JobVertexID(), 1, slotSharingGroup1);
+        final JobInformation.VertexInformation vertex2 =
+                new TestVertexInformation(new JobVertexID(), 2, new SlotSharingGroup());
+
+        TestJobInformation testJobInformation =
+                new TestJobInformation(Arrays.asList(vertex11, vertex12, vertex2));
+
+        Map<JobVertexID, Integer> maxParallelismForVertices =
+                slotAllocator
+                        .determineParallelism(
+                                testJobInformation,
+                                getSlots(vertex11.getParallelism() + vertex2.getParallelism()))
+                        .get()
+                        .getMaxParallelismForVertices();
+
+        Assertions.assertThat(maxParallelismForVertices.get(vertex11.getJobVertexID()))
+                .isEqualTo(vertex11.getParallelism());
+        Assertions.assertThat(maxParallelismForVertices.get(vertex12.getJobVertexID()))
+                .isEqualTo(vertex12.getParallelism());
+        Assertions.assertThat(maxParallelismForVertices.get(vertex2.getJobVertexID()))
+                .isEqualTo(vertex2.getParallelism());
     }
 
     @Test


### PR DESCRIPTION
Fixes an issue where the distribution of slots across slot-sharing groups did not take the max parallelism of that group into account, due to which some slots were potentially left unused.

We now update the number of slots assigned per group dynamically after each group was processed. Before slots are assigned the groups are sorted by the max parallelism in ascending order so we can assign all slots in one pass.

As a potential follow-up we could consider an alternative slot distribution pattern where slots are assigned proportional to the max parallelism of the groups.