### PR TITLE
[BP-1.15][FLINK-29729][parquet] Fix credential info configured in flink-conf.yaml is lost during creating ParquetReader

### DIFF
--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetInputFile.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetInputFile.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.formats.parquet;
+
+import org.apache.flink.core.fs.FSDataInputStream;
+
+import org.apache.parquet.io.DelegatingSeekableInputStream;
+import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.SeekableInputStream;
+
+import java.io.IOException;
+
+/**
+ * Parquet {@link InputFile} implementation, {@link #newStream()} call will delegate to Flink {@link
+ * FSDataInputStream}.
+ */
+public class ParquetInputFile implements InputFile {
+
+    private final FSDataInputStream inputStream;
+    private final long length;
+
+    public ParquetInputFile(FSDataInputStream inputStream, long length) {
+        this.inputStream = inputStream;
+        this.length = length;
+    }
+
+    @Override
+    public long getLength() {
+        return length;
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+        return new FSDataInputStreamAdapter(inputStream);
+    }
+
+    /**
+     * Adapter which makes {@link FSDataInputStream} become compatible with parquet {@link
+     * SeekableInputStream}.
+     */
+    private static class FSDataInputStreamAdapter extends DelegatingSeekableInputStream {
+
+        private final FSDataInputStream inputStream;
+
+        private FSDataInputStreamAdapter(FSDataInputStream inputStream) {
+            super(inputStream);
+            this.inputStream = inputStream;
+        }
+
+        @Override
+        public long getPos() throws IOException {
+            return inputStream.getPos();
+        }
+
+        @Override
+        public void seek(long newPos) throws IOException {
+            inputStream.seek(newPos);
+        }
+    }
+}

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/ParquetVectorizedInputFormat.java
@@ -24,6 +24,7 @@ import org.apache.flink.connector.file.src.FileSourceSplit;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
 import org.apache.flink.connector.file.src.util.Pool;
+import org.apache.flink.core.fs.FileSystem;
 import org.apache.flink.core.fs.Path;
 import org.apache.flink.formats.parquet.utils.ParquetSchemaConverter;
 import org.apache.flink.formats.parquet.utils.SerializableConfiguration;
@@ -40,12 +41,12 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.util.FlinkRuntimeException;
 import org.apache.flink.util.Preconditions;
 
+import org.apache.parquet.ParquetReadOptions;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
@@ -66,9 +67,6 @@ import java.util.Set;
 
 import static org.apache.flink.formats.parquet.vector.ParquetSplitReaderUtil.createColumnReader;
 import static org.apache.flink.formats.parquet.vector.ParquetSplitReaderUtil.createWritableColumnVector;
