### PR TITLE
[FLINK-31119][tests] Use even # of slots 

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobRecoveryITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/JobRecoveryITCase.java
@@ -47,7 +47,7 @@ import static org.junit.Assert.assertThat;
 public class JobRecoveryITCase extends TestLogger {
 
     private static final int NUM_TMS = 1;
-    private static final int SLOTS_PER_TM = 11;
+    private static final int SLOTS_PER_TM = 10;
     private static final int PARALLELISM = NUM_TMS * SLOTS_PER_TM;
 
     @ClassRule

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
@@ -25,8 +25,6 @@ import org.apache.flink.runtime.io.network.api.writer.RecordWriterBuilder;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.types.IntValue;
 
-import java.util.concurrent.CompletableFuture;
-
 /** {@link AbstractInvokable} for testing purposes. */
 public class TestingAbstractInvokables {
 
@@ -82,40 +80,6 @@ public class TestingAbstractInvokables {
             if (i1.getValue() != 42 || i2.getValue() != 1337 || i3 != null) {
                 throw new Exception("Wrong data received.");
             }
-        }
-    }
-
-    public static final class TestInvokableRecordCancel extends AbstractInvokable {
-
-        private static CompletableFuture<Boolean> gotCanceledFuture = new CompletableFuture<>();
-
-        public TestInvokableRecordCancel(Environment environment) {
-            super(environment);
-        }
-
-        @Override
-        public void invoke() throws Exception {
-            final Object o = new Object();
-            RecordWriter<IntValue> recordWriter =
-                    new RecordWriterBuilder<IntValue>().build(getEnvironment().getWriter(0));
-            for (int i = 0; i < 1024; i++) {
-                recordWriter.emit(new IntValue(42));
-            }
-
-            gotCanceledFuture.get();
-        }
-
-        @Override
-        public void cancel() {
-            gotCanceledFuture.complete(true);
-        }
-
-        public static void resetGotCanceledFuture() {
-            gotCanceledFuture = new CompletableFuture<>();
-        }
-
-        public static CompletableFuture<Boolean> gotCanceled() {
-            return gotCanceledFuture;
         }
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/jobmaster/TestingAbstractInvokables.java
@@ -58,6 +58,8 @@ public class TestingAbstractInvokables {
     /**
      * Basic receiver {@link AbstractInvokable} which verifies the sent elements from the {@link
      * Sender}.
+     *
+     * <p>This invokable must not run with a higher parallelism than {@link Sender}.
      */
     public static class Receiver extends AbstractInvokable {
 


### PR DESCRIPTION
The Sender/Receiver invokables assume that the receiver is run with parallelism greater or equal to the sender invokable.
If this is not satisfied than there is no input gate to read from, causing read operations to fail.

The test was using an uneven number of slots. This caused one invokable to run with p=5, the other with p=6.
Depending on who gets this 6th slot the test would fail or pass.

I don't think there's a well-defined order in which this should happen, so I attribute this to wrong assumptions in the test.

For clarity, with FLINK-30895 the adaptive scheduler assigns slots in order of maximum parallelism, and if 2 vertices have the same parallelism then by iteration order over a hash map. Previously it would assign them in whatever iteration order vertices were passed to the scheduler.