### PR TITLE
[FLINK-31336][table] fix interval type info lost in sql and table api.

### DIFF
--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/ExpressionConverter.java
@@ -34,6 +34,7 @@ import org.apache.flink.table.planner.calcite.FlinkTypeFactory;
 import org.apache.flink.table.planner.calcite.RexFieldVariable;
 import org.apache.flink.table.planner.expressions.RexNodeExpression;
 import org.apache.flink.table.planner.expressions.converter.CallExpressionConvertRule.ConvertContext;
+import org.apache.flink.table.planner.typeutils.LogicalRelDataTypeConverter;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.TimeType;
 
@@ -107,8 +108,7 @@ public class ExpressionConverter implements ExpressionVisitor<RexNode> {
         RexBuilder rexBuilder = relBuilder.getRexBuilder();
         FlinkTypeFactory typeFactory = (FlinkTypeFactory) relBuilder.getTypeFactory();
 
-        RelDataType relDataType = typeFactory.createFieldTypeFromLogicalType(type);
-
+        RelDataType relDataType = LogicalRelDataTypeConverter.toRelDataType(type, typeFactory);
         if (valueLiteral.isNull()) {
             return rexBuilder.makeNullLiteral(relDataType);
         }

--- a/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CastConverter.java
+++ b/flink-table/flink-table-planner/src/main/java/org/apache/flink/table/planner/expressions/converter/converters/CastConverter.java
@@ -23,6 +23,7 @@ import org.apache.flink.table.expressions.CallExpression;
 import org.apache.flink.table.expressions.TypeLiteralExpression;
 import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.planner.expressions.converter.CallExpressionConvertRule;
+import org.apache.flink.table.planner.typeutils.LogicalRelDataTypeConverter;
 
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
@@ -37,9 +38,8 @@ class CastConverter extends CustomizedConverter {
         final RexNode child = context.toRexNode(call.getChildren().get(0));
         final TypeLiteralExpression targetType = (TypeLiteralExpression) call.getChildren().get(1);
         final RelDataType targetRelDataType =
-                context.getTypeFactory()
-                        .createFieldTypeFromLogicalType(
-                                targetType.getOutputDataType().getLogicalType());
+                LogicalRelDataTypeConverter.toRelDataType(
+                        targetType.getOutputDataType().getLogicalType(), context.getTypeFactory());
 
         return context.getRelBuilder().getRexBuilder().makeAbstractCast(targetRelDataType, child);
     }

--- a/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
+++ b/flink-table/flink-table-planner/src/test/java/org/apache/flink/table/planner/functions/MiscFunctionsITCase.java
@@ -23,6 +23,8 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.ScalarFunction;
 
 import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Period;
 import java.util.stream.Stream;
 
 import static org.apache.flink.table.api.Expressions.$;
@@ -36,11 +38,60 @@ class MiscFunctionsITCase extends BuiltInFunctionTestBase {
     Stream<TestSetSpec> getTestSetSpecs() {
         return Stream.of(
                 TestSetSpec.forFunction(BuiltInFunctionDefinitions.TYPE_OF)
-                        .onFieldsWithData(12, "Hello world", false)
+                        .onFieldsWithData(
+                                12,
+                                "Hello world",
+                                false,
+                                Period.ofYears(2),
+                                Period.ofMonths(2),
+                                Duration.ofDays(2),
+                                Duration.ofHours(2),
+                                Duration.ofMinutes(2),
+                                Duration.ofSeconds(2))
+                        .andDataTypes(
+                                DataTypes.INT().notNull(),
+                                DataTypes.CHAR(11).notNull(),
+                                DataTypes.BOOLEAN().notNull(),
+                                DataTypes.INTERVAL(DataTypes.YEAR()),
+                                DataTypes.INTERVAL(DataTypes.MONTH()),
+                                DataTypes.INTERVAL(DataTypes.DAY()),
+                                DataTypes.INTERVAL(DataTypes.HOUR()),
+                                DataTypes.INTERVAL(DataTypes.MINUTE()),
+                                DataTypes.INTERVAL(DataTypes.SECOND()))
                         .testResult(
                                 call("TYPEOF", $("f0")),
                                 "TYPEOF(f0)",
                                 "INT NOT NULL",
+                                DataTypes.STRING())
+                        .testResult(
+                                call("TYPEOF", $("f3")),
+                                "TYPEOF(f3)",
+                                "INTERVAL YEAR(2) NOT NULL",
+                                DataTypes.STRING())
+                        .testResult(
+                                call("TYPEOF", $("f4")),
+                                "TYPEOF(f4)",
+                                "INTERVAL MONTH NOT NULL",
+                                DataTypes.STRING())
+                        .testResult(
+                                call("TYPEOF", $("f5")),
+                                "TYPEOF(f5)",
+                                "INTERVAL DAY(2) NOT NULL",
+                                DataTypes.STRING())
+                        .testResult(
+                                call("TYPEOF", $("f6")),
+                                "TYPEOF(f6)",
+                                "INTERVAL HOUR NOT NULL",
+                                DataTypes.STRING())
+                        .testResult(
+                                call("TYPEOF", $("f7")),
+                                "TYPEOF(f7)",
+                                "INTERVAL MINUTE NOT NULL",
+                                DataTypes.STRING())
+                        .testResult(
+                                call("TYPEOF", $("f8")),
+                                "TYPEOF(f8)",
+                                "INTERVAL SECOND(3) NOT NULL",
                                 DataTypes.STRING())
                         .testTableApiValidationError(
                                 call("TYPEOF", $("f0"), $("f2")),


### PR DESCRIPTION
## What is the purpose of the change

*fix interval type info lost in sql and table api.*


## Brief change log

Flink SQL> select typeof(interval '1' day);
 - INTERVAL SECOND(3) NOT NULL 
 which is not true, it should be 
- INTERVAL DAY(2) NOT NULL

## Verifying this change

unit test for type_of

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (docs)

