### PR TITLE
[FLINK-23314][CEP] Eagerly clear keyed state footprints

### DIFF
--- a/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
+++ b/flink-libraries/flink-cep/src/main/java/org/apache/flink/cep/operator/CepOperator.java
@@ -378,7 +378,13 @@ public class CepOperator<IN, KEY, OUT>
         if (nfaState.isStateChanged()) {
             nfaState.resetStateChanged();
             nfaState.resetNewStartPartialMatch();
-            computationStates.update(nfaState);
+            // Clear state when only start state left (currently there's only one start state)
+            // Completed matches should also be empty when only start state left in partial matches
+            if (nfaState.getPartialMatches().size() == 1) {
+                computationStates.clear();
+            } else {
+                computationStates.update(nfaState);
+            }
         }
     }
 


### PR DESCRIPTION

## What is the purpose of the change

This PR fixes in CEP, state belongs to a key is not cleaned by pattern timeout or state ttl, even if data of this key will never appear, which makes checkpoint size increase infinitely. Thus we eagerly clear those states when matches complete or all partial matches time-out.


## Verifying this change

This change added tests and can be verified as follows:
- `testKeyedCEPOperatorStateCleaning()` in CEPOperatorTest.java

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)