### PR TITLE
[FLINK-31420][test] Fix unstable test ThreadInfoRequestCoordinatorTest.

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/webmonitor/threadinfo/ThreadInfoRequestCoordinatorTest.java
@@ -173,7 +173,9 @@ class ThreadInfoRequestCoordinatorTest {
         Map<ImmutableSet<ExecutionAttemptID>, CompletableFuture<TaskExecutorThreadInfoGateway>>
                 executionWithGateways =
                         createMockSubtaskWithGateways(
-                                CompletionType.SUCCESSFULLY, CompletionType.TIMEOUT);
+                                // request future will only be completed after all gateways
+                                // successfully return thread infos.
+                                CompletionType.SUCCESSFULLY, CompletionType.NEVER_COMPLETE);
 
         List<CompletableFuture<VertexThreadInfoStats>> requestFutures = new ArrayList<>();
 


### PR DESCRIPTION
## What is the purpose of the change

*`ThreadInfoRequestCoordinatorTest#testShutDown` using two gateways contains a `timeout gateway` but expected all `request futures` not done before `shutdown`. If the timeout reached, this future will be failed, result in `request futures` to be done. This makes the test strongly dependent on the execution order of assertion and timeout, thus causing this test unstable.*


## Brief change log

  - *Let ThreadInfoRequestCoordinatorTest more comply with the specifications of Junit and AssertJ.*
  - *Fix unstable test ThreadInfoRequestCoordinatorTest#testShutDown..*

## Verifying this change

This change is dedicated to fixing an unstable test.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): no
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: no
  - The serializers: no
  - The runtime per-record code paths (performance sensitive): no
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: no
  - The S3 file system connector: no

## Documentation

  - Does this pull request introduce a new feature? no
