### PR TITLE
[FLINK-31222] Remove usage of deprecated ConverterUtils.toApplicationId.

### DIFF
--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -66,7 +66,7 @@ public class YarnClusterClientFactory
     public ApplicationId getClusterId(Configuration configuration) {
         checkNotNull(configuration);
         final String clusterId = configuration.getString(YarnConfigOptions.APPLICATION_ID);
-        return clusterId != null ? ConverterUtils.toApplicationId(clusterId) : null;
+        return clusterId != null ? ApplicationId.fromString(clusterId) : null;
     }
 
     @Override

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/YarnClusterClientFactory.java
@@ -31,7 +31,6 @@ import org.apache.flink.yarn.configuration.YarnLogConfigUtil;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
-import org.apache.hadoop.yarn.util.ConverterUtils;
 
 import javax.annotation.Nullable;
 

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -59,7 +59,6 @@ import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.exceptions.YarnException;
-import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -319,7 +318,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
             try {
                 // try converting id to ApplicationId
                 yarnApplicationIdFromYarnProperties =
-                        ConverterUtils.toApplicationId(yarnApplicationIdString);
+                    ApplicationId.fromString(yarnApplicationIdString);
             } catch (Exception e) {
                 throw new FlinkException(
                         "YARN properties contain an invalid entry for "
@@ -405,7 +404,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
             effectiveConfiguration.setString(HA_CLUSTER_ID, zooKeeperNamespace);
             effectiveConfiguration.setString(
-                    YarnConfigOptions.APPLICATION_ID, ConverterUtils.toString(applicationId));
+                    YarnConfigOptions.APPLICATION_ID, applicationId.toString());
             effectiveConfiguration.setString(
                     DeploymentOptions.TARGET, YarnSessionClusterExecutor.NAME);
         } else {
@@ -453,10 +452,10 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
     private ApplicationId getApplicationId(CommandLine commandLine) {
         if (commandLine.hasOption(applicationId.getOpt())) {
-            return ConverterUtils.toApplicationId(
+            return ApplicationId.fromString(
                     commandLine.getOptionValue(applicationId.getOpt()));
         } else if (configuration.getOptional(YarnConfigOptions.APPLICATION_ID).isPresent()) {
-            return ConverterUtils.toApplicationId(
+            return ApplicationId.fromString(
                     configuration.get(YarnConfigOptions.APPLICATION_ID));
         } else if (isYarnPropertiesFileMode(commandLine)) {
             return yarnApplicationIdFromYarnProperties;
@@ -593,7 +592,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
                 if (cmd.hasOption(applicationId.getOpt())) {
                     yarnApplicationId =
-                            ConverterUtils.toApplicationId(
+                        ApplicationId.fromString(
                                     cmd.getOptionValue(applicationId.getOpt()));
 
                     clusterClientProvider = yarnClusterDescriptor.retrieve(yarnApplicationId);

--- a/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
+++ b/flink-yarn/src/main/java/org/apache/flink/yarn/cli/FlinkYarnSessionCli.java
@@ -318,7 +318,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
             try {
                 // try converting id to ApplicationId
                 yarnApplicationIdFromYarnProperties =
-                    ApplicationId.fromString(yarnApplicationIdString);
+                        ApplicationId.fromString(yarnApplicationIdString);
             } catch (Exception e) {
                 throw new FlinkException(
                         "YARN properties contain an invalid entry for "
@@ -452,11 +452,9 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
     private ApplicationId getApplicationId(CommandLine commandLine) {
         if (commandLine.hasOption(applicationId.getOpt())) {
-            return ApplicationId.fromString(
-                    commandLine.getOptionValue(applicationId.getOpt()));
+            return ApplicationId.fromString(commandLine.getOptionValue(applicationId.getOpt()));
         } else if (configuration.getOptional(YarnConfigOptions.APPLICATION_ID).isPresent()) {
-            return ApplicationId.fromString(
-                    configuration.get(YarnConfigOptions.APPLICATION_ID));
+            return ApplicationId.fromString(configuration.get(YarnConfigOptions.APPLICATION_ID));
         } else if (isYarnPropertiesFileMode(commandLine)) {
             return yarnApplicationIdFromYarnProperties;
         }
@@ -592,8 +590,7 @@ public class FlinkYarnSessionCli extends AbstractYarnCli {
 
                 if (cmd.hasOption(applicationId.getOpt())) {
                     yarnApplicationId =
-                        ApplicationId.fromString(
-                                    cmd.getOptionValue(applicationId.getOpt()));
+                            ApplicationId.fromString(cmd.getOptionValue(applicationId.getOpt()));
 
                     clusterClientProvider = yarnClusterDescriptor.retrieve(yarnApplicationId);
                 } else {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change
JIRA: FLINK-31222. Remove usage of deprecated ConverterUtils.toApplicationId.
When reading the code, I found that we use ConverterUtils.toApplicationId to convert applicationId, this method is deprecated, we should use ApplicationId.fromString

## Brief change log

Remove usage of deprecated ConverterUtils.toApplicationId.

## Verifying this change

Manually verified.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? no
