### PR TITLE
[FLINK-31234][kubernetes] Add an option to redirect stdout to log dir.

### DIFF
--- a/docs/layouts/shortcodes/generated/environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/environment_configuration.html
@@ -75,6 +75,12 @@
             <td>Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).</td>
         </tr>
         <tr>
+            <td><h5>env.std.redirect</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>Whether redirect stdout and stderr to files when running foreground. If enabled, logs won't append the console too. Note that redirected files do not support rolling rotate.</td>
+        </tr>
+        <tr>
             <td><h5>env.yarn.conf.dir</h5></td>
             <td style="word-wrap: break-word;">(none)</td>
             <td>String</td>

--- a/docs/layouts/shortcodes/generated/environment_configuration.html
+++ b/docs/layouts/shortcodes/generated/environment_configuration.html
@@ -75,7 +75,7 @@
             <td>Additional command line options passed to SSH clients when starting or stopping JobManager, TaskManager, and Zookeeper services (start-cluster.sh, stop-cluster.sh, start-zookeeper-quorum.sh, stop-zookeeper-quorum.sh).</td>
         </tr>
         <tr>
-            <td><h5>env.std.redirect</h5></td>
+            <td><h5>env.stdout-err.redirect-to-file</h5></td>
             <td style="word-wrap: break-word;">false</td>
             <td>Boolean</td>
             <td>Whether redirect stdout and stderr to files when running foreground. If enabled, logs won't append the console too. Note that redirected files do not support rolling rotate.</td>

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -308,6 +308,20 @@ public class CoreOptions {
                     .withDescription("The maximum number of old log files to keep.");
 
     /**
+     * This option is here only for documentation generation, it is only evaluated in the shell
+     * scripts.
+     */
+    @SuppressWarnings("unused")
+    public static final ConfigOption<Boolean> FLINK_STD_REDIRECT =
+            ConfigOptions.key("env.std.redirect")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Whether redirect stdout and stderr to files when running foreground. "
+                                    + "If enabled, logs won't append the console too. "
+                                    + "Note that redirected files do not support rolling rotate.");
+
+    /**
      * This options is here only for documentation generation, it is only evaluated in the shell
      * scripts.
      */

