### PR TITLE
[FLINK-31450][table] Introduce ExecutableOperation for operations to execute

### DIFF
--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ExecutableOperationContextImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/ExecutableOperationContextImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.api.internal;
+
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.module.ModuleManager;
+import org.apache.flink.table.operations.ExecutableOperation;
+
+/** A simple implementation of {@link ExecutableOperation.Context}. */
+public class ExecutableOperationContextImpl implements ExecutableOperation.Context {
+
+    private final CatalogManager catalogManager;
+    private final ModuleManager moduleManager;
+
+    public ExecutableOperationContextImpl(
+            CatalogManager catalogManager, ModuleManager moduleManager) {
+        this.catalogManager = catalogManager;
+        this.moduleManager = moduleManager;
+    }
+
+    @Override
+    public CatalogManager getCatalogManager() {
+        return catalogManager;
+    }
+
+    @Override
+    public ModuleManager getModuleManager() {
+        return moduleManager;
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/api/internal/TableEnvironmentImpl.java
@@ -115,8 +115,6 @@ import org.apache.flink.table.operations.SourceQueryOperation;
 import org.apache.flink.table.operations.StatementSetOperation;
 import org.apache.flink.table.operations.TableSourceQueryOperation;
 import org.apache.flink.table.operations.UnloadModuleOperation;
-import org.apache.flink.table.operations.UseCatalogOperation;
-import org.apache.flink.table.operations.UseDatabaseOperation;
 import org.apache.flink.table.operations.UseModulesOperation;
 import org.apache.flink.table.operations.command.AddJarOperation;
 import org.apache.flink.table.operations.command.ExecutePlanOperation;
@@ -1233,17 +1231,6 @@ public class TableEnvironmentImpl implements TableEnvironmentInternal {
             return loadModule((LoadModuleOperation) operation);
         } else if (operation instanceof UnloadModuleOperation) {
             return unloadModule((UnloadModuleOperation) operation);
-        } else if (operation instanceof UseModulesOperation) {
-            return useModules((UseModulesOperation) operation);
-        } else if (operation instanceof UseCatalogOperation) {
-            UseCatalogOperation useCatalogOperation = (UseCatalogOperation) operation;
-            catalogManager.setCurrentCatalog(useCatalogOperation.getCatalogName());
-            return TableResultImpl.TABLE_RESULT_OK;
-        } else if (operation instanceof UseDatabaseOperation) {
-            UseDatabaseOperation useDatabaseOperation = (UseDatabaseOperation) operation;
-            catalogManager.setCurrentCatalog(useDatabaseOperation.getCatalogName());
-            catalogManager.setCurrentDatabase(useDatabaseOperation.getDatabaseName());
-            return TableResultImpl.TABLE_RESULT_OK;
         } else if (operation instanceof ShowCatalogsOperation) {
             return buildShowResult("catalog name", listCatalogs());
         } else if (operation instanceof ShowCreateTableOperation) {

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExecutableOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/ExecutableOperation.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.table.operations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.table.api.internal.TableEnvironmentImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+import org.apache.flink.table.catalog.CatalogManager;
+import org.apache.flink.table.module.ModuleManager;
+
+/**
+ * An {@link ExecutableOperation} represents an operation that is executed for its side effects.
+ *
+ * <p>This internal interface is proposed to reduce the maintenance of bloated {@link
+ * TableEnvironmentImpl#executeInternal(Operation)} and improve code readability as execution logic
+ * is co-located with the operation definition. Besides, this interface can be used to extend
+ * user-defined operation with customized execution logic once this interface is stable and public
+ * in the future.
+ */
+@Internal
+public interface ExecutableOperation extends Operation {
+
+    /**
+     * Executes the given operation and return the execution result.
+     *
+     * @param ctx the context to execute the operation.
+     * @return the content of the execution result.
+     * @see org.apache.flink.table.api.internal.TableEnvironmentInternal#executeInternal(Operation)
+     */
+    TableResultInternal execute(Context ctx);
+
+    /**
+     * The context to execute the operation. Operation may make side effect to the context, e.g.
+     * catalog manager, configuration.
+     */
+    interface Context {
+
+        CatalogManager getCatalogManager();
+
+        ModuleManager getModuleManager();
+    }
+}

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseCatalogOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseCatalogOperation.java
@@ -18,10 +18,13 @@
 
 package org.apache.flink.table.operations;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+
 /** Operation to describe a USE CATALOG statement. */
 public class UseCatalogOperation implements UseOperation {
 
-    private String catalogName;
+    private final String catalogName;
 
     public UseCatalogOperation(String catalogName) {
         this.catalogName = catalogName;
@@ -34,5 +37,11 @@ public class UseCatalogOperation implements UseOperation {
     @Override
     public String asSummaryString() {
         return String.format("USE CATALOG %s", catalogName);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager().setCurrentCatalog(catalogName);
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseDatabaseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseDatabaseOperation.java
@@ -18,6 +18,9 @@
 
 package org.apache.flink.table.operations;
 
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+
 /** Operation to describe a USE [catalogName.]dataBaseName statement. */
 public class UseDatabaseOperation implements UseOperation {
 
@@ -40,5 +43,12 @@ public class UseDatabaseOperation implements UseOperation {
     @Override
     public String asSummaryString() {
         return String.format("USE %s.%s", catalogName, databaseName);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        ctx.getCatalogManager().setCurrentCatalog(catalogName);
+        ctx.getCatalogManager().setCurrentDatabase(databaseName);
+        return TableResultImpl.TABLE_RESULT_OK;
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseModulesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseModulesOperation.java
@@ -30,11 +30,11 @@ public class UseModulesOperation implements UseOperation {
     private final List<String> moduleNames;
 
     public UseModulesOperation(List<String> moduleNames) {
-        this.moduleNames = moduleNames;
+        this.moduleNames = Collections.unmodifiableList(moduleNames);
     }
 
     public List<String> getModuleNames() {
-        return Collections.unmodifiableList(moduleNames);
+        return moduleNames;
     }
 
     @Override

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseModulesOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseModulesOperation.java
@@ -18,6 +18,10 @@
 
 package org.apache.flink.table.operations;
 
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.api.internal.TableResultImpl;
+import org.apache.flink.table.api.internal.TableResultInternal;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -36,5 +40,17 @@ public class UseModulesOperation implements UseOperation {
     @Override
     public String asSummaryString() {
         return String.format("USE MODULES: %s", moduleNames);
+    }
+
+    @Override
+    public TableResultInternal execute(Context ctx) {
+        try {
+            ctx.getModuleManager().useModules(moduleNames.toArray(new String[0]));
+            return TableResultImpl.TABLE_RESULT_OK;
+        } catch (ValidationException e) {
+            throw new ValidationException(
+                    String.format("Could not execute %s. %s", asSummaryString(), e.getMessage()),
+                    e);
+        }
     }
 }

--- a/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseOperation.java
+++ b/flink-table/flink-table-api-java/src/main/java/org/apache/flink/table/operations/UseOperation.java
@@ -29,4 +29,4 @@ import org.apache.flink.annotation.Internal;
  * switching current database.
  */
 @Internal
-public interface UseOperation extends Operation {}
+public interface UseOperation extends Operation, ExecutableOperation {}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This pull request introduces an internal interface, `ExecutableOperation` to represent an operation that is executed for its side effects. 

This internal interface is proposed to reduce the maintenance of bloated `TableEnvironmentImpl#executeInternal(Operation)` and improve code readability as execution logic is co-located with the operation definition. Besides, this interface can be used to extend user-defined operations with customized execution logic once this interface is stable and public in the future.

## Brief change log

- Introduce `ExecutableOperation` interface and make `TableEnvironmentImpl` supports it. 
- Migrate `DropOperation`s to extend `ExecutableOperation` and move the execution logic of `UseOperation`s out from `TableEnvironmentImpl`. 


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / **no**)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / **no**)
  - The serializers: (yes / **no** / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / **no** / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Yarn/Mesos, ZooKeeper: (yes / **no** / don't know)
  - The S3 file system connector: (yes / **no** / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / **no**)
  - If yes, how is the feature documented? (**not applicable** / docs / JavaDocs / not documented)
