### PR TITLE
[hotfix] Fix typo in explain.md

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/explain.md
+++ b/docs/content.zh/docs/dev/table/sql/explain.md
@@ -386,7 +386,7 @@ GroupAggregate(..., changelogMode=[I,UA,D])
 SET 'table.exec.mini-batch.enabled' = 'true';
 SET 'table.exec.mini-batch.allow-latency' = '5s';
 SET 'table.exec.mini-batch.size' = '200';
-SET 'table.optimizer.agg-phase-strategy' = 'OHE_PHASE';
+SET 'table.optimizer.agg-phase-strategy' = 'ONE_PHASE';
 
 CREATE TABLE MyTable (
   a BIGINT,

--- a/docs/content/docs/dev/table/sql/explain.md
+++ b/docs/content/docs/dev/table/sql/explain.md
@@ -380,7 +380,7 @@ If `GroupAggregate` is detected and can be optimized to the local-global aggrega
 SET 'table.exec.mini-batch.enabled' = 'true';
 SET 'table.exec.mini-batch.allow-latency' = '5s';
 SET 'table.exec.mini-batch.size' = '200';
-SET 'table.optimizer.agg-phase-strategy' = 'OHE_PHASE';
+SET 'table.optimizer.agg-phase-strategy' = 'ONE_PHASE';
 
 CREATE TABLE MyTable (
   a BIGINT,


### PR DESCRIPTION
## What is the purpose of the change

*Fix typo in explain.md.*


## Brief change log

  - *Fix typo(`OHE_PHASE` -> `ONE_PHASE`) in explain.md.*

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
