### PR TITLE
[BP-1.17][FLINK-31132] Let hive compact operator without setting parallelism subject to sink operator's configured parallelism.

### DIFF
--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/batch/BatchSink.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/table/batch/BatchSink.java
@@ -52,6 +52,11 @@ import java.util.LinkedHashMap;
 /** Helper for creating batch file sink. */
 @Internal
 public class BatchSink {
+
+    public static final String COORDINATOR_OP_NAME = "compact-coordinator";
+
+    public static final String COMPACT_OP_NAME = "compact-operator";
+
     private BatchSink() {}
 
     public static DataStreamSink<Row> createBatchNoCompactSink(
@@ -100,14 +105,14 @@ public class BatchSink {
         SingleOutputStreamOperator<CompactMessages.CompactOutput> transform =
                 dataStream
                         .transform(
-                                "coordinator",
+                                COORDINATOR_OP_NAME,
                                 TypeInformation.of(CompactMessages.CoordinatorOutput.class),
                                 new BatchCompactCoordinator(
                                         fsSupplier, compactAverageSize, compactTargetSize))
                         .setParallelism(1)
                         .setMaxParallelism(1)
                         .transform(
-                                "compact",
+                                COMPACT_OP_NAME,
                                 TypeInformation.of(CompactMessages.CompactOutput.class),
                                 new BatchCompactOperator<>(fsSupplier, readFactory, writerFactory));
         transform

--- a/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
+++ b/flink-connectors/flink-connector-hive/src/main/java/org/apache/flink/connectors/hive/HiveTableSink.java
@@ -301,7 +301,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
             final int sinkParallelism =
                     Optional.ofNullable(configuredSinkParallelism)
                             .orElse(dataStream.getParallelism());
-            boolean sinkParallelismConfigued = configuredSinkParallelism != null;
+            boolean sinkParallelismConfigured = configuredSinkParallelism != null;
             if (isBounded) {
                 TableMetaStoreFactory msFactory =
                         isInsertDirectory
@@ -338,7 +338,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                         isToLocal,
                         overwrite,
                         sinkParallelism,
-                        sinkParallelismConfigued);
+                        sinkParallelismConfigured);
             } else {
                 if (overwrite) {
                     throw new IllegalStateException("Streaming mode not support overwrite.");
@@ -351,7 +351,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                         writerFactory,
                         fileNamingBuilder,
                         sinkParallelism,
-                        sinkParallelismConfigued);
+                        sinkParallelismConfigured);
             }
         } catch (IOException e) {
             throw new FlinkRuntimeException("Failed to create staging dir", e);
@@ -374,7 +374,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
             boolean isToLocal,
             boolean overwrite,
             int sinkParallelism,
-            boolean sinkParallelismkConfigured)
+            boolean sinkParallelismConfigured)
             throws IOException {
         org.apache.flink.configuration.Configuration conf =
                 new org.apache.flink.configuration.Configuration();
@@ -402,7 +402,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                     overwrite,
                     sinkParallelism,
                     compactParallelism,
-                    sinkParallelismkConfigured,
+                    sinkParallelismConfigured,
                     compactParallelismOptional.isPresent());
         } else {
             return createBatchNoCompactSink(
@@ -414,7 +414,7 @@ public class HiveTableSink implements DynamicTableSink, SupportsPartitioning, Su
                     stagingParentDir,
                     isToLocal,
                     sinkParallelism,
-                    sinkParallelismkConfigured);
+                    sinkParallelismConfigured);
         }
     }
 

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkITCase.java
@@ -77,7 +77,7 @@ public class HiveTableCompactSinkITCase {
                         + ") TBLPROPERTIES ("
                         + " 'auto-compaction' = 'true', "
                         + " 'compaction.small-files.avg-size' = '1b', "
-                        + " 'sink.parallelism' = '4'" // set sink parallelism = 8
+                        + " 'sink.parallelism' = '4'" // set sink parallelism = 4
                         + ")");
         tableEnv.executeSql(
                         "insert into src values ('k1', 'v1'), ('k2', 'v2'),"
@@ -100,7 +100,7 @@ public class HiveTableCompactSinkITCase {
                         + " value string"
                         + ") TBLPROPERTIES ("
                         + " 'auto-compaction' = 'true', "
-                        + " 'sink.parallelism' = '4'" // set sink parallelism = 8
+                        + " 'sink.parallelism' = '4'" // set sink parallelism = 4
                         + ")");
         tableEnv.executeSql(
                         "insert into src values ('k1', 'v1'), ('k2', 'v2'),"
@@ -166,7 +166,7 @@ public class HiveTableCompactSinkITCase {
                         + ") partitioned by (p int) TBLPROPERTIES ("
                         + " 'auto-compaction' = 'true', "
                         + " 'compaction.small-files.avg-size' = '9b', "
-                        + " 'sink.parallelism' = '4'" // set sink parallelism = 8
+                        + " 'sink.parallelism' = '4'" // set sink parallelism = 4
                         + ")");
 
         tableEnv.executeSql(

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkITCase.java
@@ -26,11 +26,13 @@ import org.apache.flink.table.catalog.hive.HiveTestUtils;
 import org.apache.flink.test.junit5.MiniClusterExtension;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
+import org.apache.flink.util.TestLoggerExtension;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import java.nio.file.Files;
@@ -42,17 +44,18 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** IT case for Hive table compaction in batch mode. */
-public class HiveTableCompactSinkITCase {
+@ExtendWith(TestLoggerExtension.class)
+class HiveTableCompactSinkITCase {
 
     @RegisterExtension
-    private static final MiniClusterExtension MINI_CLUSTER = new MiniClusterExtension();
+    public static final MiniClusterExtension MINI_CLUSTER = new MiniClusterExtension();
 
     private TableEnvironment tableEnv;
     private HiveCatalog hiveCatalog;
     private String warehouse;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         hiveCatalog = HiveTestUtils.createHiveCatalog();
         hiveCatalog.open();
         warehouse = hiveCatalog.getHiveConf().getVar(HiveConf.ConfVars.METASTOREWAREHOUSE);
@@ -62,14 +65,14 @@ public class HiveTableCompactSinkITCase {
     }
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         if (hiveCatalog != null) {
             hiveCatalog.close();
         }
     }
 
     @Test
-    public void testNoCompaction() throws Exception {
+    void testNoCompaction() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE src ("
                         + " key string,"
@@ -93,7 +96,7 @@ public class HiveTableCompactSinkITCase {
     }
 
     @Test
-    public void testCompactNonPartitionedTable() throws Exception {
+    void testCompactNonPartitionedTable() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE src ("
                         + " key string,"
@@ -115,7 +118,7 @@ public class HiveTableCompactSinkITCase {
     }
 
     @Test
-    public void testCompactPartitionedTable() throws Exception {
+    void testCompactPartitionedTable() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE src ("
                         + " key string,"
@@ -158,7 +161,7 @@ public class HiveTableCompactSinkITCase {
     }
 
     @Test
-    public void testConditionalCompact() throws Exception {
+    void testConditionalCompact() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE src ("
                         + " key string,"

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkParallelismTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableCompactSinkParallelismTest.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.hive;
+
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.connector.file.table.batch.BatchSink;
+import org.apache.flink.table.api.SqlDialect;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.catalog.hive.HiveCatalog;
+import org.apache.flink.table.catalog.hive.HiveTestUtils;
+import org.apache.flink.table.operations.ModifyOperation;
+import org.apache.flink.table.operations.Operation;
+import org.apache.flink.table.planner.delegation.PlannerBase;
+import org.apache.flink.util.TestLoggerExtension;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.COMPACTION_PARALLELISM;
+import static org.apache.flink.connector.file.table.FileSystemConnectorOptions.SINK_PARALLELISM;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests to verify operator's parallelism of {@link HiveTableSink} enabled auto-compaction. */
+@ExtendWith(TestLoggerExtension.class)
+class HiveTableCompactSinkParallelismTest {
+    /**
+     * Represents the parallelism doesn't need to be checked, it should follow the setting of planer
+     * or auto inference.
+     */
+    public static final int NO_NEED_TO_CHECK_PARALLELISM = -1;
+
+    private HiveCatalog catalog;
+
+    private TableEnvironment tableEnv;
+
+    @BeforeEach
+    void before() {
+        catalog = HiveTestUtils.createHiveCatalog();
+        catalog.open();
+        tableEnv = HiveTestUtils.createTableEnvInBatchMode(SqlDialect.HIVE);
+        tableEnv.registerCatalog(catalog.getName(), catalog);
+        tableEnv.useCatalog(catalog.getName());
+    }
+
+    @AfterEach
+    void after() {
+        if (catalog != null) {
+            catalog.close();
+        }
+    }
+
+    /** If only sink parallelism is set, compact operator should follow this setting. */
+    @Test
+    void testOnlySetSinkParallelism() {
+        final int sinkParallelism = 4;
+
+        tableEnv.executeSql(
+                String.format(
+                        "CREATE TABLE src ("
+                                + " key string,"
+                                + " value string"
+                                + ") TBLPROPERTIES ("
+                                + " 'auto-compaction' = 'true', "
+                                + " '%s' = '%s' )",
+                        SINK_PARALLELISM.key(), sinkParallelism));
+
+        assertSinkAndCompactOperatorParallelism(true, true, sinkParallelism, sinkParallelism);
+    }
+
+    @Test
+    void testOnlySetCompactParallelism() {
+        final int compactParallelism = 4;
+
+        tableEnv.executeSql(
+                String.format(
+                        "CREATE TABLE src ("
+                                + " key string,"
+                                + " value string"
+                                + ") TBLPROPERTIES ("
+                                + " 'auto-compaction' = 'true', "
+                                + " '%s' = '%s' )",
+                        COMPACTION_PARALLELISM.key(), compactParallelism));
+
+        assertSinkAndCompactOperatorParallelism(
+                false, true, NO_NEED_TO_CHECK_PARALLELISM, compactParallelism);
+    }
+
+    @Test
+    void testSetBothSinkAndCompactParallelism() {
+        final int sinkParallelism = 8;
+        final int compactParallelism = 4;
+
+        tableEnv.executeSql(
+                String.format(
+                        "CREATE TABLE src ("
+                                + " key string,"
+                                + " value string"
+                                + ") TBLPROPERTIES ("
+                                + " 'auto-compaction' = 'true', "
+                                + " '%s' = '%s', "
+                                + " '%s' = '%s' )",
+                        SINK_PARALLELISM.key(),
+                        sinkParallelism,
+                        COMPACTION_PARALLELISM.key(),
+                        compactParallelism));
+
+        assertSinkAndCompactOperatorParallelism(true, true, sinkParallelism, compactParallelism);
+    }
+
+    @Test
+    void testSinkAndCompactAllNotSetParallelism() {
+        tableEnv.executeSql(
+                "CREATE TABLE src ("
+                        + " key string,"
+                        + " value string"
+                        + ") TBLPROPERTIES ("
+                        + " 'auto-compaction' = 'true' )");
+        assertSinkAndCompactOperatorParallelism(
+                false, false, NO_NEED_TO_CHECK_PARALLELISM, NO_NEED_TO_CHECK_PARALLELISM);
+    }
+
+    private void assertSinkAndCompactOperatorParallelism(
+            boolean isSinkParallelismConfigured,
+            boolean isCompactParallelismConfigured,
+            int expectedSinkParallelism,
+            int expectedCompactParallelism) {
+        String statement = "insert into src values ('k1', 'v1'), ('k2', 'v2');";
+        PlannerBase planner = (PlannerBase) ((TableEnvironmentImpl) tableEnv).getPlanner();
+        planner.getExecEnv().setParallelism(10);
+        List<Operation> operations = planner.getParser().parse(statement);
+        List<Transformation<?>> transformations =
+                planner.translate(Collections.singletonList((ModifyOperation) (operations.get(0))));
+        assertThat(transformations).hasSize(1);
+        Transformation<?> rootTransformation = transformations.get(0);
+        Transformation<?> compactTransformation =
+                findTransformationByName(rootTransformation, BatchSink.COMPACT_OP_NAME);
+        Transformation<?> hiveSinkTransformation =
+                findTransformationByName(
+                        rootTransformation, HiveTableSink.BATCH_COMPACT_WRITER_OP_NAME);
+        assertThat(hiveSinkTransformation.isParallelismConfigured())
+                .isEqualTo(isSinkParallelismConfigured);
+        assertThat(compactTransformation.isParallelismConfigured())
+                .isEqualTo(isCompactParallelismConfigured);
+        if (expectedSinkParallelism != NO_NEED_TO_CHECK_PARALLELISM) {
+            assertThat(hiveSinkTransformation.getParallelism()).isEqualTo(expectedSinkParallelism);
+        }
+        if (expectedCompactParallelism != NO_NEED_TO_CHECK_PARALLELISM) {
+            assertThat(compactTransformation.getParallelism())
+                    .isEqualTo(expectedCompactParallelism);
+        }
+    }
+
+    /**
+     * This method will recursively look forward to the transformation whose name meets the
+     * requirements. For simplicity, let's assume that each transformation has at most one input.
+     */
+    private static Transformation<?> findTransformationByName(
+            Transformation<?> transformation, String name) {
+        if (transformation == null) {
+            return null;
+        }
+
+        if (transformation.getName().equals(name)) {
+            return transformation;
+        }
+
+        return findTransformationByName(transformation.getInputs().get(0), name);
+    }
+}

--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/connectors/hive/HiveTableFactoryTest.java
@@ -44,10 +44,12 @@ import org.apache.flink.table.sinks.StreamTableSink;
 import org.apache.flink.table.sinks.TableSink;
 import org.apache.flink.table.sources.StreamTableSource;
 import org.apache.flink.table.sources.TableSource;
+import org.apache.flink.util.TestLoggerExtension;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -57,22 +59,23 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link HiveTableFactory}. */
-public class HiveTableFactoryTest {
+@ExtendWith(TestLoggerExtension.class)
+class HiveTableFactoryTest {
     private static HiveCatalog catalog;
 
-    @BeforeClass
-    public static void init() {
+    @BeforeAll
+    static void init() {
         catalog = HiveTestUtils.createHiveCatalog();
         catalog.open();
     }
 
-    @AfterClass
-    public static void close() {
+    @AfterAll
+    static void close() {
         catalog.close();
     }
 
     @Test
-    public void testGenericTable() throws Exception {
+    void testGenericTable() throws Exception {
         final TableSchema schema =
                 TableSchema.builder()
                         .field("name", DataTypes.STRING())
@@ -111,7 +114,7 @@ public class HiveTableFactoryTest {
     }
 
     @Test
-    public void testHiveTable() throws Exception {
+    void testHiveTable() throws Exception {
         final ResolvedSchema schema =
                 ResolvedSchema.of(
                         Column.physical("name", DataTypes.STRING()),

--- a/flink-connectors/flink-connector-hive/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-connectors/flink-connector-hive/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,34 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
Backport FLINK-31132 to release-1.17.
