### PR TITLE
[FLINK-30989][runtime] Some config options related to sorting and spilling are not valid.

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/MultiInputSortingDataInput.java
@@ -150,7 +150,7 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
             IOManager ioManager,
             boolean objectReuse,
             double managedMemoryFraction,
-            Configuration jobConfiguration,
+            Configuration taskManagerConfiguration,
             ExecutionConfig executionConfig) {
         int keyLength = keySerializer.getLength();
         final TypeComparator<Tuple2<byte[], StreamRecord<Object>>> comparator;
@@ -196,11 +196,11 @@ public final class MultiInputSortingDataInput<IN, K> implements StreamTaskInput<
                                                                         / numberOfInputs)
                                                         .enableSpilling(
                                                                 ioManager,
-                                                                jobConfiguration.get(
+                                                                taskManagerConfiguration.get(
                                                                         AlgorithmOptions
                                                                                 .SORT_SPILLING_THRESHOLD))
                                                         .maxNumFileHandles(
-                                                                jobConfiguration.get(
+                                                                taskManagerConfiguration.get(
                                                                                 AlgorithmOptions
                                                                                         .SPILLING_MAX_FAN)
                                                                         / numberOfInputs)

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java
@@ -86,7 +86,7 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
             IOManager ioManager,
             boolean objectReuse,
             double managedMemoryFraction,
-            Configuration jobConfiguration,
+            Configuration taskManagerConfiguration,
             TaskInvokable containingTask,
             ExecutionConfig executionConfig) {
         try {
@@ -115,12 +115,13 @@ public final class SortingDataInput<T, K> implements StreamTaskInput<T> {
                             .memoryFraction(managedMemoryFraction)
                             .enableSpilling(
                                     ioManager,
-                                    jobConfiguration.get(AlgorithmOptions.SORT_SPILLING_THRESHOLD))
+                                    taskManagerConfiguration.get(
+                                            AlgorithmOptions.SORT_SPILLING_THRESHOLD))
                             .maxNumFileHandles(
-                                    jobConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
+                                    taskManagerConfiguration.get(AlgorithmOptions.SPILLING_MAX_FAN))
                             .objectReuse(objectReuse)
                             .largeRecords(
-                                    jobConfiguration.get(
+                                    taskManagerConfiguration.get(
                                             AlgorithmOptions.USE_LARGE_RECORDS_HANDLER))
                             .build();
         } catch (MemoryAllocationException e) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamMultipleInputProcessorFactory.java
@@ -180,7 +180,7 @@ public class StreamMultipleInputProcessorFactory {
                                     ManagedMemoryUseCase.OPERATOR,
                                     taskManagerConfig,
                                     userClassloader),
-                            jobConfig,
+                            taskManagerConfig,
                             executionConfig);
 
             StreamTaskInput<?>[] sortedInputs = selectableSortingInputs.getSortedInputs();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/StreamTwoInputProcessorFactory.java
@@ -159,7 +159,7 @@ public class StreamTwoInputProcessorFactory {
                                     ManagedMemoryUseCase.OPERATOR,
                                     taskManagerConfig,
                                     userClassloader),
-                            jobConfig,
+                            taskManagerConfig,
                             executionConfig);
             inputSelectable = selectableSortingInputs.getInputSelectable();
             StreamTaskInput<?>[] sortedInputs = selectableSortingInputs.getSortedInputs();

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/OneInputStreamTask.java
@@ -149,7 +149,7 @@ public class OneInputStreamTask<IN, OUT> extends StreamTask<OUT, OneInputStreamO
                         ManagedMemoryUseCase.OPERATOR,
                         getEnvironment().getTaskConfiguration(),
                         userCodeClassLoader),
-                getJobConfiguration(),
+                getEnvironment().getTaskManagerInfo().getConfiguration(),
                 this,
                 getExecutionConfig());
     }


### PR DESCRIPTION
## What is the purpose of the change

*For some config options like `taskmanager.runtime.sort-spilling-threshold` ,`taskmanager.runtime.max-fan` ... etc. used for sorting and spilling, we get this option value from [JobConfiguration](https://github.com/apache/flink/blob/1c0870ae08730688706540b999c04b2f4c4498ee/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sort/SortingDataInput.java#L118). In fact, these parameters should be only available in the `TaskManagerConfiguration` now.*


## Brief change log

  - *Using `TaskManagerConfiguration` to load these config options.*

## Verifying this change

Manual testing.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
