### PR TITLE
[FLINK-31284][tests] Increase KerberosLoginProvider test coverage

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/security/token/hadoop/KerberosLoginProviderITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.MockedStatic;
 
 import java.io.IOException;
@@ -49,8 +51,10 @@ import static org.mockito.Mockito.when;
  */
 public class KerberosLoginProviderITCase {
 
-    @Test
-    public void isLoginPossibleMustReturnFalseByDefault() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void isLoginPossibleMustReturnFalseByDefault(boolean supportProxyUser)
+            throws IOException {
         Configuration configuration = new Configuration();
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
@@ -58,12 +62,14 @@ public class KerberosLoginProviderITCase {
             UserGroupInformation userGroupInformation = mock(UserGroupInformation.class);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertFalse(kerberosLoginProvider.isLoginPossible(false));
+            assertFalse(kerberosLoginProvider.isLoginPossible(supportProxyUser));
         }
     }
 
-    @Test
-    public void isLoginPossibleMustReturnFalseWithNonKerberos() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void isLoginPossibleMustReturnFalseWithNonKerberos(boolean supportProxyUser)
+            throws IOException {
         Configuration configuration = new Configuration();
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
 
@@ -72,12 +78,14 @@ public class KerberosLoginProviderITCase {
             ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(false);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertFalse(kerberosLoginProvider.isLoginPossible(false));
+            assertFalse(kerberosLoginProvider.isLoginPossible(supportProxyUser));
         }
     }
 
-    @Test
-    public void isLoginPossibleMustReturnTrueWithKeytab(@TempDir Path tmpDir) throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void isLoginPossibleMustReturnTrueWithKeytab(
+            boolean supportProxyUser, @TempDir Path tmpDir) throws IOException {
         Configuration configuration = new Configuration();
         configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
         final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
@@ -89,12 +97,13 @@ public class KerberosLoginProviderITCase {
             ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(true);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertTrue(kerberosLoginProvider.isLoginPossible(false));
+            assertTrue(kerberosLoginProvider.isLoginPossible(supportProxyUser));
         }
     }
 
-    @Test
-    public void isLoginPossibleMustReturnTrueWithTGT() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void isLoginPossibleMustReturnTrueWithTGT(boolean supportProxyUser) throws IOException {
         Configuration configuration = new Configuration();
         configuration.setBoolean(KERBEROS_LOGIN_USETICKETCACHE, true);
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
@@ -105,7 +114,7 @@ public class KerberosLoginProviderITCase {
             ugi.when(UserGroupInformation::isSecurityEnabled).thenReturn(true);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            assertTrue(kerberosLoginProvider.isLoginPossible(false));
+            assertTrue(kerberosLoginProvider.isLoginPossible(supportProxyUser));
         }
     }
 
@@ -143,8 +152,10 @@ public class KerberosLoginProviderITCase {
         }
     }
 
-    @Test
-    public void doLoginMustLoginWithKeytab(@TempDir Path tmpDir) throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void doLoginMustLoginWithKeytab(boolean supportProxyUser, @TempDir Path tmpDir)
+            throws IOException {
         Configuration configuration = new Configuration();
         configuration.setString(KERBEROS_LOGIN_PRINCIPAL, "principal");
         final Path keyTab = Files.createFile(tmpDir.resolve("test.keytab"));
@@ -155,13 +166,14 @@ public class KerberosLoginProviderITCase {
             UserGroupInformation userGroupInformation = mock(UserGroupInformation.class);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            kerberosLoginProvider.doLogin(false);
+            kerberosLoginProvider.doLogin(supportProxyUser);
             ugi.verify(() -> UserGroupInformation.loginUserFromKeytab(anyString(), anyString()));
         }
     }
 
-    @Test
-    public void doLoginMustLoginWithTGT() throws IOException {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void doLoginMustLoginWithTGT(boolean supportProxyUser) throws IOException {
         Configuration configuration = new Configuration();
         configuration.setBoolean(KERBEROS_LOGIN_USETICKETCACHE, true);
         KerberosLoginProvider kerberosLoginProvider = new KerberosLoginProvider(configuration);
@@ -171,7 +183,7 @@ public class KerberosLoginProviderITCase {
             when(userGroupInformation.hasKerberosCredentials()).thenReturn(true);
             ugi.when(UserGroupInformation::getCurrentUser).thenReturn(userGroupInformation);
 
-            kerberosLoginProvider.doLogin(false);
+            kerberosLoginProvider.doLogin(supportProxyUser);
             ugi.verify(() -> UserGroupInformation.loginUserFromSubject(null));
         }
     }


### PR DESCRIPTION
## What is the purpose of the change

There was a blocker fix which added some uncovered execution paths. In this PR I've added more coverage for stability.

## Brief change log

Increases `KerberosLoginProvider` test coverage.

## Verifying this change

Extended unit tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
  - If yes, how is the feature documented? not applicable
