### PR TITLE
Flink 29398 rack awareness

### DIFF
--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -470,10 +470,9 @@ For detailed explanations of security configurations, please refer to
 
 Kafka Rack Awareness allows flink to select and control the cloud region and availability zone configured by the use of rackId, this feature could allow a significant cost reduction in the cloud provider bill and achieve a better networking performance when connecting to closer and more reliable networks.
 
-### Testing
+### Validation
 
-The test function validates if there a valid rack id supplied, valid rack IDs are:
-
+Additional validation are added to make sure any input to the supplier gets propertly configured by the comsumer and makes sure null values are handled propertly.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -466,6 +466,15 @@ client dependencies in the job JAR, so you may need to rewrite it with the actua
 For detailed explanations of security configurations, please refer to
 <a href="https://kafka.apache.org/documentation/#security">the "Security" section in Apache Kafka documentation</a>.
 
+## Kafka Rack Awareness
+
+Kafka Rack Awareness allows flink to select and control the cloud region and availability zone configured by the use of rackId, this feature could allow a significant cost reduction in the cloud provider bill and achieve a better networking performance when connecting to closer and more reliable networks.
+
+### Testing
+
+The test function validates if there a valid rack id supplied, valid rack IDs are:
+
+
 ### Behind the Scene
 {{< hint info >}}
 If you are interested in how Kafka source works under the design of new data source API, you may

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -470,13 +470,11 @@ For detailed explanations of security configurations, please refer to
 
 Kafka Rack Awareness allows flink to select and control the cloud region and availability zone configured by the use of rackId, this feature could allow a significant cost reduction in the cloud provider bill and achieve a better networking performance when connecting to closer and more reliable networks.
 
-### Validation
-
-Additional validation is added to ensure any input to the supplier gets properly configured by the consumer and ensures null values are handled properly.
-
 ### RackId
 
-setRackId is the variable where the desired or available availability zones get stored, if this variable is empty Rack Awareness feature simply gets ignored and assigned the AZs that are available to taskmanagers.
+setRackId is the variable where the desired or available availability zones get stored. If provided, the Supplier will be run when the consumer is set up on the Task Manager, and the consumer's client.rack configuration will be set to the value.
+
+https://kafka.apache.org/documentation/#consumerconfigs_client.rack
 
 One of the ways this can be implemented is by making setRackId equal to an environment variable within your taskManager, for instance:
 
@@ -486,7 +484,9 @@ One of the ways this can be implemented is by making setRackId equal to an envir
 
 The "TM_NODE_AZ" is the name of the environment variable in the TaskManager image that contains the available Network zones we want to use. 
 
-Another option could be extracting the AZ directly from AWS CLI or API.
+Another implementation option could be extracting the AZ directly from AWS CLI or API.
+
+Additional validation is added to ensure any input to the supplier gets properly configured by the consumer and ensures null values are handled properly.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/docs/content/docs/connectors/datastream/kafka.md
+++ b/docs/content/docs/connectors/datastream/kafka.md
@@ -472,7 +472,21 @@ Kafka Rack Awareness allows flink to select and control the cloud region and ava
 
 ### Validation
 
-Additional validation are added to make sure any input to the supplier gets propertly configured by the comsumer and makes sure null values are handled propertly.
+Additional validation is added to ensure any input to the supplier gets properly configured by the consumer and ensures null values are handled properly.
+
+### RackId
+
+setRackId is the variable where the desired or available availability zones get stored, if this variable is empty Rack Awareness feature simply gets ignored and assigned the AZs that are available to taskmanagers.
+
+One of the ways this can be implemented is by making setRackId equal to an environment variable within your taskManager, for instance:
+
+```
+.setRackId(() -> System.getenv("TM_NODE_AZ"))
+```
+
+The "TM_NODE_AZ" is the name of the environment variable in the TaskManager image that contains the available Network zones we want to use. 
+
+Another option could be extracting the AZ directly from AWS CLI or API.
 
 ### Behind the Scene
 {{< hint info >}}

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -98,6 +98,8 @@ public class KafkaSource<OUT>
     private final KafkaRecordDeserializationSchema<OUT> deserializationSchema;
     // The configurations.
     private final Properties props;
