### PR TITLE
[FLINK-31121] Support discarding too large records in kafka sink

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/kafka.md
+++ b/docs/content.zh/docs/connectors/datastream/kafka.md
@@ -656,4 +656,10 @@ Flink 通过 Kafka 连接器提供了一流的支持，可以对 Kerberos 配置
 这个错误是由于 `FlinkKafkaProducer` 所生成的 `transactional.id` 与其他应用所使用的的产生了冲突。多数情况下，由于 `FlinkKafkaProducer` 产生的 ID 都是以 `taskName + "-" + operatorUid` 为前缀的，这些产生冲突的应用也是使用了相同 Job Graph 的 Flink Job。
 我们可以使用 `setTransactionalIdPrefix()` 方法来覆盖默认的行为，为每个不同的 Job 分配不同的 `transactional.id` 前缀来解决这个问题。
 
+### RecordTooLargeException
+
+The reason for this exception is when a message is larger than the max message size the server will accept,
+and you can set or increase config `max.request.size` to fix it. If you cannot set the configuration value
+and want to discard the large records directly, you can set config`flink.sink.discard-too-large-records` to `true`.
+
 {{< top >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -749,4 +749,10 @@ The reason for this exception is most likely a transaction timeout on the broker
 after a transaction timeout and all of its pending transactions are aborted (each `transactional.id` is
 mapped to a single `producerId`; this is described in more detail in the following [blog post](https://www.confluent.io/blog/simplified-robust-exactly-one-semantics-in-kafka-2-5/)).
 
+### RecordTooLargeException
+
+The reason for this exception is when a message is larger than the max message size the server will accept, 
+and you can set or increase config `max.request.size` to fix it. If you cannot set the configuration value 
+and want to discard the large records directly, you can set config`flink.sink.discard-too-large-records` to `true`.
+
 {{< top >}}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/WriterExceptionHandler.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/sink/WriterExceptionHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kafka.sink;
+
+import org.apache.kafka.common.errors.RecordTooLargeException;
+import org.slf4j.Logger;
+
+/**
+ * Handle exception for kafka sink to discard error records, it could be expended to other sinks if
+ * needed.
+ */
+public interface WriterExceptionHandler {
+    void onException(Exception originalException, Exception thrownException) throws Exception;
+
+    static WriterExceptionHandler createHandler(boolean discardTooLargeRecords, Logger log) {
+        if (discardTooLargeRecords) {
+            return (original, thrown) -> {
+                if (!(original instanceof RecordTooLargeException)) {
+                    throw thrown;
+                }
+                log.warn("Discard record", original);
+            };
+        } else {
+            return (original, thrown) -> {
+                throw thrown;
+            };
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

This PR aims to add an option `flink.sink.discard-too-large-records` to support discarding too large records in kafka sink.

## Brief change log
  - Added `WriterExceptionHandler` to discard too large records in `KafkaWriter`
  - Added option `flink.sink.discard-too-large-records` to turn on/off the above operation


## Verifying this change

This change added tests and can be verified as follows:

  - Added test case `testProduceTooLargeRecord` in `KafkaWriterITCase` to throw exception or discard records which are too large

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no) no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no) no
  - The serializers: (yes / no / don't know) no
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know) no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know) no
  - The S3 file system connector: (yes / no / don't know) no

## Documentation

  - Does this pull request introduce a new feature? (yes / no) no
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
