### PR TITLE
[BP-1.15][FLINK-31041][runtime] Fix multiple restoreState when GlobalFailure occurs in a short period.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultScheduler.java
@@ -382,6 +382,10 @@ public class DefaultScheduler extends SchedulerBase implements SchedulerOperatio
         final Set<ExecutionVertexID> verticesToRestart =
                 executionVertexVersioner.getUnmodifiedExecutionVertices(executionVertexVersions);
 
+        if (verticesToRestart.isEmpty()) {
+            return;
+        }
+
         removeVerticesFromRestartPending(verticesToRestart);
 
         resetForNewExecutions(verticesToRestart);


### PR DESCRIPTION
Backport [FLINK-31041](https://issues.apache.org/jira/browse/FLINK-31041) to release-1.15.