### PR TITLE
[FLINK-31393][runtime] Fix the bug that HsFileDataManager use an incorrect default timeout.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 public class HybridShuffleConfiguration {
     private static final int DEFAULT_MAX_BUFFERS_READ_AHEAD = 5;
 
-    private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMillis(5);
+    private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMinutes(5);
 
     private static final float DEFAULT_SELECTIVE_STRATEGY_SPILL_THRESHOLD = 0.7f;
 


### PR DESCRIPTION
## What is the purpose of the change

*For batch shuffle(i.e. hybrid shuffle & sort-merge shuffle), If there is a fierce contention of the batch shuffle read memory, it will throw a `TimeoutException` to fail downstream task to release memory. But for hybrid shuffle, It uses an incorrect default timeout(5ms), this will make the job very easy to fail.*


## Brief change log

  - *Increase default read buffer request timeout to 5min.*


## Verifying this change


This change is already covered by existing tests.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
