### PR TITLE
[BP-1.17][FLINK-31142][Table SQL/Client] Catch TokenMgrError in SqlCommandParserImpl#scan

### DIFF
--- a/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlCommandParserImpl.java
+++ b/flink-table/flink-sql-client/src/main/java/org/apache/flink/table/client/cli/parser/SqlCommandParserImpl.java
@@ -21,6 +21,7 @@ package org.apache.flink.table.client.cli.parser;
 import org.apache.flink.sql.parser.impl.FlinkSqlParserImplTokenManager;
 import org.apache.flink.sql.parser.impl.SimpleCharStream;
 import org.apache.flink.sql.parser.impl.Token;
+import org.apache.flink.sql.parser.impl.TokenMgrError;
 import org.apache.flink.table.api.SqlParserEOFException;
 import org.apache.flink.table.client.gateway.SqlExecutionException;
 
@@ -86,7 +87,12 @@ public class SqlCommandParserImpl implements SqlCommandParser {
             Token current = currentToken;
             while (pos-- > 0) {
                 if (current.next == null) {
-                    current.next = tokenManager.getNextToken();
+                    try {
+                        current.next = tokenManager.getNextToken();
+                    } catch (TokenMgrError tme) {
+                        throw new SqlExecutionException(
+                                "SQL parse failed. " + tme.getMessage(), tme);
+                    }
                 }
                 current = current.next;
             }

--- a/flink-table/flink-sql-client/src/test/resources/sql/select.q
+++ b/flink-table/flink-sql-client/src/test/resources/sql/select.q
@@ -230,3 +230,8 @@ SELECT INTERVAL '1' DAY as dayInterval, INTERVAL '1' YEAR as yearInterval;
 +-----------------+--------------+
 1 row in set
 !ok
+
+SELECT /*;
+[ERROR] Could not execute SQL statement. Reason:
+org.apache.flink.sql.parser.impl.TokenMgrError: Lexical error at line 1, column 11.  Encountered: <EOF> after : ""
+!error


### PR DESCRIPTION
This is 1.17 backport of https://github.com/apache/flink/pull/22007