### PR TITLE
FLINK-31053[Runtime] : Example Repair the log output format of the CheckpointCoordinator

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -741,7 +741,7 @@ public class CheckpointCoordinator {
                                         "Triggering Checkpoint {} for job {} failed due to {}",
                                         checkpoint.getCheckpointID(),
                                         job,
-                                        failure);
+                                        failure.getMessage());
 
                                 final CheckpointException cause;
                                 if (failure instanceof CheckpointException) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinator.java
@@ -738,10 +738,10 @@ public class CheckpointCoordinator {
                     .exceptionally(
                             failure -> {
                                 LOG.info(
-                                        "Triggering Checkpoint {} for job {} failed due to {}",
+                                        "Triggering Checkpoint {} for job {} failed due to : ",
                                         checkpoint.getCheckpointID(),
                                         job,
-                                        failure.getMessage());
+                                        failure);
 
                                 final CheckpointException cause;
                                 if (failure instanceof CheckpointException) {


### PR DESCRIPTION

## What is the purpose of the change
At present, an unexpected situation occurs when trigger ck, and the log output format is incorrect, because the placeholder in the log does not parse the exception, the output log will print a {}, this is not rigorous.

## Brief change log
Remove the placeholder in CheckpointCoordinator log

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency):   no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no 
  - The runtime per-record code paths (performance sensitive):  no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no 
  - The S3 file system connector:  no
  - 
## Documentation
Does this pull request introduce a new feature? no
If yes, how is the feature documented? not applicable
