### PR TITLE
[FLINK-26945][table] add DATE_SUB function.

### DIFF
--- a/docs/data/sql_functions.yml
+++ b/docs/data/sql_functions.yml
@@ -488,6 +488,9 @@ temporal:
   - sql: TIMESTAMPDIFF(timepointunit, timepoint1, timepoint2)
     table: timestampDiff(TIMEPOINTUNIT, TIMEPOINT1, TIMEPOINT2)
     description: 'Returns the (signed) number of timepointunit between timepoint1 and timepoint2. The unit for the interval is given by the first argument, which should be one of the following values: SECOND, MINUTE, HOUR, DAY, MONTH, or YEAR.'
+  - sql: DATE_SUB(date, interval)
+    table: dateSub(DATE, INTERVAL)
+    description: Subtracts interval from the date.
   - sql: CONVERT_TZ(string1, string2, string3)
     table: convertTz(STRING1, STRING2, STRING3)
     description: Converts a datetime string1 (with default ISO timestamp format 'yyyy-MM-dd HH:mm:ss') from time zone string2 to time zone string3. The format of time zone should be either an abbreviation such as "PST", a full name such as "America/Los_Angeles", or a custom ID such as "GMT-08:00". E.g., CONVERT_TZ('1970-01-01 00:00:00', 'UTC', 'America/Los_Angeles') returns '1969-12-31 16:00:00'.

--- a/flink-python/docs/reference/pyflink.table/expressions.rst
+++ b/flink-python/docs/reference/pyflink.table/expressions.rst
@@ -209,6 +209,7 @@ temporal functions
     Expression.extract
     Expression.floor
     Expression.ceil
+    Expression.dateSub
 
 
 advanced type helper functions

--- a/flink-python/pyflink/table/expression.py
+++ b/flink-python/pyflink/table/expression.py
@@ -1418,6 +1418,13 @@ class Expression(Generic[T]):
             return _binary_op("ceil")(
                 self, time_interval_unit._to_j_time_interval_unit())
 
+    def dateSub(self, interval) -> 'Expression':
+        """
+        Subtracts interval from the date.
+        e.g. `dateSub(lit("2019-01-01").to_date(), lit(1).days())` leads to 2018-12-31.
+        """
+        return _binary_op("dateSub")(self, interval)
+
     # ---------------------------- advanced type helper functions -----------------------------
 
     def get(self, name_or_index: Union[str, int]) -> 'Expression':

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/BaseExpressions.java
@@ -73,6 +73,7 @@ import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COS;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COSH;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COT;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.COUNT;
+import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DATE_SUB;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DECODE;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DEGREES;
 import static org.apache.flink.table.functions.BuiltInFunctionDefinitions.DISTINCT;
@@ -1284,6 +1285,16 @@ public abstract class BaseExpressions<InType, OutType> {
     public OutType ceil(TimeIntervalUnit timeIntervalUnit) {
         return toApiSpecificExpression(
                 unresolvedCall(CEIL, toExpr(), valueLiteral(timeIntervalUnit)));
+    }
+
+    /**
+     * Subtracts interval from the date.
+     *
+     * <p>e.g. dateSub(lit("2019-01-01").toDate(), lit(1).days()) leads to 2018-12-31.
+     */
+    public OutType dateSub(InType interval) {
+        return toApiSpecificExpression(
+                unresolvedCall(DATE_SUB, toExpr(), objectToExpression(interval)));
     }
 
     // Advanced type helper functions

--- a/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
+++ b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/functions/BuiltInFunctionDefinitions.java
@@ -1556,6 +1556,17 @@ public final class BuiltInFunctionDefinitions {
                     .outputTypeStrategy(nullableIfArgs(explicit(STRING())))
                     .build();
 
+    public static final BuiltInFunctionDefinition DATE_SUB =
+            BuiltInFunctionDefinition.newBuilder()
+                    .name("DATE_SUB")
+                    .kind(SCALAR)
+                    .inputTypeStrategy(
+                            sequence(
+                                    logical(LogicalTypeFamily.DATETIME),
+                                    logical(LogicalTypeFamily.INTERVAL)))
+                    .outputTypeStrategy(nullableIfArgs(argument(0)))
+                    .build();
+
     public static final BuiltInFunctionDefinition TIMESTAMP_DIFF =
             BuiltInFunctionDefinition.newBuilder()
                     .name("timestampDiff")

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/DirectConvertRule.java
@@ -290,6 +290,8 @@ public class DirectConvertRule implements CallExpressionConvertRule {
                 FlinkSqlOperatorTable.TO_TIMESTAMP_LTZ);
         definitionSqlOperatorHashMap.put(
                 BuiltInFunctionDefinitions.TO_TIMESTAMP, FlinkSqlOperatorTable.TO_TIMESTAMP);
+        definitionSqlOperatorHashMap.put(
+                BuiltInFunctionDefinitions.DATE_SUB, FlinkSqlOperatorTable.DATE_SUB);
 
         // catalog functions
         definitionSqlOperatorHashMap.put(

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/sql/FlinkSqlOperatorTable.java
@@ -816,6 +816,15 @@ public class FlinkSqlOperatorTable extends ReflectiveSqlOperatorTable {
                             OperandTypes.family(SqlTypeFamily.STRING, SqlTypeFamily.STRING)),
                     SqlFunctionCategory.TIMEDATE);
 
+    public static final SqlFunction DATE_SUB =
+            new SqlFunction(
+                    "DATE_SUB",
+                    SqlKind.OTHER_FUNCTION,
+                    ReturnTypes.ARG0_NULLABLE,
+                    null,
+                    OperandTypes.family(SqlTypeFamily.DATE, SqlTypeFamily.DATETIME_INTERVAL),
+                    SqlFunctionCategory.TIMEDATE);
+
     public static final SqlFunction CONVERT_TZ =
             new SqlFunction(
                     "CONVERT_TZ",

--- a/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
+++ b/flink-table/flink-table-planner/src/main/scala/org/apache/flink/table/planner/codegen/ExprCodeGenerator.scala
@@ -529,7 +529,7 @@ class ExprCodeGenerator(ctx: CodeGeneratorContext, nullableInput: Boolean)
         requireNumeric(right)
         generateBinaryArithmeticOperator(ctx, "-", resultType, left, right)
 
-      case MINUS | MINUS_DATE if isTemporal(resultType) =>
+      case MINUS | MINUS_DATE | DATE_SUB if isTemporal(resultType) =>
         val left = operands.head
         val right = operands(1)
         requireTemporal(left)


### PR DESCRIPTION
## What is the purpose of the change

*add DATE_SUB function*


## Brief change log
- *SELECT DATE_SUB('2018-05-01',INTERVAL '1' YEAR/MONTH/DAY);*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)
