### PR TITLE
[FLINK-31084][connectors/dataGen] Add default value for dataGen seque…

### DIFF
--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -141,15 +141,15 @@ CREATE TABLE datagen (
     <tr>
       <td><h5>fields.#.start</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>(Type of field)</td>
+      <td style="word-wrap: break-word;">0</td>
+      <td>Long</td>
       <td>序列生成器的起始值。</td>
     </tr>
     <tr>
       <td><h5>fields.#.end</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>(Type of field)</td>
+      <td style="word-wrap: break-word;">Integer.MAX_VALUE</td>
+      <td>Long</td>
       <td>序列生成器的结束值。</td>
     </tr>
     </tbody>

--- a/docs/content.zh/docs/connectors/table/datagen.md
+++ b/docs/content.zh/docs/connectors/table/datagen.md
@@ -148,7 +148,7 @@ CREATE TABLE datagen (
     <tr>
       <td><h5>fields.#.end</h5></td>
       <td>可选</td>
-      <td style="word-wrap: break-word;">Integer.MAX_VALUE</td>
+      <td style="word-wrap: break-word;">1048576</td>
       <td>Long</td>
       <td>序列生成器的结束值。</td>
     </tr>

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -286,15 +286,15 @@ Connector Options
     <tr>
       <td><h5>fields.#.start</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>(Type of field)</td>
+      <td style="word-wrap: break-word;">0</td>
+      <td>Long</td>
       <td>Start value of sequence generator.</td>
     </tr>
     <tr>
       <td><h5>fields.#.end</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">(none)</td>
-      <td>(Type of field)</td>
+      <td style="word-wrap: break-word;">Integer.MAX_VALUE</td>
+      <td>Long</td>
       <td>End value of sequence generator.</td>
     </tr>
     </tbody>

--- a/docs/content/docs/connectors/table/datagen.md
+++ b/docs/content/docs/connectors/table/datagen.md
@@ -293,7 +293,7 @@ Connector Options
     <tr>
       <td><h5>fields.#.end</h5></td>
       <td>optional</td>
-      <td style="word-wrap: break-word;">Integer.MAX_VALUE</td>
+      <td style="word-wrap: break-word;">1048576</td>
       <td>Long</td>
       <td>End value of sequence generator.</td>
     </tr>

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -50,12 +50,18 @@ public abstract class SequenceGenerator<T> implements DataGenerator<T> {
     /**
      * Creates a DataGenerator that emits all numbers from the given interval exactly once.
      *
+     * <p>He requires that the end must be greater than the start and that the total number cannot
+     * be greater than max-1.
+     *
      * @param start Start of the range of numbers to emit.
      * @param end End of the range of numbers to emit.
      */
     public SequenceGenerator(long start, long end) {
         Preconditions.checkArgument(
                 start < end, "The start value cannot be greater than the end value.");
+        Preconditions.checkArgument(
+                end - start <= Long.MAX_VALUE - 1,
+                "The total quantity exceeds the maximum limit: Long.MAX_VALUE - 1.");
         this.start = start;
         this.end = end;
     }
@@ -86,8 +92,6 @@ public abstract class SequenceGenerator<T> implements DataGenerator<T> {
             final int taskIdx = runtimeContext.getIndexOfThisSubtask();
             final long congruence = start + taskIdx;
 
-            Preconditions.checkArgument(
-                    end - start < Long.MAX_VALUE - 1, "Limit exceeded Long.MAX_VALUE-1");
             long totalNoOfElements = Math.abs(end - start + 1);
             final long baseSize = safeDivide(totalNoOfElements, stepSize);
             final long toCollect =

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -19,6 +19,7 @@
 package org.apache.flink.streaming.api.functions.source.datagen;
 
 import org.apache.flink.annotation.Experimental;
+import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -116,6 +117,16 @@ public abstract class SequenceGenerator<T> implements DataGenerator<T> {
         Preconditions.checkArgument(left >= 0);
         Preconditions.checkArgument(left <= Integer.MAX_VALUE * right);
         return (int) (left / right);
+    }
+
+    @VisibleForTesting
+    public long getStart() {
+        return start;
+    }
+
+    @VisibleForTesting
+    public long getEnd() {
+        return end;
     }
 
     public static SequenceGenerator<Long> longGenerator(long start, long end) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.flink.streaming.api.functions.source.datagen;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Test;
+
+import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link SequenceGenerator}. */
+public class SequenceGeneratorTest {
+
+    @Test
+    public void testStartGreaterThanEnd() {
+        assertThatThrownBy(
+                        () -> {
+                            final long start = 30;
+                            final long end = 20;
+                            SequenceGenerator.longGenerator(start, end);
+                        })
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "The start value cannot be greater than the end value."));
+    }
+
+    @Test
+    public void testTotalQuantity() {
+        assertThatThrownBy(
+                        () -> {
+                            final long start = 0;
+                            final long end = Long.MAX_VALUE;
+                            SequenceGenerator.longGenerator(start, end);
+                        })
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "The total quantity exceeds the maximum limit: Long.MAX_VALUE - 1."));
+
+        final long start1 = 0;
+        final long end1 = Long.MAX_VALUE - 1;
+        SequenceGenerator<Long> generator1 = SequenceGenerator.longGenerator(start1, end1);
+        Assertions.assertThat(generator1.getEnd() - generator1.getStart())
+                .describedAs("The maximum total should be: Long.MAX_VALUE - 1.")
+                .isEqualTo(Long.MAX_VALUE - 1);
+
+        final long start2 = 33;
+        final long end2 = 44;
+        SequenceGenerator<Long> generator2 = SequenceGenerator.longGenerator(start2, end2);
+        Assertions.assertThat(generator2.getEnd() - generator2.getStart())
+                .describedAs("The total quantity should be equal.")
+                .isEqualTo(end2 - start2);
+    }
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.flink.streaming.api.functions.source.datagen;
 
 import org.assertj.core.api.Assertions;

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
@@ -19,9 +19,8 @@
 package org.apache.flink.streaming.api.functions.source.datagen;
 
 import org.assertj.core.api.Assertions;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.apache.flink.core.testutils.FlinkAssertions.anyCauseMatches;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Tests for {@link SequenceGenerator}. */
