### PR TITLE
[FLINK-31070][Table SQL/Client] Update jline from 3.21.0 to 3.22.0

### DIFF
--- a/flink-table/flink-sql-client/pom.xml
+++ b/flink-table/flink-sql-client/pom.xml
@@ -78,14 +78,14 @@ under the License.
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-terminal</artifactId>
-			<version>3.21.0</version>
+			<version>3.22.0</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 
 		<dependency>
 			<groupId>org.jline</groupId>
 			<artifactId>jline-reader</artifactId>
-			<version>3.21.0</version>
+			<version>3.22.0</version>
 			<optional>${flink.markBundledAsOptional}</optional>
 		</dependency>
 

--- a/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
+++ b/flink-table/flink-sql-client/src/main/resources/META-INF/NOTICE
@@ -7,5 +7,5 @@ The Apache Software Foundation (http://www.apache.org/).
 This project bundles the following dependencies under the BSD license.
 See bundled license files for details.
 
-- org.jline:jline-terminal:3.21.0
-- org.jline:jline-reader:3.21.0
+- org.jline:jline-terminal:3.22.0
+- org.jline:jline-reader:3.22.0

--- a/pom.xml
+++ b/pom.xml
@@ -603,7 +603,7 @@ under the License.
 			<dependency>
 				<groupId>net.java.dev.jna</groupId>
 				<artifactId>jna</artifactId>
-				<version>5.12.1</version>
+				<version>5.13.0</version>
 			</dependency>
 
 			<!-- For dependency convergence -->


### PR DESCRIPTION
## What is the purpose of the change

The PR updates jline3 to 3.22.0

## Verifying this change

This is just a version update, so only existing tests

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes )
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no )
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
