### PR TITLE
[FLINK-28825] Add K8S pod scheduler into Kubernetes options [FLINK-28829] Support prepreparing K8S resources before JM creation [FLINK-28831][k8s]Support pluginable decorators mechanism - part 1st

### DIFF
--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -165,6 +165,12 @@
             <td>Specify how many JobManager pods will be started simultaneously. Configure the value to greater than 1 to start standby JobManagers. It will help to achieve faster recovery. Notice that high availability should be enabled when starting standby JobManagers.</td>
         </tr>
         <tr>
+            <td><h5>kubernetes.jobmanager.scheduler-name</h5></td>
+            <td style="word-wrap: break-word;">"default-scheduler"</td>
+            <td>String</td>
+            <td>Specify the kubernetes pod scheduler for jobmanager pods of deployment. The default value is using the kubernetes default pod scheduler. For customerized kubernetes pod scheduler, allow to set pod scheduler for customerized pod scheduling. If not explicitly configured, config option 'kubernetes.scheduler-name' will be used.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.jobmanager.service-account</h5></td>
             <td style="word-wrap: break-word;">"default"</td>
             <td>String</td>
@@ -219,6 +225,12 @@
             <td>The exposed type of the rest service. The exposed rest service could be used to access the Flink’s Web UI and REST endpoint.<br /><br />Possible values:<ul><li>"ClusterIP"</li><li>"NodePort"</li><li>"LoadBalancer"</li><li>"Headless_ClusterIP"</li></ul></td>
         </tr>
         <tr>
+            <td><h5>kubernetes.scheduler-name</h5></td>
+            <td style="word-wrap: break-word;">"default-scheduler"</td>
+            <td>String</td>
+            <td>Specify the kubernetes pod scheduler for Flink pods of deployment. The default value is using the kubernetes default pod scheduler. For customerized kubernetes pod scheduler, allow to set pod scheduler for customerized pod scheduling. Notice that this can be overwritten by config options 'kubernetes.jobmanager.scheduler-name' and 'kubernetes.taskmanager.scheduler-name' for jobmanager and taskmanager respectively.</td>
+        </tr>
+        <tr>
             <td><h5>kubernetes.secrets</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
@@ -271,6 +283,12 @@
             <td style="word-wrap: break-word;">(none)</td>
             <td>Map</td>
             <td>The node selector to be set for TaskManager pods. Specified as key:value pairs separated by commas. For example, environment:production,disk:ssd.</td>
+        </tr>
+        <tr>
+            <td><h5>kubernetes.taskmanager.scheduler-name</h5></td>
+            <td style="word-wrap: break-word;">"default-scheduler"</td>
+            <td>String</td>
+            <td>Specify the kubernetes pod scheduler for taskmanager pods of deployment. The default value is using the kubernetes default pod scheduler. For customerized kubernetes pod scheduler, allow to set pod scheduler for customerized pod scheduling. If not explicitly configured, config option 'kubernetes.scheduler-name' will be used.</td>
         </tr>
         <tr>
             <td><h5>kubernetes.taskmanager.service-account</h5></td>

--- a/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
+++ b/docs/layouts/shortcodes/generated/kubernetes_config_configuration.html
@@ -308,5 +308,11 @@
             <td>Integer</td>
             <td>Defines the number of Kubernetes transactional operation retries before the client gives up. For example, <code class="highlighter-rouge">FlinkKubeClient#checkAndUpdateConfigMap</code>.</td>
         </tr>
+        <tr>
+            <td><h5>kubernetes.podgroup.config</h5></td>
+            <td style="word-wrap: break-word;">5</td>
+            <td>Map</td>
+            <td>contains the config of pod group when use batchScheduler like Volcano.  For example, priorityClassName:mid-priority,minMember:1,queue:default<code class="highlighter-rouge">FlinkKubeClient#checkAndUpdateConfigMap</code>.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-kubernetes/pom.xml
+++ b/flink-kubernetes/pom.xml
@@ -64,6 +64,15 @@ under the License.
 			<version>${kubernetes.client.version}</version>
 		</dependency>
 
+		<!-- Due to volcano-model depends on kubernetes-model-core, and operate the
+		     said kubernetes resources also need volcano-model, so we make volcano-model
+		     in flink-kubernetes. -->
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>volcano-model-v1beta1</artifactId>
+			<version>${kubernetes.client.version}</version>
+		</dependency>
+
 		<!-- test dependencies -->
 		<dependency>
 			<groupId>io.fabric8</groupId>
@@ -96,6 +105,39 @@ under the License.
 				<artifactId>maven-shade-plugin</artifactId>
 				<executions>
 					<execution>
