### PR TITLE
[FLINK-31055][runtime] Fix the bug that dynamic flag of stream graph does not take effect when translating the transformations

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -310,11 +310,6 @@ public class StreamGraphGenerator {
 
     public StreamGraph generate() {
         streamGraph = new StreamGraph(executionConfig, checkpointConfig, savepointRestoreSettings);
-        streamGraph.setAutoParallelismEnabled(
-                configuration.get(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED));
-        streamGraph.setEnableCheckpointsAfterTasksFinish(
-                configuration.get(
-                        ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
         shouldExecuteInBatchMode = shouldExecuteInBatchMode();
         configureStreamGraph(streamGraph);
 
@@ -368,6 +363,11 @@ public class StreamGraphGenerator {
         graph.setVertexDescriptionMode(configuration.get(PipelineOptions.VERTEX_DESCRIPTION_MODE));
         graph.setVertexNameIncludeIndexPrefix(
                 configuration.get(PipelineOptions.VERTEX_NAME_INCLUDE_INDEX_PREFIX));
+        graph.setAutoParallelismEnabled(
+                configuration.get(BatchExecutionOptions.ADAPTIVE_AUTO_PARALLELISM_ENABLED));
+        graph.setEnableCheckpointsAfterTasksFinish(
+                configuration.get(
+                        ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
 
         if (shouldExecuteInBatchMode) {
             configureStreamGraphBatch(graph);

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -323,15 +323,6 @@ public class StreamGraphGenerator {
 
         setFineGrainedGlobalStreamExchangeMode(streamGraph);
 
-        Optional<JobManagerOptions.SchedulerType> schedulerTypeOptional =
-                executionConfig.getSchedulerType();
-        boolean dynamic =
-                shouldExecuteInBatchMode
-                        && schedulerTypeOptional.orElse(
-                                        JobManagerOptions.SchedulerType.AdaptiveBatch)
-                                == JobManagerOptions.SchedulerType.AdaptiveBatch;
-        streamGraph.setDynamic(dynamic);
-
         for (StreamNode node : streamGraph.getStreamNodes()) {
             if (node.getInEdges().stream().anyMatch(this::shouldDisableUnalignedCheckpointing)) {
                 for (StreamEdge edge : node.getInEdges()) {
@@ -354,6 +345,17 @@ public class StreamGraphGenerator {
         return partitioner.isPointwise() || partitioner.isBroadcast();
     }
 
+    private void setDynamic(final StreamGraph graph) {
+        Optional<JobManagerOptions.SchedulerType> schedulerTypeOptional =
+                executionConfig.getSchedulerType();
+        boolean dynamic =
+                shouldExecuteInBatchMode
+                        && schedulerTypeOptional.orElse(
+                                        JobManagerOptions.SchedulerType.AdaptiveBatch)
+                                == JobManagerOptions.SchedulerType.AdaptiveBatch;
+        graph.setDynamic(dynamic);
+    }
+
     private void configureStreamGraph(final StreamGraph graph) {
         checkNotNull(graph);
 
@@ -368,6 +370,7 @@ public class StreamGraphGenerator {
         graph.setEnableCheckpointsAfterTasksFinish(
                 configuration.get(
                         ExecutionCheckpointingOptions.ENABLE_CHECKPOINTS_AFTER_TASKS_FINISH));
+        setDynamic(graph);
 
         if (shouldExecuteInBatchMode) {
             configureStreamGraphBatch(graph);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForConsecutiveHashPartitionerTest.java
@@ -23,7 +23,6 @@ import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
 import org.apache.flink.streaming.api.transformations.StreamExchangeMode;
-import org.apache.flink.util.TestLogger;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -31,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 /** Test for {@link ForwardForConsecutiveHashPartitioner}. */
-class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
+class ForwardForConsecutiveHashPartitionerTest {
 
     @Test
     void testConvertToForwardPartitioner() {
@@ -46,7 +45,8 @@ class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
                         "group1",
                         "group1",
                         new ForwardForConsecutiveHashPartitioner<>(
-                                new KeyGroupStreamPartitioner<>(record -> 0L, 100)));
+                                new KeyGroupStreamPartitioner<>(record -> 0L, 100)),
+                        streamExchangeMode);
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
         Assertions.assertThat(jobVertices.size()).isEqualTo(1);
         JobVertex vertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
@@ -69,7 +69,8 @@ class ForwardForConsecutiveHashPartitionerTest extends TestLogger {
                         "group1",
                         "group2",
                         new ForwardForConsecutiveHashPartitioner<>(
-                                new KeyGroupStreamPartitioner<>(record -> 0L, 100)));
+                                new KeyGroupStreamPartitioner<>(record -> 0L, 100)),
+                        streamExchangeMode);
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
         Assertions.assertThat(jobVertices.size()).isEqualTo(2);
         JobVertex sourceVertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/ForwardForUnspecifiedPartitionerTest.java
@@ -17,20 +17,25 @@
 
 package org.apache.flink.streaming.runtime.partitioner;
 
+import org.apache.flink.api.common.RuntimeExecutionMode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.sink.DiscardingSink;
 import org.apache.flink.streaming.api.graph.NonChainedOutput;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.graph.StreamEdge;
-import org.apache.flink.util.TestLogger;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /** Test for {@link ForwardForUnspecifiedPartitioner}. */
-class ForwardForUnspecifiedPartitionerTest extends TestLogger {
+class ForwardForUnspecifiedPartitionerTest {
 
     @Test
     void testConvertToForwardPartitioner() {
@@ -38,12 +43,12 @@ class ForwardForUnspecifiedPartitionerTest extends TestLogger {
                 StreamPartitionerTestUtils.createJobGraph(
                         "group1", "group1", new ForwardForUnspecifiedPartitioner<>());
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
-        Assertions.assertThat(jobVertices.size()).isEqualTo(1);
+        assertThat(jobVertices.size()).isEqualTo(1);
         JobVertex vertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 
         StreamConfig sourceConfig = new StreamConfig(vertex.getConfiguration());
         StreamEdge edge = sourceConfig.getChainedOutputs(getClass().getClassLoader()).get(0);
-        Assertions.assertThat(edge.getPartitioner()).isInstanceOf(ForwardPartitioner.class);
+        assertThat(edge.getPartitioner()).isInstanceOf(ForwardPartitioner.class);
     }
 
     @Test
@@ -52,12 +57,48 @@ class ForwardForUnspecifiedPartitionerTest extends TestLogger {
                 StreamPartitionerTestUtils.createJobGraph(
                         "group1", "group2", new ForwardForUnspecifiedPartitioner<>());
         List<JobVertex> jobVertices = jobGraph.getVerticesSortedTopologicallyFromSources();
-        Assertions.assertThat(jobVertices.size()).isEqualTo(2);
+        assertThat(jobVertices.size()).isEqualTo(2);
         JobVertex sourceVertex = jobGraph.getVerticesSortedTopologicallyFromSources().get(0);
 
         StreamConfig sourceConfig = new StreamConfig(sourceVertex.getConfiguration());
         NonChainedOutput output =
                 sourceConfig.getOperatorNonChainedOutputs(getClass().getClassLoader()).get(0);
-        Assertions.assertThat(output.getPartitioner()).isInstanceOf(RescalePartitioner.class);
+        assertThat(output.getPartitioner()).isInstanceOf(RescalePartitioner.class);
+    }
+
+    @Test
+    void testConvertToCorrectPartitioner() {
+        testConvertToCorrectPartitioner(null, RescalePartitioner.class);
+        testConvertToCorrectPartitioner(
+                JobManagerOptions.SchedulerType.AdaptiveBatch, RescalePartitioner.class);
+        testConvertToCorrectPartitioner(
+                JobManagerOptions.SchedulerType.Default, ForwardPartitioner.class);
+    }
+
+    private void testConvertToCorrectPartitioner(
+            JobManagerOptions.SchedulerType scheduler, Class<?> expectedPartitioner) {
+        Configuration configuration = new Configuration();
+        if (scheduler != null) {
+            configuration.set(JobManagerOptions.SCHEDULER, scheduler);
+        }
+        final StreamExecutionEnvironment env =
+                StreamExecutionEnvironment.getExecutionEnvironment(configuration);
+        env.setRuntimeMode(RuntimeExecutionMode.BATCH);
+        env.fromSequence(0, 99)
+                .slotSharingGroup("group1")
+                .name("source")
+                .addSink(new DiscardingSink<>())
+                .slotSharingGroup("group2")
+                .name("sink");
+
+        List<JobVertex> jobVertices =
+                env.getStreamGraph().getJobGraph().getVerticesSortedTopologicallyFromSources();
+        assertThat(jobVertices.size()).isEqualTo(2);
+
+        JobVertex sourceVertex = jobVertices.get(0);
+        StreamConfig sourceConfig = new StreamConfig(sourceVertex.getConfiguration());
+        NonChainedOutput output =
+                sourceConfig.getOperatorNonChainedOutputs(getClass().getClassLoader()).get(0);
+        assertThat(output.getPartitioner()).isInstanceOf(expectedPartitioner);
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

Currently, the dynamic flag of stream graph is not set when [translate transformations](https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java#L324). However, the dynamic flag will be used ([here](https://github.com/apache/flink/blob/master/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/graph/StreamGraph.java#L696)) when translating, we should set the dynamic flag before the translating.

## Verifying this change
`ForwardForUnspecifiedPartitionerTest#testConvertToCorrectPartitioner`


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (**no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (**no**)
  - The serializers: (**no**)
  - The runtime per-record code paths (performance sensitive): (**no**)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (**no**)
  - The S3 file system connector: (**no**)

## Documentation

  - Does this pull request introduce a new feature? (**no**)
  - If yes, how is the feature documented? (**not applicable**)
