### PR TITLE
[FLINK-31319][connectors/kafka] Kafka new source partitionDiscoveryIntervalMs=0 cause bounded source can not quit

### DIFF
--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/enumerator/KafkaSourceEnumerator.java
@@ -298,7 +298,7 @@ public class KafkaSourceEnumerator
         if (t != null) {
             throw new FlinkRuntimeException("Failed to initialize partition splits due to ", t);
         }
-        if (partitionDiscoveryIntervalMs < 0) {
+        if (partitionDiscoveryIntervalMs <= 0) {
             LOG.debug("Partition discovery is disabled.");
             noMoreNewPartitionSplits = true;
         }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/enumerator/KafkaEnumeratorTest.java
@@ -98,6 +98,10 @@ public class KafkaEnumeratorTest {
             assertThat(context.getOneTimeCallables())
                     .as("A one time partition discovery callable should have been scheduled")
                     .hasSize(1);
+
+            // enumerator just start noMoreNewPartitionSplits will be false
+            assertThat((Boolean) Whitebox.getInternalState(enumerator, "noMoreNewPartitionSplits"))
+                    .isFalse();
         }
     }
 
@@ -115,6 +119,10 @@ public class KafkaEnumeratorTest {
             assertThat(context.getPeriodicCallables())
                     .as("A periodic partition discovery callable should have been scheduled")
                     .hasSize(1);
+
+            // enumerator just start noMoreNewPartitionSplits will be false
+            assertThat((Boolean) Whitebox.getInternalState(enumerator, "noMoreNewPartitionSplits"))
+                    .isFalse();
         }
     }
 
@@ -163,6 +171,68 @@ public class KafkaEnumeratorTest {
             registerReader(context, enumerator, READER1);
             verifyLastReadersAssignments(
                     context, Collections.singleton(READER1), PRE_EXISTING_TOPICS, 2);
+        }
+    }
+
+    @Test
+    public void testRunWithDiscoverPartitionsOnceToCheckNoMoreSplit() throws Throwable {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, DISABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+            // Start the enumerator and it should schedule a one time task to discover and assign
+            // partitions.
+            enumerator.start();
+
+            // Run the partition discover callable and check the partition assignment.
+            runOneTimePartitionDiscovery(context);
+
+            // enumerator noMoreNewPartitionSplits first will be false, when execute
+            // handlePartitionSplitChanges will be set true
+            assertThat((Boolean) Whitebox.getInternalState(enumerator, "noMoreNewPartitionSplits"))
+                    .isTrue();
+        }
+    }
+
+    @Test
+    public void testRunWithPeriodicPartitionDiscoveryOnceToCheckNoMoreSplit() throws Throwable {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                KafkaSourceEnumerator enumerator =
+                        createEnumerator(context, ENABLE_PERIODIC_PARTITION_DISCOVERY)) {
+
+            // Start the enumerator and it should schedule a one time task to discover and assign
+            // partitions.
+            enumerator.start();
+            assertThat(context.getOneTimeCallables()).isEmpty();
+            assertThat(context.getPeriodicCallables())
+                    .as("A periodic partition discovery callable should have been scheduled")
+                    .hasSize(1);
+
+            // enumerator noMoreNewPartitionSplits first will be false, even when execute
+            // handlePartitionSplitChanges it still be false
+            assertThat((Boolean) Whitebox.getInternalState(enumerator, "noMoreNewPartitionSplits"))
+                    .isFalse();
+        }
+    }
+
+    @Test
+    public void testRunWithDiscoverPartitionsOnceWithZeroMsToCheckNoMoreSplit() throws Throwable {
+        try (MockSplitEnumeratorContext<KafkaPartitionSplit> context =
+                        new MockSplitEnumeratorContext<>(NUM_SUBTASKS);
+                // set partitionDiscoveryIntervalMs = 0
+                KafkaSourceEnumerator enumerator = createEnumerator(context, 0L)) {
+
+            // Start the enumerator, and it should schedule a one time task to discover and assign
+            // partitions.
+            enumerator.start();
+            runOneTimePartitionDiscovery(context);
+
+            // enumerator noMoreNewPartitionSplits first will be false, when execute
+            // handlePartitionSplitChanges will be set true
+            assertThat((Boolean) Whitebox.getInternalState(enumerator, "noMoreNewPartitionSplits"))
+                    .isTrue();
         }
     }
 
