### PR TITLE
[FLINK-31414][checkpointing] exceptions in the alignment timer are ig…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierAlignmentUtil.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierAlignmentUtil.java
@@ -47,8 +47,8 @@ public class BarrierAlignmentUtil {
                     timerService.registerTimer(
                             timerService.getCurrentProcessingTime() + delay.toMillis(),
                             timestamp ->
-                                    mailboxExecutor.submit(
-                                            callable,
+                                    mailboxExecutor.execute(
+                                            () -> callable.call(),
                                             "Execute checkpoint barrier handler delayed action"));
             return () -> scheduledFuture.cancel(false);
         };

--- a/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierAlignmentUtilTest.java
+++ b/flink-streaming-java/src/test/java/org/apache/flink/streaming/runtime/io/checkpointing/BarrierAlignmentUtilTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.io.checkpointing;
+
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.runtime.operators.testutils.ExpectedTestException;
+import org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor;
+import org.apache.flink.streaming.runtime.tasks.TestProcessingTimeService;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxExecutorImpl;
+import org.apache.flink.streaming.runtime.tasks.mailbox.MailboxProcessor;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailbox;
+import org.apache.flink.streaming.runtime.tasks.mailbox.TaskMailboxImpl;
+import org.apache.flink.util.ExceptionUtils;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.junit.Assert.assertThrows;
+
+/** {@link BarrierAlignmentUtil} test. */
+public class BarrierAlignmentUtilTest {
+
+    @Test
+    public void testDelayableTimerNotHiddenException() throws Exception {
+        TaskMailbox mailbox = new TaskMailboxImpl();
+        MailboxProcessor mailboxProcessor =
+                new MailboxProcessor(controller -> {}, mailbox, StreamTaskActionExecutor.IMMEDIATE);
+        MailboxExecutor mailboxExecutor =
+                new MailboxExecutorImpl(
+                        mailbox, 0, StreamTaskActionExecutor.IMMEDIATE, mailboxProcessor);
+
+        TestProcessingTimeService timerService = new TestProcessingTimeService();
+        timerService.setCurrentTime(System.currentTimeMillis());
+
+        BarrierAlignmentUtil.DelayableTimer delayableTimer =
+                BarrierAlignmentUtil.createRegisterTimerCallback(mailboxExecutor, timerService);
+
+        Duration delay = Duration.ofMinutes(10);
+
+        delayableTimer.registerTask(
+                () -> {
+                    // simulate Exception in checkpoint sync phase
+                    throw new ExpectedTestException();
+                },
+                delay);
+
+        timerService.advance(delay.toMillis());
+
+        Throwable t =
+                assertThrows(
+                        "BarrierAlignmentUtil.DelayableTimer should not hidden exception",
+                        Exception.class,
+                        () -> mailboxProcessor.runMailboxStep());
+
+        ExceptionUtils.assertThrowable(t, ExpectedTestException.class);
+    }
+}


### PR DESCRIPTION
…nored


## What is the purpose of the change

fix problem described in [FLINK-31414](https://issues.apache.org/jira/browse/FLINK-31414).

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (yes, checkpointing)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
