### PR TITLE
[FLINK-31113] Support AND filter push down in orc

### DIFF
--- a/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
+++ b/flink-formats/flink-orc/src/main/java/org/apache/flink/orc/OrcFilters.java
@@ -62,6 +62,7 @@ public class OrcFilters {
                                     OrcFilters::convertIsNotNull)
                             .put(BuiltInFunctionDefinitions.NOT, OrcFilters::convertNot)
                             .put(BuiltInFunctionDefinitions.OR, OrcFilters::convertOr)
+                            .put(BuiltInFunctionDefinitions.AND, OrcFilters::convertAnd)
                             .put(
                                     BuiltInFunctionDefinitions.EQUALS,
                                     call ->
@@ -183,6 +184,22 @@ public class OrcFilters {
             return null;
         } else {
             return new Or(c1, c2);
+        }
+    }
+
+    private static Predicate convertAnd(CallExpression callExp) {
+        if (callExp.getChildren().size() < 2) {
+            return null;
+        }
+        Expression left = callExp.getChildren().get(0);
+        Expression right = callExp.getChildren().get(1);
+
+        Predicate c1 = toOrcPredicate(left);
+        Predicate c2 = toOrcPredicate(right);
+        if (c1 == null || c2 == null) {
+            return null;
+        } else {
+            return new And(c1, c2);
         }
     }
 
@@ -717,6 +734,34 @@ public class OrcFilters {
         @Override
         public String toString() {
             return "OR(" + Arrays.toString(preds) + ")";
+        }
+    }
+
+    /** An AND predicate that can be evaluated by the OrcInputFormat. */
+    public static class And extends Predicate {
+        private final Predicate[] preds;
+
+        /**
+         * Creates an AND predicate.
+         *
+         * @param predicates The conjunctive predicates.
+         */
+        public And(Predicate... predicates) {
+            this.preds = predicates;
+        }
+
+        @Override
+        public SearchArgument.Builder add(SearchArgument.Builder builder) {
+            SearchArgument.Builder withAnd = builder.startAnd();
+            for (Predicate pred : preds) {
+                withAnd = pred.add(withAnd);
+            }
+            return withAnd.end();
+        }
+
+        @Override
+        public String toString() {
+            return "AND(" + Arrays.toString(preds) + ")";
         }
     }
 }

--- a/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
+++ b/flink-formats/flink-orc/src/test/java/org/apache/flink/orc/OrcFileSystemFilterTest.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -74,5 +75,15 @@ class OrcFileSystemFilterTest {
         OrcFilters.Predicate predicate6 =
                 new OrcFilters.LessThan("long1", PredicateLeaf.Type.LONG, 10);
         assertThat(predicate5).hasToString(predicate6.toString());
+
+        // and
+        CallExpression andExpression =
+                CallExpression.permanent(
+                        BuiltInFunctionDefinitions.AND,
+                        Arrays.asList(greaterExpression, lessExpression),
+                        DataTypes.BOOLEAN());
+        OrcFilters.Predicate predicate7 = OrcFilters.toOrcPredicate(andExpression);
+        OrcFilters.Predicate predicate8 = new OrcFilters.And(predicate4, predicate6);
+        assertThat(predicate7).hasToString(predicate8.toString());
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to support AND filter push down in orc.

## Brief change log
  - Added AND predicate in `OrcFilters`


## Verifying this change
This change added tests and can be verified as follows:
  - Added AND filter test in `OrcFileSystemFilterTest`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
