### PR TITLE
[FLINK-12449][table] Add BIT_AND, BIT_OR functions supported in Table API and SQL

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -241,7 +241,12 @@ arithmetic:
   - sql: TRUNCATE(numeric1, integer2)
     table: numeric1.truncate(INTEGER2)
     description: Returns a numeric of truncated to integer2 decimal places. Returns NULL if numeric1 or integer2 is NULL. If integer2 is 0, the result has no decimal point or fractional part. integer2 can be negative to cause integer2 digits left of the decimal point of the value to become zero. This function can also pass in only one numeric1 parameter and not set Integer2 to use. If Integer2 is not set, the function truncates as if Integer2 were 0. E.g. 42.324.truncate(2) to 42.32. and 42.324.truncate() to 42.0.
-
+  - sql: BIT_AND(numeric1, numeric2)
+    table: numeric1.bitAnd(numeric2)
+    description: Returns a result of numeric1 bitwise AND numeric2. If any arg is NULL then return 0. e.g. BIT_AND(29,15), return 13.
+  - sql: BIT_OR(numeric1, numeric2)
+    table: numeric1.bitOr(numeric2)
+    description: Returns a result of numeric1 bitwise OR numeric2. If any arg is NULL then return another numeric, if both are NULL then return 0. e.g. BIT_OR(29,15), returns 31.
 string:
   - sql: string1 || string2
     table: STRING1 + STRING2

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -148,6 +148,8 @@ arithmetic functions
     Expression.bin
     Expression.hex
     Expression.truncate
+    Expression.bit_and
+    Expression.bit_or
 
 string functions
 ----------------

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -477,7 +477,6 @@ class Expression(Generic[T]):
     __and__ = _binary_op("and")
     __or__ = _binary_op("or")
     __invert__ = _unary_op('isNotTrue')
-
     __rand__ = _binary_op("and")
     __ror__ = _binary_op("or")
 
@@ -489,7 +488,6 @@ class Expression(Generic[T]):
     __mod__ = _binary_op("mod")
     __pow__ = _binary_op("power")
     __neg__ = _expressions_op("negative")
-
     __radd__ = _binary_op("plus", True)
     __rsub__ = _binary_op("minus", True)
     __rmul__ = _binary_op("times")
