### PR TITLE
[FLINK-31041][runtime] Fix multiple restoreState when GlobalFailure occurs in a short period.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -377,6 +377,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         final Set<ExecutionVertexID> verticesToRestart =
                 executionVertexVersioner.getUnmodifiedExecutionVertices(executionVertexVersions);
 
+        if (verticesToRestart.isEmpty()) {
+            return;
+        }
+
         removeVerticesFromRestartPending(verticesToRestart);
 
         resetForNewExecutions(verticesToRestart);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/TestingOperatorCoordinator.java
@@ -31,6 +31,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.BiConsumer;
 
 /** A simple testing implementation of the {@link OperatorCoordinator}. */
 public class TestingOperatorCoordinator implements OperatorCoordinator {
@@ -56,6 +57,8 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
     private final BlockingQueue<OperatorEvent> receivedOperatorEvents;
 
     private final Map<Integer, SubtaskGateway> subtaskGateways;
+
+    private BiConsumer<Long, byte[]> resetToCheckpointConsumer;
 
     private boolean started;
     private boolean closed;
@@ -124,6 +127,9 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
 
     @Override
     public void resetToCheckpoint(long checkpointId, @Nullable byte[] checkpointData) {
+        if (resetToCheckpointConsumer != null) {
+            resetToCheckpointConsumer.accept(checkpointId, checkpointData);
+        }
         lastRestoredCheckpointId = checkpointId;
         lastRestoredCheckpointState = checkpointData == null ? NULL_RESTORE_VALUE : checkpointData;
     }
@@ -186,6 +192,10 @@ public class TestingOperatorCoordinator implements OperatorCoordinator {
 
     public boolean hasCompleteCheckpoint() throws InterruptedException {
         return !lastCheckpointComplete.isEmpty();
+    }
+
+    public void setResetToCheckpointConsumer(BiConsumer<Long, byte[]> resetToCheckpointConsumer) {
+        this.resetToCheckpointConsumer = resetToCheckpointConsumer;
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## What is the purpose of the change
This pull request allows DefaultScheduler to skip the restoreState which is a heavy invocation when no task needs to be restarted.

## Brief change log
  - *DefaultScheduler#restartTasks return early when verticesToRestart is empty.*


## Verifying this change

This change added tests and can be verified as follows:
  - *Added test that validates that OperatorCoordinator#resetToCheckpoint will invoke once when fail global twice quickly*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
