### PR TITLE
[FLINK-30805] Ask for a new split when one has finished in SourceReader default implementation

### DIFF
--- a/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
+++ b/flink-connectors/flink-connector-base/src/main/java/org/apache/flink/connector/base/source/reader/SourceReaderBase.java
@@ -25,6 +25,7 @@ import org.apache.flink.api.connector.source.SourceOutput;
 import org.apache.flink.api.connector.source.SourceReader;
 import org.apache.flink.api.connector.source.SourceReaderContext;
 import org.apache.flink.api.connector.source.SourceSplit;
+import org.apache.flink.api.connector.source.SplitEnumerator;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherManager;
 import org.apache.flink.connector.base.source.reader.splitreader.SplitReader;
@@ -278,11 +279,17 @@ public abstract class SourceReaderBase<E, T, SplitT extends SourceSplit, SplitSt
     }
 
     // -------------------- Abstract method to allow different implementations ------------------
-    /** Handles the finished splits to clean the state if needed. */
-    protected abstract void onSplitFinished(Map<String, SplitStateT> finishedSplitIds);
 
     /**
-     * When new splits are added to the reader. The initialize the state of the new splits.
+     * Callback to handle when a split is finished. Default implementation asks the {@link
+     * SplitEnumerator} for a new split. It is also recommended to clean the states.
+     */
+    protected void onSplitFinished(Map<String, SplitStateT> finishedSplitIds) {
+        context.sendSplitRequest();
+    }
+
+    /**
+     * When new splits are added to the reader, this initializes the state of the new splits.
      *
      * @param split a newly added split.
      */

--- a/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
+++ b/flink-connectors/flink-connector-files/src/main/java/org/apache/flink/connector/file/src/impl/FileSourceReader.java
@@ -28,8 +28,6 @@ import org.apache.flink.connector.file.src.FileSourceSplitState;
 import org.apache.flink.connector.file.src.reader.BulkFormat;
 import org.apache.flink.connector.file.src.util.RecordAndPosition;
 
-import java.util.Map;
-
 /** A {@link SourceReader} that read records from {@link FileSourceSplit}. */
 @Internal
 public final class FileSourceReader<T, SplitT extends FileSourceSplit>
@@ -53,11 +51,6 @@ public final class FileSourceReader<T, SplitT extends FileSourceSplit>
         if (getNumberOfCurrentlyAssignedSplits() == 0) {
             context.sendSplitRequest();
         }
-    }
-
-    @Override
-    protected void onSplitFinished(Map<String, FileSourceSplitState<SplitT>> finishedSplitIds) {
-        context.sendSplitRequest();
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

While developping Cassandra source connector, I was surprised that new splits were not automatically asked by the source reader when the previous split was finished. I mean, as a source author, when one implements SplitEnumerator#handleSplitRequest()  one kind of expects this method to be called by the source framework.

## Brief change log

Add a default impl in `SourceReaderBase#onSplitFinished()` that calls `context.sendSplitRequest();`

## Verifying this change

Already covered by the existing ITests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? yes
  - If yes, how is the feature documented? javadoc

R: @MartijnVisser I though, as this change is trivial, that we could discuss in the PR rather than in the ticket.
So, do you agree that it is better for the user to have a this default impl that asks for new splits ?