### PR TITLE
[FLINK-31139][state/changelog] not upload empty state changelog file

### DIFF
--- a/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
+++ b/flink-dstl/flink-dstl-dfs/src/main/java/org/apache/flink/changelog/fs/BatchingStateChangeUploadScheduler.java
@@ -223,6 +223,11 @@ class BatchingStateChangeUploadScheduler implements StateChangeUploadScheduler {
             scheduledBytesCounter = 0;
             scheduledFuture = null;
         }
+
+        if (tasks.size() == 0) {
+            return;
+        }
+
         try {
             Throwable error = getErrorSafe();
             if (error != null) {


### PR DESCRIPTION
## What is the purpose of the change

not upload empty state changelog file, described in [FLINK-31139](https://issues.apache.org/jira/browse/FLINK-31139).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)