### PR TITLE
[FLINK-31370]  Prevent more timers from being fired if the StreamTask…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/InternalTimeServiceManager.java
@@ -25,6 +25,7 @@ import org.apache.flink.runtime.state.KeyGroupStatePartitionStreamProvider;
 import org.apache.flink.runtime.state.KeyedStateCheckpointOutputStream;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 
 import java.io.Serializable;
 
@@ -76,7 +77,8 @@ public interface InternalTimeServiceManager<K> {
                 ClassLoader userClassloader,
                 KeyContext keyContext,
                 ProcessingTimeService processingTimeService,
-                Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates)
+                Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+                StreamTaskCancellationContext cancellationContext)
                 throws Exception;
     }
 }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceManager.java
@@ -29,6 +29,7 @@ import org.apache.flink.streaming.api.operators.KeyContext;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.util.WrappingRuntimeException;
 
 import java.util.HashMap;
@@ -88,7 +89,8 @@ public class BatchExecutionInternalTimeServiceManager<K>
             ClassLoader userClassloader,
             KeyContext keyContext, // the operator
             ProcessingTimeService processingTimeService,
-            Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates) {
+            Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+            StreamTaskCancellationContext cancellationContext) {
         checkState(
                 keyedStatedBackend instanceof BatchExecutionKeyedStateBackend,
                 "Batch execution specific time service can work only with BatchExecutionKeyedStateBackend");

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTask.java
@@ -670,7 +670,8 @@ public abstract class StreamTask<OUT, OP extends StreamOperator<OUT>>
                 TtlTimeProvider.DEFAULT,
                 timerServiceProvider != null
                         ? timerServiceProvider
-                        : InternalTimeServiceManagerImpl::create);
+                        : InternalTimeServiceManagerImpl::create,
+                () -> canceled);
     }
 
     protected Counter setupNumRecordsInCounter(StreamOperator streamOperator) {

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationContext.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationContext.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.tasks;
+
+import org.apache.flink.annotation.Internal;
+
+/** Context on the {@link StreamTask} for figuring out whether it has been cancelled. */
+@FunctionalInterface
+@Internal
+public interface StreamTaskCancellationContext {
+
+    /**
+     * Factory for a context that always returns {@code false} when {@link #isCancelled()} is
+     * called.
+     *
+     * @return context
+     */
+    static StreamTaskCancellationContext alwaysRunning() {
+        return () -> false;
+    }
+
+    /**
+     * Find out whether the {@link StreamTask} this context belongs to has been cancelled.
+     *
+     * @return true if the {@code StreamTask} the has been cancelled
+     */
+    boolean isCancelled();
+}

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/InternalTimerServiceImplTest.java
@@ -30,6 +30,7 @@ import org.apache.flink.runtime.state.KeyGroupedInternalPriorityQueue;
 import org.apache.flink.runtime.state.PriorityQueueSetFactory;
 import org.apache.flink.runtime.state.heap.HeapPriorityQueueSetFactory;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 
 import org.junit.Assert;
@@ -1100,7 +1101,8 @@ public class InternalTimerServiceImplTest {
                 processingTimeService,
                 createTimerQueue(
                         "__test_processing_timers", timerSerializer, priorityQueueSetFactory),
-                createTimerQueue("__test_event_timers", timerSerializer, priorityQueueSetFactory));
+                createTimerQueue("__test_event_timers", timerSerializer, priorityQueueSetFactory),
+                StreamTaskCancellationContext.alwaysRunning());
     }
 
     private static <K, N>

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StateInitializationContextImplTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.CheckpointResponder;
 import org.apache.flink.runtime.util.LongArrayList;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -191,7 +192,8 @@ public class StateInitializationContextImplTest {
                                     ClassLoader userClassloader,
                                     KeyContext keyContext,
                                     ProcessingTimeService processingTimeService,
-                                    Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates)
+                                    Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+                                    StreamTaskCancellationContext cancellationContext)
                                     throws Exception {
                                 // We do not initialize a timer service manager here, because it
                                 // would already consume the raw keyed
@@ -200,7 +202,8 @@ public class StateInitializationContextImplTest {
                                 // stream.
                                 return null;
                             }
-                        });
+                        },
+                        StreamTaskCancellationContext.alwaysRunning());
 
         AbstractStreamOperator<?> mockOperator = mock(AbstractStreamOperator.class);
         when(mockOperator.getOperatorID()).thenReturn(operatorID);

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/StreamTaskStateInitializerImplTest.java
@@ -52,6 +52,7 @@ import org.apache.flink.runtime.state.memory.MemoryStateBackend;
 import org.apache.flink.runtime.state.ttl.TtlTimeProvider;
 import org.apache.flink.runtime.taskmanager.TestCheckpointResponder;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.util.CloseableIterable;
 
