### PR TITLE
[FLINK-21000][runtime] Add an internal split enumerator metric group

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/MetricNames.java
@@ -122,4 +122,7 @@ public class MetricNames {
     public static final String LATEST_LOAD_TIME = "latestLoadTime";
     public static final String NUM_CACHED_RECORDS = "numCachedRecords";
     public static final String NUM_CACHED_BYTES = "numCachedBytes";
+
+    // FLIP-27 for split enumerator
+    public static final String UNASSIGNED_SPLITS = "unassignedSplits";
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSplitEnumeratorMetricGroup.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/metrics/groups/InternalSplitEnumeratorMetricGroup.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.connector.source.SplitEnumerator;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
+import org.apache.flink.runtime.metrics.MetricNames;
+
+/** Special {@link MetricGroup} representing an {@link SplitEnumerator}. */
+@Internal
+public class InternalSplitEnumeratorMetricGroup extends ProxyMetricGroup<MetricGroup>
+        implements SplitEnumeratorMetricGroup {
+
+    public InternalSplitEnumeratorMetricGroup(MetricGroup parent) {
+        super(parent.addGroup("enumerator"));
+    }
+
+    @Override
+    public <G extends Gauge<Long>> G setUnassignedSplitsGauge(G unassignedSplitsGauge) {
+        return parentMetricGroup.gauge(MetricNames.UNASSIGNED_SPLITS, unassignedSplitsGauge);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/source/coordinator/SourceCoordinatorContext.java
@@ -29,6 +29,7 @@ import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.apache.flink.api.connector.source.SupportsIntermediateNoMoreSplits;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.apache.flink.metrics.groups.SplitEnumeratorMetricGroup;
+import org.apache.flink.runtime.metrics.groups.InternalSplitEnumeratorMetricGroup;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorEvent;
 import org.apache.flink.runtime.source.event.AddSplitEvent;
@@ -166,7 +167,7 @@ public class SourceCoordinatorContext<SplitT extends SourceSplit>
 
     @Override
     public SplitEnumeratorMetricGroup metricGroup() {
-        return null;
+        return new InternalSplitEnumeratorMetricGroup(operatorCoordinatorContext.metricGroup());
     }
 
     @Override

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSplitEnumeratorGroupTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/metrics/groups/InternalSplitEnumeratorGroupTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.metrics.groups;
+
+import org.apache.flink.api.common.JobID;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.metrics.MetricRegistry;
+import org.apache.flink.runtime.metrics.util.TestingMetricRegistry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link InternalSplitEnumeratorMetricGroup}. */
+class InternalSplitEnumeratorGroupTest {
+
+    private static final MetricRegistry registry = TestingMetricRegistry.builder().build();
+
+    @Test
+    void testGenerateScopeDefault() {
+        final JobID jobId = new JobID();
+        final JobVertexID jobVertexId = new JobVertexID();
+        final OperatorID operatorId = new OperatorID();
+        JobManagerOperatorMetricGroup jmJobGroup =
+                JobManagerMetricGroup.createJobManagerMetricGroup(registry, "localhost")
+                        .addJob(jobId, "myJobName")
+                        .getOrAddOperator(jobVertexId, "taskName", operatorId, "opName");
+        InternalOperatorCoordinatorMetricGroup operatorCoordinatorMetricGroup =
+                new InternalOperatorCoordinatorMetricGroup(jmJobGroup);
+        InternalSplitEnumeratorMetricGroup splitEnumeratorMetricGroup =
+                new InternalSplitEnumeratorMetricGroup(operatorCoordinatorMetricGroup);
+
+        assertThat(splitEnumeratorMetricGroup.getScopeComponents())
+                .containsExactly(
+                        "localhost",
+                        "jobmanager",
+                        "myJobName",
+                        "opName",
+                        "coordinator",
+                        "enumerator");
+        assertThat(splitEnumeratorMetricGroup.getMetricIdentifier("name"))
+                .isEqualTo("localhost.jobmanager.myJobName.opName.coordinator.enumerator.name");
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request adds an internal split enumerator metric group.

## Brief change log

  - Add InternalOperatorEnumeratorMetricGroup
  - make SourceCoordinatorContext#metricGroup return an instance of InternalOperatorEnumeratorMetricGroup
  - Define the metric name 'unassignedSplits' in MetricNames

## Verifying this change

This change added unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not documented
