### PR TITLE
[FLINK-31166][table] Fix array_contains does not support null argumen…

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayElementArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayElementArgumentTypeStrategy.java
@@ -42,7 +42,7 @@ class ArrayElementArgumentTypeStrategy implements ArgumentTypeStrategy {
             CallContext callContext, int argumentPos, boolean throwOnFailure) {
         final ArrayType haystackType =
                 (ArrayType) callContext.getArgumentDataTypes().get(0).getLogicalType();
-        final LogicalType haystackElementType = haystackType.getElementType();
+        final LogicalType haystackElementType = haystackType.getElementType().copy(true);
         final LogicalType needleType =
                 callContext.getArgumentDataTypes().get(argumentPos).getLogicalType();
         if (supportsImplicitCast(needleType, haystackElementType)) {

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayElementArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayElementArgumentTypeStrategy.java
@@ -42,9 +42,14 @@ class ArrayElementArgumentTypeStrategy implements ArgumentTypeStrategy {
             CallContext callContext, int argumentPos, boolean throwOnFailure) {
         final ArrayType haystackType =
                 (ArrayType) callContext.getArgumentDataTypes().get(0).getLogicalType();
-        final LogicalType haystackElementType = haystackType.getElementType().copy(true);
         final LogicalType needleType =
                 callContext.getArgumentDataTypes().get(argumentPos).getLogicalType();
+        LogicalType haystackElementType = haystackType.getElementType();
+
+        if (!haystackElementType.isNullable() && needleType.isNullable()) {
+            haystackElementType = haystackType.getElementType().copy(true);
+        }
+
         if (supportsImplicitCast(needleType, haystackElementType)) {
             return Optional.of(DataTypes.of(haystackElementType));
         }

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayElementArgumentTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/ArrayElementArgumentTypeStrategy.java
@@ -47,7 +47,7 @@ class ArrayElementArgumentTypeStrategy implements ArgumentTypeStrategy {
         LogicalType haystackElementType = haystackType.getElementType();
 
         if (!haystackElementType.isNullable() && needleType.isNullable()) {
-            haystackElementType = haystackType.getElementType().copy(true);
+            haystackElementType = haystackElementType.copy(true);
         }
 
         if (supportsImplicitCast(needleType, haystackElementType)) {

--- a/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
+++ b/flink-table/flink-table-common/src/test/java/org/apache/flink/table/types/inference/InputTypeStrategiesTest.java
@@ -624,7 +624,19 @@ class InputTypeStrategiesTest extends InputTypeStrategiesTestBase {
                                         InputTypeStrategies.COMMON_ARG))
                         .calledWithArgumentTypes(DataTypes.INT(), DataTypes.BIGINT())
                         .expectSignature("f(<COMMON>, <COMMON>)")
-                        .expectArgumentTypes(DataTypes.BIGINT(), DataTypes.BIGINT()));
+                        .expectArgumentTypes(DataTypes.BIGINT(), DataTypes.BIGINT()),
+                TestSpec.forStrategy(
+                                "ArrayElement argument type strategy",
+                                sequence(
+                                        logical(LogicalTypeRoot.ARRAY),
+                                        SpecificInputTypeStrategies.ARRAY_ELEMENT_ARG))
+                        .calledWithArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT().notNull()).notNull(),
+                                DataTypes.INT())
+                        .expectSignature("f(<ARRAY>, <ARRAY ELEMENT>)")
+                        .expectArgumentTypes(
+                                DataTypes.ARRAY(DataTypes.INT().notNull()).notNull(),
+                                DataTypes.INT()));
     }
 
     /** Simple pojo that should be converted to a Structured type. */

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -110,6 +110,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 "ARRAY_CONTAINS(f5, CAST(NULL AS INT))",
                                 false,
                                 DataTypes.BOOLEAN().notNull())
+                        .testResult(
+                                $("f5").arrayContains(lit(4, DataTypes.INT().notNull())),
+                                "ARRAY_CONTAINS(f5, 4)",
+                                false,
+                                DataTypes.BOOLEAN().notNull())
                         // invalid signatures
                         .testSqlValidationError(
                                 "ARRAY_CONTAINS(f0, TRUE)",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -115,6 +115,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 "ARRAY_CONTAINS(f5, 4)",
                                 false,
                                 DataTypes.BOOLEAN().notNull())
+                        .testResult(
+                                $("f5").arrayContains(lit(3, DataTypes.INT().notNull())),
+                                "ARRAY_CONTAINS(f5, 3)",
+                                true,
+                                DataTypes.BOOLEAN().notNull())
                         // invalid signatures
                         .testSqlValidationError(
                                 "ARRAY_CONTAINS(f0, TRUE)",

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CollectionFunctionsITCase.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
+import static org.apache.flink.table.api.Expressions.lit;
 import static org.apache.flink.table.api.Expressions.row;
 
 /** Tests for {@link BuiltInFunctionDefinitions} around arrays. */
@@ -44,14 +45,16 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                     Row.of(true, LocalDate.of(1990, 10, 14)),
                                     null
                                 },
-                                new Integer[] {1, null, 3})
+                                new Integer[] {1, null, 3},
+                                new Integer[] {1, 2, 3})
                         .andDataTypes(
                                 DataTypes.ARRAY(DataTypes.INT()),
                                 DataTypes.ARRAY(DataTypes.INT()),
                                 DataTypes.ARRAY(DataTypes.STRING()).notNull(),
                                 DataTypes.ARRAY(
                                         DataTypes.ROW(DataTypes.BOOLEAN(), DataTypes.DATE())),
-                                DataTypes.ARRAY(DataTypes.INT()))
+                                DataTypes.ARRAY(DataTypes.INT()),
+                                DataTypes.ARRAY(DataTypes.INT().notNull()).notNull())
                         // ARRAY<INT>
                         .testResult(
                                 $("f0").arrayContains(2),
@@ -102,6 +105,11 @@ class CollectionFunctionsITCase extends BuiltInFunctionTestBase {
                                 "ARRAY_CONTAINS(f4, NULL)",
                                 true,
                                 DataTypes.BOOLEAN().nullable())
+                        .testResult(
+                                $("f5").arrayContains(lit(null, DataTypes.INT())),
+                                "ARRAY_CONTAINS(f5, CAST(NULL AS INT))",
+                                false,
+                                DataTypes.BOOLEAN().notNull())
                         // invalid signatures
                         .testSqlValidationError(
                                 "ARRAY_CONTAINS(f0, TRUE)",


### PR DESCRIPTION
## What is the purpose of the change

*Fix array_contains does not support null argument when the array element type is not null.*

- fix select array_contains(array[1, 2, 3], cast(null as int)); which has exception now

## Verifying this change
- add unit test

## Does this pull request potentially affect one of the following parts
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): yes
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing
- Kubernetes/Yarn/Mesos, ZooKeeper: no
- The S3 file system connector: no

## Documentation
- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? docs / JavaDocs