### PR TITLE
[FLINK-27815] add join sort by batch sql

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/FlinkBatchRuleSets.scala
@@ -36,6 +36,7 @@ object FlinkBatchRuleSets {
     FlinkRewriteSubQueryRule.FILTER,
     FlinkSubQueryRemoveRule.FILTER,
     JoinConditionTypeCoerceRule.INSTANCE,
+    JoinConditionCommuteRule.INSTANCE,
     FlinkJoinPushExpressionsRule.INSTANCE
   )
 
@@ -87,6 +88,7 @@ object FlinkBatchRuleSets {
     SimplifyFilterConditionRule.INSTANCE,
     SimplifyJoinConditionRule.INSTANCE,
     JoinConditionTypeCoerceRule.INSTANCE,
+    JoinConditionCommuteRule.INSTANCE,
     CoreRules.JOIN_PUSH_EXPRESSIONS
   )
 

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinConditionCommuteRule.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/plan/rules/logical/JoinConditionCommuteRule.scala
@@ -1,0 +1,89 @@
+package org.apache.flink.table.planner.plan.rules.logical
+
+import org.apache.calcite.plan.{RelOptRule, RelOptRuleCall, RelOptUtil}
+import org.apache.calcite.plan.RelOptRule.{any, operand}
+import org.apache.calcite.rel.`type`.RelDataTypeFactory
+import org.apache.calcite.rel.core.{Join, Project}
+import org.apache.calcite.rel.rules.JoinCommuteRule
+import org.apache.calcite.rex.{RexCall, RexInputRef, RexNode}
+import org.apache.calcite.sql.SqlKind
+import org.apache.calcite.sql.`type`.SqlTypeUtil
+
+import scala.collection.JavaConversions.asScalaBuffer
+
+class JoinConditionCommuteRule extends RelOptRule(
+  operand(classOf[Join], any),
+  "JoinConditionCommuteRule") {
+
+  override def matches(call: RelOptRuleCall): Boolean = {
+    val join: Join = call.rel(0)
+    if (join.getCondition.isAlwaysTrue) {
+      return false
+    }
+    val typeFactory = call.builder().getTypeFactory
+    hasEqualsRefsOfDifferentTypes(typeFactory, join.getCondition)
+  }
+
+  override def onMatch(call: RelOptRuleCall): Unit = {
+    val topProject:Project = call.rel(0)
+    val join:Join = call.rel(1)
+
+    // 1. We check if it is a permutation project. If it is
+    //    not, or this is the identity, the rule will do nothing
+    val topPermutation = topProject.getPermutation
+    if (topPermutation == null) return
+    if (topPermutation.isIdentity) return
+
+    // 2. We swap the join
+    val swapped = JoinCommuteRule.swap(join, true)
+    if (swapped == null) return
+
+    // 3. The result should have a project on top, otherwise we
+    //    bail out.
+    if (swapped.isInstanceOf[Join]) return
+
+    // 4. We check if it is a permutation project. If it is
+
+    val bottomProject = swapped.asInstanceOf[Project]
+    val bottomPermutation = bottomProject.getPermutation
+    if (bottomPermutation == null) return
+    if (bottomPermutation.isIdentity) return
+
+    // 5. If the product of the topPermutation and bottomPermutation yields
+    //    the identity, then we can swap the join and remove the project on
+    //    top.
+    val product = topPermutation.product(bottomPermutation)
+    if (!product.isIdentity) return
+
+    // 6. Return the new join as a replacement
+    val swappedJoin = bottomProject.getInput(0).asInstanceOf[Join]
+    call.transformTo(swappedJoin)
+  }
+
+  /**
+   * Returns true if two input refs of an equal call have different types in join condition,
+   * else false.
+   */
+  private def hasEqualsRefsOfDifferentTypes(
+                                             typeFactory: RelDataTypeFactory,
+                                             predicate: RexNode): Boolean = {
+    val conjunctions = RelOptUtil.conjunctions(predicate)
+    conjunctions.exists {
+      case c: RexCall if c.isA(SqlKind.EQUALS) =>
+        (c.operands.head, c.operands.last) match {
+          case (ref1: RexInputRef, ref2: RexInputRef) =>
+            !SqlTypeUtil.equalSansNullability(
+              typeFactory,
+              ref1.getType,
+              ref2.getType)
+          case _ => false
+        }
+      case _ => false
+    }
+  }
+}
+
+object JoinConditionCommuteRule {
+  val INSTANCE = new JoinConditionCommuteRule
+}
+


### PR DESCRIPTION
Related to [FLINK-27815](https://issues.apache.org/jira/browse/FLINK-27815)
## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
