### PR TITLE
[FLINK-31396][network] Replace the nano time by milliseconds as the timeout time for batch read buffer pool

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPool.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/disk/BatchShuffleReadBufferPool.java
@@ -82,7 +82,7 @@ public class BatchShuffleReadBufferPool {
 
     /** The timestamp when the last buffer is recycled or allocated. */
     @GuardedBy("buffers")
-    private long lastBufferOperationTimestamp = System.nanoTime();
+    private long lastBufferOperationTimestamp = System.currentTimeMillis();
 
     /** Whether this buffer pool has been destroyed or not. */
     @GuardedBy("buffers")
@@ -224,7 +224,7 @@ public class BatchShuffleReadBufferPool {
             while (allocated.size() < numBuffersPerRequest) {
                 allocated.add(buffers.poll());
             }
-            lastBufferOperationTimestamp = System.nanoTime();
+            lastBufferOperationTimestamp = System.currentTimeMillis();
         }
         return allocated;
     }
@@ -261,7 +261,7 @@ public class BatchShuffleReadBufferPool {
                     buffers.size() < numBuffersPerRequest
                             && buffers.size() + segments.size() >= numBuffersPerRequest;
             buffers.addAll(segments);
-            lastBufferOperationTimestamp = System.nanoTime();
+            lastBufferOperationTimestamp = System.currentTimeMillis();
             if (shouldNotify) {
                 buffers.notifyAll();
             }

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadScheduler.java
@@ -220,8 +220,8 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
             // only visibility requirements here.
             // noinspection FieldAccessNotGuarded
             checkState(!isReleased, "Result partition has been already released.");
-        } while (System.nanoTime() < timeoutTime
-                || System.nanoTime() < (timeoutTime = getBufferRequestTimeoutTime()));
+        } while (System.currentTimeMillis() < timeoutTime
+                || System.currentTimeMillis() < (timeoutTime = getBufferRequestTimeoutTime()));
 
         // This is a safe net against potential deadlocks.
         //
@@ -242,7 +242,7 @@ class SortMergeResultPartitionReadScheduler implements Runnable, BufferRecycler 
     }
 
     private long getBufferRequestTimeoutTime() {
-        return bufferPool.getLastBufferOperationTimestamp() + bufferRequestTimeout.toNanos();
+        return bufferPool.getLastBufferOperationTimestamp() + bufferRequestTimeout.toMillis();
     }
 
     private void releaseBuffers(Queue<MemorySegment> buffers) {

--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HsFileDataManager.java
@@ -257,8 +257,8 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
                 return new ArrayDeque<>(buffers);
             }
             checkState(!isReleased, "Result partition has been already released.");
-        } while (System.nanoTime() < timeoutTime
-                || System.nanoTime() < (timeoutTime = getBufferRequestTimeoutTime()));
+        } while (System.currentTimeMillis() < timeoutTime
+                || System.currentTimeMillis() < (timeoutTime = getBufferRequestTimeoutTime()));
 
         // This is a safe net against potential deadlocks.
         //
@@ -311,7 +311,7 @@ public class HsFileDataManager implements Runnable, BufferRecycler {
     }
 
     private long getBufferRequestTimeoutTime() {
-        return bufferPool.getLastBufferOperationTimestamp() + bufferRequestTimeout.toNanos();
+        return bufferPool.getLastBufferOperationTimestamp() + bufferRequestTimeout.toMillis();
     }
 
     private void releaseBuffers(Queue<MemorySegment> buffers) {

--- a/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/io/network/partition/SortMergeResultPartitionReadSchedulerTest.java
@@ -272,10 +272,10 @@ class SortMergeResultPartitionReadSchedulerTest {
         readScheduler.run();
 
         assertThat(bufferPool.getAvailableBuffers()).isZero();
-        long startTimestamp = System.nanoTime();
+        long startTimestamp = System.currentTimeMillis();
         assertThatThrownBy(readScheduler::allocateBuffers).isInstanceOf(TimeoutException.class);
-        long requestDuration = System.nanoTime() - startTimestamp;
-        assertThat(requestDuration > bufferRequestTimeout.toNanos()).isTrue();
+        long requestDuration = System.currentTimeMillis() - startTimestamp;
+        assertThat(requestDuration > bufferRequestTimeout.toMillis()).isTrue();
 
         readScheduler.release();
     }
@@ -289,15 +289,15 @@ class SortMergeResultPartitionReadSchedulerTest {
                 new SortMergeResultPartitionReadScheduler(
                         bufferPool, executor, this, bufferRequestTimeout);
 
-        long startTimestamp = System.nanoTime();
+        long startTimestamp = System.currentTimeMillis();
         Queue<MemorySegment> allocatedBuffers = new ArrayDeque<>();
 
         assertThatCode(() -> allocatedBuffers.addAll(readScheduler.allocateBuffers()))
                 .doesNotThrowAnyException();
-        long requestDuration = System.nanoTime() - startTimestamp;
+        long requestDuration = System.currentTimeMillis() - startTimestamp;
 
         assertThat(allocatedBuffers).hasSize(3);
-        assertThat(requestDuration).isGreaterThan(bufferRequestTimeout.toNanos() * 2);
+        assertThat(requestDuration).isGreaterThan(bufferRequestTimeout.toMillis() * 2);
 
         bufferPool.recycle(allocatedBuffers);
         bufferPool.destroy();


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

When running TPC-DS tests, I encountered the read buffer request timeout because of configuring too less read buffers. But I found the timeout time may be less than 5m occasionally, 5m is the expected time. 
I read the docs of `System.nanotime`, the docs say that  t1 < t0 should not be used, because of the possibility of numerical overflow. 
I tested the `System.currentTimeMillis` and it can work as expected. The timeout time need not be as precise as nano time, and `System.currentTimeMillis` is more efficient than nano time, so I decide to use the mill sec to replace nano time.

## Brief change log

  - *Replace the nano time by milliseconds as the timeout time for batch read buffer pool*


## Verifying this change

This change is already covered by existing tests*.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes / **no**/ don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
