### PR TITLE
[hotfix] Add GuardedBy annotation and some clean up for result partition.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataBuffer.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/DataBuffer.java
@@ -58,7 +58,7 @@ public interface DataBuffer {
     /** Returns true if not all data appended to this {@link DataBuffer} is consumed. */
     boolean hasRemaining();
 
-    /** Finishes this {@link DataBuffer} which means no record can be appended any more. */
+    /** Finishes this {@link DataBuffer} which means no record can be appended anymore. */
     void finish();
 
     /** Whether this {@link DataBuffer} is finished or not. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartition.java
@@ -32,8 +32,8 @@ import java.io.IOException;
 import static org.apache.flink.util.Preconditions.checkState;
 
 /**
- * A pipelined in-memory only subpartition, which allows to reconnecting after failure. Only one
- * view is allowed at a time to read teh subpartition.
+ * A pipelined in-memory only subpartition, which allows to reconnect after failure. Only one view
+ * is allowed at a time to read teh subpartition.
  */
 public class PipelinedApproximateSubpartition extends PipelinedSubpartition {
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionView.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedApproximateSubpartitionView.java
@@ -30,7 +30,7 @@ public class PipelinedApproximateSubpartitionView extends PipelinedSubpartitionV
      * Pipelined ResultPartition relies on its subpartition view's release to decide whether the
      * partition is ready to release. In contrast, Approximate Pipelined ResultPartition is put into
      * the JobMaster's Partition Tracker and relies on the tracker to release partitions after the
-     * job is finished. Hence in the approximate pipelined case, no resource related to view is
+     * job is finished. Hence, in the approximate pipelined case, no resource related to view is
      * needed to be released.
      */
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedResultPartition.java
@@ -36,7 +36,7 @@ import static org.apache.flink.util.Preconditions.checkArgument;
 /**
  * A result output of a task, pipelined (streamed) to the receivers.
  *
- * <p>This result partition implementation is used both in batch and streaming. For streaming it
+ * <p>This result partition implementation is used both in batch and streaming. For streaming, it
  * supports low latency transfers (ensure data is sent within x milliseconds) or unconstrained while
  * for batch it transfers only once a buffer is full. Additionally, for streaming use this typically
  * limits the length of the buffer backlog to not have too much data in flight, while for batch we
@@ -91,7 +91,7 @@ public class PipelinedResultPartition extends BufferWritingResultPartition
 
     /**
      * The total number of references to subpartitions of this result. The result partition can be
-     * safely released, iff the reference count is zero. Every subpartition is an user of the result
+     * safely released, iff the reference count is zero. Every subpartition is a user of the result
      * as well the {@link PipelinedResultPartition} is a user itself, as it's writing to those
      * results. Even if all consumers are released, partition can not be released until writer
      * releases the partition as well.

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PipelinedSubpartition.java
@@ -262,7 +262,7 @@ public class PipelinedSubpartition extends ResultSubpartition
         return needNotifyPriorityEvent();
     }
 
-    // It just be called after add priorityEvent.
+    // It is just called after add priorityEvent.
     @GuardedBy("buffers")
     private boolean needNotifyPriorityEvent() {
         assert Thread.holdsLock(buffers);
@@ -382,7 +382,7 @@ public class PipelinedSubpartition extends ResultSubpartition
             if (Buffer.DataType.TIMEOUTABLE_ALIGNED_CHECKPOINT_BARRIER
                     == bufferConsumer.getDataType()) {
                 barrier = parseAndCheckTimeoutableCheckpointBarrier(bufferConsumer);
-                // It may be a aborted barrier
+                // It may be an aborted barrier
                 if (barrier.getId() != checkpointId) {
                     continue;
                 }
@@ -496,7 +496,7 @@ public class PipelinedSubpartition extends ResultSubpartition
                         "When there are multiple buffers, an unfinished bufferConsumer can not be at the head of the buffers queue.");
 
                 if (buffers.size() == 1) {
-                    // turn off flushRequested flag if we drained all of the available data
+                    // turn off flushRequested flag if we drained all the available data
                     flushRequested = false;
                 }
 
@@ -690,7 +690,7 @@ public class PipelinedSubpartition extends ResultSubpartition
             if (buffers.isEmpty() || flushRequested) {
                 return;
             }
-            // if there is more then 1 buffer, we already notified the reader
+            // if there is more than 1 buffer, we already notified the reader
             // (at the latest when adding the second buffer)
             boolean isDataAvailableInUnfinishedBuffer =
                     buffers.size() == 1 && buffers.peek().getBufferConsumer().isDataAvailable();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
@@ -70,7 +70,7 @@ public final class PrioritizedDeque<T> implements Iterable<T> {
                 priorPriority.addFirst(deque.poll());
             }
             deque.addFirst(element);
-            // readd them before the newly added element
+            // read them before the newly added element
             for (final T priorityEvent : priorPriority) {
                 deque.addFirst(priorityEvent);
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/PrioritizedDeque.java
@@ -215,11 +215,6 @@ public final class PrioritizedDeque<T> implements Iterable<T> {
         return deque.size();
     }
 
-    /** Returns the number of non-priority elements. */
-    public int getNumUnprioritizedElements() {
-        return size() - getNumPriorityElements();
-    }
-
     /** @return read-only iterator */
     public Iterator<T> iterator() {
         return Collections.unmodifiableCollection(deque).iterator();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartition.java
@@ -509,7 +509,7 @@ public class SortMergeResultPartition extends ResultPartition {
     @Override
     public void close() {
         releaseFreeBuffers();
-        // the close method will be always called by the task thread, so there is need to make
+        // the close method will always be called by the task thread, so there is need to make
         // the sort buffer fields volatile and visible to the cancel thread intermediately
         releaseDataBuffer(unicastDataBuffer);
         releaseDataBuffer(broadcastDataBuffer);

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -217,10 +217,14 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             if (!buffers.isEmpty()) {
                 return new ArrayDeque<>(buffers);
             }
+            // only visibility requirements here.
+            // noinspection FieldAccessNotGuarded
             checkState(!isReleased, "Result partition has been already released.");
         } while (System.nanoTime() < timeoutTime
                 || System.nanoTime() < (timeoutTime = getBufferRequestTimeoutTime()));
 
+        // only visibility requirements here.
+        // noinspection FieldAccessNotGuarded
         if (numRequestedBuffers <= 0) {
             throw new TimeoutException(
                     String.format(
@@ -291,6 +295,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         }
     }
 
+    @GuardedBy("lock")
     private void mayNotifyReleased() {
         assert Thread.holdsLock(lock);
 
@@ -361,6 +366,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         }
     }
 
+    @GuardedBy("lock")
     private PartitionedFileReader createFileReader(
             PartitionedFile resultFile, int targetSubpartition) throws IOException {
         assert Thread.holdsLock(lock);
@@ -387,6 +393,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         }
     }
 
+    @GuardedBy("lock")
     private void openFileChannels(PartitionedFile resultFile) throws IOException {
         assert Thread.holdsLock(lock);
 
@@ -395,6 +402,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         indexFileChannel = openFileChannel(resultFile.getIndexFilePath());
     }
 
+    @GuardedBy("lock")
     private void closeFileChannels() {
         assert Thread.holdsLock(lock);
 
@@ -413,6 +421,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
         }
     }
 
+    @GuardedBy("lock")
     private void mayTriggerReading() {
         assert Thread.holdsLock(lock);
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -235,7 +235,7 @@ class SortMergeSubpartitionReader
     @SuppressWarnings("FieldAccessNotGuarded")
     @Override
     public int unsynchronizedGetNumberOfQueuedBuffers() {
-        return Math.max(0, buffersRead.size());
+        return buffersRead.size();
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeSubpartitionReader.java
@@ -231,6 +231,8 @@ class SortMergeSubpartitionReader
         }
     }
 
+    // suppress warning as this method is only for unsafe purpose.
+    @SuppressWarnings("FieldAccessNotGuarded")
     @Override
     public int unsynchronizedGetNumberOfQueuedBuffers() {
         return Math.max(0, buffersRead.size());

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsResultPartition.java
@@ -70,8 +70,6 @@ public class HsResultPartition extends ResultPartition {
 
     private final Path dataFilePath;
 
-    private final Path indexFilePath;
-
     private final int networkBufferSize;
 
     private final HybridShuffleConfiguration hybridShuffleConfiguration;
@@ -114,11 +112,10 @@ public class HsResultPartition extends ResultPartition {
                 bufferPoolFactory);
         this.networkBufferSize = networkBufferSize;
         this.dataFilePath = new File(dataFileBashPath + DATA_FILE_SUFFIX).toPath();
-        this.indexFilePath = new File(dataFileBashPath + INDEX_FILE_SUFFIX).toPath();
         this.dataIndex =
                 new HsFileDataIndexImpl(
                         isBroadcastOnly ? 1 : numSubpartitions,
-                        indexFilePath,
+                        new File(dataFileBashPath + INDEX_FILE_SUFFIX).toPath(),
                         hybridShuffleConfiguration.getSpilledIndexSegmentSize(),
                         hybridShuffleConfiguration.getNumRetainedInMemoryRegionsMax());
         this.hybridShuffleConfiguration = hybridShuffleConfiguration;


### PR DESCRIPTION
## What is the purpose of the change
Add GuardedBy annotation and some clean up for result partition.

## Brief change log

 - *Add missing @GuardedBy annotation for SortMergeResultPartitionReadScheduler and PipelinedSubpartition.*
 - *Fix some typo and syntax mistakes.*
 - *Clean up code of HsResultPartition, PrioritizedDeque and SortMergeSubpartitionReader.*


## Verifying this change


This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
