### PR TITLE
[FLINK-31208][Connectors/Kafka] KafkaSourceReader overrides meaningle…

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaSourceReader.java
@@ -186,12 +186,6 @@ public class KafkaSourceReader<T>
         return splitState.toKafkaPartitionSplit();
     }
 
-    @Override
-    public void pauseOrResumeSplits(
-            Collection<String> splitsToPause, Collection<String> splitsToResume) {
-        splitFetcherManager.pauseOrResumeSplits(splitsToPause, splitsToResume);
-    }
-
     // ------------------------
 
     @VisibleForTesting


### PR DESCRIPTION
## What is the purpose of the change
As described in [FLINK-31208](https://issues.apache.org/jira/browse/FLINK-31208?filter=-2), an override method named pauseOrResumeSplits in KafkaSourceReader is redundant.


## Brief change log
Just remove this redundant method.

## Verifying this change
The method  content is same as its parent class SourceReaderBase,  thus there is no influence to verify.