### PR TITLE
[FLINK-31282][Client]Fix the SQL Problem to create and close zookeepr connections frequently

### DIFF
--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -64,7 +64,7 @@ public class ClusterClientJobClientAdapter<ClusterID>
         this.clusterClientProvider = checkNotNull(clusterClientProvider);
         this.classLoader = classLoader;
     }
-    
+
     public ClusterClientProvider<ClusterID> getClusterClientProvider() {
         return this.clusterClientProvider;
     }

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -64,6 +64,10 @@ public class ClusterClientJobClientAdapter<ClusterID>
         this.clusterClientProvider = checkNotNull(clusterClientProvider);
         this.classLoader = classLoader;
     }
+    
+    public ClusterClientProvider<ClusterID> getClusterClientProvider() {
+        return this.clusterClientProvider;
+    }
 
     @Override
     public JobID getJobID() {

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -71,7 +71,7 @@ public class ClusterClientJobClientAdapter<ClusterID>
     }
 
     private ClusterClient<ClusterID> getClusterClient() {
-        if(clusterClient == null) {
+        if (clusterClient == null) {
             clusterClient = clusterClientProvider.getClusterClient();
         }
         return clusterClient;

--- a/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
+++ b/flink-clients/src/main/java/org/apache/flink/client/deployment/ClusterClientJobClientAdapter.java
@@ -58,7 +58,7 @@ public class ClusterClientJobClientAdapter<ClusterID>
     private final ClassLoader classLoader;
 
     private ClusterClient<ClusterID> clusterClient;
-    //when select then isQuery = true;
+    // when select then isQuery = true;
     private Boolean isQuery = false;
 
     public ClusterClientJobClientAdapter(
@@ -70,8 +70,8 @@ public class ClusterClientJobClientAdapter<ClusterID>
         this.classLoader = classLoader;
     }
 
-    private ClusterClient<ClusterID> getClusterClient(){
-        if(clusterClient == null){
+    private ClusterClient<ClusterID> getClusterClient() {
+        if(clusterClient == null) {
             clusterClient = clusterClientProvider.getClusterClient();
         }
         return clusterClient;
@@ -84,22 +84,22 @@ public class ClusterClientJobClientAdapter<ClusterID>
 
     @Override
     public CompletableFuture<JobStatus> getJobStatus() {
-        if(!isQuery) {
+        if (!isQuery) {
             return bridgeClientRequest(
                     clusterClientProvider, (clusterClient -> clusterClient.getJobStatus(jobID)));
         }
         CompletableFuture<JobStatus> jobStatus = new CompletableFuture<JobStatus>();
-        try{
+        try {
             jobStatus = this.getClusterClient().getJobStatus(jobID);
-            if(jobStatus.get().isTerminalState() || jobStatus.get().isGloballyTerminalState()){
-                if(clusterClient != null){
+            if (jobStatus.get().isTerminalState() || jobStatus.get().isGloballyTerminalState()) {
+                if (clusterClient != null) {
                     clusterClient.close();
                 }
             }
-        }catch (Exception e){
-            //do nothing
+        } catch (Exception e) {
+            // do nothing
         }
-        return  jobStatus;
+        return jobStatus;
     }
 
     @Override
@@ -163,7 +163,7 @@ public class ClusterClientJobClientAdapter<ClusterID>
     @Override
     public CompletableFuture<CoordinationResponse> sendCoordinationRequest(
             OperatorID operatorId, CoordinationRequest request) {
-        if(request instanceof CollectCoordinationRequest){
+        if (request instanceof CollectCoordinationRequest) {
             this.isQuery = true;
             return this.getClusterClient().sendCoordinationRequest(jobID, operatorId, request);
         }


### PR DESCRIPTION
[FLINK-31282][Componets: Client]

## What is the purpose of the change

Fix the Problem to **create and close zookeepr connections frequently**
when executing sql  **Select**  ,  In the next()  function of CollectResultFetcher.  there are two functions called : 
  isJobTerminated() will call **jobClient.getJobStatus()** 
 sendRequest() willl call **gateway.sendCoordinationRequest()**    .
 Everytime , Both of them  will  **create and close a zookeeper connection** In ClusterClientJobClientAdapter.bridgeClientRequet()

## Brief change log

I set a flag "isQuery" ,when it is true ,i will change to use the same clusterclient.  the Connection will be create and close just for once.

## Verifying this change
I got the right connection in my product cluster. 