### PR TITLE
[FLINK-31110][web] Show "User Configuration" preserving lines and whitespaces

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/configuration/job-configuration.component.less
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/configuration/job-configuration.component.less
@@ -21,6 +21,10 @@
     .nz-disable-td {
       width: 100%;
     }
+
+    .ant-table-cell {
+      white-space: pre-wrap;
+    }
   }
 }
 


### PR DESCRIPTION
From JIRA description:
>Currently one can use env.getConfig().setGlobalJobParameters(...) for setting user configurations. It will also show up in the Web UI > Running Jobs > Job Configuration > User Configuration section. This is nice so users can confirm the user configuration (key/value pair) gets populated.
>
>However, it prints the plain string which does not work well with values that contains whitespaces and line breaks. For example, we have some prettified JSON configuration and sometimes formatted SQL statements in those configurations, and it's showing in a compacted HTML format - not human readable.
>
>I propose we keep the whitespaces and lines for this "User Configuration" section in the Web UI. The implementation can be as simple as adding style="white-space: pre-wrap;" to the rows in that section.