### PR TITLE
[FLINK-31017][FLINK-31042][CEP] Fix no after-match processing when pattern timeout

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/NFA.java
@@ -270,12 +270,15 @@ public class NFA<T> {
             advanceTime(
                     final SharedBufferAccessor<T> sharedBufferAccessor,
                     final NFAState nfaState,
-                    final long timestamp)
+                    final long timestamp,
+                    final AfterMatchSkipStrategy afterMatchSkipStrategy)
                     throws Exception {
 
-        final Collection<Map<String, List<T>>> pendingMatches = new ArrayList<>();
+        final List<Map<String, List<T>>> pendingResult = new ArrayList<>();
         final Collection<Tuple2<Map<String, List<T>>, Long>> timeoutResult = new ArrayList<>();
         final PriorityQueue<ComputationState> newPartialMatches =
+                new PriorityQueue<>(NFAState.COMPUTATION_STATE_COMPARATOR);
+        final PriorityQueue<ComputationState> potentialMatches =
                 new PriorityQueue<>(NFAState.COMPUTATION_STATE_COMPARATOR);
 
         for (ComputationState computationState : nfaState.getPartialMatches()) {
@@ -294,13 +297,16 @@ public class NFA<T> {
                             computationState.getStartTimestamp(),
                             windowTime);
             if (isTimeoutForPreviousEvent || isTimeoutForFirstEvent) {
+                nfaState.setStateChanged();
+
                 if (getState(computationState).isPending()) {
-                    // extract the Pending State
-                    Map<String, List<T>> pendingPattern =
-                            sharedBufferAccessor.materializeMatch(
-                                    extractCurrentMatches(sharedBufferAccessor, computationState));
-                    pendingMatches.add(pendingPattern);
-                } else if (handleTimeout) {
+                    // save pending states for after-match pruning, where those states will be
+                    // released
+                    potentialMatches.add(computationState);
+                    continue;
+                }
+
+                if (handleTimeout) {
                     // extract the timed out event pattern
                     Map<String, List<T>> timedOutPattern =
                             sharedBufferAccessor.materializeMatch(
@@ -315,20 +321,29 @@ public class NFA<T> {
                                             : computationState.getStartTimestamp() + windowTime));
                 }
 
+                // release timeout states
                 sharedBufferAccessor.releaseNode(
                         computationState.getPreviousBufferEntry(), computationState.getVersion());
-
-                nfaState.setStateChanged();
             } else {
                 newPartialMatches.add(computationState);
             }
         }
 
+        // If a timeout partial match "frees" some completed matches
+        // Or if completed not-followed-by matches need pruning
+        processMatchesAccordingToSkipStrategy(
+                sharedBufferAccessor,
+                nfaState,
+                afterMatchSkipStrategy,
+                potentialMatches,
+                newPartialMatches,
+                pendingResult);
+
         nfaState.setNewPartialMatches(newPartialMatches);
 
         sharedBufferAccessor.advanceTime(timestamp);
 
-        return Tuple2.of(pendingMatches, timeoutResult);
+        return Tuple2.of(pendingResult, timeoutResult);
     }
 
     private boolean isStateTimedOut(
@@ -349,7 +364,7 @@ public class NFA<T> {
 
         final PriorityQueue<ComputationState> newPartialMatches =
                 new PriorityQueue<>(NFAState.COMPUTATION_STATE_COMPARATOR);
-        final PriorityQueue<ComputationState> potentialMatches =
+        PriorityQueue<ComputationState> potentialMatches =
                 new PriorityQueue<>(NFAState.COMPUTATION_STATE_COMPARATOR);
 
         // iterate over all current computations
@@ -406,28 +421,13 @@ public class NFA<T> {
         }
 
         List<Map<String, List<T>>> result = new ArrayList<>();
-        if (afterMatchSkipStrategy.isSkipStrategy()) {
-            processMatchesAccordingToSkipStrategy(
-                    sharedBufferAccessor,
-                    nfaState,
-                    afterMatchSkipStrategy,
-                    potentialMatches,
-                    newPartialMatches,
-                    result);
-        } else {
-            for (ComputationState match : potentialMatches) {
-                Map<String, List<T>> materializedMatch =
-                        sharedBufferAccessor.materializeMatch(
-                                sharedBufferAccessor
-                                        .extractPatterns(
-                                                match.getPreviousBufferEntry(), match.getVersion())
-                                        .get(0));
-
-                result.add(materializedMatch);
-                sharedBufferAccessor.releaseNode(
-                        match.getPreviousBufferEntry(), match.getVersion());
-            }
-        }
+        processMatchesAccordingToSkipStrategy(
+                sharedBufferAccessor,
+                nfaState,
+                afterMatchSkipStrategy,
+                potentialMatches,
+                newPartialMatches,
+                result);
 
         nfaState.setNewPartialMatches(newPartialMatches);
 
@@ -445,35 +445,36 @@ public class NFA<T> {
 
         nfaState.getCompletedMatches().addAll(potentialMatches);
 
-        ComputationState earliestMatch = nfaState.getCompletedMatches().peek();
+        ComputationState earliestMatch;
+        while ((earliestMatch = nfaState.getCompletedMatches().peek()) != null) {
 
-        if (earliestMatch != null) {
-
-            ComputationState earliestPartialMatch;
-            while (earliestMatch != null
-                    && ((earliestPartialMatch = partialMatches.peek()) == null
-                            || isEarlier(earliestMatch, earliestPartialMatch))) {
-
-                nfaState.setStateChanged();
-                nfaState.getCompletedMatches().poll();
-                List<Map<String, List<EventId>>> matchedResult =
-                        sharedBufferAccessor.extractPatterns(
-                                earliestMatch.getPreviousBufferEntry(), earliestMatch.getVersion());
-
-                afterMatchSkipStrategy.prune(partialMatches, matchedResult, sharedBufferAccessor);
-
-                afterMatchSkipStrategy.prune(
-                        nfaState.getCompletedMatches(), matchedResult, sharedBufferAccessor);
-
-                result.add(sharedBufferAccessor.materializeMatch(matchedResult.get(0)));
-                sharedBufferAccessor.releaseNode(
-                        earliestMatch.getPreviousBufferEntry(), earliestMatch.getVersion());
-                earliestMatch = nfaState.getCompletedMatches().peek();
+            // Care for ordering when it's not NO_SKIP
+            if (afterMatchSkipStrategy.isSkipStrategy()) {
+                ComputationState earliestPartialMatch = partialMatches.peek();
+                if (earliestPartialMatch != null
+                        && !isEarlier(earliestMatch, earliestPartialMatch)) {
+                    break;
+                }
             }
 
-            nfaState.getPartialMatches()
-                    .removeIf(pm -> pm.getStartEventID() != null && !partialMatches.contains(pm));
+            nfaState.setStateChanged();
+            nfaState.getCompletedMatches().poll();
+            List<Map<String, List<EventId>>> matchedResult =
+                    sharedBufferAccessor.extractPatterns(
+                            earliestMatch.getPreviousBufferEntry(), earliestMatch.getVersion());
+
+            afterMatchSkipStrategy.prune(partialMatches, matchedResult, sharedBufferAccessor);
+
+            afterMatchSkipStrategy.prune(
+                    nfaState.getCompletedMatches(), matchedResult, sharedBufferAccessor);
+
+            result.add(sharedBufferAccessor.materializeMatch(matchedResult.get(0)));
+            sharedBufferAccessor.releaseNode(
+                    earliestMatch.getPreviousBufferEntry(), earliestMatch.getVersion());
         }
+
+        nfaState.getPartialMatches()
+                .removeIf(pm -> pm.getStartEventID() != null && !partialMatches.contains(pm));
     }
 
     private boolean isEarlier(

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/nfa/aftermatch/AfterMatchSkipStrategy.java
@@ -103,6 +103,9 @@ public abstract class AfterMatchSkipStrategy implements Serializable {
             Collection<Map<String, List<EventId>>> matchedResult,
             SharedBufferAccessor<?> sharedBufferAccessor)
             throws Exception {
+        if (!isSkipStrategy()) {
+            return;
+        }
 
         EventId pruningId = getPruningId(matchedResult);
         if (pruningId != null) {

--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -426,7 +426,11 @@ public class CepOperator<IN, KEY, OUT>
                             Collection<Map<String, List<IN>>>,
                             Collection<Tuple2<Map<String, List<IN>>, Long>>>
                     pendingMatchesAndTimeout =
-                            nfa.advanceTime(sharedBufferAccessor, nfaState, timestamp);
+                            nfa.advanceTime(
+                                    sharedBufferAccessor,
+                                    nfaState,
+                                    timestamp,
+                                    afterMatchSkipStrategy);
 
             Collection<Map<String, List<IN>>> pendingMatches = pendingMatchesAndTimeout.f0;
             Collection<Tuple2<Map<String, List<IN>>, Long>> timedOut = pendingMatchesAndTimeout.f1;

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/CEPITCase.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.cep;
 
+import org.apache.flink.api.common.eventtime.SerializableTimestampAssigner;
+import org.apache.flink.api.common.eventtime.TimestampAssignerSupplier;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.typeinfo.Types;
@@ -29,6 +32,7 @@ import org.apache.flink.cep.nfa.NFA;
 import org.apache.flink.cep.nfa.aftermatch.AfterMatchSkipStrategy;
 import org.apache.flink.cep.pattern.Pattern;
 import org.apache.flink.cep.pattern.WithinType;
+import org.apache.flink.cep.pattern.conditions.IterativeCondition;
 import org.apache.flink.cep.pattern.conditions.RichIterativeCondition;
 import org.apache.flink.cep.pattern.conditions.SimpleCondition;
 import org.apache.flink.configuration.Configuration;
@@ -41,6 +45,7 @@ import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Either;
+import org.apache.flink.util.CloseableIterator;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 
@@ -1027,5 +1032,71 @@ public class CEPITCase extends AbstractTestBase {
                         });
 
         env.execute();
+    }
+
+    @Test
+    public void testPartialMatchTimeoutOutputCompletedMatch() throws Exception {
+        StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(envConfiguration);
+
+        // (Event, timestamp)
+        DataStream<Event> input =
+                env.fromElements(
+                                Tuple2.of(new Event(1, "start", 1.0), 0L),
+                                Tuple2.of(new Event(2, "start", 2.0), 1L),
+                                Tuple2.of(new Event(3, "start", 3.0), 2L),
+                                Tuple2.of(new Event(4, "start", 4.0), 3L),
+                                Tuple2.of(new Event(5, "end", 5.0), 4L))
+                        .assignTimestampsAndWatermarks(
+                                WatermarkStrategy.<Tuple2<Event, Long>>forBoundedOutOfOrderness(
+                                                Duration.ofMillis(5))
+                                        .withTimestampAssigner(
+                                                TimestampAssignerSupplier.of(
+                                                        (SerializableTimestampAssigner<
+                                                                        Tuple2<Event, Long>>)
+                                                                (element, recordTimestamp) ->
+                                                                        element.f1)))
+                        .map((MapFunction<Tuple2<Event, Long>, Event>) value -> value.f0);
+
+        Pattern<Event, ?> pattern =
+                Pattern.<Event>begin("start", AfterMatchSkipStrategy.skipPastLastEvent())
+                        .where(SimpleCondition.of(value -> value.getName().equals("start")))
+                        .oneOrMore()
+                        .consecutive()
+                        .greedy()
+                        .followedBy("middle")
+                        .where(
+                                new IterativeCondition<Event>() {
+                                    @Override
+                                    public boolean filter(Event value, Context<Event> ctx)
+                                            throws Exception {
+                                        int count = 0;
+                                        for (Event ignored : ctx.getEventsForPattern("start")) {
+                                            count++;
+                                        }
+                                        if (count > 2) {
+                                            return value.getName().equals("middle");
+                                        } else {
+                                            return value.getName().equals("end");
+                                        }
+                                    }
+                                })
+                        .within(Time.milliseconds(100L));
+
+        DataStream<String> result =
+                CEP.pattern(input, pattern)
+                        .select(
+                                (PatternSelectFunction<Event, String>)
+                                        pattern1 ->
+                                                pattern1.get("start").get(0).getId()
+                                                        + ","
+                                                        + pattern1.get("middle").get(0).getId());
+
+        List<String> resultList = new ArrayList<>();
+        try (CloseableIterator<String> iterator = result.executeAndCollect()) {
+            iterator.forEachRemaining(resultList::add);
+        }
+        resultList.sort(String::compareTo);
+        assertEquals(Arrays.asList("3,5"), resultList);
     }
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAITCase.java
@@ -402,7 +402,12 @@ public class NFAITCase extends TestLogger {
         for (StreamRecord<Event> event : events) {
 
             Collection<Tuple2<Map<String, List<Event>>, Long>> timeoutPatterns =
-                    nfa.advanceTime(sharedBufferAccessor, nfaState, event.getTimestamp()).f1;
+                    nfa.advanceTime(
+                                    sharedBufferAccessor,
+                                    nfaState,
+                                    event.getTimestamp(),
+                                    AfterMatchSkipStrategy.noSkip())
+                            .f1;
             Collection<Map<String, List<Event>>> matchedPatterns =
                     nfa.process(
                             sharedBufferAccessor,
@@ -467,7 +472,12 @@ public class NFAITCase extends TestLogger {
         for (StreamRecord<Event> event : events) {
 
             Collection<Tuple2<Map<String, List<Event>>, Long>> timeoutPatterns =
-                    nfa.advanceTime(sharedBufferAccessor, nfaState, event.getTimestamp()).f1;
+                    nfa.advanceTime(
+                                    sharedBufferAccessor,
+                                    nfaState,
+                                    event.getTimestamp(),
+                                    AfterMatchSkipStrategy.noSkip())
+                            .f1;
             Collection<Map<String, List<Event>>> matchedPatterns =
                     nfa.process(
                             sharedBufferAccessor,
@@ -530,7 +540,12 @@ public class NFAITCase extends TestLogger {
 
         for (StreamRecord<Event> event : events) {
             Collection<Map<String, List<Event>>> pendingMatches =
-                    nfa.advanceTime(sharedBufferAccessor, nfaState, event.getTimestamp()).f0;
+                    nfa.advanceTime(
+                                    sharedBufferAccessor,
+                                    nfaState,
+                                    event.getTimestamp(),
+                                    AfterMatchSkipStrategy.noSkip())
+                            .f0;
             resultingPendingMatches.addAll(pendingMatches);
             nfa.process(
                     sharedBufferAccessor,
@@ -2304,7 +2319,7 @@ public class NFAITCase extends TestLogger {
         nfaTestHarness.feedRecord(new StreamRecord<>(end1, 6));
 
         // pruning element
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 10);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
         assertEquals(1, nfaState.getPartialMatches().size());
         assertEquals("start", nfaState.getPartialMatches().peek().getCurrentStateName());
@@ -2345,7 +2360,7 @@ public class NFAITCase extends TestLogger {
         nfaTestHarness.feedRecord(new StreamRecord<>(end1, 6));
 
         // pruning element
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 10);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
         assertEquals(1, nfaState.getPartialMatches().size());
         assertEquals("start", nfaState.getPartialMatches().peek().getCurrentStateName());
@@ -2389,7 +2404,7 @@ public class NFAITCase extends TestLogger {
         nfaTestHarness.consumeRecord(new StreamRecord<>(end1, 6));
 
         // pruning element
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 10);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
         assertEquals(1, nfaState.getPartialMatches().size());
         assertEquals("start", nfaState.getPartialMatches().peek().getCurrentStateName());
@@ -2425,7 +2440,7 @@ public class NFAITCase extends TestLogger {
         nfaTestHarness.consumeRecord(new StreamRecord<>(end1, 6));
 
         // pruning element
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 10);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
         assertEquals(1, nfaState.getPartialMatches().size());
         assertEquals("start", nfaState.getPartialMatches().peek().getCurrentStateName());
@@ -2461,7 +2476,7 @@ public class NFAITCase extends TestLogger {
         nfaTestHarness.consumeRecord(new StreamRecord<>(end1, 6));
 
         // pruning element
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 10);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 10, AfterMatchSkipStrategy.noSkip());
 
         assertEquals(3, nfaState.getPartialMatches().size());
         assertEquals(
@@ -2826,7 +2841,8 @@ public class NFAITCase extends TestLogger {
                     AfterMatchSkipStrategy.noSkip(),
                     timerService);
             Mockito.verify(accessor, Mockito.never()).advanceTime(anyLong());
-            nfa.advanceTime(accessor, nfa.createInitialNFAState(), 2);
+            nfa.advanceTime(
+                    accessor, nfa.createInitialNFAState(), 2, AfterMatchSkipStrategy.noSkip());
             Mockito.verify(accessor, Mockito.times(1)).advanceTime(2);
         }
     }
@@ -2857,7 +2873,7 @@ public class NFAITCase extends TestLogger {
         try (SharedBufferAccessor<Event> accessor = sharedBuffer.getAccessor()) {
             nfa.process(accessor, nfaState, a1, 1, AfterMatchSkipStrategy.noSkip(), timerService);
             nfa.process(accessor, nfaState, a2, 2, AfterMatchSkipStrategy.noSkip(), timerService);
-            nfa.advanceTime(accessor, nfaState, 4);
+            nfa.advanceTime(accessor, nfaState, 4, AfterMatchSkipStrategy.noSkip());
         }
 
         assertThat(

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStatusChangeITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NFAStatusChangeITCase.java
@@ -191,7 +191,7 @@ public class NFAStatusChangeITCase {
         // both the queue of ComputationStatus and eventSharedBuffer have not changed
         // as the timestamp is within the window
         nfaState.resetStateChanged();
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 8L);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 8L, skipStrategy);
         assertFalse(
                 "NFA status should not change as the timestamp is within the window",
                 nfaState.isStateChanged());
@@ -201,7 +201,7 @@ public class NFAStatusChangeITCase {
         // be removed from eventSharedBuffer as the timeout happens
         nfaState.resetStateChanged();
         Collection<Tuple2<Map<String, List<Event>>, Long>> timeoutResults =
-                nfa.advanceTime(sharedBufferAccessor, nfaState, 12L).f1;
+                nfa.advanceTime(sharedBufferAccessor, nfaState, 12L, skipStrategy).f1;
         assertTrue(
                 "NFA status should change as timeout happens",
                 nfaState.isStateChanged() && !timeoutResults.isEmpty());
@@ -285,7 +285,7 @@ public class NFAStatusChangeITCase {
         NFAState nfaState = nfa.createInitialNFAState();
 
         nfaState.resetStateChanged();
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 6L);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 6L, skipStrategy);
         nfa.process(
                 sharedBufferAccessor,
                 nfaState,
@@ -295,7 +295,7 @@ public class NFAStatusChangeITCase {
                 timerService);
 
         nfaState.resetStateChanged();
-        nfa.advanceTime(sharedBufferAccessor, nfaState, 17L);
+        nfa.advanceTime(sharedBufferAccessor, nfaState, 17L, skipStrategy);
         assertTrue(nfaState.isStateChanged());
     }
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NotPatternITCase.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/nfa/NotPatternITCase.java
@@ -33,6 +33,7 @@ import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static org.apache.flink.cep.utils.NFATestUtilities.comparePatterns;
@@ -1090,7 +1091,7 @@ public class NotPatternITCase extends TestLogger {
         inputEvents.add(new StreamRecord<>(c2, 10));
 
         Pattern<Event, ?> pattern =
-                Pattern.<Event>begin("a", AfterMatchSkipStrategy.skipToNext())
+                Pattern.<Event>begin("a", AfterMatchSkipStrategy.skipPastLastEvent())
                         .where(SimpleCondition.of(value -> value.getName().equals("a")))
                         .oneOrMore()
                         .allowCombinations()
@@ -1104,15 +1105,10 @@ public class NotPatternITCase extends TestLogger {
 
         NFATestHarness harness =
                 NFATestHarness.forNFA(nfa)
-                        .withAfterMatchSkipStrategy(AfterMatchSkipStrategy.skipToNext())
+                        .withAfterMatchSkipStrategy(AfterMatchSkipStrategy.skipPastLastEvent())
                         .build();
         final List<List<Event>> matches = harness.feedRecords(inputEvents);
 
-        comparePatterns(
-                matches,
-                Lists.newArrayList(
-                        Lists.newArrayList(a1, a2, a3, c1),
-                        Lists.newArrayList(a2, a3, c1),
-                        Lists.newArrayList(a3, c1)));
+        comparePatterns(matches, Collections.singletonList(Lists.newArrayList(a1, a2, a3, c1)));
     }
 }

--- a/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/NFATestHarness.java
+++ b/flink-libraries/flink-cep/src/test/java/org/apache/flink/cep/utils/NFATestHarness.java
@@ -100,7 +100,12 @@ public final class NFATestHarness {
             throws Exception {
         try (SharedBufferAccessor<Event> sharedBufferAccessor = sharedBuffer.getAccessor()) {
             Collection<Map<String, List<Event>>> pendingMatches =
-                    nfa.advanceTime(sharedBufferAccessor, nfaState, inputEvent.getTimestamp()).f0;
+                    nfa.advanceTime(
+                                    sharedBufferAccessor,
+                                    nfaState,
+                                    inputEvent.getTimestamp(),
+                                    afterMatchSkipStrategy)
+                            .f0;
             Collection<Map<String, List<Event>>> matchedPatterns =
                     nfa.process(
                             sharedBufferAccessor,


### PR DESCRIPTION


## What is the purpose of the change

This PR addes after-match processing when a pattern timeout, e.g. after-match not working on patterns ending with not-followed-by.

## Verifying this change

This change added tests and can be verified as follows:
- testPartialMatchTimeoutOutputCompletedMatch() in CEPITCase.java, which validates that if a early-started partial match times out, then those completed matches stored in NFAState should be emitted
- testNotFollowedByWithinAtEndAfterMatch() in NotPatternITCase.java, which validates that after-match skip strategy also works when a pattern times out to complete

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)