### PR TITLE
[FLINK-31401][streaming][tests] Make parallelism assumption explicit in StreamingJobGraphGeneratorTest

### DIFF
--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/api/graph/StreamingJobGraphGeneratorTest.java
@@ -259,6 +259,9 @@ class StreamingJobGraphGeneratorTest {
     @Test
     public void testTransformationSetParallelism() {
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        /* The default parallelism of the environment (that is inherited by the source)
+        and the parallelism of the map operator needs to be different for this test */
+        env.setParallelism(4);
         env.fromSequence(1L, 3L).map(i -> i).setParallelism(10).print().setParallelism(20);
         StreamGraph streamGraph = env.getStreamGraph();
 


### PR DESCRIPTION
Minor improvement to the test, so that it does not fail on 10 core machines.

cc @JunRuiLee 