@@ -1008,6 +1006,22 @@ class Expression(Generic[T]):
         E.g. truncate(42.345, 2) to 42.34, 42.truncate(-1) to 40
         """
         return _binary_op("truncate")(self, n)
+
+    def bit_and(self, numeric) -> 'Expression':
+        """
+        Returns a result of numeric1 bitwise AND numeric2.
+        If any arg is NULL then return 0.
+        e.g. bit_and(29,15), return 13.
+        """
+        return _binary_op("bitAnd")(self, numeric)
+
+    def bit_or(self, numeric) -> 'Expression':
+        """
+        Returns a result of numeric1 bitwise OR numeric2.
+        If any arg is NULL then return another numeric, if both are NULL then return 0.
+        e.g. bit_or(29,15), returns 31.
+        """
+        return _binary_op("bitOr")(self, numeric)
 
     # ---------------------------- string functions ----------------------------------
 

--- a/flink-python/pyflink/table/tests/test_expression.py
+++ b/flink-python/pyflink/table/tests/test_expression.py
@@ -124,6 +124,8 @@ class PyFlinkBatchExpressionTests(PyFlinkTestCase):
         self.assertEqual('bin(a)', str(expr1.bin))
         self.assertEqual('hex(a)', str(expr1.hex))
         self.assertEqual('truncate(a, 3)', str(expr1.truncate(3)))
+        self.assertEqual('bit_and(a, 3)', str(expr1.bit_and(3)))
+        self.assertEqual('bit_or(a, 3)', str(expr1.bit_or(3)))
 
         # string functions
         self.assertEqual('substring(a, b)', str(expr1.substring(expr2)))

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -63,6 +63,8 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.ATAN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.AVG;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BETWEEN;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BIN;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BIT_AND;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.BIT_OR;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CARDINALITY;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CAST;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.CEIL;
@@ -773,6 +775,22 @@ public abstract class BaseExpressions<InType, OutType> {
     /** Returns a number of truncated to 0 decimal places. E.g. truncate(42.345) to 42.0. */
     public OutType truncate() {
         return toApiSpecificExpression(unresolvedCall(TRUNCATE, toExpr()));
+    }
+
+    /**
+     * Returns a result of numeric1 bitwise AND numeric2. If any arg is NULL then return 0. e.g.
+     * BIT_AND(29,15), return 13.
+     */
+    public OutType bitAnd(InType n) {
+        return toApiSpecificExpression(unresolvedCall(BIT_AND, toExpr(), objectToExpression(n)));
+    }
+
+    /**
+     * Returns a result of numeric1 bitwise OR numeric2. If any arg is NULL then return another
+     * numeric, if both are NULL then return 0. e.g. BIT_OR(29,15), returns 31.
+     */
+    public OutType bitOr(InType n) {
+        return toApiSpecificExpression(unresolvedCall(BIT_OR, toExpr(), objectToExpression(n)));
     }
 
     // String operations

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1459,6 +1459,30 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(SpecificTypeStrategies.ROUND))
                     .build();
 
+    public static final BuiltInFunctionDefinition BIT_AND =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("bit_and")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                    logical(LogicalTypeFamily.INTEGER_NUMERIC)))
+                    .outputTypeStrategy(argument(0))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.BitAndFunction")
+                    .build();
+
+    public static final BuiltInFunctionDefinition BIT_OR =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("bit_or")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeFamily.INTEGER_NUMERIC),
+                                    logical(LogicalTypeFamily.INTEGER_NUMERIC)))
+                    .outputTypeStrategy(argument(0))
+                    .runtimeClass("org.apache.flink.table.runtime.functions.scalar.BitOrFunction")
+                    .build();
+
     // --------------------------------------------------------------------------------------------
     // Catalog functions
     // --------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/calls/BuiltInMethods.scala
@@ -189,15 +189,6 @@ object BuiltInMethods {
 
   // BIT FUNCTIONS
 
-  val BITAND_BYTE =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitAnd", classOf[JByte], classOf[JByte])
-  val BITAND_SHORT =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitAnd", classOf[JShort], classOf[JShort])
-  val BITAND_INTEGER =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitAnd", classOf[JInteger], classOf[JInteger])
-  val BITAND_LONG =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitAnd", classOf[JLong], classOf[JLong])
-
   val BITNOT_BYTE =
     Types.lookupMethod(classOf[SqlFunctionUtils], "bitNot", classOf[JByte])
   val BITNOT_SHORT =
@@ -206,15 +197,6 @@ object BuiltInMethods {
     Types.lookupMethod(classOf[SqlFunctionUtils], "bitNot", classOf[JInteger])
   val BITNOT_LONG =
     Types.lookupMethod(classOf[SqlFunctionUtils], "bitNot", classOf[JLong])
-
-  val BITOR_BYTE =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitOr", classOf[JByte], classOf[JByte])
-  val BITOR_SHORT =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitOr", classOf[JShort], classOf[JShort])
-  val BITOR_INTEGER =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitOr", classOf[JInteger], classOf[JInteger])
-  val BITOR_LONG =
-    Types.lookupMethod(classOf[SqlFunctionUtils], "bitOr", classOf[JLong], classOf[JLong])
 
   val BITXOR_BYTE =
     Types.lookupMethod(classOf[SqlFunctionUtils], "bitXor", classOf[JByte], classOf[JByte])

--- a/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
+++ b/flink-table/flink-table-planner/src/test/scala/org/apache/flink/table/planner/expressions/ScalarFunctionsTest.scala
@@ -1664,6 +1664,64 @@ class ScalarFunctionsTest extends ScalarTypesTestBase {
     )
   }
 
+  @Test
+  def testBitAnd(): Unit = {
+    // byte
+    testAllApis('f2.bitAnd('f9), "BIT_AND(f2, f9)", "2")
+    // short
+    testAllApis('f3.bitAnd('f10), "BIT_AND(f3, f10)", "1")
+    // int
+    testAllApis(29.bitAnd(15), "BIT_AND(29, 15)", "13")
+    // long
+    testAllApis('f4.bitAnd('f11), "BIT_AND(f4, f11)", "4")
+    // null
+    testAllApis('f2.bitAnd(nullOf(DataTypes.TINYINT())), "BIT_AND(f2, cast (null AS TINYINT))", "0")
+    testAllApis(
+      'f3.bitAnd(nullOf(DataTypes.SMALLINT())),
+      "BIT_AND(f3, cast (null AS SMALLINT))",
+      "0")
+    testAllApis(29.bitAnd(nullOf(DataTypes.INT())), "BIT_AND(29, cast (null AS INTEGER))", "0")
+    testAllApis('f4.bitAnd(nullOf(DataTypes.BIGINT())), "BIT_AND(f4, cast (null AS BIGINT))", "0")
+  }
+
+  @Test
+  def testBitOr(): Unit = {
+    // byte
+    testAllApis('f2.bitOr('f9), "BIT_OR(f2, f9)", "-2")
+    // short
+    testAllApis('f3.bitOr('f10), "BIT_OR(f3, f10)", "-1")
+    // int
+    testAllApis(29.bitOr(15), "BIT_OR(29, 15)", "31")
+    // long
+    testAllApis('f4.bitOr('f11), "BIT_OR(f4, f11)", "-4")
+    // null
+    testAllApis('f2.bitOr(nullOf(DataTypes.TINYINT())), "BIT_OR(f2, cast (null AS TINYINT))", "42")
+    testAllApis(
+      'f3.bitOr(nullOf(DataTypes.SMALLINT())),
+      "BIT_OR(f3, cast (null AS SMALLINT))",
+      "43")
+    testAllApis(29.bitOr(nullOf(DataTypes.INT())), "BIT_OR(29, cast (null AS INTEGER))", "29")
+    testAllApis('f4.bitOr(nullOf(DataTypes.BIGINT())), "BIT_OR(f4, cast (null AS BIGINT))", "44")
+    // both null
+    testAllApis(
+      'f21.cast(DataTypes.TINYINT()).bitOr(nullOf(DataTypes.TINYINT)),
+      "BIT_OR(cast " +
+        "(null AS TINYINT), cast (null AS TINYINT))",
+      "0")
+    testAllApis(
+      'f21.cast(DataTypes.SMALLINT()).bitOr(nullOf(DataTypes.SMALLINT)),
+      "BIT_OR(cast (null AS SMALLINT), cast (null AS SMALLINT))",
+      "0")
+    testAllApis(
+      'f21.cast(DataTypes.INT()).bitOr(nullOf(DataTypes.INT)),
+      "BIT_OR(cast (null AS INTEGER), cast (null AS INTEGER))",
+      "0")
+    testAllApis(
+      'f21.cast(DataTypes.BIGINT()).bitOr(nullOf(DataTypes.BIGINT)),
+      "BIT_OR(cast (null AS BIGINT), cast (null AS BIGINT))",
+      "0")
+  }
+
   // ----------------------------------------------------------------------------------------------
   // Temporal functions
   // ----------------------------------------------------------------------------------------------

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/SqlFunctionUtils.java
@@ -1012,35 +1012,6 @@ public class SqlFunctionUtils {
         }
     }
 
-    public static Byte bitAnd(Byte a, Byte b) {
-        if (a == null || b == null) {
-            return 0;
-        }
-        return (byte) (a & b);
-    }
-
-    public static Short bitAnd(Short a, Short b) {
-        if (a == null || b == null) {
-            return 0;
-        }
-        return (short) (a & b);
-    }
-
-    public static Integer bitAnd(Integer a, Integer b) {
-        if (a == null || b == null) {
-            return 0;
-        }
-
-        return a & b;
-    }
-
-    public static Long bitAnd(Long a, Long b) {
-        if (a == null || b == null) {
-            return 0L;
-        }
-        return a & b;
-    }
-
     public static Byte bitNot(Byte a) {
         if (a == null) {
             a = 0;
@@ -1067,54 +1038,6 @@ public class SqlFunctionUtils {
             a = 0L;
         }
         return ~a;
-    }
-
-    public static Byte bitOr(Byte a, Byte b) {
-        if (a == null || b == null) {
-            if (a == null) {
-                a = 0;
-            }
-            if (b == null) {
-                b = 0;
-            }
-        }
-        return (byte) (a | b);
-    }
-
-    public static Short bitOr(Short a, Short b) {
-        if (a == null || b == null) {
-            if (a == null) {
-                a = 0;
-            }
-            if (b == null) {
-                b = 0;
-            }
-        }
-        return (short) (a | b);
-    }
-
-    public static Integer bitOr(Integer a, Integer b) {
-        if (a == null || b == null) {
-            if (a == null) {
-                a = 0;
-            }
-            if (b == null) {
-                b = 0;
-            }
-        }
-        return a | b;
-    }
-
-    public static Long bitOr(Long a, Long b) {
-        if (a == null || b == null) {
-            if (a == null) {
-                a = 0L;
-            }
-            if (b == null) {
-                b = 0L;
-            }
-        }
-        return a | b;
     }
 
     public static Byte bitXor(Byte a, Byte b) {

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/BitAndFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/BitAndFunction.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#BIT_AND}. */
+@Internal
+public class BitAndFunction extends BuiltInScalarFunction {
+
+    public BitAndFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.BIT_AND, context);
+    }
+
+    public Byte eval(Byte a, Byte b) {
+        if (a == null || b == null) {
+            return 0;
+        }
+        return (byte) (a & b);
+    }
+
+    public Short eval(Short a, Short b) {
+        if (a == null || b == null) {
+            return 0;
+        }
+        return (short) (a & b);
+    }
+
+    public Integer eval(Integer a, Integer b) {
+        if (a == null || b == null) {
+            return 0;
+        }
+        return a & b;
+    }
+
+    public Long eval(Long a, Long b) {
+        if (a == null || b == null) {
+            return 0L;
+        }
+        return a & b;
+    }
+}

--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/BitOrFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/BitOrFunction.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.runtime.functions.scalar;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.functions.SpecializedFunction;
+
+/** Implementation of {@link BuiltInFunctionDefinitions#BIT_OR}. */
+@Internal
+public class BitOrFunction extends BuiltInScalarFunction {
+
+    public BitOrFunction(SpecializedFunction.SpecializedContext context) {
+        super(BuiltInFunctionDefinitions.BIT_OR, context);
+    }
+
+    public Byte eval(Byte a, Byte b) {
+        if (a == null || b == null) {
+            if (a == null) {
+                a = 0;
+            }
+            if (b == null) {
+                b = 0;
+            }
+        }
+        return (byte) (a | b);
+    }
+
+    public Short eval(Short a, Short b) {
+        if (a == null || b == null) {
+            if (a == null) {
+                a = 0;
+            }
+            if (b == null) {
+                b = 0;
+            }
+        }
+        return (short) (a | b);
+    }
+
+    public Integer eval(Integer a, Integer b) {
+        if (a == null || b == null) {
+            if (a == null) {
+                a = 0;
+            }
+            if (b == null) {
+                b = 0;
+            }
+        }
+        return a | b;
+    }
+
+    public Long eval(Long a, Long b) {
+        if (a == null || b == null) {
+            if (a == null) {
+                a = 0L;
+            }
+            if (b == null) {
+                b = 0L;
+            }
+        }
+        return a | b;
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

Add BIT_AND, BIT_OR function

## Brief change log

BIT_AND, BIT_OR for table & sql

## Verifying this change
ScalarFunctionsTest

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: yes
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? docs