### PR TITLE
[FLINK-31183][Connector/Kinesis] Fix bug where EFO Consumer can fail …

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -149,7 +149,7 @@ public class ShardConsumer<T> implements Runnable {
                     // we can close this consumer thread once we've reached the end of the
                     // subscribed shard
                     break;
-                } else if (result == CANCELLED) {
+                } else if (isRunning() && result == CANCELLED) {
                     final String errorMessage =
                             "Shard consumer cancelled: " + subscribedShard.getShard().getShardId();
                     LOG.info(errorMessage);

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherFactory.java
@@ -47,6 +47,9 @@ public class FanOutRecordPublisherFactory implements RecordPublisherFactory {
      */
     private final KinesisProxyV2Interface kinesisProxy;
 
+    /** A flag to indicate whether the FanOutRecordPublisherFactory has been closed. */
+    private boolean closed = false;
+
     /**
      * Instantiate a factory responsible for creating {@link FanOutRecordPublisher}.
      *
@@ -89,11 +92,13 @@ public class FanOutRecordPublisherFactory implements RecordPublisherFactory {
                 streamShardHandle,
                 kinesisProxy,
                 configuration,
-                BACKOFF);
+                BACKOFF,
+                () -> !closed);
     }
 
     @Override
     public void close() {
+        closed = true;
         kinesisProxy.close();
     }
 }

--- a/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherTest.java
+++ b/flink-connectors/flink-connector-kinesis/src/test/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherTest.java
@@ -35,6 +35,7 @@ import com.amazonaws.kinesis.agg.RecordAggregator;
 import com.amazonaws.services.kinesis.clientlibrary.types.UserRecord;
 import com.amazonaws.services.kinesis.model.HashKeyRange;
 import io.netty.handler.timeout.ReadTimeoutException;
+import org.assertj.core.api.Assertions;
 import org.hamcrest.Matchers;
 import org.junit.Rule;
 import org.junit.Test;
@@ -51,6 +52,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -213,7 +215,8 @@ public class FanOutRecordPublisherTest {
                         createDummyStreamShardHandle("stream-name", "shardId-00000", hashKeyRange),
                         kinesis,
                         createConfiguration(),
-                        new FullJitterBackoff());
+                        new FullJitterBackoff(),
+                        () -> true);
         publisher.run(
                 new TestConsumer(SENTINEL_AT_TIMESTAMP_SEQUENCE_NUM.get().getSequenceNumber()));
 
@@ -332,7 +335,8 @@ public class FanOutRecordPublisherTest {
                         createDummyStreamShardHandle(),
                         kinesis,
                         configuration,
-                        backoff)
+                        backoff,
+                        () -> true)
                 .run(new TestConsumer());
 
         verify(backoff)
@@ -368,7 +372,8 @@ public class FanOutRecordPublisherTest {
                         createDummyStreamShardHandle(),
                         kinesis,
                         configuration,
-                        backoff);
+                        backoff,
+                        () -> true);
 
         int count = 0;
         while (recordPublisher.run(new TestConsumer()) == INCOMPLETE) {
@@ -398,7 +403,8 @@ public class FanOutRecordPublisherTest {
                         createDummyStreamShardHandle(),
                         kinesis,
                         configuration,
-                        backoff);
+                        backoff,
+                        () -> true);
 
         int count = 0;
         while (recordPublisher.run(new TestConsumer()) == RecordPublisherRunResult.INCOMPLETE) {
@@ -428,7 +434,8 @@ public class FanOutRecordPublisherTest {
                         createDummyStreamShardHandle(),
                         kinesis,
                         configuration,
-                        backoff);
+                        backoff,
+                        () -> true);
 
         recordPublisher.run(new TestConsumer());
         recordPublisher.run(new TestConsumer());
@@ -459,7 +466,8 @@ public class FanOutRecordPublisherTest {
                         createDummyStreamShardHandle(),
                         kinesis,
                         configuration,
-                        backoff);
+                        backoff,
+                        () -> true);
 
         recordPublisher.run(new TestConsumer());
         recordPublisher.run(new TestConsumer());
@@ -560,6 +568,37 @@ public class FanOutRecordPublisherTest {
         assertEquals(CANCELLED, actual);
     }
 
+    @Test
+    public void testCancelExitsGracefully() throws Exception {
+        SingleShardFanOutKinesisV2 kinesis =
+                FakeKinesisFanOutBehavioursFactory.boundedShard()
+                        .withBatchCount(10)
+                        .withBatchesPerSubscription(3)
+                        .withRecordsPerBatch(12)
+                        .build();
+
+        AtomicBoolean run = new AtomicBoolean(true);
+        RecordPublisher recordPublisher =
+                new FanOutRecordPublisher(
+                        StartingPosition.fromTimestamp(new Date()),
+                        "arn",
+                        createDummyStreamShardHandle(),
+                        kinesis,
+                        createConfiguration(),
+                        new FullJitterBackoff(),
+                        run::get);
+
+        TestConsumer consumer = new TestConsumer();
+
+        int count = 0;
+        while (recordPublisher.run(consumer) == INCOMPLETE) {
+            run.set(false);
+            count++;
+        }
+
+        Assertions.assertThat(count).isEqualTo(1);
+    }
+
     private List<UserRecord> flattenToUserRecords(final List<RecordBatch> recordBatch) {
         return recordBatch.stream()
                 .flatMap(b -> b.getDeaggregatedRecords().stream())
@@ -584,7 +623,8 @@ public class FanOutRecordPublisherTest {
                 createDummyStreamShardHandle(),
                 kinesis,
                 createConfiguration(),
-                new FullJitterBackoff());
+                new FullJitterBackoff(),
+                () -> true);
     }
 
     private FanOutRecordPublisherConfiguration createConfiguration() {


### PR DESCRIPTION
…to stop gracefully during stop-with-savepoint

## What is the purpose of the change

Update Kinesis EFO consumer to exit gracefully during stop-with-savepoint. There is an edgecase where an exception is thrown causing the job to fail during stop-with-savepoint.

## Brief change log

- Add a callback to `FanoutShardSubscriber` that allows the EFO subscriber threads to check if the consumer should be running

## Verifying this change

- Additional unit tests added
- Manually verified via Flink cluster using stop-with-savepoint

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
