### PR TITLE
[FLINK-31377][table] Fix array_contains ArrayData.ElementGetter shoul…

### DIFF
--- a/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsFunction.java
+++ b/flink-table/flink-table-runtime/src/main/java/org/apache/flink/table/runtime/functions/scalar/ArrayContainsFunction.java
@@ -25,6 +25,7 @@ import org.apache.flink.table.functions.BuiltInFunctionDefinitions;
 import org.apache.flink.table.functions.FunctionContext;
 import org.apache.flink.table.functions.SpecializedFunction.ExpressionEvaluator;
 import org.apache.flink.table.functions.SpecializedFunction.SpecializedContext;
+import org.apache.flink.table.types.CollectionDataType;
 import org.apache.flink.table.types.DataType;
 import org.apache.flink.util.FlinkRuntimeException;
 
@@ -44,14 +45,16 @@ public class ArrayContainsFunction extends BuiltInScalarFunction {
 
     public ArrayContainsFunction(SpecializedContext context) {
         super(BuiltInFunctionDefinitions.ARRAY_CONTAINS, context);
-        final DataType needleDataType = context.getCallContext().getArgumentDataTypes().get(1);
-        elementGetter = ArrayData.createElementGetter(needleDataType.getLogicalType());
+        final DataType elementDataType =
+                ((CollectionDataType) context.getCallContext().getArgumentDataTypes().get(0))
+                        .getElementDataType();
+        elementGetter = ArrayData.createElementGetter(elementDataType.getLogicalType());
         equalityEvaluator =
                 context.createEvaluator(
                         $("element").isEqual($("needle")),
                         DataTypes.BOOLEAN(),
-                        DataTypes.FIELD("element", needleDataType.notNull().toInternal()),
-                        DataTypes.FIELD("needle", needleDataType.notNull().toInternal()));
+                        DataTypes.FIELD("element", elementDataType.notNull().toInternal()),
+                        DataTypes.FIELD("needle", elementDataType.notNull().toInternal()));
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

*Fix array_contains ArrayData.ElementGetter should use element type instead of needle type.*

- needle and element type are identical. because " a NOT NULL type can be stored in NULL type but not vice versa." and after dig the code TypeInferenceOperandChecker.insertImplicitCasts, you can see here supportsAvoidingCast.

```
Stream<TestSetSpec> getTestSetSpecs() {
    return Stream.of(
            TestSetSpec.forFunction(BuiltInFunctionDefinitions.ARRAY_CONTAINS)
                    .onFieldsWithData(
                            new Map[] {
                                null,
                                CollectionUtil.map(entry(1, "a"), entry(2, "b")),
                                CollectionUtil.map(entry(3, "c"), entry(4, "d")),
                            },
                            null)
                    .andDataTypes(
                            DataTypes.ARRAY(DataTypes.MAP(DataTypes.INT(), DataTypes.STRING())),
                            DataTypes.STRING())
                    .testResult(
                            $("f0").arrayContains(
                                            CollectionUtil.map(entry(3, "c"), entry(4, "d"))),
                            "ARRAY_CONTAINS(f0, MAP[3, 'c', 4, 'd'])",
                            true,
                            DataTypes.BOOLEAN()));
}

```

## Verifying this change
- add unit test

## Does this pull request potentially affect one of the following parts
- Dependencies (does it add or upgrade a dependency): no
- The public API, i.e., is any changed class annotated with @Public(Evolving): yes
- The serializers: no
- The runtime per-record code paths (performance sensitive): no
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing
- Kubernetes/Yarn/Mesos, ZooKeeper: no
- The S3 file system connector: no

## Documentation
- Does this pull request introduce a new feature? yes
- If yes, how is the feature documented? docs / JavaDocs