### PR TITLE
[FLINK-31185][Python] Support side-output in broadcast processing

### DIFF
--- a/flink-python/pyflink/datastream/tests/test_data_stream.py
+++ b/flink-python/pyflink/datastream/tests/test_data_stream.py
@@ -589,6 +589,40 @@ class DataStreamTests(object):
         side_expected = ['0', '0', '1', '1', '2', '3']
         self.assert_equals_sorted(side_expected, side_sink.get_results())
 
+    def test_co_broadcast_side_output(self):
+        tag = OutputTag("side", Types.INT())
+
+        class MyBroadcastProcessFunction(BroadcastProcessFunction):
+
+            def process_element(self, value, ctx):
+                yield value[0]
+                yield tag, value[1]
+
+            def process_broadcast_element(self, value, ctx):
+                yield value[1]
+                yield tag, value[0]
+
+        self.env.set_parallelism(2)
+        ds = self.env.from_collection([('a', 0), ('b', 1), ('c', 2)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        ds_broadcast = self.env.from_collection([(3, 'd'), (4, 'f')],
+                                                type_info=Types.ROW([Types.INT(), Types.STRING()]))
+        map_state_desc = MapStateDescriptor(
+            "dummy", key_type_info=Types.INT(), value_type_info=Types.STRING()
+        )
+        ds = ds.connect(ds_broadcast.broadcast(map_state_desc)).process(
+            MyBroadcastProcessFunction(), output_type=Types.STRING()
+        )
+        side_sink = DataStreamTestSinkFunction()
+        ds.get_side_output(tag).add_sink(side_sink)
+        ds.add_sink(self.test_sink)
+
+        self.env.execute("test_co_broadcast_process_side_output")
+        main_expected = ['a', 'b', 'c', 'd', 'd', 'f', 'f']
+        self.assert_equals_sorted(main_expected, self.test_sink.get_results())
+        side_expected = ['0', '1', '2', '3', '3', '4', '4']
+        self.assert_equals_sorted(side_expected, side_sink.get_results())
+
     def test_keyed_process_side_output(self):
         tag = OutputTag("side", Types.INT())
 
@@ -663,6 +697,49 @@ class DataStreamTests(object):
         main_expected = ['1', '2', '3', '4', '5', '6', '7', '8']
         self.assert_equals_sorted(main_expected, main_sink.get_results())
         side_expected = ['1', '1', '2', '2', '3', '3', '4', '4']
+        self.assert_equals_sorted(side_expected, side_sink.get_results())
+
+    def test_keyed_co_broadcast_side_output(self):
+        tag = OutputTag("side", Types.INT())
+
+        class MyKeyedBroadcastProcessFunction(KeyedBroadcastProcessFunction):
+
+            def __init__(self):
+                self.reducing_state = None  # type: ReducingState
+
+            def open(self, context: RuntimeContext):
+                self.reducing_state = context.get_reducing_state(
+                    ReducingStateDescriptor("reduce", lambda i, j: i+j, Types.INT())
+                )
+
+            def process_element(self, value, ctx):
+                self.reducing_state.add(value[1])
+                yield value[0]
+                yield tag, self.reducing_state.get()
+
+            def process_broadcast_element(self, value, ctx):
+                yield value[1]
+                yield tag, value[0]
+
+        self.env.set_parallelism(2)
+        ds = self.env.from_collection([('a', 0), ('b', 1), ('a', 2), ('b', 3)],
+                                      type_info=Types.ROW([Types.STRING(), Types.INT()]))
+        ds_broadcast = self.env.from_collection([(5, 'c'), (6, 'd')],
+                                                type_info=Types.ROW([Types.INT(), Types.STRING()]))
+        map_state_desc = MapStateDescriptor(
+            "dummy", key_type_info=Types.INT(), value_type_info=Types.STRING()
+        )
+        ds = ds.key_by(lambda e: e[0]).connect(ds_broadcast.broadcast(map_state_desc)).process(
+            MyKeyedBroadcastProcessFunction(), output_type=Types.STRING()
+        )
+        side_sink = DataStreamTestSinkFunction()
+        ds.get_side_output(tag).add_sink(side_sink)
+        ds.add_sink(self.test_sink)
+
+        self.env.execute("test_keyed_co_broadcast_process_side_output")
+        main_expected = ['a', 'a', 'b', 'b', 'c', 'c', 'd', 'd']
+        self.assert_equals_sorted(main_expected, self.test_sink.get_results())
+        side_expected = ['0', '1', '2', '4', '5', '5', '6', '6']
         self.assert_equals_sorted(side_expected, side_sink.get_results())
 
     def test_side_output_stream_execute_and_collect(self):

--- a/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
@@ -102,7 +102,6 @@ def extract_process_function(
         def process_func(values):
             if values is None:
                 return
-                yield
             for value in values:
                 if isinstance(value, tuple) and isinstance(value[0], OutputTag):
                     output_tag = value[0]  # type: OutputTag
@@ -113,7 +112,6 @@ def extract_process_function(
         def process_func(values):
             if values is None:
                 return
-                yield
             yield from values
 
     def open_func():

--- a/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
+++ b/flink-python/pyflink/fn_execution/datastream/embedded/operations.py
@@ -100,6 +100,9 @@ def extract_process_function(
         side_output_context = SideOutputContext(j_side_output_context)
 
         def process_func(values):
+            if values is None:
+                return
+                yield
             for value in values:
                 if isinstance(value, tuple) and isinstance(value[0], OutputTag):
                     output_tag = value[0]  # type: OutputTag
@@ -108,6 +111,9 @@ def extract_process_function(
                     yield value
     else:
         def process_func(values):
+            if values is None:
+                return
+                yield
             yield from values
 
     def open_func():
@@ -174,14 +180,10 @@ def extract_process_function(
         process_broadcast_element = user_defined_func.process_broadcast_element
 
         def process_element_func1(value):
-            elements = process_element(value, read_only_broadcast_ctx)
-            if elements:
-                yield from elements
+            yield from process_func(process_element(value, read_only_broadcast_ctx))
 
         def process_element_func2(value):
-            elements = process_broadcast_element(value, broadcast_ctx)
-            if elements:
-                yield from elements
+            yield from process_func(process_broadcast_element(value, broadcast_ctx))
 
         return TwoInputOperation(
             open_func, close_func, process_element_func1, process_element_func2)
@@ -221,19 +223,20 @@ def extract_process_function(
         timer_context = InternalKeyedBroadcastProcessFunctionOnTimerContext(
             j_timer_context, user_defined_function_proto.key_type_info, j_operator_state_backend)
 
+        keyed_state_backend = KeyedStateBackend(
+            read_only_broadcast_ctx,
+            j_keyed_state_backend)
+        runtime_context.set_keyed_state_backend(keyed_state_backend)
+
         process_element = user_defined_func.process_element
         process_broadcast_element = user_defined_func.process_broadcast_element
         on_timer = user_defined_func.on_timer
 
         def process_element_func1(value):
-            elements = process_element(value[1], read_only_broadcast_ctx)
-            if elements:
-                yield from elements
+            yield from process_func(process_element(value[1], read_only_broadcast_ctx))
 
         def process_element_func2(value):
-            elements = process_broadcast_element(value, broadcast_ctx)
-            if elements:
-                yield from elements
+            yield from process_func(process_broadcast_element(value, broadcast_ctx))
 
         def on_timer_func(timestamp):
             yield from on_timer(timestamp, timer_context)

--- a/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
+++ b/flink-python/src/main/java/org/apache/flink/python/chain/PythonOperatorChainingOptimizer.java
@@ -55,6 +55,8 @@ import org.apache.flink.streaming.api.transformations.SinkTransformation;
 import org.apache.flink.streaming.api.transformations.TimestampsAndWatermarksTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
 import org.apache.flink.streaming.api.transformations.UnionTransformation;
+import org.apache.flink.streaming.api.transformations.python.PythonBroadcastStateTransformation;
+import org.apache.flink.streaming.api.transformations.python.PythonKeyedBroadcastStateTransformation;
 import org.apache.flink.streaming.runtime.partitioner.ForwardPartitioner;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Lists;
@@ -405,6 +407,11 @@ public class PythonOperatorChainingOptimizer {
     private static boolean areOperatorsChainable(
             Transformation<?> upTransform, Transformation<?> downTransform) {
         if (!areOperatorsChainableByChainingStrategy(upTransform, downTransform)) {
+            return false;
+        }
+
+        if (upTransform instanceof PythonBroadcastStateTransformation
+                || upTransform instanceof PythonKeyedBroadcastStateTransformation) {
             return false;
         }
 

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -217,6 +217,9 @@ public class PythonConfigUtil {
         } else if (transformation instanceof AbstractMultipleInputTransformation) {
             operatorFactory =
                     ((AbstractMultipleInputTransformation<?>) transformation).getOperatorFactory();
+        } else if (transformation instanceof DelegateOperatorTransformation) {
+            operatorFactory =
+                    ((DelegateOperatorTransformation<?>) transformation).getOperatorFactory();
         }
 
         if (operatorFactory instanceof SimpleOperatorFactory

--- a/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
+++ b/flink-python/src/main/java/org/apache/flink/python/util/PythonConfigUtil.java
@@ -42,6 +42,7 @@ import org.apache.flink.streaming.api.transformations.OneInputTransformation;
 import org.apache.flink.streaming.api.transformations.PartitionTransformation;
 import org.apache.flink.streaming.api.transformations.SideOutputTransformation;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
+import org.apache.flink.streaming.api.transformations.python.DelegateOperatorTransformation;
 import org.apache.flink.streaming.api.transformations.python.PythonBroadcastStateTransformation;
 import org.apache.flink.streaming.api.transformations.python.PythonKeyedBroadcastStateTransformation;
 import org.apache.flink.streaming.api.utils.ByteArrayWrapper;
@@ -152,6 +153,8 @@ public class PythonConfigUtil {
             return ((TwoInputTransformation<?, ?, ?>) transform).getOperatorFactory();
         } else if (transform instanceof AbstractMultipleInputTransformation) {
             return ((AbstractMultipleInputTransformation<?>) transform).getOperatorFactory();
+        } else if (transform instanceof DelegateOperatorTransformation<?>) {
+            return ((DelegateOperatorTransformation<?>) transform).getOperatorFactory();
         } else {
             return null;
         }
@@ -260,6 +263,9 @@ public class PythonConfigUtil {
         } else if (transform instanceof TwoInputTransformation) {
             return isPythonDataStreamOperator(
                     ((TwoInputTransformation<?, ?, ?>) transform).getOperatorFactory());
+        } else if (transform instanceof PythonBroadcastStateTransformation
+                || transform instanceof PythonKeyedBroadcastStateTransformation) {
+            return true;
         } else {
             return false;
         }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/DataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/DataStreamPythonFunctionOperator.java
@@ -22,15 +22,13 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
-import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.OutputTag;
 
 import java.util.Collection;
 
 /** Interface for Python DataStream operators. */
 @Internal
-public interface DataStreamPythonFunctionOperator<OUT>
-        extends ResultTypeQueryable<OUT>, StreamOperator<OUT> {
+public interface DataStreamPythonFunctionOperator<OUT> extends ResultTypeQueryable<OUT> {
 
     /**
      * Sets the number of partitions. This is used for partitionCustom which takes the number of

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/DataStreamPythonFunctionOperator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/operators/python/DataStreamPythonFunctionOperator.java
@@ -22,13 +22,15 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.util.OutputTag;
 
 import java.util.Collection;
 
 /** Interface for Python DataStream operators. */
 @Internal
-public interface DataStreamPythonFunctionOperator<OUT> extends ResultTypeQueryable<OUT> {
+public interface DataStreamPythonFunctionOperator<OUT>
+        extends ResultTypeQueryable<OUT>, StreamOperator<OUT> {
 
     /**
      * Sets the number of partitions. This is used for partitionCustom which takes the number of

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/DelegateOperatorTransformation.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/DelegateOperatorTransformation.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations.python;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.runtime.checkpoint.CheckpointOptions;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * For those {@link org.apache.flink.api.dag.Transformation} that don't have an operator entity,
+ * {@link DelegateOperatorTransformation} provides a {@link SimpleOperatorFactory} containing a
+ * {@link DelegateOperator} , which can hold {@link OutputTag}s when optimizing transformations for
+ * Python jobs, and later be queried at the translation stage.
+ */
+public interface DelegateOperatorTransformation<OUT> {
+
+    SimpleOperatorFactory<OUT> getOperatorFactory();
+
+    /** {@link DelegateOperator} holds {@link OutputTag}s. */
+    class DelegateOperator<OUT> implements DataStreamPythonFunctionOperator<OUT> {
+
+        private final Map<String, OutputTag<?>> sideOutputTags = new HashMap<>();
+
+        @Override
+        public void addSideOutputTags(Collection<OutputTag<?>> outputTags) {
+            for (OutputTag<?> outputTag : outputTags) {
+                sideOutputTags.put(outputTag.getId(), outputTag);
+            }
+        }
+
+        @Override
+        public Collection<OutputTag<?>> getSideOutputTags() {
+            return sideOutputTags.values();
+        }
+
+        @Override
+        public void notifyCheckpointComplete(long checkpointId) throws Exception {}
+
+        @Override
+        public TypeInformation<OUT> getProducedType() {
+            return null;
+        }
+
+        @Override
+        public void setNumPartitions(int numPartitions) {}
+
+        @Override
+        public DataStreamPythonFunctionInfo getPythonFunctionInfo() {
+            return null;
+        }
+
+        @Override
+        public <T> DataStreamPythonFunctionOperator<T> copy(
+                DataStreamPythonFunctionInfo pythonFunctionInfo,
+                TypeInformation<T> outputTypeInfo) {
+            return null;
+        }
+
+        @Override
+        public void setCurrentKey(Object key) {}
+
+        @Override
+        public Object getCurrentKey() {
+            return null;
+        }
+
+        @Override
+        public void open() throws Exception {}
+
+        @Override
+        public void finish() throws Exception {}
+
+        @Override
+        public void close() throws Exception {}
+
+        @Override
+        public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {}
+
+        @Override
+        public OperatorSnapshotFutures snapshotState(
+                long checkpointId,
+                long timestamp,
+                CheckpointOptions checkpointOptions,
+                CheckpointStreamFactory storageLocation)
+                throws Exception {
+            return null;
+        }
+
+        @Override
+        public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
+                throws Exception {}
+
+        @Override
+        public void setKeyContextElement1(StreamRecord<?> record) throws Exception {}
+
+        @Override
+        public void setKeyContextElement2(StreamRecord<?> record) throws Exception {}
+
+        @Override
+        public OperatorMetricGroup getMetricGroup() {
+            return null;
+        }
+
+        @Override
+        public OperatorID getOperatorID() {
+            return null;
+        }
+    }
+}

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/DelegateOperatorTransformation.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/DelegateOperatorTransformation.java
@@ -18,17 +18,15 @@
 package org.apache.flink.streaming.api.transformations.python;
 
 import org.apache.flink.api.common.typeinfo.TypeInformation;
-import org.apache.flink.metrics.groups.OperatorMetricGroup;
-import org.apache.flink.runtime.checkpoint.CheckpointOptions;
-import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.state.CheckpointStreamFactory;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.python.env.PythonEnvironmentManager;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
-import org.apache.flink.streaming.api.operators.OperatorSnapshotFutures;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.streaming.api.operators.StreamTaskStateInitializer;
+import org.apache.flink.streaming.api.operators.python.AbstractPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.util.OutputTag;
+
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -37,17 +35,46 @@ import java.util.Map;
 /**
  * For those {@link org.apache.flink.api.dag.Transformation} that don't have an operator entity,
  * {@link DelegateOperatorTransformation} provides a {@link SimpleOperatorFactory} containing a
- * {@link DelegateOperator} , which can hold {@link OutputTag}s when optimizing transformations for
- * Python jobs, and later be queried at the translation stage.
+ * {@link DelegateOperator} , which can hold special configurations during transformation
+ * preprocessing for Python jobs, and later be queried at translation stage. Currently, those
+ * configurations include {@link OutputTag}s, {@code numPartitions} and general {@link
+ * Configuration}.
  */
 public interface DelegateOperatorTransformation<OUT> {
 
     SimpleOperatorFactory<OUT> getOperatorFactory();
 
-    /** {@link DelegateOperator} holds {@link OutputTag}s. */
-    class DelegateOperator<OUT> implements DataStreamPythonFunctionOperator<OUT> {
+    static void configureDelegatedOperator(
+            DelegateOperatorTransformation<?> transformation,
+            AbstractPythonFunctionOperator<?> operator) {
+        DelegateOperator<?> delegateOperator =
+                (DelegateOperator<?>) transformation.getOperatorFactory().getOperator();
+
+        operator.getConfiguration().addAll(delegateOperator.getConfiguration());
+
+        if (operator instanceof DataStreamPythonFunctionOperator) {
+            DataStreamPythonFunctionOperator<?> dataStreamOperator =
+                    (DataStreamPythonFunctionOperator<?>) operator;
+            dataStreamOperator.addSideOutputTags(delegateOperator.getSideOutputTags());
+            if (delegateOperator.getNumPartitions() != null) {
+                dataStreamOperator.setNumPartitions(delegateOperator.getNumPartitions());
+            }
+        }
+    }
+
+    /**
+     * {@link DelegateOperator} holds configurations, e.g. {@link OutputTag}s, which will be applied
+     * to the actual python operator at translation stage.
+     */
+    class DelegateOperator<OUT> extends AbstractPythonFunctionOperator<OUT>
+            implements DataStreamPythonFunctionOperator<OUT> {
 
         private final Map<String, OutputTag<?>> sideOutputTags = new HashMap<>();
+        private @Nullable Integer numPartitions = null;
+
+        public DelegateOperator() {
+            super(new Configuration());
+        }
 
         @Override
         public void addSideOutputTags(Collection<OutputTag<?>> outputTags) {
@@ -62,76 +89,40 @@ public interface DelegateOperatorTransformation<OUT> {
         }
 
         @Override
-        public void notifyCheckpointComplete(long checkpointId) throws Exception {}
+        public void setNumPartitions(int numPartitions) {
+            this.numPartitions = numPartitions;
+        }
 
-        @Override
-        public TypeInformation<OUT> getProducedType() {
-            return null;
+        @Nullable
+        public Integer getNumPartitions() {
+            return numPartitions;
         }
 
         @Override
-        public void setNumPartitions(int numPartitions) {}
+        public TypeInformation<OUT> getProducedType() {
+            throw new RuntimeException("This should not be invoked on a DelegateOperator!");
+        }
 
         @Override
         public DataStreamPythonFunctionInfo getPythonFunctionInfo() {
-            return null;
+            throw new RuntimeException("This should not be invoked on a DelegateOperator!");
         }
 
         @Override
         public <T> DataStreamPythonFunctionOperator<T> copy(
                 DataStreamPythonFunctionInfo pythonFunctionInfo,
                 TypeInformation<T> outputTypeInfo) {
-            return null;
+            throw new RuntimeException("This should not be invoked on a DelegateOperator!");
         }
 
         @Override
-        public void setCurrentKey(Object key) {}
-
-        @Override
-        public Object getCurrentKey() {
-            return null;
+        protected void invokeFinishBundle() throws Exception {
+            throw new RuntimeException("This should not be invoked on a DelegateOperator!");
         }
 
         @Override
-        public void open() throws Exception {}
-
-        @Override
-        public void finish() throws Exception {}
-
-        @Override
-        public void close() throws Exception {}
-
-        @Override
-        public void prepareSnapshotPreBarrier(long checkpointId) throws Exception {}
-
-        @Override
-        public OperatorSnapshotFutures snapshotState(
-                long checkpointId,
-                long timestamp,
-                CheckpointOptions checkpointOptions,
-                CheckpointStreamFactory storageLocation)
-                throws Exception {
-            return null;
-        }
-
-        @Override
-        public void initializeState(StreamTaskStateInitializer streamTaskStateManager)
-                throws Exception {}
-
-        @Override
-        public void setKeyContextElement1(StreamRecord<?> record) throws Exception {}
-
-        @Override
-        public void setKeyContextElement2(StreamRecord<?> record) throws Exception {}
-
-        @Override
-        public OperatorMetricGroup getMetricGroup() {
-            return null;
-        }
-
-        @Override
-        public OperatorID getOperatorID() {
-            return null;
+        protected PythonEnvironmentManager createPythonEnvironmentManager() {
+            throw new RuntimeException("This should not be invoked on a DelegateOperator!");
         }
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/DelegateOperatorTransformation.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/DelegateOperatorTransformation.java
@@ -44,7 +44,7 @@ public interface DelegateOperatorTransformation<OUT> {
 
     SimpleOperatorFactory<OUT> getOperatorFactory();
 
-    static void configureDelegatedOperator(
+    static void configureOperator(
             DelegateOperatorTransformation<?> transformation,
             AbstractPythonFunctionOperator<?> operator) {
         DelegateOperator<?> delegateOperator =

--- a/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/PythonBroadcastStateTransformation.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/api/transformations/python/PythonBroadcastStateTransformation.java
@@ -23,6 +23,7 @@ import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.dag.Transformation;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.streaming.api.functions.python.DataStreamPythonFunctionInfo;
+import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
 import org.apache.flink.streaming.api.transformations.AbstractBroadcastStateTransformation;
 
 import java.util.List;
@@ -34,10 +35,12 @@ import java.util.List;
  */
 @Internal
 public class PythonBroadcastStateTransformation<IN1, IN2, OUT>
-        extends AbstractBroadcastStateTransformation<IN1, IN2, OUT> {
+        extends AbstractBroadcastStateTransformation<IN1, IN2, OUT>
+        implements DelegateOperatorTransformation<OUT> {
 
     private final Configuration configuration;
     private final DataStreamPythonFunctionInfo dataStreamPythonFunctionInfo;
+    private final SimpleOperatorFactory<OUT> delegateOperatorFactory;
 
     public PythonBroadcastStateTransformation(
             String name,
@@ -57,6 +60,7 @@ public class PythonBroadcastStateTransformation<IN1, IN2, OUT>
                 parallelism);
         this.configuration = configuration;
         this.dataStreamPythonFunctionInfo = dataStreamPythonFunctionInfo;
+        this.delegateOperatorFactory = SimpleOperatorFactory.of(new DelegateOperator<>());
         updateManagedMemoryStateBackendUseCase(false);
     }
 
@@ -66,5 +70,9 @@ public class PythonBroadcastStateTransformation<IN1, IN2, OUT>
 
     public DataStreamPythonFunctionInfo getDataStreamPythonFunctionInfo() {
         return dataStreamPythonFunctionInfo;
+    }
+
+    public SimpleOperatorFactory<OUT> getOperatorFactory() {
+        return delegateOperatorFactory;
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonBroadcastStateTransformationTranslator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonBroadcastStateTransformationTranslator.java
@@ -73,7 +73,7 @@ public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
                             transformation.getOutputType());
         }
 
-        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
+        DelegateOperatorTransformation.configureOperator(transformation, operator);
 
         return translateInternal(
                 transformation,
@@ -115,7 +115,7 @@ public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
                             transformation.getOutputType());
         }
 
-        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
+        DelegateOperatorTransformation.configureOperator(transformation, operator);
 
         return translateInternal(
                 transformation,

--- a/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonBroadcastStateTransformationTranslator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonBroadcastStateTransformationTranslator.java
@@ -21,7 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
+import org.apache.flink.streaming.api.operators.python.AbstractPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonBatchCoBroadcastProcessOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonCoProcessOperator;
 import org.apache.flink.streaming.api.operators.python.process.ExternalPythonBatchCoBroadcastProcessOperator;
@@ -53,7 +53,7 @@ public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
 
         Configuration config = transformation.getConfiguration();
 
-        DataStreamPythonFunctionOperator<OUT> operator;
+        AbstractPythonFunctionOperator<OUT> operator;
 
         if (config.get(PythonOptions.PYTHON_EXECUTION_MODE).equals("thread")) {
             operator =
@@ -73,7 +73,7 @@ public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
                             transformation.getOutputType());
         }
 
-        setOperatorSideOutputTags(transformation, operator);
+        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
 
         return translateInternal(
                 transformation,
@@ -94,7 +94,7 @@ public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
 
         Configuration config = transformation.getConfiguration();
 
-        DataStreamPythonFunctionOperator<OUT> operator;
+        AbstractPythonFunctionOperator<OUT> operator;
 
         if (config.get(PythonOptions.PYTHON_EXECUTION_MODE).equals("thread")) {
             operator =
@@ -115,7 +115,7 @@ public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
                             transformation.getOutputType());
         }
 
-        setOperatorSideOutputTags(transformation, operator);
+        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
 
         return translateInternal(
                 transformation,
@@ -126,14 +126,5 @@ public class PythonBroadcastStateTransformationTranslator<IN1, IN2, OUT>
                 null,
                 null,
                 context);
-    }
-
-    public static void setOperatorSideOutputTags(
-            DelegateOperatorTransformation<?> transformation,
-            DataStreamPythonFunctionOperator<?> operator) {
-        DataStreamPythonFunctionOperator<?> delegateOperator =
-                (DataStreamPythonFunctionOperator<?>)
-                        transformation.getOperatorFactory().getOperator();
-        operator.addSideOutputTags(delegateOperator.getSideOutputTags());
     }
 }

--- a/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonKeyedBroadcastStateTransformationTranslator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonKeyedBroadcastStateTransformationTranslator.java
@@ -21,7 +21,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonBatchKeyedCoBroadcastProcessOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonKeyedCoProcessOperator;
 import org.apache.flink.streaming.api.operators.python.process.ExternalPythonBatchKeyedCoBroadcastProcessOperator;
@@ -53,7 +53,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
 
         Configuration config = transformation.getConfiguration();
 
-        StreamOperator<OUT> operator;
+        DataStreamPythonFunctionOperator<OUT> operator;
 
         if (config.get(PythonOptions.PYTHON_EXECUTION_MODE).equals("thread")) {
             operator =
@@ -72,6 +72,9 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
                             transformation.getBroadcastInput().getOutputType(),
                             transformation.getOutputType());
         }
+
+        PythonBroadcastStateTransformationTranslator.setOperatorSideOutputTags(
+                transformation, operator);
 
         return translateInternal(
                 transformation,
@@ -92,7 +95,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
 
         Configuration config = transformation.getConfiguration();
 
-        StreamOperator<OUT> operator;
+        DataStreamPythonFunctionOperator<OUT> operator;
 
         if (config.get(PythonOptions.PYTHON_EXECUTION_MODE).equals("thread")) {
             operator =
@@ -112,6 +115,9 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
                             transformation.getBroadcastInput().getOutputType(),
                             transformation.getOutputType());
         }
+
+        PythonBroadcastStateTransformationTranslator.setOperatorSideOutputTags(
+                transformation, operator);
 
         return translateInternal(
                 transformation,

--- a/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonKeyedBroadcastStateTransformationTranslator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonKeyedBroadcastStateTransformationTranslator.java
@@ -21,11 +21,12 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.python.PythonOptions;
 import org.apache.flink.streaming.api.operators.SimpleOperatorFactory;
-import org.apache.flink.streaming.api.operators.python.DataStreamPythonFunctionOperator;
+import org.apache.flink.streaming.api.operators.python.AbstractPythonFunctionOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonBatchKeyedCoBroadcastProcessOperator;
 import org.apache.flink.streaming.api.operators.python.embedded.EmbeddedPythonKeyedCoProcessOperator;
 import org.apache.flink.streaming.api.operators.python.process.ExternalPythonBatchKeyedCoBroadcastProcessOperator;
 import org.apache.flink.streaming.api.operators.python.process.ExternalPythonKeyedCoProcessOperator;
+import org.apache.flink.streaming.api.transformations.python.DelegateOperatorTransformation;
 import org.apache.flink.streaming.api.transformations.python.PythonKeyedBroadcastStateTransformation;
 import org.apache.flink.streaming.runtime.translators.AbstractTwoInputTransformationTranslator;
 import org.apache.flink.types.Row;
@@ -53,7 +54,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
 
         Configuration config = transformation.getConfiguration();
 
-        DataStreamPythonFunctionOperator<OUT> operator;
+        AbstractPythonFunctionOperator<OUT> operator;
 
         if (config.get(PythonOptions.PYTHON_EXECUTION_MODE).equals("thread")) {
             operator =
@@ -73,8 +74,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
                             transformation.getOutputType());
         }
 
-        PythonBroadcastStateTransformationTranslator.setOperatorSideOutputTags(
-                transformation, operator);
+        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
 
         return translateInternal(
                 transformation,
@@ -95,7 +95,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
 
         Configuration config = transformation.getConfiguration();
 
-        DataStreamPythonFunctionOperator<OUT> operator;
+        AbstractPythonFunctionOperator<OUT> operator;
 
         if (config.get(PythonOptions.PYTHON_EXECUTION_MODE).equals("thread")) {
             operator =
@@ -116,8 +116,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
                             transformation.getOutputType());
         }
 
-        PythonBroadcastStateTransformationTranslator.setOperatorSideOutputTags(
-                transformation, operator);
+        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
 
         return translateInternal(
                 transformation,

--- a/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonKeyedBroadcastStateTransformationTranslator.java
+++ b/flink-python/src/main/java/org/apache/flink/streaming/runtime/translators/python/PythonKeyedBroadcastStateTransformationTranslator.java
@@ -74,7 +74,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
                             transformation.getOutputType());
         }
 
-        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
+        DelegateOperatorTransformation.configureOperator(transformation, operator);
 
         return translateInternal(
                 transformation,
@@ -116,7 +116,7 @@ public class PythonKeyedBroadcastStateTransformationTranslator<OUT>
                             transformation.getOutputType());
         }
 
-        DelegateOperatorTransformation.configureDelegatedOperator(transformation, operator);
+        DelegateOperatorTransformation.configureOperator(transformation, operator);
 
         return translateInternal(
                 transformation,


### PR DESCRIPTION
## What is the purpose of the change

This PR supports using side-output functionality in broadcast processing case in pyflink.


## Brief change log

- add operator delegation when processing side-outputs in transformations, since broadcast transformation doesn't have a solid operator
- move delegated side-output tags to solid operator in translation stage, making the python operator aware of side-output
- adjust embedded-mode code to support side-output in broadcast operator


## Verifying this change


This change added tests and can be verified as follows:
- `test_co_broadcast_side_output` and `test_keyed_co_broadcast_side_output` in test_data_stream.py

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not applicable)