@@ -317,11 +318,13 @@ public class StreamTaskStateInitializerImplTest {
                                 ClassLoader userClassloader,
                                 KeyContext keyContext,
                                 ProcessingTimeService processingTimeService,
-                                Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates)
+                                Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+                                StreamTaskCancellationContext cancellationContext)
                                 throws Exception {
                             return null;
                         }
-                    });
+                    },
+                    StreamTaskCancellationContext.alwaysRunning());
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/operators/sorted/state/BatchExecutionInternalTimeServiceTest.java
@@ -36,6 +36,7 @@ import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.KeyContext;
 import org.apache.flink.streaming.api.operators.Triggerable;
 import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.util.TestLogger;
 
@@ -90,7 +91,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                 this.getClass().getClassLoader(),
                 new DummyKeyContext(),
                 new TestProcessingTimeService(),
-                Collections.emptyList());
+                Collections.emptyList(),
+                StreamTaskCancellationContext.alwaysRunning());
     }
 
     @Test
@@ -134,7 +136,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        StreamTaskCancellationContext.alwaysRunning());
 
         List<Long> timers = new ArrayList<>();
         InternalTimerService<VoidNamespace> timerService =
@@ -169,7 +172,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        StreamTaskCancellationContext.alwaysRunning());
 
         List<Long> timers = new ArrayList<>();
         InternalTimerService<VoidNamespace> timerService =
@@ -197,7 +201,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         new TestProcessingTimeService(),
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        StreamTaskCancellationContext.alwaysRunning());
 
         List<Long> timers = new ArrayList<>();
         TriggerWithTimerServiceAccess<Integer, VoidNamespace> eventTimeTrigger =
@@ -243,7 +248,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         processingTimeService,
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        StreamTaskCancellationContext.alwaysRunning());
 
         List<Long> timers = new ArrayList<>();
         InternalTimerService<VoidNamespace> timerService =
@@ -277,7 +283,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         processingTimeService,
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        StreamTaskCancellationContext.alwaysRunning());
 
         List<Long> timers = new ArrayList<>();
         TriggerWithTimerServiceAccess<Integer, VoidNamespace> trigger =
@@ -316,7 +323,8 @@ public class BatchExecutionInternalTimeServiceTest extends TestLogger {
                         this.getClass().getClassLoader(),
                         new DummyKeyContext(),
                         processingTimeService,
-                        Collections.emptyList());
+                        Collections.emptyList(),
+                        StreamTaskCancellationContext.alwaysRunning());
 
         List<Long> timers = new ArrayList<>();
         TriggerWithTimerServiceAccess<Integer, VoidNamespace> trigger =

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationTest.java
@@ -25,22 +25,33 @@ import org.apache.flink.runtime.execution.Environment;
 import org.apache.flink.runtime.execution.ExecutionState;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironment;
 import org.apache.flink.runtime.io.network.NettyShuffleEnvironmentBuilder;
+import org.apache.flink.runtime.state.KeyedStateBackend;
+import org.apache.flink.runtime.state.VoidNamespace;
+import org.apache.flink.runtime.state.VoidNamespaceSerializer;
 import org.apache.flink.runtime.taskmanager.Task;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.InternalTimer;
