### PR TITLE
[FLINK-31192][connectors/dataGen] Fix dataGen takes too long to initi…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -47,7 +47,7 @@ public abstract class SequenceGenerator<T> implements DataGenerator<T> {
     private long totalNoOfElements;
     /**
      * Save the intermediate state of the data to be sent by the current subtask,When the state
-     * returns, the sequence values continue to be sent based on the intermediate state
+     * returns, the sequence values continue to be sent based on the intermediate state.
      */
     private ArrayList<InternalState> internalStates;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -25,17 +25,15 @@ import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.util.Preconditions;
 
 import org.apache.flink.shaded.guava30.com.google.common.collect.Queues;
-
-import org.apache.flink.util.Preconditions;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.NoSuchElementException;
-import java.util.PriorityQueue;
 import java.util.Queue;
 
 /**

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -46,8 +46,8 @@ public abstract class SequenceGenerator<T> implements DataGenerator<T> {
     private final long end;
     private long totalNoOfElements;
     /**
-     * Save the intermediate state of the data to be sent by the current subtask,When the state
-     * returns, the sequence values continue to be sent based on the intermediate state.
+     * Save the intermediate state of the data to be sent by the current subtask,when the state
+     * restore, the sequence values continue to be sent based on the intermediate state.
      */
     private ArrayList<InternalState> internalStates;
 

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGenerator.java
@@ -19,7 +19,6 @@
 package org.apache.flink.streaming.api.functions.source.datagen;
 
 import org.apache.flink.annotation.Experimental;
-import org.apache.flink.annotation.VisibleForTesting;
 import org.apache.flink.api.common.functions.RuntimeContext;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -82,7 +81,6 @@ public abstract class SequenceGenerator<T> implements DataGenerator<T> {
         this.start = inclStart;
         this.end = inclEnd;
         this.subTaskStates = Queues.newPriorityQueue();
-
     }
 
     @Override

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
@@ -1,0 +1,33 @@
+package org.apache.flink.streaming.api.functions.source.datagen;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link SequenceGenerator}. */
+public class SequenceGeneratorTest {
+
+    @Test
+    public void testStartGreaterThanEnd() {
+        final long end = 0;
+        final long  start= Long.MAX_VALUE;
+        assertThatThrownBy(() -> SequenceGenerator.longGenerator(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The start value (%s) cannot be greater than the end value (%s).",
+                        start, end);
+    }
+
+    @Test
+    public void testTooLargeRange() {
+        final long start = 0;
+        final long end = Long.MAX_VALUE;
+        assertThatThrownBy(() -> SequenceGenerator.longGenerator(start, end))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(
+                        "The total size of range (%s, %s) exceeds the maximum limit: Long.MAX_VALUE - 1.",
+                        start, end);
+    }
+
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/functions/source/datagen/SequenceGeneratorTest.java
@@ -1,6 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.flink.streaming.api.functions.source.datagen;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -11,7 +28,7 @@ public class SequenceGeneratorTest {
     @Test
     public void testStartGreaterThanEnd() {
         final long end = 0;
-        final long  start= Long.MAX_VALUE;
+        final long start = Long.MAX_VALUE;
         assertThatThrownBy(() -> SequenceGenerator.longGenerator(start, end))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(
@@ -29,5 +46,4 @@ public class SequenceGeneratorTest {
                         "The total size of range (%s, %s) exceeds the maximum limit: Long.MAX_VALUE - 1.",
                         start, end);
     }
-
 }

--- a/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitor.java
+++ b/flink-table/flink-table-api-java-bridge/src/main/java/org/apache/flink/connector/datagen/table/SequenceGeneratorVisitor.java
@@ -207,7 +207,7 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
         return new SequenceGenerator<StringData>(start, end) {
             @Override
             public StringData next() {
-                return StringData.fromString(valuesToEmit.poll().toString());
+                return StringData.fromString(nextValue().toString());
             }
         };
     }
@@ -216,7 +216,7 @@ public class SequenceGeneratorVisitor extends DataGenVisitorBase {
         return new SequenceGenerator<byte[]>(start, end) {
             @Override
             public byte[] next() {
-                Long value = valuesToEmit.poll();
+                Long value = nextValue();
                 if (value != null) {
                     return Longs.toByteArray(value);
                 } else {


### PR DESCRIPTION
## What is the purpose of the change
In the sequence mode, the dataGen field will preload all the sequence values when it is initialized, and it will take a long time during this period

## Brief change log
- Adapt the way of preloading the value to generate a sequence value every time the next method is called
- The checkpoint saves not all the sequence values, but the position where the current task sends the sequence value

## Verifying this change
`DataGeneratorSourceTest` and `DataGenTableSourceFactoryTest`

## Does this pull request potentially affect one of the following parts:
  - Dependencies (does it add or upgrade a dependency):   no 
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`:   no 
  - The serializers:   no 
  - The runtime per-record code paths (performance sensitive):   no  
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper:   no 
  - The S3 file system connector:   no 

## Documentation
  - Does this pull request introduce a new feature?  no 