+    // Client rackId callback
+    private final Supplier<String> rackIdSupplier;
 
     KafkaSource(
             KafkaSubscriber subscriber,
@@ -105,13 +107,15 @@ public class KafkaSource<OUT>
             @Nullable OffsetsInitializer stoppingOffsetsInitializer,
             Boundedness boundedness,
             KafkaRecordDeserializationSchema<OUT> deserializationSchema,
-            Properties props) {
+            Properties props,
+            Supplier<String> rackIdSupplier) {
         this.subscriber = subscriber;
         this.startingOffsetsInitializer = startingOffsetsInitializer;
         this.stoppingOffsetsInitializer = stoppingOffsetsInitializer;
         this.boundedness = boundedness;
         this.deserializationSchema = deserializationSchema;
         this.props = props;
+        this.rackIdSupplier = rackIdSupplier;
     }
 
     /**
@@ -157,7 +161,8 @@ public class KafkaSource<OUT>
                 new KafkaSourceReaderMetrics(readerContext.metricGroup());
 
         Supplier<KafkaPartitionSplitReader> splitReaderSupplier =
-                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics);
+                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics,
+                        rackIdSupplier);
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSource.java
@@ -161,8 +161,9 @@ public class KafkaSource<OUT>
                 new KafkaSourceReaderMetrics(readerContext.metricGroup());
 
         Supplier<KafkaPartitionSplitReader> splitReaderSupplier =
-                () -> new KafkaPartitionSplitReader(props, readerContext, kafkaSourceReaderMetrics,
-                        rackIdSupplier);
+                () ->
+                        new KafkaPartitionSplitReader(
+                                props, readerContext, kafkaSourceReaderMetrics, rackIdSupplier);
         KafkaRecordEmitter<OUT> recordEmitter = new KafkaRecordEmitter<>(deserializationSchema);
 
         return new KafkaSourceReader<>(

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -361,7 +361,7 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
-     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader
+     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader.
      *
      * @param rackIdCallback callback to provide Kafka consumer client.rack
      * @return this KafkaSourceBuilder

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/KafkaSourceBuilder.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -80,6 +81,7 @@ import static org.apache.flink.util.Preconditions.checkState;
  *     .setTopics(Arrays.asList(TOPIC1, TOPIC2))
  *     .setDeserializer(KafkaRecordDeserializationSchema.valueOnly(StringDeserializer.class))
  *     .setUnbounded(OffsetsInitializer.latest())
+ *     .setRackId(() -> MY_RACK_ID)
  *     .build();
  * }</pre>
  *
@@ -100,6 +102,8 @@ public class KafkaSourceBuilder<OUT> {
     private KafkaRecordDeserializationSchema<OUT> deserializationSchema;
     // The configurations.
     protected Properties props;
+    // Client rackId supplier
+    private Supplier<String> rackIdSupplier;
 
     KafkaSourceBuilder() {
         this.subscriber = null;
@@ -108,6 +112,7 @@ public class KafkaSourceBuilder<OUT> {
         this.boundedness = Boundedness.CONTINUOUS_UNBOUNDED;
         this.deserializationSchema = null;
         this.props = new Properties();
+        this.rackIdSupplier = null;
     }
 
     /**
@@ -356,6 +361,17 @@ public class KafkaSourceBuilder<OUT> {
     }
 
     /**
+     * Set the clientRackId supplier to be passed down to the KafkaPartitionSplitReader
+     *
+     * @param rackIdCallback callback to provide Kafka consumer client.rack
+     * @return this KafkaSourceBuilder
+     */
+    public KafkaSourceBuilder<OUT> setRackId(Supplier<String> rackIdCallback) {
+        this.rackIdSupplier = rackIdCallback;
+        return this;
+    }
+
+    /**
      * Set an arbitrary property for the KafkaSource and KafkaConsumer. The valid keys can be found
      * in {@link ConsumerConfig} and {@link KafkaSourceOptions}.
      *
@@ -422,7 +438,8 @@ public class KafkaSourceBuilder<OUT> {
                 stoppingOffsetsInitializer,
                 boundedness,
                 deserializationSchema,
-                props);
+                props,
+                rackIdSupplier);
     }
 
     // ------------- private helpers  --------------

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -79,12 +79,14 @@ public class KafkaPartitionSplitReader
     public KafkaPartitionSplitReader(
             Properties props,
             SourceReaderContext context,
-            KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
+            KafkaSourceReaderMetrics kafkaSourceReaderMetrics,
+            Supplier<String> rackIdSupplier) {
         this.subtaskId = context.getIndexOfSubtask();
         this.kafkaSourceReaderMetrics = kafkaSourceReaderMetrics;
         Properties consumerProps = new Properties();
         consumerProps.putAll(props);
         consumerProps.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, createConsumerClientId(props));
+        setConsumerClientRack(consumerProps, rackIdSupplier);
         this.consumer = new KafkaConsumer<>(consumerProps);
         this.stoppingOffsets = new HashMap<>();
         this.groupId = consumerProps.getProperty(ConsumerConfig.GROUP_ID_CONFIG);
@@ -255,6 +257,12 @@ public class KafkaPartitionSplitReader
     }
 
     // --------------- private helper method ----------------------
+
+    private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
+        if (rackIdSupplier != null) {
+            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackIdSupplier.get());
+        }
+    }
 
     private void parseStartingOffsets(
             KafkaPartitionSplit split,

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -79,6 +79,13 @@ public class KafkaPartitionSplitReader
     public KafkaPartitionSplitReader(
             Properties props,
             SourceReaderContext context,
+            KafkaSourceReaderMetrics kafkaSourceReaderMetrics) {
+        this(props, context, kafkaSourceReaderMetrics, () -> null);
+    }
+
+    public KafkaPartitionSplitReader(
+            Properties props,
+            SourceReaderContext context,
             KafkaSourceReaderMetrics kafkaSourceReaderMetrics,
             Supplier<String> rackIdSupplier) {
         this.subtaskId = context.getIndexOfSubtask();
@@ -260,7 +267,10 @@ public class KafkaPartitionSplitReader
 
     private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
-            consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackIdSupplier.get());
+            String rackId = rackIdSupplier.get();
+            if (rackId != null) {
+                consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
+            }
         }
     }
 

--- a/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
+++ b/flink-connectors/flink-connector-kafka/src/main/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReader.java
@@ -265,10 +265,10 @@ public class KafkaPartitionSplitReader
 
     // --------------- private helper method ----------------------
 
-    private void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
+    void setConsumerClientRack(Properties consumerProps, Supplier<String> rackIdSupplier) {
         if (rackIdSupplier != null) {
             String rackId = rackIdSupplier.get();
-            if (rackId != null) {
+            if (rackId != null && !rackId.isEmpty()) {
                 consumerProps.setProperty(ConsumerConfig.CLIENT_RACK_CONFIG, rackId);
             }
         }

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -74,6 +74,7 @@ public class KafkaPartitionSplitReaderTest {
     private static final String TOPIC1 = "topic1";
     private static final String TOPIC2 = "topic2";
     private static final String TOPIC3 = "topic3";
+    private static final String CLIENT_RACK = "use1-az1";
 
     private static Map<Integer, Map<String, KafkaPartitionSplit>> splitsByOwners;
     private static Map<TopicPartition, Long> earliestOffsets;
@@ -394,7 +395,8 @@ public class KafkaPartitionSplitReaderTest {
         return new KafkaPartitionSplitReader(
                 props,
                 new TestingReaderContext(new Configuration(), sourceReaderMetricGroup),
-                kafkaSourceReaderMetrics);
+                kafkaSourceReaderMetrics,
+                () -> CLIENT_RACK);
     }
 
     private Map<String, KafkaPartitionSplit> assignSplits(

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -323,10 +323,11 @@ public class KafkaPartitionSplitReaderTest {
     @Test
     public void testConsumerClientRackSupplier() {
         AtomicReference<Boolean> supplierCalled = new AtomicReference<>(false);
+        String rackId = "use-az1";
         Supplier<String> rackIdSupplier =
                 () -> {
                     supplierCalled.set(true);
-                    return "foo";
+                    return rackId;
                 };
         Properties properties = new Properties();
         createReader(
@@ -334,7 +335,7 @@ public class KafkaPartitionSplitReaderTest {
                 UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
                 rackIdSupplier);
         assertThat(supplierCalled.get()).isEqualTo(true);
-        assertThat("foo".equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
+        assertThat(rackId.equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
     }
 
     // ------------------

--- a/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
+++ b/flink-connectors/flink-connector-kafka/src/test/java/org/apache/flink/connector/kafka/source/reader/KafkaPartitionSplitReaderTest.java
@@ -323,12 +323,18 @@ public class KafkaPartitionSplitReaderTest {
     @Test
     public void testConsumerClientRackSupplier() {
         AtomicReference<Boolean> supplierCalled = new AtomicReference<>(false);
-        Supplier<String> rackIdSupplier = () -> {
-            supplierCalled.set(true);
-            return null;
-        };
-        createReader(new Properties(), UnregisteredMetricsGroup.createSourceReaderMetricGroup(), rackIdSupplier);
+        Supplier<String> rackIdSupplier =
+                () -> {
+                    supplierCalled.set(true);
+                    return "foo";
+                };
+        Properties properties = new Properties();
+        createReader(
+                properties,
+                UnregisteredMetricsGroup.createSourceReaderMetricGroup(),
+                rackIdSupplier);
         assertThat(supplierCalled.get()).isEqualTo(true);
+        assertThat("foo".equals(properties.getProperty(ConsumerConfig.CLIENT_RACK_CONFIG)));
     }
 
     // ------------------
@@ -394,8 +400,7 @@ public class KafkaPartitionSplitReaderTest {
     }
 
     private KafkaPartitionSplitReader createReader(
-            Properties additionalProperties,
-            SourceReaderMetricGroup sourceReaderMetricGroup) {
+            Properties additionalProperties, SourceReaderMetricGroup sourceReaderMetricGroup) {
         return createReader(additionalProperties, sourceReaderMetricGroup, () -> null);
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