+import org.apache.flink.streaming.api.operators.InternalTimerService;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.Triggerable;
+import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxDefaultAction;
 import org.apache.flink.testutils.TestingUtils;
 import org.apache.flink.testutils.executor.TestExecutorResource;
+import org.apache.flink.util.Preconditions;
 import org.apache.flink.util.TestLogger;
+import org.apache.flink.util.function.ThrowingConsumer;
 
+import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import java.io.Closeable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
 import static org.apache.flink.streaming.runtime.tasks.StreamTaskTest.createTask;
@@ -255,6 +266,95 @@ public class StreamTaskCancellationTest extends TestLogger {
         @Override
         protected void processInput(MailboxDefaultAction.Controller controller) {
             throw new CancelTaskException();
+        }
+    }
+
+    @Test
+    public void testCancelTaskShouldPreventAdditionalEventTimeTimersFromBeingFired()
+            throws Exception {
+        testCancelTaskShouldPreventAdditionalTimersFromBeingFired(false);
+    }
+
+    @Test
+    public void testCancelTaskShouldPreventAdditionalProcessingTimeTimersFromBeingFired()
+            throws Exception {
+        testCancelTaskShouldPreventAdditionalTimersFromBeingFired(true);
+    }
+
+    private void testCancelTaskShouldPreventAdditionalTimersFromBeingFired(boolean processingTime)
+            throws Exception {
+        final int numKeyedTimersToRegister = 100;
+        final int numKeyedTimersToFire = 10;
+        final AtomicInteger numKeyedTimersFired = new AtomicInteger(0);
+        try (StreamTaskMailboxTestHarness<String> harness =
+                new StreamTaskMailboxTestHarnessBuilder<>(OneInputStreamTask::new, STRING_TYPE_INFO)
+                        .addInput(STRING_TYPE_INFO)
+                        .setKeyType(STRING_TYPE_INFO)
+                        .setupOutputForSingletonOperatorChain(
+                                new TaskWithPreRegisteredTimers(
+                                        numKeyedTimersToRegister, processingTime))
+                        .build()) {
+            TaskWithPreRegisteredTimers.setOnTimerListener(
+                    key -> {
+                        if (numKeyedTimersFired.incrementAndGet() >= numKeyedTimersToFire) {
+                            harness.cancel();
+                        }
+                    });
+            harness.processElement(new Watermark(Long.MAX_VALUE));
+        }
+        Assertions.assertThat(numKeyedTimersFired).hasValue(numKeyedTimersToFire);
+    }
+
+    private static class TaskWithPreRegisteredTimers extends AbstractStreamOperator<String>
+            implements OneInputStreamOperator<String, String>, Triggerable<String, VoidNamespace> {
+
+        private static ThrowingConsumer<String, Exception> onTimerListener;
+
+        private final int numTimersToRegister;
+        private final boolean processingTime;
+
+        private TaskWithPreRegisteredTimers(int numTimersToRegister, boolean processingTime) {
+            this.numTimersToRegister = numTimersToRegister;
+            this.processingTime = processingTime;
+        }
+
+        @Override
+        public void open() throws Exception {
+            final InternalTimerService<VoidNamespace> timerService =
+                    getInternalTimerService("test-timers", VoidNamespaceSerializer.INSTANCE, this);
+            final KeyedStateBackend<String> keyedStateBackend = getKeyedStateBackend();
+            for (int keyIdx = 0; keyIdx < numTimersToRegister; keyIdx++) {
+                final String key = "key-" + keyIdx;
+                keyedStateBackend.setCurrentKey(key);
+                if (processingTime) {
+                    timerService.registerProcessingTimeTimer(VoidNamespace.INSTANCE, 0);
+                } else {
+                    timerService.registerEventTimeTimer(VoidNamespace.INSTANCE, 0);
+                }
+            }
+        }
+
+        @Override
+        public void processElement(StreamRecord<String> element) throws Exception {
+            // No-op.
+        }
+
+        @Override
+        public void onEventTime(InternalTimer<String, VoidNamespace> timer) throws Exception {
+            Preconditions.checkState(!processingTime);
+            Preconditions.checkNotNull(onTimerListener).accept(timer.getKey());
+        }
+
+        @Override
+        public void onProcessingTime(InternalTimer<String, VoidNamespace> timer) throws Exception {
+            Preconditions.checkState(processingTime);
+            Preconditions.checkNotNull(onTimerListener).accept(timer.getKey());
+        }
+
+        private static void setOnTimerListener(
+                ThrowingConsumer<String, Exception> onTimerListener) {
+            TaskWithPreRegisteredTimers.onTimerListener =
+                    Preconditions.checkNotNull(onTimerListener);
         }
     }
 }

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskMailboxTestHarness.java
@@ -167,6 +167,10 @@ public class StreamTaskMailboxTestHarness<OUT> implements AutoCloseable {
         streamTask.cleanUp(null);
     }
 
