### PR TITLE
[FLINK-31015][connectors/common] Fix SplitReader doesn't extends AutoCloseable but implements close method

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -33,7 +33,7 @@ import java.util.Collection;
  * @param <SplitT> the split type.
  */
 @PublicEvolving
-public interface SplitReader<E, SplitT extends SourceSplit> {
+public interface SplitReader<E, SplitT extends SourceSplit> extends AutoCloseable {
 
     /**
      * Fetch elements into the blocking queue for the given splits. The fetch call could be blocking
@@ -62,13 +62,6 @@ public interface SplitReader<E, SplitT extends SourceSplit> {
 
     /** Wake up the split reader in case the fetcher thread is blocking in {@link #fetch()}. */
     void wakeUp();
-
-    /**
-     * Close the split reader.
-     *
-     * @throws Exception if closing the split reader failed.
-     */
-    void close() throws Exception;
 
     /**
      * Pauses or resumes reading of individual splits readers.


### PR DESCRIPTION
## What is the purpose of the change

SplitReader doesn't extend AutoCloseable but implements close method. We  need to let it extends AutoCloseable which could enable us to utilize Java's try close feature.

## Brief change log

Let SplitReader interface extends AutoCloseable.

## Verifying this change

Because SplitReader#close override AutoCloseable#close with same signature and behavior. It has no effect on connector implementations. It can be tested by current ci test cases.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? not applicable