### PR TITLE
[FLINK-31099][python] Fix chained WindowOperator throws NPE in PyFlink Thread Mode

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_window.py
+++ b/flink-python/pyflink/datastream/tests/test_window.py
@@ -603,6 +603,39 @@ class EmbeddedWindowTests(WindowTests, PyFlinkStreamingTestCase):
         config = get_j_env_configuration(self.env._j_stream_execution_environment)
         config.setString("python.execution-mode", "thread")
 
+    def test_chained_window(self):
+        class MyTimestampAssigner(TimestampAssigner):
+            def extract_timestamp(self, value: tuple, record_timestamp: int) -> int:
+                return value[0]
+
+        ds = self.env.from_collection(
+            [(1676461680000, "a1", "b1", 1), (1676461680000, "a1", "b1", 1),
+             (1676461680000, "a2", "b2", 1), (1676461680000, "a1", "b2", 1),
+             (1676461740000, "a1", "b1", 1), (1676461740000, "a2", "b2", 1)]
+        ).assign_timestamps_and_watermarks(
+            WatermarkStrategy.for_monotonous_timestamps().with_timestamp_assigner(
+                MyTimestampAssigner())
+        )
+        ds.key_by(
+            lambda x: (x[0], x[1], x[2])
+        ).window(
+            TumblingEventTimeWindows.of(Time.minutes(1))
+        ).reduce(
+            lambda x, y: (x[0], x[1], x[2], x[3] + y[3]),
+            output_type=Types.TUPLE([Types.LONG(), Types.STRING(), Types.STRING(), Types.INT()])
+        ).map(
+            lambda x: (x[0], x[1], x[3]),
+            output_type=Types.TUPLE([Types.LONG(), Types.STRING(), Types.INT()])
+        ).add_sink(self.test_sink)
+        self.env.execute('test_chained_window')
+        results = self.test_sink.get_results()
+        expected = ['(1676461680000,a1,1)',
+                    '(1676461680000,a1,2)',
+                    '(1676461680000,a2,1)',
+                    '(1676461740000,a1,1)',
+                    '(1676461740000,a2,1)']
+        self.assert_equals_sorted(expected, results)
+
 
 class SecondColumnTimestampAssigner(TimestampAssigner):
 

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/embedded/EmbeddedPythonWindowOperator.java
@@ -136,7 +136,8 @@ public class EmbeddedPythonWindowOperator<K, IN, OUT, W extends Window>
     @Override
     public <T> DataStreamPythonFunctionOperator<T> copy(
             DataStreamPythonFunctionInfo pythonFunctionInfo, TypeInformation<T> outputTypeInfo) {
-        return null;
+        return new EmbeddedPythonWindowOperator<>(
+                config, pythonFunctionInfo, getInputTypeInfo(), outputTypeInfo, windowSerializer);
     }
 
     private void invokeUserFunction(InternalTimer<K, W> timer) throws Exception {


### PR DESCRIPTION
## What is the purpose of the change

*This pull request will fix chained WindowOperator throws NPE in PyFlink Thread Mode*


## Verifying this change

This change added tests and can be verified as follows:

  - *`test_chained_window` in `test_window.py`*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
