### PR TITLE
[BP-1.16][FLINK-30917][runtime] Let adaptive batch scheduler also respect the user-configured max parallelism when deciding parallelism

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -203,7 +203,10 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
 
         } else {
             parallelism =
-                    vertexParallelismDecider.decideParallelismForVertex(consumedResultsInfo.get());
+                    vertexParallelismDecider.decideParallelismForVertex(
+                            jobVertex.getJobVertexId(),
+                            consumedResultsInfo.get(),
+                            jobVertex.getMaxParallelism());
             if (forwardGroup != null) {
                 forwardGroup.setParallelism(parallelism);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismDecider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/VertexParallelismDecider.java
@@ -18,6 +18,8 @@
 
 package org.apache.flink.runtime.scheduler.adaptivebatch;
 
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+
 import java.util.List;
 
 /**
@@ -29,8 +31,13 @@ public interface VertexParallelismDecider {
     /**
      * Computing the parallelism.
      *
+     * @param jobVertexId The job vertex id.
      * @param consumedResults The information of consumed blocking results.
+     * @param vertexMaxParallelism The max parallelism of the job vertex.
      * @return the parallelism of the job vertex.
      */
-    int decideParallelismForVertex(List<BlockingResultInfo> consumedResults);
+    int decideParallelismForVertex(
+            JobVertexID jobVertexId,
+            List<BlockingResultInfo> consumedResults,
+            int vertexMaxParallelism);
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultSchedulerBuilder.java
@@ -95,7 +95,7 @@ public class DefaultSchedulerBuilder {
     private JobStatusListener jobStatusListener = (ignoredA, ignoredB, ignoredC) -> {};
     private ExecutionDeployer.Factory executionDeployerFactory =
             new DefaultExecutionDeployer.Factory();
-    private VertexParallelismDecider vertexParallelismDecider = (ignored) -> 0;
+    private VertexParallelismDecider vertexParallelismDecider = (ignoredA, ignoredB, ignoredC) -> 0;
     private int defaultMaxParallelism =
             JobManagerOptions.ADAPTIVE_BATCH_SCHEDULER_MAX_PARALLELISM.defaultValue();
     private BlocklistOperations blocklistOperations = ignore -> {};

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptivebatch/SpeculativeSchedulerTest.java
@@ -355,7 +355,7 @@ class SpeculativeSchedulerTest {
                 ComponentMainThreadExecutorServiceAdapter.forMainThread();
         final SpeculativeScheduler scheduler =
                 createSchedulerBuilder(jobGraph, mainThreadExecutor)
-                        .setVertexParallelismDecider(ignore -> 3)
+                        .setVertexParallelismDecider((ignoreA, ignoredB, ignoredC) -> 3)
                         .buildSpeculativeScheduler();
         mainThreadExecutor.execute(scheduler::startScheduling);
 


### PR DESCRIPTION
## What is the purpose of the change

Currently, the adaptive batch scheduler only respects the global maximum parallelism(which is configured by option jobmanager.adaptive-batch-scheduler.max-parallelism) when deciding parallelism for job vertices, the maximum parallelism of vertices configured by the user through setMaxParallelism will not be respected.

In this ticket, we will change the behavior so that the user-configured max parallelism also be respected.

## Verifying this change
Add tests in `DefaultVertexParallelismAndInputInfosDeciderTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
