### PR TITLE
[FLINK-31120] Add concurrent access control for collectorIterators in  StreamExecutionEnvironment

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -149,8 +149,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Public
 public class StreamExecutionEnvironment implements AutoCloseable {
 
-    private final List<CollectResultIterator<?>> collectIterators =
-            Collections.synchronizedList(new ArrayList<>());
+    private final List<CollectResultIterator<?>> collectIterators = new ArrayList<>();
 
     @Internal
     public void registerCollectIterator(CollectResultIterator<?> iterator) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/environment/StreamExecutionEnvironment.java
@@ -149,14 +149,12 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
 @Public
 public class StreamExecutionEnvironment implements AutoCloseable {
 
-    private static final List<CollectResultIterator<?>> collectIterators =
+    private final List<CollectResultIterator<?>> collectIterators =
             Collections.synchronizedList(new ArrayList<>());
 
     @Internal
     public void registerCollectIterator(CollectResultIterator<?> iterator) {
-        synchronized (collectIterators) {
-            collectIterators.add(iterator);
-        }
+        collectIterators.add(iterator);
     }
 
     /**
@@ -2202,10 +2200,8 @@ public class StreamExecutionEnvironment implements AutoCloseable {
         try {
             JobClient jobClient = jobClientFuture.get();
             jobListeners.forEach(jobListener -> jobListener.onJobSubmitted(jobClient, null));
-            synchronized (collectIterators) {
-                collectIterators.forEach(iterator -> iterator.setJobClient(jobClient));
-                collectIterators.clear();
-            }
+            collectIterators.forEach(iterator -> iterator.setJobClient(jobClient));
+            collectIterators.clear();
             return jobClient;
         } catch (ExecutionException executionException) {
             final Throwable strippedException =


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*This change mainly to add a concurrent access control for the static list `collectIterators` in `StreamExecutionEnvironment`. There are still chances to cause a ConcurrentModifyException, although most of time we are accessing StreamExecutionEnvironment in a single thread.*


## Brief change log

- Made collectorIterators a synchronizedList in StreamExecutionEnvironment.


## Verifying this change

This change has test cases covered by ITCases which are executed in concurrent mode. It's a stability issue that might have a small probability to reproduce a failure case. 

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
