### PR TITLE
[FLINK-31268][metrics] Change not to initialize operator coordinator metric group lazily

### DIFF
--- a/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
+++ b/flink-core/src/main/java/org/apache/flink/api/connector/source/lib/util/IteratorSourceEnumerator.java
@@ -48,6 +48,7 @@ public class IteratorSourceEnumerator<SplitT extends IteratorSourceSplit<?, ?>>
             SplitEnumeratorContext<SplitT> context, Collection<SplitT> splits) {
         this.context = checkNotNull(context);
         this.remainingSplits = new ArrayDeque<>(splits);
+        this.context.metricGroup().setUnassignedSplitsGauge(() -> (long) remainingSplits.size());
     }
 
     // ------------------------------------------------------------------------

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphBuilder.java
@@ -42,6 +42,7 @@ import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.jsonplan.JsonPlanGenerator;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
 import org.apache.flink.runtime.jobgraph.tasks.JobCheckpointingSettings;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
 import org.apache.flink.runtime.state.CheckpointStorage;
@@ -94,7 +95,8 @@ public class DefaultExecutionGraphBuilder {
             boolean isDynamicGraph,
             ExecutionJobVertex.Factory executionJobVertexFactory,
             MarkPartitionFinishedStrategy markPartitionFinishedStrategy,
-            boolean nonFinishedHybridPartitionShouldBeUnknown)
+            boolean nonFinishedHybridPartitionShouldBeUnknown,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws JobExecutionException, JobException {
 
         checkNotNull(jobGraph, "job graph cannot be null");
@@ -216,7 +218,7 @@ public class DefaultExecutionGraphBuilder {
                     jobName,
                     jobId);
         }
-        executionGraph.attachJobGraph(sortedTopology);
+        executionGraph.attachJobGraph(sortedTopology, jobManagerJobMetricGroup);
 
         if (log.isDebugEnabled()) {
             log.debug(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/ExecutionGraph.java
@@ -37,6 +37,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.strategy.SchedulingTopology;
@@ -151,7 +152,9 @@ public interface ExecutionGraph extends AccessExecutionGraph {
 
     void setInternalTaskFailuresListener(InternalFailuresListener internalTaskFailuresListener);
 
-    void attachJobGraph(List<JobVertex> topologicallySorted) throws JobException;
+    void attachJobGraph(
+            List<JobVertex> topologicallySorted, JobManagerJobMetricGroup jobManagerJobMetricGroup)
+            throws JobException;
 
     void transitionToRunning();
 
@@ -213,13 +216,17 @@ public interface ExecutionGraph extends AccessExecutionGraph {
     @Nonnull
     ComponentMainThreadExecutor getJobMasterMainThreadExecutor();
 
-    default void initializeJobVertex(ExecutionJobVertex ejv, long createTimestamp)
+    default void initializeJobVertex(
+            ExecutionJobVertex ejv,
+            long createTimestamp,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws JobException {
         initializeJobVertex(
                 ejv,
                 createTimestamp,
                 VertexInputInfoComputationUtils.computeVertexInputInfos(
-                        ejv, getAllIntermediateResults()::get));
+                        ejv, getAllIntermediateResults()::get),
+                jobManagerJobMetricGroup);
     }
 
     /**
@@ -234,7 +241,8 @@ public interface ExecutionGraph extends AccessExecutionGraph {
     void initializeJobVertex(
             ExecutionJobVertex ejv,
             long createTimestamp,
-            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos)
+            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws JobException;
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/executiongraph/SpeculativeExecutionJobVertex.java
@@ -21,6 +21,7 @@ package org.apache.flink.runtime.executiongraph;
 import org.apache.flink.api.common.time.Time;
 import org.apache.flink.runtime.JobException;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinatorStore;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
@@ -61,10 +62,17 @@ public class SpeculativeExecutionJobVertex extends ExecutionJobVertex {
     protected OperatorCoordinatorHolder createOperatorCoordinatorHolder(
             SerializedValue<OperatorCoordinator.Provider> provider,
             ClassLoader classLoader,
-            CoordinatorStore coordinatorStore)
+            CoordinatorStore coordinatorStore,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws Exception {
         return OperatorCoordinatorHolder.create(
-                provider, this, classLoader, coordinatorStore, true, getTaskInformation());
+                provider,
+                this,
+                classLoader,
+                coordinatorStore,
+                true,
+                getTaskInformation(),
+                jobManagerJobMetricGroup);
     }
 
     /** Factory to create {@link SpeculativeExecutionJobVertex}. */

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -116,20 +116,17 @@ public class OperatorCoordinatorHolder
 
     private final IncompleteFuturesTracker unconfirmedEvents;
 
-    private final TaskInformation taskInformation;
     private final int operatorParallelism;
     private final int operatorMaxParallelism;
 
     private GlobalFailureHandler globalFailureHandler;
     private ComponentMainThreadExecutor mainThreadExecutor;
-    private OperatorCoordinatorMetricGroup operatorCoordinatorMetricGroup;
 
     private OperatorCoordinatorHolder(
             final OperatorID operatorId,
             final OperatorCoordinator coordinator,
             final LazyInitializedCoordinatorContext context,
             final SubtaskAccess.SubtaskAccessFactory taskAccesses,
-            final TaskInformation taskInformation,
             final int operatorParallelism,
             final int operatorMaxParallelism) {
 
@@ -139,7 +136,6 @@ public class OperatorCoordinatorHolder
         this.taskAccesses = checkNotNull(taskAccesses);
         this.operatorParallelism = operatorParallelism;
         this.operatorMaxParallelism = operatorMaxParallelism;
-        this.taskInformation = taskInformation;
 
         this.subtaskGatewayMap = new HashMap<>();
         this.unconfirmedEvents = new IncompleteFuturesTracker();
@@ -147,23 +143,12 @@ public class OperatorCoordinatorHolder
 
     public void lazyInitialize(
             GlobalFailureHandler globalFailureHandler,
-            ComponentMainThreadExecutor mainThreadExecutor,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
+            ComponentMainThreadExecutor mainThreadExecutor) {
 
         this.globalFailureHandler = globalFailureHandler;
         this.mainThreadExecutor = mainThreadExecutor;
-        JobManagerOperatorMetricGroup parentMetricGroup =
-                jobManagerJobMetricGroup.getOrAddOperator(
-                        taskInformation.getJobVertexId(),
-                        taskInformation.getTaskName(),
-                        operatorId,
-                        context.operatorName);
-        this.operatorCoordinatorMetricGroup =
-                new InternalOperatorCoordinatorMetricGroup(parentMetricGroup);
 
-        context.lazyInitialize(
-                globalFailureHandler, mainThreadExecutor, operatorCoordinatorMetricGroup);
-
+        context.lazyInitialize(globalFailureHandler, mainThreadExecutor);
         setupAllSubtaskGateways();
     }
 
@@ -483,7 +468,8 @@ public class OperatorCoordinatorHolder
             ClassLoader classLoader,
             CoordinatorStore coordinatorStore,
             boolean supportsConcurrentExecutionAttempts,
-            TaskInformation taskInformation)
+            TaskInformation taskInformation,
+            JobManagerJobMetricGroup metricGroup)
             throws Exception {
 
         try (TemporaryClassLoaderContext ignored = TemporaryClassLoaderContext.of(classLoader)) {
@@ -504,7 +490,8 @@ public class OperatorCoordinatorHolder
                     jobVertex.getMaxParallelism(),
                     taskAccesses,
                     supportsConcurrentExecutionAttempts,
-                    taskInformation);
+                    taskInformation,
+                    metricGroup);
         }
     }
 
