### PR TITLE
[FLINK-31300][table] TRY_CAST for constructed types

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/AbstractCastRule.java
@@ -18,8 +18,6 @@
 
 package org.apache.flink.table.planner.functions.casting;
 
-import org.apache.flink.table.types.logical.LogicalType;
-
 /** Base class for all cast rules. */
 abstract class AbstractCastRule<IN, OUT> implements CastRule<IN, OUT> {
 
@@ -32,10 +30,5 @@ abstract class AbstractCastRule<IN, OUT> implements CastRule<IN, OUT> {
     @Override
     public CastRulePredicate getPredicateDefinition() {
         return predicate;
-    }
-
-    @Override
-    public boolean canFail(LogicalType inputLogicalType, LogicalType targetLogicalType) {
-        return false;
     }
 }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRule.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/functions/casting/CastRule.java
@@ -46,7 +46,9 @@ public interface CastRule<IN, OUT> {
             Context context, LogicalType inputLogicalType, LogicalType targetLogicalType);
 
     /** Returns true if the {@link CastExecutor} can fail at runtime. */
-    boolean canFail(LogicalType inputLogicalType, LogicalType targetLogicalType);
+    default boolean canFail(LogicalType inputLogicalType, LogicalType targetLogicalType) {
+        return false;
+    }
 
     /** Casting context. */
     interface Context {


### PR DESCRIPTION

## What is the purpose of the change

Currently the queries
```sql
select try_cast(array['a'] as array<int>);
select try_cast(map['a', '1'] as map<int, int>);
```
are failing with `NumberFormatException`. The PR makes them returning `null` as it should be in case of `try_cast`


## Brief change log
The main issue is that there is already implemented method `org.apache.flink.table.planner.functions.casting.ConstructedToConstructedCastRule` 
however in case of e.g. `org.apache.flink.table.planner.functions.casting.ArrayToArrayCastRule` it inherits from `AbstractCastRule` containing `canFail`. Since methods from classes have more priority than default from interfaces it will be called. The idea is to move `canFail`'s implementation from `AbstractCastRule` to parent's interface `CastRule`.


## Verifying this change

Specific tests for maps and arrays are added at 
_flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/CastFunctionMiscITCase.java_

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no )
  - The runtime per-record code paths (performance sensitive): ( no )
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
