### PR TITLE
[FLINK-31240][table] Reduce the overhead of conversion between DataStream and Table

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/types/Row.java
+++ b/flink-core/src/main/java/org/apache/flink/types/Row.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import static org.apache.flink.types.RowUtils.deepEqualsRow;
 import static org.apache.flink.types.RowUtils.deepHashCodeRow;
@@ -291,6 +292,10 @@ public final class Row implements Serializable {
                 throw new IllegalArgumentException(
                         String.format("Unknown field name '%s' for mapping to a position.", name));
             }
+            assert fieldByPosition != null;
+            return fieldByPosition[pos];
+        } else if (Pattern.matches("^f[1-9]+[0-9]*$|^f0$", name)) {
+            int pos = Integer.parseInt(name.substring(1));
             assert fieldByPosition != null;
             return fieldByPosition[pos];
         } else {

--- a/flink-core/src/test/java/org/apache/flink/types/RowTest.java
+++ b/flink-core/src/test/java/org/apache/flink/types/RowTest.java
@@ -38,6 +38,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.internal.matchers.ThrowableMessageMatcher.hasMessage;
 
@@ -132,6 +133,18 @@ public class RowTest {
         assertThat(row.getField(0), equalTo(13));
         assertThat(row.getField(1), equalTo(true));
         assertThat(row.getField(2), equalTo("Hello"));
+
+        // test accessing positioned row by default name
+        assertEquals(13, row.getField("f0"));
+        assertTrue((boolean) row.getField("f1"));
+        assertEquals("Hello", row.getField("f2"));
+
+        try {
+            row.getField("f01");
+            fail();
+        } catch (Throwable t) {
+            assertThat(t, hasMessage(containsString("not supported in position-based field mode")));
+        }
 
         // test equality
         final Row otherRow1 = Row.withPositions(RowKind.DELETE, 3);

--- a/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
+++ b/flink-table/flink-table-api-scala-bridge/src/main/scala/org/apache/flink/table/api/bridge/scala/internal/StreamTableEnvironmentImpl.scala
@@ -143,8 +143,16 @@ class StreamTableEnvironmentImpl(
     Preconditions.checkNotNull(table, "Table must not be null.")
     Preconditions.checkNotNull(targetDataType, "Target data type must not be null.")
 
+    val dataTypeFactory = catalogManager.getDataTypeFactory
+
+    val originalDataStream = bypassTableConversion(table, targetDataType, dataTypeFactory)
+
+    if (originalDataStream != null) {
+      return originalDataStream.asInstanceOf[DataStream[T]]
+    }
+
     val schemaTranslationResult = SchemaTranslator.createProducingResult(
-      catalogManager.getDataTypeFactory,
+      dataTypeFactory,
       table.getResolvedSchema,
       targetDataType)
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request reduces the overhead of conversion between DataStream and Table in some cases.

## Brief change log

  - Checks if there are paired `fromDataStream`/`toDataStream` function call without any transformation, if so using the source datastream directly.


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

This change added tests and can be verified as follows:

  - Added test that validates that the overhead is reduced in the specific pattern.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: (no )

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