@@ -519,9 +506,15 @@ public class OperatorCoordinatorHolder
             final int operatorMaxParallelism,
             final SubtaskAccess.SubtaskAccessFactory taskAccesses,
             final boolean supportsConcurrentExecutionAttempts,
-            final TaskInformation taskInformation)
+            final TaskInformation taskInformation,
+            final JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws Exception {
-
+        JobManagerOperatorMetricGroup parentMetricGroup =
+                jobManagerJobMetricGroup.getOrAddOperator(
+                        taskInformation.getJobVertexId(),
+                        taskInformation.getTaskName(),
+                        opId,
+                        operatorName);
         final LazyInitializedCoordinatorContext context =
                 new LazyInitializedCoordinatorContext(
                         opId,
@@ -529,7 +522,8 @@ public class OperatorCoordinatorHolder
                         userCodeClassLoader,
                         operatorParallelism,
                         coordinatorStore,
-                        supportsConcurrentExecutionAttempts);
+                        supportsConcurrentExecutionAttempts,
+                        new InternalOperatorCoordinatorMetricGroup(parentMetricGroup));
 
         final OperatorCoordinator coordinator = coordinatorProvider.create(context);
 
@@ -538,7 +532,6 @@ public class OperatorCoordinatorHolder
                 coordinator,
                 context,
                 taskAccesses,
-                taskInformation,
                 operatorParallelism,
                 operatorMaxParallelism);
     }
@@ -568,10 +561,10 @@ public class OperatorCoordinatorHolder
         private final int operatorParallelism;
         private final CoordinatorStore coordinatorStore;
         private final boolean supportsConcurrentExecutionAttempts;
+        private final OperatorCoordinatorMetricGroup metricGroup;
 
         private GlobalFailureHandler globalFailureHandler;
         private Executor schedulerExecutor;
-        private OperatorCoordinatorMetricGroup metricGroup;
 
         private volatile boolean failed;
 
@@ -581,22 +574,20 @@ public class OperatorCoordinatorHolder
                 final ClassLoader userCodeClassLoader,
                 final int operatorParallelism,
                 final CoordinatorStore coordinatorStore,
-                final boolean supportsConcurrentExecutionAttempts) {
+                final boolean supportsConcurrentExecutionAttempts,
+                final OperatorCoordinatorMetricGroup metricGroup) {
             this.operatorId = checkNotNull(operatorId);
             this.operatorName = checkNotNull(operatorName);
             this.userCodeClassLoader = checkNotNull(userCodeClassLoader);
             this.operatorParallelism = operatorParallelism;
             this.coordinatorStore = checkNotNull(coordinatorStore);
             this.supportsConcurrentExecutionAttempts = supportsConcurrentExecutionAttempts;
+            this.metricGroup = checkNotNull(metricGroup);
         }
 
