### PR TITLE
[FLINK-31369][sql-gateway] Harden modifiers in tests for sql-gateway module

### DIFF
--- a/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointStatementITCase.java
+++ b/flink-connectors/flink-connector-hive/src/test/java/org/apache/flink/table/endpoint/hive/HiveServer2EndpointStatementITCase.java
@@ -87,7 +87,7 @@ public class HiveServer2EndpointStatementITCase extends AbstractSqlGatewayStatem
     }
 
     @AfterEach
-    public void after() throws Exception {
+    void after() throws Exception {
         statement.close();
         connection.close();
     }

--- a/flink-table/flink-sql-gateway/pom.xml
+++ b/flink-table/flink-sql-gateway/pom.xml
@@ -145,6 +145,12 @@
                     <goals>
                         <goal>test-jar</goal>
                     </goals>
+					<configuration>
+						<excludes>
+							<!-- test-jar is still used by JUnit4 modules -->
+							<exclude>META-INF/services/org.junit.jupiter.api.extension.Extension</exclude>
+						</excludes>
+					</configuration>
                 </execution>
             </executions>
         </plugin>

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/AbstractSqlGatewayStatementITCase.java
@@ -102,7 +102,7 @@ public abstract class AbstractSqlGatewayStatementITCase extends AbstractTestBase
     }
 
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
         service = SQL_GATEWAY_SERVICE_EXTENSION.getService();
     }
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/SqlGatewayTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/SqlGatewayTest.java
@@ -41,13 +41,13 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 /** Tests for the {@link SqlGateway}. */
-public class SqlGatewayTest {
+class SqlGatewayTest {
 
     private Map<String, String> originalEnv;
     private ByteArrayOutputStream output;
 
     @BeforeEach
-    public void before(@TempDir File tempFolder) throws IOException {
+    void before(@TempDir File tempFolder) throws IOException {
         originalEnv = System.getenv();
 
         // prepare yaml
@@ -64,7 +64,7 @@ public class SqlGatewayTest {
     }
 
     @AfterEach
-    public void cleanup() throws Exception {
+    void cleanup() throws Exception {
         CommonTestUtils.setEnv(originalEnv);
         if (output != null) {
             output.close();
@@ -72,7 +72,7 @@ public class SqlGatewayTest {
     }
 
     @Test
-    public void testPrintStartGatewayHelp() {
+    void testPrintStartGatewayHelp() {
         String[] args = new String[] {"--help"};
         SqlGateway.startSqlGateway(new PrintStream(output), args);
 
@@ -87,7 +87,7 @@ public class SqlGatewayTest {
     }
 
     @Test
-    public void testConfigureSqlGateway() throws Exception {
+    void testConfigureSqlGateway() throws Exception {
         String id = UUID.randomUUID().toString();
         String[] args =
                 new String[] {
@@ -121,7 +121,7 @@ public class SqlGatewayTest {
     }
 
     @Test
-    public void testFailedToStartSqlGateway() {
+    void testFailedToStartSqlGateway() {
         try (PrintStream stream = new PrintStream(output)) {
             assertThatThrownBy(() -> SqlGateway.startSqlGateway(stream, new String[0]))
                     .doesNotHaveToString(

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/OperationRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/OperationRelatedITCase.java
@@ -88,17 +88,17 @@ class OperationRelatedITCase extends RestAPIITCaseBase {
         // Get the RUNNING status when an operation is submitted
         ids = submitOperation();
         status = getOperationStatus(ids);
-        assertThat(OperationStatus.RUNNING.toString()).isEqualTo(status);
+        assertThat(OperationStatus.RUNNING).hasToString(status);
         // Get the CANCELED status when an operation is canceled
         ids = submitOperation();
         status = cancelOperation(ids);
-        assertThat(OperationStatus.CANCELED.toString()).isEqualTo(status);
+        assertThat(OperationStatus.CANCELED).hasToString(status);
         status = getOperationStatus(ids);
-        assertThat(OperationStatus.CANCELED.toString()).isEqualTo(status);
+        assertThat(OperationStatus.CANCELED).hasToString(status);
         // Get the CLOSED status when an operation is closed
         ids = submitOperation();
         status = closeOperation(ids);
-        assertThat(OperationStatus.CLOSED.toString()).isEqualTo(status);
+        assertThat(OperationStatus.CLOSED).hasToString(status);
         SessionHandle sessionHandle = new SessionHandle(UUID.fromString(ids.get(0)));
         OperationHandle operationHandle = new OperationHandle(UUID.fromString(ids.get(1)));
         assertThatThrownBy(

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SessionRelatedITCase.java
@@ -154,7 +154,7 @@ class SessionRelatedITCase extends RestAPIITCaseBase {
                         emptyRequestBody);
         Map<String, String> getProperties = future.get().getProperties();
         for (String key : properties.keySet()) {
-            assertThat(properties.get(key)).isEqualTo(getProperties.get(key));
+            assertThat(properties).containsEntry(key, getProperties.get(key));
         }
     }
 
@@ -172,7 +172,7 @@ class SessionRelatedITCase extends RestAPIITCaseBase {
                         sessionMessageParameters,
                         emptyRequestBody);
         future.get();
-        assertThat(session.getLastAccessTime() > lastAccessTime).isTrue();
+        assertThat(session.getLastAccessTime()).isGreaterThan(lastAccessTime);
     }
 
     @Test

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/SqlGatewayRestEndpointStatementITCase.java
@@ -109,12 +109,12 @@ public class SqlGatewayRestEndpointStatementITCase extends AbstractSqlGatewaySta
     private SessionHandle sessionHandle;
 
     @BeforeAll
-    public static void setup() throws Exception {
+    static void setup() throws Exception {
         restClient = getTestingRestClient();
     }
 
     @AfterAll
-    public static void cleanUp() throws Exception {
+    static void cleanUp() throws Exception {
         restClient.shutdown();
     }
 

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/StatementRelatedITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/rest/StatementRelatedITCase.java
@@ -31,9 +31,7 @@ import org.apache.flink.table.gateway.rest.message.statement.CompleteStatementRe
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
-import java.nio.file.Path;
 import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -44,14 +42,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Test basic logic of handlers inherited from {@link AbstractSqlGatewayRestHandler} in statement
  * related cases.
  */
-public class StatementRelatedITCase extends RestAPIITCaseBase {
+class StatementRelatedITCase extends RestAPIITCaseBase {
 
     private SessionHandle sessionHandle;
     private SessionMessageParameters sessionMessageParameters;
-    private @TempDir Path tempDir;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         CompletableFuture<OpenSessionResponseBody> response =
                 sendRequest(
                         OpenSessionHeaders.getInstance(),
@@ -64,7 +61,7 @@ public class StatementRelatedITCase extends RestAPIITCaseBase {
     }
 
     @Test
-    public void testCompleteStatement() throws Exception {
+    void testCompleteStatement() throws Exception {
         CompletableFuture<CompleteStatementResponseBody> completeStatementResponse =
                 sendRequest(
                         CompleteStatementHeaders.getInstance(),

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceITCase.java
@@ -148,13 +148,13 @@ public class SqlGatewayServiceITCase {
                     "SqlGatewayService Test Pool", IgnoreExceptionHandler.INSTANCE);
 
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
         sessionManager = (SessionManagerImpl) SQL_GATEWAY_SERVICE_EXTENSION.getSessionManager();
         service = (SqlGatewayServiceImpl) SQL_GATEWAY_SERVICE_EXTENSION.getService();
     }
 
     @Test
-    public void testOpenSessionWithConfig() {
+    void testOpenSessionWithConfig() {
         Map<String, String> options = new HashMap<>();
         options.put("key1", "val1");
         options.put("key2", "val2");
@@ -171,7 +171,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testOpenSessionWithEnvironment() throws Exception {
+    void testOpenSessionWithEnvironment() {
         String catalogName = "default";
         String databaseName = "testDb";
         String moduleName = "testModule";
@@ -196,7 +196,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testConfigureSessionWithLegalStatement(@TempDir java.nio.file.Path tmpDir)
+    void testConfigureSessionWithLegalStatement(@TempDir java.nio.file.Path tmpDir)
             throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
@@ -273,7 +273,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testFetchResultsInRunning() throws Exception {
+    void testFetchResultsInRunning() throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
         CountDownLatch startRunningLatch = new CountDownLatch(1);
@@ -293,7 +293,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testGetOperationFinishedAndFetchResults() throws Exception {
+    void testGetOperationFinishedAndFetchResults() throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
         CountDownLatch startRunningLatch = new CountDownLatch(1);
@@ -323,7 +323,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testCancelOperation() throws Exception {
+    void testCancelOperation() throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
         CountDownLatch startRunningLatch = new CountDownLatch(1);
@@ -350,7 +350,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testOperationGetErrorAndFetchError() throws Exception {
+    void testOperationGetErrorAndFetchError() throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
         CountDownLatch startRunningLatch = new CountDownLatch(1);
@@ -381,7 +381,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testExecuteSqlWithConfig() {
+    void testExecuteSqlWithConfig() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         String key = "username";
         String value = "Flink";
@@ -402,7 +402,7 @@ public class SqlGatewayServiceITCase {
 
     @ParameterizedTest
     @CsvSource({"WITH SAVEPOINT,true", "WITH SAVEPOINT WITH DRAIN,true", "'',false"})
-    public void testStopJobStatementWithSavepoint(
+    void testStopJobStatementWithSavepoint(
             String option,
             boolean hasSavepoint,
             @InjectClusterClient RestClusterClient<?> restClusterClient,
@@ -444,19 +444,19 @@ public class SqlGatewayServiceITCase {
             Path savepointPath = Paths.get(savepoint);
             assertThat(savepointPath.getFileName().toString()).startsWith("savepoint-");
         } else {
-            assertThat(stopResults.get(0).getString(0).toString()).isEqualTo("OK");
+            assertThat(stopResults.get(0).getString(0)).hasToString("OK");
         }
     }
 
     @Test
-    public void testGetOperationSchemaUntilOperationIsReady() throws Exception {
+    void testGetOperationSchemaUntilOperationIsReady() throws Exception {
         runGetOperationSchemaUntilOperationIsReadyOrError(
                 this::getDefaultResultSet,
                 task -> assertThat(task.get()).isEqualTo(getDefaultResultSet().getResultSchema()));
     }
 
     @Test
-    public void testShowJobsOperation(@InjectClusterClient RestClusterClient<?> restClusterClient)
+    void testShowJobsOperation(@InjectClusterClient RestClusterClient<?> restClusterClient)
             throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         Configuration configuration = new Configuration(MINI_CLUSTER.getClientConfiguration());
@@ -496,8 +496,8 @@ public class SqlGatewayServiceITCase {
                                 () ->
                                         new IllegalStateException(
                                                 "Test job " + jobId + " not found."));
-        assertThat(jobRow.getString(1).toString()).isEqualTo(pipelineName);
-        assertThat(jobRow.getString(2).toString()).isEqualTo("RUNNING");
+        assertThat(jobRow.getString(1)).hasToString(pipelineName);
+        assertThat(jobRow.getString(2)).hasToString("RUNNING");
         assertThat(jobRow.getTimestamp(3, 3).getMillisecond())
                 .isBetween(timeOpStart, timeOpSucceed);
     }
@@ -507,7 +507,7 @@ public class SqlGatewayServiceITCase {
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testGetCurrentCatalog() {
+    void testGetCurrentCatalog() {
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
@@ -520,7 +520,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testListCatalogs() {
+    void testListCatalogs() {
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
@@ -532,7 +532,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testListDatabases() throws Exception {
+    void testListDatabases() throws Exception {
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
@@ -552,7 +552,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testListTables() {
+    void testListTables() {
         SessionHandle sessionHandle = createInitializedSession(service);
         assertThat(
                         service.listTables(
@@ -560,43 +560,30 @@ public class SqlGatewayServiceITCase {
                                 "cat1",
                                 "db1",
                                 new HashSet<>(Arrays.asList(TableKind.TABLE, TableKind.VIEW))))
-                .isEqualTo(
-                        new HashSet<>(
-                                Arrays.asList(
-                                        new TableInfo(
-                                                ObjectIdentifier.of("cat1", "db1", "tbl1"),
-                                                TableKind.TABLE),
-                                        new TableInfo(
-                                                ObjectIdentifier.of("cat1", "db1", "tbl2"),
-                                                TableKind.TABLE),
-                                        new TableInfo(
-                                                ObjectIdentifier.of("cat1", "db1", "tbl3"),
-                                                TableKind.VIEW),
-                                        new TableInfo(
-                                                ObjectIdentifier.of("cat1", "db1", "tbl4"),
-                                                TableKind.VIEW))));
+                .containsExactlyInAnyOrder(
+                        new TableInfo(ObjectIdentifier.of("cat1", "db1", "tbl1"), TableKind.TABLE),
+                        new TableInfo(ObjectIdentifier.of("cat1", "db1", "tbl2"), TableKind.TABLE),
+                        new TableInfo(ObjectIdentifier.of("cat1", "db1", "tbl3"), TableKind.VIEW),
+                        new TableInfo(ObjectIdentifier.of("cat1", "db1", "tbl4"), TableKind.VIEW));
         assertThat(
                         service.listTables(
                                 sessionHandle,
                                 "cat1",
                                 "db2",
                                 Collections.singleton(TableKind.TABLE)))
-                .isEqualTo(
-                        Collections.singleton(
-                                new TableInfo(
-                                        ObjectIdentifier.of("cat1", "db2", "tbl1"),
-                                        TableKind.TABLE)));
+                .containsExactly(
+                        new TableInfo(ObjectIdentifier.of("cat1", "db2", "tbl1"), TableKind.TABLE));
         assertThat(
                         service.listTables(
                                 sessionHandle,
                                 "cat2",
                                 "db0",
                                 Collections.singleton(TableKind.VIEW)))
-                .isEqualTo(Collections.emptySet());
+                .isEmpty();
     }
 
     @Test
-    public void testListSystemFunctions() {
+    void testListSystemFunctions() {
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
@@ -613,7 +600,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testListUserDefinedFunctions() {
+    void testListUserDefinedFunctions() {
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
@@ -650,7 +637,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testCompleteStatement() throws Exception {
+    void testCompleteStatement() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
         String createTable1 =
@@ -696,7 +683,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testGetTable() {
+    void testGetTable() {
         SessionHandle sessionHandle = createInitializedSession(service);
         ResolvedCatalogTable actualTable =
                 (ResolvedCatalogTable)
@@ -716,7 +703,7 @@ public class SqlGatewayServiceITCase {
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testCancelOperationAndFetchResultInParallel() {
+    void testCancelOperationAndFetchResultInParallel() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         CountDownLatch latch = new CountDownLatch(1);
         // Make sure cancel the Operation before finish.
@@ -736,7 +723,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testCloseOperationAndFetchResultInParallel() {
+    void testCloseOperationAndFetchResultInParallel() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         OperationHandle operationHandle =
                 submitDefaultOperation(
@@ -765,7 +752,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testCancelAndCloseOperationInParallel() throws Exception {
+    void testCancelAndCloseOperationInParallel() throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         int operationNum = 200;
         List<OperationManager.Operation> operations = new ArrayList<>(operationNum);
@@ -807,7 +794,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testSubmitOperationAndCloseOperationManagerInParallel1() throws Exception {
+    void testSubmitOperationAndCloseOperationManagerInParallel1() throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         OperationManager manager = service.getSession(sessionHandle).getOperationManager();
         int submitThreadsNum = 100;
@@ -830,7 +817,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testSubmitOperationAndCloseOperationManagerInParallel2() throws Exception {
+    void testSubmitOperationAndCloseOperationManagerInParallel2() throws Exception {
         int count = 3;
         CountDownLatch startRunning = new CountDownLatch(1);
         CountDownLatch terminateRunning = new CountDownLatch(1);
@@ -854,7 +841,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testExecuteOperationInSequence() throws Exception {
+    void testExecuteOperationInSequence() throws Exception {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
         AtomicReference<Integer> v = new AtomicReference<>(0);
 
@@ -881,7 +868,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testReleaseLockWhenFailedToSubmitOperation() throws Exception {
+    void testReleaseLockWhenFailedToSubmitOperation() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         int maximumThreads = 500;
         List<SessionHandle> sessions = new ArrayList<>();
@@ -945,7 +932,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testFetchResultsFromCanceledOperation() {
+    void testFetchResultsFromCanceledOperation() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
         CountDownLatch latch = new CountDownLatch(1);
@@ -962,7 +949,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testRequestNonExistOperation() {
+    void testRequestNonExistOperation() {
         SessionHandle sessionHandle = service.openSession(defaultSessionEnvironment);
 
         OperationHandle operationHandle = OperationHandle.create();
@@ -983,7 +970,7 @@ public class SqlGatewayServiceITCase {
     }
 
     @Test
-    public void testGetOperationSchemaWhenOperationGetError() throws Exception {
+    void testGetOperationSchemaWhenOperationGetError() throws Exception {
         String msg = "Artificial Exception.";
         runGetOperationSchemaUntilOperationIsReadyOrError(
                 () -> {

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceStatementITCase.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/SqlGatewayServiceStatementITCase.java
@@ -151,7 +151,7 @@ public class SqlGatewayServiceStatementITCase extends AbstractSqlGatewayStatemen
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testIsQueryResult() throws Exception {
+    void testIsQueryResult() throws Exception {
         SessionHandle sessionHandle = createInitializedSession(service);
 
         BiFunction<SessionHandle, OperationHandle, Boolean> isQueryResultGetter =
@@ -178,7 +178,7 @@ public class SqlGatewayServiceStatementITCase extends AbstractSqlGatewayStatemen
     }
 
     @Test
-    public void testHasJobID() throws Exception {
+    void testHasJobID() throws Exception {
         SessionHandle sessionHandle = createInitializedSession(service);
 
         BiFunction<SessionHandle, OperationHandle, Boolean> hasJobIDGetter =
@@ -204,7 +204,7 @@ public class SqlGatewayServiceStatementITCase extends AbstractSqlGatewayStatemen
     }
 
     @Test
-    public void testResultKind() throws Exception {
+    void testResultKind() throws Exception {
         SessionHandle sessionHandle = createInitializedSession(service);
 
         BiFunction<SessionHandle, OperationHandle, ResultKind> resultKindGetter =

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/context/SessionContextTest.java
@@ -48,22 +48,22 @@ class SessionContextTest {
     private SessionContext sessionContext;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         sessionContext = createSessionContext();
     }
 
     @AfterEach
-    public void cleanUp() {
+    void cleanUp() {
         sessionContext.close();
     }
 
     @AfterAll
-    public static void closeResources() {
+    static void closeResources() {
         EXECUTOR_SERVICE.shutdown();
     }
 
     @Test
-    public void testSetAndResetOption() {
+    void testSetAndResetOption() {
         // table config option
         sessionContext.set(TABLE_SQL_DIALECT.key(), "hive");
         // runtime config option
@@ -88,7 +88,7 @@ class SessionContextTest {
     }
 
     @Test
-    public void testSetAndResetKeyInConfigOptions() {
+    void testSetAndResetKeyInConfigOptions() {
         // table config option
         sessionContext.set(TABLE_SQL_DIALECT.key(), "hive");
         // runtime config option
@@ -117,7 +117,7 @@ class SessionContextTest {
     }
 
     @Test
-    public void testSetAndResetArbitraryKey() {
+    void testSetAndResetArbitraryKey() {
         // other property not in flink-conf
         sessionContext.set("aa", "11");
         sessionContext.set("bb", "22");

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/result/ResultFetcherTest.java
@@ -33,7 +33,6 @@ import org.apache.flink.table.gateway.service.utils.IgnoreExceptionHandler;
 import org.apache.flink.table.gateway.service.utils.SqlExecutionException;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
-import org.apache.flink.util.TestLogger;
 import org.apache.flink.util.concurrent.ExecutorThreadFactory;
 
 import org.apache.commons.collections.iterators.IteratorChain;
@@ -64,7 +63,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /** Test for {@link ResultFetcher}. */
-public class ResultFetcherTest extends TestLogger {
+class ResultFetcherTest {
 
     private static ResolvedSchema schema;
     private static List<RowData> data;
@@ -73,7 +72,7 @@ public class ResultFetcherTest extends TestLogger {
             new ExecutorThreadFactory("Result Fetcher Test Pool", IgnoreExceptionHandler.INSTANCE);
 
     @BeforeAll
-    public static void setUp() {
+    static void setUp() {
         schema =
                 ResolvedSchema.of(
                         Column.physical("boolean", DataTypes.BOOLEAN()),
@@ -161,7 +160,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultsMultipleTimesWithLimitedBufferSize() {
+    void testFetchResultsMultipleTimesWithLimitedBufferSize() {
         int bufferSize = data.size() / 2;
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), bufferSize);
@@ -172,7 +171,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultsMultipleTimesWithLimitedFetchSize() {
+    void testFetchResultsMultipleTimesWithLimitedFetchSize() {
         int bufferSize = data.size();
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), bufferSize);
@@ -183,7 +182,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultsInWithLimitedBufferSizeInOrientation() {
+    void testFetchResultsInWithLimitedBufferSizeInOrientation() {
         int bufferSize = data.size() / 2;
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), bufferSize);
@@ -196,7 +195,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultsMultipleTimesWithLimitedFetchSizeInOrientation() {
+    void testFetchResultsMultipleTimesWithLimitedFetchSizeInOrientation() {
         int bufferSize = data.size();
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), bufferSize);
@@ -209,7 +208,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultInParallel() throws Exception {
+    void testFetchResultInParallel() throws Exception {
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), data.size() / 2);
         CommonTestUtils.waitUtil(
@@ -220,7 +219,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultInOrientationInParallel() throws Exception {
+    void testFetchResultInOrientationInParallel() throws Exception {
         List<Iterator<RowData>> dataSuppliers =
                 data.stream()
                         .map(
@@ -268,13 +267,13 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultFromDummyStoreInParallel() throws Exception {
+    void testFetchResultFromDummyStoreInParallel() throws Exception {
         checkFetchResultInParallel(
                 ResultFetcher.fromResults(OperationHandle.create(), schema, data));
     }
 
     @Test
-    public void testFetchResultAfterClose() throws Exception {
+    void testFetchResultAfterClose() throws Exception {
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), data.size() + 1);
         List<RowData> actual = Collections.emptyList();
@@ -315,7 +314,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchResultWithToken() {
+    void testFetchResultWithToken() {
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), data.size());
         Long nextToken = 0L;
@@ -347,7 +346,7 @@ public class ResultFetcherTest extends TestLogger {
     // --------------------------------------------------------------------------------------------
 
     @Test
-    public void testFetchFailedResult() {
+    void testFetchFailedResult() {
         String message = "Artificial Exception";
         ResultFetcher fetcher =
                 buildResultFetcher(
@@ -368,7 +367,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchIllegalToken() {
+    void testFetchIllegalToken() {
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), data.size());
         assertThatThrownBy(() -> fetcher.fetchResults(2, Integer.MAX_VALUE))
@@ -376,7 +375,7 @@ public class ResultFetcherTest extends TestLogger {
     }
 
     @Test
-    public void testFetchBeforeWithDifferentSize() throws Exception {
+    void testFetchBeforeWithDifferentSize() throws Exception {
         ResultFetcher fetcher =
                 buildResultFetcher(Collections.singletonList(data.iterator()), data.size() / 2);
         CommonTestUtils.waitUtil(

--- a/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/session/SessionManagerImplTest.java
+++ b/flink-table/flink-sql-gateway/src/test/java/org/apache/flink/table/gateway/service/session/SessionManagerImplTest.java
@@ -26,7 +26,6 @@ import org.apache.flink.table.gateway.api.session.SessionHandle;
 import org.apache.flink.table.gateway.api.utils.MockedEndpointVersion;
 import org.apache.flink.table.gateway.api.utils.SqlGatewayException;
 import org.apache.flink.table.gateway.service.context.DefaultContext;
-import org.apache.flink.util.TestLogger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,12 +39,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /** Test for {@link SessionManagerImpl}. */
-public class SessionManagerImplTest extends TestLogger {
+class SessionManagerImplTest {
 
     private SessionManagerImpl sessionManager;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         Configuration conf = new Configuration();
         conf.set(
                 SqlGatewayServiceConfigOptions.SQL_GATEWAY_SESSION_IDLE_TIMEOUT,
@@ -59,14 +58,14 @@ public class SessionManagerImplTest extends TestLogger {
     }
 
     @AfterEach
-    public void cleanUp() {
+    void cleanUp() {
         if (sessionManager != null) {
             sessionManager.stop();
         }
     }
 
     @Test
-    public void testIdleSessionCleanup() throws Exception {
+    void testIdleSessionCleanup() throws Exception {
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)
@@ -87,7 +86,7 @@ public class SessionManagerImplTest extends TestLogger {
     }
 
     @Test
-    public void testSessionNumberLimit() {
+    void testSessionNumberLimit() {
         SessionEnvironment environment =
                 SessionEnvironment.newBuilder()
                         .setSessionEndpointVersion(MockedEndpointVersion.V1)

--- a/flink-table/flink-sql-gateway/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/flink-table/flink-sql-gateway/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.util.TestLoggerExtension


### PR DESCRIPTION
## What is the purpose of the change

The PR hardens modifiers for junit5 tests

as a follow up for https://github.com/apache/flink/pull/22127#discussion_r1129192778

## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive):  (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no )
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable )
