### PR TITLE
[FLINK-31297][Runtime] Use processResourceRequirements to allocate sk manager in FineGrainedSlotManagerTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/resourcemanager/slotmanager/FineGrainedSlotManagerTestBase.java
@@ -44,7 +44,6 @@ import org.apache.flink.util.function.RunnableWithException;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
@@ -152,7 +151,6 @@ abstract class FineGrainedSlotManagerTestBase {
                 new ScheduledExecutorServiceAdapter(EXECUTOR_RESOURCE.getExecutor());
         private final Executor mainThreadExecutor = EXECUTOR_RESOURCE.getExecutor();
         private FineGrainedSlotManager slotManager;
-        private Duration requirementCheckDelay = Duration.ZERO;
 
         final TestingResourceAllocationStrategy.Builder resourceAllocationStrategyBuilder =
                 TestingResourceAllocationStrategy.newBuilder();
@@ -179,10 +177,6 @@ abstract class FineGrainedSlotManagerTestBase {
 
         ResourceManagerId getResourceManagerId() {
             return resourceManagerId;
-        }
-
-        public void setRequirementCheckDelay(Duration requirementCheckDelay) {
-            this.requirementCheckDelay = requirementCheckDelay;
         }
 
         public void setSlotManagerMetricGroup(SlotManagerMetricGroup slotManagerMetricGroup) {


### PR DESCRIPTION


## What is the purpose of the change

We use TaskManagerTracker.addPendingTaskManager to allocate task manager in FineGrainedSlotManagerTest. This make the resource requirements different between FineGrainedSlotManager and TaskManagerTracker. And the FineGrainedSlotManager may trigger resource recycling after the requirementCheckDelay.

So we use processResourceRequirements to allocate task manager. And set the requirementCheckDelay to 0 to stabilize this test.

## Brief change log

*(for example:)*
  - *use processResourceRequirements to allocate task manager*
  - *set the requirementCheckDelay to 0 to stabilize the test*


## Verifying this change
  - this test ran successfully 200 times


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
