### PR TITLE
[hotfix] Apply spotless for AbstractHaServicesTest

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/highavailability/AbstractHaServicesTest.java
@@ -69,10 +69,11 @@ class AbstractHaServicesTest {
 
         haServices.closeAndCleanupAllData();
 
-        assertThat(closeOperations).contains(
-                CloseOperations.HA_CLEANUP,
-                CloseOperations.HA_CLOSE,
-                CloseOperations.BLOB_CLEANUP_AND_CLOSE);
+        assertThat(closeOperations)
+                .contains(
+                        CloseOperations.HA_CLEANUP,
+                        CloseOperations.HA_CLOSE,
+                        CloseOperations.BLOB_CLEANUP_AND_CLOSE);
     }
 
     /**


### PR DESCRIPTION
After https://github.com/apache/flink/commit/593cc139ab30bb81ab38d94b7b697d00eaaecada there is an issue with spotless.
The PR is aiming to fix it

## What is the purpose of the change



## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): ( no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: ( no)
  - The serializers: ( no)
  - The runtime per-record code paths (performance sensitive): ( no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: ( no)
  - The S3 file system connector: ( no)

## Documentation

  - Does this pull request introduce a new feature? ( no)
  - If yes, how is the feature documented? (not applicable)
