### PR TITLE
[FLINK-31261][runtime] Make AdaptiveScheduler aware of local state size

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/CompletedCheckpointStore.java
@@ -64,7 +64,7 @@ public interface CompletedCheckpointStore {
      * Returns the latest {@link CompletedCheckpoint} instance or <code>null</code> if none was
      * added.
      */
-    default CompletedCheckpoint getLatestCheckpoint() throws Exception {
+    default CompletedCheckpoint getLatestCheckpoint() {
         List<CompletedCheckpoint> allCheckpoints = getAllCheckpoints();
         if (allCheckpoints.isEmpty()) {
             return null;
@@ -105,7 +105,7 @@ public interface CompletedCheckpointStore {
      *
      * <p>Returns an empty list if no checkpoint has been added yet.
      */
-    List<CompletedCheckpoint> getAllCheckpoints() throws Exception;
+    List<CompletedCheckpoint> getAllCheckpoints();
 
     /** Returns the current number of retained checkpoints. */
     int getNumberOfRetainedCheckpoints();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/checkpoint/DeactivatedCheckpointCompletedCheckpointStore.java
@@ -45,7 +45,7 @@ public enum DeactivatedCheckpointCompletedCheckpointStore implements CompletedCh
             throws Exception {}
 
     @Override
-    public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
+    public List<CompletedCheckpoint> getAllCheckpoints() {
         throw unsupportedOperationException();
     }
 

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobAllocationsInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobAllocationsInformation.java
@@ -48,7 +48,10 @@ public class JobAllocationsInformation {
     }
 
     public static JobAllocationsInformation fromGraph(@Nullable ExecutionGraph graph) {
-        return graph == null ? empty() : new JobAllocationsInformation(calculateAllocations(graph));
+        return graph == null
+                ? empty()
+                : new JobAllocationsInformation(
+                        calculateAllocations(graph, StateSizeEstimates.fromGraph(graph)));
     }
 
     public List<VertexAllocationInformation> getAllocations(JobVertexID jobVertexID) {
@@ -56,10 +59,11 @@ public class JobAllocationsInformation {
     }
 
     private static Map<JobVertexID, List<VertexAllocationInformation>> calculateAllocations(
-            ExecutionGraph graph) {
+            ExecutionGraph graph, StateSizeEstimates stateSizeEstimates) {
         final Map<JobVertexID, List<VertexAllocationInformation>> allocations = new HashMap<>();
         for (ExecutionJobVertex vertex : graph.getVerticesTopologically()) {
             JobVertexID jobVertexId = vertex.getJobVertexId();
+            long avgKgSize = stateSizeEstimates.estimate(jobVertexId).orElse(0L);
             for (ExecutionVertex executionVertex : vertex.getTaskVertices()) {
                 AllocationID allocationId =
                         executionVertex.getCurrentExecutionAttempt().getAssignedAllocationID();
@@ -70,7 +74,9 @@ public class JobAllocationsInformation {
                                 executionVertex.getParallelSubtaskIndex());
                 allocations
                         .computeIfAbsent(jobVertexId, ignored -> new ArrayList<>())
-                        .add(new VertexAllocationInformation(allocationId, jobVertexId, kgr));
+                        .add(
+                                new VertexAllocationInformation(
+                                        allocationId, jobVertexId, kgr, avgKgSize));
             }
         }
         return allocations;
@@ -89,12 +95,17 @@ public class JobAllocationsInformation {
         private final AllocationID allocationID;
         private final JobVertexID jobVertexID;
         private final KeyGroupRange keyGroupRange;
+        public final long averageKeyGroupSizeInBytes;
 
         public VertexAllocationInformation(
-                AllocationID allocationID, JobVertexID jobVertexID, KeyGroupRange keyGroupRange) {
+                AllocationID allocationID,
+                JobVertexID jobVertexID,
+                KeyGroupRange keyGroupRange,
+                long averageKeyGroupSizeInBytes) {
             this.allocationID = allocationID;
             this.jobVertexID = jobVertexID;
             this.keyGroupRange = keyGroupRange;
+            this.averageKeyGroupSizeInBytes = averageKeyGroupSizeInBytes;
         }
 
         public AllocationID getAllocationID() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobAllocationsInformation.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/JobAllocationsInformation.java
@@ -63,8 +63,8 @@ public class JobAllocationsInformation {
         final Map<JobVertexID, List<VertexAllocationInformation>> allocations = new HashMap<>();
         for (ExecutionJobVertex vertex : graph.getVerticesTopologically()) {
             JobVertexID jobVertexId = vertex.getJobVertexId();
-            long avgKgSize = stateSizeEstimates.estimate(jobVertexId).orElse(0L);
             for (ExecutionVertex executionVertex : vertex.getTaskVertices()) {
+                long stateSize = stateSizeEstimates.estimate(executionVertex.getID()).orElse(0L);
                 AllocationID allocationId =
                         executionVertex.getCurrentExecutionAttempt().getAssignedAllocationID();
                 KeyGroupRange kgr =
@@ -76,7 +76,7 @@ public class JobAllocationsInformation {
                         .computeIfAbsent(jobVertexId, ignored -> new ArrayList<>())
                         .add(
                                 new VertexAllocationInformation(
-                                        allocationId, jobVertexId, kgr, avgKgSize));
+                                        allocationId, jobVertexId, kgr, stateSize));
             }
         }
         return allocations;
@@ -95,17 +95,17 @@ public class JobAllocationsInformation {
         private final AllocationID allocationID;
         private final JobVertexID jobVertexID;
         private final KeyGroupRange keyGroupRange;
-        public final long averageKeyGroupSizeInBytes;
+        public final long stateSizeInBytes;
 
         public VertexAllocationInformation(
                 AllocationID allocationID,
                 JobVertexID jobVertexID,
                 KeyGroupRange keyGroupRange,
-                long averageKeyGroupSizeInBytes) {
+                long stateSizeInBytes) {
             this.allocationID = allocationID;
             this.jobVertexID = jobVertexID;
             this.keyGroupRange = keyGroupRange;
-            this.averageKeyGroupSizeInBytes = averageKeyGroupSizeInBytes;
+            this.stateSizeInBytes = stateSizeInBytes;
         }
 
         public AllocationID getAllocationID() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssigner.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssigner.java
@@ -199,9 +199,13 @@ public class StateLocalitySlotAssigner implements SlotAssigner {
     private static long estimateSize(
             KeyGroupRange newRange, VertexAllocationInformation allocation) {
         KeyGroupRange oldRange = allocation.getKeyGroupRange();
-        // Estimate state size per key group. For scoring, assume 1 if size estimate is 0 to
-        // accommodate for averaging non-zero states
-        long keyGroupSize = Math.max(allocation.averageKeyGroupSizeInBytes, 1L);
+        if (allocation.stateSizeInBytes * oldRange.getNumberOfKeyGroups() == 0) {
+            return 0L;
+        }
+        // round up to 1
+        long keyGroupSize =
+                allocation.stateSizeInBytes
+                        / Math.min(allocation.stateSizeInBytes, oldRange.getNumberOfKeyGroups());
         int numberOfKeyGroups = oldRange.getIntersection(newRange).getNumberOfKeyGroups();
         return numberOfKeyGroups * keyGroupSize;
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateSizeEstimates.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateSizeEstimates.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.runtime.scheduler.adaptive.allocator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.runtime.OperatorIDPair;
+import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
+import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.executiongraph.ExecutionGraph;
+import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
+import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.state.KeyedStateHandle;
+
+import javax.annotation.Nullable;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+
+/** Managed Keyed State size estimates used to make scheduling decisions. */
+@Internal
+public class StateSizeEstimates {
+    private final Map<JobVertexID, Long> averages;
+
+    public StateSizeEstimates() {
+        this(Collections.emptyMap());
+    }
+
+    public StateSizeEstimates(Map<JobVertexID, Long> averages) {
+        this.averages = averages;
+    }
+
+    public Optional<Long> estimate(JobVertexID jobVertexId) {
+        return Optional.ofNullable(averages.get(jobVertexId));
+    }
+
+    static StateSizeEstimates empty() {
+        return new StateSizeEstimates();
+    }
+
+    public static StateSizeEstimates fromGraph(@Nullable ExecutionGraph executionGraph) {
+        return Optional.ofNullable(executionGraph)
+                .flatMap(graph -> Optional.ofNullable(graph.getCheckpointCoordinator()))
+                .flatMap(coordinator -> Optional.ofNullable(coordinator.getCheckpointStore()))
+                .flatMap(store -> Optional.ofNullable(store.getLatestCheckpoint()))
+                .map(
+                        cp ->
+                                build(
+                                        fromCompletedCheckpoint(cp),
+                                        mapVerticesToOperators(executionGraph)))
+                .orElse(empty());
+    }
+
+    private static StateSizeEstimates build(
+            Map<OperatorID, Long> sizePerOperator,
+            Map<JobVertexID, Set<OperatorID>> verticesToOperators) {
+        Map<JobVertexID, Long> verticesToSizes =
+                verticesToOperators.entrySet().stream()
+                        .collect(
+                                toMap(Map.Entry::getKey, e -> size(e.getValue(), sizePerOperator)));
+        return new StateSizeEstimates(verticesToSizes);
+    }
+
+    private static long size(Set<OperatorID> ids, Map<OperatorID, Long> sizes) {
+        return ids.stream().mapToLong(key -> sizes.getOrDefault(key, 0L)).sum();
+    }
+
+    private static Map<JobVertexID, Set<OperatorID>> mapVerticesToOperators(
+            ExecutionGraph executionGraph) {
+        return executionGraph.getAllVertices().entrySet().stream()
+                .collect(toMap(Map.Entry::getKey, e -> getOperatorIDS(e.getValue())));
+    }
+
+    private static Set<OperatorID> getOperatorIDS(ExecutionJobVertex v) {
+        return v.getOperatorIDs().stream()
+                .map(OperatorIDPair::getGeneratedOperatorID)
+                .collect(Collectors.toSet());
+    }
+
+    private static Map<OperatorID, Long> fromCompletedCheckpoint(CompletedCheckpoint cp) {
+        Stream<Map.Entry<OperatorID, OperatorState>> states =
+                cp.getOperatorStates().entrySet().stream();
+        return states.collect(
+                toMap(
+                        Map.Entry::getKey,
+                        e -> calculateAverageKeyGroupStateSizeInBytes(e.getValue())));
+    }
+
+    private static long calculateAverageKeyGroupStateSizeInBytes(OperatorState state) {
+        Stream<KeyedStateHandle> handles =
+                state.getSubtaskStates().values().stream()
+                        .flatMap(s -> s.getManagedKeyedState().stream());
+        Stream<Tuple2<Long, Integer>> sizeAndCount =
+                handles.map(
+                        h ->
+                                Tuple2.of(
+                                        h.getStateSize(),
+                                        h.getKeyGroupRange().getNumberOfKeyGroups()));
+        Optional<Tuple2<Long, Integer>> totalSizeAndCount =
+                sizeAndCount.reduce(
+                        (left, right) -> Tuple2.of(left.f0 + right.f0, left.f1 + right.f1));
+        Optional<Long> average = totalSizeAndCount.filter(t2 -> t2.f1 > 0).map(t2 -> t2.f0 / t2.f1);
+        return average.orElse(0L);
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateSizeEstimates.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateSizeEstimates.java
@@ -18,42 +18,44 @@
 package org.apache.flink.runtime.scheduler.adaptive.allocator;
 
 import org.apache.flink.annotation.Internal;
-import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.runtime.OperatorIDPair;
 import org.apache.flink.runtime.checkpoint.CompletedCheckpoint;
 import org.apache.flink.runtime.checkpoint.OperatorState;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
+import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.KeyedStateHandle;
 
 import javax.annotation.Nullable;
 
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
+import static java.util.Collections.emptyMap;
 import static java.util.stream.Collectors.toMap;
 
 /** Managed Keyed State size estimates used to make scheduling decisions. */
 @Internal
 public class StateSizeEstimates {
-    private final Map<JobVertexID, Long> averages;
+    private final Map<ExecutionVertexID, Long> stateSizes;
 
     public StateSizeEstimates() {
-        this(Collections.emptyMap());
+        this(emptyMap());
     }
 
-    public StateSizeEstimates(Map<JobVertexID, Long> averages) {
-        this.averages = averages;
+    public StateSizeEstimates(Map<ExecutionVertexID, Long> stateSizes) {
+        this.stateSizes = stateSizes;
     }
 
-    public Optional<Long> estimate(JobVertexID jobVertexId) {
-        return Optional.ofNullable(averages.get(jobVertexId));
+    public Optional<Long> estimate(ExecutionVertexID jobVertexId) {
+        return Optional.ofNullable(stateSizes.get(jobVertexId));
     }
 
     static StateSizeEstimates empty() {
@@ -67,30 +69,41 @@ public class StateSizeEstimates {
                 .flatMap(store -> Optional.ofNullable(store.getLatestCheckpoint()))
                 .map(
                         cp ->
-                                build(
-                                        fromCompletedCheckpoint(cp),
-                                        mapVerticesToOperators(executionGraph)))
+                                new StateSizeEstimates(
+                                        merge(
+                                                fromCompletedCheckpoint(cp),
+                                                mapVerticesToOperators(executionGraph))))
                 .orElse(empty());
     }
 
-    private static StateSizeEstimates build(
-            Map<OperatorID, Long> sizePerOperator,
+    /**
+     * Map {@link ExecutionVertexID}s to state sizes according to the supplied mappings of operators
+     * to state sizes and {@link JobVertexID}s to {@link OperatorID}s.
+     */
+    private static Map<ExecutionVertexID, Long> merge(
+            Map<OperatorID, Map<Integer, Long>> operatorsToSubtaskSizes,
             Map<JobVertexID, Set<OperatorID>> verticesToOperators) {
-        Map<JobVertexID, Long> verticesToSizes =
-                verticesToOperators.entrySet().stream()
-                        .collect(
-                                toMap(Map.Entry::getKey, e -> size(e.getValue(), sizePerOperator)));
-        return new StateSizeEstimates(verticesToSizes);
-    }
-
-    private static long size(Set<OperatorID> ids, Map<OperatorID, Long> sizes) {
-        return ids.stream().mapToLong(key -> sizes.getOrDefault(key, 0L)).sum();
+        Map<ExecutionVertexID, Long> result = new HashMap<>();
+        for (Entry<JobVertexID, Set<OperatorID>> vertexAndOperators :
+                verticesToOperators.entrySet()) {
+            for (OperatorID operatorID : vertexAndOperators.getValue()) {
+                for (Entry<Integer, Long> subtaskIdAndSize :
+                        operatorsToSubtaskSizes.getOrDefault(operatorID, emptyMap()).entrySet()) {
+                    result.merge(
+                            new ExecutionVertexID(
+                                    vertexAndOperators.getKey(), subtaskIdAndSize.getKey()),
+                            subtaskIdAndSize.getValue(),
+                            Long::sum);
+                }
+            }
+        }
+        return result;
     }
 
     private static Map<JobVertexID, Set<OperatorID>> mapVerticesToOperators(
             ExecutionGraph executionGraph) {
         return executionGraph.getAllVertices().entrySet().stream()
-                .collect(toMap(Map.Entry::getKey, e -> getOperatorIDS(e.getValue())));
+                .collect(toMap(Entry::getKey, e -> getOperatorIDS(e.getValue())));
     }
 
     private static Set<OperatorID> getOperatorIDS(ExecutionJobVertex v) {
@@ -99,29 +112,22 @@ public class StateSizeEstimates {
                 .collect(Collectors.toSet());
     }
 
-    private static Map<OperatorID, Long> fromCompletedCheckpoint(CompletedCheckpoint cp) {
-        Stream<Map.Entry<OperatorID, OperatorState>> states =
-                cp.getOperatorStates().entrySet().stream();
-        return states.collect(
-                toMap(
-                        Map.Entry::getKey,
-                        e -> calculateAverageKeyGroupStateSizeInBytes(e.getValue())));
+    private static Map<OperatorID, Map<Integer, Long>> fromCompletedCheckpoint(
+            CompletedCheckpoint cp) {
+        Map<OperatorID, Map<Integer, Long>> result = new HashMap<>();
+        for (Entry<OperatorID, OperatorState> e : cp.getOperatorStates().entrySet()) {
+            result.put(e.getKey(), calculateStateSizeInBytes(e.getValue()));
+        }
+        return result;
     }
 
-    private static long calculateAverageKeyGroupStateSizeInBytes(OperatorState state) {
-        Stream<KeyedStateHandle> handles =
-                state.getSubtaskStates().values().stream()
-                        .flatMap(s -> s.getManagedKeyedState().stream());
-        Stream<Tuple2<Long, Integer>> sizeAndCount =
-                handles.map(
-                        h ->
-                                Tuple2.of(
-                                        h.getStateSize(),
-                                        h.getKeyGroupRange().getNumberOfKeyGroups()));
-        Optional<Tuple2<Long, Integer>> totalSizeAndCount =
-                sizeAndCount.reduce(
-                        (left, right) -> Tuple2.of(left.f0 + right.f0, left.f1 + right.f1));
-        Optional<Long> average = totalSizeAndCount.filter(t2 -> t2.f1 > 0).map(t2 -> t2.f0 / t2.f1);
-        return average.orElse(0L);
+    private static Map<Integer, Long> calculateStateSizeInBytes(OperatorState state) {
+        Map<Integer, Long> sizesPerSubtask = new HashMap<>();
+        for (Entry<Integer, OperatorSubtaskState> e : state.getSubtaskStates().entrySet()) {
+            for (KeyedStateHandle handle : e.getValue().getManagedKeyedState()) {
+                sizesPerSubtask.merge(e.getKey(), handle.getStateSize(), Long::sum);
+            }
+        }
+        return sizesPerSubtask;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/checkpoint/CheckpointCoordinatorFailureTest.java
@@ -299,18 +299,17 @@ class CheckpointCoordinatorFailureTest extends TestLogger {
         }
 
         @Override
-        public CompletedCheckpoint getLatestCheckpoint() throws Exception {
+        public CompletedCheckpoint getLatestCheckpoint() {
             throw new UnsupportedOperationException("Not implemented.");
         }
 
         @Override
-        public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner)
-                throws Exception {
+        public void shutdown(JobStatus jobStatus, CheckpointsCleaner checkpointsCleaner) {
             throw new UnsupportedOperationException("Not implemented.");
         }
 
         @Override
-        public List<CompletedCheckpoint> getAllCheckpoints() throws Exception {
+        public List<CompletedCheckpoint> getAllCheckpoints() {
             return Collections.emptyList();
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
@@ -294,11 +294,6 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
         freeSlots.add(new TestSlotInfo(allocation1));
         freeSlots.add(new TestSlotInfo(allocation2));
 
-        Map<JobVertexID, Long> stateSizes = new HashMap<>();
-        stateSizes.put(vertex1.getJobVertexID(), 10L);
-        stateSizes.put(vertex2.getJobVertexID(), 10L);
-        stateSizes.put(vertex3.getJobVertexID(), 10L);
-
         JobSchedulingPlan schedulingPlan =
                 SlotSharingSlotAllocator.createSlotSharingSlotAllocator(
                                 (allocationId, resourceProfile) ->

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/SlotSharingSlotAllocatorTest.java
@@ -265,12 +265,18 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
                 vertex1.getJobVertexID(),
                 Collections.singletonList(
                         new VertexAllocationInformation(
-                                allocation1, vertex1.getJobVertexID(), KeyGroupRange.of(1, 100))));
+                                allocation1,
+                                vertex1.getJobVertexID(),
+                                KeyGroupRange.of(1, 100),
+                                1)));
         locality.put(
                 vertex2.getJobVertexID(),
                 Collections.singletonList(
                         new VertexAllocationInformation(
-                                allocation1, vertex2.getJobVertexID(), KeyGroupRange.of(1, 100))));
+                                allocation1,
+                                vertex2.getJobVertexID(),
+                                KeyGroupRange.of(1, 100),
+                                1)));
 
         // previous allocation allocation2: v3
         AllocationID allocation2 = new AllocationID();
@@ -278,7 +284,10 @@ public class SlotSharingSlotAllocatorTest extends TestLogger {
                 vertex3.getJobVertexID(),
                 Collections.singletonList(
                         new VertexAllocationInformation(
-                                allocation2, vertex3.getJobVertexID(), KeyGroupRange.of(1, 100))));
+                                allocation2,
+                                vertex3.getJobVertexID(),
+                                KeyGroupRange.of(1, 100),
+                                1)));
 
         List<SlotInfo> freeSlots = new ArrayList<>();
         IntStream.range(0, 10).forEach(i -> freeSlots.add(new TestSlotInfo(new AllocationID())));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssignerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssignerTest.java
@@ -53,9 +53,9 @@ class StateLocalitySlotAssignerTest {
         List<VertexAllocationInformation> allocations =
                 Arrays.asList(
                         new VertexAllocationInformation(
-                                alloc1, vertex.getJobVertexID(), KeyGroupRange.of(0, 9)),
+                                alloc1, vertex.getJobVertexID(), KeyGroupRange.of(0, 9), 1),
                         new VertexAllocationInformation(
-                                alloc2, vertex.getJobVertexID(), KeyGroupRange.of(10, 19)));
+                                alloc2, vertex.getJobVertexID(), KeyGroupRange.of(10, 19), 1));
 
         assign(vertex, Arrays.asList(alloc1, alloc2), allocations);
     }
@@ -76,7 +76,8 @@ class StateLocalitySlotAssignerTest {
                             iterator.next(),
                             vertex.getJobVertexID(),
                             KeyGroupRangeAssignment.computeKeyGroupRangeForOperatorIndex(
-                                    vertex.getMaxParallelism(), oldParallelism, i)));
+                                    vertex.getMaxParallelism(), oldParallelism, i),
+                            1));
         }
 
         Collection<SlotAssignment> assignments = assign(vertex, allocationIDs, prevAllocations);
@@ -106,7 +107,8 @@ class StateLocalitySlotAssignerTest {
                 new VertexAllocationInformation(
                         biggestAllocation,
                         vertex.getJobVertexID(),
-                        KeyGroupRange.of(0, halfOfKeyGroupRange - 1)));
+                        KeyGroupRange.of(0, halfOfKeyGroupRange - 1),
+                        1));
 
         // and the remaining subtasks had only one key group each
         for (int subtaskIdx = 1; subtaskIdx < oldParallelism; subtaskIdx++) {
@@ -115,7 +117,8 @@ class StateLocalitySlotAssignerTest {
                     new VertexAllocationInformation(
                             iterator.next(),
                             vertex.getJobVertexID(),
-                            KeyGroupRange.of(keyGroup, keyGroup)));
+                            KeyGroupRange.of(keyGroup, keyGroup),
+                            1));
         }
 
         Collection<SlotAssignment> assignments = assign(vertex, allocationIDs, prevAllocations);

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssignerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/allocator/StateLocalitySlotAssignerTest.java
@@ -44,6 +44,36 @@ import static org.hamcrest.Matchers.hasSize;
 
 /** {@link StateLocalitySlotAssigner} test. */
 class StateLocalitySlotAssignerTest {
+
+    @Test
+    public void testDownScaleWithUnevenStateSize() {
+        int newParallelism = 1;
+        VertexInformation vertex = createVertex(newParallelism);
+        AllocationID allocationWith100bytes = new AllocationID();
+        AllocationID allocationWith200bytes = new AllocationID();
+
+        List<VertexAllocationInformation> allocations =
+                Arrays.asList(
+                        new VertexAllocationInformation(
+                                allocationWith100bytes,
+                                vertex.getJobVertexID(),
+                                KeyGroupRange.of(0, 99),
+                                1),
+                        new VertexAllocationInformation(
+                                allocationWith200bytes,
+                                vertex.getJobVertexID(),
+                                KeyGroupRange.of(100, 100),
+                                200));
+
+        Collection<SlotAssignment> assignments =
+                assign(
+                        vertex,
+                        Arrays.asList(allocationWith100bytes, allocationWith200bytes),
+                        allocations);
+
+        verifyAssignments(assignments, newParallelism, allocationWith200bytes);
+    }
+
     @Test
     public void testSlotsAreNotWasted() {
         VertexInformation vertex = createVertex(2);


### PR DESCRIPTION
## What is the purpose of the change

FLINK-21450 / #21981 made Adaptive Scheduler aware of Local State.
This PR improves on that by estimating state size (instead of number of key groups).

## Verifying this change

- Added unit test: `StateLocalitySlotAssignerTest.testDownScaleWithUnevenStateSize`

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
