### PR TITLE
[FLINK-30829] Make the backpressure tab could be sort by busy/backpressure/idle seperately

### DIFF
--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.html
@@ -21,7 +21,7 @@
   [nzLoading]="isLoading"
   [nzData]="listOfSubTaskBackpressure"
   [nzScroll]="{ y: 'calc( 100% - 90px )' }"
-  [nzWidthConfig]="['24%', '28%', '24%', '24%']"
+  [nzWidthConfig]="['16%', '16%', '16%', '16%', '16%', '20%']"
   [nzFrontPagination]="false"
   [nzShowPagination]="false"
   [nzVirtualItemSize]="36"
@@ -31,7 +31,7 @@
 >
   <thead>
     <tr>
-      <th colspan="4" class="title">
+      <th colspan="6" class="title">
         <span *ngIf="selectedVertex?.detail?.status === 'RUNNING'">
           Measurement:
           <span *ngIf="backpressure['end-timestamp']">
@@ -57,7 +57,9 @@
     </tr>
     <tr>
       <th>SubTask</th>
-      <th [nzSortFn]="sortByBusyRatio" [nzSortOrder]="'descend'">Backpressured / Idle / Busy</th>
+      <th [nzSortFn]="sortByBackpressureRatio" [nzSortOrder]="'descend'">Backpressure</th>
+      <th [nzSortFn]="sortByIdleRatio" [nzSortOrder]="'descend'">Idle</th>
+      <th [nzSortFn]="sortByBusyRatio" [nzSortOrder]="'descend'">Busy</th>
       <th>Backpressure Status</th>
       <th>Thread Dump</th>
     </tr>
@@ -76,11 +78,9 @@
               [attempt-{{ subtask['attempt-number'] + 1 }}]
             </span>
           </td>
-          <td>
-            {{ this.prettyPrint(subtask['ratio']) }} /
-            {{ this.prettyPrint(subtask['idleRatio']) }} /
-            {{ this.prettyPrint(subtask['busyRatio']) }}
-          </td>
+          <td>{{ this.prettyPrint(subtask['ratio']) }}</td>
+          <td>{{ this.prettyPrint(subtask['idleRatio']) }}</td>
+          <td>{{ this.prettyPrint(subtask['busyRatio']) }}</td>
           <td>
             <flink-dynamic-host
               [data]="{ state: subtask['backpressure-level'] }"
@@ -114,11 +114,9 @@
                   &nbsp;[attempt-{{ attempt['attempt-number'] + 1 }}]
                 </ng-container>
               </td>
-              <td>
-                {{ this.prettyPrint(attempt['ratio']) }} /
-                {{ this.prettyPrint(attempt['idleRatio']) }} /
-                {{ this.prettyPrint(attempt['busyRatio']) }}
-              </td>
+              <td>{{ this.prettyPrint(attempt['ratio']) }}</td>
+              <td>{{ this.prettyPrint(attempt['idleRatio']) }}</td>
+              <td>{{ this.prettyPrint(attempt['busyRatio']) }}</td>
               <td>
                 <flink-dynamic-host
                   [data]="{ state: attempt['backpressure-level'] }"

--- a/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.ts
+++ b/flink-runtime-web/web-dashboard/src/app/pages/job/overview/backpressure/job-overview-drawer-backpressure.component.ts
@@ -153,6 +153,14 @@ export class JobOverviewDrawerBackpressureComponent implements OnInit, OnDestroy
     }
   }
 
+  sortByBackpressureRatio(a: JobBackpressureSubtask, b: JobBackpressureSubtask): number {
+    return a.ratio - b.ratio;
+  }
+
+  sortByIdleRatio(a: JobBackpressureSubtask, b: JobBackpressureSubtask): number {
+    return a.idleRatio - b.idleRatio;
+  }
+
   sortByBusyRatio(a: JobBackpressureSubtask, b: JobBackpressureSubtask): number {
     return a.busyRatio - b.busyRatio;
   }


### PR DESCRIPTION
## Brief change log
  - *Make the backpressure tab could be sort by busy/backpressure/idle seperately*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes)
  - If yes, how is the feature documented? (not documented)

### Before
![image](https://user-images.githubusercontent.com/104502720/223322296-2a008294-75c8-426c-b086-da8dc7f4f09a.png)

### After
![image](https://user-images.githubusercontent.com/104502720/223322342-ee04d2a7-ecd8-4af7-bdae-4aa133caf9fa.png)

