### PR TITLE
[FLINK-31085][formats] Add schema option to confluent registry avro formats

### DIFF
--- a/docs/content.zh/docs/connectors/table/formats/avro-confluent.md
+++ b/docs/content.zh/docs/connectors/table/formats/avro-confluent.md
@@ -260,6 +260,13 @@ Format 参数
             <td>Password for SSL truststore</td>
         </tr>
         <tr>
+            <td><h5>avro-confluent.schema</h5></td>
+            <td>optional</td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The schema registered or to be registered in the Confluent Schema Registry. If no schema is provided Flink converts the table schema to avro schema. The schema provided must match the table schema.</td>
+        </tr>
+        <tr>
             <td><h5>avro-confluent.subject</h5></td>
             <td>optional</td>
             <td style="word-wrap: break-word;">(none)</td>

--- a/docs/content.zh/docs/connectors/table/formats/debezium.md
+++ b/docs/content.zh/docs/connectors/table/formats/debezium.md
@@ -328,6 +328,13 @@ Flink 提供了 `debezium-avro-confluent` 和 `debezium-json` 两种 format 来�
             <td>Password for SSL truststore</td>
         </tr>
         <tr>
+            <td><h5>debezium-avro-confluent.schema</h5></td>
+            <td>optional</td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The schema registered or to be registered in the Confluent Schema Registry. If no schema is provided Flink converts the table schema to avro schema. The schema provided must match the Debezium schema which is a nullable record type including fields 'before', 'after', 'op'.</td>
+        </tr>
+        <tr>
             <td><h5>debezium-avro-confluent.subject</h5></td>
             <td>optional</td>
             <td style="word-wrap: break-word;">(none)</td>

--- a/docs/content/docs/connectors/table/formats/avro-confluent.md
+++ b/docs/content/docs/connectors/table/formats/avro-confluent.md
@@ -264,6 +264,14 @@ Format Options
             <td>Password for SSL truststore</td>
         </tr>
         <tr>
+            <td><h5>avro-confluent.schema</h5></td>
+            <td>optional</td>
+            <td>no</td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The schema registered or to be registered in the Confluent Schema Registry. If no schema is provided Flink converts the table schema to avro schema. The schema provided must match the table schema.</td>
+        </tr>
+        <tr>
             <td><h5>avro-confluent.subject</h5></td>
             <td>optional</td>
             <td>yes</td>

--- a/docs/content/docs/connectors/table/formats/debezium.md
+++ b/docs/content/docs/connectors/table/formats/debezium.md
@@ -322,6 +322,13 @@ Use format `debezium-avro-confluent` to interpret Debezium Avro messages and for
             <td>Password for SSL truststore</td>
         </tr>
         <tr>
