### PR TITLE
[FLINK-31144][coordination] Modify the judgment logic of whether to ignore the input locations of a ConsumePartitionGroup if the corresponding ConsumerVertexGroup is too large.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetriever.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetriever.java
@@ -92,11 +92,9 @@ public class DefaultPreferredLocationsRetriever implements PreferredLocationsRet
                 inputsLocationsRetriever.getConsumedPartitionGroups(executionVertexId);
         for (ConsumedPartitionGroup consumedPartitionGroup : consumedPartitionGroups) {
             // Ignore the location of a consumed partition group if it has too many distinct
-            // consumers compared to the consumed partition group size. This is to avoid tasks
-            // unevenly distributed on nodes when running batch jobs or running jobs in
-            // session/standalone mode.
-            if ((double) consumedPartitionGroup.getConsumerVertexGroup().size()
-                            / consumedPartitionGroup.size()
+            // consumers. This is to avoid tasks unevenly distributed on nodes when running batch
+            // jobs or running jobs in session/standalone mode.
+            if (consumedPartitionGroup.getConsumerVertexGroup().size()
                     > MAX_DISTINCT_CONSUMERS_TO_CONSIDER) {
                 continue;
             }

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetrieverTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/scheduler/DefaultPreferredLocationsRetrieverTest.java
@@ -71,26 +71,14 @@ class DefaultPreferredLocationsRetrieverTest {
 
     @Test
     void testInputLocations() {
-        {
-            final List<TaskManagerLocation> producerLocations =
-                    Collections.singletonList(new LocalTaskManagerLocation());
-            testInputLocationsInternal(
-                    1,
-                    MAX_DISTINCT_CONSUMERS_TO_CONSIDER,
-                    producerLocations,
-                    producerLocations,
-                    Collections.emptySet());
-        }
-        {
-            final List<TaskManagerLocation> producerLocations =
-                    Arrays.asList(new LocalTaskManagerLocation(), new LocalTaskManagerLocation());
-            testInputLocationsInternal(
-                    2,
-                    MAX_DISTINCT_CONSUMERS_TO_CONSIDER * 2,
-                    producerLocations,
-                    producerLocations,
-                    Collections.emptySet());
-        }
+        final List<TaskManagerLocation> producerLocations =
+                Collections.singletonList(new LocalTaskManagerLocation());
+        testInputLocationsInternal(
+                1,
+                MAX_DISTINCT_CONSUMERS_TO_CONSIDER,
+                producerLocations,
+                producerLocations,
+                Collections.emptySet());
     }
 
     @Test
@@ -101,7 +89,7 @@ class DefaultPreferredLocationsRetrieverTest {
     @Test
     void testInputLocationsIgnoresEdgeOfTooManyConsumers() {
         testNoPreferredInputLocationsInternal(1, MAX_DISTINCT_CONSUMERS_TO_CONSIDER + 1);
-        testNoPreferredInputLocationsInternal(2, MAX_DISTINCT_CONSUMERS_TO_CONSIDER * 2 + 1);
+        testNoPreferredInputLocationsInternal(2, MAX_DISTINCT_CONSUMERS_TO_CONSIDER + 1);
     }
 
     @Test


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

Currently, the judgment logic of whether to ignore the input locations of a ConsumePartitionGroup if the corresponding ConsumerVertexGroup is too large is to divide the size of the ConsumerVertexGroup by the size of the ConsumedPartitionGroup. But this will lead to a N^2 complexity to compute the input locations when there are N upstream task and N downstream tasks.
This pr wants to modify the judgment logic to consumeVertexGroup.size() > MAX_DISTINCT_CONSUMERS_TO_CONSIDER.


## Verifying this change

This change can be verified by DefaultPreferredLocationsRetrieverTest.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
