### PR TITLE
[BP-1.17][FLINK-30629][test] Set CLIENT_ALIVENESS_CHECK_DURATION to clientHeartbeatInterval for testJobCancelledIfClientHeartbeatTimeout.

### DIFF
--- a/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
+++ b/flink-clients/src/test/java/org/apache/flink/client/ClientHeartbeatTest.java
@@ -94,7 +94,7 @@ public class ClientHeartbeatTest {
         Configuration configuration = new Configuration();
         configuration.set(
                 Dispatcher.CLIENT_ALIVENESS_CHECK_DURATION,
-                Duration.ofMillis(clientHeartbeatTimeout));
+                Duration.ofMillis(clientHeartbeatInterval));
         if (shutdownOnAttachedExit) {
             configuration.setBoolean(DeploymentOptions.ATTACHED, true);
             configuration.setBoolean(DeploymentOptions.SHUTDOWN_IF_ATTACHED, true);


### PR DESCRIPTION
Backports FLINK-30629 to release-1.17.
