### PR TITLE
[FLINK-25622][Python] Fix recursive extraction in PythonUDF SQL optimization

### DIFF
--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.xml
@@ -520,4 +520,22 @@ FlinkLogicalCalc(select=[a, f0 AS EXPR$1, b])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPythonFunctionWithJavaFunctionInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT pyFunc1(a, RowJavaFunc(d).f0) FROM MyTable]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(EXPR$0=[pyFunc1($0, RowJavaFunc($3).f0)])
++- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[pyFunc1(a, f0) AS EXPR$0])
++- FlinkLogicalCalc(select=[a, RowJavaFunc(d).f0 AS f0])
+   +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
+++ b/flink-table/flink-table-planner/src/test/resources/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.xml
@@ -105,4 +105,26 @@ FlinkLogicalCalc(select=[a, b, c, f00 AS x, f10 AS y])
 ]]>
     </Resource>
   </TestCase>
+  <TestCase name="testPythonTableFunctionWithNestedCompositeInputs">
+    <Resource name="sql">
+      <![CDATA[SELECT a, b, c, x, y FROM MyTable, LATERAL TABLE(func(d._1 * a, pyFunc(d._2._1, c))) AS T(x, y)]]>
+    </Resource>
+    <Resource name="ast">
+      <![CDATA[
+LogicalProject(a=[$0], b=[$1], c=[$2], x=[$4], y=[$5])
++- LogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
+   :- LogicalTableScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]])
+   +- LogicalTableFunctionScan(invocation=[func(*($cor0.d._1, $cor0.a), pyFunc($cor0.d._2._1, $cor0.c))], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+]]>
+    </Resource>
+    <Resource name="optimized rel plan">
+      <![CDATA[
+FlinkLogicalCalc(select=[a, b, c, f00 AS x, f10 AS y])
++- FlinkLogicalCorrelate(correlation=[$cor0], joinType=[inner], requiredColumns=[{0, 2, 3}])
+   :- FlinkLogicalCalc(select=[a, b, c, d, *(d._1, a) AS f0, d._2._1 AS f1])
+   :  +- FlinkLogicalLegacyTableSourceScan(table=[[default_catalog, default_database, MyTable, source: [TestTableSource(a, b, c, d)]]], fields=[a, b, c, d])
+   +- FlinkLogicalTableFunctionScan(invocation=[func($4, pyFunc($5, $2))], rowType=[RecordType(INTEGER f0, INTEGER f1)], elementType=[class [Ljava.lang.Object;])
+]]>
+    </Resource>
+  </TestCase>
 </Root>

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCalcSplitRuleTest.scala
@@ -229,4 +229,10 @@ class PythonCalcSplitRuleTest extends TableTestBase {
     val sqlQuery = "SELECT a + 1 FROM MyTable where RowJavaFunc(pyFunc5(a).f0).f0 is NULL and b > 0"
     util.verifyRelPlan(sqlQuery)
   }
+
+  @Test
+  def testPythonFunctionWithJavaFunctionInputs(): Unit = {
+    val sqlQuery = "SELECT pyFunc1(a, RowJavaFunc(d).f0) FROM MyTable"
+    util.verifyRelPlan(sqlQuery)
+  }
 }

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/plan/rules/logical/PythonCorrelateSplitRuleTest.scala
@@ -83,6 +83,14 @@ class PythonCorrelateSplitRuleTest extends TableTestBase {
   }
 
   @Test
+  def testPythonTableFunctionWithNestedCompositeInputs(): Unit = {
+    util.addTableSource[(Int, Int, Int, (Int, (Int, Int)))]("MyTable", 'a, 'b, 'c, 'd)
+    val sqlQuery = "SELECT a, b, c, x, y FROM MyTable, " +
+      "LATERAL TABLE(func(d._1 * a, pyFunc(d._2._1, c))) AS T(x, y)"
+    util.verifyRelPlan(sqlQuery)
+  }
+
+  @Test
   def testJavaTableFunctionWithPythonCalcCompositeInputs(): Unit = {
     util.addTableSource[(Int, Int, String, (String, String))]("MyTable", 'a, 'b, 'c, 'd)
     val sqlQuery = "SELECT a, b, c, x FROM MyTable, " +


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes recursive extraction when splitting PythonCalc-related node in SQL optimization.
e.g.
```
PythonRexCall
+- RexFieldAccess
   +- RexCall

PythonRexCall
+- RexFieldAccess
   +- RexFieldAccess
      +- RexCorrelVariable
```


## Verifying this change

This change added tests and can be verified as follows:
- `testPythonFunctionWithJavaFunctionInputs` in PythonCalcSplitRuleTest.scala
- `testPythonTableFunctionWithNestedCompositeInputs` in PythonCorrelateSplitRuleTest.scala

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
