### PR TITLE
[BP-1.16][FLINK-31393] Fix the bug that HsFileDataManager use an incorrect default timeout.

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
+++ b/flink-runtime/src/main/java/org/apache/flink/runtime/io/network/partition/hybrid/HybridShuffleConfiguration.java
@@ -24,7 +24,7 @@ import java.time.Duration;
 public class HybridShuffleConfiguration {
     private static final int DEFAULT_MAX_BUFFERS_READ_AHEAD = 5;
 
-    private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMillis(5);
+    private static final Duration DEFAULT_BUFFER_REQUEST_TIMEOUT = Duration.ofMinutes(5);
 
     private static final float DEFAULT_SELECTIVE_STRATEGY_SPILL_THRESHOLD = 0.7f;
 


### PR DESCRIPTION
Backport FLINK-31393 to release-1.16.
