### PR TITLE
[FLINK-31383] Add support for documenting additionProperties of the R…

### DIFF
--- a/docs/static/generated/rest_v1_dispatcher.yml
+++ b/docs/static/generated/rest_v1_dispatcher.yml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v1/1.17-SNAPSHOT
+  version: v1/1.18-SNAPSHOT
 paths:
   /cluster:
     delete:

--- a/docs/static/generated/rest_v1_sql_gateway.yml
+++ b/docs/static/generated/rest_v1_sql_gateway.yml
@@ -6,7 +6,7 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: v1/1.17-SNAPSHOT
+  version: v1/1.18-SNAPSHOT
 paths:
   /api_versions:
     get:

--- a/flink-annotations/src/main/java/org/apache/flink/annotation/docs/FlinkJsonSchema.java
+++ b/flink-annotations/src/main/java/org/apache/flink/annotation/docs/FlinkJsonSchema.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.annotation.docs;
+
+import org.apache.flink.annotation.Internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** Annotations for auto-generating a documentation of json payloads. */
+@Internal
+public class FlinkJsonSchema {
+
+    private FlinkJsonSchema() {}
+
+    /**
+     * This allows documenting a class that supports setting dynamic properties of a certain type.
+     */
+    @Target(ElementType.TYPE)
+    @Retention(RetentionPolicy.RUNTIME)
+    @Internal
+    public @interface AdditionalFields {
+
+        /**
+         * An actual type the additional fields need to match.
+         *
+         * @return type of the additional fields
+         */
+        Class<?> type();
+    }
+}

--- a/flink-docs/src/main/java/org/apache/flink/docs/rest/ApiSpecGeneratorUtils.java
+++ b/flink-docs/src/main/java/org/apache/flink/docs/rest/ApiSpecGeneratorUtils.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest;
+
+import org.apache.flink.annotation.docs.Documentation;
+import org.apache.flink.annotation.docs.FlinkJsonSchema;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.MessageParameters;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.ResponseBody;
+
+import java.util.Optional;
+
+/** Helper methods for generation API documentation. */
+public class ApiSpecGeneratorUtils {
+
+    private ApiSpecGeneratorUtils() {}
+
+    /**
+     * Checks whether the given endpoint should be documented.
+     *
+     * @param spec endpoint to check
+     * @return true if the endpoint should be documented
+     */
+    public static boolean shouldBeDocumented(
+            MessageHeaders<
+                            ? extends RequestBody,
+                            ? extends ResponseBody,
+                            ? extends MessageParameters>
+                    spec) {
+        return spec.getClass().getAnnotation(Documentation.ExcludeFromDocumentation.class) == null;
+    }
+
+    /**
+     * Find whether the class contains dynamic fields that need to be documented.
+     *
+     * @param clazz class to check
+     * @return optional that is non-empty if the class is annotated with {@link
+     *     FlinkJsonSchema.AdditionalFields}
+     */
+    public static Optional<Class<?>> findAdditionalFieldType(Class<?> clazz) {
+        final FlinkJsonSchema.AdditionalFields annotation =
+                clazz.getAnnotation(FlinkJsonSchema.AdditionalFields.class);
+        return Optional.ofNullable(annotation).map(FlinkJsonSchema.AdditionalFields::type);
+    }
+}

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/RestAPIDocGeneratorTest.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/RestAPIDocGeneratorTest.java
@@ -18,10 +18,12 @@
 
 package org.apache.flink.docs.rest;
 
+import org.apache.flink.annotation.docs.FlinkJsonSchema;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.apache.flink.docs.rest.data.TestEmptyMessageHeaders;
 import org.apache.flink.docs.rest.data.TestExcludeMessageHeaders;
 import org.apache.flink.runtime.rest.handler.RestHandlerSpecification;
+import org.apache.flink.runtime.rest.messages.EmptyRequestBody;
 import org.apache.flink.runtime.rest.util.DocumentingRestEndpoint;
 import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
 import org.apache.flink.util.FileUtils;
@@ -60,6 +62,22 @@ class RestAPIDocGeneratorTest {
                         "This REST API should also not appear in the generated documentation.");
     }
 
