### PR TITLE
[FLINK-31279][table] fix builtin function of times wrong check.

### DIFF
--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/CodeGenUtils.scala
@@ -434,6 +434,18 @@ object CodeGenUtils {
       throw new CodeGenException("Integer expression type expected.")
     }
 
+  def requireNumericAndTimeInterval(left: GeneratedExpression, right: GeneratedExpression): Unit = {
+    val numericAndTimeInterval = TypeCheckUtils.isNumeric(left.resultType) &&
+      TypeCheckUtils.isTimeInterval(right.resultType)
+    val timeIntervalAndTimeNumeric = TypeCheckUtils.isTimeInterval(left.resultType) &&
+      TypeCheckUtils.isNumeric(right.resultType)
+    if (!(numericAndTimeInterval || timeIntervalAndTimeNumeric)) {
+      throw new CodeGenException(
+        "Numeric and Temporal expression type, or Temporal and Numeric expression type expected. " +
+          " But were " + s"'${left.resultType}' and '${right.resultType}'.")
+    }
+  }
+
   def udfFieldName(udf: UserDefinedFunction): String = {
     s"function_${udf.functionIdentifier.replace('.', '$')}"
   }

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -546,8 +546,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
       case MULTIPLY if isTimeInterval(resultType) =>
         val left = operands.head
         val right = operands(1)
-        requireTimeInterval(left)
-        requireNumeric(right)
+        requireNumericAndTimeInterval(left, right)
         generateBinaryArithmeticOperator(ctx, "*", resultType, left, right)
 
       case DIVIDE | DIVIDE_INTEGER if isNumeric(resultType) =>


### PR DESCRIPTION
## What is the purpose of the change

*fix builtin function of times wrong check.*


## Brief change log

Flink SQL> select 2 * interval '3'  day;
[ERROR] Could not execute SQL statement. Reason:
org.apache.flink.table.planner.codegen.CodeGenException: Interval expression type expected. 

## Verifying this change

unit test

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

