### PR TITLE
[FLINK-31183][Connector/Kinesis] Fix bug where EFO Consumer can fail …

### DIFF
--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/ShardConsumer.java
@@ -149,7 +149,7 @@ public class ShardConsumer<T> implements Runnable {
                     // we can close this consumer thread once we've reached the end of the
                     // subscribed shard
                     break;
-                } else if (result == CANCELLED) {
+                } else if (isRunning() && result == CANCELLED) {
                     final String errorMessage =
                             "Shard consumer cancelled: " + subscribedShard.getShard().getShardId();
                     LOG.info(errorMessage);

--- a/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherFactory.java
+++ b/flink-connectors/flink-connector-kinesis/src/main/java/org/apache/flink/streaming/connectors/kinesis/internals/publisher/fanout/FanOutRecordPublisherFactory.java
@@ -47,6 +47,9 @@ public class FanOutRecordPublisherFactory implements RecordPublisherFactory {
      */
     private final KinesisProxyV2Interface kinesisProxy;
 
+    /** A flag to indicate whether the FanOutRecordPublisherFactory has been closed. */
+    private boolean closed = false;
+
     /**
      * Instantiate a factory responsible for creating {@link FanOutRecordPublisher}.
      *
@@ -89,11 +92,13 @@ public class FanOutRecordPublisherFactory implements RecordPublisherFactory {
                 streamShardHandle,
                 kinesisProxy,
                 configuration,
-                BACKOFF);
+                BACKOFF,
+                () -> !closed);
     }
 
     @Override
     public void close() {
+        closed = true;
         kinesisProxy.close();
     }
 }


### PR DESCRIPTION
…to stop gracefully during stop-with-savepoint

## What is the purpose of the change

Update Kinesis EFO consumer to exit gracefully during stop-with-savepoint. There is an edgecase where an exception is thrown causing the job to fail during stop-with-savepoint.

## Brief change log

- Add a callback to `FanoutShardSubscriber` that allows the EFO subscriber threads to check if the consumer should be running

## Verifying this change

- Additional unit tests added
- Manually verified via Flink cluster using stop-with-savepoint

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
