### PR TITLE
[FLINK-31387][streaming-java] Harden StreamTaskCancellationTest#testC…

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/tasks/StreamTaskCancellationTest.java
@@ -301,6 +301,13 @@ public class StreamTaskCancellationTest extends TestLogger {
                         }
                     });
             harness.processElement(new Watermark(Long.MAX_VALUE));
+
+            // We need to wait for the first timer being fired, otherwise this is prone to race
+            // condition because processing time timers are put into mailbox from a different
+            // thread.
+            while (processingTime && numKeyedTimersFired.get() == 0) {
+                harness.processAll();
+            }
         }
         Assertions.assertThat(numKeyedTimersFired).hasValue(numKeyedTimersToFire);
     }


### PR DESCRIPTION
…ancelTaskShouldPreventAdditionalProcessingTimeTimersFromBeingFired by waiting for the first timer to be fired.

https://issues.apache.org/jira/browse/FLINK-31387

This fixes a flaky test. I could reliably reproduce the failure locally, and it passed more than 10k runs after the fix.