### PR TITLE
[FLINK-31142][Table SQL/Client] Catch TokenMgrError in SqlCommandParserImpl#scan

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlCommandParserImpl.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlCommandParserImpl.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.client.cli.parser;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImplTokenManager;
 import org.apache.flink.sql.parser.impl.SimpleCharStream;
 import org.apache.flink.sql.parser.impl.Token;
+import org.apache.flink.sql.parser.impl.TokenMgrError;
 import org.apache.flink.table.api.SqlParserEOFException;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 
@@ -86,7 +87,12 @@ public class SqlCommandParserImpl implements SqlCommandParser {
             Token current = currentToken;
             while (pos-- > 0) {
                 if (current.next == null) {
-                    current.next = tokenManager.getNextToken();
+                    try {
+                        current.next = tokenManager.getNextToken();
+                    } catch (TokenMgrError tme) {
+                        throw new SqlExecutionException(
+                                "SQL parse failed. " + tme.getMessage(), tme);
+                    }
                 }
                 current = current.next;
             }

--- a/flink-table/flink-sql-client/src/test/resources/sql/select.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/select.q
@@ -336,3 +336,8 @@ SELECT INTERVAL '1' DAY as dayInterval, INTERVAL '1' YEAR as yearInterval;
 +-----------------+--------------+
 1 row in set
 !ok
+
+SELECT /*;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.sql.parser.impl.TokenMgrError: Lexical error at line 1, column 11.  Encountered: <EOF> after : ""
+!error


### PR DESCRIPTION
## What is the purpose of the change
After https://issues.apache.org/jira/browse/FLINK-29945 sql client started to close the session in case some invalid queries rather than just fail with error and allow user to enter another one. 

example of queries
```sql
SELECT /*;
```
```sql
SELECT @;
```
```sql
SELECT #;
```

It seems that before this change all the parser exceptions are handled via `org.apache.calcite.sql.parser.SqlAbstractParserImpl#normalizeException` which under the hood catches `TokenMgrError`. Now it works directly with `TokenIterator` that's why extra catch is required.

## Verifying this change

The test query reproducing the issue added to _flink-table/flink-sql-client/src/test/resources/sql/select.q_



## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
