### PR TITLE
[hotfix][doc] to_timestamp() should use order_time_string column instead of order_time

### DIFF
--- a/docs/content.zh/docs/dev/table/sql/create.md
+++ b/docs/content.zh/docs/dev/table/sql/create.md
@@ -482,7 +482,7 @@ CREATE TABLE Orders_in_file (
     `user` BIGINT,
     product STRING,
     order_time_string STRING,
-    order_time AS to_timestamp(order_time)
+    order_time AS to_timestamp(order_time_string)
     
 )
 PARTITIONED BY (`user`) 

--- a/docs/content/docs/dev/table/sql/create.md
+++ b/docs/content/docs/dev/table/sql/create.md
@@ -482,7 +482,7 @@ CREATE TABLE Orders_in_file (
     `user` BIGINT,
     product STRING,
     order_time_string STRING,
-    order_time AS to_timestamp(order_time)
+    order_time AS to_timestamp(order_time_string)
     
 )
 PARTITIONED BY (`user`) 


### PR DESCRIPTION
## What is the purpose of the change

Fix code example bug in the doc that will make user confused. 


## Brief change log

  - `order_time AS to_timestamp(order_time_string)` instead of `order_time AS to_timestamp(order_time)`
  - update both content/ and content.zh/

