### PR TITLE
[FLINK-30629][test] Set CLIENT_ALIVENESS_CHECK_DURATION to clientHeartbeatInterval for testJobCancelledIfClientHeartbeatTimeout 

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
@@ -94,7 +94,7 @@ public class ClientHeartbeatTest {
         Configuration configuration = new Configuration();
         configuration.set(
                 Dispatcher.CLIENT_ALIVENESS_CHECK_DURATION,
-                Duration.ofMillis(clientHeartbeatTimeout));
+                Duration.ofMillis(clientHeartbeatInterval));
         if (shutdownOnAttachedExit) {
             configuration.setBoolean(DeploymentOptions.ATTACHED, true);
             configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, true);


### PR DESCRIPTION
## What is the purpose of the change

*`ClientHeartbeatTest#testJobCancelledIfClientHeartbeatTimeout` gave an inappropriate timeout value(1s), which will make it very unstable. In fact, we might want to do is setting the `CLIENT_ALIVENESS_CHECK_DURATION` to `ClientHeartbeatTest.clientHeartbeatInterval` instead which leads to the job being cancelled after 550ms (500ms + 50ms) in the worst case which makes the 1 second wait time within the test more reasonable again.*

## Brief change log

  - *Set CLIENT_ALIVENESS_CHECK_DURATION to clientHeartbeatInterval for testJobCancelledIfClientHeartbeatTimeout.*


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