@@ -29,43 +28,45 @@ public class SequenceGeneratorTest {
 
     @Test
     public void testStartGreaterThanEnd() {
-        assertThatThrownBy(
-                        () -> {
-                            final long start = 30;
-                            final long end = 20;
-                            SequenceGenerator.longGenerator(start, end);
-                        })
-                .satisfies(
-                        anyCauseMatches(
-                                IllegalArgumentException.class,
-                                "The start value cannot be greater than the end value."));
+        final long start = 0;
+        final long end = Long.MAX_VALUE;
+        SequenceGenerator.longGenerator(start, end);
+        assertThatThrownBy(() -> SequenceGenerator.longGenerator(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The start value (%s) cannot be greater than the end value (%s).",
+                        start, end);
     }
 
     @Test
-    public void testTotalQuantity() {
-        assertThatThrownBy(
-                        () -> {
-                            final long start = 0;
-                            final long end = Long.MAX_VALUE;
-                            SequenceGenerator.longGenerator(start, end);
-                        })
-                .satisfies(
-                        anyCauseMatches(
-                                IllegalArgumentException.class,
-                                "The total quantity exceeds the maximum limit: Long.MAX_VALUE - 1."));
+    public void testTooLargeRange() {
+        final long start = 0;
+        final long end = Long.MAX_VALUE;
+        SequenceGenerator.longGenerator(start, end);
+        assertThatThrownBy(() -> SequenceGenerator.longGenerator(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The total size of range (%s, %s) exceeds the maximum limit: Long.MAX_VALUE - 1..",
+                        start, end);
+    }
 
-        final long start1 = 0;
-        final long end1 = Long.MAX_VALUE - 1;
-        SequenceGenerator<Long> generator1 = SequenceGenerator.longGenerator(start1, end1);
-        Assertions.assertThat(generator1.getEnd() - generator1.getStart())
+    @Test
+    public void testMaxRange() {
+        final long start = 0;
+        final long end = Long.MAX_VALUE - 1;
+        SequenceGenerator<Long> generator = SequenceGenerator.longGenerator(start, end);
+        Assertions.assertThat(generator.getEnd() - generator.getStart())
                 .describedAs("The maximum total should be: Long.MAX_VALUE - 1.")
                 .isEqualTo(Long.MAX_VALUE - 1);
+    }
 
-        final long start2 = 33;
-        final long end2 = 44;
-        SequenceGenerator<Long> generator2 = SequenceGenerator.longGenerator(start2, end2);
-        Assertions.assertThat(generator2.getEnd() - generator2.getStart())
+    @Test
+    public void testSequenceCreation() {
+        final long start = 33;
+        final long end = 44;
+        SequenceGenerator<Long> generator = SequenceGenerator.longGenerator(start, end);
+        Assertions.assertThat(generator.getEnd() - generator.getStart())
                 .describedAs("The total quantity should be equal.")
-                .isEqualTo(end2 - start2);
+                .isEqualTo(end - start);
     }
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
@@ -93,4 +93,9 @@ public class DataGenTableSource implements ScanTableSource, SupportsLimitPushDow
     public void applyLimit(long limit) {
         this.numberOfRows = limit;
     }
+
+    @VisibleForTesting
+    public DataGenerator<?>[] getFieldGenerators() {
+        return fieldGenerators;
+    }
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/DataGenTableSource.java
@@ -95,7 +95,7 @@ public class DataGenTableSource implements ScanTableSource, SupportsLimitPushDow
     }
 
     @VisibleForTesting
-    public DataGenerator<?>[] getFieldGenerators() {
+    DataGenerator<?>[] getFieldGenerators() {
         return fieldGenerators;
     }
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitor.java
@@ -48,10 +48,6 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
 
     private final ReadableConfig config;
 
-    private final String startKeyStr;
-
-    private final String endKeyStr;
-
     private final ConfigOption<Integer> intStart;
 
     private final ConfigOption<Integer> intEnd;
@@ -60,32 +56,35 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
 
     private final ConfigOption<Long> longEnd;
 
+    static final int START_DEFAULT_VALUE = 0;
+    static final int END_DEFAULT_VALUE = 1048576;
+
     public SequenceGeneratorVisitor(String name, ReadableConfig config) {
         super(name, config);
 
         this.config = config;
 
-        this.startKeyStr =
-                DataGenConnectorOptionsUtil.FIELDS
-                        + "."
-                        + name
-                        + "."
-                        + DataGenConnectorOptionsUtil.START;
-        this.endKeyStr =
-                DataGenConnectorOptionsUtil.FIELDS
-                        + "."
-                        + name
-                        + "."
-                        + DataGenConnectorOptionsUtil.END;
+        String startKeyStr =
+                String.join(
+                        ".",
+                        DataGenConnectorOptionsUtil.FIELDS,
+                        name,
+                        DataGenConnectorOptionsUtil.START);
+        String endKeyStr =
+                String.join(
+                        ".",
+                        DataGenConnectorOptionsUtil.FIELDS,
+                        name,
+                        DataGenConnectorOptionsUtil.END);
 
         ConfigOptions.OptionBuilder startKey = key(startKeyStr);
         ConfigOptions.OptionBuilder endKey = key(endKeyStr);
 
         // Under sequence, if end and start are not set, the default value is used
-        this.intStart = startKey.intType().defaultValue(0);
-        this.intEnd = endKey.intType().defaultValue(Integer.MAX_VALUE);
-        this.longStart = startKey.longType().defaultValue(0L);
-        this.longEnd = endKey.longType().defaultValue((long) Integer.MAX_VALUE);
+        this.intStart = startKey.intType().defaultValue(START_DEFAULT_VALUE);
+        this.intEnd = endKey.intType().defaultValue(END_DEFAULT_VALUE);
+        this.longStart = startKey.longType().defaultValue((long) START_DEFAULT_VALUE);
+        this.longEnd = endKey.longType().defaultValue((long) END_DEFAULT_VALUE);
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitor.java
@@ -24,7 +24,6 @@ import org.apache.flink.configuration.ConfigOptions;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.functions.source.datagen.RandomGenerator;
 import org.apache.flink.streaming.api.functions.source.datagen.SequenceGenerator;
-import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.BigIntType;
 import org.apache.flink.table.types.logical.BinaryType;
@@ -82,25 +81,11 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
         ConfigOptions.OptionBuilder startKey = key(startKeyStr);
         ConfigOptions.OptionBuilder endKey = key(endKeyStr);
 
-        config.getOptional(startKey.stringType().noDefaultValue())
-                .orElseThrow(
-                        () ->
-                                new ValidationException(
-                                        "Could not find required property '"
-                                                + startKeyStr
-                                                + "' for sequence generator."));
-        config.getOptional(endKey.stringType().noDefaultValue())
-                .orElseThrow(
-                        () ->
-                                new ValidationException(
-                                        "Could not find required property '"
-                                                + endKeyStr
-                                                + "' for sequence generator."));
-
-        this.intStart = startKey.intType().noDefaultValue();
-        this.intEnd = endKey.intType().noDefaultValue();
-        this.longStart = startKey.longType().noDefaultValue();
-        this.longEnd = endKey.longType().noDefaultValue();
+        // Under sequence, if end and start are not set, the default value is used
+        this.intStart = startKey.intType().defaultValue(0);
+        this.intEnd = endKey.intType().defaultValue(Integer.MAX_VALUE);
+        this.longStart = startKey.longType().defaultValue(0L);
+        this.longEnd = endKey.longType().defaultValue((long) Integer.MAX_VALUE);
     }
 
     @Override

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitorTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitorTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.datagen.table;
+
+import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
+import org.apache.flink.streaming.api.functions.source.datagen.SequenceGenerator;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.apache.flink.table.factories.utils.FactoryMocks.createTableSource;
+
+/** Tests for {@link SequenceGeneratorVisitor}. */
+public class SequenceGeneratorVisitorTest {
+
+    @Test
+    void testDefaultValueForSequence() {
+        DescriptorProperties descriptor = new DescriptorProperties();
+        descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+        descriptor.putString(
+                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.KIND,
+                DataGenConnectorOptionsUtil.SEQUENCE);
+
+        DataGenTableSource source =
+                (DataGenTableSource)
+                        createTableSource(
+                                ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
+                                descriptor.asMap());
+        DataGenerator<?>[] fieldGenerators = source.getFieldGenerators();
+        SequenceGenerator<?> fieldGenerator = (SequenceGenerator<?>) fieldGenerators[0];
+        long start = fieldGenerator.getStart();
+        long end = fieldGenerator.getEnd();
+
+        Assertions.assertThat(SequenceGeneratorVisitor.START_DEFAULT_VALUE)
+                .describedAs(
+                        "The default start value should be %s.",
+                        SequenceGeneratorVisitor.START_DEFAULT_VALUE)
+                .isEqualTo(start);
+        Assertions.assertThat(SequenceGeneratorVisitor.END_DEFAULT_VALUE)
+                .describedAs(
+                        "The default start value should be %s.",
+                        SequenceGeneratorVisitor.END_DEFAULT_VALUE)
+                .isEqualTo(end);
+    }
+
+    @Test
+    void testStartEndForSequence() {
+        DescriptorProperties descriptor = new DescriptorProperties();
+        descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+        descriptor.putString(
+                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.KIND,
+                DataGenConnectorOptionsUtil.SEQUENCE);
+        final int setupStart = 10;
+        descriptor.putLong(
+                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.START,
+                setupStart);
+        final int setupEnd = 100;
+        descriptor.putLong(
+                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.END,
+                setupEnd);
+
+        DataGenTableSource source =
+                (DataGenTableSource)
+                        createTableSource(
+                                ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
+                                descriptor.asMap());
+        DataGenerator<?>[] fieldGenerators = source.getFieldGenerators();
+        SequenceGenerator<?> fieldGenerator = (SequenceGenerator<?>) fieldGenerators[0];
+        long start = fieldGenerator.getStart();
+        long end = fieldGenerator.getEnd();
+
+        Assertions.assertThat(setupStart)
+                .describedAs("The default start value should be %s. ", setupStart)
+                .isEqualTo(start);
+        Assertions.assertThat(setupEnd)
+                .describedAs("The default start value should be %s. ", setupEnd)
+                .isEqualTo(end);
+    }
+}

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -327,66 +327,6 @@ class DataGenTableSourceFactoryTest {
     }
 
     @Test
-    void testCornerCaseForSequence() {
-        // An example of testing that the end value is greater than the start value
-        assertThatThrownBy(
-                        () -> {
-                            DescriptorProperties descriptor = new DescriptorProperties();
-                            descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-                            descriptor.putString(
-                                    DataGenConnectorOptionsUtil.FIELDS
-                                            + ".f0."
-                                            + DataGenConnectorOptionsUtil.KIND,
-                                    DataGenConnectorOptionsUtil.SEQUENCE);
-                            descriptor.putLong(
-                                    DataGenConnectorOptionsUtil.FIELDS
-                                            + ".f0."
-                                            + DataGenConnectorOptionsUtil.START,
-                                    100);
-                            descriptor.putLong(
-                                    DataGenConnectorOptionsUtil.FIELDS
-                                            + ".f0."
-                                            + DataGenConnectorOptionsUtil.END,
-                                    10);
-                            createTableSource(
-                                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
-                                    descriptor.asMap());
-                        })
-                .satisfies(
-                        anyCauseMatches(
-                                IllegalArgumentException.class,
-                                "The start value cannot be greater than the end value."));
-
-        // Example of testing end=Long.MAX_VALUE
-        assertThatThrownBy(
-                        () -> {
-                            DescriptorProperties descriptor = new DescriptorProperties();
-                            descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-                            descriptor.putString(
-                                    DataGenConnectorOptionsUtil.FIELDS
-                                            + ".f0."
-                                            + DataGenConnectorOptionsUtil.KIND,
-                                    DataGenConnectorOptionsUtil.SEQUENCE);
-                            descriptor.putLong(
-                                    DataGenConnectorOptionsUtil.FIELDS
-                                            + ".f0."
-                                            + DataGenConnectorOptionsUtil.START,
-                                    0);
-                            descriptor.putLong(
-                                    DataGenConnectorOptionsUtil.FIELDS
-                                            + ".f0."
-                                            + DataGenConnectorOptionsUtil.END,
-                                    Long.MAX_VALUE);
-                            runGenerator(
-                                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
-                                    descriptor);
-                        })
-                .satisfies(
-                        anyCauseMatches(
-                                IllegalArgumentException.class, "Limit exceeded Long.MAX_VALUE-1"));
-    }
-
-    @Test
     void testWrongKey() {
         assertThatThrownBy(
                         () -> {

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -23,10 +23,8 @@ import org.apache.flink.connector.datagen.table.DataGenConnectorOptionsUtil;
 import org.apache.flink.connector.datagen.table.DataGenTableSource;
 import org.apache.flink.connector.datagen.table.DataGenTableSourceFactory;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
-import org.apache.flink.streaming.api.functions.source.datagen.DataGenerator;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSource;
 import org.apache.flink.streaming.api.functions.source.datagen.DataGeneratorSourceTest;
-import org.apache.flink.streaming.api.functions.source.datagen.SequenceGenerator;
 import org.apache.flink.streaming.api.operators.StreamSource;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.util.AbstractStreamOperatorTestHarness;
@@ -40,7 +38,6 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.descriptors.DescriptorProperties;
 import org.apache.flink.util.InstantiationUtil;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -264,66 +261,6 @@ class DataGenTableSourceFactoryTest {
                     }
                 },
                 expectedOutput);
-    }
-
-    @Test
-    void testDefaultValueForSequence() {
-        DescriptorProperties descriptor = new DescriptorProperties();
-        descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-        descriptor.putString(
-                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.KIND,
-                DataGenConnectorOptionsUtil.SEQUENCE);
-
-        DataGenTableSource source =
-                (DataGenTableSource)
-                        createTableSource(
-                                ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
-                                descriptor.asMap());
-        DataGenerator<?>[] fieldGenerators = source.getFieldGenerators();
-        SequenceGenerator<?> fieldGenerator = (SequenceGenerator<?>) fieldGenerators[0];
-        long start = fieldGenerator.getStart();
-        long end = fieldGenerator.getEnd();
-
-        Assertions.assertThat(0)
-                .describedAs("The default start value should be 0")
-                .isEqualTo(start);
-        Assertions.assertThat(Integer.MAX_VALUE)
-                .describedAs("The default start value should be Integer.MAX_VALUE")
-                .isEqualTo(end);
-    }
-
-    @Test
-    void testStartEndForSequence() {
-        DescriptorProperties descriptor = new DescriptorProperties();
-        descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
-        descriptor.putString(
-                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.KIND,
-                DataGenConnectorOptionsUtil.SEQUENCE);
-        final int setupStart = 10;
-        descriptor.putLong(
-                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.START,
-                setupStart);
-        final int setupEnd = 100;
-        descriptor.putLong(
-                DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.END,
-                setupEnd);
-
-        DataGenTableSource source =
-                (DataGenTableSource)
-                        createTableSource(
-                                ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
-                                descriptor.asMap());
-        DataGenerator<?>[] fieldGenerators = source.getFieldGenerators();
-        SequenceGenerator<?> fieldGenerator = (SequenceGenerator<?>) fieldGenerators[0];
-        long start = fieldGenerator.getStart();
-        long end = fieldGenerator.getEnd();
-
-        Assertions.assertThat(setupStart)
-                .describedAs("The default start value should be " + setupStart)
-                .isEqualTo(start);
-        Assertions.assertThat(setupEnd)
-                .describedAs("The default start value should be " + setupEnd)
-                .isEqualTo(end);
     }
 
     @Test

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -327,6 +327,66 @@ class DataGenTableSourceFactoryTest {
     }
 
     @Test
+    void testCornerCaseForSequence() {
+        // An example of testing that the end value is greater than the start value
+        assertThatThrownBy(
+                        () -> {
+                            DescriptorProperties descriptor = new DescriptorProperties();
+                            descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+                            descriptor.putString(
+                                    DataGenConnectorOptionsUtil.FIELDS
+                                            + ".f0."
+                                            + DataGenConnectorOptionsUtil.KIND,
+                                    DataGenConnectorOptionsUtil.SEQUENCE);
+                            descriptor.putLong(
+                                    DataGenConnectorOptionsUtil.FIELDS
+                                            + ".f0."
+                                            + DataGenConnectorOptionsUtil.START,
+                                    100);
+                            descriptor.putLong(
+                                    DataGenConnectorOptionsUtil.FIELDS
+                                            + ".f0."
+                                            + DataGenConnectorOptionsUtil.END,
+                                    10);
+                            createTableSource(
+                                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
+                                    descriptor.asMap());
+                        })
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class,
+                                "The start value cannot be greater than the end value."));
+
+        // Example of testing end=Long.MAX_VALUE
+        assertThatThrownBy(
+                        () -> {
+                            DescriptorProperties descriptor = new DescriptorProperties();
+                            descriptor.putString(FactoryUtil.CONNECTOR.key(), "datagen");
+                            descriptor.putString(
+                                    DataGenConnectorOptionsUtil.FIELDS
+                                            + ".f0."
+                                            + DataGenConnectorOptionsUtil.KIND,
+                                    DataGenConnectorOptionsUtil.SEQUENCE);
+                            descriptor.putLong(
+                                    DataGenConnectorOptionsUtil.FIELDS
+                                            + ".f0."
+                                            + DataGenConnectorOptionsUtil.START,
+                                    0);
+                            descriptor.putLong(
+                                    DataGenConnectorOptionsUtil.FIELDS
+                                            + ".f0."
+                                            + DataGenConnectorOptionsUtil.END,
+                                    Long.MAX_VALUE);
+                            runGenerator(
+                                    ResolvedSchema.of(Column.physical("f0", DataTypes.BIGINT())),
+                                    descriptor);
+                        })
+                .satisfies(
+                        anyCauseMatches(
+                                IllegalArgumentException.class, "Limit exceeded Long.MAX_VALUE-1"));
+    }
+
+    @Test
     void testWrongKey() {
         assertThatThrownBy(
                         () -> {

--- a/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
+++ b/flink-table/flink-table-api-java-bridge/src/test/java/org/apache/flink/table/factories/DataGenTableSourceFactoryTest.java
@@ -299,11 +299,11 @@ class DataGenTableSourceFactoryTest {
         descriptor.putString(
                 DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.KIND,
                 DataGenConnectorOptionsUtil.SEQUENCE);
-        int setupStart = 0;
+        final int setupStart = 10;
         descriptor.putLong(
                 DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.START,
                 setupStart);
-        int setupEnd = 100;
+        final int setupEnd = 100;
         descriptor.putLong(
                 DataGenConnectorOptionsUtil.FIELDS + ".f0." + DataGenConnectorOptionsUtil.END,
                 setupEnd);

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/DefaultLookupCache.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/connector/source/lookup/cache/DefaultLookupCache.java
@@ -244,7 +244,6 @@ public class DefaultLookupCache implements LookupCache {
                             + "potential memory issues as the cache size may grow infinitely.");
         }
     }
-
     /** Builder for {@link DefaultLookupCache}. */
     @PublicEvolving
     public static class Builder {


### PR DESCRIPTION
## What is the purpose of the change
The field configuration description of datagen is optional, but in actual sequence mode, start and end are required, as a user, I would expect the positive integer values to be returned starting from 0 if I don't specify anything here.

## Brief change log
- Added default value for sequence mode
- Modify the original test method, because it is not applicable after adding the default
- Modify the document default value description

## Verifying this change
This change modifies the original testLackStartForSequence and testLackEndForSequence methods of DataGenTableSourceFactoryTest and replaces them with testDefaultValueForSequence and testStartEndForSequence methods to verify this change.
Increase SequenceGeneratorTest.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency):  no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:  / no
  - The serializers:  no 
  - The runtime per-record code paths (performance sensitive):  no 
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:  no 
  - The S3 file system connector:  no 

## Documentation
  - Does this pull request introduce a new feature?  no