+    @Test
+    void testAdditionalFields() {
+        final String messageHtmlEntry =
+                RestAPIDocGenerator.createMessageHtmlEntry(
+                        TestAdditionalFields.class, null, EmptyRequestBody.class);
+        assertThat(messageHtmlEntry)
+                .isEqualTo(
+                        "{\n"
+                                + "  \"type\" : \"object\",\n"
+                                + "  \"id\" : \"urn:jsonschema:org:apache:flink:docs:rest:RestAPIDocGeneratorTest:TestAdditionalFields\",\n"
+                                + "  \"additionalProperties\" : {\n"
+                                + "    \"type\" : \"string\"\n"
+                                + "  }\n"
+                                + "}");
+    }
+
     private static class TestExcludeDocumentingRestEndpoint implements DocumentingRestEndpoint {
 
         @Override
@@ -86,4 +104,7 @@ class RestAPIDocGeneratorTest {
                             null));
         }
     }
+
+    @FlinkJsonSchema.AdditionalFields(type = String.class)
+    private static class TestAdditionalFields {}
 }

--- a/flink-docs/src/test/java/org/apache/flink/docs/rest/data/TestAdditionalFieldsMessageHeaders.java
+++ b/flink-docs/src/test/java/org/apache/flink/docs/rest/data/TestAdditionalFieldsMessageHeaders.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.docs.rest.data;
+
+import org.apache.flink.annotation.docs.FlinkJsonSchema;
+import org.apache.flink.runtime.rest.HttpMethodWrapper;
+import org.apache.flink.runtime.rest.messages.EmptyMessageParameters;
+import org.apache.flink.runtime.rest.messages.EmptyResponseBody;
+import org.apache.flink.runtime.rest.messages.MessageHeaders;
+import org.apache.flink.runtime.rest.messages.RequestBody;
+import org.apache.flink.runtime.rest.messages.RuntimeMessageHeaders;
+import org.apache.flink.runtime.rest.versioning.RuntimeRestAPIVersion;
+
+import org.apache.flink.shaded.netty4.io.netty.handler.codec.http.HttpResponseStatus;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * A {@link MessageHeaders} for testing purpose. Its request body contains additional fields,
+ * response body and message parameters are empty.
+ */
+public class TestAdditionalFieldsMessageHeaders
+        implements RuntimeMessageHeaders<
+                TestAdditionalFieldsMessageHeaders.AdditionalFieldsRequestBody,
+                EmptyResponseBody,
+                EmptyMessageParameters> {
+
+    /** Testing request body. */
+    @FlinkJsonSchema.AdditionalFields(type = String.class)
+    public static class AdditionalFieldsRequestBody implements RequestBody {}
+
+    private static final String URL = "/test/additional-fields";
+    private static final String DESCRIPTION = "This is an testing REST API with additional fields.";
+
+    private final String url;
+    private final String description;
+    private final String operationId;
+
+    public TestAdditionalFieldsMessageHeaders(String operationId) {
+        this(URL, DESCRIPTION, operationId);
+    }
+
+    private TestAdditionalFieldsMessageHeaders(String url, String description, String operationId) {
+        this.url = url;
+        this.description = description;
+        this.operationId = operationId;
+    }
+
+    @Override
+    public Class<AdditionalFieldsRequestBody> getRequestClass() {
+        return AdditionalFieldsRequestBody.class;
+    }
+
+    @Override
+    public Class<EmptyResponseBody> getResponseClass() {
+        return EmptyResponseBody.class;
+    }
+
+    @Override
+    public HttpMethodWrapper getHttpMethod() {
+        return HttpMethodWrapper.PUT;
+    }
+
+    @Override
+    public HttpResponseStatus getResponseStatusCode() {
+        return HttpResponseStatus.OK;
+    }
+
+    @Override
+    public String operationId() {
+        return operationId;
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public EmptyMessageParameters getUnresolvedMessageParameters() {
+        return EmptyMessageParameters.getInstance();
+    }
+
+    @Override
+    public String getTargetRestEndpointURL() {
+        return url;
+    }
+
+    @Override
+    public Collection<RuntimeRestAPIVersion> getSupportedAPIVersions() {
+        return Collections.singleton(RuntimeRestAPIVersion.V0);
+    }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/FLINK-31383

For implementing the request and response body of the resource requirements endpoint, we need to be able to document "additionalProperties" because these payloads have only top-level dynamic properties of the same type.

An example of what we want to be able to document is:

```
@JsonAnySetter
@JsonAnyGetter
@JsonSerialize(keyUsing = JobVertexIDKeySerializer.class)
@JsonDeserialize(keyUsing = JobVertexIDKeyDeserializer.class)
private final Map<JobVertexID, JobVertexResourceRequirements> jobVertexResourceRequirements;
```

The PR doesn't affect any existing functionality and the new feature will be leveraged in a separate PR.