### PR TITLE
[FLINK-31036][test][checkpoint] FileSystemCheckpointStorage as the default for test

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/testutils/MiniClusterResource.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.runtime.testutils;
 
+import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
 import org.apache.flink.configuration.HeartbeatManagerOptions;
@@ -199,6 +200,14 @@ public class MiniClusterResource extends ExternalResource {
                 new Configuration(miniClusterResourceConfiguration.getConfiguration());
         configuration.setString(
                 CoreOptions.TMP_DIRS, temporaryFolder.newFolder().getAbsolutePath());
+        if (!configuration.contains(CheckpointingOptions.CHECKPOINTS_DIRECTORY)) {
+            // The channel state or checkpoint file may exceed the upper limit of
+            // JobManagerCheckpointStorage, so use FileSystemCheckpointStorage as
+            // the default checkpoint storage for all tests.
+            configuration.set(
+                    CheckpointingOptions.CHECKPOINTS_DIRECTORY,
+                    temporaryFolder.newFolder().toURI().toString());
+        }
 
         // we need to set this since a lot of test expect this because TestBaseUtils.startCluster()
         // enabled this by default


### PR DESCRIPTION
## What is the purpose of the change

FileSystemCheckpointStorage as the default for test, because the checkpoint size of JobManagerCheckpointStorage isn't enough in some tests.

## Brief change log

FileSystemCheckpointStorage as the default for test.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? (not documented