@@ -261,7 +331,7 @@ public class KafkaEnumeratorTest {
                 KafkaSourceEnumerator enumerator =
                         createEnumerator(
                                 context2,
-                                ENABLE_PERIODIC_PARTITION_DISCOVERY,
+                                ENABLE_PERIODIC_PARTITION_DISCOVERY ? 1 : -1,
                                 PRE_EXISTING_TOPICS,
                                 preexistingAssignments,
                                 new Properties())) {
@@ -290,7 +360,7 @@ public class KafkaEnumeratorTest {
                 KafkaSourceEnumerator enumerator =
                         createEnumerator(
                                 context,
-                                ENABLE_PERIODIC_PARTITION_DISCOVERY,
+                                ENABLE_PERIODIC_PARTITION_DISCOVERY ? 1 : -1,
                                 PRE_EXISTING_TOPICS,
                                 Collections.emptySet(),
                                 properties)) {
@@ -405,6 +475,12 @@ public class KafkaEnumeratorTest {
 
     private KafkaSourceEnumerator createEnumerator(
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
+            long partitionDiscoveryIntervalMs) {
+        return createEnumerator(enumContext, partitionDiscoveryIntervalMs, EXCLUDE_DYNAMIC_TOPIC);
+    }
+
+    private KafkaSourceEnumerator createEnumerator(
+            MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
             boolean enablePeriodicPartitionDiscovery,
             boolean includeDynamicTopic) {
         List<String> topics = new ArrayList<>(PRE_EXISTING_TOPICS);
@@ -413,7 +489,23 @@ public class KafkaEnumeratorTest {
         }
         return createEnumerator(
                 enumContext,
-                enablePeriodicPartitionDiscovery,
+                enablePeriodicPartitionDiscovery ? 1 : -1,
+                topics,
+                Collections.emptySet(),
+                new Properties());
+    }
+
+    private KafkaSourceEnumerator createEnumerator(
+            MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
+            long partitionDiscoveryIntervalMs,
+            boolean includeDynamicTopic) {
+        List<String> topics = new ArrayList<>(PRE_EXISTING_TOPICS);
+        if (includeDynamicTopic) {
+            topics.add(DYNAMIC_TOPIC_NAME);
+        }
+        return createEnumerator(
+                enumContext,
+                partitionDiscoveryIntervalMs,
                 topics,
                 Collections.emptySet(),
                 new Properties());
@@ -425,7 +517,7 @@ public class KafkaEnumeratorTest {
      */
     private KafkaSourceEnumerator createEnumerator(
             MockSplitEnumeratorContext<KafkaPartitionSplit> enumContext,
-            boolean enablePeriodicPartitionDiscovery,
+            long partitionDiscoveryIntervalMs,
             Collection<String> topicsToSubscribe,
             Set<TopicPartition> assignedPartitions,
             Properties overrideProperties) {
@@ -442,10 +534,9 @@ public class KafkaEnumeratorTest {
         Properties props =
                 new Properties(KafkaSourceTestEnv.getConsumerProperties(StringDeserializer.class));
         KafkaSourceEnumerator.deepCopyProperties(overrideProperties, props);
-        String partitionDiscoverInterval = enablePeriodicPartitionDiscovery ? "1" : "-1";
         props.setProperty(
                 KafkaSourceOptions.PARTITION_DISCOVERY_INTERVAL_MS.key(),
-                partitionDiscoverInterval);
+                String.valueOf(partitionDiscoveryIntervalMs));
 
         return new KafkaSourceEnumerator(
                 subscriber,


### PR DESCRIPTION
## What is the purpose of the change

Fix error kafka partitionDiscoveryIntervalMs checking for noMoreNewSplits.

## Brief change log

Correct partitionDiscoveryIntervalMs checking for noMoreNewSplits with <=0

## Verifying this change

Add KafkaEnumeratorTest
#testRunWithDiscoverPartitionsOnceWithZeroMsToCheckNoMoreSplit,
#testRunWithDiscoverPartitionsToCheckNoMoreSplitOnce
#testRunWithPeriodicPartitionDiscoveryToCheckNoMoreSplitOnce
new cases and refine existed cases.

## Does this pull request potentially affect one of the following parts:

- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
- The S3 file system connector: no

## Documentation

- Does this pull request introduce a new feature?  no
- If yes, how is the feature documented? docs