-import static org.apache.parquet.filter2.compat.RowGroupFilter.filterRowGroups;
-import static org.apache.parquet.format.converter.ParquetMetadataConverter.range;
-import static org.apache.parquet.hadoop.ParquetFileReader.readFooter;
 import static org.apache.parquet.hadoop.ParquetInputFormat.getFilter;
 
 /**
@@ -114,36 +112,34 @@ public abstract class ParquetVectorizedInputFormat<T, SplitT extends FileSourceS
         final long splitOffset = split.offset();
         final long splitLength = split.length();
 
-        org.apache.hadoop.fs.Path hadoopPath = new org.apache.hadoop.fs.Path(filePath.toUri());
-        ParquetMetadata footer =
-                readFooter(
-                        hadoopConfig.conf(),
-                        hadoopPath,
-                        range(splitOffset, splitOffset + splitLength));
-        MessageType fileSchema = footer.getFileMetaData().getSchema();
+        // Using Flink FileSystem instead of Hadoop FileSystem directly, so we can get the hadoop
+        // config that create inputFile needed from flink-conf.yaml
+        final FileSystem fs = filePath.getFileSystem();
+        final ParquetInputFile inputFile =
+                new ParquetInputFile(fs.open(filePath), fs.getFileStatus(filePath).getLen());
+
+        // Notice: This filter is RowGroups level, not individual records.
         FilterCompat.Filter filter = getFilter(hadoopConfig.conf());
-        List<BlockMetaData> blocks = filterRowGroups(filter, footer.getBlocks(), fileSchema);
+        ParquetReadOptions parquetReadOptions =
+                ParquetReadOptions.builder()
+                        .withRange(splitOffset, splitOffset + splitLength)
+                        .withRecordFilter(filter)
+                        .build();
+        ParquetFileReader parquetFileReader = ParquetFileReader.open(inputFile, parquetReadOptions);
 
+        MessageType fileSchema = parquetFileReader.getFooter().getFileMetaData().getSchema();
+        // Pruning unnecessary column, we should set the projection schema before running any
+        // filtering (e.g. getting filtered record count) because projection impacts filtering
         MessageType requestedSchema = clipParquetSchema(fileSchema);
-        ParquetFileReader reader =
-                new ParquetFileReader(
-                        hadoopConfig.conf(),
-                        footer.getFileMetaData(),
-                        hadoopPath,
-                        blocks,
-                        requestedSchema.getColumns());
-
-        long totalRowCount = 0;
-        for (BlockMetaData block : blocks) {
-            totalRowCount += block.getRowCount();
-        }
+        parquetFileReader.setRequestedSchema(requestedSchema);
 
         checkSchema(fileSchema, requestedSchema);
 
+        final long totalRowCount = parquetFileReader.getFilteredRecordCount();
         final Pool<ParquetReaderBatch<T>> poolOfBatches =
                 createPoolOfBatches(split, requestedSchema, numBatchesToCirculate(config));
 
-        return new ParquetReader(reader, requestedSchema, totalRowCount, poolOfBatches);
+        return new ParquetReader(parquetFileReader, requestedSchema, totalRowCount, poolOfBatches);
     }
 
     protected int numBatchesToCirculate(Configuration config) {

--- a/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormat.java
+++ b/flink-formats/flink-parquet/src/main/java/org/apache/flink/formats/parquet/avro/AvroParquetRecordFormat.java
@@ -24,15 +24,14 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.file.src.reader.StreamFormat;
 import org.apache.flink.connector.file.src.util.CheckpointedPosition;
 import org.apache.flink.core.fs.FSDataInputStream;
+import org.apache.flink.formats.parquet.ParquetInputFile;
 import org.apache.flink.util.function.SerializableSupplier;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.parquet.avro.AvroParquetReader;
 import org.apache.parquet.hadoop.ParquetReader;
-import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.io.InputFile;
-import org.apache.parquet.io.SeekableInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +69,7 @@ class AvroParquetRecordFormat<E> implements StreamFormat<E> {
      *
      * <p>Several wrapper classes haven be created to Flink abstraction become compatible with the
      * parquet abstraction. Please refer to the inner classes {@link AvroParquetRecordReader},
-     * {@link ParquetInputFile}, {@link FSDataInputStreamAdapter} for details.
+     * {@link ParquetInputFile}, {@code FSDataInputStreamAdapter} for details.
      */
     @Override
     public Reader<E> createReader(
@@ -186,55 +185,6 @@ class AvroParquetRecordFormat<E> implements StreamFormat<E> {
 
         private void incrementPosition() {
             skipCount++;
-        }
-    }
-
-    /**
-     * Parquet {@link InputFile} implementation, {@link #newStream()} call will delegate to Flink
-     * {@link FSDataInputStream}.
-     */
-    private static class ParquetInputFile implements InputFile {
-
-        private final FSDataInputStream inputStream;
-        private final long length;
-
-        private ParquetInputFile(FSDataInputStream inputStream, long length) {
-            this.inputStream = inputStream;
-            this.length = length;
-        }
-
-        @Override
-        public long getLength() {
-            return length;
-        }
-
-        @Override
-        public SeekableInputStream newStream() {
-            return new FSDataInputStreamAdapter(inputStream);
-        }
-    }
-
-    /**
-     * Adapter which makes {@link FSDataInputStream} become compatible with parquet {@link
-     * SeekableInputStream}.
-     */
-    private static class FSDataInputStreamAdapter extends DelegatingSeekableInputStream {
-
-        private final FSDataInputStream inputStream;
-
-        private FSDataInputStreamAdapter(FSDataInputStream inputStream) {
-            super(inputStream);
-            this.inputStream = inputStream;
-        }
-
-        @Override
-        public long getPos() throws IOException {
-            return inputStream.getPos();
-        }
-
-        @Override
-        public void seek(long newPos) throws IOException {
-            inputStream.seek(newPos);
         }
     }
 }


### PR DESCRIPTION
This is a cherry-pick back to release-1.15 branch.