### PR TITLE
[FLINK-30802] Add details on SplitReader#fetch() interruption/resume

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/splitreader/SplitReader.java
@@ -41,7 +41,10 @@ public interface SplitReader<E, SplitT extends SourceSplit> extends AutoCloseabl
      * implementation may either decide to return without throwing an exception, or it can just
      * throw an interrupted exception. In either case, this method should be reentrant, meaning that
      * the next fetch call should just resume from where the last fetch call was waken up or
-     * interrupted.
+     * interrupted. It is up to the implementer to either read all the records of the split or to
+     * stop reading them at some point (for example when a given threshold is exceeded). In that
+     * later case, when fetch is called again, the reading should restart at the record where it
+     * left off based on the {@code SplitState}.
      *
      * @return the Ids of the finished splits.
      * @throws IOException when encountered IO errors, such as deserialization failures.


### PR DESCRIPTION
After a discussion in https://github.com/apache/flink-connector-cassandra/pull/3#discussion_r1087830169
R: @zentol 