-        void lazyInitialize(
-                GlobalFailureHandler globalFailureHandler,
-                Executor schedulerExecutor,
-                OperatorCoordinatorMetricGroup metricGroup) {
+        void lazyInitialize(GlobalFailureHandler globalFailureHandler, Executor schedulerExecutor) {
             this.globalFailureHandler = checkNotNull(globalFailureHandler);
             this.schedulerExecutor = checkNotNull(schedulerExecutor);
-            this.metricGroup = metricGroup;
         }
 
         void unInitialize() {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolder.java
@@ -19,6 +19,7 @@
 package org.apache.flink.runtime.operators.coordination;
 
 import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.metrics.MetricGroup;
 import org.apache.flink.metrics.groups.OperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.checkpoint.OperatorCoordinatorCheckpointContext;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
@@ -27,7 +28,6 @@ import org.apache.flink.runtime.executiongraph.TaskInformation;
 import org.apache.flink.runtime.jobgraph.OperatorID;
 import org.apache.flink.runtime.metrics.groups.InternalOperatorCoordinatorMetricGroup;
 import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
-import org.apache.flink.runtime.metrics.groups.JobManagerOperatorMetricGroup;
 import org.apache.flink.runtime.operators.coordination.util.IncompleteFuturesTracker;
 import org.apache.flink.runtime.scheduler.GlobalFailureHandler;
 import org.apache.flink.util.ExceptionUtils;
@@ -509,7 +509,7 @@ public class OperatorCoordinatorHolder
             final TaskInformation taskInformation,
             final JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws Exception {
-        JobManagerOperatorMetricGroup parentMetricGroup =
+        final MetricGroup parentMetricGroup =
                 jobManagerJobMetricGroup.getOrAddOperator(
                         taskInformation.getJobVertexId(),
                         taskInformation.getTaskName(),

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultExecutionGraphFactory.java
@@ -184,7 +184,8 @@ public class DefaultExecutionGraphFactory implements ExecutionGraphFactory {
                         isDynamicGraph,
                         executionJobVertexFactory,
                         markPartitionFinishedStrategy,
-                        nonFinishedHybridPartitionShouldBeUnknown);
+                        nonFinishedHybridPartitionShouldBeUnknown,
+                        jobManagerJobMetricGroup);
 
         final CheckpointCoordinator checkpointCoordinator =
                 newExecutionGraph.getCheckpointCoordinator();

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandler.java
@@ -26,7 +26,6 @@ import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.ExecutionJobVertex;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequestHandler;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
@@ -72,12 +71,9 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
     }
 
     @Override
-    public void initializeOperatorCoordinators(
-            ComponentMainThreadExecutor mainThreadExecutor,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
+    public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
         for (OperatorCoordinatorHolder coordinatorHolder : coordinatorMap.values()) {
-            coordinatorHolder.lazyInitialize(
-                    globalFailureHandler, mainThreadExecutor, jobManagerJobMetricGroup);
+            coordinatorHolder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
         }
     }
 
@@ -154,13 +150,11 @@ public class DefaultOperatorCoordinatorHandler implements OperatorCoordinatorHan
     @Override
     public void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
+            ComponentMainThreadExecutor mainThreadExecutor) {
 
         for (OperatorCoordinatorHolder coordinator : coordinators) {
             coordinatorMap.put(coordinator.operatorId(), coordinator);
-            coordinator.lazyInitialize(
-                    globalFailureHandler, mainThreadExecutor, jobManagerJobMetricGroup);
+            coordinator.lazyInitialize(globalFailureHandler, mainThreadExecutor);
         }
         startOperatorCoordinators(coordinators);
     }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/OperatorCoordinatorHandler.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinator;
@@ -40,9 +39,7 @@ public interface OperatorCoordinatorHandler {
      *
      * @param mainThreadExecutor Executor for submitting work to the main thread.
      */
-    void initializeOperatorCoordinators(
-            ComponentMainThreadExecutor mainThreadExecutor,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup);
+    void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor);
 
     /** Start all operator coordinators. */
     void startAllOperatorCoordinators();
@@ -81,6 +78,5 @@ public interface OperatorCoordinatorHandler {
      */
     void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup);
+            ComponentMainThreadExecutor mainThreadExecutor);
 }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/SchedulerBase.java
@@ -234,8 +234,7 @@ public abstract class SchedulerBase implements SchedulerNG, CheckpointScheduling
 
         this.operatorCoordinatorHandler =
                 new DefaultOperatorCoordinatorHandler(executionGraph, this::handleGlobalFailure);