+            <td><h5>debezium-avro-confluent.schema</h5></td>
+            <td>optional</td>
+            <td style="word-wrap: break-word;">(none)</td>
+            <td>String</td>
+            <td>The schema registered or to be registered in the Confluent Schema Registry. If no schema is provided Flink converts the table schema to avro schema. The schema provided must match the Debezium schema which is a nullable record type including fields 'before', 'after', 'op'.</td>
+        </tr>
+        <tr>
             <td><h5>debezium-avro-confluent.subject</h5></td>
             <td>optional</td>
             <td style="word-wrap: break-word;">(none)</td>

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/streaming/connectors/kafka/table/KafkaDynamicTableFactoryTest.java
@@ -936,7 +936,7 @@ public class KafkaDynamicTableFactoryTest {
 
     private SerializationSchema<RowData> createDebeziumAvroSerSchema(
             RowType rowType, String subject) {
-        return new DebeziumAvroSerializationSchema(rowType, TEST_REGISTRY_URL, subject, null);
+        return new DebeziumAvroSerializationSchema(rowType, TEST_REGISTRY_URL, subject, null, null);
     }
 
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/AvroConfluentFormatOptions.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/AvroConfluentFormatOptions.java
@@ -49,6 +49,18 @@ public class AvroConfluentFormatOptions {
                                     + "is used as the value or key format. But for other connectors (e.g. 'filesystem'), "
                                     + "the subject option is required when used as sink.");
 
+    public static final ConfigOption<String> SCHEMA =
+            ConfigOptions.key("schema")
+                    .stringType()
+                    .noDefaultValue()
+                    .withFallbackKeys("schema-registry.schema")
+                    .withDescription(
+                            "The schema registered or to be registered in the Confluent Schema Registry. "
+                                    + "If no schema is provided Flink converts the table schema to avro schema. "
+                                    + "The schema provided must match the table schema ('avro-confluent') or "
+                                    + "the Debezium schema which is a nullable record type including "
+                                    + "fields 'before', 'after', 'op' ('debezium-avro-confluent').");
+
     // --------------------------------------------------------------------------------------------
     // Commonly used options maintained by Flink for convenience
     // --------------------------------------------------------------------------------------------

--- a/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
+++ b/flink-formats/flink-avro-confluent-registry/src/main/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroDeserializationSchema.java
@@ -34,6 +34,9 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.Collector;
 
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
+
 import javax.annotation.Nullable;
 
 import java.io.IOException;
@@ -41,6 +44,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.String.format;
+import static org.apache.flink.formats.avro.registry.confluent.debezium.DebeziumAvroFormatFactory.validateSchemaString;
 import static org.apache.flink.table.types.utils.TypeConversions.fromLogicalToDataType;
 
 /**
@@ -80,16 +84,21 @@ public final class DebeziumAvroDeserializationSchema implements DeserializationS
             RowType rowType,
             TypeInformation<RowData> producedTypeInfo,
             String schemaRegistryUrl,
+            @Nullable String schemaString,
             @Nullable Map<String, ?> registryConfigs) {
         this.producedTypeInfo = producedTypeInfo;
         RowType debeziumAvroRowType = createDebeziumAvroRowType(fromLogicalToDataType(rowType));
 
+        validateSchemaString(schemaString, debeziumAvroRowType);
+        Schema schema =
+                schemaString == null
+                        ? AvroSchemaConverter.convertToSchema(debeziumAvroRowType)
+                        : new Parser().parse(schemaString);
+
         this.avroDeserializer =
                 new AvroRowDataDeserializationSchema(
                         ConfluentRegistryAvroDeserializationSchema.forGeneric(
-                                AvroSchemaConverter.convertToSchema(debeziumAvroRowType),
-                                schemaRegistryUrl,
-                                registryConfigs),
+                                schema, schemaRegistryUrl, registryConfigs),
                         AvroToRowDataConverters.createRowConverter(debeziumAvroRowType),
                         producedTypeInfo);
     }

--- a/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
+++ b/flink-formats/flink-avro-confluent-registry/src/test/java/org/apache/flink/formats/avro/registry/confluent/debezium/DebeziumAvroFormatFactoryTest.java
@@ -32,6 +32,7 @@ import org.apache.flink.table.runtime.connector.source.ScanRuntimeProviderContex
 import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
 import org.apache.flink.table.types.logical.RowType;
 
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -40,6 +41,8 @@ import java.util.Map;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSink;
 import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Tests for {@link DebeziumAvroFormatFactory}. */
 class DebeziumAvroFormatFactoryTest {
@@ -50,6 +53,68 @@ class DebeziumAvroFormatFactoryTest {
                     Column.physical("b", DataTypes.INT()),
                     Column.physical("c", DataTypes.BOOLEAN()));
 
+    private static final String RECORD_SCHEMA =
+            "    {\n"
+                    + "        \"type\": \"record\",\n"
+                    + "        \"name\": \"test\",\n"
+                    + "        \"fields\": [\n"
+                    + "            {\n"
+                    + "                \"name\": \"before\",\n"
+                    + "                \"type\": [\n"
+                    + "                    \"null\",\n"
+                    + "                    {\n"
+                    + "                        \"type\": \"record\",\n"
+                    + "                        \"name\": \"testSchema\",\n"
+                    + "                        \"fields\": [\n"
+                    + "                            {\n"
+                    + "                                \"name\": \"a\",\n"
+                    + "                                \"type\": [\n"
+                    + "                                    \"null\",\n"
+                    + "                                    \"string\"\n"
+                    + "                                ],\n"
+                    + "                                \"default\": null\n"
+                    + "                            },\n"
+                    + "                            {\n"
+                    + "                                \"name\": \"b\",\n"
+                    + "                                \"type\": [\n"
+                    + "                                    \"null\",\n"
+                    + "                                    \"int\"\n"
+                    + "                                ],\n"
+                    + "                                \"default\": null\n"
+                    + "                            },\n"
+                    + "                            {\n"
+                    + "                                \"name\": \"c\",\n"
+                    + "                                \"type\": [\n"
+                    + "                                    \"null\",\n"
+                    + "                                    \"boolean\"\n"
+                    + "                                ],\n"
+                    + "                                \"default\": null\n"
+                    + "                            }\n"
+                    + "                        ]\n"
+                    + "                    }\n"
+                    + "                ],\n"
+                    + "                \"default\": null\n"
+                    + "            },\n"
+                    + "            {\n"
+                    + "                \"name\": \"after\",\n"
+                    + "                \"type\": [\n"
+                    + "                    \"null\",\n"
+                    + "                    \"testSchema\"\n"
+                    + "                ],\n"
+                    + "                \"default\": null\n"
+                    + "            },\n"
+                    + "            {\n"
+                    + "                \"name\": \"op\",\n"
+                    + "                \"type\": [\n"
+                    + "                    \"null\",\n"
+                    + "                    \"string\"\n"
+                    + "                ],\n"
+                    + "                \"default\": null\n"
+                    + "            }\n"
+                    + "        ]\n"
+                    + "    }\n";
+    private static final String AVRO_SCHEMA = "[\n\"null\",\n" + RECORD_SCHEMA + "]";
+
     private static final RowType ROW_TYPE =
             (RowType) SCHEMA.toPhysicalRowDataType().getLogicalType();
 
@@ -59,22 +124,91 @@ class DebeziumAvroFormatFactoryTest {
     @Test
     void testSeDeSchema() {
         final Map<String, String> options = getAllOptions();
-
-        final Map<String, String> registryConfigs = new HashMap<>();
-        registryConfigs.put("basic.auth.user.info", "something1");
-        registryConfigs.put("basic.auth.credentials.source", "something2");
+        final Map<String, String> registryConfigs = getRegistryConfigs();
 
         DebeziumAvroDeserializationSchema expectedDeser =
                 new DebeziumAvroDeserializationSchema(
-                        ROW_TYPE, InternalTypeInfo.of(ROW_TYPE), REGISTRY_URL, registryConfigs);
+                        ROW_TYPE,
+                        InternalTypeInfo.of(ROW_TYPE),
+                        REGISTRY_URL,
+                        null,
+                        registryConfigs);
+        DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
+        assertEquals(expectedDeser, actualDeser);
+
+        DebeziumAvroSerializationSchema expectedSer =
+                new DebeziumAvroSerializationSchema(
+                        ROW_TYPE, REGISTRY_URL, SUBJECT, null, registryConfigs);
+        SerializationSchema<RowData> actualSer = createSerializationSchema(options);
+        assertEquals(expectedSer, actualSer);
+    }
+
+    @Test
+    public void testSeDeSchemaWithSchemaOption() {
+        final Map<String, String> options = getAllOptions();
+        options.put("debezium-avro-confluent.schema", AVRO_SCHEMA);
+
+        final Map<String, String> registryConfigs = getRegistryConfigs();
+
+        DebeziumAvroDeserializationSchema expectedDeser =
+                new DebeziumAvroDeserializationSchema(
+                        ROW_TYPE,
+                        InternalTypeInfo.of(ROW_TYPE),
+                        REGISTRY_URL,
+                        AVRO_SCHEMA,
+                        registryConfigs);
         DeserializationSchema<RowData> actualDeser = createDeserializationSchema(options);
         assertThat(actualDeser).isEqualTo(expectedDeser);
 
         DebeziumAvroSerializationSchema expectedSer =
                 new DebeziumAvroSerializationSchema(
-                        ROW_TYPE, REGISTRY_URL, SUBJECT, registryConfigs);
+                        ROW_TYPE, REGISTRY_URL, SUBJECT, AVRO_SCHEMA, registryConfigs);
         SerializationSchema<RowData> actualSer = createSerializationSchema(options);
         assertThat(actualSer).isEqualTo(expectedSer);
+    }
+
+    @Test
+    public void testSeDeSchemaWithInvalidSchemaOption() {
+        final Map<String, String> options = getAllOptions();
+        options.put("debezium-avro-confluent.schema", RECORD_SCHEMA);
+
+        assertThrows(IllegalArgumentException.class, () -> createDeserializationSchema(options));
+        assertThrows(IllegalArgumentException.class, () -> createSerializationSchema(options));
+
+        String basicSchema = "[ \"null\", \"string\" ]";
+        options.put("debezium-avro-confluent.schema", basicSchema);
+        assertThrows(IllegalArgumentException.class, () -> createDeserializationSchema(options));
+        assertThrows(IllegalArgumentException.class, () -> createSerializationSchema(options));
+
+        String invalidSchema =
+                "[\"null\", "
+                        + "{ \"type\" : \"record\","
+                        + "\"name\" : \"debezium\","
+                        + "\"fields\": [{\n"
+                        + "        \"default\": null,\n"
+                        + "        \"name\": \"op\",\n"
+                        + "        \"type\": [\n"
+                        + "          \"null\",\n"
+                        + "          \"string\"\n"
+                        + "        ]\n"
+                        + "      }]"
+                        + "}]";
+        options.put("debezium-avro-confluent.schema", invalidSchema);
+        assertThrows(IllegalArgumentException.class, () -> createDeserializationSchema(options));
+        assertThrows(IllegalArgumentException.class, () -> createSerializationSchema(options));
+
+        String invalidRecordSchema = AVRO_SCHEMA.replace("int", "string");
+        options.put("debezium-avro-confluent.schema", invalidRecordSchema);
+        assertThrows(IllegalArgumentException.class, () -> createDeserializationSchema(options));
+        assertThrows(IllegalArgumentException.class, () -> createSerializationSchema(options));
+    }
+
+    @NotNull
+    private Map<String, String> getRegistryConfigs() {
+        final Map<String, String> registryConfigs = new HashMap<>();
+        registryConfigs.put("basic.auth.user.info", "something1");
+        registryConfigs.put("basic.auth.credentials.source", "something2");
+        return registryConfigs;
     }
 
     private Map<String, String> getAllOptions() {

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroRowDataSerializationSchema.java
@@ -76,8 +76,12 @@ public class AvroRowDataSerializationSchema implements SerializationSchema<RowDa
 
     @Override
     public void open(InitializationContext context) throws Exception {
-        this.schema = AvroSchemaConverter.convertToSchema(rowType);
         this.nestedSchema.open(context);
+        if (this.nestedSchema instanceof AvroSerializationSchema) {
+            this.schema = ((AvroSerializationSchema<GenericRecord>) this.nestedSchema).getSchema();
+        } else {
+            this.schema = AvroSchemaConverter.convertToSchema(rowType);
+        }
     }
 
     @Override

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
@@ -23,6 +23,7 @@ import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.WrappingRuntimeException;
 
 import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
@@ -116,6 +117,11 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 
     protected ByteArrayOutputStream getOutputStream() {
         return arrayOutputStream;
+    }
+
+    @Override
+    public void open(InitializationContext context) throws Exception {
+        this.schema = new Parser().parse(schemaString);
     }
 
     @Override

--- a/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
+++ b/flink-formats/flink-avro/src/main/java/org/apache/flink/formats/avro/AvroSerializationSchema.java
@@ -121,7 +121,9 @@ public class AvroSerializationSchema<T> implements SerializationSchema<T> {
 
     @Override
     public void open(InitializationContext context) throws Exception {
-        this.schema = new Parser().parse(schemaString);
+        if (schemaString != null) {
+            this.schema = new Parser().parse(schemaString);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change
When using `avro-confluent` and `debezium-avro-confluent` formats with schemas already defined in the Confluent Schema Registry, serialization fails, because Flink uses a default name `record` when converting row types to avro schemas. So if the predefined schema has a different name, the serialization schema will be incompatible with the registered schema due to name mismatch. Check [this description](https://lists.apache.org/thread/5xppmnqjqwfzxqo4gvd3lzz8wzs566zp) to reproduce the error.

## Brief change log
- A new optional option `schema` can be defined for `avro-confluent` and `debezium-avro-confluent` formats to ensure that the proper schema is used for serialization and deserialization.
- When schema is defined, it is validated against the table schema and if valid it's used for serialization and deserialization instead of the default conversion. When no schema is defined, the schema is created based on the row type.
- The `open` method of `AvroRowDataSerialization` schema makes sure to use the schema of the nested schema if the nested schema is an `AvroSerializationSchema`.
- The `open` method of `AvroSerializationSchema` makes sure that the schema provided is defined, so it can be used by `AvroRowDataSerialization`.

## Verifying this change
This change added tests and can be verified as follows:

- Extended `RegistryAvroFormatFactoryTest.testDeserializationSchemaWithOptionalProperties` and `RegistryAvroFormatFactoryTest.testSerializationSchemaWithOptionalProperties` with the schema option
- Added test to `RegistryAvroFormatFactoryTest` that validates that exception is thrown in case of an invalid schema
- Added test that validate that the constructor of `DebeziumAvroSerializationSchema` and `DebeziumAvroDeserializationSchema` creates the proper schema when the schema string is provided
- Extended `DebeziumAvroFormatFactoryTest.testSeDeSchemaWithSchemaOption` with the schema option
- Added test to `DebeziumAvroFormatFactoryTest` that validates that exception is thrown in case of an invalid schema
- Added test to `AvroRowDataDeSerializationSchemaTest` that validates that record is deserialized and serialized properly based on nullable schema with a name that is not "record"
- Added test to `AvroSerializationSchemaTest` that validates the `open` method of `AvroSerializationSchema`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: yes
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Added a description for the new `schema` option of `avro-confluent` and `debezium-avro-confluent` formats.