--- a/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
+++ b/flink-core/src/main/java/org/apache/flink/configuration/CoreOptions.java
@@ -312,8 +312,8 @@ public class CoreOptions {
      * scripts.
      */
     @SuppressWarnings("unused")
-    public static final ConfigOption<Boolean> FLINK_STD_REDIRECT =
-            ConfigOptions.key("env.std.redirect")
+    public static final ConfigOption<Boolean> FLINK_STD_REDIRECT_TO_FILE =
+            ConfigOptions.key("env.stdout-err.redirect-to-file")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription(

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -172,7 +172,7 @@ KEY_TASKM_COMPUTE_NUMA="taskmanager.compute.numa"
 KEY_ENV_PID_DIR="env.pid.dir"
 KEY_ENV_LOG_DIR="env.log.dir"
 KEY_ENV_LOG_MAX="env.log.max"
-KEY_ENV_STD_REDIRECT="env.std.redirect"
+KEY_ENV_STD_REDIRECT_TO_FILE="env.stdout-err.redirect-to-file"
 KEY_ENV_YARN_CONF_DIR="env.yarn.conf.dir"
 KEY_ENV_HADOOP_CONF_DIR="env.hadoop.conf.dir"
 KEY_ENV_HBASE_CONF_DIR="env.hbase.conf.dir"
@@ -292,8 +292,8 @@ if [ -z "${MAX_LOG_FILE_NUMBER}" ]; then
     export MAX_LOG_FILE_NUMBER
 fi
 
-if [ -z "${STD_REDIRECT}" ]; then
-    STD_REDIRECT=$(readFromConfig ${KEY_ENV_STD_REDIRECT} "false" "${YAML_CONF}")
+if [ -z "${STD_REDIRECT_TO_FILE}" ]; then
+    STD_REDIRECT_TO_FILE=$(readFromConfig ${KEY_ENV_STD_REDIRECT_TO_FILE} "false" "${YAML_CONF}")
 fi
 
 if [ -z "${FLINK_LOG_DIR}" ]; then

--- a/flink-dist/src/main/flink-bin/bin/config.sh
+++ b/flink-dist/src/main/flink-bin/bin/config.sh
@@ -172,6 +172,7 @@ KEY_TASKM_COMPUTE_NUMA="taskmanager.compute.numa"
 KEY_ENV_PID_DIR="env.pid.dir"
 KEY_ENV_LOG_DIR="env.log.dir"
 KEY_ENV_LOG_MAX="env.log.max"
+KEY_ENV_STD_REDIRECT="env.std.redirect"
 KEY_ENV_YARN_CONF_DIR="env.yarn.conf.dir"
 KEY_ENV_HADOOP_CONF_DIR="env.hadoop.conf.dir"
 KEY_ENV_HBASE_CONF_DIR="env.hbase.conf.dir"
@@ -289,6 +290,10 @@ fi
 if [ -z "${MAX_LOG_FILE_NUMBER}" ]; then
     MAX_LOG_FILE_NUMBER=$(readFromConfig ${KEY_ENV_LOG_MAX} ${DEFAULT_ENV_LOG_MAX} "${YAML_CONF}")
     export MAX_LOG_FILE_NUMBER
+fi
+
+if [ -z "${STD_REDIRECT}" ]; then
+    STD_REDIRECT=$(readFromConfig ${KEY_ENV_STD_REDIRECT} "false" "${YAML_CONF}")
 fi
 
 if [ -z "${FLINK_LOG_DIR}" ]; then

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -102,6 +102,8 @@ id=$([ -f "$pid" ] && echo $(wc -l < "$pid") || echo "0")
 
 FLINK_LOG_PREFIX="${FLINK_LOG_DIR}/flink-${FLINK_IDENT_STRING}-${SERVICE}-${id}-${HOSTNAME}"
 log="${FLINK_LOG_PREFIX}.log"
+out="${FLINK_LOG_PREFIX}.out"
+err="${FLINK_LOG_PREFIX}.err"
 
 log_setting=("-Dlog.file=${log}" "-Dlog4j.configuration=file:${FLINK_CONF_DIR}/log4j-console.properties" "-Dlog4j.configurationFile=file:${FLINK_CONF_DIR}/log4j-console.properties" "-Dlogback.configurationFile=file:${FLINK_CONF_DIR}/logback-console.xml")
 
@@ -115,5 +117,12 @@ echo $$ >> "$pid" 2>/dev/null
 
 # Evaluate user options for local variable expansion
 FLINK_ENV_JAVA_OPTS=$(eval echo ${FLINK_ENV_JAVA_OPTS})
+
+if [ "${STD_REDIRECT}" == "true" ]; then
+  # disable console appender to avoid redundant logs in log file and out file
+  log_setting=("-Dconsole.log.level=OFF" "${log_setting[@]}")
+  exec 1>"${out}"
+  exec 2>"${err}"
+fi
 
 exec "$JAVA_RUN" $JVM_ARGS ${FLINK_ENV_JAVA_OPTS} "${log_setting[@]}" -classpath "`manglePathList "$FLINK_TM_CLASSPATH:$SQL_GATEWAY_CLASSPATH:$INTERNAL_HADOOP_CLASSPATHS"`" ${CLASS_TO_RUN} "${ARGS[@]}"

--- a/flink-dist/src/main/flink-bin/bin/flink-console.sh
+++ b/flink-dist/src/main/flink-bin/bin/flink-console.sh
@@ -118,8 +118,8 @@ echo $$ >> "$pid" 2>/dev/null
 # Evaluate user options for local variable expansion
 FLINK_ENV_JAVA_OPTS=$(eval echo ${FLINK_ENV_JAVA_OPTS})
 
-if [ "${STD_REDIRECT}" == "true" ]; then
-  # disable console appender to avoid redundant logs in log file and out file
+if [ "${STD_REDIRECT_TO_FILE}" == "true" ]; then
+  # disable console appender to avoid redundant logs in out file
   log_setting=("-Dconsole.log.level=OFF" "${log_setting[@]}")
   exec 1>"${out}"
   exec 2>"${err}"

--- a/flink-dist/src/main/flink-bin/conf/log4j-console.properties
+++ b/flink-dist/src/main/flink-bin/conf/log4j-console.properties
@@ -47,6 +47,8 @@ appender.console.name = ConsoleAppender
 appender.console.type = CONSOLE
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS} %-5p %-60c %x - %m%n
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = ${sys:console.log.level:-ALL}
 
 # Log all infos in the given rolling file
 appender.rolling.name = RollingFileAppender

--- a/flink-dist/src/main/flink-bin/conf/logback-console.xml
+++ b/flink-dist/src/main/flink-bin/conf/logback-console.xml
@@ -21,6 +21,9 @@
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{60} %X{sourceThread} - %msg%n</pattern>
         </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>${console.log.level:-ALL}</level>
+        </filter>
     </appender>
 
     <appender name="rolling" class="ch.qos.logback.core.rolling.RollingFileAppender">


### PR DESCRIPTION
## What is the purpose of the change

Add an option for redirecting stdout/stderr to files. When this is enabled.
1. flink-console.sh will redirect stdout/err to file.
2. flink-console.sh use log4j.properties as log4j configuration to avoid logs both in log file and stdout file.
Of course, this option is false by default.


## Brief change log
  - *introduce new option kubernetes.flink.std.redirect.enabled, default is false*
  - *when enabled, use log4j.properties/logback.xml as log configuration to avoid output log duplicated*
  - *when enabled, redirect stdout/stderr to log directory so that user can view these in Flink's web ui*


## Verifying this change
  - *Added unit tests for FlinkConfMountDecoratorTest.java*
  - *Manually verified the change with kubernetes.flink.std.redirect.enabled is true or false.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
