### PR TITLE
[FLINK-31227][docs] Remove scala version for file system artifactId

### DIFF
--- a/docs/content.zh/docs/connectors/datastream/filesystem.md
+++ b/docs/content.zh/docs/connectors/datastream/filesystem.md
@@ -421,7 +421,7 @@ Flink 内置了为 Avro Format 数据创建 Parquet 写入工厂的快捷方法�
 
 如果在程序中使用 Parquet 的 Bulk-encoded Format，需要添加如下依赖到项目中：
 
-{{< artifact flink-parquet withScalaVersion >}}
+{{< artifact flink-parquet >}}
 
 {{< py_download_link "parquet" >}}
 
@@ -722,7 +722,7 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
 
 如果在程序中使用 ORC 的 Bulk-encoded Format，需要添加如下依赖到项目中：
 
-{{< artifact flink-orc withScalaVersion >}}
+{{< artifact flink-orc >}}
 
 
 然后，类似这样使用 `FileSink` 以 ORC Format 输出数据：

--- a/docs/content/docs/connectors/datastream/filesystem.md
+++ b/docs/content/docs/connectors/datastream/filesystem.md
@@ -418,7 +418,7 @@ For writing to other Parquet compatible data formats, users need to create the P
 
 To use the Parquet bulk encoder in your application you need to add the following dependency:
 
-{{< artifact flink-parquet withScalaVersion >}}
+{{< artifact flink-parquet >}}
 
 {{< py_download_link "parquet" >}}
 
@@ -725,7 +725,7 @@ class PersonVectorizer(schema: String) extends Vectorizer[Person](schema) {
 
 To use the ORC bulk encoder in an application, users need to add the following dependency:
 
-{{< artifact flink-orc withScalaVersion >}}
+{{< artifact flink-orc >}}
 
 
 And then a `FileSink` that writes data in ORC format can be created like this:


### PR DESCRIPTION

## What is the purpose of the change
Current artifacts for `flink-orc`, `flink-parquet` don't have scala version, but document guide includes it.
https://mvnrepository.com/artifact/org.apache.flink/flink-orc/1.16.0
https://mvnrepository.com/artifact/org.apache.flink/flink-parquet/1.16.0

## Brief change log
Remove scala version for file system artifactId

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
