### PR TITLE
[FLINK-31182][table] Fix CompiledPlan containing UNNEST

### DIFF
--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -192,7 +192,7 @@ public final class BuiltInFunctionDefinitions {
             BuiltInFunctionDefinition.newBuilder()
                     .name("$UNNEST_ROWS$1")
                     .kind(TABLE)
-                    .outputTypeStrategy(TypeStrategies.MISSING)
+                    .outputTypeStrategy(SpecificTypeStrategies.UNUSED)
                     .runtimeClass(
                             "org.apache.flink.table.runtime.functions.table.UnnestRowsFunction")
                     .internal()

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/SpecificTypeStrategies.java
@@ -31,6 +31,9 @@ import org.apache.flink.table.types.inference.TypeStrategy;
 @Internal
 public final class SpecificTypeStrategies {
 
+    /** See {@link UnusedTypeStrategy}. */
+    public static final TypeStrategy UNUSED = new UnusedTypeStrategy();
+
     /** See {@link RowTypeStrategy}. */
     public static final TypeStrategy ROW = new RowTypeStrategy();
 

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/UnusedTypeStrategy.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/types/inference/strategies/UnusedTypeStrategy.java
@@ -1,0 +1,55 @@
+package org.apache.flink.table.types.inference.strategies;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
+import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.inference.CallContext;
+import org.apache.flink.table.types.inference.TypeStrategies;
+import org.apache.flink.table.types.inference.TypeStrategy;
+
+import java.util.Optional;
+
+/**
+ * Placeholder for an unused type strategy.
+ *
+ * <p>For some internal helper functions the planner does not use a type inference. For example,
+ * {@link BuiltInFunctionDefinitions#INTERNAL_UNNEST_ROWS}). Those functions differ from {@link
+ * TypeStrategies#MISSING} in the sense that there is neither a Flink stack type inference nor a
+ * Calcite stack type inference being used. Instead, the types are created by a planner rule.
+ */
+@Internal
+final class UnusedTypeStrategy implements TypeStrategy {
+
+    @Override
+    public Optional<DataType> inferType(CallContext callContext) {
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof UnusedTypeStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        return UnusedTypeStrategy.class.hashCode();
+    }
+}

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CorrelateJsonPlanITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/runtime/stream/jsonplan/CorrelateJsonPlanITCase.java
@@ -26,7 +26,6 @@ import org.apache.flink.types.Row;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -42,8 +41,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
     }
 
     @Test
-    public void testSystemFuncByObject()
-            throws ExecutionException, InterruptedException, IOException {
+    public void testSystemFuncByObject() throws ExecutionException, InterruptedException {
         tableEnv.createTemporarySystemFunction(
                 "STRING_SPLIT", new JavaUserDefinedTableFunctions.StringSplit());
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
@@ -55,8 +53,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
     }
 
     @Test
-    public void testSystemFuncByClass()
-            throws ExecutionException, InterruptedException, IOException {
+    public void testSystemFuncByClass() throws ExecutionException, InterruptedException {
         tableEnv.createTemporarySystemFunction(
                 "STRING_SPLIT", JavaUserDefinedTableFunctions.StringSplit.class);
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
@@ -68,8 +65,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
     }
 
     @Test
-    public void testTemporaryFuncByObject()
-            throws ExecutionException, InterruptedException, IOException {
+    public void testTemporaryFuncByObject() throws ExecutionException, InterruptedException {
         tableEnv.createTemporaryFunction(
                 "STRING_SPLIT", new JavaUserDefinedTableFunctions.StringSplit());
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
@@ -81,8 +77,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
     }
 
     @Test
-    public void testTemporaryFuncByClass()
-            throws ExecutionException, InterruptedException, IOException {
+    public void testTemporaryFuncByClass() throws ExecutionException, InterruptedException {
         tableEnv.createTemporaryFunction(
                 "STRING_SPLIT", JavaUserDefinedTableFunctions.StringSplit.class);
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
@@ -94,7 +89,7 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
     }
 
     @Test
-    public void testFilter() throws ExecutionException, InterruptedException, IOException {
+    public void testFilter() throws ExecutionException, InterruptedException {
         tableEnv.createTemporarySystemFunction(
                 "STRING_SPLIT", new JavaUserDefinedTableFunctions.StringSplit());
         createTestValuesSinkTable("MySink", "a STRING", "b STRING");
@@ -104,6 +99,21 @@ public class CorrelateJsonPlanITCase extends JsonPlanTestBase {
                         + "where try_cast(v as int) > 0";
         compileSqlAndExecutePlan(query).await();
         List<String> expected = Arrays.asList("+I[1,1,hi, 1]", "+I[1,1,hi, 1]");
+        assertResult(expected, TestValuesTableFactory.getResults("MySink"));
+    }
+
+    @Test
+    public void testUnnest() throws ExecutionException, InterruptedException {
+        List<Row> data =
+                Collections.singletonList(
+                        Row.of("Bob", new Row[] {Row.of("1"), Row.of("2"), Row.of("3")}));
+        createTestValuesSourceTable(
+                "MyNestedTable", data, "name STRING", "arr ARRAY<ROW<nested STRING>>");
+        createTestValuesSinkTable("MySink", "name STRING", "nested STRING");
+        String query =
+                "INSERT INTO MySink SELECT name, nested FROM MyNestedTable CROSS JOIN UNNEST(arr) AS t (nested)";
+        compileSqlAndExecutePlan(query).await();
+        List<String> expected = Arrays.asList("+I[Bob, 1]", "+I[Bob, 2]", "+I[Bob, 3]");
         assertResult(expected, TestValuesTableFactory.getResults("MySink"));
     }
 }


### PR DESCRIPTION
## What is the purpose of the change

UNNEST is a special case among built-in functions. It's a planner rule that usually constructs it. However, for the CompiledPlan feature, it must be resolvable. `MISSING` type strategy is not correct here as it indicates to fall back to Calcite built-in function stack which does also not exist.

## Brief change log

- Replace `MISSING` with `UNUSED` strategy.

## Verifying this change

This change added tests and can be verified as follows: `CorrelateJsonPlanITCase`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? no
