### PR TITLE
[FLINK-28786][following] Fix PyFlink execution failure on Mac Os with M1 chip

### DIFF
--- a/flink-python/pyflink/fn_execution/__init__.py
+++ b/flink-python/pyflink/fn_execution/__init__.py
@@ -15,3 +15,10 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ################################################################################
+
+import os
+
+if 'PYFLINK_CYTHON' in os.environ:
+    PYFLINK_CYTHON = bool(os.environ['PYFLINK_CYTHON'])
+else:
+    PYFLINK_CYTHON = True

--- a/flink-python/pyflink/fn_execution/beam/beam_coders.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_coders.py
@@ -20,14 +20,21 @@ from apache_beam.coders.coders import FastCoder, LengthPrefixCoder
 from apache_beam.portability import common_urns
 from apache_beam.typehints import typehints
 
+from pyflink import fn_execution
 from pyflink.fn_execution.coders import LengthPrefixBaseCoder
 from pyflink.fn_execution.flink_fn_execution_pb2 import CoderInfoDescriptor
 
-try:
-    from pyflink.fn_execution.beam import beam_coder_impl_fast as beam_coder_impl
-    from pyflink.fn_execution.beam.beam_coder_impl_fast import FlinkFieldCoderBeamWrapper
-    from pyflink.fn_execution.beam.beam_coder_impl_fast import FlinkLengthPrefixCoderBeamWrapper
-except ImportError:
+if fn_execution.PYFLINK_CYTHON:
+    try:
+        from pyflink.fn_execution.beam import beam_coder_impl_fast as beam_coder_impl
+        from pyflink.fn_execution.beam.beam_coder_impl_fast import FlinkFieldCoderBeamWrapper
+        from pyflink.fn_execution.beam.beam_coder_impl_fast import FlinkLengthPrefixCoderBeamWrapper
+    except:
+        from pyflink.fn_execution.beam import beam_coder_impl_slow as beam_coder_impl
+        from pyflink.fn_execution.beam.beam_coder_impl_slow import FlinkFieldCoderBeamWrapper
+        from pyflink.fn_execution.beam.beam_coder_impl_slow import FlinkLengthPrefixCoderBeamWrapper
+        fn_execution.PYFLINK_CYTHON = False
+else:
     from pyflink.fn_execution.beam import beam_coder_impl_slow as beam_coder_impl
     from pyflink.fn_execution.beam.beam_coder_impl_slow import FlinkFieldCoderBeamWrapper
     from pyflink.fn_execution.beam.beam_coder_impl_slow import FlinkLengthPrefixCoderBeamWrapper

--- a/flink-python/pyflink/fn_execution/beam/beam_operations.py
+++ b/flink-python/pyflink/fn_execution/beam/beam_operations.py
@@ -21,6 +21,17 @@ from apache_beam.runners import common
 from apache_beam.runners.worker import bundle_processor, operation_specs
 from apache_beam.utils import proto_utils
 
+from pyflink import fn_execution
+
+if fn_execution.PYFLINK_CYTHON:
+    try:
+        import pyflink.fn_execution.beam.beam_operations_fast as beam_operations
+    except:
+        import pyflink.fn_execution.beam.beam_operations_slow as beam_operations
+        fn_execution.PYFLINK_CYTHON = False
+else:
+    import pyflink.fn_execution.beam.beam_operations_slow as beam_operations
+
 from pyflink.fn_execution import flink_fn_execution_pb2
 from pyflink.fn_execution.coders import from_proto, from_type_info_proto, TimeWindowCoder, \
     CountWindowCoder, FlattenRowCoder
@@ -29,12 +40,6 @@ from pyflink.fn_execution.state_impl import RemoteKeyedStateBackend, RemoteOpera
 import pyflink.fn_execution.datastream.operations as datastream_operations
 from pyflink.fn_execution.datastream.process import operations
 import pyflink.fn_execution.table.operations as table_operations
-
-try:
-    import pyflink.fn_execution.beam.beam_operations_fast as beam_operations
-except ImportError:
-    import pyflink.fn_execution.beam.beam_operations_slow as beam_operations
-
 
 # ----------------- UDF --------------------
 

--- a/flink-python/pyflink/fn_execution/coders.py
+++ b/flink-python/pyflink/fn_execution/coders.py
@@ -21,8 +21,19 @@ from abc import ABC, abstractmethod
 from typing import Union
 
 import pytz
-from pyflink.datastream.formats.avro import GenericRecordAvroTypeInfo, AvroSchema
 
+from pyflink import fn_execution
+
+if fn_execution.PYFLINK_CYTHON:
+    try:
+        from pyflink.fn_execution import coder_impl_fast as coder_impl
+    except:
+        from pyflink.fn_execution import coder_impl_slow as coder_impl
+        fn_execution.PYFLINK_CYTHON = False
+else:
+    from pyflink.fn_execution import coder_impl_slow as coder_impl
+
+from pyflink.datastream.formats.avro import GenericRecordAvroTypeInfo, AvroSchema
 from pyflink.common.typeinfo import TypeInformation, BasicTypeInfo, BasicType, DateTypeInfo, \
     TimeTypeInfo, TimestampTypeInfo, PrimitiveArrayTypeInfo, BasicArrayTypeInfo, TupleTypeInfo, \
     MapTypeInfo, ListTypeInfo, RowTypeInfo, PickledBytesTypeInfo, ObjectArrayTypeInfo, \
@@ -32,10 +43,6 @@ from pyflink.table.types import TinyIntType, SmallIntType, IntType, BigIntType, 
     LocalZonedTimestampType, RowType, RowField, to_arrow_type, TimestampType, ArrayType, MapType, \
     BinaryType, NullType
 
-try:
-    from pyflink.fn_execution import coder_impl_fast as coder_impl
-except:
-    from pyflink.fn_execution import coder_impl_slow as coder_impl
 
 __all__ = ['FlattenRowCoder', 'RowCoder', 'BigIntCoder', 'TinyIntCoder', 'BooleanCoder',
            'SmallIntCoder', 'IntCoder', 'FloatCoder', 'DoubleCoder', 'BinaryCoder', 'CharCoder',


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix PyFlink execution failure on Mac Os with M1 chip*


## Brief change log

  - *If import  apache_beam cython implementation failure, we will fall back to python implementation*

## Verifying this change

This change added tests and can be verified as follows:

  - *Manual test*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