+    public void cancel() throws Exception {
+        streamTask.cancel();
+    }
+
     @Override
     public void close() throws Exception {
         if (streamTask.isRunning()) {

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/util/AbstractStreamOperatorTestHarness.java
@@ -76,6 +76,7 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.OperatorEventDispatcherImpl;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.StreamTask;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
 import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
@@ -149,7 +150,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
                         ClassLoader userClassloader,
                         KeyContext keyContext,
                         ProcessingTimeService processingTimeService,
-                        Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates)
+                        Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+                        StreamTaskCancellationContext cancellationContext)
                         throws Exception {
                     InternalTimeServiceManagerImpl<K> typedTimeServiceManager =
                             InternalTimeServiceManagerImpl.create(
@@ -157,7 +159,8 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
                                     userClassloader,
                                     keyContext,
                                     processingTimeService,
-                                    rawKeyedStates);
+                                    rawKeyedStates,
+                                    cancellationContext);
                     timeServiceManager = typedTimeServiceManager;
                     return typedTimeServiceManager;
                 }
@@ -331,7 +334,11 @@ public class AbstractStreamOperatorTestHarness<OUT> implements AutoCloseable {
             TtlTimeProvider ttlTimeProvider,
             InternalTimeServiceManager.Provider timeServiceManagerProvider) {
         return new StreamTaskStateInitializerImpl(
-                env, stateBackend, ttlTimeProvider, timeServiceManagerProvider);
+                env,
+                stateBackend,
+                ttlTimeProvider,
+                timeServiceManagerProvider,
+                StreamTaskCancellationContext.alwaysRunning());
     }
 
     public void setStateBackend(StateBackend stateBackend) {

--- a/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
+++ b/flink-tests/src/test/java/org/apache/flink/test/state/operator/restore/StreamOperatorSnapshotRestoreTest.java
@@ -58,6 +58,7 @@ import org.apache.flink.streaming.api.operators.StreamOperator;
 import org.apache.flink.streaming.api.watermark.Watermark;
 import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.runtime.tasks.ProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskCancellationContext;
 import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
 import org.apache.flink.util.TernaryBoolean;
 import org.apache.flink.util.TestLogger;
@@ -236,7 +237,8 @@ public class StreamOperatorSnapshotRestoreTest extends TestLogger {
                             ClassLoader userClassloader,
                             KeyContext keyContext,
                             ProcessingTimeService processingTimeService,
-                            Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates)
+                            Iterable<KeyGroupStatePartitionStreamProvider> rawKeyedStates,
+                            StreamTaskCancellationContext cancellationContext)
                             throws IOException {
                         return null;
                     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31370

If the task is canceled while the watermark progresses, it may be stuck in the Cancelling state for a long time (e.g., when many windows are firing). This is closely related to [FLINK-20217](https://issues.apache.org/jira/browse/FLINK-20217), which might bring a more robust solution for checkpoint and cancellation code paths.

As a stopgap solution, we'll introduce a check allowing InternalTimerService to break out of the firing loop if the StreamTask has been marked as canceled.


*Performance consideration*: This adds a lookup to a volatile field on the per-timer code path.