### PR TITLE
[Flink-clients][api] Adding a method to get ClusterClientProvider

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -64,7 +64,7 @@ public class ClusterClientJobClientAdapter<ClusterID>
         this.clusterClientProvider = checkNotNull(clusterClientProvider);
         this.classLoader = classLoader;
     }
-    
+
     public ClusterClientProvider<ClusterID> getClusterClientProvider() {
         return this.clusterClientProvider;
     }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -64,6 +64,10 @@ public class ClusterClientJobClientAdapter<ClusterID>
         this.clusterClientProvider = checkNotNull(clusterClientProvider);
         this.classLoader = classLoader;
     }
+    
+    public ClusterClientProvider<ClusterID> getClusterClientProvider() {
+        return this.clusterClientProvider;
+    }
 
     @Override
     public JobID getJobID() {


### PR DESCRIPTION

## What is the purpose of the change

1. To get **ClusterId** simple . such as yarn applicationId 

2. when running job in **yarn-per-job or yarn-application** mode， we always need to get **yarn applicationId**  which is **clusterId** in **ClusterClientProvider**  of the **ClusterClientJobClientAdapter**, ClusterClientJobClientAdapter is  implement of **JobClient**

3.   If we can get ClusterClientProvider,  then we can get **clusterId**  by
  **jobClient.getClusterClientProvider().getClusterClient().getClusterId().toString()**

this will be very helpful . 