-        operatorCoordinatorHandler.initializeOperatorCoordinators(
-                this.mainThreadExecutor, jobManagerJobMetricGroup);
+        operatorCoordinatorHandler.initializeOperatorCoordinators(this.mainThreadExecutor);
 
         this.exceptionHistory =
                 new BoundedFIFOQueue<>(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptive/CreatingExecutionGraph.java
@@ -123,7 +123,7 @@ public class CreatingExecutionGraph implements State {
                 final OperatorCoordinatorHandler operatorCoordinatorHandler =
                         operatorCoordinatorHandlerFactory.create(executionGraph, context);
                 operatorCoordinatorHandler.initializeOperatorCoordinators(
-                        context.getMainThreadExecutor(), context.getMetricGroup());
+                        context.getMainThreadExecutor());
                 operatorCoordinatorHandler.startAllOperatorCoordinators();
                 final String updatedPlan =
                         JsonPlanGenerator.generatePlan(

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/adaptivebatch/AdaptiveBatchScheduler.java
@@ -278,7 +278,9 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
                     // ExecutionGraph#initializeJobVertex(ExecutionJobVertex, long) to initialize.
                     // TODO: In the future, if we want to load balance for job vertices whose
                     // parallelism has already been decided, we need to refactor the logic here.
-                    getExecutionGraph().initializeJobVertex(jobVertex, createTimestamp);
+                    getExecutionGraph()
+                            .initializeJobVertex(
+                                    jobVertex, createTimestamp, jobManagerJobMetricGroup);
                     newlyInitializedJobVertices.add(jobVertex);
                 } else {
                     Optional<List<BlockingResultInfo>> consumedResultsInfo =
@@ -294,7 +296,8 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
                                 .initializeJobVertex(
                                         jobVertex,
                                         createTimestamp,
-                                        parallelismAndInputInfos.getJobVertexInputInfos());
+                                        parallelismAndInputInfos.getJobVertexInputInfos(),
+                                        jobManagerJobMetricGroup);
                         newlyInitializedJobVertices.add(jobVertex);
                     }
                 }
