### PR TITLE
[FLINK-31109][yarn] Support Hadoop proxy user when delegation token f…

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/modules/HadoopModule.java
@@ -70,22 +70,22 @@ public class HadoopModule implements SecurityModule {
         UserGroupInformation loginUser;
 
         try {
-            if (HadoopUserUtils.isProxyUser((UserGroupInformation.getCurrentUser()))
-                    && securityConfig
-                            .getFlinkConfig()
-                            .getBoolean(SecurityOptions.DELEGATION_TOKENS_ENABLED)) {
-                throw new UnsupportedOperationException(
-                        "Hadoop Proxy user is supported only when"
-                                + " delegation tokens fetch is managed outside of Flink!"
-                                + " Please try again with "
-                                + SecurityOptions.DELEGATION_TOKENS_ENABLED.key()
-                                + " config set to false!");
-            }
-
             KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(securityConfig);
             if (kerberosLoginProvider.isLoginPossible(true)) {
                 kerberosLoginProvider.doLogin(true);
                 loginUser = UserGroupInformation.getLoginUser();
+
+                if (HadoopUserUtils.isProxyUser((loginUser))
+                        && securityConfig
+                                .getFlinkConfig()
+                                .getBoolean(SecurityOptions.DELEGATION_TOKENS_ENABLED)) {
+                    throw new UnsupportedOperationException(
+                            "Hadoop Proxy user is supported only when"
+                                    + " delegation tokens fetch is managed outside of Flink!"
+                                    + " Please try again with "
+                                    + SecurityOptions.DELEGATION_TOKENS_ENABLED.key()
+                                    + " config set to false!");
+                }
 
                 if (loginUser.isFromKeytab()) {
                     String fileLocation =

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HBaseDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HBaseDelegationTokenProvider.java
@@ -116,7 +116,7 @@ public class HBaseDelegationTokenProvider implements DelegationTokenProvider {
             return false;
         }
         return hbaseConf.get("hbase.security.authentication").equals("kerberos")
-                && kerberosLoginProvider.isLoginPossible();
+                && kerberosLoginProvider.isLoginPossible(false);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/HadoopFSDelegationTokenProvider.java
@@ -99,7 +99,7 @@ public class HadoopFSDelegationTokenProvider implements DelegationTokenProvider 
             return false;
         }
         return HadoopUtils.isKerberosSecurityEnabled(UserGroupInformation.getCurrentUser())
-                && kerberosLoginProvider.isLoginPossible();
+                && kerberosLoginProvider.isLoginPossible(false);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
@@ -59,7 +59,7 @@ public class KerberosLoginProvider {
         this.useTicketCache = securityConfiguration.useTicketCache();
     }
 
-    public boolean isLoginPossible() throws IOException {
+    public boolean isLoginPossible(boolean supportProxyUser) throws IOException {
         if (UserGroupInformation.isSecurityEnabled()) {
             LOG.debug("Security is enabled");
         } else {
@@ -77,6 +77,8 @@ public class KerberosLoginProvider {
                 LOG.debug("Login from ticket cache is possible");
                 return true;
             }
+        } else if (supportProxyUser) {
+            return true;
         } else {
             throwProxyUserNotSupported();
         }
@@ -89,7 +91,7 @@ public class KerberosLoginProvider {
     /**
      * Does kerberos login and sets current user. Must be called when isLoginPossible returns true.
      */
-    public void doLogin() throws IOException {
+    public void doLogin(boolean supportProxyUser) throws IOException {
         if (principal != null) {
             LOG.info(
                     "Attempting to login to KDC using principal: {} keytab: {}", principal, keytab);
@@ -99,6 +101,8 @@ public class KerberosLoginProvider {
             LOG.info("Attempting to load user's ticket cache");
             UserGroupInformation.loginUserFromSubject(null);
             LOG.info("Loaded user's ticket cache successfully");
+        } else if (supportProxyUser) {
+            LOG.info("Delegation token fetch is managed and therefore login is managed");
         } else {
             throwProxyUserNotSupported();
         }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProvider.java
@@ -102,7 +102,7 @@ public class KerberosLoginProvider {
             UserGroupInformation.loginUserFromSubject(null);
             LOG.info("Loaded user's ticket cache successfully");
         } else if (supportProxyUser) {
-            LOG.info("Delegation token fetch is managed and therefore login is managed");
+            LOG.info("Proxy user doesn't need login since it must have credentials already");
         } else {
             throwProxyUserNotSupported();
         }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
@@ -58,7 +58,7 @@ public class KerberosLoginProviderITCase {
             UserGroupInformation userGroupInformation = mock(UserGroupInformation.class);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertFalse(kerberosLoginProvider.isLoginPossible(true));
+            assertFalse(kerberosLoginProvider.isLoginPossible(false));
         }
     }
 
@@ -72,7 +72,7 @@ public class KerberosLoginProviderITCase {
             ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(false);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertFalse(kerberosLoginProvider.isLoginPossible(true));
+            assertFalse(kerberosLoginProvider.isLoginPossible(false));
         }
     }
 
@@ -89,7 +89,7 @@ public class KerberosLoginProviderITCase {
             ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(true);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertTrue(kerberosLoginProvider.isLoginPossible(true));
+            assertTrue(kerberosLoginProvider.isLoginPossible(false));
         }
     }
 
@@ -105,7 +105,7 @@ public class KerberosLoginProviderITCase {
             ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(true);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertTrue(kerberosLoginProvider.isLoginPossible(true));
+            assertTrue(kerberosLoginProvider.isLoginPossible(false));
         }
     }
 
@@ -155,7 +155,7 @@ public class KerberosLoginProviderITCase {
             UserGroupInformation userGroupInformation = mock(UserGroupInformation.class);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            kerberosLoginProvider.doLogin(true);
+            kerberosLoginProvider.doLogin(false);
             ugi.verify(() -> UserGroupInformation.loginUserFromKeytab(anyString(), anyString()));
         }
     }
@@ -171,7 +171,7 @@ public class KerberosLoginProviderITCase {
             when(userGroupInformation.hasKerberosCredentials()).thenReturn(true);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            kerberosLoginProvider.doLogin(true);
+            kerberosLoginProvider.doLogin(false);
             ugi.verify(() -> UserGroupInformation.loginUserFromSubject(null));
         }
     }


### PR DESCRIPTION
…etch is disabled

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

FLINK-28330 removed old delegation token framework code as part of it removed the existing support for delegation tokens that are managed outside of Flink

## Brief change log

- As part of `YarnClusterDescriptor#setTokensFor` load the available delegation tokens in the client machine and then load the tokens obtained through `DelegationTokenManager` if `security.delegation.tokens.enabled` is set to true.
- `HadoopModule` should throw exception if the `UserGroupInformation.currentUser` is a hadoop proxy user and also `security.delegation.tokens.enabled` is set to true.

## Verifying this change

- Added tests in the `HadoopModuleTest` and in `KerberosLoginProviderITCase`.
- Manually tested in our env where delegation token fetch is managed.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
