### PR TITLE
[FLINK-31283][docs] Update the scala-2.11 related building doc

### DIFF
--- a/docs/content.zh/docs/flinkDev/building.md
+++ b/docs/content.zh/docs/flinkDev/building.md
@@ -149,12 +149,7 @@ mvn clean install
 Flink 有使用 [Scala](http://scala-lang.org) 来写的 API，库和运行时模块。使用 Scala API 和库的同学必须配置 Flink 的 Scala 版本和自己的 Flink 版本（因为 Scala 
 并不严格的向后兼容）。
 
-从 1.7 版本开始，Flink 可以使用 Scala 2.11（默认）和 2.12 来构建。
-
-如果使用 Scala 2.12 来进行构建，执行如下命令：
-```bash
-mvn clean install -DskipTests -Dscala-2.12
-```
+从 1.15 版本开始，Flink 已经不再支持使用Scala 2.11编译，默认使用 2.12 来构建。
 
 要针对特定的二进制 Scala 版本进行构建，可以使用
 ```bash

--- a/docs/content/docs/flinkDev/building.md
+++ b/docs/content/docs/flinkDev/building.md
@@ -156,12 +156,7 @@ Users that purely use the Java APIs and libraries can *ignore* this section.
 
 Flink has APIs, libraries, and runtime modules written in [Scala](http://scala-lang.org). Users of the Scala API and libraries may have to match the Scala version of Flink with the Scala version of their projects (because Scala is not strictly backwards compatible).
 
-Since version 1.7 Flink builds with Scala version 2.11 (default) and 2.12.
-
-To build Flink against Scala 2.12, issue the following command:
-```bash
-mvn clean install -DskipTests -Dscala-2.12
-```
+Since version 1.15 Flink dropped the support of Scala 2.11 and it will use Scala 2.12 to build by default.
 
 To build against a specific binary Scala version you can use:
 ```bash


### PR DESCRIPTION
## What is the purpose of the change

After [FLINK-20845](https://issues.apache.org/jira/browse/FLINK-20845), Flink dropped the support of Scala 2.11. However, the doc of "building from source" still has the description on scala-2.11. We should update this.


## Brief change log

only to docs


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