@@ -448,9 +451,7 @@ public class AdaptiveBatchScheduler extends DefaultScheduler {
 
     private void initializeOperatorCoordinatorsFor(ExecutionJobVertex vertex) {
         operatorCoordinatorHandler.registerAndStartNewCoordinators(
-                vertex.getOperatorCoordinators(),
-                getMainThreadExecutor(),
-                jobManagerJobMetricGroup);
+                vertex.getOperatorCoordinators(), getMainThreadExecutor());
     }
 
     /**

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
@@ -65,6 +66,9 @@ class DefaultExecutionGraphConstructionTest {
     static final TestExecutorExtension<ScheduledExecutorService> EXECUTOR_RESOURCE =
             TestingUtils.defaultExecutorExtension();
 
+    private static final JobManagerJobMetricGroup JOB_MANAGER_JOB_METRIC_GROUP =
+            UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup();
+
     private ExecutionGraph createDefaultExecutionGraph(List<JobVertex> vertices) throws Exception {
         return TestingDefaultExecutionGraphBuilder.newBuilder()
                 .setVertexParallelismStore(SchedulerBase.computeVertexParallelismStore(vertices))
@@ -95,10 +99,8 @@ class DefaultExecutionGraphConstructionTest {
 
         ExecutionGraph eg1 = createDefaultExecutionGraph(ordered);
         ExecutionGraph eg2 = createDefaultExecutionGraph(ordered);
-        eg1.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
-        eg2.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg1.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
+        eg2.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         assertThat(
                         Sets.intersection(
@@ -154,8 +156,7 @@ class DefaultExecutionGraphConstructionTest {
         List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
         verifyTestGraph(eg, v1, v2, v3, v4, v5);
     }
 
@@ -212,12 +213,7 @@ class DefaultExecutionGraphConstructionTest {
         List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v5, v4));
 
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        assertThatThrownBy(
-                        () ->
-                                eg.attachJobGraph(
-                                        ordered,
-                                        UnregisteredMetricGroups
-                                                .createUnregisteredJobManagerJobMetricGroup()))
+        assertThatThrownBy(() -> eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP))
                 .isInstanceOf(JobException.class);
     }
 
@@ -268,8 +264,7 @@ class DefaultExecutionGraphConstructionTest {
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2, v3, v4, v5));
 
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         assertThat(eg.getAllVertices().get(v3.getID()).getSplitAssigner()).isEqualTo(assigner1);
         assertThat(eg.getAllVertices().get(v5.getID()).getSplitAssigner()).isEqualTo(assigner2);
@@ -289,8 +284,7 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> vertices = new ArrayList<>(Arrays.asList(v1, v2, v3));
         ExecutionGraph eg = createDefaultExecutionGraph(vertices);
-        eg.attachJobGraph(
-                vertices, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(vertices, JOB_MANAGER_JOB_METRIC_GROUP);
 
         ExecutionJobVertex ejv1 = checkNotNull(eg.getJobVertex(v1.getID()));
         assertThat(ejv1.getProducedDataSets()).hasSize(1);
@@ -328,8 +322,7 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -364,8 +357,7 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -404,8 +396,7 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -436,12 +427,10 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDynamicExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
-        eg.initializeJobVertex(
-                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(ejv1, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -455,8 +444,7 @@ class DefaultExecutionGraphConstructionTest {
         assertThat(partition1.getConsumedPartitionGroups()).isEmpty();
 
         ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
-        eg.initializeJobVertex(
-                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(ejv2, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
 
         ConsumedPartitionGroup consumedPartitionGroup =
                 partition1.getConsumedPartitionGroups().get(0);
@@ -477,12 +465,10 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDynamicExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
-        eg.initializeJobVertex(
-                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(ejv1, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -501,8 +487,7 @@ class DefaultExecutionGraphConstructionTest {
         assertThat(partition4.getConsumedPartitionGroups()).isEmpty();
 
         ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
-        eg.initializeJobVertex(
-                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.initializeJobVertex(ejv2, 0L, JOB_MANAGER_JOB_METRIC_GROUP);
 
         ConsumedPartitionGroup consumedPartitionGroup1 =
                 partition1.getConsumedPartitionGroups().get(0);
@@ -525,8 +510,7 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDynamicExecutionGraph(ordered);
-        eg.attachJobGraph(
-                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg.attachJobGraph(ordered, JOB_MANAGER_JOB_METRIC_GROUP);
 
         assertThat(eg.getAllVertices()).hasSize(2);
         Iterator<ExecutionJobVertex> jobVertices = eg.getVerticesTopologically().iterator();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/DefaultExecutionGraphConstructionTest.java
@@ -29,6 +29,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.testutils.TestingUtils;
@@ -94,8 +95,10 @@ class DefaultExecutionGraphConstructionTest {
 
         ExecutionGraph eg1 = createDefaultExecutionGraph(ordered);
         ExecutionGraph eg2 = createDefaultExecutionGraph(ordered);
-        eg1.attachJobGraph(ordered);
-        eg2.attachJobGraph(ordered);
+        eg1.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        eg2.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         assertThat(
                         Sets.intersection(
@@ -151,7 +154,8 @@ class DefaultExecutionGraphConstructionTest {
         List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v4, v5));
 
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         verifyTestGraph(eg, v1, v2, v3, v4, v5);
     }
 
@@ -208,7 +212,13 @@ class DefaultExecutionGraphConstructionTest {
         List<JobVertex> ordered = new ArrayList<JobVertex>(Arrays.asList(v1, v2, v3, v5, v4));
 
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        assertThatThrownBy(() -> eg.attachJobGraph(ordered)).isInstanceOf(JobException.class);
+        assertThatThrownBy(
+                        () ->
+                                eg.attachJobGraph(
+                                        ordered,
+                                        UnregisteredMetricGroups
+                                                .createUnregisteredJobManagerJobMetricGroup()))
+                .isInstanceOf(JobException.class);
     }
 
     @Test
@@ -258,7 +268,8 @@ class DefaultExecutionGraphConstructionTest {
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2, v3, v4, v5));
 
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         assertThat(eg.getAllVertices().get(v3.getID()).getSplitAssigner()).isEqualTo(assigner1);
         assertThat(eg.getAllVertices().get(v5.getID()).getSplitAssigner()).isEqualTo(assigner2);
@@ -278,7 +289,8 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> vertices = new ArrayList<>(Arrays.asList(v1, v2, v3));
         ExecutionGraph eg = createDefaultExecutionGraph(vertices);
-        eg.attachJobGraph(vertices);
+        eg.attachJobGraph(
+                vertices, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         ExecutionJobVertex ejv1 = checkNotNull(eg.getJobVertex(v1.getID()));
         assertThat(ejv1.getProducedDataSets()).hasSize(1);
@@ -316,7 +328,8 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -351,7 +364,8 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -390,7 +404,8 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDefaultExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -421,10 +436,12 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDynamicExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
-        eg.initializeJobVertex(ejv1, 0L);
+        eg.initializeJobVertex(
+                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -438,7 +455,8 @@ class DefaultExecutionGraphConstructionTest {
         assertThat(partition1.getConsumedPartitionGroups()).isEmpty();
 
         ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
-        eg.initializeJobVertex(ejv2, 0L);
+        eg.initializeJobVertex(
+                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         ConsumedPartitionGroup consumedPartitionGroup =
                 partition1.getConsumedPartitionGroups().get(0);
@@ -459,10 +477,12 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDynamicExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         ExecutionJobVertex ejv1 = eg.getJobVertex(v1.getID());
-        eg.initializeJobVertex(ejv1, 0L);
+        eg.initializeJobVertex(
+                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(v1.getID())).getProducedDataSets()[0];
@@ -481,7 +501,8 @@ class DefaultExecutionGraphConstructionTest {
         assertThat(partition4.getConsumedPartitionGroups()).isEmpty();
 
         ExecutionJobVertex ejv2 = eg.getJobVertex(v2.getID());
-        eg.initializeJobVertex(ejv2, 0L);
+        eg.initializeJobVertex(
+                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         ConsumedPartitionGroup consumedPartitionGroup1 =
                 partition1.getConsumedPartitionGroups().get(0);
@@ -504,7 +525,8 @@ class DefaultExecutionGraphConstructionTest {
 
         List<JobVertex> ordered = new ArrayList<>(Arrays.asList(v1, v2));
         ExecutionGraph eg = createDynamicExecutionGraph(ordered);
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         assertThat(eg.getAllVertices()).hasSize(2);
         Iterator<ExecutionJobVertex> jobVertices = eg.getVerticesTopologically().iterator();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/EdgeManagerBuildUtilTest.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 import org.apache.flink.testutils.TestingUtils;
@@ -99,12 +100,17 @@ class EdgeManagerBuildUtilTest {
         final ExecutionJobVertex consumer = vertexIterator.next();
 
         // initialize producer and consumer
-        eg.initializeJobVertex(producer, 1L, Collections.emptyMap());
+        eg.initializeJobVertex(
+                producer,
+                1L,
+                Collections.emptyMap(),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         eg.initializeJobVertex(
                 consumer,
                 1L,
                 Collections.singletonMap(
-                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo));
+                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(producer.getJobVertexId()))
@@ -169,12 +175,17 @@ class EdgeManagerBuildUtilTest {
         final ExecutionJobVertex consumer = vertexIterator.next();
 
         // initialize producer and consumer
-        eg.initializeJobVertex(producer, 1L, Collections.emptyMap());
+        eg.initializeJobVertex(
+                producer,
+                1L,
+                Collections.emptyMap(),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         eg.initializeJobVertex(
                 consumer,
                 1L,
                 Collections.singletonMap(
-                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo));
+                        producer.getProducedDataSets()[0].getId(), jobVertexInputInfo),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         IntermediateResult result =
                 Objects.requireNonNull(eg.getJobVertex(producer.getJobVertexId()))
@@ -302,7 +313,8 @@ class EdgeManagerBuildUtilTest {
             eg = builder.build(EXECUTOR_RESOURCE.getExecutor());
         }
 
-        eg.attachJobGraph(ordered);
+        eg.attachJobGraph(
+                ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         return eg;
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/ExecutionJobVertexTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.scheduler.VertexParallelismInformation;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
@@ -159,7 +160,8 @@ class ExecutionJobVertexTest {
                 Time.milliseconds(1L),
                 1L,
                 new DefaultSubtaskAttemptNumberStore(Collections.emptyList()),
-                new CoordinatorStoreImpl());
+                new CoordinatorStoreImpl(),
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
     }
 
     private static ExecutionJobVertex createDynamicExecutionJobVertex() throws Exception {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/PointwisePatternTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.testutils.TestingUtils;
@@ -265,7 +266,8 @@ public class PointwisePatternTest {
                                 SchedulerBase.computeVertexParallelismStore(ordered))
                         .build(EXECUTOR_RESOURCE.getExecutor());
         try {
-            eg.attachJobGraph(ordered);
+            eg.attachJobGraph(
+                    ordered, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         } catch (JobException e) {
             e.printStackTrace();
             fail("Job failed with exception: " + e.getMessage());

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/TestingDefaultExecutionGraphBuilder.java
@@ -38,6 +38,7 @@ import org.apache.flink.runtime.io.network.partition.NoOpJobMasterPartitionTrack
 import org.apache.flink.runtime.io.network.partition.ResultPartitionType;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.shuffle.ShuffleMaster;
@@ -196,7 +197,8 @@ public class TestingDefaultExecutionGraphBuilder {
                 isDynamicGraph,
                 executionJobVertexFactory,
                 markPartitionFinishedStrategy,
-                nonFinishedHybridPartitionShouldBeUnknown);
+                nonFinishedHybridPartitionShouldBeUnknown,
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
     }
 
     public DefaultExecutionGraph build(ScheduledExecutorService executorService)

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/executiongraph/VertexSlotSharingTest.java
@@ -23,6 +23,7 @@ import org.apache.flink.runtime.jobgraph.DistributionPattern;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.tasks.AbstractInvokable;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
@@ -92,7 +93,9 @@ public class VertexSlotSharingTest {
                             .setVertexParallelismStore(
                                     SchedulerBase.computeVertexParallelismStore(vertices))
                             .build(EXECUTOR_RESOURCE.getExecutor());
-            eg.attachJobGraph(vertices);
+            eg.attachJobGraph(
+                    vertices,
+                    UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
             // verify that the vertices are all in the same slot sharing group
             SlotSharingGroup group1;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/operators/coordination/OperatorCoordinatorHolderTest.java
@@ -526,12 +526,10 @@ public class OperatorCoordinatorHolderTest extends TestLogger {
                                 1,
                                 1,
                                 NoOpInvokable.class.getName(),
-                                new Configuration()));
+                                new Configuration()),
+                        UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
-        holder.lazyInitialize(
-                globalFailureHandler,
-                mainThreadExecutor,
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+        holder.lazyInitialize(globalFailureHandler, mainThreadExecutor);
         holder.start();
 
         return holder;

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultOperatorCoordinatorHandlerTest.java
@@ -64,17 +64,17 @@ public class DefaultOperatorCoordinatorHandlerTest {
         ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
         executionGraph.start(ComponentMainThreadExecutorServiceAdapter.forMainThread());
 
-        executionGraph.initializeJobVertex(ejv1, 0L);
+        executionGraph.initializeJobVertex(
+                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         DefaultOperatorCoordinatorHandler handler =
                 new DefaultOperatorCoordinatorHandler(executionGraph, throwable -> {});
         assertThat(handler.getCoordinatorMap().keySet(), containsInAnyOrder(operatorId1));
 
-        executionGraph.initializeJobVertex(ejv2, 0L);
+        executionGraph.initializeJobVertex(
+                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         handler.registerAndStartNewCoordinators(
-                ejv2.getOperatorCoordinators(),
-                executionGraph.getJobMasterMainThreadExecutor(),
-                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
+                ejv2.getOperatorCoordinators(), executionGraph.getJobMasterMainThreadExecutor());
 
         assertThat(
                 handler.getCoordinatorMap().keySet(), containsInAnyOrder(operatorId1, operatorId2));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SchedulerTestingUtils.java
@@ -54,6 +54,7 @@ import org.apache.flink.runtime.jobmaster.LogicalSlot;
 import org.apache.flink.runtime.jobmaster.TestingLogicalSlotBuilder;
 import org.apache.flink.runtime.jobmaster.slotpool.PhysicalSlotProvider;
 import org.apache.flink.runtime.messages.checkpoint.AcknowledgeCheckpoint;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
 import org.apache.flink.runtime.state.CheckpointStorage;
 import org.apache.flink.runtime.state.StateBackend;
@@ -389,7 +390,9 @@ public class SchedulerTestingUtils {
             JobVertexID jobVertex, ExecutionGraph executionGraph) {
         try {
             executionGraph.initializeJobVertex(
-                    executionGraph.getJobVertex(jobVertex), System.currentTimeMillis());
+                    executionGraph.getJobVertex(jobVertex),
+                    System.currentTimeMillis(),
+                    UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
             executionGraph.notifyNewlyInitializedJobVertices(
                     Collections.singletonList(executionGraph.getJobVertex(jobVertex)));
         } catch (JobException exception) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/SsgNetworkMemoryCalculationUtilsTest.java
@@ -34,6 +34,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobGraphTestUtils;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.adaptivebatch.AdaptiveBatchScheduler;
 import org.apache.flink.runtime.shuffle.PartitionDescriptor;
 import org.apache.flink.runtime.shuffle.ProducerDescriptor;
@@ -152,15 +153,18 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         ExecutionJobVertex map = jobVertices.next();
         ExecutionJobVertex sink = jobVertices.next();
 
-        executionGraph.initializeJobVertex(source, 0L);
+        executionGraph.initializeJobVertex(
+                source, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         triggerComputeNumOfSubpartitions(source.getProducedDataSets()[0]);
 
         map.setParallelism(5);
-        executionGraph.initializeJobVertex(map, 0L);
+        executionGraph.initializeJobVertex(
+                map, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         triggerComputeNumOfSubpartitions(map.getProducedDataSets()[0]);
 
         sink.setParallelism(7);
-        executionGraph.initializeJobVertex(sink, 0L);
+        executionGraph.initializeJobVertex(
+                sink, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         assertNetworkMemory(
                 slotSharingGroups,
@@ -225,12 +229,18 @@ public class SsgNetworkMemoryCalculationUtilsTest {
         final ExecutionJobVertex producer = vertexIterator.next();
         final ExecutionJobVertex consumer = vertexIterator.next();
 
-        eg.initializeJobVertex(producer, 0L);
+        eg.initializeJobVertex(
+                producer,
+                0L,
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         final IntermediateResult result = producer.getProducedDataSets()[0];
         triggerComputeNumOfSubpartitions(result);
 
         consumer.setParallelism(decidedConsumerParallelism);
-        eg.initializeJobVertex(consumer, 0L);
+        eg.initializeJobVertex(
+                consumer,
+                0L,
+                UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
 
         Map<IntermediateDataSetID, Integer> maxInputChannelNums = new HashMap<>();
         Map<IntermediateDataSetID, ResultPartitionType> inputPartitionTypes = new HashMap<>();

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adapter/DefaultExecutionTopologyTest.java
@@ -31,6 +31,7 @@ import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobmanager.scheduler.SlotSharingGroup;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.strategy.ConsumedPartitionGroup;
 import org.apache.flink.runtime.scheduler.strategy.ConsumerVertexGroup;
 import org.apache.flink.runtime.scheduler.strategy.ExecutionVertexID;
@@ -177,11 +178,13 @@ class DefaultExecutionTopologyTest {
         final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
         final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
 
-        executionGraph.initializeJobVertex(ejv1, 0L);
+        executionGraph.initializeJobVertex(
+                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
         assertThat(adapter.getVertices()).hasSize(3);
 
-        executionGraph.initializeJobVertex(ejv2, 0L);
+        executionGraph.initializeJobVertex(
+                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv2));
         assertThat(adapter.getVertices()).hasSize(6);
 
@@ -197,10 +200,12 @@ class DefaultExecutionTopologyTest {
         final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
         final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
 
-        executionGraph.initializeJobVertex(ejv1, 0L);
+        executionGraph.initializeJobVertex(
+                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
 
-        executionGraph.initializeJobVertex(ejv2, 0L);
+        executionGraph.initializeJobVertex(
+                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         assertThatThrownBy(
                         () ->
                                 adapter.notifyExecutionGraphUpdated(
@@ -217,12 +222,14 @@ class DefaultExecutionTopologyTest {
         final ExecutionJobVertex ejv1 = executionGraph.getJobVertex(jobVertices[0].getID());
         final ExecutionJobVertex ejv2 = executionGraph.getJobVertex(jobVertices[1].getID());
 
-        executionGraph.initializeJobVertex(ejv1, 0L);
+        executionGraph.initializeJobVertex(
+                ejv1, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv1));
         SchedulingPipelinedRegion regionOld =
                 adapter.getPipelinedRegionOfVertex(new ExecutionVertexID(ejv1.getJobVertexId(), 0));
 
-        executionGraph.initializeJobVertex(ejv2, 0L);
+        executionGraph.initializeJobVertex(
+                ejv2, 0L, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         adapter.notifyExecutionGraphUpdated(executionGraph, Collections.singletonList(ejv2));
         SchedulingPipelinedRegion regionNew =
                 adapter.getPipelinedRegionOfVertex(new ExecutionVertexID(ejv1.getJobVertexId(), 0));

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/ExecutingTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateDataSetID;
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.operators.coordination.CoordinatorStoreImpl;
 import org.apache.flink.runtime.scheduler.DefaultVertexParallelismInfo;
 import org.apache.flink.runtime.scheduler.ExecutionGraphHandler;
@@ -834,7 +835,8 @@ public class ExecutingTest extends TestLogger {
                     Time.milliseconds(1L),
                     1L,
                     new DefaultSubtaskAttemptNumberStore(Collections.emptyList()),
-                    new CoordinatorStoreImpl());
+                    new CoordinatorStoreImpl(),
+                    UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
             mockExecutionVertex = executionVertexSupplier.apply(this);
         }
 

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/StateTrackingMockExecutionGraph.java
@@ -53,6 +53,7 @@ import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.runtime.jobgraph.JobVertexID;
 import org.apache.flink.runtime.jobgraph.tasks.CheckpointCoordinatorConfiguration;
+import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.query.KvStateLocationRegistry;
 import org.apache.flink.runtime.scheduler.InternalFailuresListener;
 import org.apache.flink.runtime.scheduler.exceptionhistory.TestingAccessExecution;
@@ -327,7 +328,9 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     }
 
     @Override
-    public void attachJobGraph(List<JobVertex> topologicallySorted) throws JobException {
+    public void attachJobGraph(
+            List<JobVertex> topologicallySorted, JobManagerJobMetricGroup jobManagerJobMetricGroup)
+            throws JobException {
         throw new UnsupportedOperationException();
     }
 
@@ -381,7 +384,8 @@ class StateTrackingMockExecutionGraph implements ExecutionGraph {
     public void initializeJobVertex(
             ExecutionJobVertex ejv,
             long createTimestamp,
-            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos)
+            Map<IntermediateDataSetID, JobVertexInputInfo> jobVertexInputInfos,
+            JobManagerJobMetricGroup jobManagerJobMetricGroup)
             throws JobException {
         throw new UnsupportedOperationException();
     }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/adaptive/TestingOperatorCoordinatorHandler.java
@@ -21,7 +21,6 @@ package org.apache.flink.runtime.scheduler.adaptive;
 import org.apache.flink.runtime.concurrent.ComponentMainThreadExecutor;
 import org.apache.flink.runtime.executiongraph.ExecutionAttemptID;
 import org.apache.flink.runtime.jobgraph.OperatorID;
-import org.apache.flink.runtime.metrics.groups.JobManagerJobMetricGroup;
 import org.apache.flink.runtime.operators.coordination.CoordinationRequest;
 import org.apache.flink.runtime.operators.coordination.CoordinationResponse;
 import org.apache.flink.runtime.operators.coordination.OperatorCoordinatorHolder;
@@ -45,9 +44,7 @@ class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
     }
 
     @Override
-    public void initializeOperatorCoordinators(
-            ComponentMainThreadExecutor mainThreadExecutor,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
+    public void initializeOperatorCoordinators(ComponentMainThreadExecutor mainThreadExecutor) {
         // No-op.
     }
 
@@ -72,8 +69,7 @@ class TestingOperatorCoordinatorHandler implements OperatorCoordinatorHandler {
     @Override
     public void registerAndStartNewCoordinators(
             Collection<OperatorCoordinatorHolder> coordinators,
-            ComponentMainThreadExecutor mainThreadExecutor,
-            JobManagerJobMetricGroup jobManagerJobMetricGroup) {
+            ComponentMainThreadExecutor mainThreadExecutor) {
         throw new UnsupportedOperationException();
     }
 }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/benchmark/topology/BuildExecutionGraphBenchmark.java
@@ -22,6 +22,7 @@ import org.apache.flink.runtime.executiongraph.ExecutionGraph;
 import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuilder;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.runtime.scheduler.VertexParallelismStore;
 import org.apache.flink.runtime.scheduler.benchmark.JobConfiguration;
@@ -58,6 +59,7 @@ public class BuildExecutionGraphBenchmark extends SchedulerBenchmarkBase {
     }
 
     public void buildTopology() throws Exception {
-        executionGraph.attachJobGraph(jobVertices);
+        executionGraph.attachJobGraph(
+                jobVertices, UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/partitioner/RescalePartitionerTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.executiongraph.TestingDefaultExecutionGraphBuild
 import org.apache.flink.runtime.jobgraph.IntermediateResultPartitionID;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.runtime.jobgraph.JobVertex;
+import org.apache.flink.runtime.metrics.groups.UnregisteredMetricGroups;
 import org.apache.flink.runtime.scheduler.SchedulerBase;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -131,7 +132,9 @@ public class RescalePartitionerTest extends StreamPartitionerTest {
                         .build(EXECUTOR_RESOURCE.getExecutor());
 
         try {
-            eg.attachJobGraph(jobVertices);
+            eg.attachJobGraph(
+                    jobVertices,
+                    UnregisteredMetricGroups.createUnregisteredJobManagerJobMetricGroup());
         } catch (JobException e) {
             e.printStackTrace();
             fail("Building ExecutionGraph failed: " + e.getMessage());


### PR DESCRIPTION
## What is the purpose of the change

 This pull request makes operator coordinator metric group not to be initialized lazily.

## Brief change log

  - Pass the JobManagerJobMetricGroup when create execution graph
  - Set metric group immediately when creating the operator coordinator context instead of lazy initialize

## Verifying this change

This change is already covered by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no
  - 
## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