+						<id>shade-k8s-volcano</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<includes combine.children="append">
+										<include>**/*VolcanoStepDecorator*</include>
+										<include>META-INF/services/*PluginFactory*</include>
+									</includes>
+								</filter>
+							</filters>
+							<relocations>
+								<relocation>
+									<pattern>io.fabric8</pattern>
+									<shadedPattern>org.apache.flink.kubernetes.shaded.io.fabric8</shadedPattern>
+								</relocation>
+							</relocations>
+							<outputFile>
+								flink-kubernetes-volcano.jar
+							</outputFile>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
 						<id>shade-flink</id>
 						<phase>package</phase>
 						<goals>
@@ -107,6 +149,7 @@ under the License.
 									<include>io.fabric8:kubernetes-client</include>
 									<include>io.fabric8:kubernetes-model-*</include>
 									<include>io.fabric8:zjsonpatch</include>
+									<include>io.fabric8:volcano-model-*</include>
 
 									<!-- Shade all the dependencies of kubernetes client  -->
 									<include>com.fasterxml.jackson.core:jackson-core</include>
@@ -172,6 +215,26 @@ under the License.
 								    <shadedPattern>org.apache.flink.kubernetes.shaded.io.fabric8</shadedPattern>
 								</relocation>
 							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>create-ext-decorator-jar</id>
+						<phase>process-test-classes</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<finalName>ext-decorator</finalName>
+							<attach>false</attach>
+							<descriptors>
+								<descriptor>src/test/assembly/test-ext-decorator-assembly.xml</descriptor>
+							</descriptors>
 						</configuration>
 					</execution>
 				</executions>

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -33,6 +33,7 @@ import org.apache.flink.kubernetes.kubeclient.services.ServiceType;
 import org.apache.flink.kubernetes.utils.Constants;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -50,6 +51,8 @@ public class KubernetesConfigOptions {
     private static final String KUBERNETES_SERVICE_ACCOUNT_KEY = "kubernetes.service-account";
     private static final String KUBERNETES_POD_TEMPLATE_FILE_KEY = "kubernetes.pod-template-file";
     private static final String KUBERNETES_POD_SCHEDULER_NAME_KEY = "kubernetes.scheduler-name";
+
+    private static final String KUBERNETES_PODGROUP_CONFIG = "kubernetes.podgroup.config";
 
     public static final ConfigOption<String> CONTEXT =
             key("kubernetes.context")
@@ -484,6 +487,19 @@ public class KubernetesConfigOptions {
                                     + "' and '"
                                     + TASK_MANAGER_POD_SCHEDULER_NAME.key()
                                     + "' for jobmanager and taskmanager respectively.");
+
+    public static final ConfigOption<Map<String, String>> POD_GROUP_CONFOG =
+            key(KUBERNETES_PODGROUP_CONFIG)
+                    .mapType()
+                    .defaultValue(
+                            new HashMap<String, String>() {
+                                {
+                                    put("priorityClassName", "mid-priority");
+                                    put("minMember", "1");
+                                    put("queue", "default");
+                                }
+                            })
+                    .withDescription("the pod group config of volcano");
 
     /**
      * This option is here only for documentation generation, it is the fallback key of

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/configuration/KubernetesConfigOptions.java
@@ -49,6 +49,7 @@ public class KubernetesConfigOptions {
 
     private static final String KUBERNETES_SERVICE_ACCOUNT_KEY = "kubernetes.service-account";
     private static final String KUBERNETES_POD_TEMPLATE_FILE_KEY = "kubernetes.pod-template-file";
+    private static final String KUBERNETES_POD_SCHEDULER_NAME_KEY = "kubernetes.scheduler-name";
 
     public static final ConfigOption<String> CONTEXT =
             key("kubernetes.context")
@@ -443,6 +444,46 @@ public class KubernetesConfigOptions {
     public static final ConfigOption<String> JOB_MANAGER_POD_TEMPLATE;
 
     public static final ConfigOption<String> TASK_MANAGER_POD_TEMPLATE;
+
+    public static final ConfigOption<String> JOB_MANAGER_POD_SCHEDULER_NAME =
+            key("kubernetes.jobmanager.scheduler-name")
+                    .stringType()
+                    .defaultValue("default-scheduler")
+                    .withFallbackKeys(KUBERNETES_POD_SCHEDULER_NAME_KEY)
+                    .withDescription(
+                            "Specify the kubernetes pod scheduler for jobmanager pods of deployment. "
+                                    + "The default value is using the kubernetes default pod scheduler. "
+                                    + "For customerized kubernetes pod scheduler, allow to set pod scheduler "
+                                    + "for customerized pod scheduling. If not explicitly configured, config option '"
+                                    + KUBERNETES_POD_SCHEDULER_NAME_KEY
+                                    + "' will be used.");
+
+    public static final ConfigOption<String> TASK_MANAGER_POD_SCHEDULER_NAME =
+            key("kubernetes.taskmanager.scheduler-name")
+                    .stringType()
+                    .defaultValue("default-scheduler")
+                    .withFallbackKeys(KUBERNETES_POD_SCHEDULER_NAME_KEY)
+                    .withDescription(
+                            "Specify the kubernetes pod scheduler for taskmanager pods of deployment. "
+                                    + "The default value is using the kubernetes default pod scheduler. "
+                                    + "For customerized kubernetes pod scheduler, allow to set pod scheduler "
+                                    + "for customerized pod scheduling. If not explicitly configured, config option '"
+                                    + KUBERNETES_POD_SCHEDULER_NAME_KEY
+                                    + "' will be used.");
+
+    public static final ConfigOption<String> POD_SCHEDULER_NAME =
+            key(KUBERNETES_POD_SCHEDULER_NAME_KEY)
+                    .stringType()
+                    .defaultValue("default-scheduler")
+                    .withDescription(
+                            "Specify the kubernetes pod scheduler for Flink pods of deployment. "
+                                    + "The default value is using the kubernetes default pod scheduler. "
+                                    + "For customerized kubernetes pod scheduler, allow to set pod scheduler "
+                                    + "for customerized pod scheduling. Notice that this can be overwritten by config options '"
+                                    + JOB_MANAGER_POD_SCHEDULER_NAME.key()
+                                    + "' and '"
+                                    + TASK_MANAGER_POD_SCHEDULER_NAME.key()
+                                    + "' for jobmanager and taskmanager respectively.");
 
     /**
      * This option is here only for documentation generation, it is the fallback key of

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClient.java
@@ -112,6 +112,10 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
     public void createJobManagerComponent(KubernetesJobManagerSpecification kubernetesJMSpec) {
         final Deployment deployment = kubernetesJMSpec.getDeployment();
         final List<HasMetadata> accompanyingResources = kubernetesJMSpec.getAccompanyingResources();
+        final List<HasMetadata> prePreparedResources = kubernetesJMSpec.getPrePreparedResources();
+
+        // before create Deployment
+        this.internalClient.resourceList(prePreparedResources).createOrReplace();
 
         // create Deployment
         LOG.debug(
@@ -121,6 +125,8 @@ public class Fabric8FlinkKubeClient implements FlinkKubeClient {
         final Deployment createdDeployment =
                 this.internalClient.apps().deployments().create(deployment);
 
+        // Add all prepared AccompanyingResources to refresh owner reference
+        accompanyingResources.addAll(prePreparedResources);
         // Note that we should use the uid of the created Deployment for the OwnerReference.
         setOwnerReference(createdDeployment, accompanyingResources);
 

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerSpecification.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/KubernetesJobManagerSpecification.java
@@ -30,10 +30,15 @@ public class KubernetesJobManagerSpecification {
 
     private List<HasMetadata> accompanyingResources;
 
+    private List<HasMetadata> prePreparedResources;
+
     public KubernetesJobManagerSpecification(
-            Deployment deployment, List<HasMetadata> accompanyingResources) {
+            Deployment deployment,
+            List<HasMetadata> accompanyingResources,
+            List<HasMetadata> prePreparedResources) {
         this.deployment = deployment;
         this.accompanyingResources = accompanyingResources;
+        this.prePreparedResources = prePreparedResources;
     }
 
     public Deployment getDeployment() {
@@ -42,5 +47,9 @@ public class KubernetesJobManagerSpecification {
 
     public List<HasMetadata> getAccompanyingResources() {
         return accompanyingResources;
+    }
+
+    public List<HasMetadata> getPrePreparedResources() {
+        return prePreparedResources;
     }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/AbstractKubernetesStepDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/AbstractKubernetesStepDecorator.java
@@ -87,4 +87,9 @@ public abstract class AbstractKubernetesStepDecorator implements KubernetesStepD
     public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
         return Collections.emptyList();
     }
+
+    @Override
+    public List<HasMetadata> buildPrePreparedResources() {
+        return Collections.emptyList();
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtils.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.core.plugin.PluginManager;
+import org.apache.flink.core.plugin.PluginUtils;
+import org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+
+import org.apache.flink.shaded.guava30.com.google.common.collect.Iterators;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+/** The flink-kubernetes decorator plugins loading class. */
+public class ExtStepDecoratorUtils {
+    private static final Logger LOG = LoggerFactory.getLogger(ExtStepDecoratorUtils.class);
+
+    public static List<ExtPluginDecorator> loadExtStepDecorators(
+            AbstractKubernetesParameters kubernetesComponentConf) {
+        List<ExtPluginDecorator> extendedStepDecorators = new ArrayList<>();
+        Map<String, ExtPluginDecorator> decoratorFactories = new HashMap<>();
+        PluginManager pluginManager =
+                PluginUtils.createPluginManagerFromRootFolder(
+                        kubernetesComponentConf.getFlinkConfiguration());
+
+        // get all factories
+        Iterator<ExtPluginDecorator> factoryIteratorSPI =
+                ServiceLoader.load(ExtPluginDecorator.class).iterator();
+        Iterator<ExtPluginDecorator> factoryIteratorPlugins =
+                pluginManager != null
+                        ? pluginManager.load(ExtPluginDecorator.class)
+                        : Collections.emptyIterator();
+        Iterator<ExtPluginDecorator> factoryIterator =
+                Iterators.concat(factoryIteratorPlugins, factoryIteratorSPI);
+        while (factoryIterator.hasNext()) {
+            try {
+                ExtPluginDecorator factory = factoryIterator.next();
+                factory.configure(kubernetesComponentConf);
+                String factoryClassName = factory.getClass().getName();
+                ExtPluginDecorator existingFactory = decoratorFactories.get(factoryClassName);
+                if (existingFactory == null) {
+                    decoratorFactories.put(factoryClassName, factory);
+                    Collections.addAll(extendedStepDecorators, factory);
+                    LOG.info("Load ext plugin step decorator: {}.", factoryClassName);
+                }
+            } catch (Exception e) {
+                LOG.error("Loading ext plugin step decorator Failed: {}", e.getStackTrace());
+                return Collections.emptyList();
+            }
+        }
+        return extendedStepDecorators;
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecorator.java
@@ -104,6 +104,7 @@ public class InitJobManagerDecorator extends AbstractKubernetesStepDecorator {
                         kubernetesJobManagerParameters.getTolerations().stream()
                                 .map(e -> KubernetesToleration.fromMap(e).getInternalResource())
                                 .collect(Collectors.toList()))
+                .withSchedulerName(kubernetesJobManagerParameters.getPodSchedulerName())
                 .endSpec();
 
         final Container basicMainContainer = decorateMainContainer(flinkPod.getMainContainer());

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecorator.java
@@ -96,6 +96,7 @@ public class InitTaskManagerDecorator extends AbstractKubernetesStepDecorator {
                 .withRestartPolicy(Constants.RESTART_POLICY_OF_NEVER)
                 .withHostNetwork(kubernetesTaskManagerParameters.isHostNetworkEnabled())
                 .withDnsPolicy(dnsPolicy)
+                .withSchedulerName(kubernetesTaskManagerParameters.getPodSchedulerName())
                 .endSpec();
 
         // Merge fields

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KubernetesStepDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/KubernetesStepDecorator.java
@@ -43,4 +43,7 @@ public interface KubernetesStepDecorator {
      * feature. This could only be applicable on the client-side submission process.
      */
     List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException;
+
+    /** Build the Kubernetes resources before Flink Job Manager deployment creation. */
+    List<HasMetadata> buildPrePreparedResources();
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtPluginDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtPluginDecorator.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators.extended;
+
+import org.apache.flink.kubernetes.kubeclient.decorators.KubernetesStepDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+
+/** The interface class which should be implemented by plugin decorators. */
+public interface ExtPluginDecorator extends KubernetesStepDecorator {
+    void configure(AbstractKubernetesParameters kubernetesComponentConf);
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/volcano/VolcanoStepDecorator.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/volcano/VolcanoStepDecorator.java
@@ -1,0 +1,95 @@
+package org.apache.flink.kubernetes.kubeclient.decorators.extended.volcano;
+
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesTaskManagerParameters;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.volcano.scheduling.v1beta1.PodGroupBuilder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+/** The interface class which should be implemented by plugin decorators. */
+public class VolcanoStepDecorator implements ExtPluginDecorator {
+    private AbstractKubernetesParameters kubernetesComponentConf = null;
+    private Boolean isTaskManager = Boolean.FALSE;
+    private static final String DEFAULT_SCHEDULER_NAME = "default-scheduler";
+    private static final String VOLCANO_SCHEDULER_NAME = "volcano";
+    private static final String priorityClassName = "priorityClassName";
+    private static final String minMember = "minMember";
+    private static final String queue = "queue";
+
+    public VolcanoStepDecorator() {}
+
+    @Override
+    public void configure(AbstractKubernetesParameters kubernetesComponentConf) {
+        this.kubernetesComponentConf = checkNotNull(kubernetesComponentConf);
+        if (this.kubernetesComponentConf instanceof KubernetesTaskManagerParameters) {
+            this.isTaskManager = Boolean.TRUE;
+        }
+    }
+
+    @Override
+    public FlinkPod decorateFlinkPod(FlinkPod flinkPod) {
+        String configuredSchedulerName = kubernetesComponentConf.getPodSchedulerName();
+        if (configuredSchedulerName == null
+                || configuredSchedulerName.equals(DEFAULT_SCHEDULER_NAME)) {
+            return flinkPod;
+        }
+        final PodBuilder basicPodBuilder = new PodBuilder(flinkPod.getPodWithoutMainContainer());
+        String fakename = this.kubernetesComponentConf.getClusterId();
+        basicPodBuilder
+                .editOrNewMetadata()
+                .withAnnotations(
+                        Collections.singletonMap("scheduling.k8s.io/group-name", "pg-" + fakename))
+                .endMetadata();
+        return new FlinkPod.Builder(flinkPod).withPod(basicPodBuilder.build()).build();
+    }
+
+    @Override
+    public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<HasMetadata> buildPrePreparedResources() {
+        String configuredSchedulerName = kubernetesComponentConf.getPodSchedulerName();
+        if (!this.isTaskManager && configuredSchedulerName.equals(VOLCANO_SCHEDULER_NAME)) {
+            String fakename = this.kubernetesComponentConf.getClusterId();
+            PodGroupBuilder podGroupBuilder = new PodGroupBuilder();
+            podGroupBuilder.editOrNewMetadata().withName("pg-" + fakename).endMetadata();
+            Map<String, String> podGroupConfig = kubernetesComponentConf.getPodGroupConfig();
+            for (Map.Entry<String, String> stringStringEntry : podGroupConfig.entrySet()) {
+                switch (stringStringEntry.getKey()) {
+                    case priorityClassName:
+                        podGroupBuilder
+                                .editOrNewSpec()
+                                .withPriorityClassName(stringStringEntry.getValue())
+                                .endSpec();
+                        break;
+                    case minMember:
+                        podGroupBuilder
+                                .editOrNewSpec()
+                                .withMinMember(Integer.parseInt(stringStringEntry.getValue()))
+                                .endSpec();
+                        break;
+                    case queue:
+                        podGroupBuilder
+                                .editOrNewSpec()
+                                .withQueue(stringStringEntry.getValue())
+                                .endSpec();
+                        break;
+                }
+            }
+            return Collections.singletonList(podGroupBuilder.build());
+        }
+        return Collections.emptyList();
+    }
+}

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactory.java
@@ -65,6 +65,7 @@ public class KubernetesJobManagerFactory {
             throws IOException {
         FlinkPod flinkPod = Preconditions.checkNotNull(podTemplate).copy();
         List<HasMetadata> accompanyingResources = new ArrayList<>();
+        List<HasMetadata> prePreparedResources = new ArrayList<>();
 
         final List<KubernetesStepDecorator> stepDecorators =
                 new ArrayList<>(
@@ -90,6 +91,7 @@ public class KubernetesJobManagerFactory {
                         new PodTemplateMountDecorator(kubernetesJobManagerParameters)));
 
         for (KubernetesStepDecorator stepDecorator : stepDecorators) {
+            prePreparedResources.addAll(stepDecorator.buildPrePreparedResources());
             flinkPod = stepDecorator.decorateFlinkPod(flinkPod);
             accompanyingResources.addAll(stepDecorator.buildAccompanyingKubernetesResources());
         }
@@ -97,7 +99,8 @@ public class KubernetesJobManagerFactory {
         final Deployment deployment =
                 createJobManagerDeployment(flinkPod, kubernetesJobManagerParameters);
 
-        return new KubernetesJobManagerSpecification(deployment, accompanyingResources);
+        return new KubernetesJobManagerSpecification(
+                deployment, accompanyingResources, prePreparedResources);
     }
 
     private static Deployment createJobManagerDeployment(

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesTaskManagerFactory.java
@@ -22,6 +22,7 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.kubernetes.kubeclient.FlinkPod;
 import org.apache.flink.kubernetes.kubeclient.decorators.CmdTaskManagerDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.EnvSecretsDecorator;
+import org.apache.flink.kubernetes.kubeclient.decorators.ExtStepDecoratorUtils;
 import org.apache.flink.kubernetes.kubeclient.decorators.FlinkConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.HadoopConfMountDecorator;
 import org.apache.flink.kubernetes.kubeclient.decorators.InitTaskManagerDecorator;
@@ -66,6 +67,10 @@ public class KubernetesTaskManagerFactory {
         }
 
         stepDecorators.add(new FlinkConfMountDecorator(kubernetesTaskManagerParameters));
+
+        // load extend step decorators via SPI
+        stepDecorators.addAll(
+                ExtStepDecoratorUtils.loadExtStepDecorators(kubernetesTaskManagerParameters));
 
         for (KubernetesStepDecorator stepDecorator : stepDecorators) {
             flinkPod = stepDecorator.decorateFlinkPod(flinkPod);

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -206,4 +206,9 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     public boolean isHostNetworkEnabled() {
         return flinkConfig.getBoolean(KubernetesConfigOptions.KUBERNETES_HOSTNETWORK_ENABLED);
     }
+
+    @Override
+    public String getPodSchedulerName() {
+        return flinkConfig.get(KubernetesConfigOptions.POD_SCHEDULER_NAME);
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/AbstractKubernetesParameters.java
@@ -211,4 +211,9 @@ public abstract class AbstractKubernetesParameters implements KubernetesParamete
     public String getPodSchedulerName() {
         return flinkConfig.get(KubernetesConfigOptions.POD_SCHEDULER_NAME);
     }
+
+    @Override
+    public Map<String, String> getPodGroupConfig() {
+        return flinkConfig.get(KubernetesConfigOptions.POD_GROUP_CONFOG);
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParameters.java
@@ -204,4 +204,9 @@ public class KubernetesJobManagerParameters extends AbstractKubernetesParameters
     public String getEntrypointArgs() {
         return flinkConfig.getString(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_ENTRYPOINT_ARGS);
     }
+
+    @Override
+    public String getPodSchedulerName() {
+        return flinkConfig.get(KubernetesConfigOptions.JOB_MANAGER_POD_SCHEDULER_NAME);
+    }
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -113,4 +113,7 @@ public interface KubernetesParameters {
 
     /** The custom kubernetes pod scheduler name. */
     String getPodSchedulerName();
+
+    /** Get podGroupConfig of volcano. */
+    Map<String, String> getPodGroupConfig();
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesParameters.java
@@ -110,4 +110,7 @@ public interface KubernetesParameters {
      * container(s).
      */
     List<Map<String, String>> getEnvironmentsFromSecrets();
+
+    /** The custom kubernetes pod scheduler name. */
+    String getPodSchedulerName();
 }

--- a/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
+++ b/flink-kubernetes/src/main/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParameters.java
@@ -196,4 +196,9 @@ public class KubernetesTaskManagerParameters extends AbstractKubernetesParameter
         return flinkConfig.getString(
                 KubernetesConfigOptions.KUBERNETES_TASKMANAGER_ENTRYPOINT_ARGS);
     }
+
+    @Override
+    public String getPodSchedulerName() {
+        return flinkConfig.get(KubernetesConfigOptions.TASK_MANAGER_POD_SCHEDULER_NAME);
+    }
 }

--- a/flink-kubernetes/src/main/resources/META-INF/services/org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator
+++ b/flink-kubernetes/src/main/resources/META-INF/services/org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.kubeclient.decorators.extended.volcano.VolcanoStepDecorator

--- a/flink-kubernetes/src/test/assembly/test-ext-decorator-assembly.xml
+++ b/flink-kubernetes/src/test/assembly/test-ext-decorator-assembly.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<assembly>
+	<id>test-jar</id>
+	<formats>
+		<format>jar</format>
+	</formats>
+	<includeBaseDirectory>false</includeBaseDirectory>
+	<fileSets>
+		<fileSet>
+			<directory>${project.build.testOutputDirectory}</directory>
+			<outputDirectory>/</outputDirectory>
+			<!-- the service impl -->
+			<includes>
+				<include>org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtTestDecorator.class</include>
+			</includes>
+		</fileSet>
+		<fileSet>
+			<!-- declaring the service impl -->
+			<directory>${project.basedir}/src/test/resources/META-INF/services/*ExtPluginDecorator*</directory>
+			<outputDirectory>/META-INF/services</outputDirectory>
+		</fileSet>
+	</fileSets>
+</assembly>

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/Fabric8FlinkKubeClientTest.java
@@ -630,4 +630,37 @@ public class Fabric8FlinkKubeClientTest extends KubernetesClientTestBase {
                         .withData(data)
                         .build());
     }
+
+    @Test
+    void testMockPrePreparedResources() throws Exception {
+        // regenerate a test JM spec
+        Deployment testDeployment = kubernetesJobManagerSpecification.getDeployment();
+        List<HasMetadata> testAccompanyingResources =
+                kubernetesJobManagerSpecification.getAccompanyingResources();
+        List<HasMetadata> mockPrePreparedResources = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Pod mockPod =
+                    new PodBuilder()
+                            .editOrNewMetadata()
+                            .withName(String.format("mock-pod-preprepared-resource%d", i))
+                            .endMetadata()
+                            .editOrNewSpec()
+                            .endSpec()
+                            .build();
+            mockPrePreparedResources.add(mockPod);
+        }
+        KubernetesJobManagerSpecification testKubernetesJobManagerSpecification =
+                new KubernetesJobManagerSpecification(
+                        testDeployment, testAccompanyingResources, mockPrePreparedResources);
+        flinkKubeClient.createJobManagerComponent(testKubernetesJobManagerSpecification);
+
+        // check the preprepared resources had been created.
+        final List<Pod> resultPods = kubeClient.pods().inNamespace(NAMESPACE).list().getItems();
+        assertThat(resultPods).hasSize(3);
+
+        final List<Deployment> resultedDeployments =
+                kubeClient.apps().deployments().inNamespace(NAMESPACE).list().getItems();
+        // check resource owner reference had been refreshed.
+        testOwnerReferenceSetting(resultedDeployments.get(0), resultPods);
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtilsTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/ExtStepDecoratorUtilsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators;
+
+import org.apache.flink.client.deployment.ClusterSpecification;
+import org.apache.flink.configuration.ConfigConstants;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.core.testutils.CommonTestUtils;
+import org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtTestDecorator;
+import org.apache.flink.kubernetes.kubeclient.parameters.KubernetesJobManagerParameters;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/** The test class for {@link ExtStepDecoratorUtils}. */
+public class ExtStepDecoratorUtilsTest {
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private static final String EXT_DECORATOR_NAME = "ext-decorator";
+    private static final String EXT_JAR = EXT_DECORATOR_NAME + "-test-jar.jar";
+
+    @Test
+    public void testLoadExtStepDecorators() throws IOException {
+        File testRootFolder = temporaryFolder.newFolder();
+        File testPluginFolder = new File(testRootFolder, EXT_DECORATOR_NAME);
+        assertTrue(testPluginFolder.mkdirs());
+        File testPluginJar = new File("target", EXT_JAR);
+        assertTrue(testPluginJar.exists());
+        Files.copy(testPluginJar.toPath(), Paths.get(testPluginFolder.toString(), EXT_JAR));
+        Map<String, String> oriEnv = System.getenv();
+        try {
+            HashMap<String, String> currentEnv = new HashMap<>(oriEnv);
+            currentEnv.put(ConfigConstants.ENV_FLINK_PLUGINS_DIR, testRootFolder.getPath());
+            CommonTestUtils.setEnv(currentEnv);
+            final Configuration flinkConfig = new Configuration();
+            final ClusterSpecification clusterSpecification =
+                    new ClusterSpecification.ClusterSpecificationBuilder()
+                            .setMasterMemoryMB(1024)
+                            .setTaskManagerMemoryMB(1024)
+                            .setSlotsPerTaskManager(3)
+                            .createClusterSpecification();
+            KubernetesJobManagerParameters kubernetesJobManagerParameters =
+                    new KubernetesJobManagerParameters(flinkConfig, clusterSpecification);
+            assertEquals(
+                    ExtTestDecorator.class,
+                    ExtStepDecoratorUtils.loadExtStepDecorators(kubernetesJobManagerParameters)
+                            .get(0)
+                            .getClass());
+        } finally {
+            CommonTestUtils.setEnv(oriEnv);
+        }
+    }
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitJobManagerDecoratorTest.java
@@ -63,6 +63,7 @@ class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
                     new Toleration("NoExecute", "key2", "Exists", 6000L, null));
 
     private static final String USER_DEFINED_FLINK_LOG_DIR = "/path/of/flink-log";
+    private static final String TEST_K8S_POD_SCHEDULER = "test-k8s-pod-scheduler";
 
     private Pod resultPod;
     private Container resultMainContainer;
@@ -79,6 +80,8 @@ class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
         this.flinkConfig.setString(
                 KubernetesConfigOptions.JOB_MANAGER_TOLERATIONS.key(), TOLERATION_STRING);
         this.flinkConfig.set(KubernetesConfigOptions.FLINK_LOG_DIR, USER_DEFINED_FLINK_LOG_DIR);
+        this.flinkConfig.set(
+                KubernetesConfigOptions.JOB_MANAGER_POD_SCHEDULER_NAME, TEST_K8S_POD_SCHEDULER);
     }
 
     @Override
@@ -226,5 +229,10 @@ class InitJobManagerDecoratorTest extends KubernetesJobManagerTestBase {
     @Test
     void testDNSPolicyDefaultValue() {
         assertThat(this.resultPod.getSpec().getDnsPolicy()).isEqualTo(Constants.DNS_POLICY_DEFAULT);
+    }
+
+    @Test
+    void testPodSchedulerName() {
+        assertThat(this.resultPod.getSpec().getSchedulerName()).isEqualTo(TEST_K8S_POD_SCHEDULER);
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/InitTaskManagerDecoratorTest.java
@@ -72,6 +72,7 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
     private static final String RESOURCE_CONFIG_KEY = "test.com/test";
 
     private static final String USER_DEFINED_FLINK_LOG_DIR = "/path/of/flink-log";
+    private static final String TEST_K8S_POD_SCHEDULER = "test-k8s-pod-scheduler";
 
     private Pod resultPod;
     private Container resultMainContainer;
@@ -100,6 +101,8 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
                         KubernetesConfigOptions.EXTERNAL_RESOURCE_KUBERNETES_CONFIG_KEY_SUFFIX),
                 RESOURCE_CONFIG_KEY);
         this.flinkConfig.set(KubernetesConfigOptions.FLINK_LOG_DIR, USER_DEFINED_FLINK_LOG_DIR);
+        this.flinkConfig.set(
+                KubernetesConfigOptions.TASK_MANAGER_POD_SCHEDULER_NAME, TEST_K8S_POD_SCHEDULER);
     }
 
     @Override
@@ -289,5 +292,10 @@ class InitTaskManagerDecoratorTest extends KubernetesTaskManagerTestBase {
                                         KubernetesConfigOptions.KUBERNETES_NODE_NAME_LABEL),
                                 "NotIn",
                                 new ArrayList<>(BLOCKED_NODES)));
+    }
+
+    @Test
+    void testPodSchedulerName() {
+        assertThat(this.resultPod.getSpec().getSchedulerName()).isEqualTo(TEST_K8S_POD_SCHEDULER);
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtTestDecorator.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/decorators/extended/ExtTestDecorator.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.kubernetes.kubeclient.decorators.extended;
+
+import org.apache.flink.kubernetes.kubeclient.FlinkPod;
+import org.apache.flink.kubernetes.kubeclient.parameters.AbstractKubernetesParameters;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** The test class for testing the plugin decorators. */
+public class ExtTestDecorator implements ExtPluginDecorator {
+    @Override
+    public FlinkPod decorateFlinkPod(FlinkPod flinkPod) {
+        return flinkPod;
+    }
+
+    @Override
+    public List<HasMetadata> buildAccompanyingKubernetesResources() throws IOException {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public List<HasMetadata> buildPrePreparedResources() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void configure(AbstractKubernetesParameters kubernetesComponentConf) {
+        return;
+    }
+}

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -485,4 +485,15 @@ class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBase {
                                         && x.getMetadata().getName().equals(configMapName))
                 .collect(Collectors.toList());
     }
+
+    @Test
+    void testPrePreparedResourcesWontAffectOriginalProcess() throws IOException {
+        kubernetesJobManagerSpecification =
+                KubernetesJobManagerFactory.buildKubernetesJobManagerSpecification(
+                        flinkPod, kubernetesJobManagerParameters);
+        final List<HasMetadata> prePreparedResources =
+                this.kubernetesJobManagerSpecification.getPrePreparedResources();
+        assertThat(prePreparedResources).hasSize(0);
+        assertThat(prePreparedResources).isEmpty();
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/factory/KubernetesJobManagerFactoryTest.java
@@ -494,6 +494,5 @@ class KubernetesJobManagerFactoryTest extends KubernetesJobManagerTestBase {
         final List<HasMetadata> prePreparedResources =
                 this.kubernetesJobManagerSpecification.getPrePreparedResources();
         assertThat(prePreparedResources).hasSize(0);
-        assertThat(prePreparedResources).isEmpty();
     }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesJobManagerParametersTest.java
@@ -254,4 +254,27 @@ class KubernetesJobManagerParametersTest extends KubernetesTestBase {
         flinkConfig.set(KubernetesConfigOptions.KUBERNETES_JOBMANAGER_REPLICAS, 2);
         assertThat(kubernetesJobManagerParameters.getReplicas()).isEqualTo(2);
     }
+
+    @Test
+    void testGetPodSchedulerName() {
+        final String testJobManagerSchedulerName = "test-k8s-job-manager-pod-scheduler";
+        flinkConfig.set(
+                KubernetesConfigOptions.JOB_MANAGER_POD_SCHEDULER_NAME,
+                testJobManagerSchedulerName);
+        assertThat(kubernetesJobManagerParameters.getPodSchedulerName())
+                .isEqualTo(testJobManagerSchedulerName);
+    }
+
+    @Test
+    void testGetPodSchedulerNameWithDefaultValue() {
+        assertThat(kubernetesJobManagerParameters.getPodSchedulerName())
+                .isEqualTo("default-scheduler");
+    }
+
+    @Test
+    void testGetPodSchedulerNameFallback() {
+        final String testScheduler = "test-k8s-pod-scheduler";
+        flinkConfig.set(KubernetesConfigOptions.POD_SCHEDULER_NAME, testScheduler);
+        assertThat(kubernetesJobManagerParameters.getPodSchedulerName()).isEqualTo(testScheduler);
+    }
 }

--- a/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
+++ b/flink-kubernetes/src/test/java/org/apache/flink/kubernetes/kubeclient/parameters/KubernetesTaskManagerParametersTest.java
@@ -202,4 +202,27 @@ class KubernetesTaskManagerParametersTest extends KubernetesTestBase {
     void testGetServiceAccountShouldReturnDefaultIfNotExplicitlySet() {
         assertThat(kubernetesTaskManagerParameters.getServiceAccount()).isEqualTo("default");
     }
+
+    @Test
+    void testGetPodSchedulerName() {
+        final String testJobManagerSchedulerName = "test-k8s-job-manager-pod-scheduler";
+        flinkConfig.set(
+                KubernetesConfigOptions.TASK_MANAGER_POD_SCHEDULER_NAME,
+                testJobManagerSchedulerName);
+        assertThat(kubernetesTaskManagerParameters.getPodSchedulerName())
+                .isEqualTo(testJobManagerSchedulerName);
+    }
+
+    @Test
+    void testGetPodSchedulerNameWithDefaultValue() {
+        assertThat(kubernetesTaskManagerParameters.getPodSchedulerName())
+                .isEqualTo("default-scheduler");
+    }
+
+    @Test
+    void testGetPodSchedulerNameFallback() {
+        final String testScheduler = "test-k8s-pod-scheduler";
+        flinkConfig.set(KubernetesConfigOptions.POD_SCHEDULER_NAME, testScheduler);
+        assertThat(kubernetesTaskManagerParameters.getPodSchedulerName()).isEqualTo(testScheduler);
+    }
 }

--- a/flink-kubernetes/src/test/resources/META-INF/services/org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator
+++ b/flink-kubernetes/src/test/resources/META-INF/services/org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtPluginDecorator
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.kubernetes.kubeclient.decorators.extended.ExtTestDecorator


### PR DESCRIPTION
commit  [FLINK-28825] 
We introduce 3 options for supporting specify the K8S pod scheduler
name.

What is the purpose of the change
(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)

This change is introduced by FLIP-250 for supporting specify pod scheduler name by users. This PR introduces 3 options for it.

Brief change log
New options are:
kubernetes.jobmanager.scheduler-name
kubernetes.taskmanager.scheduler-name
kubernetes.scheduler-name

The first two of them can be specified by users to control the k8s pod
scheduler they used for jobmanager and taskmanager. The last one is the
fallback one, the first two options will overwrite it.

Verifying this change
Kubernetes deployment support 3 new options now. Can check the backend pods scheduler name whether is the same with the specified one.

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
The S3 file system connector: (no)
Documentation
Does this pull request introduce a new feature? (yes)
If yes, how is the feature documented? (not applicable)

commit [FLINK-28829] 
In this PR, we introduces several things for supporting create another k8s resources before JM deploy creation

What is the purpose of the change
(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)
For supporting customized k8s scheduler, we need to extend the ability of current code tree to support the cases of all customized k8s scheduler during they schedule the real pods. So we'd better to extend all cases during k8s scheduling, such as before/during/after our target resources creation. In this PR, we add the before case. And current code tree had covered during/after cases.

Brief change log
We introduce a new interface func for all decorators to support
create pre-prepared k8s resources.
We extend a attribute for JM spec for storing the resources list.
Extending the ability for supporting refresh the preprepared
resource's ownerreference based on original code logic.
Add the ability for creating K8S resource before JM deployment
creation in Fabric client.
Verifying this change
We can not verify this change at this moment, as this is a internal process in flink-kubernetes now. It doesn't affect the user interface now. The only way we can test it is mocking a JM spec with another k8s resources which is not contained by Flink. And check whether the resources can be created before the JM and refresh the correct ower reference(Flink cluster id-- deployment id).

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
The S3 file system connector: (no)
Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not documented)

commit  [FLINK-28831]
We introduce a pluginable decoarators mechanism into Flink JobManager and TaskManager.
For 1st part, we relies on the existing flink plugin mechanism and make the KubernetesStepDecorator
as the SPI. And load the extended plugins from plugins directory.
And notice the 1st part only introduces the basic mechanism and doesn't affect the major process login.
There will be another follow up PRs for introduce this mechanism one by one.

What is the purpose of the change
We introduce the basic plugin mechanism for supporting add more pluginable K8S step decorators in Flink Kubernetes. So in PR introduce the its 1st part.

Brief change log
Relied on the Flink existing plugin mechanism to load the plugins from flink-dist/plugins/ directory.
Introduce a new Interface class ExtPluginDecorator  which is extended from KubernetesStepDecorator, and introduce a new interface function for initialize the upcoming StepDecorators if necessary.
Introduce the basic UTs for plugin mechanism.
Verifying this change
Run the UTs, or package a sample jar which implement the interface class ExtPluginDecorator , then verify the said implement class is loaded in Flink by LOG. Notice that this is the first part of plugin mechanism, and it doen't affect the major Flink Kubernetes process yet. So we can only verify the said functionality via LOG now. Once the following PRs are ready and merged, we will introduce a full insight e2e tests.

Does this pull request potentially affect one of the following parts:
Dependencies (does it add or upgrade a dependency): (no)
The public API, i.e., is any changed class annotated with @Public(Evolving): (no)
The serializers: (no)
The runtime per-record code paths (performance sensitive): (no)
Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes)
The S3 file system connector: (no)
Documentation
Does this pull request introduce a new feature? (no)
If yes, how is the feature documented? (not documented)


